### PR TITLE
config/lang: address vet reports

### DIFF
--- a/config/lang/check_types.go
+++ b/config/lang/check_types.go
@@ -96,7 +96,7 @@ func (v *TypeCheck) visitConcat(n *ast.Concat) {
 	for i, t := range types {
 		if t != ast.TypeString {
 			v.createErr(n, fmt.Sprintf(
-				"argument %d must be a sting", n, i+1))
+				"argument %d must be a string", i+1))
 			return
 		}
 	}

--- a/config/lang/lex.go
+++ b/config/lang/lex.go
@@ -77,7 +77,7 @@ func (x *parserLex) lex(yylval *parserSymType) int {
 	case parserModeInterpolation:
 		return x.lexModeInterpolation(yylval)
 	default:
-		x.Error(fmt.Sprintf("Unknown parse mode: %s", x.mode))
+		x.Error(fmt.Sprintf("Unknown parse mode: %d", x.mode))
 		return lexEOF
 	}
 }


### PR DESCRIPTION
Fixes the following vet reports:

```
config/lang/check_types.go:98: arg n for printf verb %d of wrong type: *github.com/hashicorp/terraform/config/lang/ast.Concat
config/lang/lex.go:80: arg x.mode for printf verb %s of wrong type: lang.parserMode
```