### PR TITLE
helper/schema: Exists API

### DIFF
--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -409,3 +409,71 @@ func TestResourceRefresh_delete(t *testing.T) {
 		t.Fatalf("bad: %#v", actual)
 	}
 }
+
+func TestResourceRefresh_existsError(t *testing.T) {
+	r := &Resource{
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+	}
+
+	r.Exists = func(*ResourceData, interface{}) (bool, error) {
+		return false, fmt.Errorf("error")
+	}
+
+	r.Read = func(d *ResourceData, m interface{}) error {
+		panic("shouldn't be called")
+	}
+
+	s := &terraform.InstanceState{
+		ID: "bar",
+		Attributes: map[string]string{
+			"foo": "12",
+		},
+	}
+
+	actual, err := r.Refresh(s, 42)
+	if err == nil {
+		t.Fatalf("should error")
+	}
+	if !reflect.DeepEqual(actual, s) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestResourceRefresh_noExists(t *testing.T) {
+	r := &Resource{
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+	}
+
+	r.Exists = func(*ResourceData, interface{}) (bool, error) {
+		return false, nil
+	}
+
+	r.Read = func(d *ResourceData, m interface{}) error {
+		panic("shouldn't be called")
+	}
+
+	s := &terraform.InstanceState{
+		ID: "bar",
+		Attributes: map[string]string{
+			"foo": "12",
+		},
+	}
+
+	actual, err := r.Refresh(s, 42)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if actual != nil {
+		t.Fatalf("should have no state")
+	}
+}

--- a/website/source/docs/plugins/provider.html.md
+++ b/website/source/docs/plugins/provider.html.md
@@ -158,6 +158,10 @@ The CRUD operations in more detail, along with their contracts:
   * `Delete` - This is called to delete the resource. Terraform guarantees
       an existing ID will be set.
 
+  * `Exists` - This is called to verify a resource still exists. It is
+      called prior to `Read`, and lowers the burden of `Read` to be able
+      to assume the resource exists.
+
 ## Schemas
 
 Both providers and resources require a schema to be specified. The schema


### PR DESCRIPTION
This adds `Exists` to the `helper/schema.Resource`. This is called prior to `Read` and handles the situation that a resource no longer exists. 

I added this as a formal CRUD-like operation because we get so many bugs where `Read` isn't handling the case where a resource doesn't exist properly. By documenting this case and exposing it as a first-class callback, I hope that resources in the future will be of high quality.

For backwards compatibility, this is an optional field, but we don't document it as such in the website since we want to encourage its use.

/cc @pearkes 