### PR TITLE
fixing version numbers: RCs should be labeled x.x.x-rcx

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -34,7 +34,7 @@ func runCheckpoint(c *Config) {
 
 	version := Version
 	if VersionPrerelease != "" {
-		version += fmt.Sprintf(".%s", VersionPrerelease)
+		version += fmt.Sprintf("-%s", VersionPrerelease)
 	}
 
 	signaturePath := filepath.Join(configDir, "checkpoint_signature")

--- a/command/version.go
+++ b/command/version.go
@@ -38,7 +38,7 @@ func (c *VersionCommand) Run(args []string) int {
 
 	fmt.Fprintf(&versionString, "Terraform v%s", c.Version)
 	if c.VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, ".%s", c.VersionPrerelease)
+		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
 
 		if c.Revision != "" {
 			fmt.Fprintf(&versionString, " (%s)", c.Revision)


### PR DESCRIPTION
see conversation with ryanuber: https://github.com/hashicorp/go-checkpoint/issues/2#issuecomment-73199209