### PR TITLE
fix build: upstream azure client change

### DIFF
--- a/builtin/providers/azure/resource_virtual_machine.go
+++ b/builtin/providers/azure/resource_virtual_machine.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/MSOpenTech/azure-sdk-for-go/clients/hostedServiceClient"
+	"github.com/MSOpenTech/azure-sdk-for-go/clients/vmClient"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/MSOpenTech/azure-sdk-for-go/clients/vmClient"
 )
 
 func resourceVirtualMachine() *schema.Resource {
@@ -220,7 +221,7 @@ func resourceVirtualMachineDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Deleting Azure Hosted Service: %s", d.Id())
-	if err := vmClient.DeleteHostedService(d.Id()); err != nil {
+	if err := hostedServiceClient.DeleteHostedService(d.Id()); err != nil {
 		return fmt.Errorf("Error deleting Azure hosted service: %s", err)
 	}
 


### PR DESCRIPTION
looks like https://github.com/MSOpenTech/azure-sdk-for-go/pull/30
changed the API for hosted services, which broke our build.