### PR TITLE
builtin/providers/cloudstack: make build pass

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_disk.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_disk.go
@@ -183,7 +183,7 @@ func resourceCloudStackDiskUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		// Create a new parameter struct
-		p := cs.Volume.NewResizeVolumeParams(d.Id())
+		p := cs.Volume.NewResizeVolumeParams()
 
 		// Retrieve the disk_offering UUID
 		diskofferingid, e := retrieveUUID(cs, "disk_offering", d.Get("disk_offering").(string))

--- a/builtin/providers/cloudstack/resource_cloudstack_vpc.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_vpc.go
@@ -124,7 +124,7 @@ func resourceCloudStackVPCUpdate(d *schema.ResourceData, meta interface{}) error
 	// Check if the name or display text is changed
 	if d.HasChange("name") || d.HasChange("display_text") {
 		// Create a new parameter struct
-		p := cs.VPC.NewUpdateVPCParams(d.Id())
+		p := cs.VPC.NewUpdateVPCParams(d.Id(), d.Get("name").(string))
 
 		// Set the display text
 		displaytext, ok := d.GetOk("display_text")


### PR DESCRIPTION
'make test' failed due to build failure in cloudstack provider:

```
# github.com/hashicorp/terraform/builtin/providers/cloudstack
builtin/providers/cloudstack/resource_cloudstack_disk.go:186: too many arguments in call to cs.Volume.NewResizeVolumeParams
builtin/providers/cloudstack/resource_cloudstack_vpc.go:127: not enough arguments in call to cs.VPC.NewUpdateVPCParams
FAIL github.com/hashicorp/terraform/builtin/bins/provider-cloudstack [build failed]
```

Fix the reported errors to make the build pass.