### PR TITLE
dme - DNSMadeEasy Provider

### DIFF
--- a/builtin/providers/dnsmadeeasy/config.go
+++ b/builtin/providers/dnsmadeeasy/config.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	dme "github.com/soniah/dnsmadeeasy"
+	"log"
+)
+
+// Config contains DNSMadeEasy provider settings
+type Config struct {
+	AKey       string
+	SKey       string
+	UseSandbox bool
+}
+
+// Client returns a new client for accessing DNSMadeEasy
+func (c *Config) Client() (*dme.Client, error) {
+	client, err := dme.NewClient(c.AKey, c.SKey)
+	if err != nil {
+		return nil, fmt.Errorf("Error setting up client: %s", err)
+	}
+
+	if c.UseSandbox {
+		client.URL = dme.SandboxURL
+	}
+
+	log.Printf("[INFO] DNSMadeEasy Client configured for AKey: %s", client.AKey)
+
+	return client, nil
+}

--- a/builtin/providers/dnsmadeeasy/main.go
+++ b/builtin/providers/dnsmadeeasy/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: Provider,
+	})
+}

--- a/builtin/providers/dnsmadeeasy/provider.go
+++ b/builtin/providers/dnsmadeeasy/provider.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Provider provides a Provider...
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"akey": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("DME_AKEY"),
+				Description: "A DNSMadeEasy API Key.",
+			},
+			"skey": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("DME_SKEY"),
+				Description: "The Secret Key for API operations.",
+			},
+			"usesandbox": &schema.Schema{
+				Type:        schema.TypeBool,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("DME_USESANDBOX"),
+				Description: "If true, use the DME Sandbox.",
+			},
+		},
+
+		ResourcesMap: map[string]*schema.Resource{
+			"dme_record": resourceDMERecord(),
+		},
+
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func envDefaultFunc(k string) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		if v := os.Getenv(k); v != "" {
+			if v == "true" {
+				return true, nil
+			} else if v == "false" {
+				return false, nil
+			}
+			return v, nil
+		}
+		return nil, nil
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := Config{
+		AKey:       d.Get("akey").(string),
+		SKey:       d.Get("skey").(string),
+		UseSandbox: d.Get("usesandbox").(bool),
+	}
+	return config.Client()
+}

