### PR TITLE
Add split function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -19,6 +19,7 @@ func init() {
 		"file":    interpolationFuncFile(),
 		"join":    interpolationFuncJoin(),
 		"element": interpolationFuncElement(),
+		"split":   interpolationFuncSplit(),
 	}
 }
 
@@ -74,6 +75,18 @@ func interpolationFuncJoin() ast.Function {
 			}
 
 			return strings.Join(list, args[0].(string)), nil
+		},
+	}
+}
+
+// interpolationFuncSplit implements the "split" function that allows
+// strings to split into multi-variable values
+func interpolationFuncSplit() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString, ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			return strings.Replace(args[1].(string), args[0].(string), InterpSplitDelim, -1), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -107,6 +107,33 @@ func TestInterpolateFuncJoin(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncSplit(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${split(",")}`,
+				nil,
+				true,
+			},
+
+			{
+				`${split(",", "foo")}`,
+				"foo",
+				false,
+			},
+
+			{
+				`${split(".", "foo.bar.baz")}`,
+				fmt.Sprintf(
+					"foo%sbar%sbaz",
+					InterpSplitDelim,
+					InterpSplitDelim),
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncLookup(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Vars: map[string]ast.Variable{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -72,6 +72,11 @@ The supported built-in functions are:
       only possible with splat variables from resources with a count
       greater than one. Example: `join(",", aws_instance.foo.*.id)`
 
+  * `split(delim, string)` - Splits the string previously created by `join` 
+      back into a list. This is useful for pushing lists through module 
+      outputs since they currently only support string values.
+      Example: `split(",", module.amod.server_ids)`
+
   * `lookup(map, key)` - Performs a dynamic lookup into a mapping
       variable.
 


### PR DESCRIPTION
Adds the split function.

This allows a workaround for #845 by using `join` within the module, and `split` when using the output variable.