### PR TITLE
provider/cloudstack: fixing the cloudstack_disk provider

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_disk.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_disk.go
@@ -42,6 +42,7 @@ func resourceCloudStackDisk() *schema.Resource {
 			"size": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 
 			"shrink_ok": &schema.Schema{


### PR DESCRIPTION
This value is read back from the environment to the state, without setting this to `Computed: true` it will see the read back value as a diff.