--- a/builtin/providers/dnsmadeeasy/provider_test.go
+++ b/builtin/providers/dnsmadeeasy/provider_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		// provider is called terraform-provider-dme ie dme
+		"dme": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProviderImpl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("DME_SKEY"); v == "" {
+		t.Fatal("DME_SKEY must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("DME_AKEY"); v == "" {
+		t.Fatal("DME_AKEY must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("DME_DOMAINID"); v == "" {
+		t.Fatal("DME_DOMAINID must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("DME_USESANDBOX"); v == "" {
+		t.Fatal("DME_USESANDBOX must be set for acceptance tests. Use the strings 'true' or 'false'.")
+	}
+}

--- a/builtin/providers/dnsmadeeasy/resource_dme_record.go
+++ b/builtin/providers/dnsmadeeasy/resource_dme_record.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	dme "github.com/soniah/dnsmadeeasy"
+)
+
+func resourceDMERecord() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDMERecordCreate,
+		Read:   resourceDMERecordRead,
+		Update: resourceDMERecordUpdate,
+		Delete: resourceDMERecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			// Use recordid for TF ID.
+			"domainid": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"mxLevel": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"weight": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"priority": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"keywords": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"title": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hardLink": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"redirectType": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceDMERecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*dme.Client)
+
+	domainid := d.Get("domainid").(string)
+	log.Printf("[INFO] Creating record for domainid: %s", domainid)
+
+	cr := make(map[string]interface{})
+	if err := getAll(d, cr); err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] record create configuration: %#v", cr)
+
+	result, err := client.CreateRecord(domainid, cr)
+	if err != nil {
+		return fmt.Errorf("Failed to create record: %s", err)
+	}
+
+	d.SetId(result)
+	log.Printf("[INFO] record ID: %s", d.Id())
+
+	return resourceDMERecordRead(d, meta)
+}
+
+func resourceDMERecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*dme.Client)
+
+	domainid := d.Get("domainid").(string)
+	recordid := d.Id()
+	log.Printf("[INFO] Reading record for domainid: %s recordid: %s", domainid, recordid)
+
+	rec, err := client.ReadRecord(domainid, recordid)
+	if err != nil {
+		return fmt.Errorf("Couldn't find record: %s", err)
+	}
+
+	return setAll(d, rec)
+}
+
+func resourceDMERecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*dme.Client)
+
+	domainid := d.Get("domainid").(string)
+	recordid := d.Id()
+
+	cr := make(map[string]interface{})
+	if err := getAll(d, cr); err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] record update configuration: %+#v", cr)
+
+	if _, err := client.UpdateRecord(domainid, recordid, cr); err != nil {
+		return fmt.Errorf("Error updating record: %s", err)
+	}
+
+	return resourceDMERecordRead(d, meta)
+}
+
+func resourceDMERecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*dme.Client)
+
+	domainid := d.Get("domainid").(string)
+	recordid := d.Id()
+	log.Printf("[INFO] Deleting record for domainid: %s recordid: %s", domainid, recordid)
+
+	if err := client.DeleteRecord(domainid, recordid); err != nil {
+		return fmt.Errorf("Error deleting record: %s", err)
+	}
+
+	return nil
+}
+
+func getAll(d *schema.ResourceData, cr map[string]interface{}) error {
+
+	if attr, ok := d.GetOk("name"); ok {
+		cr["name"] = attr.(string)
+	}
+	if attr, ok := d.GetOk("type"); ok {
+		cr["type"] = attr.(string)
+	}
+	if attr, ok := d.GetOk("ttl"); ok {
+		cr["ttl"] = int64(attr.(int))
+	}
+	if attr, ok := d.GetOk("value"); ok {
+		cr["value"] = attr.(string)
+	}
+
+	switch strings.ToUpper(d.Get("type").(string)) {
+	case "A", "CNAME", "ANAME", "TXT", "SPF", "NS", "PTR", "AAAA":
+		// all done
+	case "MX":
+		if attr, ok := d.GetOk("mxLevel"); ok {
+			cr["mxLevel"] = int64(attr.(int))
+		}
+	case "SRV":
+		if attr, ok := d.GetOk("priority"); ok {
+			cr["priority"] = int64(attr.(int))
+		}
+		if attr, ok := d.GetOk("weight"); ok {
+			cr["weight"] = int64(attr.(int))
+		}
+		if attr, ok := d.GetOk("port"); ok {
+			cr["port"] = int64(attr.(int))
+		}
+	case "HTTPRED":
+		if attr, ok := d.GetOk("hardLink"); ok && attr.(bool) {
+			cr["hardLink"] = "true"
+		}
+		if attr, ok := d.GetOk("redirectType"); ok {
+			cr["redirectType"] = attr.(string)
+		}
+		if attr, ok := d.GetOk("title"); ok {
+			cr["title"] = attr.(string)
+		}
+		if attr, ok := d.GetOk("keywords"); ok {
+			cr["keywords"] = attr.(string)
+		}
+		if attr, ok := d.GetOk("description"); ok {
+			cr["description"] = attr.(string)
+		}
+	default:
+		return fmt.Errorf("getAll: type not found")
+	}
+	return nil
+}
+
+func setAll(d *schema.ResourceData, rec *dme.Record) error {
+	d.Set("type", rec.Type)
+	d.Set("name", rec.Name)
+	d.Set("ttl", rec.TTL)
+	d.Set("value", rec.Value)
+
+	switch rec.Type {
+	case "A", "CNAME", "ANAME", "TXT", "SPF", "NS", "PTR":
+		// all done
+	case "AAAA":
+		// overwrite value set above - DME ipv6 is lower case
+		d.Set("value", strings.ToLower(rec.Value))
+	case "MX":
+		d.Set("mxLevel", rec.MXLevel)
+	case "SRV":
+		d.Set("priority", rec.Priority)
+		d.Set("weight", rec.Weight)
+		d.Set("port", rec.Port)
+	case "HTTPRED":
+		d.Set("hardLink", rec.HardLink)
+		d.Set("redirectType", rec.RedirectType)
+		d.Set("title", rec.Title)
+		d.Set("keywords", rec.Keywords)
+		d.Set("description", rec.Description)
+	default:
+		return fmt.Errorf("setAll: type not found")
+	}
+	return nil
+}

