### PR TITLE
Remove 'go get ... vet' from updatedeps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ testrace: generate
 updatedeps:
 	go get -u github.com/mitchellh/gox
 	go get -u golang.org/x/tools/cmd/stringer
-	go get -u golang.org/x/tools/cmd/vet
 	go list ./... \
 		| xargs go list -f '{{join .Deps "\n"}}' \
 		| grep -v github.com/hashicorp/terraform \


### PR DESCRIPTION
Remove 'go get ... vet' from updatedeps target

This package attempts to install itself to GOROOT which will fail for
non-root users. Most users will have already installed the vet tool via a
system package, so it shouldn't be necessary to 'go get' here.

Moreover, the 'vet' make target already checks that it is installed before
running it, running 'go get' if necessary.

This is the output when running 'make updatedeps' as a regular user
without this change:

```
$ make updatedeps
go get -u github.com/mitchellh/gox
go get -u golang.org/x/tools/cmd/stringer
go get -u golang.org/x/tools/cmd/vet
go install golang.org/x/tools/cmd/vet: open /usr/local/go/pkg/tool/linux_amd64/vet: permission denied
make: *** [updatedeps] Error 1
```