### PR TITLE
Fix typo in refresh command error output

### DIFF
--- a/command/refresh.go
+++ b/command/refresh.go
@@ -30,7 +30,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	var configPath string
 	args = cmdFlags.Args()
 	if len(args) > 1 {
-		c.Ui.Error("The apply command expects at most one argument.")
+		c.Ui.Error("The refresh command expects at most one argument.")
 		cmdFlags.Usage()
 		return 1
 	} else if len(args) == 1 {


### PR DESCRIPTION
Noticed this while I was digging around to see how the commands work. Extremely minor fix, didn't see any other ones.