### PR TITLE
config: fix for #786 - better error reporting

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -103,6 +104,13 @@ func (c *Config) Discover() error {
 		if err := c.discover(filepath.Dir(exePath)); err != nil {
 			return err
 		}
+	}
+
+	if len(c.Providers) == 0 {
+		return errors.New("no providers found")
+	}
+	if len(c.Provisioners) == 0 {
+		return errors.New("no provisioners found")
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -107,10 +106,10 @@ func (c *Config) Discover() error {
 	}
 
 	if len(c.Providers) == 0 {
-		return errors.New("no providers found")
+		return fmt.Errorf("no providers found")
 	}
 	if len(c.Provisioners) == 0 {
-		return errors.New("no provisioners found")
+		return fmt.Errorf("no provisioners found")
 	}
 
 	return nil


### PR DESCRIPTION
As discussed in #786 , terraform crashes when no providers could be found. I can think of no good reason to run terraform without any provider or provisioner, so I've added extra error reporting.