### PR TITLE
Avoid unnecessary updating of aws_subnet

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -41,6 +41,7 @@ func resourceAwsSubnet() *schema.Resource {
 			"map_public_ip_on_launch": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 
 			"tags": tagsSchema(),


### PR DESCRIPTION
If map_public_ip_on_launch was not specified, AWS picks a default of
"0", which is different than the "" in the state file, triggerinng an
update each time. Mark that parameter as Computed, avoiding the update.