### PR TITLE
Doc fix: Referencing security groups from aws_instance correctly

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -35,8 +35,8 @@ The following arguments are supported:
 * `instance_type` - (Required) The type of instance to start
 * `key_name` - (Optional) The key name to use for the instance.
 * `security_groups` - (Optional) A list of security group IDs or names to associate with.
-   If you are within a VPC, you'll need to use the security group ID. Otherwise,
-   for EC2, use the security group name.
+   If you are within a non-default VPC, you'll need to use the security group ID. Otherwise,
+   for EC2 and the default VPC, use the security group name.
 * `subnet_id` - (Optional) The VPC Subnet ID to launch in.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.
 * `private_ip` - (Optional) Private IP address to associate with the


### PR DESCRIPTION
Fixes #575