### PR TITLE
Update Makefile for use with Go 1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ testrace: config/y.go
 	TF_ACC= go test -race $(TEST) $(TESTARGS)
 
 updatedeps: config/y.go
-	go get -u -v ./...
+	@if [ $(shell go version | cut -f3 -d" " | cut -f2 -d.) -lt 4 ]; then \
+		go get -u -v ./...; \
+	else \
+		go get -f -u -v ./...; \
+	fi
 
 config/y.go: config/expr.y
 	cd config/ && \


### PR DESCRIPTION
`go get -u` now checks that remote repo paths match the ones predicted by the import paths.

So if working on TF from a forked repo, you cannot use `updatedeps` as `go get` will complain about the differences between the import and the path to your fork.