--- a/builtin/providers/dnsmadeeasy/resource_dme_record_test.go
+++ b/builtin/providers/dnsmadeeasy/resource_dme_record_test.go
@@ -1,0 +1,515 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	dme "github.com/soniah/dnsmadeeasy"
+)
+
+var _ = fmt.Sprintf("dummy") // dummy
+var _ = os.DevNull           // dummy
+
+func TestAccDMERecordA(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigA, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testa"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "1.1.1.1"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordCName(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigCName, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testcname"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "CNAME"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "foo"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+/*
+
+ANAME can't be tested under sandbox, as the value of the ANAME must be a
+resolvable address.
+
+func TestAccDMERecordAName(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigAName, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testaname"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "ANAME"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "foo"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+*/
+
+func TestAccDMERecordMX(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigMX, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testmx"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "MX"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "foo"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "mxLevel", "10"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordHTTPRED(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigHTTPRED, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testhttpred"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "HTTPRED"),
+
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "https://github.com/soniah/terraform-provider-dme"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "hardLink", "true"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "redirectType", "Hidden Frame Masked"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "title", "An Example"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "keywords", "terraform example"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "description", "This is a description"),
+
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordTXT(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigTXT, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testtxt"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "TXT"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "\"foo\""),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordSPF(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigSPF, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testspf"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "SPF"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "\"foo\""),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordPTR(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigPTR, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testptr"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "PTR"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "foo"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordNS(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigNS, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testns"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "NS"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "foo"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordAAAA(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigAAAA, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testaaaa"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "AAAA"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "fe80::0202:b3ff:fe1e:8329"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMERecordSRV(t *testing.T) {
+	var record dme.Record
+	domainid := os.Getenv("DME_DOMAINID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDMERecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testDMERecordConfigSRV, domainid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDMERecordExists("dme_record.test", &record),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "domainid", domainid),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "name", "testsrv"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "type", "SRV"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "value", "foo"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "priority", "10"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "weight", "20"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "port", "30"),
+					resource.TestCheckResourceAttr(
+						"dme_record.test", "ttl", "2000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDMERecordDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*dme.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "dnsmadeeasy_record" {
+			continue
+		}
+
+		_, err := client.ReadRecord(rs.Primary.Attributes["domainid"], rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Record still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDMERecordExists(n string, record *dme.Record) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*dme.Client)
+
+		foundRecord, err := client.ReadRecord(rs.Primary.Attributes["domainid"], rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundRecord.StringRecordID() != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		*record = *foundRecord
+
+		return nil
+	}
+}
+
+const testDMERecordConfigA = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testa"
+  type = "A"
+  value = "1.1.1.1"
+  ttl = 2000
+}`
+
+const testDMERecordConfigCName = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testcname"
+  type = "CNAME"
+  value = "foo"
+  ttl = 2000
+}`
+
+const testDMERecordConfigAName = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testaname"
+  type = "ANAME"
+  value = "foo"
+  ttl = 2000
+}`
+
+const testDMERecordConfigMX = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testmx"
+  type = "MX"
+  value = "foo"
+  mxLevel = 10
+  ttl = 2000
+}`
+
+const testDMERecordConfigHTTPRED = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testhttpred"
+  type = "HTTPRED"
+  value = "https://github.com/soniah/terraform-provider-dme"
+  hardLink = true
+  redirectType = "Hidden Frame Masked"
+  title = "An Example"
+  keywords = "terraform example"
+  description = "This is a description"
+  ttl = 2000
+}`
+
+const testDMERecordConfigTXT = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testtxt"
+  type = "TXT"
+  value = "foo"
+  ttl = 2000
+}`
+
+const testDMERecordConfigSPF = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testspf"
+  type = "SPF"
+  value = "foo"
+  ttl = 2000
+}`
+
+const testDMERecordConfigPTR = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testptr"
+  type = "PTR"
+  value = "foo"
+  ttl = 2000
+}`
+
+const testDMERecordConfigNS = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testns"
+  type = "NS"
+  value = "foo"
+  ttl = 2000
+}`
+
+const testDMERecordConfigAAAA = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testaaaa"
+  type = "AAAA"
+  value = "FE80::0202:B3FF:FE1E:8329"
+  ttl = 2000
+}`
+
+const testDMERecordConfigSRV = `
+resource "dme_record" "test" {
+  domainid = "%s"
+  name = "testsrv"
+  type = "SRV"
+  value = "foo"
+  priority = 10
+  weight = 20
+  port = 30
+  ttl = 2000
+}`

