### PR TITLE
Add support for using OpenStack Swift as a Terraform Remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ FEATURES:
 
   * **New provider: `azure`** - initially just supporting Linux virtual
       machines [GH-899]
+  * **New remote: `swift`** - new support for using OpenStack Swift as a remote
 
 IMPROVEMENTS:
 
-  * **New resources: `google_compute_forwarding_rule`, `google_compute_http_health_check`, 
-      and `google_compute_target_pool`** - Together these provide network-level 
+  * **New resources: `google_compute_forwarding_rule`, `google_compute_http_health_check`,
+      and `google_compute_target_pool`** - Together these provide network-level
       load balancing. [GH-588]
-  * **New resource: `aws_main_route_table_association`** - Manage the main routing table 
+  * **New resource: `aws_main_route_table_association`** - Manage the main routing table
       of a VPC. [GH-918]
   * core: Formalized the syntax of interpolations and documented it
       very heavily.
@@ -22,7 +23,7 @@ IMPROVEMENTS:
   * provider/aws: The `aws_db_instance` resource no longer requires both
       `final_snapshot_identifier` and `skip_final_snapshot`; the presence or
       absence of the former now implies the latter. [GH-874]
-  * provider/aws: Avoid unecessary update of `aws_subnet` when 
+  * provider/aws: Avoid unecessary update of `aws_subnet` when
       `map_public_ip_on_launch` is not specified in config. [GH-898]
   * provider/google: Remove "client secrets file", as it's no longer necessary
       for API authentication [GH-884].

--- a/command/init.go
+++ b/command/init.go
@@ -156,13 +156,13 @@ Options:
                          Required for Atlas backend, optional for Consul.
 
   -backend=atlas         Specifies the type of remote backend. Must be one
-                         of Atlas, Consul, or HTTP. Defaults to atlas.
+                         of Atlas, Consul, Swift or HTTP. Defaults to atlas.
 
   -name=name             Name of the state file in the state storage server.
                          Required for Atlas backend.
 
-  -path=path             Path of the remote state in Consul. Required for the
-                         Consul backend.
+  -path=path             Path of the remote state in Consul and Swift. Required for the
+                         Consul and Swift backends.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/remote.go
+++ b/command/remote.go
@@ -330,7 +330,7 @@ Options:
                          Required for Atlas backend, optional for Consul.
 
   -backend=Atlas         Specifies the type of remote backend. Must be one
-                         of Atlas, Consul, or HTTP. Defaults to Atlas.
+                         of Atlas, Consul, Swift or HTTP. Defaults to Atlas.
 
   -backup=path           Path to backup the existing state file before
                          modifying. Defaults to the "-state" path with
@@ -342,8 +342,8 @@ Options:
   -name=name             Name of the state file in the state storage server.
                          Required for Atlas backend.
 
-  -path=path             Path of the remote state in Consul. Required for the
-                         Consul backend.
+  -path=path             Path of the remote state in Consul and Swift. Required for the
+                         Consul and Swift backends.
 
   -pull=true             Controls if the remote state is pulled before disabling.
                          This defaults to true to ensure the latest state is cached

--- a/remote/client.go
+++ b/remote/client.go
@@ -57,6 +57,8 @@ func NewClientByType(ctype string, conf map[string]string) (RemoteClient, error)
 		return NewAtlasRemoteClient(conf)
 	case "consul":
 		return NewConsulRemoteClient(conf)
+    case "swift":
+        return NewSwiftRemoteClient(conf)
 	case "http":
 		return NewHTTPRemoteClient(conf)
 	default:

--- a/remote/swift.go
+++ b/remote/swift.go
@@ -1,0 +1,134 @@
+package remote
+
+import (
+    "bytes"
+    "bufio"
+	"crypto/md5"
+	"fmt"
+    "io/ioutil"
+    "os"
+    "strings"
+
+    "github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
+	"github.com/rackspace/gophercloud/openstack/objectstorage/v1/containers"
+	"github.com/rackspace/gophercloud/openstack/objectstorage/v1/objects"
+)
+
+const TFSTATE_NAME = "tfstate.tf"
+
+// SwiftRemoteClient implements the RemoteClient interface
+// for a Swift compatible server.
+type SwiftRemoteClient struct {
+    client *gophercloud.ServiceClient
+    path string
+}
+
+func NewSwiftRemoteClient(conf map[string]string) (*SwiftRemoteClient, error) {
+	client := &SwiftRemoteClient{}
+
+	if err := client.validateConfig(conf); err != nil {
+		return nil, err
+	}
+
+    return client, nil
+}
+
+func (c *SwiftRemoteClient) validateConfig(conf map[string]string) (err error) {
+    if val := os.Getenv("OS_AUTH_URL"); val == "" {
+        return fmt.Errorf("missing OS_AUTH_URL environment variable")
+    }
+    if val := os.Getenv("OS_USERNAME"); val == "" {
+        return fmt.Errorf("missing OS_USERNAME environment variable")
+    }
+    if val := os.Getenv("OS_TENANT_NAME"); val == "" {
+        return fmt.Errorf("missing OS_TENANT_NAME environment variable")
+    }
+    if val := os.Getenv("OS_PASSWORD"); val == "" {
+        return fmt.Errorf("missing OS_PASSWORD environment variable")
+    }
+    path, ok := conf["path"]
+    if !ok || path == "" {
+        return fmt.Errorf("missing 'path' configuration")
+    }
+
+    provider, err := openstack.AuthenticatedClient(gophercloud.AuthOptions{
+        IdentityEndpoint: os.Getenv("OS_AUTH_URL"),
+        Username:         os.Getenv("OS_USERNAME"),
+        TenantName:       os.Getenv("OS_TENANT_NAME"),
+        Password:         os.Getenv("OS_PASSWORD"),
+	})
+
+    c.path = path
+    c.client, err = openstack.NewObjectStorageV1(provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+
+    return err
+}
+
+func (c *SwiftRemoteClient) GetState() (*RemoteStatePayload, error) {
+    fmt.Println("Downloading object...")
+    result := objects.Download(c.client, c.path, TFSTATE_NAME, nil)
+
+    if result.Err != nil {
+        // GopherCloud doesn't give us an elegant way to distinguish
+        // between an actual error and "not found".
+        reader := bufio.NewReader(result.Body)
+
+        if buffer, err := ioutil.ReadAll(reader); err == nil {
+            body := string(buffer[:])
+            fmt.Println("BODY: " + body)
+            // If the object doesn't exist, then return empty state.
+            if strings.Contains(body, "404") {
+                fmt.Println("Body contains 404")
+                return nil, nil
+            }
+        } else {
+            return nil, err
+        }
+
+        // Return the non-404 HTTP error.
+        return nil, result.Err
+    }
+
+    reader := bufio.NewReader(result.Body)
+    scanner := bufio.NewScanner(reader)
+
+	// Create the payload
+	payload := &RemoteStatePayload{
+		State: scanner.Bytes(),
+	}
+
+	// Generate the MD5
+	hash := md5.Sum(payload.State)
+	payload.MD5 = hash[:md5.Size]
+	return payload, nil
+}
+
+func (c *SwiftRemoteClient) PutState(state []byte, force bool) error {
+    // Ensure the Swift Container exists.
+    if err := c.ensureContainer(); err != nil {
+        return err
+    }
+
+    readbuffer := bytes.NewBuffer(state)
+    reader := bufio.NewReader(readbuffer)
+    result := objects.Create(c.client, c.path, TFSTATE_NAME, reader, nil)
+
+    return result.Err
+}
+
+func (c *SwiftRemoteClient) DeleteState() error {
+    result := objects.Delete(c.client, c.path, TFSTATE_NAME, nil)
+	return result.Err
+}
+
+func (c *SwiftRemoteClient) ensureContainer() error {
+    result := containers.Create(c.client, c.path, nil)
+    if result.Err != nil {
+        return result.Err
+    }
+
+    return nil
+}


### PR DESCRIPTION
Implemented an OpenStack Swift remote for Terraform.  This commit supports generic OpenStack end points, but does not yet include support for Rackspace Cloudfiles.