### PR TITLE
terraform: add block_device support to resource_aws_launch_configuration

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -95,6 +95,17 @@ func testAccCheckAWSLaunchConfigurationAttributes(conf *autoscaling.LaunchConfig
 			return fmt.Errorf("Bad instance_type: %s", conf.InstanceType)
 		}
 
+		// Map out the block devices by name, which should be unique.
+		blockDevices := make(map[string]autoscaling.BlockDeviceMapping)
+		for _, blockDevice := range conf.BlockDevices {
+			blockDevices[blockDevice.DeviceName] = blockDevice
+		}
+
+		// Check if the secondary block device exists.
+		if _, ok := blockDevices["/dev/sdb"]; !ok {
+			return fmt.Errorf("block device doesn't exist: /dev/sdb")
+		}
+
 		return nil
 	}
 }
@@ -139,6 +150,11 @@ resource "aws_launch_configuration" "bar" {
   instance_type = "t1.micro"
   user_data = "foobar-user-data"
   associate_public_ip_address = true
+  block_device {
+    device_name = "/dev/sdb"
+    volume_type = "gp2"
+    volume_size = 10
+  }
 }
 `
 

--- a/website/source/docs/providers/aws/r/launch_config.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_config.html.markdown
@@ -32,6 +32,17 @@ The following arguments are supported:
 * `key_name` - (Optional) The key name that should be used for the instance.
 * `security_groups` - (Optional) A list of associated security group IDS.
 * `user_data` - (Optional) The user data to provide when launching the instance.
+* `block_device_mapping` - (Optional) A list of block devices to add. Their keys are documented below.
+
+Each `block_device_mapping` supports the following:
+
+* `device_name` - The name of the device to mount.
+* `virtual_name` - (Optional) The virtual device name.
+* `snapshot_id` - (Optional) The Snapshot ID to mount.
+* `volume_type` - (Optional) The type of volume. Can be standard, gp2, or io1. Defaults to standard.
+* `volume_size` - (Optional) The size of the volume in gigabytes.
+* `delete_on_termination` - (Optional) Should the volume be destroyed on instance termination (defaults true).
+* `encrypted` - (Optional) Should encryption be enabled (defaults false).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds the ability to define `block_device` entries on `resource_aws_launch_configuration`s.

Note, this is dependent on an open PR in the mitchell/goamz repo https://github.com/mitchellh/goamz/pull/210.

This should address https://github.com/hashicorp/terraform/issues/756.

