### PR TITLE
fix the GOPATH/bin for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ cd /opt/go/src && ./all.bash
 mkdir -p /opt/gopath
 cat <<EOF >/etc/profile.d/gopath.sh
 export GOPATH="/opt/gopath"
-export PATH="/opt/go/bin:\$GOPATH/bin:\$PATH"
+export PATH="/opt/go/bin:$GOPATH/bin:\$PATH"
 EOF
 
 # Make sure the GOPATH is usable by vagrant


### PR DESCRIPTION
With the old setup $PATH is /opt/go/bin:/bin