### PR TITLE
Fix error when refreshing on a deleted AWS subnet

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -94,6 +94,11 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := ec2conn.DescribeSubnets([]string{d.Id()}, ec2.NewFilter())
 
 	if err != nil {
+		if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidSubnetID.NotFound" {
+			// Update state to indicate the subnet no longer exists.
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	if resp == nil {


### PR DESCRIPTION
If a subnet exists in the state file and a refresh is performed, the
read function for subnets would return an error. Now it updates the
state to indicate that the subnet no longer exists, so Terraform can
plan to recreate it.