### PR TITLE
config/module: fix URL file path handling on Windows

### DIFF
--- a/config/module/detect.go
+++ b/config/module/detect.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"fmt"
-	"net/url"
 	"path/filepath"
 )
 
@@ -67,7 +66,7 @@ func Detect(src string, pwd string) (string, error) {
 			}
 		}
 		if subDir != "" {
-			u, err := url.Parse(result)
+			u, err := urlParse(result)
 			if err != nil {
 				return "", fmt.Errorf("Error parsing URL: %s", err)
 			}

--- a/config/module/url_helper.go
+++ b/config/module/url_helper.go
@@ -9,13 +9,8 @@ import (
 
 func urlParse(rawURL string) (*url.URL, error) {
 	if runtime.GOOS == "windows" {
-		if len(rawURL) > 1 && rawURL[1] == ':' {
-			// Assume we're dealing with a file path.
-			rawURL = fmtFileURL(rawURL)
-		} else {
-			// Make sure we're using "/" on Windows. URLs are "/"-based.
-			rawURL = filepath.ToSlash(rawURL)
-		}
+		// Make sure we're using "/" on Windows. URLs are "/"-based.
+		rawURL = filepath.ToSlash(rawURL)
 	}
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -26,13 +21,18 @@ func urlParse(rawURL string) (*url.URL, error) {
 		return u, err
 	}
 
-	if u.Scheme != "file" {
-		return u, err
+	if len(rawURL) > 1 && rawURL[1] == ':' {
+		// Assume we're dealing with a drive letter file path on Windows.
+		// We need to adjust the URL Path for drive letter file paths
+		// because url.Parse("c:/users/user") yields URL Scheme = "c"
+		// and URL path = "/users/user".
+		u.Path = fmt.Sprintf("%s:%s", u.Scheme, u.Path)
+		u.Scheme = ""
 	}
 
 	// Remove leading slash for absolute file paths on Windows.
 	// For example, url.Parse yields u.Path = "/C:/Users/user" for
-	// rawurl = "file:///C:/Users/user", which is an incorrect syntax.
+	// rawURL = "file:///C:/Users/user", which is an incorrect syntax.
 	if len(u.Path) > 2 && u.Path[0] == '/' && u.Path[2] == ':' {
 		u.Path = u.Path[1:]
 	}


### PR DESCRIPTION
Only adjust the URL Scheme when parsing drive letter file paths on
Windows, don't add a file scheme prefix.
FileDetector is responsible for adding the file scheme prefix.

Fixes #839.

/cc @mitchellh 