### PR TITLE
config/module: fix HgGetter test failures on Windows

### DIFF
--- a/config/module/url_helper.go
+++ b/config/module/url_helper.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 func urlParse(rawURL string) (*url.URL, error) {
@@ -28,6 +29,13 @@ func urlParse(rawURL string) (*url.URL, error) {
 		// and URL path = "/users/user".
 		u.Path = fmt.Sprintf("%s:%s", u.Scheme, u.Path)
 		u.Scheme = ""
+	}
+
+	if len(u.Host) > 1 && u.Host[1] == ':' && strings.HasPrefix(rawURL, "file://") {
+		// Assume we're dealing with a drive letter file path on Windows
+		// where the drive letter has been parsed into the URL Host.
+		u.Path = fmt.Sprintf("%s%s", u.Host, u.Path)
+		u.Host = ""
 	}
 
 	// Remove leading slash for absolute file paths on Windows.


### PR DESCRIPTION
HgGetter tests failed on windows/amd64 using Mercurial version 3.2.4:
```
--- FAIL: TestHgGetter (0.11s)
        get_hg_test.go:35: err: C:\Program Files\Mercurial\hg.exe exited with 255: abort: file:// URLs can only refer to localhost
--- FAIL: TestHgGetter_branch (0.11s)
        get_hg_test.go:62: err: C:\Program Files\Mercurial\hg.exe exited with 255: abort: file:// URLs can only refer to localhost
FAIL
FAIL    github.com/hashicorp/terraform/config/module    5.615s
```
This commit fixes the failures by adjusting the file:// URL to a form that Mercurial expects.

Handling Windows file paths is getting more ugly. Is it a bad choice to strip the leading '/' in [config/module/url_helper.go:33](https://github.com/hashicorp/terraform/blob/5bbfc0d4e2c27aabdc3d9d7c0bbe21411d10c3f9/config/module/url_helper.go#L33-L38) after all?

/cc @mitchellh