### PR TITLE
Fix for outputs.

### DIFF
--- a/examples/aws-count/outputs.tf
+++ b/examples/aws-count/outputs.tf
@@ -1,3 +1,3 @@
 output "address" {
-  value = "Instances: ${aws_instance.web.*.id}"
+  value = "Instances: ${element(aws_instance.web.*.id, 0)}"
 }


### PR DESCRIPTION
Fix for error in examples below from occurring:

Errors:

  * module root: 1 error(s) occurred:

* output 'address': multi-variable must be in a slice


