### PR TITLE
Allow vpc_peering_connection

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -66,6 +66,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_security_group":               resourceAwsSecurityGroup(),
 			"aws_subnet":                       resourceAwsSubnet(),
 			"aws_vpc":                          resourceAwsVpc(),
+			"aws_vpc_peering_connection":       resourceAwsVpcPeeringConnection(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -47,6 +47,11 @@ func resourceAwsRouteTable() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
+						"vpc_peering_connection_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 				Set: resourceAwsRouteTableHash,
@@ -125,6 +130,7 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 
 		m["gateway_id"] = r.GatewayId
 		m["instance_id"] = r.InstanceId
+		m["vpc_peering_connection_id"] = r.VpcPeeringConnectionId
 
 		route.Add(m)
 	}
@@ -166,10 +172,11 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			m := route.(map[string]interface{})
 
 			opts := ec2.CreateRoute{
-				RouteTableId:         d.Id(),
-				DestinationCidrBlock: m["cidr_block"].(string),
-				GatewayId:            m["gateway_id"].(string),
-				InstanceId:           m["instance_id"].(string),
+				RouteTableId:           d.Id(),
+				DestinationCidrBlock:   m["cidr_block"].(string),
+				GatewayId:              m["gateway_id"].(string),
+				InstanceId:             m["instance_id"].(string),
+				VpcPeeringConnectionId: m["vpc_peering_connection_id"].(string),
 			}
 
 			_, err := ec2conn.CreateRoute(&opts)
