### PR TITLE
Remove the client secrets file for Google provider

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -1,8 +1,8 @@
 package aws
 
 import (
-	"github.com/mitchellh/goamz/ec2"
 	"fmt"
+	"github.com/mitchellh/goamz/ec2"
 )
 
 func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.NetworkAclEntry, error) {
@@ -11,7 +11,7 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.
 		data := eRaw.(map[string]interface{})
 		protocol := data["protocol"].(string)
 		_, ok := protocolIntegers()[protocol]
-		if(!ok){
+		if !ok {
 			return nil, fmt.Errorf("Invalid Protocol %s for rule %#v", protocol, data)
 		}
 		p := extractProtocolInteger(data["protocol"].(string))
@@ -69,7 +69,7 @@ func protocolIntegers() map[string]int {
 		"udp":  17,
 		"tcp":  6,
 		"icmp": 1,
-		"all": -1,
+		"all":  -1,
 	}
 	return protocolIntegers
 }

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -2,8 +2,8 @@ package aws
 
 import (
 	"fmt"
-	"testing"
 	"reflect"
+	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -252,12 +252,12 @@ func testAccCheckInstanceExists(n string, i *ec2.Instance) resource.TestCheckFun
 func TestInstanceTenancySchema(t *testing.T) {
 	actualSchema := resourceAwsInstance().Schema["tenancy"]
 	expectedSchema := &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			}
-	if !reflect.DeepEqual(actualSchema, expectedSchema  ) {
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+	}
+	if !reflect.DeepEqual(actualSchema, expectedSchema) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
 			actualSchema,

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -129,26 +129,25 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-		resource.TestStep{
-		Config: testAccRouteTableConfigTags,
-		Check: resource.ComposeTestCheckFunc(
-			testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-			testAccCheckTags(&route_table.Tags, "foo", "bar"),
-		),
-	},
+			resource.TestStep{
+				Config: testAccRouteTableConfigTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
+					testAccCheckTags(&route_table.Tags, "foo", "bar"),
+				),
+			},
 
-		resource.TestStep{
-		Config: testAccRouteTableConfigTagsUpdate,
-		Check: resource.ComposeTestCheckFunc(
-			testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-			testAccCheckTags(&route_table.Tags, "foo", ""),
-			testAccCheckTags(&route_table.Tags, "bar", "baz"),
-		),
-	},
-	},
+			resource.TestStep{
+				Config: testAccRouteTableConfigTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
+					testAccCheckTags(&route_table.Tags, "foo", ""),
+					testAccCheckTags(&route_table.Tags, "bar", "baz"),
+				),
+			},
+		},
 	})
 }
