### PR TITLE
Add Validate command

### DIFF
--- a/command/test-fixtures/validate-error/main.tf
+++ b/command/test-fixtures/validate-error/main.tf
@@ -1,0 +1,4 @@
+resource "test_instance" "foo" {
+    "invalid" syntax
+    ami = "bar"
+}

--- a/command/test-fixtures/validate/main.tf
+++ b/command/test-fixtures/validate/main.tf
@@ -1,0 +1,3 @@
+resource "test_instance" "foo" {
+    ami = "bar"
+}

--- a/command/validate.go
+++ b/command/validate.go
@@ -1,0 +1,82 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ValidateCommand is a cli.Command implementation that validates the
+// Terraform configuration files.
+type ValidateCommand struct {
+	Meta
+}
+
+func (c *ValidateCommand) Run(args []string) int {
+	args = c.Meta.process(args, true)
+
+	cmdFlags := c.Meta.flagSet("validate")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	var configPath string
+	args = cmdFlags.Args()
+	if len(args) > 1 {
+		c.Ui.Error("The validate command expects at most one argument.")
+		cmdFlags.Usage()
+		return 1
+	} else if len(args) == 1 {
+		configPath = args[0]
+	} else {
+		var err error
+		configPath, err = os.Getwd()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error getting pwd: %s", err))
+		}
+	}
+
+	// Build the context based on the arguments given
+	ctx, _, err := c.Context(contextOpts{
+		Path:      configPath,
+		StatePath: c.Meta.statePath,
+	})
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	if !validateContext(ctx, c.Ui) {
+		return 1
+	}
+
+	c.Ui.Info("Terraform configuration valid.")
+	return 0
+}
+
+func (c *ValidateCommand) Help() string {
+	helpText := `
+Usage: terraform validate [options] [dir]
+
+  Validate all terraform files in the specified directory.
+
+Options:
+
+  -input=true         Ask for input for variables if not directly set.
+
+  -no-color           If specified, output won't contain any color.
+
+  -var 'foo=bar'      Set a variable in the Terraform configuration. This
+                      flag can be set multiple times.
+
+  -var-file=foo       Set variables in the Terraform configuration from
+                      a file. If "terraform.tfvars" is present, it will be
+                      automatically loaded if this flag is not specified.
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *ValidateCommand) Synopsis() string {
+	return "Validate configuration files"
+}

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -1,0 +1,62 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestValidate(t *testing.T) {
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ValidateCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		testFixturePath("validate"),
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
+func TestValidate_tooManyArgs(t *testing.T) {
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ValidateCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		testFixturePath("validate"),
+		"too", "many", "things",
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
+func TestValidate_badConfig(t *testing.T) {
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ValidateCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		testFixturePath("validate-error"),
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}

--- a/commands.go
+++ b/commands.go
@@ -108,6 +108,12 @@ func init() {
 			}, nil
 		},
 
+		"validate": func() (cli.Command, error) {
+			return &command.ValidateCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{
 				Meta:              meta,


### PR DESCRIPTION
I was looking for a simple way to validate that the configuration was
valid for things like CI or git pre-commit. I started with an HCL
validator but I think it makes more sense for terraform to have a
command that checks syntax and config. I fully admit this command is
some copypasta and I may have made mistakes but it seems to work as
expected.