### PR TITLE
Adding colon to interpolated regex so they can be used in concats

### DIFF
--- a/config/interpolate_walk.go
+++ b/config/interpolate_walk.go
@@ -16,7 +16,7 @@ const InterpSplitDelim = `B780FFEC-B661-4EB8-9236-A01737AD98B6`
 
 // interpRegexp is a regexp that matches interpolations such as ${foo.bar}
 var interpRegexp *regexp.Regexp = regexp.MustCompile(
-	`(?i)(\$+)\{([\s*-.,\\/\(\)a-z0-9_"]+)\}`)
+	`(?i)(\$+)\{([\s*-.,\\/\(\):a-z0-9_"]+)\}`)
 
 // interpolationWalker implements interfaces for the reflectwalk package
 // (github.com/mitchellh/reflectwalk) that can be used to automatically

--- a/config/interpolate_walk_test.go
+++ b/config/interpolate_walk_test.go
@@ -129,6 +129,25 @@ func TestInterpolationWalker_detect(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			Input: map[string]interface{}{
+				"foo": `${concat("localhost", ":8080")}`,
+			},
+			Result: []Interpolation{
+				&FunctionInterpolation{
+					Func: nil,
+					Args: []Interpolation{
+						&LiteralInterpolation{
+							Literal: "localhost",
+						},
+						&LiteralInterpolation{
+							Literal: ":8080",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Fixes #696 

I don't think the regex is sustainable or at the very least, we need to come up with a list of valid characters that can be used within an interpolation. Since we now have `concat`, basically the user can input any string values which we continually come up against this regex.

So for now, I've just added the colon to to regex valid chars to fix my own case.