### PR TITLE
Support service accounts on GCE instances

### DIFF
--- a/builtin/providers/google/service_scope.go
+++ b/builtin/providers/google/service_scope.go
@@ -1,0 +1,25 @@
+package google
+
+func canonicalizeServiceScope(scope string) string {
+	// This is a convenience map of short names used by the gcloud tool
+	// to the GCE auth endpoints they alias to.
+	scopeMap := map[string]string{
+		"bigquery":       "https://www.googleapis.com/auth/bigquery",
+		"compute-ro":     "https://www.googleapis.com/auth/compute.readonly",
+		"compute-rw":     "https://www.googleapis.com/auth/compute",
+		"datastore":      "https://www.googleapis.com/auth/datastore",
+		"sql":            "https://www.googleapis.com/auth/sqlservice",
+		"sql-admin":      "https://www.googleapis.com/auth/sqlservice.admin",
+		"storage-full":   "https://www.googleapis.com/auth/devstorage.full_control",
+		"storage-ro":     "https://www.googleapis.com/auth/devstorage.read_only",
+		"storage-rw":     "https://www.googleapis.com/auth/devstorage.read_write",
+		"taskqueue":      "https://www.googleapis.com/auth/taskqueue",
+		"userinfo-email": "https://www.googleapis.com/auth/userinfo.email",
+	}
+
+	if matchedUrl, ok := scopeMap[scope]; ok {
+		return matchedUrl
+	} else {
+		return scope
+	}
+}

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -30,6 +30,10 @@ resource "google_compute_instance" "default" {
 	metadata {
 		foo = "bar"
 	}
+
+	service_account {
+		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+	}
 }
 ```
 
@@ -60,6 +64,8 @@ The following arguments are supported:
     specified multiple times for multiple networks. Structure is documented
     below.
 
+* `service_account` - (Optional) Service account to attach to the instance.
+
 * `tags` - (Optional) Tags to attach to the instance.
 
 The `disk` block supports:
@@ -81,6 +87,11 @@ The `network` block supports:
 
 * `address` - (Optional) The IP address of a reserved IP address to assign
      to this interface.
+
+The `service_account` block supports:
+
+* `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
+    short names are supported.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Update the Google Compute Engine provider to add support for service accounts on `google_compute_instance`. Both gcloud shorthand (`compute-ro`, `storage-ro`, etc.) and OAuth2 URLs are supported. Shorthand names will be automatically canonicalized to their respective OAuth2 URLs.

This feature is currently limited to a single service account (supporting multiple scopes) and an automatically-generated service account email.