### PR TITLE
helper/schema: fix DiffFieldReader map handling

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -180,6 +180,8 @@ func TestAccInstance_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
 					testAccCheckTags(&v.Tags, "foo", "bar"),
+					// Guard against regression of https://github.com/hashicorp/terraform/issues/914
+					testAccCheckTags(&v.Tags, "#", ""),
 				),
 			},
 

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -82,6 +82,11 @@ func (r *DiffFieldReader) readMap(
 		if !strings.HasPrefix(k, prefix) {
 			continue
 		}
+		if strings.HasPrefix(k, prefix+"#") {
+			// Ignore the count field
+			continue
+		}
+
 		resultSet = true
 
 		k = k[len(prefix):]

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -153,8 +153,8 @@ func (r *DiffFieldReader) readSet(
 		if !strings.HasPrefix(k, prefix) {
 			continue
 		}
-		if strings.HasPrefix(k, prefix+"#") {
-			// Ignore the count field
+		if strings.HasSuffix(k, "#") {
+			// Ignore any count field
 			continue
 		}
 


### PR DESCRIPTION
An `InstanceDiff` will include `ResourceAttrDiff` entries for the
"length" / `#` field of maps. This makes sense, since for something like
`terraform plan` it's useful to see when counts are changing.

The `DiffFieldReader` was not taking these entries into account when
reading maps out, and was therefore incorrectly returning maps that
included an extra `'#'` field, which was causing all sorts of havoc
for providers (extra tags on AWS instances, broken google compute
instance launch, possibly others).

 * fixes #914 - extra tags on AWS instances
 * fixes #883 - general core issue sprouted from #757
 * removes the hack+TODO from #757