### PR TITLE
Update README on running acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ If you're working on a feature of a provider and want to verify it is functionin
 To run the acceptance tests, invoke `make testacc`:
 
 ```sh
-$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=VPC'
+$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=Vpc'
+go generate ./...
+TF_ACC=1 go test ./builtin/providers/aws -v -run=Vpc -timeout 45m
+=== RUN TestAccVpc_basic
+2015/02/10 14:11:17 [INFO] Test: Using us-west-2 as test region
+[...]
+[...]
 ...
 ```
 


### PR DESCRIPTION
Mostly formatting/typo fix; running as is gets you an empty OK pass message:

```console
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=VPC'
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=VPC -timeout 45m
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.006s
$ 
```

Instead of this:

```console
make testacc TEST=./builtin/providers/aws TESTARGS='-run=Vpc'
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=Vpc -timeout 45m
=== RUN TestAccVpc_basic
2015/02/10 14:43:53 [INFO] Test: Using us-west-2 as test region
2015/02/10 14:43:53 [WARN] Test: Executing step 0
[...]
[..]
$
```