### PR TITLE
Fixed wrong cross zone balancing error log.

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -328,7 +328,7 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err := elbconn.ModifyLoadBalancerAttributes(&attrs)
 		if err != nil {
-			return fmt.Errorf("Failure configuring health check: %s", err)
+			return fmt.Errorf("Failure configuring cross zone balancing: %s", err)
 		}
 		d.SetPartial("cross_zone_load_balancing")
 	}


### PR DESCRIPTION
If updating the cross zone balancing in the aws elb resource fails, the
error log claimed that the health check configuration failed. Fixed.