### PR TITLE
Add SelfLink fields to all GCE resources

### DIFF
--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -46,6 +46,11 @@ func resourceComputeDisk() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -132,7 +137,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	_, err := config.clientCompute.Disks.Get(
+	disk, err := config.clientCompute.Disks.Get(
 		config.Project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -144,6 +149,8 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 
 		return fmt.Errorf("Error reading disk: %s", err)
 	}
+
+	d.Set("self_link", disk.SelfLink)
 
 	return nil
 }

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -86,6 +86,11 @@ func resourceComputeFirewall() *schema.Resource {
 					return hashcode.String(v.(string))
 				},
 			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -159,7 +164,7 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	_, err := config.clientCompute.Firewalls.Get(
+	firewall, err := config.clientCompute.Firewalls.Get(
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -171,6 +176,8 @@ func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error
 
 		return fmt.Errorf("Error reading firewall: %s", err)
 	}
+
+	d.Set("self_link", firewall.SelfLink)
 
 	return nil
 }

--- a/builtin/providers/google/resource_compute_network.go
+++ b/builtin/providers/google/resource_compute_network.go
@@ -33,6 +33,11 @@ func resourceComputeNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -98,6 +103,7 @@ func resourceComputeNetworkRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Set("gateway_ipv4", network.GatewayIPv4)
+	d.Set("self_link", network.SelfLink)
 
 	return nil
 }

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -80,6 +80,11 @@ func resourceComputeRoute() *schema.Resource {
 					return hashcode.String(v.(string))
 				},
 			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -183,7 +188,7 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	_, err := config.clientCompute.Routes.Get(
+	route, err := config.clientCompute.Routes.Get(
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -195,6 +200,8 @@ func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 		return fmt.Errorf("Error reading route: %#v", err)
 	}
+
+	d.Set("self_link", route.SelfLink)
 
 	return nil
 }


### PR DESCRIPTION
SelfLink providers the URL reference to a resource in GCE, all resources should expose this field.