### PR TITLE
provider/google: Add Ubuntu images

### DIFF
--- a/builtin/providers/google/image.go
+++ b/builtin/providers/google/image.go
@@ -24,6 +24,7 @@ func readImage(c *Config, name string) (*compute.Image, error) {
 		"opensuse": "opensuse-cloud",
 		"rhel":     "rhel-cloud",
 		"sles":     "suse-cloud",
+		"ubuntu":   "ubuntu-os-cloud",
 	}
 
 	// If we match a lookup for an alternate project, then try that next.


### PR DESCRIPTION
Ubuntu images are now GA, so add them to the list of available public images