### PR TITLE
[AWS] Adding default network ACL ID and default security group ID to VPC reference attributes

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -47,6 +47,11 @@ func resourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"default_network_acl_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -139,6 +144,8 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("main_route_table_id", v[0].RouteTableId)
 	}
 
+	resourceAwsVpcSetDefaultNetworkAcl(ec2conn, d)
+
 	return nil
 }
 
@@ -227,4 +234,21 @@ func VPCStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 		vpc := &resp.VPCs[0]
 		return vpc, vpc.State, nil
 	}
+}
+
+
+func resourceAwsVpcSetDefaultNetworkAcl(conn *ec2.EC2, d *schema.ResourceData) error  {
+	filter := ec2.NewFilter()
+	filter.Add("default", "true")
+	filter.Add("vpc-id", d.Id())
+	networkAclResp, err := conn.NetworkAcls(nil, filter)
+
+	if err != nil {
+		return err
+	}
+	if v := networkAclResp.NetworkAcls; len(v) > 0 {
+		d.Set("default_network_acl_id", v[0].NetworkAclId)
+	}
+
+	return nil
 }

--- a/website/source/docs/providers/aws/r/vpc.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc.html.markdown
@@ -54,3 +54,5 @@ The following attributes are exported:
 * `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support
 * `main_route_table_id` - The ID of the main route table associated with
      this VPC.
+* `default_network_acl_id` - The ID of the network ACL created by default on VPC creation
+* `default_security_group_id` - The ID of the security group created by default on VPC creation


### PR DESCRIPTION
This fixes issue https://github.com/hashicorp/terraform/issues/466