### PR TITLE
providers/aws: ignore ec2 root devices

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -97,6 +97,11 @@ func TestAccAWSInstance_blockDevicesCheck(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						"aws_instance.foo", &v),
+					// though two block devices exist in EC2, terraform state should only
+					// have the one block device we created, as terraform does not manage
+					// the root device
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "block_device.#", "1"),
 					testCheck(),
 				),
 			},

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -358,9 +358,9 @@ resource "aws_instance" "foo" {
 	ami = "ami-55a7ea65"
 	instance_type = "m1.small"
 	block_device {
-	  device_name = "/dev/sdb"
-	  volume_type = "gp2"
-	  volume_size = 10
+		device_name = "/dev/sdb"
+		volume_type = "gp2"
+		volume_size = 10
 	}
 }
 `


### PR DESCRIPTION
fixes #859

EC2 root block devices are attached automatically at launch [1] and show
up in DescribeInstances responses from then on. By skipping these when
recording state, Terraform can avoid thinking there should be block
device changes when there are none.

Note this requires that https://github.com/mitchellh/goamz/pull/214 land
first so the proper field is exposed.

[1] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html