### PR TITLE
docs: update available boolean values

### DIFF
--- a/website/source/docs/configuration/syntax.html.md
+++ b/website/source/docs/configuration/syntax.html.md
@@ -63,7 +63,7 @@ Basic bullet point reference:
   * Numbers can be suffixed with `[kKmMgG]b` for power of 2 multiples,
     example: `1kb` is equal to `1024`.
 
-  * Boolean values: `true`, `false`, `on`, `off`, `yes`, `no`.
+  * Boolean values: `true`, `false`.
 
   * Lists of primitive types can be made by wrapping it in `[]`.
     Example: `["foo", "bar", 42]`.


### PR DESCRIPTION
According to https://github.com/hashicorp/hcl/issues/15, only `true` and `false` are valid boolean values.