### PR TITLE
Make schema.ResourceData an interface

### DIFF
--- a/builtin/providers/atlas/provider.go
+++ b/builtin/providers/atlas/provider.go
@@ -39,7 +39,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	var err error
 	client := atlas.DefaultClient()
 	if v := d.Get("address").(string); v != "" {

--- a/builtin/providers/atlas/resource_artifact.go
+++ b/builtin/providers/atlas/resource_artifact.go
@@ -86,7 +86,7 @@ func resourceArtifact() *schema.Resource {
 	}
 }
 
-func resourceArtifactRead(d *schema.ResourceData, meta interface{}) error {
+func resourceArtifactRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*atlas.Client)
 
 	// Parse the slug from the name given of the artifact since the API
@@ -161,7 +161,7 @@ func resourceArtifactRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceArtifactDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceArtifactDelete(d schema.ResourceData, meta interface{}) error {
 	// This just always succeeds since this is a readonly element.
 	d.SetId("")
 	return nil

--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -1,8 +1,8 @@
 package aws
 
 import (
-	"github.com/mitchellh/goamz/ec2"
 	"fmt"
+	"github.com/mitchellh/goamz/ec2"
 )
 
 func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.NetworkAclEntry, error) {
@@ -11,7 +11,7 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.
 		data := eRaw.(map[string]interface{})
 		protocol := data["protocol"].(string)
 		_, ok := protocolIntegers()[protocol]
-		if(!ok){
+		if !ok {
 			return nil, fmt.Errorf("Invalid Protocol %s for rule %#v", protocol, data)
 		}
 		p := extractProtocolInteger(data["protocol"].(string))
@@ -69,7 +69,7 @@ func protocolIntegers() map[string]int {
 		"udp":  17,
 		"tcp":  6,
 		"icmp": 1,
-		"all": -1,
+		"all":  -1,
 	}
 	return protocolIntegers
 }

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -86,7 +86,7 @@ func init() {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		AccessKey: d.Get("access_key").(string),
 		SecretKey: d.Get("secret_key").(string),

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -121,7 +121,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 	}
 }
 
-func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsAutoscalingGroupCreate(d schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	var autoScalingGroupOpts autoscaling.CreateAutoScalingGroup
@@ -177,7 +177,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	return resourceAwsAutoscalingGroupRead(d, meta)
 }
 