@@ -254,6 +261,10 @@ func resourceAwsRouteTableHash(v interface{}) int {
 	}
 
 	if v, ok := m["instance_id"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["vpc_peering_connection_id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -13,22 +13,25 @@ import (
 func resourceAwsVpcPeeringConnection() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsVpcPeeringCreate,
-		Read:   resourceAwsVpcPeeringConnectionRead,
-		Update: nil,
+		Read:   resourceAwsVpcPeeringRead,
+		Update: resourceAwsVpcPeeringUpdate,
 		Delete: resourceAwsVpcPeeringDelete,
 
 		Schema: map[string]*schema.Schema{
 			"peer_owner_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"peer_vpc_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"vpc_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"tags": tagsSchema(),
 		},
@@ -74,7 +77,7 @@ func resourceAwsVpcPeeringCreate(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsVpcPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 	pcRaw, _, err := resourceAwsVpcPeeringConnectionStateRefreshFunc(ec2conn, d.Id())()
 	if err != nil {
@@ -94,6 +97,19 @@ func resourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interface{
 
 	return nil
 }
+
+func resourceAwsVpcPeeringUpdate(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	if err := setTags(ec2conn, d); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
+
+	return resourceAwsRouteTableRead(d, meta)
+}
+
 func resourceAwsVpcPeeringDelete(d *schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).ec2conn
 

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -1,0 +1,129 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mitchellh/goamz/ec2"
+)
+
+func resourceAwsVpcPeeringConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsVpcPeeringCreate,
+		Read:   resourceAwsVpcPeeringConnectionRead,
+		Update: nil,
+		Delete: resourceAwsVpcPeeringDelete,
+
+		Schema: map[string]*schema.Schema{
+			"peer_owner_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"peer_vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsVpcPeeringCreate(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	// Create the vpc peering connection
+	createOpts := &ec2.CreateVpcPeeringConnection{
+		PeerOwnerId: d.Get("peer_owner_id").(string),
+		PeerVpcId:   d.Get("peer_vpc_id").(string),
+		VpcId:       d.Get("vpc_id").(string),
+	}
+	log.Printf("[DEBUG] VpcPeeringCreate create config: %#v", createOpts)
+	resp, err := ec2conn.CreateVpcPeeringConnection(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating vpc peering connection: %s", err)
+	}
+
+	// Get the ID and store it
+	rt := &resp.VpcPeeringConnection
+	d.SetId(rt.VpcPeeringConnectionId)
+	log.Printf("[INFO] Vpc Peering Connection ID: %s", d.Id())
+
+	// Wait for the vpc peering connection to become available
+	log.Printf(
+		"[DEBUG] Waiting for vpc peering connection (%s) to become available",
+		d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  "ready",
+		Refresh: resourceAwsVpcPeeringConnectionStateRefreshFunc(ec2conn, d.Id()),
+		Timeout: 1 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf(
+			"Error waiting for vpc peering (%s) to become available: %s",
+			d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+	pcRaw, _, err := resourceAwsVpcPeeringConnectionStateRefreshFunc(ec2conn, d.Id())()
+	if err != nil {
+		return err
+	}
+	if pcRaw == nil {
+		d.SetId("")
+		return nil
+	}
+
+	pc := pcRaw.(*ec2.VpcPeeringConnection)
+
+	d.Set("peer_owner_id", pc.AccepterVpcInfo.OwnerId)
+	d.Set("peer_vpc_id", pc.AccepterVpcInfo.VpcId)
+	d.Set("vpc_id", pc.RequesterVpcInfo.VpcId)
+	d.Set("tags", tagsToMap(pc.Tags))
+
+	return nil
+}
+func resourceAwsVpcPeeringDelete(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	_, err := ec2conn.DeleteVpcPeeringConnection(d.Id())
+	return err
+}
+
+// resourceAwsVpcPeeringConnectionStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// a VpcPeeringConnection.
+func resourceAwsVpcPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+
+		resp, err := conn.DescribeVpcPeeringConnection([]string{id}, ec2.NewFilter())
+		if err != nil {
+			if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidVpcPeeringConnectionID.NotFound" {
+				resp = nil
+			} else {
+				log.Printf("Error on VpcPeeringConnectionStateRefresh: %s", err)
+				return nil, "", err
+			}
+		}
+
+		if resp == nil {
+			// Sometimes AWS just has consistency issues and doesn't see
+			// our instance yet. Return an empty state.
+			return nil, "", nil
+		}
+
+		pc := &resp.VpcPeeringConnections[0]
+
+		return pc, "ready", nil
+	}
+}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/goamz/ec2"
+)
+
+func TestAccAWSVPCPeeringConnection_normal(t *testing.T) {
+	var conf ec2.Address
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcPeeringConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists("aws_vpc_peering_connection.foo", &conf),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSVpcPeeringConnectionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_vpc_peering_connection" {
+			continue
+		}
+
+		describe, err := conn.DescribeVpcPeeringConnection([]string{rs.Primary.ID}, ec2.NewFilter())
+
+		if err == nil {
+			if len(describe.VpcPeeringConnections) != 0 {
+				return fmt.Errorf("vpc peering connection still exists")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSVpcPeeringConnectionExists(n string, res *ec2.Address) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No vpc peering connection id is set")
+		}
+
+		return nil
+	}
+}
+
+const testAccVpcPeeringConfig = `
+resource "aws_vpc" "foo" {
+    cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc" "bar" {
+    cidr_block = "10.0.1.0/16"
+}
+
+resource "aws_vpc_peering_connection" "foo" {
+    peer_owner_id = "12345"
+    vpc_id = "${aws_vpc.foo.id}"
+    peer_vpc_id = "${aws_vpc.bar.id}"
+}
+`

--- a/website/source/docs/providers/aws/r/route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/route_table.html.markdown
@@ -39,8 +39,9 @@ Each route supports the following:
 * `cidr_block` - (Required) The CIDR block of the route.
 * `gateway_id` - (Optional) The Internet Gateway ID.
 * `instance_id` - (Optional) The EC2 instance ID.
+* `vpc_peering_connection_id` - (Optional) The VPC Peering ID.
 
-Each route must contain either a `gateway_id` or an `instance_id`. Note that the
+Each route must contain either a `gateway_id`, an `instance_id` or a `vpc_peering_connection_id`. Note that the
 default route, mapping the VPC's CIDR block to "local", is created implicitly and
 cannot be specified.
 

--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -48,11 +48,12 @@ The following arguments are supported:
 * `vpc_id` - (Required) The ID of the requester VPC.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-
-Note: You still have to accept the peering with the aws console, aws-cli or goamz
-
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The ID of the VPC Peering Connection
+* `id` - The ID of the VPC Peering Connectiona
+
+
+## Notes
+You still have to accept the peering with the aws console, aws-cli or goamz

--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "aws"
+page_title: "AWS: aws_vpc_peering_connection"
+sidebar_current: "docs-aws-resource-vpc-peering-connection"
+description: |-
+  Provides an VPC Peering Connection resource.
+---
+
+# aws\_vpc\_peering\_connection
+
+Provides an VPC Peering Connection resource.
+
+## Example Usage
+
+Basic usage:
+
+```
+resource "aws_vpc" "main" {
+    cidr_block = "10.0.0.0/16"
+}
+```
+
+Basic usage with tags:
+
+```
+
+resource "aws_vpc_peering_connection" "foo" {
+    peer_owner_id = "${var.peer_owner_id}"
+    peer_vpc_id = "${aws_vpc.bar.id}"
+    vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_vpc" "foo" {
+    cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc" "bar" {
+    cidr_block = "10.2.0.0/16"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `peer_owner_id` - (Required) The AWS account ID of the owner of the peer VPC.
+* `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC peering connection.
+* `vpc_id` - (Required) The ID of the requester VPC.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+
+Note: You still have to accept the peering with the aws console, aws-cli or goamz
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the VPC Peering Connection


### PR DESCRIPTION
It's my first time writing go, so be careful.

At the moment, you need to create the peering connection with ami-cli or aws-console.
For a better integration it is required to improve https://github.com/mitchellh/goamz for creating the peering connection and link it into terraform