### PR TITLE
add aws_key_pair resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elb":                     resourceAwsElb(),
 			"aws_instance":                resourceAwsInstance(),
 			"aws_internet_gateway":        resourceAwsInternetGateway(),
+			"aws_key_pair":                resourceAwsKeyPair(),
 			"aws_launch_configuration":    resourceAwsLaunchConfiguration(),
 			"aws_network_acl":             resourceAwsNetworkAcl(),
 			"aws_route53_record":          resourceAwsRoute53Record(),

--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsKeyPair() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsKeyPairCreate,
+		Read:   resourceAwsKeyPairRead,
+		Update: nil,
+		Delete: resourceAwsKeyPairDelete,
+
+		Schema: map[string]*schema.Schema{
+			"key_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"public_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"fingerprint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	keyName := d.Get("key_name").(string)
+	publicKey := d.Get("public_key").(string)
+	resp, err := ec2conn.ImportKeyPair(keyName, publicKey)
+	if err != nil {
+		return fmt.Errorf("Error import KeyPair: %s", err)
+	}
+
+	d.SetId(resp.KeyName)
+
+	return nil
+}
+
+func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	resp, err := ec2conn.KeyPairs([]string{d.Id()}, nil)
+	if err != nil {
+		return fmt.Errorf("Error retrieving KeyPair: %s", err)
+	}
+
+	for _, keyPair := range resp.Keys {
+		if keyPair.Name == d.Id() {
+			d.Set("key_name", keyPair.Name)
+			d.Set("fingerprint", keyPair.Fingerprint)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Unable to find key pair within: %#v", resp.Keys)
+}
+
+func resourceAwsKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	_, err := ec2conn.DeleteKeyPair(d.Id())
+	return err
+}

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/goamz/ec2"
+)
+
+func TestAccAWSKeyPair_normal(t *testing.T) {
+	var conf ec2.KeyPair
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKeyPairDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSKeyPairConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKeyPairExists("aws_key_pair.a_key_pair", &conf),
+					testAccCheckAWSKeyPairFingerprint("d7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62", &conf),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSKeyPairDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_key_pair" {
+			continue
+		}
+
+		// Try to find key pair
+		resp, err := conn.KeyPairs(
+			[]string{rs.Primary.ID}, nil)
+		if err == nil {
+			if len(resp.Keys) > 0 {
+				return fmt.Errorf("still exist.")
+			}
+			return nil
+		}
+
+		// Verify the error is what we want
+		ec2err, ok := err.(*ec2.Error)
+		if !ok {
+			return err
+		}
+		if ec2err.Code != "InvalidKeyPair.NotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSKeyPairFingerprint(expectedFingerprint string, conf *ec2.KeyPair) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if conf.Fingerprint != expectedFingerprint {
+			return fmt.Errorf("incorrect fingerprint. expected %s, got %s", expectedFingerprint, conf.Fingerprint)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSKeyPairExists(n string, res *ec2.KeyPair) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No KeyPair name is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		resp, err := conn.KeyPairs(
+			[]string{rs.Primary.ID}, nil)
+		if err != nil {
+			return err
+		}
+		if len(resp.Keys) != 1 ||
+			resp.Keys[0].Name != rs.Primary.ID {
+			return fmt.Errorf("KeyPair not found")
+		}
+		*res = resp.Keys[0]
+
+		return nil
+	}
+}
+
+const testAccAWSKeyPairConfig = `
+resource "aws_key_pair" "a_key_pair" {
+	key_name   = "tf-acc-key-pair"
+	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+`

--- a/website/source/docs/providers/aws/r/key_pair.html.markdown
+++ b/website/source/docs/providers/aws/r/key_pair.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: aws_key_pair"
+sidebar_current: "docs-aws-resource-key-pair"
+description: |-
+  Provides a Key Pair resource. Currently this supports importing an existing key pair but not creating a new key pair.
+---
+
+# aws\_key\_pair
+
+Provides an [EC2 key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) resource. A key pair is used to control login access to EC2 instances. 
+
+Currently this resource only supports importing an existing key pair, not creating a new key pair.
+
+When importing an existing key pair the public key material may be in any format supported by AWS. Supported formats (per the [AWS documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws)) are:
+
+* OpenSSH public key format (the format in ~/.ssh/authorized_keys)
+* Base64 encoded DER format
+* SSH public key file format as specified in RFC4716
+
+## Example Usage
+
+```
+resource "aws_key_pair" "deployer" {
+  key_name = "deployer-key" 
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `key_name` - (Required) The name for the key pair.
+* `public_key` - (Required) The public key material. 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `key_name` - The key pair name.
+* `fingerprint` - The MD5 public key fingerprint as specified in section 4 of RFC 4716.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -53,7 +53,7 @@
 					<a href="/docs/providers/aws/r/launch_config.html">aws_launch_configuration</a>
                     </li>
 
-                    <li<%= sidebar_current("docs-aws-resource-network-acl|") %>>
+                    <li<%= sidebar_current("docs-aws-resource-network-acl") %>>
 					<a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
 					</li>
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -56,6 +56,9 @@
                     <li<%= sidebar_current("docs-aws-resource-network-acl") %>>
 					<a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
 					</li>
+                    <li<%= sidebar_current("docs-aws-resource-key-pair") %>>
+					<a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
+					</li>
 
                     <li<%= sidebar_current("docs-aws-resource-route-table|") %>>
 					<a href="/docs/providers/aws/r/route_table.html">aws_route_table</a>


### PR DESCRIPTION
For now this only supports importing a key pair (by specifying a
public_key) property. In the future it'd be fairly trivial to support
key pair creation, with the private key returned as a computed property.

In real world usage you'd probably want to provide that public_key
property via a variable rather than hard-coding it into a terraform
config that'd end up in source control.