### PR TITLE
Updated getting started build page

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -146,7 +146,7 @@ as your `example.tf`, and watch it go! It will take a few minutes
 since Terraform waits for the EC2 instance to become available.
 
 ```
-$ terraform apply
+$ terraform apply .
 aws_instance.example: Creating...
   ami:           "" => "ami-408c7f28"
   instance_type: "" => "t1.micro"


### PR DESCRIPTION
Running "terraform apply" in a directory that contains terraform files assumes that you are trying to init from a module, and fails as the destination dir is not empty. Using "." at the end of the command instead allows apply to proceed without doing init first.