### PR TITLE
providers/digitalocean: force fqdn in dns rr value

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_record.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record.go
@@ -68,10 +68,18 @@ func resourceDigitalOceanRecord() *schema.Resource {
 func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
+	rrValue := d.Get("value").(string)
+	// Ensure all records with domain value are absolute (ending with dot)
+	if t := d.Get("type").(string); t == "CNAME" || t == "MX" || t == "NS" || t == "SRV" {
+		if rrValue[len(rrValue)-1] != '.' {
+			rrValue += "."
+		}
+	}
+
 	newRecord := digitalocean.CreateRecord{
 		Type:     d.Get("type").(string),
 		Name:     d.Get("name").(string),
-		Data:     d.Get("value").(string),
+		Data:     rrValue,
 		Priority: d.Get("priority").(string),
 		Port:     d.Get("port").(string),
 		Weight:   d.Get("weight").(string),

--- a/builtin/providers/digitalocean/resource_digitalocean_record_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record_test.go
@@ -88,13 +88,67 @@ func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
 				Config: testAccCheckDigitalOceanRecordConfig_cname,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
-					testAccCheckDigitalOceanRecordAttributesHostname(&record),
+					testAccCheckDigitalOceanRecordAttributesHostname("a", &record),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "name", "terraform"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_record.foobar", "value", "a.foobar-test-terraform.com"),
+						"digitalocean_record.foobar", "value", "a.foobar-test-terraform.com."),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "type", "CNAME"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanRecord_RelativeHostnameValue(t *testing.T) {
+	var record digitalocean.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanRecordConfig_relative_cname,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
+					testAccCheckDigitalOceanRecordAttributesHostname("a.b", &record),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "name", "terraform"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "value", "a.b"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "type", "CNAME"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanRecord_ExternalHostnameValue(t *testing.T) {
+	var record digitalocean.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanRecordConfig_external_cname,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
+					testAccCheckDigitalOceanRecordAttributesHostname("a.foobar-test-terraform.net", &record),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "name", "terraform"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "value", "a.foobar-test-terraform.net."),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "type", "CNAME"),
 				),
@@ -173,11 +227,11 @@ func testAccCheckDigitalOceanRecordExists(n string, record *digitalocean.Record)
 	}
 }
 
-func testAccCheckDigitalOceanRecordAttributesHostname(record *digitalocean.Record) resource.TestCheckFunc {
+func testAccCheckDigitalOceanRecordAttributesHostname(data string, record *digitalocean.Record) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if record.Data != "a.foobar-test-terraform.com" {
-			return fmt.Errorf("Bad value: %s", record.Data)
+		if record.Data != data {
+			return fmt.Errorf("Bad value: expected %s, got %s", data, record.Data)
 		}
 
 		return nil
@@ -222,6 +276,34 @@ resource "digitalocean_record" "foobar" {
     domain = "${digitalocean_domain.foobar.name}"
 
     name = "terraform"
-    value = "a.foobar-test-terraform.com"
+    value = "a.foobar-test-terraform.com."
+    type = "CNAME"
+}`
+
+const testAccCheckDigitalOceanRecordConfig_relative_cname = `
+resource "digitalocean_domain" "foobar" {
+    name = "foobar-test-terraform.com"
+    ip_address = "192.168.0.10"
+}
+
+resource "digitalocean_record" "foobar" {
+    domain = "${digitalocean_domain.foobar.name}"
+
+    name = "terraform"
+    value = "a.b"
+    type = "CNAME"
+}`
+
+const testAccCheckDigitalOceanRecordConfig_external_cname = `
+resource "digitalocean_domain" "foobar" {
+    name = "foobar-test-terraform.com"
+    ip_address = "192.168.0.10"
+}
+
+resource "digitalocean_record" "foobar" {
+    domain = "${digitalocean_domain.foobar.name}"
+
+    name = "terraform"
+    value = "a.foobar-test-terraform.net."
     type = "CNAME"
 }`

--- a/builtin/providers/digitalocean/resource_digitalocean_record_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record_test.go
@@ -76,6 +76,33 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
+	var record digitalocean.Record
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanRecordConfig_cname,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
+					testAccCheckDigitalOceanRecordAttributesHostname(&record),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "name", "terraform"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "value", "a.foobar-test-terraform.com"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "type", "CNAME"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*digitalocean.Client)
 
@@ -146,6 +173,17 @@ func testAccCheckDigitalOceanRecordExists(n string, record *digitalocean.Record)
 	}
 }
 
+func testAccCheckDigitalOceanRecordAttributesHostname(record *digitalocean.Record) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if record.Data != "a.foobar-test-terraform.com" {
+			return fmt.Errorf("Bad value: %s", record.Data)
+		}
+
+		return nil
+	}
+}
+
 const testAccCheckDigitalOceanRecordConfig_basic = `
 resource "digitalocean_domain" "foobar" {
     name = "foobar-test-terraform.com"
@@ -172,4 +210,18 @@ resource "digitalocean_record" "foobar" {
     name = "terraform"
     value = "192.168.0.11"
     type = "A"
+}`
+
+const testAccCheckDigitalOceanRecordConfig_cname = `
+resource "digitalocean_domain" "foobar" {
+    name = "foobar-test-terraform.com"
+    ip_address = "192.168.0.10"
+}
+
+resource "digitalocean_record" "foobar" {
+    domain = "${digitalocean_domain.foobar.name}"
+
+    name = "terraform"
+    value = "a.foobar-test-terraform.com"
+    type = "CNAME"
 }`


### PR DESCRIPTION
Digital Ocean requires FQDN value (ending with dot) when creating some records (CNAME, MX, NS, etc.), while GET requests return a value without trailing dot. This forces the resource to be recreated:

```shell
paystee@ws1 tmp/do > cat no-dot.json
{
    "type": "CNAME",
    "name": "test1",
    "data": "value1.example.com",
    "priority": null,
    "port": null,
    "weight": null
}
paystee@ws1 tmp/do > curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer secret' -d @no-dot.json 'https://api.digitalocean.com/v2/domains/example.com/records'
{"id":"unprocessable_entity","message":"Data needs to end with a dot (.)"}
```
```shell
paystee@ws1 tmp/do > cat with-dot.json
{
    "type": "CNAME",
    "name": "test2",
    "data": "value2.example.com.",
    "priority": null,
    "port": null,
    "weight": null
}
paystee@ws1 tmp/do > curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer secret' -d @with-dot.json 'https://api.digitalocean.com/v2/domains/example.com/records'
{"domain_record":{"id":3986126,"type":"CNAME","name":"test2","data":"value2.example.com.","priority":null,"port":null,"weight":null}}
paystee@ws1 tmp/do > curl -X GET -H 'Content-Type: application/json' -H 'Authorization: Bearer secret' 'https://api.digitalocean.com/v2/domains/example.com/records/3986126'
{"domain_record":{"id":3986126,"type":"CNAME","name":"test2","data":"value2.example.com","priority":null,"port":null,"weight":null}}
```

This PR fixes the issue. The user must specify absolute value for hostname-targeted records without trailing dot to make it work.

The one downside I see is that it will affect records that were created using relative values (e.g. `a` instead of `a.example.com`).