-
 
 func testAccCheckRouteTableDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -57,7 +57,7 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Create the VPC
 	createOpts := &ec2.CreateVpc{
-		CidrBlock: d.Get("cidr_block").(string),
+		CidrBlock:       d.Get("cidr_block").(string),
 		InstanceTenancy: d.Get("instance_tenancy").(string),
 	}
 	log.Printf("[DEBUG] VPC create config: %#v", createOpts)

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -216,4 +216,3 @@ resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
 }
 `
-

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -297,8 +297,8 @@ func Test_flattenParameters(t *testing.T) {
 			},
 			Output: []map[string]interface{}{
 				map[string]interface{}{
-					"name":         "character_set_client",
-					"value":        "utf8",
+					"name":  "character_set_client",
+					"value": "utf8",
 				},
 			},
 		},

--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -16,13 +16,12 @@ const clientScopes string = "https://www.googleapis.com/auth/compute"
 const authURL string = "https://accounts.google.com/o/oauth2/auth"
 const tokenURL string = "https://accounts.google.com/o/oauth2/token"
 
-
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
-	AccountFile       string
-	Project           string
-	Region            string
+	AccountFile string
+	Project     string
+	Region      string
 
 	clientCompute *compute.Service
 }
@@ -67,8 +66,8 @@ func (c *Config) loadAndValidate() error {
 		Config: &oauth.Config{
 			ClientId: account.ClientId,
 			Scope:    clientScopes,
-			AuthURL:      authURL,
-			TokenURL:     tokenURL,
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
 		},
 		Token: token,
 	}

--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -13,8 +13,6 @@ import (
 )
 
 const clientScopes string = "https://www.googleapis.com/auth/compute"
-const authURL string = "https://accounts.google.com/o/oauth2/auth"
-const tokenURL string = "https://accounts.google.com/o/oauth2/token"
 
 // Config is the configuration structure used to instantiate the Google
 // provider.
@@ -66,8 +64,6 @@ func (c *Config) loadAndValidate() error {
 		Config: &oauth.Config{
 			ClientId: account.ClientId,
 			Scope:    clientScopes,
-			AuthURL:  authURL,
-			TokenURL: tokenURL,
 		},
 		Token: token,
 	}

--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -13,12 +13,14 @@ import (
 )
 
 const clientScopes string = "https://www.googleapis.com/auth/compute"
+const authURL string = "https://accounts.google.com/o/oauth2/auth"
+const tokenURL string = "https://accounts.google.com/o/oauth2/token"
+
 
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
 	AccountFile       string
-	ClientSecretsFile string
 	Project           string
 	Region            string
 
@@ -27,7 +29,17 @@ type Config struct {
 
 func (c *Config) loadAndValidate() error {
 	var account accountFile
-	var secrets clientSecretsFile
+
+	// TODO: validation that it isn't blank
+	if c.AccountFile == "" {
+		c.AccountFile = os.Getenv("GOOGLE_ACCOUNT_FILE")
+	}
+	if c.Project == "" {
+		c.Project = os.Getenv("GOOGLE_PROJECT")
+	}
+	if c.Region == "" {
+		c.Region = os.Getenv("GOOGLE_REGION")
+	}
 
 	if err := loadJSON(&account, c.AccountFile); err != nil {
 		return fmt.Errorf(
@@ -36,24 +48,15 @@ func (c *Config) loadAndValidate() error {
 			err)
 	}
 
-	if err := loadJSON(&secrets, c.ClientSecretsFile); err != nil {
-		return fmt.Errorf(
-			"Error loading client secrets file '%s': %s",
-			c.ClientSecretsFile,
-			err)
-	}
-
 	// Get the token for use in our requests
 	log.Printf("[INFO] Requesting Google token...")
 	log.Printf("[INFO]   -- Email: %s", account.ClientEmail)
 	log.Printf("[INFO]   -- Scopes: %s", clientScopes)
 	log.Printf("[INFO]   -- Private Key Length: %d", len(account.PrivateKey))
-	log.Printf("[INFO]   -- Token URL: %s", secrets.Web.TokenURI)
 	jwtTok := jwt.NewToken(
 		account.ClientEmail,
 		clientScopes,
 		[]byte(account.PrivateKey))
-	jwtTok.ClaimSet.Aud = secrets.Web.TokenURI
 	token, err := jwtTok.Assert(new(http.Client))
 	if err != nil {
 		return fmt.Errorf("Error retrieving auth token: %s", err)
@@ -64,8 +67,8 @@ func (c *Config) loadAndValidate() error {
 		Config: &oauth.Config{
 			ClientId: account.ClientId,
 			Scope:    clientScopes,
-			TokenURL: secrets.Web.TokenURI,
-			AuthURL:  secrets.Web.AuthURI,
+			AuthURL:      authURL,
+			TokenURL:     tokenURL,
 		},
 		Token: token,
 	}
@@ -85,16 +88,6 @@ type accountFile struct {
 	PrivateKey   string `json:"private_key"`
 	ClientEmail  string `json:"client_email"`
 	ClientId     string `json:"client_id"`
-}
-
-// clientSecretsFile represents the structure of the client secrets JSON file.
-type clientSecretsFile struct {
-	Web struct {
-		AuthURI     string `json:"auth_uri"`
-		ClientEmail string `json:"client_email"`
-		ClientId    string `json:"client_id"`
-		TokenURI    string `json:"token_uri"`
-	}
 }
 
 func loadJSON(result interface{}, path string) error {

--- a/builtin/providers/google/config_test.go
+++ b/builtin/providers/google/config_test.go
@@ -22,20 +22,3 @@ func TestConfigLoadJSON_account(t *testing.T) {
 		t.Fatalf("bad: %#v", actual)
 	}
 }
-
-func TestConfigLoadJSON_client(t *testing.T) {
-	var actual clientSecretsFile
-	if err := loadJSON(&actual, "./test-fixtures/fake_client.json"); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	var expected clientSecretsFile
-	expected.Web.AuthURI = "https://accounts.google.com/o/oauth2/auth"
-	expected.Web.ClientEmail = "foo@developer.gserviceaccount.com"
-	expected.Web.ClientId = "foo.apps.googleusercontent.com"
-	expected.Web.TokenURI = "https://accounts.google.com/o/oauth2/token"
-
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
-	}
-}

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -17,12 +17,6 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: envDefaultFunc("GOOGLE_ACCOUNT_FILE"),
 			},
 
-			"client_secrets_file": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: envDefaultFunc("GOOGLE_CLIENT_FILE"),
-			},
-
 			"project": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -62,7 +56,6 @@ func envDefaultFunc(k string) schema.SchemaDefaultFunc {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		AccountFile:       d.Get("account_file").(string),
-		ClientSecretsFile: d.Get("client_secrets_file").(string),
 		Project:           d.Get("project").(string),
 		Region:            d.Get("region").(string),
 	}

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -55,9 +55,9 @@ func envDefaultFunc(k string) schema.SchemaDefaultFunc {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AccountFile:       d.Get("account_file").(string),
-		Project:           d.Get("project").(string),
-		Region:            d.Get("region").(string),
+		AccountFile: d.Get("account_file").(string),
+		Project:     d.Get("project").(string),
+		Region:      d.Get("region").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/builtin/providers/heroku/provider.go
+++ b/builtin/providers/heroku/provider.go
@@ -30,7 +30,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_addon":  resourceHerokuAddon(),
 			"heroku_domain": resourceHerokuDomain(),
 			"heroku_drain":  resourceHerokuDrain(),
-			"heroku_cert":  resourceHerokuCert(),
+			"heroku_cert":   resourceHerokuCert(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/heroku/resource_heroku_cert_test.go
+++ b/builtin/providers/heroku/resource_heroku_cert_test.go
@@ -2,9 +2,9 @@ package heroku
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
-    "os"
-    "io/ioutil"
 
 	"github.com/cyberdelia/heroku-go/v3"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -13,11 +13,11 @@ import (
 
 func TestAccHerokuCert_Basic(t *testing.T) {
 	var endpoint heroku.SSLEndpoint
-    wd, _ := os.Getwd()
-    certificateChainFile := wd + "/test-fixtures/terraform.cert"
-    certificateChainBytes, _ := ioutil.ReadFile(certificateChainFile)
-    certificateChain := string(certificateChainBytes)
-    testAccCheckHerokuCertConfig_basic := `
+	wd, _ := os.Getwd()
+	certificateChainFile := wd + "/test-fixtures/terraform.cert"
+	certificateChainBytes, _ := ioutil.ReadFile(certificateChainFile)
+	certificateChain := string(certificateChainBytes)
+	testAccCheckHerokuCertConfig_basic := `
     resource "heroku_app" "foobar" {
         name = "terraform-test-cert-app"
         region = "eu"
@@ -47,7 +47,7 @@ func TestAccHerokuCert_Basic(t *testing.T) {
 					testAccCheckHerokuCertExists("heroku_cert.ssl_certificate", &endpoint),
 					testAccCheckHerokuCertificateChain(&endpoint, certificateChain),
 					resource.TestCheckResourceAttr(
-                        "heroku_cert.ssl_certificate", "cname", "terraform-test-cert-app.herokuapp.com"),
+						"heroku_cert.ssl_certificate", "cname", "terraform-test-cert-app.herokuapp.com"),
 				),
 			},
 		},
@@ -112,5 +112,3 @@ func testAccCheckHerokuCertExists(n string, endpoint *heroku.SSLEndpoint) resour
 		return nil
 	}
 }
-
-

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -13,11 +13,11 @@ var Funcs map[string]InterpolationFunc
 
 func init() {
 	Funcs = map[string]InterpolationFunc{
-		"concat": interpolationFuncConcat,
-		"file":   interpolationFuncFile,
-		"join":   interpolationFuncJoin,
-		"lookup": interpolationFuncLookup,
-		"element":  interpolationFuncElement,
+		"concat":  interpolationFuncConcat,
+		"file":    interpolationFuncFile,
+		"join":    interpolationFuncJoin,
+		"lookup":  interpolationFuncLookup,
+		"element": interpolationFuncElement,
 	}
 }
 
@@ -108,7 +108,7 @@ func interpolationFuncElement(
 			"invalid number for index, got %s", args[1])
 	}
 
-	v := list[index % len(list)]
+	v := list[index%len(list)]
 
 	return v, nil
 }

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -42,14 +42,14 @@ The following keys can be used to configure the provider.
 
 * `region` - (Required) The region to operate under.
 
-## Authentication JSON Files
+## Authentication JSON File
 
-Authenticating with Google Cloud services requires two separate JSON
-files: one which we call the _account file_ and the _client secrets file_.
+Authenticating with Google Cloud services requires a JSON
+file which we call the _account file_.
 
-Both of these files are downloaded directly from the
+This file is downloaded directly from the
 [Google Developers Console](https://console.developers.google.com). To make
-the process more straightforwarded, it is documented here.
+the process more straightforwarded, it is documented here:
 
 1. Log into the [Google Developers Console](https://console.developers.google.com)
    and select a project.

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -20,7 +20,6 @@ Use the navigation to the left to read about the available resources.
 # Configure the Google Cloud provider
 provider "google" {
     account_file = "account.json"
-    client_secrets_file = "client_secrets.json"
     project = "my-gce-project"
     region = "us-central1"
 }
@@ -38,10 +37,6 @@ The following keys can be used to configure the provider.
 * `account_file` - (Required) Path to the JSON file used to describe
   your account credentials, downloaded from Google Cloud Console. More
   details on retrieving this file are below.
-
-* `client_secrets_file` - (Required) Path to the JSON file containing
-  the secrets for your account, downloaded from Google Cloud Console.
-  More details on retrieving this file are below.
 
 * `project` - (Required) The name of the project to apply any resources to.
 
@@ -61,11 +56,6 @@ the process more straightforwarded, it is documented here.
 
 2. Under the "APIs & Auth" section, click "Credentials."
 
-3. Create a new OAuth client ID and select "Installed application" as the
-   type of account. Once created, click the "Download JSON" button underneath
-   the account. The file should start with "client\_secret". This is your _client
-   secrets file_.
-
-4. Create a new OAuth client ID and select "Service account" as the type
+3. Create a new OAuth client ID and select "Service account" as the type
    of account. Once created, a JSON file should be downloaded. This is your
    _account file_.

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -57,5 +57,4 @@ the process more straightforwarded, it is documented here:
 2. Under the "APIs & Auth" section, click "Credentials."
 
 3. Create a new OAuth client ID and select "Service account" as the type
-   of account. Once created, a JSON file should be downloaded. This is your
-   _account file_.
+   of account. Once created, and after a P12 key is downloaded, a JSON file should be downloaded. This is your _account file_.


### PR DESCRIPTION
Terraform seems to work without the client secrets json file. I haven't run all the acceptance tests but I'm able to interact with the API.