### PR TITLE
Verbosity in acceptance tests should not be forced

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/terraform"
@@ -87,12 +86,6 @@ func Test(t TestT, c TestCase) {
 		t.Skip(fmt.Sprintf(
 			"Acceptance tests skipped unless env '%s' set",
 			TestEnvVar))
-		return
-	}
-
-	// We require verbose mode so that the user knows what is going on.
-	if !testTesting && !testing.Verbose() {
-		t.Fatal("Acceptance tests must be run with the -v flag on tests")
 		return
 	}
 


### PR DESCRIPTION
This condition has been added along with first batch of acceptance tests, so it's not something brought for a reason that would appear during test runs in different environment and by different people I reckon.

So I'm raising the question: Is there any point in forcing users to make acceptance tests verbose?

You may argue we're not forcing them, but that's what such error message effectively does as it's added to each acceptance test case in **non-verbose** mode.

IMO user will see all fails/errors even in normal mode without `-v` and if needed, he'll dig in and pass `-v` to find out more.