### PR TITLE
Remove service_accounts (legacy dupe of service_account)

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -109,30 +109,6 @@ func resourceComputeInstance() *schema.Resource {
 				},
 			},
 
-			"service_accounts": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"email": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-
-						"scopes": &schema.Schema{
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-
 			"can_ip_forward": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,


### PR DESCRIPTION
#588 contained an original implementation of service acconts (service_accounts attribute)
#725 contained another implementation (service_account) which was merged first and conflicted with mine
I removed my implementation from 588 but forgot to remove this part until now.