### PR TITLE
DON'T MERGE: initial instance state discussion start

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -196,3 +196,15 @@ func (p *Provider) Resources() []terraform.ResourceType {
 
 	return result
 }
+
+func (p *Provider) InitialInstanceState(
+	info *terraform.InstanceInfo,
+	state *terraform.InstanceState,
+	config *terraform.ResourceConfig) (*terraform.InstanceState, error) {
+	r, ok := p.ResourcesMap[info.Type]
+	if !ok {
+		return nil, fmt.Errorf("unknown resource type: %s", info.Type)
+	}
+
+	return r.InitialInstanceState(config, state, p.meta)
+}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -47,11 +47,16 @@ type Resource struct {
 	// accordingly. If this function isn't set, it will not be called. It
 	// is highly recommended to set it. The *ResourceData passed to Exists
 	// should _not_ be modified.
-	Create CreateFunc
-	Read   ReadFunc
-	Update UpdateFunc
-	Delete DeleteFunc
-	Exists ExistsFunc
+	//
+	// CreateInitialInstanceState is a function that will populate initial state
+	// with data that can be retrieved from an existing instances defined in
+	// config
+	Create                     CreateFunc
+	Read                       ReadFunc
+	Update                     UpdateFunc
+	Delete                     DeleteFunc
+	Exists                     ExistsFunc
+	CreateInitialInstanceState CreateInitialInstanceStateFunc
 }
 
 // See Resource documentation.
@@ -68,6 +73,9 @@ type DeleteFunc func(*ResourceData, interface{}) error
 
 // See Resource documentation.
 type ExistsFunc func(*ResourceData, interface{}) (bool, error)
+
+// See Resource documentation
+type CreateInitialInstanceStateFunc func(*terraform.ResourceConfig, *terraform.InstanceState, interface{}) (*terraform.InstanceState, error)
 
 // Apply creates, updates, and/or deletes a resource.
 func (r *Resource) Apply(
@@ -188,4 +196,11 @@ func (r *Resource) InternalValidate() error {
 	}
 
 	return schemaMap(r.Schema).InternalValidate()
+}
+
+func (r *Resource) InitialInstanceState(config *terraform.ResourceConfig, state *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if r.CreateInitialInstanceState != nil {
+		return r.CreateInitialInstanceState(config, state, meta)
+	}
+	return &terraform.InstanceState{}, nil
 }

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -69,6 +69,10 @@ type ResourceProvider interface {
 	// Refresh refreshes a resource and updates all of its attributes
 	// with the latest information.
 	Refresh(*InstanceInfo, *InstanceState) (*InstanceState, error)
+
+	// Try resolve id from config if possible (the resource is unique, and can be
+	// existing even if we don't know about it).
+	InitialInstanceState(*InstanceInfo, *InstanceState, *ResourceConfig) (*InstanceState, error)
 }
 
 // ResourceType is a type of resource that a resource provider can manage.


### PR DESCRIPTION
As I know there is a design decision that terraform should be a bootstrapping solution:

https://groups.google.com/forum/#!topic/terraform-tool/skTu7AvAD2c

Our use case is that we already have 26 services held in heroku, and recreating them would be a little bit too cumbersome (esp that not all application properties can be managed by terraform - ie. access to a given application).

With this PR I would like to propose some kind of initial state creation that can be optionally added to any provider. The whole idea is of course applicable for the ones that have some kind of uniqueness key in the resource config (ie. heroku application name is unique within organization). My first idea was to generate id only, and then let Read function do the job - so that refresh action work. But in the end it appeared that many resources Read function needs more than just id.

An example use of this extension will follow in a separate PR.