### PR TITLE
Support storage_type parameter for aws_db_instance

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -55,6 +55,13 @@ func resourceAwsDbInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"storage_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"identifier": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -190,6 +197,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		EngineVersion:        d.Get("engine_version").(string),
 	}
 
+	if attr, ok := d.GetOk("storage_type"); ok {
+		opts.StorageType = attr.(string)
+	}
+
 	if attr, ok := d.GetOk("backup_retention_period"); ok {
 		opts.BackupRetentionPeriod = attr.(int)
 		opts.SetBackupRetentionPeriod = true
@@ -296,6 +307,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("engine", v.Engine)
 	d.Set("engine_version", v.EngineVersion)
 	d.Set("allocated_storage", v.AllocatedStorage)
+	d.Set("storage_type", v.StorageType)
 	d.Set("instance_class", v.DBInstanceClass)
 	d.Set("availability_zone", v.AvailabilityZone)
 	d.Set("backup_retention_period", v.BackupRetentionPeriod)

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -37,6 +37,9 @@ The following arguments are supported:
 * `engine_version` - (Required) The engine version to use.
 * `identifier` - (Required) The name of the RDS instance
 * `instance_class` - (Required) The instance type of the RDS instance.
+* `storage_type` - (Optional) One of "standard" (magnetic), "gp2" (general
+	purpose SSD), or "io1" (provisioned IOPS SSD). The default is "io1" if
+	`iops` is specified, "standard" if not.
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
     when this DB instance is deleted. If omitted, no final snapshot will be
     made.
@@ -48,7 +51,8 @@ The following arguments are supported:
 * `availability_zone` - (Optional) The AZ for the RDS instance.
 * `backup_retention_period` - (Optional) The days to retain backups for.
 * `backup_window` - (Optional) The backup window.
-* `iops` - (Optional) The amount of provisioned IOPS
+* `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
+    storage_type of "io1".
 * `maintenance_window` - (Optional) The window to perform maintenance in.
 * `multi_az` - (Optional) Specifies if the RDS instance is multi-AZ
 * `port` - (Optional) The port on which the DB accepts connections.


### PR DESCRIPTION
This allows provisioning "gp2" (general purpose SSD) storage for DB
instances.

This requires [a change to goamz](https://github.com/mitchellh/goamz/pull/215) to work. Resolves #439.