### PR TITLE
providers/aws: read ASG termination policies

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -197,6 +197,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("max_size", g.MaxSize)
 	d.Set("name", g.Name)
 	d.Set("vpc_zone_identifier", strings.Split(g.VPCZoneIdentifier, ","))
+	d.Set("termination_policies", g.TerminationPolicies)
 
 	return nil
 }


### PR DESCRIPTION
Right now we yield a perpetual diff on ASGs because we're not reading
termination policies back out in the provider.

This depends on https://github.com/mitchellh/goamz/pull/218 and fixes
it.