### PR TITLE
Makefile: new deps strategy fixes deps in branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,15 @@ testrace: generate
 # updatedeps installs all the dependencies that Terraform needs to run
 # and build.
 updatedeps:
-	$(eval REF := $(shell sh -c "\
-		git symbolic-ref --short HEAD 2>/dev/null \
-		|| git rev-parse HEAD"))
+	go get -u github.com/phinze/deplist
 	go get -u github.com/mitchellh/gox
 	go get -u golang.org/x/tools/cmd/stringer
 	go get -u golang.org/x/tools/cmd/vet
-	go get -f -u -v ./...
-	git checkout $(REF)
+	go list github.com/hashicorp/terraform/... \
+		| xargs -n 1 deplist -s \
+		| grep -v github.com/hashicorp/terraform \
+		| sort -u \
+		| xargs go get -f -u -v
 
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.


### PR DESCRIPTION
Currently when running `make updatedeps` from a branch, the dependency list from master ends up getting used. We tried to work around this in 35490f7812395ff46fcba52989b3fbc3e44215c3, and got part way there, but here's what was happening:

 - record the current SHA
 - run `go get -f -u -v ./...` which ends up checking out master
 - master is checked out early in the `go get` process, which means all
   subsequent dependencies are resolved from master
 - re-checkout the recorded SHA
 - run tests

This works in most cases, except when the branch being tested actually changes the list of dependencies in some way.

Here we move away from letting `go get -v` walk through everything in `./...`, instead building our own list of dependencies with the help of `deplist`. We can then filter terraform packages out from the list, so they don't get touched, and safely update the rest.

This should solve problems like those observed in #899 and #900.