### PR TITLE
266 aws native config

### DIFF
--- a/builtin/providers/aws/provider_test.go
+++ b/builtin/providers/aws/provider_test.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -27,6 +29,152 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
+}
+
+func prepareFakeCredentialFile(access_key_id string, secret_key string) (*os.File, error) {
+	credentialFile, err := ioutil.TempFile("", "aws_credential_test")
+
+	if err != nil {
+		return nil, err
+	}
+
+	contents := fmt.Sprintf(`[default]
+aws_access_key_id = %s
+aws_secret_access_key = %s
+`, access_key_id, secret_key)
+
+	credentialFile.Write([]byte(fmt.Sprintf(contents)))
+	credentialFile.Close()
+
+	return credentialFile, nil
+
+}
+
+func cleanAwsEnvConfig() func() {
+	oldAccessKey := os.Getenv("AWS_ACCESS_KEY")
+	oldSecretKey := os.Getenv("AWS_SECRET_KEY")
+	oldAccessKeyId := os.Getenv("AWS_ACCESS_KEY_ID")
+	oldSecretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+	os.Setenv("AWS_ACCESS_KEY", "")
+	os.Setenv("AWS_SECRET_KEY", "")
+	os.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	return func() {
+		os.Setenv("AWS_ACCESS_KEY", oldAccessKey)
+		os.Setenv("AWS_SECRET_KEY", oldSecretKey)
+		os.Setenv("AWS_ACCESS_KEY_ID", oldAccessKeyId)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", oldSecretAccessKey)
+	}
+}
+
+func TestEnvVarsOverrideCredentialsFile(t *testing.T) {
+	resetEnvVars := cleanAwsEnvConfig()
+	defer resetEnvVars()
+
+	os.Setenv("AWS_ACCESS_KEY_ID", "access_key_id_from_aws_cli_env_var")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret_access_key_from_aws_cli_env_var")
+
+	credentialFile, err := prepareFakeCredentialFile("access_key_id_from_config", "secret_access_key_from_config")
+
+	if err != nil {
+		t.Fatalf("Could not create temporary AWS config file: '%s'", err)
+	}
+
+	os.Setenv("AWS_CREDENTIAL_FILE", credentialFile.Name())
+	defer os.Remove(credentialFile.Name())
+
+	auth := awsAuthSource{}
+
+	access_key, _ := auth.accessKeyResolver()()
+
+	if access_key != "access_key_id_from_aws_cli_env_var" {
+		t.Errorf("expected: %s, got: %#v", "access_key_id_from_aws_cli_env_var", access_key)
+	}
+
+	secret_key, _ := auth.secretKeyResolver()()
+
+	if secret_key != "secret_access_key_from_aws_cli_env_var" {
+		t.Errorf("expected: %#v, got: %#v", "secret_access_key_from_aws_cli_env_var", secret_key)
+	}
+}
+
+// See:
+// - https://github.com/hashicorp/terraform/pull/851
+// - https://github.com/hashicorp/terraform/issues/866
+//
+// We should not change default behaviour in a minor release, if end-user has both variations
+// of the env key set in their environment then we should give preference to the legacy one.
+func TestDeprecatedEnvVarsOverrideOfficialOnes(t *testing.T) {
+	resetEnvVars := cleanAwsEnvConfig()
+	defer resetEnvVars()
+
+	os.Setenv("AWS_ACCESS_KEY", "access_key_id_from_legacy_env_var")
+	os.Setenv("AWS_SECRET_KEY", "secret_access_key_from_legacy_env_var")
+	os.Setenv("AWS_ACCESS_KEY_ID", "access_key_id_from_aws_cli_env_var")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret_access_key_from_aws_cli_env_var")
+
+	auth := awsAuthSource{}
+
+	access_key, _ := auth.accessKeyResolver()()
+
+	if access_key != "access_key_id_from_legacy_env_var" {
+		t.Errorf("expected: %s, got: %#v", "access_key_id_from_legacy_env_var", access_key)
+	}
+
+	secret_key, _ := auth.secretKeyResolver()()
+
+	if secret_key != "secret_access_key_from_legacy_env_var" {
+		t.Errorf("expected: %s, got: %#v", "secret_access_key_from_legacy_env_var", secret_key)
+	}
+}
+
+func TestLoadCredentialsFromFileWhenNoConfigInEnv(t *testing.T) {
+	resetEnvVars := cleanAwsEnvConfig()
+	defer resetEnvVars()
+
+	credentialFile, err := prepareFakeCredentialFile("access_key_id_from_config", "secret_access_key_from_config")
+
+	if err != nil {
+		t.Fatalf("Could not create temporary AWS config file: '%s'", err)
+	}
+
+	os.Setenv("AWS_CREDENTIAL_FILE", credentialFile.Name())
+	defer os.Remove(credentialFile.Name())
+
+	auth := awsAuthSource{}
+
+	access_key, _ := auth.accessKeyResolver()()
+
+	if access_key != "access_key_id_from_config" {
+		t.Errorf("expected: %s, got: %#v", "access_key_id_from_config", access_key)
+	}
+
+	secret_key, _ := auth.secretKeyResolver()()
+
+	if secret_key != "secret_access_key_from_config" {
+		t.Errorf("expected: %s, bad: %#v", "secret_access_key_from_config", secret_key)
+	}
+}
+
+func TestAuthSourcerReturnsNilWhenDefaultsCannotBeFound(t *testing.T) {
+	resetEnvVars := cleanAwsEnvConfig()
+	defer resetEnvVars()
+
+	auth := awsAuthSource{}
+
+	access_key, _ := auth.accessKeyResolver()()
+
+	if access_key != nil {
+		t.Errorf("expected: nil, got: %#v", access_key)
+	}
+
+	secret_key, _ := auth.secretKeyResolver()()
+
+	if secret_key != nil {
+		t.Errorf("expected: nil, got: %#v", secret_key)
+	}
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -35,10 +35,16 @@ resource "aws_instance" "web" {
 The following arguments are supported:
 
 * `access_key` - (Required) This is the AWS access key. It must be provided, but
-  it can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable.
+  it can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, or the
+  [AWS cli credentials file](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files).
 
 * `secret_key` - (Required) This is the AWS secret key. It must be provided, but
-  it can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable.
+  it can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, or the
+  [AWS cli credentials file](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files).
 
 * `region` - (Required) This is the AWS region. It must be provided, but
   it can also be sourced from the `AWS_DEFAULT_REGION` environment variables.
+
+It's possible to load credentials from a [specific profile](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles)
+within the AWS cli's credentials file by setting the `AWS_PROFILE` environment variable.
+The `default` profile will be used if this variable is not set.


### PR DESCRIPTION
This is still a bit rough/verbose at the moment. Fairly new to Go so I'm sure there things I've done which aren't idiomatic. Please let me know if I've done something wrong/there is a better way to do this with terraform.

Tests pass locally, but I haven't run a full integration test against AWS to verify. Also, the credentials file is being loaded every time `DefaultFunc` is called, which probably isn't very efficient. Not sure how much of an issue this will be in practice though?

refs #266 

TODO:

- [x] Load credentials from `~/.aws/credentials`
- [x] Allow specifying profile via `AWS_PROFILE` (this is handled by goamz)
- [x] ~~Load config from `~/.aws/config`~~ ([amazon say this file is meant solely for their CLI tool](https://github.com/aws/aws-cli/issues/1095#issuecomment-69965076))
- [ ] Run integration tests
- [x] Check if we need to preload the credentials/config file