-func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsAutoscalingGroupRead(d schema.ResourceData, meta interface{}) error {
 	g, err := getAwsAutoscalingGroup(d, meta)
 	if err != nil {
 		return err
@@ -201,7 +201,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsAutoscalingGroupUpdate(d schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	opts := autoscaling.UpdateAutoScalingGroup{
@@ -233,7 +233,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 	return resourceAwsAutoscalingGroupRead(d, meta)
 }
 
-func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsAutoscalingGroupDelete(d schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	// Read the autoscaling group first. If it doesn't exist, we're done.
@@ -277,7 +277,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 }
 
 func getAwsAutoscalingGroup(
-	d *schema.ResourceData,
+	d schema.ResourceData,
 	meta interface{}) (*autoscaling.AutoScalingGroup, error) {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
@@ -309,7 +309,7 @@ func getAwsAutoscalingGroup(
 	return nil, nil
 }
 
-func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsAutoscalingGroupDrain(d schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	// First, set the capacity to zero so the group will drain

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -176,7 +176,7 @@ func resourceAwsDbInstance() *schema.Resource {
 	}
 }
 
-func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbInstanceCreate(d schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 	opts := rds.CreateDBInstance{
 		AllocatedStorage:     d.Get("allocated_storage").(int),
@@ -280,7 +280,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceAwsDbInstanceRead(d, meta)
 }
 
-func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbInstanceRead(d schema.ResourceData, meta interface{}) error {
 	v, err := resourceAwsBbInstanceRetrieve(d, meta)
 
 	if err != nil {
@@ -334,7 +334,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbInstanceDelete(d schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
 	log.Printf("[DEBUG] DB Instance destroy: %v", d.Id())
@@ -372,7 +372,7 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsBbInstanceRetrieve(
-	d *schema.ResourceData, meta interface{}) (*rds.DBInstance, error) {
+	d schema.ResourceData, meta interface{}) (*rds.DBInstance, error) {
 	conn := meta.(*AWSClient).rdsconn
 
 	opts := rds.DescribeDBInstances{
@@ -403,7 +403,7 @@ func resourceAwsBbInstanceRetrieve(
 }
 
 func resourceAwsDbInstanceStateRefreshFunc(
-	d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	d schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		v, err := resourceAwsBbInstanceRetrieve(d, meta)
 

--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -56,7 +56,7 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 	}
 }
 
-func resourceAwsDbParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbParameterGroupCreate(d schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
 
 	createOpts := rds.CreateDBParameterGroup{
@@ -83,7 +83,7 @@ func resourceAwsDbParameterGroupCreate(d *schema.ResourceData, meta interface{})
 	return resourceAwsDbParameterGroupUpdate(d, meta)
 }
 
-func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbParameterGroupRead(d schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
 
 	describeOpts := rds.DescribeDBParameterGroups{
@@ -120,7 +120,7 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbParameterGroupUpdate(d schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
 
 	d.Partial(true)
@@ -163,7 +163,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 	return resourceAwsDbParameterGroupRead(d, meta)
 }
 
-func resourceAwsDbParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbParameterGroupDelete(d schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     "destroyed",
@@ -176,7 +176,7 @@ func resourceAwsDbParameterGroupDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsDbParameterGroupDeleteRefreshFunc(
-	d *schema.ResourceData,
+	d schema.ResourceData,
 	meta interface{}) resource.StateRefreshFunc {
 	rdsconn := meta.(*AWSClient).rdsconn
 

--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -68,7 +68,7 @@ func resourceAwsDbSecurityGroup() *schema.Resource {
 	}
 }
 
-func resourceAwsDbSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbSecurityGroupCreate(d schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
 	var err error
@@ -126,7 +126,7 @@ func resourceAwsDbSecurityGroupCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceAwsDbSecurityGroupRead(d, meta)
 }
 
-func resourceAwsDbSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbSecurityGroupRead(d schema.ResourceData, meta interface{}) error {
 	sg, err := resourceAwsDbSecurityGroupRetrieve(d, meta)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func resourceAwsDbSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceAwsDbSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbSecurityGroupDelete(d schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
 	log.Printf("[DEBUG] DB Security Group destroy: %v", d.Id())
@@ -180,7 +180,7 @@ func resourceAwsDbSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceAwsDbSecurityGroupRetrieve(d *schema.ResourceData, meta interface{}) (*rds.DBSecurityGroup, error) {
+func resourceAwsDbSecurityGroupRetrieve(d schema.ResourceData, meta interface{}) (*rds.DBSecurityGroup, error) {
 	conn := meta.(*AWSClient).rdsconn
 
 	opts := rds.DescribeDBSecurityGroups{
@@ -266,7 +266,7 @@ func resourceAwsDbSecurityGroupIngressHash(v interface{}) int {
 }
 
 func resourceAwsDbSecurityGroupStateRefreshFunc(
-	d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	d schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		v, err := resourceAwsDbSecurityGroupRetrieve(d, meta)
 

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -43,7 +43,7 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 	}
 }
 
-func resourceAwsDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbSubnetGroupCreate(d schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
 
 	subnetIdsSet := d.Get("subnet_ids").(*schema.Set)
@@ -69,7 +69,7 @@ func resourceAwsDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) er
 	return resourceAwsDbSubnetGroupRead(d, meta)
 }
 
-func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbSubnetGroupRead(d schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
 
 	describeOpts := rds.DescribeDBSubnetGroups{
@@ -92,7 +92,7 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceAwsDbSubnetGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsDbSubnetGroupDelete(d schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     "destroyed",
@@ -105,7 +105,7 @@ func resourceAwsDbSubnetGroupDelete(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceAwsDbSubnetGroupDeleteRefreshFunc(
-	d *schema.ResourceData,
+	d schema.ResourceData,
 	meta interface{}) resource.StateRefreshFunc {
 	rdsconn := meta.(*AWSClient).rdsconn
 

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -58,7 +58,7 @@ func resourceAwsEip() *schema.Resource {
 	}
 }
 
-func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEipCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// By default, we're not in a VPC
@@ -95,7 +95,7 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsEipUpdate(d, meta)
 }
 
-func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEipRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	domain := resourceAwsEipDomain(d)
@@ -142,7 +142,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEipUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	domain := resourceAwsEipDomain(d)
@@ -175,7 +175,7 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsEipRead(d, meta)
 }
 
-func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEipDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	if err := resourceAwsEipRead(d, meta); err != nil {
@@ -226,7 +226,7 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 	})
 }
 
-func resourceAwsEipDomain(d *schema.ResourceData) string {
+func resourceAwsEipDomain(d schema.ResourceData) string {
 	if v, ok := d.GetOk("domain"); ok {
 		return v.(string)
 	} else if strings.Contains(d.Id(), "eipalloc") {

--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -160,7 +160,7 @@ func resourceAwsElb() *schema.Resource {
 	}
 }
 
-func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsElbCreate(d schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 
 	// Expand the "listener" set to goamz compat []elb.Listener
@@ -232,7 +232,7 @@ func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsElbUpdate(d, meta)
 }
 
-func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsElbRead(d schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 
 	// Retrieve the ELB properties for updating the state
@@ -274,7 +274,7 @@ func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsElbUpdate(d schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 
 	d.Partial(true)
@@ -335,7 +335,7 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsElbRead(d, meta)
 }
 
-func resourceAwsElbDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsElbDelete(d schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 
 	log.Printf("[INFO] Deleting ELB: %s", d.Id())

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -194,7 +194,7 @@ func resourceAwsInstance() *schema.Resource {
 	}
 }
 
-func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInstanceCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Figure out user data
@@ -307,7 +307,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsInstanceUpdate(d, meta)
 }
 
-func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInstanceRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	resp, err := ec2conn.Instances([]string{d.Id()}, ec2.NewFilter())
@@ -416,7 +416,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInstanceUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	modify := false
@@ -447,7 +447,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInstanceDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Terminating instance: %s", d.Id())

--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -27,7 +27,7 @@ func resourceAwsInternetGateway() *schema.Resource {
 	}
 }
 
-func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInternetGatewayCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Create the gateway
@@ -46,7 +46,7 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceAwsInternetGatewayAttach(d, meta)
 }
 
-func resourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInternetGatewayRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	igRaw, _, err := IGStateRefreshFunc(ec2conn, d.Id())()
@@ -72,7 +72,7 @@ func resourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceAwsInternetGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInternetGatewayUpdate(d schema.ResourceData, meta interface{}) error {
 	if d.HasChange("vpc_id") {
 		// If we're already attached, detach it first
 		if err := resourceAwsInternetGatewayDetach(d, meta); err != nil {
@@ -96,7 +96,7 @@ func resourceAwsInternetGatewayUpdate(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInternetGatewayDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Detach if it is attached
@@ -128,7 +128,7 @@ func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) 
 	})
 }
 
-func resourceAwsInternetGatewayAttach(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInternetGatewayAttach(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	if d.Get("vpc_id").(string) == "" {
@@ -170,7 +170,7 @@ func resourceAwsInternetGatewayAttach(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceAwsInternetGatewayDetach(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsInternetGatewayDetach(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Get the old VPC ID to detach from

--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -32,7 +32,7 @@ func resourceAwsKeyPair() *schema.Resource {
 	}
 }
 
-func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsKeyPairCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	keyName := d.Get("key_name").(string)
@@ -47,7 +47,7 @@ func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsKeyPairRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	resp, err := ec2conn.KeyPairs([]string{d.Id()}, nil)
@@ -66,7 +66,7 @@ func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 	return fmt.Errorf("Unable to find key pair within: %#v", resp.Keys)
 }
 
-func resourceAwsKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsKeyPairDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	_, err := ec2conn.DeleteKeyPair(d.Id())

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -91,7 +91,7 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 	}
 }
 
-func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsLaunchConfigurationCreate(d schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	var createLaunchConfigurationOpts autoscaling.CreateLaunchConfiguration
@@ -125,7 +125,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	})
 }
 
-func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsLaunchConfigurationRead(d schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	describeOpts := autoscaling.DescribeLaunchConfigurations{
@@ -162,7 +162,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceAwsLaunchConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsLaunchConfigurationDelete(d schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	log.Printf("[DEBUG] Launch Configuration destroy: %v", d.Id())

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -106,7 +106,7 @@ func resourceAwsNetworkAcl() *schema.Resource {
 	}
 }
 
-func resourceAwsNetworkAclCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsNetworkAclCreate(d schema.ResourceData, meta interface{}) error {
 
 	ec2conn := meta.(*AWSClient).ec2conn
 
@@ -130,7 +130,7 @@ func resourceAwsNetworkAclCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceAwsNetworkAclUpdate(d, meta)
 }
 
-func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsNetworkAclRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	resp, err := ec2conn.NetworkAcls([]string{d.Id()}, ec2.NewFilter())
@@ -163,7 +163,7 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsNetworkAclUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 	d.Partial(true)
 
@@ -206,7 +206,7 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 	return resourceAwsNetworkAclRead(d, meta)
 }
 
-func updateNetworkAclEntries(d *schema.ResourceData, entryType string, ec2conn *ec2.EC2) error {
+func updateNetworkAclEntries(d schema.ResourceData, entryType string, ec2conn *ec2.EC2) error {
 
 	o, n := d.GetChange(entryType)
 
@@ -246,7 +246,7 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, ec2conn *
 	return nil
 }
 
-func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsNetworkAclDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Deleting Network Acl: %s", d.Id())

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -56,7 +56,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 	}
 }
 
-func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRoute53RecordCreate(d schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).route53
 
 	// Get the record
@@ -130,7 +130,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRoute53RecordRead(d schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).route53
 
 	zone := d.Get("zone_id").(string)
@@ -168,7 +168,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRoute53RecordDelete(d schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).route53
 
 	// Get the records
@@ -224,7 +224,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData) (*route53.ResourceRecordSet, error) {
+func resourceAwsRoute53RecordBuildSet(d schema.ResourceData) (*route53.ResourceRecordSet, error) {
 	recs := d.Get("records").(*schema.Set).List()
 	records := make([]string, 0, len(recs))
 

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -31,7 +31,7 @@ func resourceAwsRoute53Zone() *schema.Resource {
 	}
 }
 
-func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRoute53ZoneCreate(d schema.ResourceData, meta interface{}) error {
 	r53 := meta.(*AWSClient).route53
 
 	req := &route53.CreateHostedZoneRequest{
@@ -67,7 +67,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRoute53ZoneRead(d schema.ResourceData, meta interface{}) error {
 	r53 := meta.(*AWSClient).route53
 
 	_, err := r53.GetHostedZone(d.Id())
@@ -83,7 +83,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRoute53ZoneDelete(d schema.ResourceData, meta interface{}) error {
 	r53 := meta.(*AWSClient).route53
 
 	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",

--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -55,7 +55,7 @@ func resourceAwsRouteTable() *schema.Resource {
 	}
 }
 
-func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Create the routing table
@@ -93,7 +93,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceAwsRouteTableUpdate(d, meta)
 }
 
-func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id())()
@@ -136,7 +136,7 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Check if the route set as a whole has changed
@@ -191,7 +191,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 	return resourceAwsRouteTableRead(d, meta)
 }
 
-func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// First request the routing table since we'll have to disassociate

--- a/builtin/providers/aws/resource_aws_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_route_table_association.go
@@ -30,7 +30,7 @@ func resourceAwsRouteTableAssociation() *schema.Resource {
 	}
 }
 
-func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableAssociationCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf(
@@ -53,7 +53,7 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableAssociationRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Get the routing table that this association belongs to
@@ -85,7 +85,7 @@ func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableAssociationUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf(
@@ -114,7 +114,7 @@ func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func resourceAwsRouteTableAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsRouteTableAssociationDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Deleting route table association: %s", d.Id())

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -129,26 +129,25 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-		resource.TestStep{
-		Config: testAccRouteTableConfigTags,
-		Check: resource.ComposeTestCheckFunc(
-			testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-			testAccCheckTags(&route_table.Tags, "foo", "bar"),
-		),
-	},
+			resource.TestStep{
+				Config: testAccRouteTableConfigTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
+					testAccCheckTags(&route_table.Tags, "foo", "bar"),
+				),
+			},
 
-		resource.TestStep{
-		Config: testAccRouteTableConfigTagsUpdate,
-		Check: resource.ComposeTestCheckFunc(
-			testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-			testAccCheckTags(&route_table.Tags, "foo", ""),
-			testAccCheckTags(&route_table.Tags, "bar", "baz"),
-		),
-	},
-	},
+			resource.TestStep{
+				Config: testAccRouteTableConfigTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
+					testAccCheckTags(&route_table.Tags, "foo", ""),
+					testAccCheckTags(&route_table.Tags, "bar", "baz"),
+				),
+			},
+		},
 	})
 }
-
 
 func testAccCheckRouteTableDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -31,7 +31,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 	}
 }
 
-func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsS3BucketCreate(d schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
 	// Get the bucket and acl
@@ -51,7 +51,7 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsS3BucketRead(d schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
 	bucket := s3conn.Bucket(d.Id())
@@ -63,7 +63,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsS3BucketDelete(d schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
 	log.Printf("[DEBUG] S3 Delete Bucket: %s", d.Id())

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -94,7 +94,7 @@ func resourceAwsSecurityGroup() *schema.Resource {
 	}
 }
 
-func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSecurityGroupCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	securityGroupOpts := ec2.SecurityGroup{
@@ -139,7 +139,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 	return resourceAwsSecurityGroupUpdate(d, meta)
 }
 
-func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSecurityGroupRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	sgRaw, _, err := SGStateRefreshFunc(ec2conn, d.Id())()
@@ -215,7 +215,7 @@ func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSecurityGroupUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	sgRaw, _, err := SGStateRefreshFunc(ec2conn, d.Id())()
@@ -278,7 +278,7 @@ func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	return resourceAwsSecurityGroupRead(d, meta)
 }
 
-func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSecurityGroupDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[DEBUG] Security Group destroy: %v", d.Id())

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -49,7 +49,7 @@ func resourceAwsSubnet() *schema.Resource {
 	}
 }
 
-func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSubnetCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	createOpts := &ec2.CreateSubnet{
@@ -89,7 +89,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsSubnetUpdate(d, meta)
 }
 
-func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSubnetRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	resp, err := ec2conn.DescribeSubnets([]string{d.Id()}, ec2.NewFilter())
@@ -112,7 +112,7 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSubnetUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	d.Partial(true)
@@ -145,7 +145,7 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsSubnetRead(d, meta)
 }
 
-func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSubnetDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Deleting subnet: %s", d.Id())

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -57,18 +57,17 @@ func resourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
-
 			"tags": tagsSchema(),
 		},
 	}
 }
 
-func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsVpcCreate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Create the VPC
 	createOpts := &ec2.CreateVpc{
-		CidrBlock: d.Get("cidr_block").(string),
+		CidrBlock:       d.Get("cidr_block").(string),
 		InstanceTenancy: d.Get("instance_tenancy").(string),
 	}
 	log.Printf("[DEBUG] VPC create config: %#v", createOpts)
@@ -106,7 +105,7 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsVpcUpdate(d, meta)
 }
 
-func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsVpcRead(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Refresh the VPC state
@@ -156,7 +155,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsVpcUpdate(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	// Turn on partial mode
@@ -202,7 +201,7 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsVpcRead(d, meta)
 }
 
-func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsVpcDelete(d schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Deleting VPC: %s", d.Id())
@@ -243,8 +242,7 @@ func VPCStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	}
 }
 
-
-func resourceAwsVpcSetDefaultNetworkAcl(conn *ec2.EC2, d *schema.ResourceData) error  {
+func resourceAwsVpcSetDefaultNetworkAcl(conn *ec2.EC2, d schema.ResourceData) error {
 	filter := ec2.NewFilter()
 	filter.Add("default", "true")
 	filter.Add("vpc-id", d.Id())
@@ -260,7 +258,7 @@ func resourceAwsVpcSetDefaultNetworkAcl(conn *ec2.EC2, d *schema.ResourceData) e
 	return nil
 }
 
-func resourceAwsVpcSetDefaultSecurityGroup(conn *ec2.EC2, d *schema.ResourceData) error  {
+func resourceAwsVpcSetDefaultSecurityGroup(conn *ec2.EC2, d schema.ResourceData) error {
 	filter := ec2.NewFilter()
 	filter.Add("group-name", "default")
 	filter.Add("vpc-id", d.Id())

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -216,4 +216,3 @@ resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
 }
 `
-

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -297,8 +297,8 @@ func Test_flattenParameters(t *testing.T) {
 			},
 			Output: []map[string]interface{}{
 				map[string]interface{}{
-					"name":         "character_set_client",
-					"value":        "utf8",
+					"name":  "character_set_client",
+					"value": "utf8",
 				},
 			},
 		},

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -17,7 +17,7 @@ func tagsSchema() *schema.Schema {
 
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags"
-func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
+func setTags(conn *ec2.EC2, d schema.ResourceData) error {
 	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})

--- a/builtin/providers/azure/provider.go
+++ b/builtin/providers/azure/provider.go
@@ -18,7 +18,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"azure_virtual_machine":  resourceVirtualMachine(),
+			"azure_virtual_machine": resourceVirtualMachine(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -35,7 +35,7 @@ func envDefaultFunc(k string) schema.SchemaDefaultFunc {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		PublishSettingsFile: d.Get("publish_settings_file").(string),
 	}

--- a/builtin/providers/azure/resource_virtual_machine.go
+++ b/builtin/providers/azure/resource_virtual_machine.go
@@ -118,7 +118,7 @@ func resourceVirtualMachine() *schema.Resource {
 	}
 }
 
-func resourceVirtualMachineCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceVirtualMachineCreate(d schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Azure Virtual Machine Configuration...")
 	vmConfig, err := vmClient.CreateAzureVMConfiguration(
 		d.Get("name").(string),
@@ -182,7 +182,7 @@ func resourceVirtualMachineCreate(d *schema.ResourceData, meta interface{}) erro
 	return resourceVirtualMachineRead(d, meta)
 }
 
-func resourceVirtualMachineRead(d *schema.ResourceData, meta interface{}) error {
+func resourceVirtualMachineRead(d schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Getting Azure Virtual Machine Deployment: %s", d.Id())
 	VMDeployment, err := vmClient.GetVMDeployment(d.Id(), d.Id())
 	if err != nil {
@@ -214,7 +214,7 @@ func resourceVirtualMachineRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceVirtualMachineDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceVirtualMachineDelete(d schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting Azure Virtual Machine Deployment: %s", d.Id())
 	if err := vmClient.DeleteVMDeployment(d.Id(), d.Id()); err != nil {
 		return fmt.Errorf("Error deleting Azure virtual machine deployment: %s", err)

--- a/builtin/providers/azure/resource_virtual_machine_test.go
+++ b/builtin/providers/azure/resource_virtual_machine_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MSOpenTech/azure-sdk-for-go/clients/vmClient"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/MSOpenTech/azure-sdk-for-go/clients/vmClient"
 )
 
 func TestAccAzureVirtualMachine_Basic(t *testing.T) {

--- a/builtin/providers/cloudflare/provider.go
+++ b/builtin/providers/cloudflare/provider.go
@@ -32,7 +32,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Email: d.Get("email").(string),
 		Token: d.Get("token").(string),

--- a/builtin/providers/cloudflare/resource_cloudflare_record.go
+++ b/builtin/providers/cloudflare/resource_cloudflare_record.go
@@ -54,7 +54,7 @@ func resourceCloudFlareRecord() *schema.Resource {
 	}
 }
 
-func resourceCloudFlareRecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudFlareRecordCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.Client)
 
 	// Create the new record
@@ -86,7 +86,7 @@ func resourceCloudFlareRecordCreate(d *schema.ResourceData, meta interface{}) er
 	return resourceCloudFlareRecordRead(d, meta)
 }
 
-func resourceCloudFlareRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudFlareRecordRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.Client)
 
 	rec, err := client.RetrieveRecord(d.Get("domain").(string), d.Id())
@@ -104,7 +104,7 @@ func resourceCloudFlareRecordRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceCloudFlareRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudFlareRecordUpdate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.Client)
 
 	// CloudFlare requires we send all values for an update request
@@ -132,7 +132,7 @@ func resourceCloudFlareRecordUpdate(d *schema.ResourceData, meta interface{}) er
 	return resourceCloudFlareRecordRead(d, meta)
 }
 
-func resourceCloudFlareRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudFlareRecordDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudflare.Client)
 
 	log.Printf("[INFO] Deleting record: %s, %s", d.Get("domain").(string), d.Id())

--- a/builtin/providers/cloudstack/provider.go
+++ b/builtin/providers/cloudstack/provider.go
@@ -52,7 +52,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		ApiURL:    d.Get("api_url").(string),
 		ApiKey:    d.Get("api_key").(string),

--- a/builtin/providers/cloudstack/resource_cloudstack_disk.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_disk.go
@@ -65,7 +65,7 @@ func resourceCloudStackDisk() *schema.Resource {
 	}
 }
 
-func resourceCloudStackDiskCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackDiskCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	d.Partial(true)
 
@@ -124,7 +124,7 @@ func resourceCloudStackDiskCreate(d *schema.ResourceData, meta interface{}) erro
 	return resourceCloudStackDiskRead(d, meta)
 }
 
-func resourceCloudStackDiskRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackDiskRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the volume details
@@ -170,7 +170,7 @@ func resourceCloudStackDiskRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceCloudStackDiskUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackDiskUpdate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	d.Partial(true)
 
@@ -245,7 +245,7 @@ func resourceCloudStackDiskUpdate(d *schema.ResourceData, meta interface{}) erro
 	return resourceCloudStackDiskRead(d, meta)
 }
 
-func resourceCloudStackDiskDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackDiskDelete(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Detach the volume
@@ -271,7 +271,7 @@ func resourceCloudStackDiskDelete(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceCloudStackDiskAttach(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackDiskAttach(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// First check if the disk isn't already attached
@@ -310,7 +310,7 @@ func resourceCloudStackDiskAttach(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceCloudStackDiskDetach(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackDiskDetach(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Check if the volume is actually attached, before detaching

--- a/builtin/providers/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_egress_firewall.go
@@ -81,7 +81,7 @@ func resourceCloudStackEgressFirewall() *schema.Resource {
 	}
 }
 
-func resourceCloudStackEgressFirewallCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackEgressFirewallCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Make sure all required parameters are there
@@ -124,7 +124,7 @@ func resourceCloudStackEgressFirewallCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceCloudStackEgressFirewallCreateRule(
-	d *schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	uuids := rule["uuids"].(map[string]interface{})
 
@@ -200,7 +200,7 @@ func resourceCloudStackEgressFirewallCreateRule(
 	return nil
 }
 
-func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackEgressFirewallRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create an empty schema.Set to hold all rules
@@ -335,7 +335,7 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceCloudStackEgressFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackEgressFirewallUpdate(d schema.ResourceData, meta interface{}) error {
 	// Make sure all required parameters are there
 	if err := verifyEgressFirewallParams(d); err != nil {
 		return err
@@ -379,7 +379,7 @@ func resourceCloudStackEgressFirewallUpdate(d *schema.ResourceData, meta interfa
 	return resourceCloudStackEgressFirewallRead(d, meta)
 }
 
-func resourceCloudStackEgressFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackEgressFirewallDelete(d schema.ResourceData, meta interface{}) error {
 	// Delete all rules
 	if rs := d.Get("rule").(*schema.Set); rs.Len() > 0 {
 		for _, rule := range rs.List() {
@@ -399,7 +399,7 @@ func resourceCloudStackEgressFirewallDelete(d *schema.ResourceData, meta interfa
 }
 
 func resourceCloudStackEgressFirewallDeleteRule(
-	d *schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	uuids := rule["uuids"].(map[string]interface{})
 
@@ -469,7 +469,7 @@ func resourceCloudStackEgressFirewallRuleHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func verifyEgressFirewallParams(d *schema.ResourceData) error {
+func verifyEgressFirewallParams(d schema.ResourceData) error {
 	managed := d.Get("managed").(bool)
 	_, rules := d.GetOk("rule")
 
@@ -481,7 +481,7 @@ func verifyEgressFirewallParams(d *schema.ResourceData) error {
 	return nil
 }
 
-func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
+func verifyEgressFirewallRuleParams(d schema.ResourceData, rule map[string]interface{}) error {
 	protocol := rule["protocol"].(string)
 	if protocol != "tcp" && protocol != "udp" && protocol != "icmp" {
 		return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_firewall.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_firewall.go
@@ -81,7 +81,7 @@ func resourceCloudStackFirewall() *schema.Resource {
 	}
 }
 
-func resourceCloudStackFirewallCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackFirewallCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Make sure all required parameters are there
@@ -124,7 +124,7 @@ func resourceCloudStackFirewallCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceCloudStackFirewallCreateRule(
-	d *schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	uuids := rule["uuids"].(map[string]interface{})
 
@@ -200,7 +200,7 @@ func resourceCloudStackFirewallCreateRule(
 	return nil
 }
 
-func resourceCloudStackFirewallRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackFirewallRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create an empty schema.Set to hold all rules
@@ -335,7 +335,7 @@ func resourceCloudStackFirewallRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceCloudStackFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackFirewallUpdate(d schema.ResourceData, meta interface{}) error {
 	// Make sure all required parameters are there
 	if err := verifyFirewallParams(d); err != nil {
 		return err
@@ -379,7 +379,7 @@ func resourceCloudStackFirewallUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceCloudStackFirewallRead(d, meta)
 }
 
-func resourceCloudStackFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackFirewallDelete(d schema.ResourceData, meta interface{}) error {
 	// Delete all rules
 	if rs := d.Get("rule").(*schema.Set); rs.Len() > 0 {
 		for _, rule := range rs.List() {
@@ -399,7 +399,7 @@ func resourceCloudStackFirewallDelete(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceCloudStackFirewallDeleteRule(
-	d *schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	uuids := rule["uuids"].(map[string]interface{})
 
@@ -469,7 +469,7 @@ func resourceCloudStackFirewallRuleHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func verifyFirewallParams(d *schema.ResourceData) error {
+func verifyFirewallParams(d schema.ResourceData) error {
 	managed := d.Get("managed").(bool)
 	_, rules := d.GetOk("rule")
 
@@ -481,7 +481,7 @@ func verifyFirewallParams(d *schema.ResourceData) error {
 	return nil
 }
 
-func verifyFirewallRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
+func verifyFirewallRuleParams(d schema.ResourceData, rule map[string]interface{}) error {
 	protocol := rule["protocol"].(string)
 	if protocol != "tcp" && protocol != "udp" && protocol != "icmp" {
 		return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_instance.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance.go
@@ -86,7 +86,7 @@ func resourceCloudStackInstance() *schema.Resource {
 	}
 }
 
-func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackInstanceCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Retrieve the service_offering UUID
@@ -159,7 +159,7 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceCloudStackInstanceRead(d, meta)
 }
 
-func resourceCloudStackInstanceRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackInstanceRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the virtual machine details
@@ -187,7 +187,7 @@ func resourceCloudStackInstanceRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceCloudStackInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackInstanceUpdate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	d.Partial(true)
 
@@ -252,7 +252,7 @@ func resourceCloudStackInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceCloudStackInstanceRead(d, meta)
 }
 
-func resourceCloudStackInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackInstanceDelete(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create a new parameter struct

--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
@@ -36,7 +36,7 @@ func resourceCloudStackIPAddress() *schema.Resource {
 	}
 }
 
-func resourceCloudStackIPAddressCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackIPAddressCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	if err := verifyIPAddressParams(d); err != nil {
@@ -79,7 +79,7 @@ func resourceCloudStackIPAddressCreate(d *schema.ResourceData, meta interface{})
 	return resourceCloudStackIPAddressRead(d, meta)
 }
 
-func resourceCloudStackIPAddressRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackIPAddressRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the network ACL list details
@@ -121,7 +121,7 @@ func resourceCloudStackIPAddressRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceCloudStackIPAddressDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackIPAddressDelete(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create a new parameter struct
@@ -142,7 +142,7 @@ func resourceCloudStackIPAddressDelete(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func verifyIPAddressParams(d *schema.ResourceData) error {
+func verifyIPAddressParams(d schema.ResourceData) error {
 	_, network := d.GetOk("network")
 	_, vpc := d.GetOk("vpc")
 

--- a/builtin/providers/cloudstack/resource_cloudstack_network.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_network.go
@@ -61,7 +61,7 @@ func resourceCloudStackNetwork() *schema.Resource {
 	}
 }
 
-func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	name := d.Get("name").(string)
@@ -130,7 +130,7 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 	return resourceCloudStackNetworkRead(d, meta)
 }
 
-func resourceCloudStackNetworkRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the virtual machine details
@@ -155,7 +155,7 @@ func resourceCloudStackNetworkRead(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceCloudStackNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkUpdate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	name := d.Get("name").(string)
 
@@ -199,7 +199,7 @@ func resourceCloudStackNetworkUpdate(d *schema.ResourceData, meta interface{}) e
 	return resourceCloudStackNetworkRead(d, meta)
 }
 
-func resourceCloudStackNetworkDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkDelete(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create a new parameter struct

--- a/builtin/providers/cloudstack/resource_cloudstack_network_acl.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_network_acl.go
@@ -38,7 +38,7 @@ func resourceCloudStackNetworkACL() *schema.Resource {
 	}
 }
 
-func resourceCloudStackNetworkACLCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkACLCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	name := d.Get("name").(string)
@@ -70,7 +70,7 @@ func resourceCloudStackNetworkACLCreate(d *schema.ResourceData, meta interface{}
 	return resourceCloudStackNetworkACLRead(d, meta)
 }
 
-func resourceCloudStackNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkACLRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the network ACL list details
@@ -100,7 +100,7 @@ func resourceCloudStackNetworkACLRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceCloudStackNetworkACLDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkACLDelete(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create a new parameter struct

--- a/builtin/providers/cloudstack/resource_cloudstack_network_acl_rule.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_network_acl_rule.go
@@ -93,7 +93,7 @@ func resourceCloudStackNetworkACLRule() *schema.Resource {
 	}
 }
 
-func resourceCloudStackNetworkACLRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkACLRuleCreate(d schema.ResourceData, meta interface{}) error {
 	// Make sure all required parameters are there
 	if err := verifyNetworkACLParams(d); err != nil {
 		return err
@@ -128,7 +128,7 @@ func resourceCloudStackNetworkACLRuleCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceCloudStackNetworkACLRuleCreateRule(
-	d *schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	uuids := rule["uuids"].(map[string]interface{})
 
@@ -213,7 +213,7 @@ func resourceCloudStackNetworkACLRuleCreateRule(
 	return nil
 }
 
-func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkACLRuleRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create an empty schema.Set to hold all rules
@@ -352,7 +352,7 @@ func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceCloudStackNetworkACLRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkACLRuleUpdate(d schema.ResourceData, meta interface{}) error {
 	// Make sure all required parameters are there
 	if err := verifyNetworkACLParams(d); err != nil {
 		return err
@@ -395,7 +395,7 @@ func resourceCloudStackNetworkACLRuleUpdate(d *schema.ResourceData, meta interfa
 	return resourceCloudStackNetworkACLRuleRead(d, meta)
 }
 
-func resourceCloudStackNetworkACLRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNetworkACLRuleDelete(d schema.ResourceData, meta interface{}) error {
 	// Delete all rules
 	if rs := d.Get("rule").(*schema.Set); rs.Len() > 0 {
 		for _, rule := range rs.List() {
@@ -415,7 +415,7 @@ func resourceCloudStackNetworkACLRuleDelete(d *schema.ResourceData, meta interfa
 }
 
 func resourceCloudStackNetworkACLRuleDeleteRule(
-	d *schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	uuids := rule["uuids"].(map[string]interface{})
 
@@ -489,7 +489,7 @@ func resourceCloudStackNetworkACLRuleHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func verifyNetworkACLParams(d *schema.ResourceData) error {
+func verifyNetworkACLParams(d schema.ResourceData) error {
 	managed := d.Get("managed").(bool)
 	_, rules := d.GetOk("rule")
 
@@ -501,7 +501,7 @@ func verifyNetworkACLParams(d *schema.ResourceData) error {
 	return nil
 }
 
-func verifyNetworkACLRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
+func verifyNetworkACLRuleParams(d schema.ResourceData, rule map[string]interface{}) error {
 	action := rule["action"].(string)
 	if action != "allow" && action != "deny" {
 		return fmt.Errorf("Parameter action only accepts 'allow' or 'deny' as values")

--- a/builtin/providers/cloudstack/resource_cloudstack_nic.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_nic.go
@@ -38,7 +38,7 @@ func resourceCloudStackNIC() *schema.Resource {
 	}
 }
 
-func resourceCloudStackNICCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNICCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Retrieve the network UUID
@@ -83,7 +83,7 @@ func resourceCloudStackNICCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceCloudStackNICRead(d, meta)
 }
 
-func resourceCloudStackNICRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNICRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the virtual machine details
@@ -118,7 +118,7 @@ func resourceCloudStackNICRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceCloudStackNICDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackNICDelete(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Retrieve the virtual_machine UUID

--- a/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
@@ -63,7 +63,7 @@ func resourceCloudStackPortForward() *schema.Resource {
 	}
 }
 
-func resourceCloudStackPortForwardCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackPortForwardCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Retrieve the ipaddress UUID
@@ -101,7 +101,7 @@ func resourceCloudStackPortForwardCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceCloudStackPortForwardCreateForward(
-	d *schema.ResourceData, meta interface{}, ipaddressid string, forward map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, ipaddressid string, forward map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Make sure all required parameters are there
@@ -132,7 +132,7 @@ func resourceCloudStackPortForwardCreateForward(
 	return nil
 }
 
-func resourceCloudStackPortForwardRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackPortForwardRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create an empty schema.Set to hold all forwards
@@ -189,7 +189,7 @@ func resourceCloudStackPortForwardRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceCloudStackPortForwardUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackPortForwardUpdate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Retrieve the ipaddress UUID
@@ -235,7 +235,7 @@ func resourceCloudStackPortForwardUpdate(d *schema.ResourceData, meta interface{
 	return resourceCloudStackPortForwardRead(d, meta)
 }
 
-func resourceCloudStackPortForwardDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackPortForwardDelete(d schema.ResourceData, meta interface{}) error {
 	// Delete all forwards
 	if rs := d.Get("forward").(*schema.Set); rs.Len() > 0 {
 		for _, forward := range rs.List() {
@@ -255,7 +255,7 @@ func resourceCloudStackPortForwardDelete(d *schema.ResourceData, meta interface{
 }
 
 func resourceCloudStackPortForwardDeleteForward(
-	d *schema.ResourceData, meta interface{}, forward map[string]interface{}) error {
+	d schema.ResourceData, meta interface{}, forward map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create the parameter struct
@@ -289,7 +289,7 @@ func resourceCloudStackPortForwardHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func verifyPortForwardParams(d *schema.ResourceData, forward map[string]interface{}) error {
+func verifyPortForwardParams(d schema.ResourceData, forward map[string]interface{}) error {
 	protocol := forward["protocol"].(string)
 	if protocol != "tcp" && protocol != "udp" {
 		return fmt.Errorf(

--- a/builtin/providers/cloudstack/resource_cloudstack_vpc.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_vpc.go
@@ -49,7 +49,7 @@ func resourceCloudStackVPC() *schema.Resource {
 	}
 }
 
-func resourceCloudStackVPCCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackVPCCreate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	name := d.Get("name").(string)
@@ -86,7 +86,7 @@ func resourceCloudStackVPCCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceCloudStackVPCRead(d, meta)
 }
 
-func resourceCloudStackVPCRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackVPCRead(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the VPC details
@@ -118,7 +118,7 @@ func resourceCloudStackVPCRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceCloudStackVPCUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackVPCUpdate(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Check if the name or display text is changed
@@ -145,7 +145,7 @@ func resourceCloudStackVPCUpdate(d *schema.ResourceData, meta interface{}) error
 	return resourceCloudStackVPCRead(d, meta)
 }
 
-func resourceCloudStackVPCDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudStackVPCDelete(d schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Create a new parameter struct

--- a/builtin/providers/consul/resource_consul_keys.go
+++ b/builtin/providers/consul/resource_consul_keys.go
@@ -83,7 +83,7 @@ func resourceConsulKeysHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func resourceConsulKeysCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceConsulKeysCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*consulapi.Client)
 	kv := client.KV()
 
@@ -150,7 +150,7 @@ func resourceConsulKeysCreate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
+func resourceConsulKeysRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*consulapi.Client)
 	kv := client.KV()
 
@@ -198,7 +198,7 @@ func resourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceConsulKeysDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceConsulKeysDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*consulapi.Client)
 	kv := client.KV()
 

--- a/builtin/providers/consul/resource_provider.go
+++ b/builtin/providers/consul/resource_provider.go
@@ -31,7 +31,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	var config Config
 	configRaw := d.Get("").(map[string]interface{})
 	if err := mapstructure.Decode(configRaw, &config); err != nil {

--- a/builtin/providers/consul/resource_provider_test.go
+++ b/builtin/providers/consul/resource_provider_test.go
@@ -19,7 +19,7 @@ func init() {
 	}
 
 	// Use the demo address for the acceptance tests
-	testAccProvider.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+	testAccProvider.ConfigureFunc = func(d schema.ResourceData) (interface{}, error) {
 		conf := consulapi.DefaultConfig()
 		conf.Address = "demo.consul.io:80"
 		return consulapi.NewClient(conf)

--- a/builtin/providers/digitalocean/provider.go
+++ b/builtin/providers/digitalocean/provider.go
@@ -27,7 +27,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Token: d.Get("token").(string),
 	}

--- a/builtin/providers/digitalocean/resource_digitalocean_domain.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_domain.go
@@ -31,7 +31,7 @@ func resourceDigitalOceanDomain() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDomainCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	// Build up our creation options
@@ -52,7 +52,7 @@ func resourceDigitalOceanDomainCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanDomainRead(d, meta)
 }
 
-func resourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	domain, err := client.RetrieveDomain(d.Id())
@@ -72,7 +72,7 @@ func resourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceDigitalOceanDomainDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	log.Printf("[INFO] Deleting Domain: %s", d.Id())

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -100,7 +100,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDropletCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	// Build up our creation options
@@ -160,7 +160,7 @@ func resourceDigitalOceanDropletCreate(d *schema.ResourceData, meta interface{})
 	return resourceDigitalOceanDropletRead(d, meta)
 }
 
-func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	// Retrieve the droplet properties for updating the state
@@ -204,7 +204,7 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletUpdate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	if d.HasChange("size") {
@@ -328,7 +328,7 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 	return resourceDigitalOceanDropletRead(d, meta)
 }
 
-func resourceDigitalOceanDropletDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	log.Printf("[INFO] Deleting droplet: %s", d.Id())
@@ -349,7 +349,7 @@ func resourceDigitalOceanDropletDelete(d *schema.ResourceData, meta interface{})
 }
 
 func WaitForDropletAttribute(
-	d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}) (interface{}, error) {
+	d schema.ResourceData, target string, pending []string, attribute string, meta interface{}) (interface{}, error) {
 	// Wait for the droplet so we can get the networking attributes
 	// that show up after a while
 	log.Printf(
@@ -371,7 +371,7 @@ func WaitForDropletAttribute(
 // TODO This function still needs a little more refactoring to make it
 // cleaner and more efficient
 func newDropletStateRefreshFunc(
-	d *schema.ResourceData, attribute string, meta interface{}) resource.StateRefreshFunc {
+	d schema.ResourceData, attribute string, meta interface{}) resource.StateRefreshFunc {
 	client := meta.(*digitalocean.Client)
 	return func() (interface{}, string, error) {
 		err := resourceDigitalOceanDropletRead(d, meta)
@@ -405,7 +405,7 @@ func newDropletStateRefreshFunc(
 }
 
 // Powers on the droplet and waits for it to be active
-func powerOnAndWait(d *schema.ResourceData, meta interface{}) error {
+func powerOnAndWait(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 	err := client.PowerOn(d.Id())
 

--- a/builtin/providers/digitalocean/resource_digitalocean_record.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record.go
@@ -65,7 +65,7 @@ func resourceDigitalOceanRecord() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	newRecord := digitalocean.CreateRecord{
@@ -89,7 +89,7 @@ func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanRecordRead(d, meta)
 }
 
-func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	rec, err := client.RetrieveRecord(d.Get("domain").(string), d.Id())
@@ -114,7 +114,7 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceDigitalOceanRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordUpdate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	var updateRecord digitalocean.UpdateRecord
@@ -131,7 +131,7 @@ func resourceDigitalOceanRecordUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanRecordRead(d, meta)
 }
 
-func resourceDigitalOceanRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*digitalocean.Client)
 
 	log.Printf(

--- a/builtin/providers/dnsimple/provider.go
+++ b/builtin/providers/dnsimple/provider.go
@@ -32,7 +32,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Email: d.Get("email").(string),
 		Token: d.Get("token").(string),

--- a/builtin/providers/dnsimple/resource_dnsimple_record.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record.go
@@ -59,7 +59,7 @@ func resourceDNSimpleRecord() *schema.Resource {
 	}
 }
 
-func resourceDNSimpleRecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSimpleRecordCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*dnsimple.Client)
 
 	// Create the new record
@@ -87,7 +87,7 @@ func resourceDNSimpleRecordCreate(d *schema.ResourceData, meta interface{}) erro
 	return resourceDNSimpleRecordRead(d, meta)
 }
 
-func resourceDNSimpleRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSimpleRecordRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*dnsimple.Client)
 
 	rec, err := client.RetrieveRecord(d.Get("domain").(string), d.Id())
@@ -111,7 +111,7 @@ func resourceDNSimpleRecordRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceDNSimpleRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSimpleRecordUpdate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*dnsimple.Client)
 
 	updateRecord := &dnsimple.ChangeRecord{}
@@ -142,7 +142,7 @@ func resourceDNSimpleRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 	return resourceDNSimpleRecordRead(d, meta)
 }
 
-func resourceDNSimpleRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSimpleRecordDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*dnsimple.Client)
 
 	log.Printf("[INFO] Deleting record: %s, %s", d.Get("domain").(string), d.Id())

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -44,7 +44,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		AccountFile: d.Get("account_file").(string),
 		Project:     d.Get("project").(string),

--- a/builtin/providers/google/resource_compute_address.go
+++ b/builtin/providers/google/resource_compute_address.go
@@ -32,12 +32,11 @@ func resourceComputeAddress() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 		},
 	}
 }
 
-func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeAddressCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Build the address parameter
@@ -79,7 +78,7 @@ func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) erro
 	return resourceComputeAddressRead(d, meta)
 }
 
-func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeAddressRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	addr, err := config.clientCompute.Addresses.Get(
@@ -101,7 +100,7 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceComputeAddressDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeAddressDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the address

--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -50,7 +50,7 @@ func resourceComputeDisk() *schema.Resource {
 	}
 }
 
-func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeDiskCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Get the zone
@@ -129,7 +129,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceComputeDiskRead(d, meta)
 }
 
-func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeDiskRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	_, err := config.clientCompute.Disks.Get(
@@ -148,7 +148,7 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeDiskDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the disk

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -108,7 +108,7 @@ func resourceComputeFirewallAllowHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeFirewallCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	firewall, err := resourceFirewall(d, meta)
@@ -151,7 +151,7 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceComputeFirewallRead(d, meta)
 }
 
-func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeFirewallRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	_, err := config.clientCompute.Firewalls.Get(
@@ -170,7 +170,7 @@ func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeFirewallUpdate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	d.Partial(true)
@@ -211,7 +211,7 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 	return resourceComputeFirewallRead(d, meta)
 }
 
-func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeFirewallDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the firewall
@@ -246,7 +246,7 @@ func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceFirewall(
-	d *schema.ResourceData,
+	d schema.ResourceData,
 	meta interface{}) (*compute.Firewall, error) {
 	config := meta.(*Config)
 

--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -64,16 +64,16 @@ func resourceComputeForwardingRule() *schema.Resource {
 	}
 }
 
-func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeForwardingRuleCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	frule := &compute.ForwardingRule{
-		IPAddress:  d.Get("ip_address").(string),
-		IPProtocol: d.Get("ip_protocol").(string),
+		IPAddress:   d.Get("ip_address").(string),
+		IPProtocol:  d.Get("ip_protocol").(string),
 		Description: d.Get("description").(string),
-		Name: d.Get("name").(string),
-		PortRange: d.Get("port_range").(string),
-		Target: d.Get("target").(string),
+		Name:        d.Get("name").(string),
+		PortRange:   d.Get("port_range").(string),
+		Target:      d.Get("target").(string),
 	}
 
 	log.Printf("[DEBUG] ForwardingRule insert request: %#v", frule)
@@ -113,7 +113,7 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 	return resourceComputeForwardingRuleRead(d, meta)
 }
 
-func resourceComputeForwardingRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeForwardingRuleUpdate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	d.Partial(true)
@@ -158,7 +158,7 @@ func resourceComputeForwardingRuleUpdate(d *schema.ResourceData, meta interface{
 	return resourceComputeForwardingRuleRead(d, meta)
 }
 
-func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeForwardingRuleRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	frule, err := config.clientCompute.ForwardingRules.Get(
@@ -181,7 +181,7 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceComputeForwardingRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeForwardingRuleDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the ForwardingRule
@@ -216,4 +216,3 @@ func resourceComputeForwardingRuleDelete(d *schema.ResourceData, meta interface{
 	d.SetId("")
 	return nil
 }
-

--- a/builtin/providers/google/resource_compute_forwarding_rule_test.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule_test.go
@@ -122,4 +122,3 @@ resource "google_compute_forwarding_rule" "foobar" {
     target = "${google_compute_target_pool.foobar-tp.self_link}"
 }
 `
-

--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -80,14 +80,14 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 	}
 }
 
-func resourceComputeHttpHealthCheckCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeHttpHealthCheckCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Build the parameter
 	hchk := &compute.HttpHealthCheck{
 		Description: d.Get("description").(string),
-		Host: d.Get("host").(string),
-		Name: d.Get("name").(string),
+		Host:        d.Get("host").(string),
+		Name:        d.Get("name").(string),
 		RequestPath: d.Get("request_path").(string),
 	}
 	if d.Get("check_interval_sec") != nil {
@@ -142,14 +142,14 @@ func resourceComputeHttpHealthCheckCreate(d *schema.ResourceData, meta interface
 	return resourceComputeHttpHealthCheckRead(d, meta)
 }
 
-func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeHttpHealthCheckUpdate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Build the parameter
 	hchk := &compute.HttpHealthCheck{
 		Description: d.Get("description").(string),
-		Host: d.Get("host").(string),
-		Name: d.Get("name").(string),
+		Host:        d.Get("host").(string),
+		Name:        d.Get("name").(string),
 		RequestPath: d.Get("request_path").(string),
 	}
 	if d.Get("check_interval_sec") != nil {
@@ -204,7 +204,7 @@ func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface
 	return resourceComputeHttpHealthCheckRead(d, meta)
 }
 
-func resourceComputeHttpHealthCheckRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeHttpHealthCheckRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	hchk, err := config.clientCompute.HttpHealthChecks.Get(
@@ -225,7 +225,7 @@ func resourceComputeHttpHealthCheckRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceComputeHttpHealthCheckDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeHttpHealthCheckDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the HttpHealthCheck

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -197,7 +197,7 @@ func resourceComputeInstance() *schema.Resource {
 	}
 }
 
-func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeInstanceCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Get the zone
@@ -381,7 +381,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceComputeInstanceRead(d, meta)
 }
 
-func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeInstanceRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	instance, err := config.clientCompute.Instances.Get(
@@ -444,7 +444,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeInstanceUpdate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Enable partial mode for the resource since it is possible
@@ -521,7 +521,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	return resourceComputeInstanceRead(d, meta)
 }
 
-func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeInstanceDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	op, err := config.clientCompute.Instances.Delete(
@@ -556,7 +556,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceInstanceMetadata(d *schema.ResourceData) *compute.Metadata {
+func resourceInstanceMetadata(d schema.ResourceData) *compute.Metadata {
 	var metadata *compute.Metadata
 	if metadataList := d.Get("metadata").([]interface{}); len(metadataList) > 0 {
 		m := new(compute.Metadata)
@@ -585,7 +585,7 @@ func resourceInstanceMetadata(d *schema.ResourceData) *compute.Metadata {
 	return metadata
 }
 
-func resourceInstanceTags(d *schema.ResourceData) *compute.Tags {
+func resourceInstanceTags(d schema.ResourceData) *compute.Tags {
 	// Calculate the tags
 	var tags *compute.Tags
 	if v := d.Get("tags"); v != nil {

--- a/builtin/providers/google/resource_compute_network.go
+++ b/builtin/providers/google/resource_compute_network.go
@@ -37,7 +37,7 @@ func resourceComputeNetwork() *schema.Resource {
 	}
 }
 
-func resourceComputeNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeNetworkCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Build the network parameter
@@ -81,7 +81,7 @@ func resourceComputeNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	return resourceComputeNetworkRead(d, meta)
 }
 
-func resourceComputeNetworkRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeNetworkRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	network, err := config.clientCompute.Networks.Get(
@@ -102,7 +102,7 @@ func resourceComputeNetworkRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceComputeNetworkDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeNetworkDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the network

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -84,7 +84,7 @@ func resourceComputeRoute() *schema.Resource {
 	}
 }
 
-func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeRouteCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Look up the network to attach the route to
@@ -180,7 +180,7 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 	return resourceComputeRouteRead(d, meta)
 }
 
-func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeRouteRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	_, err := config.clientCompute.Routes.Get(
@@ -199,7 +199,7 @@ func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceComputeRouteDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeRouteDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the route

--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -72,11 +72,11 @@ func resourceComputeTargetPool() *schema.Resource {
 }
 
 func convertStringArr(ifaceArr []interface{}) []string {
-    arr := make([]string, len(ifaceArr))
-    for i, v := range ifaceArr {
-        arr[i] = v.(string)
-    }
-    return arr
+	arr := make([]string, len(ifaceArr))
+	for i, v := range ifaceArr {
+		arr[i] = v.(string)
+	}
+	return arr
 }
 
 func waitOp(config *Config, op *compute.Operation,
@@ -134,7 +134,7 @@ func convertInstances(config *Config, names []string) ([]string, error) {
 	return urls, nil
 }
 
-func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeTargetPoolCreate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	hchkUrls, err := convertHealthChecks(
@@ -151,11 +151,11 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 
 	// Build the parameter
 	tpool := &compute.TargetPool{
-		BackupPool: d.Get("backup_pool").(string),
-		Description: d.Get("description").(string),
-		HealthChecks: hchkUrls,
-		Instances:  instanceUrls,
-		Name: d.Get("name").(string),
+		BackupPool:      d.Get("backup_pool").(string),
+		Description:     d.Get("description").(string),
+		HealthChecks:    hchkUrls,
+		Instances:       instanceUrls,
+		Name:            d.Get("name").(string),
 		SessionAffinity: d.Get("session_affinity").(string),
 	}
 	if d.Get("failover_ratio") != nil {
@@ -215,8 +215,7 @@ func calcAddRemove(from []string, to []string) ([]string, []string) {
 	return add, remove
 }
 
-
-func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeTargetPoolUpdate(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	d.Partial(true)
@@ -360,7 +359,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 	return resourceComputeTargetPoolRead(d, meta)
 }
 
-func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeTargetPoolRead(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	tpool, err := config.clientCompute.TargetPools.Get(
@@ -381,7 +380,7 @@ func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeTargetPoolDelete(d schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	// Delete the TargetPool

--- a/builtin/providers/heroku/provider.go
+++ b/builtin/providers/heroku/provider.go
@@ -36,7 +36,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Email:  d.Get("email").(string),
 		APIKey: d.Get("api_key").(string),

--- a/builtin/providers/heroku/resource_heroku_addon.go
+++ b/builtin/providers/heroku/resource_heroku_addon.go
@@ -57,7 +57,7 @@ func resourceHerokuAddon() *schema.Resource {
 	}
 }
 
-func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAddonCreate(d schema.ResourceData, meta interface{}) error {
 	addonLock.Lock()
 	defer addonLock.Unlock()
 
@@ -89,7 +89,7 @@ func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceHerokuAddonRead(d, meta)
 }
 
-func resourceHerokuAddonRead(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAddonRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	addon, err := resourceHerokuAddonRetrieve(
@@ -119,7 +119,7 @@ func resourceHerokuAddonRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceHerokuAddonUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAddonUpdate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)
@@ -138,7 +138,7 @@ func resourceHerokuAddonUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceHerokuAddonRead(d, meta)
 }
 
-func resourceHerokuAddonDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAddonDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	log.Printf("[INFO] Deleting Addon: %s", d.Id())

--- a/builtin/providers/heroku/resource_heroku_app.go
+++ b/builtin/providers/heroku/resource_heroku_app.go
@@ -122,7 +122,7 @@ func resourceHerokuApp() *schema.Resource {
 	}
 }
 
-func switchHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {
+func switchHerokuAppCreate(d schema.ResourceData, meta interface{}) error {
 	orgCount := d.Get("organization.#").(int)
 	if orgCount > 1 {
 		return fmt.Errorf("Error Creating Heroku App: Only 1 Heroku Organization is permitted")
@@ -135,7 +135,7 @@ func switchHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 }
 
-func resourceHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAppCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	// Build up our creation options
@@ -176,7 +176,7 @@ func resourceHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceHerokuAppRead(d, meta)
 }
 
-func resourceHerokuOrgAppCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuOrgAppCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 	// Build up our creation options
 	opts := heroku.OrganizationAppCreateOpts{}
@@ -234,7 +234,7 @@ func resourceHerokuOrgAppCreate(d *schema.ResourceData, meta interface{}) error 
 	return resourceHerokuAppRead(d, meta)
 }
 
-func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAppRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 	app, err := resourceHerokuAppRetrieve(d.Id(), client)
 	if err != nil {
@@ -275,7 +275,7 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceHerokuAppUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAppUpdate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	// If name changed, update it
@@ -314,7 +314,7 @@ func resourceHerokuAppUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceHerokuAppRead(d, meta)
 }
 
-func resourceHerokuAppDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuAppDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	log.Printf("[INFO] Deleting App: %s", d.Id())

--- a/builtin/providers/heroku/resource_heroku_cert.go
+++ b/builtin/providers/heroku/resource_heroku_cert.go
@@ -45,7 +45,7 @@ func resourceHerokuCert() *schema.Resource {
 	}
 }
 
-func resourceHerokuCertCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuCertCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)
@@ -67,7 +67,7 @@ func resourceHerokuCertCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceHerokuCertRead(d, meta)
 }
 
-func resourceHerokuCertRead(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuCertRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	cert, err := resourceHerokuSSLCertRetrieve(
@@ -83,7 +83,7 @@ func resourceHerokuCertRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceHerokuCertUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuCertUpdate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)
@@ -108,7 +108,7 @@ func resourceHerokuCertUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceHerokuCertRead(d, meta)
 }
 
-func resourceHerokuCertDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuCertDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	log.Printf("[INFO] Deleting SSL Cert: %s", d.Id())

--- a/builtin/providers/heroku/resource_heroku_cert_test.go
+++ b/builtin/providers/heroku/resource_heroku_cert_test.go
@@ -2,9 +2,9 @@ package heroku
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
-    "os"
-    "io/ioutil"
 
 	"github.com/cyberdelia/heroku-go/v3"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -13,11 +13,11 @@ import (
 
 func TestAccHerokuCert_Basic(t *testing.T) {
 	var endpoint heroku.SSLEndpoint
-    wd, _ := os.Getwd()
-    certificateChainFile := wd + "/test-fixtures/terraform.cert"
-    certificateChainBytes, _ := ioutil.ReadFile(certificateChainFile)
-    certificateChain := string(certificateChainBytes)
-    testAccCheckHerokuCertConfig_basic := `
+	wd, _ := os.Getwd()
+	certificateChainFile := wd + "/test-fixtures/terraform.cert"
+	certificateChainBytes, _ := ioutil.ReadFile(certificateChainFile)
+	certificateChain := string(certificateChainBytes)
+	testAccCheckHerokuCertConfig_basic := `
     resource "heroku_app" "foobar" {
         name = "terraform-test-cert-app"
         region = "eu"
@@ -47,7 +47,7 @@ func TestAccHerokuCert_Basic(t *testing.T) {
 					testAccCheckHerokuCertExists("heroku_cert.ssl_certificate", &endpoint),
 					testAccCheckHerokuCertificateChain(&endpoint, certificateChain),
 					resource.TestCheckResourceAttr(
-                        "heroku_cert.ssl_certificate", "cname", "terraform-test-cert-app.herokuapp.com"),
+						"heroku_cert.ssl_certificate", "cname", "terraform-test-cert-app.herokuapp.com"),
 				),
 			},
 		},
@@ -112,5 +112,3 @@ func testAccCheckHerokuCertExists(n string, endpoint *heroku.SSLEndpoint) resour
 		return nil
 	}
 }
-
-

--- a/builtin/providers/heroku/resource_heroku_domain.go
+++ b/builtin/providers/heroku/resource_heroku_domain.go
@@ -35,7 +35,7 @@ func resourceHerokuDomain() *schema.Resource {
 	}
 }
 
-func resourceHerokuDomainCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuDomainCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)
@@ -56,7 +56,7 @@ func resourceHerokuDomainCreate(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceHerokuDomainDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuDomainDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	log.Printf("[INFO] Deleting Domain: %s", d.Id())
@@ -70,7 +70,7 @@ func resourceHerokuDomainDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceHerokuDomainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuDomainRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)

--- a/builtin/providers/heroku/resource_heroku_drain.go
+++ b/builtin/providers/heroku/resource_heroku_drain.go
@@ -35,7 +35,7 @@ func resourceHerokuDrain() *schema.Resource {
 	}
 }
 
-func resourceHerokuDrainCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuDrainCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)
@@ -56,7 +56,7 @@ func resourceHerokuDrainCreate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceHerokuDrainDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuDrainDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	log.Printf("[INFO] Deleting drain: %s", d.Id())
@@ -70,7 +70,7 @@ func resourceHerokuDrainDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceHerokuDrainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceHerokuDrainRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	dr, err := client.LogDrainInfo(d.Get("app").(string), d.Id())

--- a/builtin/providers/mailgun/provider.go
+++ b/builtin/providers/mailgun/provider.go
@@ -26,7 +26,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d schema.ResourceData) (interface{}, error) {
 	config := Config{
 		APIKey: d.Get("api_key").(string),
 	}

--- a/builtin/providers/mailgun/resource_mailgun_domain.go
+++ b/builtin/providers/mailgun/resource_mailgun_domain.go
@@ -100,7 +100,7 @@ func resourceMailgunDomain() *schema.Resource {
 	}
 }
 
-func resourceMailgunDomainCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceMailgunDomainCreate(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*mailgun.Client)
 
 	opts := mailgun.CreateDomain{}
@@ -132,7 +132,7 @@ func resourceMailgunDomainCreate(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceMailgunDomainDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceMailgunDomainDelete(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*mailgun.Client)
 
 	log.Printf("[INFO] Deleting Domain: %s", d.Id())
@@ -146,7 +146,7 @@ func resourceMailgunDomainDelete(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceMailgunDomainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceMailgunDomainRead(d schema.ResourceData, meta interface{}) error {
 	client := meta.(*mailgun.Client)
 
 	_, err := resourceMailginDomainRetrieve(d.Id(), client, d)
@@ -158,7 +158,7 @@ func resourceMailgunDomainRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceMailginDomainRetrieve(id string, client *mailgun.Client, d *schema.ResourceData) (*mailgun.DomainResponse, error) {
+func resourceMailginDomainRetrieve(id string, client *mailgun.Client, d schema.ResourceData) (*mailgun.DomainResponse, error) {
 	resp, err := client.RetrieveDomain(id)
 
 	if err != nil {

--- a/builtin/providers/null/resource.go
+++ b/builtin/providers/null/resource.go
@@ -23,20 +23,20 @@ func resource() *schema.Resource {
 	}
 }
 
-func resourceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCreate(d schema.ResourceData, meta interface{}) error {
 	d.SetId(fmt.Sprintf("%d", rand.Int()))
 	return nil
 }
 
-func resourceRead(d *schema.ResourceData, meta interface{}) error {
+func resourceRead(d schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceUpdate(d schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDelete(d schema.ResourceData, meta interface{}) error {
 	d.SetId("")
 	return nil
 }

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -48,7 +48,7 @@ type Provider struct {
 // the subsequent resources as the meta parameter. This return value is
 // usually used to pass along a configured API client, a configuration
 // structure, etc.
-type ConfigureFunc func(*ResourceData) (interface{}, error)
+type ConfigureFunc func(ResourceData) (interface{}, error)
 
 // InternalValidate should be called to validate the structure
 // of the provider.

--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -34,7 +34,7 @@ func TestProviderConfigure(t *testing.T) {
 					},
 				},
 
-				ConfigureFunc: func(d *ResourceData) (interface{}, error) {
+				ConfigureFunc: func(d ResourceData) (interface{}, error) {
 					if d.Get("foo").(int) == 42 {
 						return nil, nil
 					}
@@ -57,7 +57,7 @@ func TestProviderConfigure(t *testing.T) {
 					},
 				},
 
-				ConfigureFunc: func(d *ResourceData) (interface{}, error) {
+				ConfigureFunc: func(d ResourceData) (interface{}, error) {
 					if d.Get("foo").(int) == 42 {
 						return nil, nil
 					}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -55,19 +55,19 @@ type Resource struct {
 }
 
 // See Resource documentation.
-type CreateFunc func(*ResourceData, interface{}) error
+type CreateFunc func(ResourceData, interface{}) error
 
 // See Resource documentation.
-type ReadFunc func(*ResourceData, interface{}) error
+type ReadFunc func(ResourceData, interface{}) error
 
 // See Resource documentation.
-type UpdateFunc func(*ResourceData, interface{}) error
+type UpdateFunc func(ResourceData, interface{}) error
 
 // See Resource documentation.
-type DeleteFunc func(*ResourceData, interface{}) error
+type DeleteFunc func(ResourceData, interface{}) error
 
 // See Resource documentation.
-type ExistsFunc func(*ResourceData, interface{}) (bool, error)
+type ExistsFunc func(ResourceData, interface{}) (bool, error)
 
 // Apply creates, updates, and/or deletes a resource.
 func (r *Resource) Apply(

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -648,10 +648,9 @@ func TestResourceDataGet(t *testing.T) {
 
 			State: &terraform.InstanceState{
 				Attributes: map[string]string{
-					"ratio":        "0.5",
+					"ratio": "0.5",
 				},
 			},
-
 
 			Diff: nil,
 
@@ -672,10 +671,9 @@ func TestResourceDataGet(t *testing.T) {
 
 			State: &terraform.InstanceState{
 				Attributes: map[string]string{
-					"ratio":        "-0.5",
+					"ratio": "-0.5",
 				},
 			},
-
 
 			Diff: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
@@ -685,7 +683,6 @@ func TestResourceDataGet(t *testing.T) {
 					},
 				},
 			},
-
 
 			Key: "ratio",
 
@@ -1533,7 +1530,6 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ratios",
 			GetValue: []interface{}{1.0, 2.2, 5.5},
 		},
-
 	}
 
 	for i, tc := range cases {
@@ -2544,7 +2540,7 @@ func TestResourceDataState(t *testing.T) {
 }
 
 func TestResourceDataSetConnInfo(t *testing.T) {
-	d := &ResourceData{}
+	d := &resourceData{}
 	d.SetId("foo")
 	d.SetConnInfo(map[string]string{
 		"foo": "bar",
@@ -2561,7 +2557,7 @@ func TestResourceDataSetConnInfo(t *testing.T) {
 }
 
 func TestResourceDataSetId(t *testing.T) {
-	d := &ResourceData{}
+	d := &resourceData{}
 	d.SetId("foo")
 
 	actual := d.State()
@@ -2571,7 +2567,7 @@ func TestResourceDataSetId(t *testing.T) {
 }
 
 func TestResourceDataSetId_clear(t *testing.T) {
-	d := &ResourceData{
+	d := &resourceData{
 		state: &terraform.InstanceState{ID: "bar"},
 	}
 	d.SetId("")
@@ -2583,7 +2579,7 @@ func TestResourceDataSetId_clear(t *testing.T) {
 }
 
 func TestResourceDataSetId_override(t *testing.T) {
-	d := &ResourceData{
+	d := &resourceData{
 		state: &terraform.InstanceState{ID: "bar"},
 	}
 	d.SetId("foo")

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -19,7 +19,7 @@ func TestResourceApply_create(t *testing.T) {
 	}
 
 	called := false
-	r.Create = func(d *ResourceData, m interface{}) error {
+	r.Create = func(d ResourceData, m interface{}) error {
 		called = true
 		d.SetId("foo")
 		return nil
@@ -68,7 +68,7 @@ func TestResourceApply_destroy(t *testing.T) {
 	}
 
 	called := false
-	r.Delete = func(d *ResourceData, m interface{}) error {
+	r.Delete = func(d ResourceData, m interface{}) error {
 		called = true
 		return nil
 	}
@@ -112,12 +112,12 @@ func TestResourceApply_destroyCreate(t *testing.T) {
 	}
 
 	change := false
-	r.Create = func(d *ResourceData, m interface{}) error {
+	r.Create = func(d ResourceData, m interface{}) error {
 		change = d.HasChange("tags")
 		d.SetId("foo")
 		return nil
 	}
-	r.Delete = func(d *ResourceData, m interface{}) error {
+	r.Delete = func(d ResourceData, m interface{}) error {
 		return nil
 	}
 
@@ -177,7 +177,7 @@ func TestResourceApply_destroyPartial(t *testing.T) {
 		},
 	}
 
-	r.Delete = func(d *ResourceData, m interface{}) error {
+	r.Delete = func(d ResourceData, m interface{}) error {
 		d.Set("foo", 42)
 		return fmt.Errorf("some error")
 	}
@@ -221,7 +221,7 @@ func TestResourceApply_update(t *testing.T) {
 		},
 	}
 
-	r.Update = func(d *ResourceData, m interface{}) error {
+	r.Update = func(d ResourceData, m interface{}) error {
 		d.Set("foo", 42)
 		return nil
 	}
@@ -346,7 +346,7 @@ func TestResourceRefresh(t *testing.T) {
 		},
 	}
 
-	r.Read = func(d *ResourceData, m interface{}) error {
+	r.Read = func(d ResourceData, m interface{}) error {
 		if m != 42 {
 			return fmt.Errorf("meta not passed")
 		}
@@ -389,7 +389,7 @@ func TestResourceRefresh_delete(t *testing.T) {
 		},
 	}
 
-	r.Read = func(d *ResourceData, m interface{}) error {
+	r.Read = func(d ResourceData, m interface{}) error {
 		d.SetId("")
 		return nil
 	}
@@ -421,11 +421,11 @@ func TestResourceRefresh_existsError(t *testing.T) {
 		},
 	}
 
-	r.Exists = func(*ResourceData, interface{}) (bool, error) {
+	r.Exists = func(ResourceData, interface{}) (bool, error) {
 		return false, fmt.Errorf("error")
 	}
 
-	r.Read = func(d *ResourceData, m interface{}) error {
+	r.Read = func(d ResourceData, m interface{}) error {
 		panic("shouldn't be called")
 	}
 
@@ -455,11 +455,11 @@ func TestResourceRefresh_noExists(t *testing.T) {
 		},
 	}
 
-	r.Exists = func(*ResourceData, interface{}) (bool, error) {
+	r.Exists = func(ResourceData, interface{}) (bool, error) {
 		return false, nil
 	}
 
-	r.Read = func(d *ResourceData, m interface{}) error {
+	r.Read = func(d ResourceData, m interface{}) error {
 		panic("shouldn't be called")
 	}
 

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -259,8 +259,8 @@ type schemaMap map[string]*Schema
 // The diff is optional.
 func (m schemaMap) Data(
 	s *terraform.InstanceState,
-	d *terraform.InstanceDiff) (*ResourceData, error) {
-	return &ResourceData{
+	d *terraform.InstanceDiff) (*resourceData, error) {
+	return &resourceData{
 		schema: m,
 		state:  s,
 		diff:   d,
@@ -275,7 +275,7 @@ func (m schemaMap) Diff(
 	result := new(terraform.InstanceDiff)
 	result.Attributes = make(map[string]*terraform.ResourceAttrDiff)
 
-	d := &ResourceData{
+	d := &resourceData{
 		schema: m,
 		state:  s,
 		config: c,
@@ -501,8 +501,7 @@ func (m schemaMap) diff(
 	k string,
 	schema *Schema,
 	diff *terraform.InstanceDiff,
-	d *ResourceData,
-	all bool) error {
+	d *resourceData, all bool) error {
 	var err error
 	switch schema.Type {
 	case TypeBool:
@@ -530,8 +529,7 @@ func (m schemaMap) diffList(
 	k string,
 	schema *Schema,
 	diff *terraform.InstanceDiff,
-	d *ResourceData,
-	all bool) error {
+	d *resourceData, all bool) error {
 	o, n, _, computedList := d.diffChange(k)
 	if computedList {
 		n = nil
@@ -648,8 +646,7 @@ func (m schemaMap) diffMap(
 	k string,
 	schema *Schema,
 	diff *terraform.InstanceDiff,
-	d *ResourceData,
-	all bool) error {
+	d *resourceData, all bool) error {
 	prefix := k + "."
 
 	// First get all the values from the state
@@ -730,8 +727,7 @@ func (m schemaMap) diffSet(
 	k string,
 	schema *Schema,
 	diff *terraform.InstanceDiff,
-	d *ResourceData,
-	all bool) error {
+	d *resourceData, all bool) error {
 	o, n, _, computedSet := d.diffChange(k)
 	if computedSet {
 		n = nil
@@ -844,8 +840,7 @@ func (m schemaMap) diffString(
 	k string,
 	schema *Schema,
 	diff *terraform.InstanceDiff,
-	d *ResourceData,
-	all bool) error {
+	d *resourceData, all bool) error {
 	var originalN interface{}
 	var os, ns string
 	o, n, _, _ := d.diffChange(k)


### PR DESCRIPTION
This will ease the implementation of mock ResourceData providers for
unit testing providers. Resolves #890.

This requires that providers change their function signatures slightly,
which can be accomplished with gofmt:

    gofmt -r '*schema.ResourceData -> schema.ResourceData' -w ./

I wasn't sure if it was possible (or desirable) to preserve the previous
provider function signatures (with a pointer), but this way seems like
more idiomatic go and the change is trivial with gofmt.