### PR TITLE
Implement apply_method for RDS parameters

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -48,6 +48,19 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"apply_method": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "immediate",
+							// this parameter is not actually state, but a
+							// meta-parameter describing how the RDS API call
+							// to modify the parameter group should be made.
+							// Future reads of the resource from AWS don't tell
+							// us what we used for apply_method previously, so
+							// by squashing state to an empty string we avoid
+							// needing to do an update for every future run.
+							StateFunc: func(interface{}) string { return "" },
+						},
 					},
 				},
 				Set: resourceAwsDbParameterHash,

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -99,9 +99,7 @@ func expandParameters(configured []interface{}) ([]rds.Parameter, error) {
 		data := pRaw.(map[string]interface{})
 
 		p := rds.Parameter{
-			// Only immediate is supported for now; should add in pending-reboot at some point
-			// but gets tricky as the DescribeParameterGroups AWS call doesn't return this data
-			ApplyMethod:    "immediate",
+			ApplyMethod:    data["apply_method"].(string),
 			ParameterName:  data["name"].(string),
 			ParameterValue: data["value"].(string),
 		}

--- a/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
@@ -41,6 +41,9 @@ Parameter blocks support the following:
 
 * `name` - (Required) The name of the DB parameter.
 * `value` - (Required) The value of the DB parameter.
+* `apply_method` - (Optional) "immediate" (default), or "pending-reboot". Some
+    engines can't apply some parameters without a reboot, and you will need to
+    specify "pending-reboot" here.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is necessary to support creating parameter groups with parameters
that require a reboot, since the RDS API will return an error when
attempting to set those parameters with ApplyMethod "immediate".