--- a/website/source/docs/providers/dnsmadeeasy/index.html.markdown
+++ b/website/source/docs/providers/dnsmadeeasy/index.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "dnsmadeeasy"
+page_title: "Provider: DNSMadeEasy"
+sidebar_current: "docs-dnsmadeeasy-index"
+description: |-
+  The DNSMadeEasy provider is used to interact with the resources supported by DNSMadeEasy. The provider needs to be configured with the proper credentials before it can be used.
+---
+
+# DNSMadeEasy Provider
+
+The DNSMadeEasy provider is used to interact with the
+resources supported by DNSMadeEasy. The provider needs to be configured
+with the proper credentials before it can be used.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```
+# Configure the DNSMadeEasy provider
+provider "dme" {
+    akey = "${var.dme_akey}"
+    skey = "${var.dme_skey}"
+    usesandbox = true
+}
+
+# Create an A record
+resource "dme_record" "www" {
+    domainid = "123456"
+    ...
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `akey` - (Required) The DNSMadeEasy API key
+* `skey` - (Required) The DNSMadeEasy Secret key
+* `usesandbox` - (Optional) If true, the DNSMadeEasy sandbox will be
+  used

--- a/website/source/docs/providers/dnsmadeeasy/r/record.html.markdown
+++ b/website/source/docs/providers/dnsmadeeasy/r/record.html.markdown
@@ -1,0 +1,244 @@
+---
+layout: "dme"
+page_title: "DNSMadeEasy: dme_record"
+sidebar_current: "docs-dme-resource-record"
+description: |-
+  Provides a DNSMadeEasy record resource.
+---
+
+# dme\_record
+
+Provides a DNSMadeEasy record resource.
+
+## Example Usage
+
+```
+# Add an A record to the domain
+resource "dme_record" "www" {
+  domainid = "123456"
+  name = "www"
+  type = "A"
+  value = "192.168.1.1"
+  ttl = 3600
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domainid` - (String, Required) The domain id to add the
+  record to
+* `name` - (Required) The name of the record
+* `type` - (Required) The type of the record
+* `value` - (Required) The value of the record; it's usage
+  will depend on the `type` (see below)
+* `ttl` - (Integer, Optional) The TTL of the record
+
+Additional arguments are listed below under DNS Record Types.
+
+## DNS Record Types
+
+The type of record being created affects the interpretation of
+the `value` argument; also, some additional arguments are
+required for some record types.
+http://help.dnsmadeeasy.com/tutorials/managed-dns/ has more
+information.
+
+### A Record
+
+* `value` is the hostname
+
+### CNAME Record
+
+* `value` is the alias name
+
+### ANAME Record
+
+* `value` is the aname target
+
+### MX Record
+
+* `value` is the server
+* `mxLevel` (Integer, Required) is the MX level
+
+###  HTTPRED Record
+
+* `value` is the URL
+* `hardLink` (Boolean, Optional) If true, any request that is
+  made for this record will have the path removed after the
+  fully qualified domain name portion of the requested URL
+* `redirectType` (Required) One of 'Hidden Frame Masked',
+  'Standard 301', or 'Standard 302'
+* `title` (Optional) If set, the hidden iframe that is
+  used in conjunction with the Hidden Frame Masked Redirect
+  Type will have the HTML meta description data field set to
+  the value of this field
+* `keywords` (Optional) If set, the hidden iframe that is used
+  in conjunction with the Hidden Frame Masked Redirect Type
+  will have the HTML meta keywords data field set to the value
+  of this field
+* `description` (Optional) A human-readable description.
+
+### TXT Record
+
+* `value` is free form text
+
+### SPF Record
+
+* `value` is the SPF definition of hosts allowed to send email
+
+###  PTR Record
+
+* `value` is the reverse DNS for the host
+
+### NS Record
+
+* `value` is the host name of the server
+
+### AAAA Record
+
+* `value` is the IPv6 address
+
+### SRV Record
+
+* `value` is the host
+* `priority` (Integer, Required). Acts the same way as MX Level
+* `weight` (Integer, Required). Hits will be assigned proportionately
+  by weight
+* `port` (Integer, Required). The actual port of the service offered
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the record
+* `type` - The type of the record
+* `value` - The value of the record
+  `type` (see below)
+* `ttl` - The TTL of the record
+
+Additional fields may also be exported by some record types -
+see DNS Record Types.
+
+## Record Type Examples
+
+Following are examples of using each of the record types.
+
+```
+# Provide your API and Secret Keys, and whether the sandbox
+# is being used (defaults to false)
+provider "dme" {
+  akey = "aaaaaa1a-11a1-1aa1-a101-11a1a11aa1aa"
+  skey = "11a0a11a-a1a1-111a-a11a-a11110a11111"
+  usesandbox = true
+}
+
+# A Record
+resource "dme_record" "testa" {
+  domainid = "123456"
+  name = "testa"
+  type = "A"
+  value = "1.1.1.1"
+  ttl = 1000
+}
+
+# CNAME record
+resource "dme_record" "testcname" {
+  domainid = "123456"
+  name = "testcname"
+  type = "CNAME"
+  value = "foo"
+  ttl = 1000
+}
+
+# ANAME record
+resource "dme_record" "testaname" {
+  domainid = "123456"
+  name = "testaname"
+  type = "ANAME"
+  value = "foo"
+  ttl = 1000
+}
+
+# MX record
+resource "dme_record" "testmx" {
+  domainid = "123456"
+  name = "testmx"
+  type = "MX"
+  value = "foo"
+  mxLevel = 10
+  ttl = 1000
+}
+
+# HTTPRED
+resource "dme_record" "testhttpred" {
+  domainid = "123456"
+  name = "testhttpred"
+  type = "HTTPRED"
+  value = "https://github.com/soniah/terraform-provider-dme"
+  hardLink = true
+  redirectType = "Hidden Frame Masked"
+  title = "An Example"
+  keywords = "terraform example"
+  description = "This is a description"
+  ttl = 2000
+}
+
+# TXT record
+resource "dme_record" "testtxt" {
+  domainid = "123456"
+  name = "testtxt"
+  type = "TXT"
+  value = "foo"
+  ttl = 1000
+}
+
+# SPF record
+resource "dme_record" "testspf" {
+  domainid = "123456"
+  name = "testspf"
+  type = "SPF"
+  value = "foo"
+  ttl = 1000
+}
+
+# PTR record
+resource "dme_record" "testptr" {
+  domainid = "123456"
+  name = "testptr"
+  type = "PTR"
+  value = "foo"
+  ttl = 1000
+}
+
+# NS record
+resource "dme_record" "testns" {
+  domainid = "123456"
+  name = "testns"
+  type = "NS"
+  value = "foo"
+  ttl = 1000
+}
+
+# AAAA record
+resource "dme_record" "testaaaa" {
+  domainid = "123456"
+  name = "testaaaa"
+  type = "AAAA"
+  value = "FE80::0202:B3FF:FE1E:8329"
+  ttl = 1000
+}
+
+# SRV record
+resource "dme_record" "testsrv" {
+  domainid = "123456"
+  name = "testsrv"
+  type = "SRV"
+  value = "foo"
+  priority = 10
+  weight = 20
+  port = 30
+  ttl = 1000
+}
+```


### PR DESCRIPTION
Pull request for dme - DNSMadeEasy Provider. See also issue #829.

The DNSMadeEasy REST API has probably grown over time, and is slightly
inconsistent. Most DNS record types take a 'value' field, however
this value field is sometimes named something else in the web interface.
Also, some record types require fields in addtion to 'value'.

I've attempted to document these requirements in my documentation - let me
know if you'd like me to lay out the documentation in a different manner, to
conform with your standards.