### PR TITLE
Makefile: simplify updatedeps; no need for deplist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,11 @@ testrace: generate
 # updatedeps installs all the dependencies that Terraform needs to run
 # and build.
 updatedeps:
-	go get -u github.com/phinze/deplist
 	go get -u github.com/mitchellh/gox
 	go get -u golang.org/x/tools/cmd/stringer
 	go get -u golang.org/x/tools/cmd/vet
-	go list github.com/hashicorp/terraform/... \
-		| xargs -n 1 deplist -s \
+	go list ./... \
+		| xargs go list -f '{{join .Deps "\n"}}' \
 		| grep -v github.com/hashicorp/terraform \
 		| sort -u \
 		| xargs go get -f -u -v


### PR DESCRIPTION
After discussing with the very gracious @cespare over at
https://github.com/cespare/deplist/pull/2 I now understand that we can
pull off the same logic with just `go list`.

The logic is now simpler and more consistent:

 * List out all packages in our repo
 * For each of those packages, list their dependencies
 * Filter out any dependencies that already live in this repo
 * Remove duplicates
 * And fetch the rest. `go get` will work out all transitive dependencies
   from there