### PR TITLE
builtin/providers/cloudstack: fix err checks in tests

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_disk_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_disk_test.go
@@ -152,7 +152,7 @@ func testAccCheckCloudStackDiskDestroy(s *terraform.State) error {
 		}
 
 		p := cs.Volume.NewDeleteVolumeParams(rs.Primary.ID)
-		err, _ := cs.Volume.DeleteVolume(p)
+		_, err := cs.Volume.DeleteVolume(p)
 
 		if err != nil {
 			return fmt.Errorf(
@@ -177,7 +177,7 @@ func testAccCheckCloudStackDiskDestroyAdvanced(s *terraform.State) error {
 		}
 
 		p := cs.Volume.NewDeleteVolumeParams(rs.Primary.ID)
-		err, _ := cs.Volume.DeleteVolume(p)
+		_, err := cs.Volume.DeleteVolume(p)
 
 		if err != nil {
 			return fmt.Errorf(
@@ -196,7 +196,7 @@ func testAccCheckCloudStackDiskDestroyAdvanced(s *terraform.State) error {
 		}
 
 		p := cs.VirtualMachine.NewDestroyVirtualMachineParams(rs.Primary.ID)
-		err, _ := cs.VirtualMachine.DestroyVirtualMachine(p)
+		_, err := cs.VirtualMachine.DestroyVirtualMachine(p)
 
 		if err != nil {
 			return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_instance_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance_test.go
@@ -173,7 +173,7 @@ func testAccCheckCloudStackInstanceDestroy(s *terraform.State) error {
 		}
 
 		p := cs.VirtualMachine.NewDestroyVirtualMachineParams(rs.Primary.ID)
-		err, _ := cs.VirtualMachine.DestroyVirtualMachine(p)
+		_, err := cs.VirtualMachine.DestroyVirtualMachine(p)
 
 		if err != nil {
 			return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress_test.go
@@ -104,7 +104,7 @@ func testAccCheckCloudStackIPAddressDestroy(s *terraform.State) error {
 		}
 
 		p := cs.Address.NewDisassociateIpAddressParams(rs.Primary.ID)
-		err, _ := cs.Address.DisassociateIpAddress(p)
+		_, err := cs.Address.DisassociateIpAddress(p)
 
 		if err != nil {
 			return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_network_acl_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_network_acl_test.go
@@ -87,7 +87,7 @@ func testAccCheckCloudStackNetworkACLDestroy(s *terraform.State) error {
 		}
 
 		p := cs.NetworkACL.NewDeleteNetworkACLListParams(rs.Primary.ID)
-		err, _ := cs.NetworkACL.DeleteNetworkACLList(p)
+		_, err := cs.NetworkACL.DeleteNetworkACLList(p)
 
 		if err != nil {
 			return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_network_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_network_test.go
@@ -141,7 +141,7 @@ func testAccCheckCloudStackNetworkDestroy(s *terraform.State) error {
 		}
 
 		p := cs.Network.NewDeleteNetworkParams(rs.Primary.ID)
-		err, _ := cs.Network.DeleteNetwork(p)
+		_, err := cs.Network.DeleteNetwork(p)
 
 		if err != nil {
 			return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_nic_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_nic_test.go
@@ -141,7 +141,7 @@ func testAccCheckCloudStackNICDestroy(s *terraform.State) error {
 		}
 
 		p := cs.VirtualMachine.NewDestroyVirtualMachineParams(rs.Primary.ID)
-		err, _ := cs.VirtualMachine.DestroyVirtualMachine(p)
+		_, err := cs.VirtualMachine.DestroyVirtualMachine(p)
 
 		if err != nil {
 			return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_vpc_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_vpc_test.go
@@ -93,7 +93,7 @@ func testAccCheckCloudStackVPCDestroy(s *terraform.State) error {
 		}
 
 		p := cs.VPC.NewDeleteVPCParams(rs.Primary.ID)
-		err, _ := cs.VPC.DeleteVPC(p)
+		_, err := cs.VPC.DeleteVPC(p)
 
 		if err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
Wrong return value is used to determine if an error occured.
Make sure to check the actual Error value that the functions return.