### PR TITLE
Add spot_price parameter to aws_launch_configuration resource

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -81,6 +81,12 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"spot_price": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -96,6 +102,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	createLaunchConfigurationOpts.KeyName = d.Get("key_name").(string)
 	createLaunchConfigurationOpts.UserData = d.Get("user_data").(string)
 	createLaunchConfigurationOpts.AssociatePublicIpAddress = d.Get("associate_public_ip_address").(bool)
+	createLaunchConfigurationOpts.SpotPrice = d.Get("spot_price").(string)
 
 	if v, ok := d.GetOk("security_groups"); ok {
 		createLaunchConfigurationOpts.SecurityGroups = expandStringList(
@@ -150,6 +157,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	d.Set("instance_type", lc.InstanceType)
 	d.Set("name", lc.Name)
 	d.Set("security_groups", lc.SecurityGroups)
+	d.Set("spot_price", lc.SpotPrice)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -30,6 +30,18 @@ func TestAccAWSLaunchConfiguration(t *testing.T) {
 						"aws_launch_configuration.bar", "instance_type", "t1.micro"),
 					resource.TestCheckResourceAttr(
 						"aws_launch_configuration.bar", "associate_public_ip_address", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_launch_configuration.bar", "spot_price", ""),
+				),
+			},
+
+			resource.TestStep{
+				Config: TestAccAWSLaunchConfigurationWithSpotPriceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
+					testAccCheckAWSLaunchConfigurationAttributes(&conf),
+					resource.TestCheckResourceAttr(
+						"aws_launch_configuration.bar", "spot_price", "0.01"),
 				),
 			},
 		},
@@ -127,5 +139,16 @@ resource "aws_launch_configuration" "bar" {
   instance_type = "t1.micro"
   user_data = "foobar-user-data"
   associate_public_ip_address = true
+}
+`
+
+const TestAccAWSLaunchConfigurationWithSpotPriceConfig = `
+resource "aws_launch_configuration" "bar" {
+  name = "foobar-terraform-test"
+  image_id = "ami-21f78e11"
+  instance_type = "t1.micro"
+  user_data = "foobar-user-data"
+  associate_public_ip_address = true
+  spot_price = "0.01"
 }
 `


### PR DESCRIPTION
This just adds the spot_price parameter to the aws_launch_configuration resource. Should be self-explanatory!