### PR TITLE
core: sets should init only once...

### DIFF
--- a/helper/schema/set.go
+++ b/helper/schema/set.go
@@ -59,7 +59,7 @@ func (s *Set) List() []interface{} {
 // a new third set that has only the elements unique to this set.
 func (s *Set) Difference(other *Set) *Set {
 	result := &Set{F: s.F}
-	result.init()
+	result.once.Do(result.init)
 
 	for k, v := range s.m {
 		if _, ok := other.m[k]; !ok {
@@ -74,7 +74,7 @@ func (s *Set) Difference(other *Set) *Set {
 // and returns a new third set.
 func (s *Set) Intersection(other *Set) *Set {
 	result := &Set{F: s.F}
-	result.init()
+	result.once.Do(result.init)
 
 	for k, v := range s.m {
 		if _, ok := other.m[k]; ok {
@@ -89,7 +89,7 @@ func (s *Set) Intersection(other *Set) *Set {
 // set.
 func (s *Set) Union(other *Set) *Set {
 	result := &Set{F: s.F}
-	result.init()
+	result.once.Do(result.init)
 
 	for k, v := range s.m {
 		result.m[k] = v

--- a/helper/schema/set_test.go
+++ b/helper/schema/set_test.go
@@ -40,8 +40,11 @@ func TestSetDifference(t *testing.T) {
 	s2.Add(5)
 	s2.Add(25)
 
-	expected := []interface{}{1}
-	actual := s1.Difference(s2).List()
+	difference := s1.Difference(s2)
+	difference.Add(2)
+
+	expected := []interface{}{1, 2}
+	actual := difference.List()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -57,8 +60,11 @@ func TestSetIntersection(t *testing.T) {
 	s2.Add(5)
 	s2.Add(25)
 
-	expected := []interface{}{5}
-	actual := s1.Intersection(s2).List()
+	intersection := s1.Intersection(s2)
+	intersection.Add(2)
+
+	expected := []interface{}{2, 5}
+	actual := intersection.List()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -74,8 +80,11 @@ func TestSetUnion(t *testing.T) {
 	s2.Add(5)
 	s2.Add(25)
 
-	expected := []interface{}{1, 5, 25}
-	actual := s1.Union(s2).List()
+	union := s1.Union(s2)
+	union.Add(2)
+
+	expected := []interface{}{1, 2, 5, 25}
+	actual := union.List()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}


### PR DESCRIPTION
Currently the `sync.Once` call is only used to init a Set in the add() func. So when you add a value to a Set that is the result of one of the Set operations (i.e. union, difference, intersect) the Set will be reinitialised and the exiting values will be lost.

I don’t have a clue why this is showing up in my ACC tests just now, as this code is in there for quite some time already. Somehow it seems to have something to do with the refactoring of the helper/schema done
last week, as I cannot reproduce this with 47f02f80bca83ebde01959be840de800fc639a04

/CC @mitchellh 