### PR TITLE
Add docs for AWS IG tags

### DIFF
--- a/website/source/docs/providers/aws/r/internet_gateway.html.markdown
+++ b/website/source/docs/providers/aws/r/internet_gateway.html.markdown
@@ -15,6 +15,10 @@ Provides a resource to create a VPC Internet Gateway.
 ```
 resource "aws_internet_gateway" "gw" {
     vpc_id = "${aws_vpc.main.id}"
+
+    tags {
+        Name = "main"
+    }
 }
 ```
 
@@ -23,6 +27,7 @@ resource "aws_internet_gateway" "gw" {
 The following arguments are supported:
 
 * `vpc_id` - (Required) The VPC ID to create in.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
There's already support for this since https://github.com/hashicorp/terraform/pull/720 but it's not documented yet.