### PR TITLE
Update hashcode to always generate a positive index

### DIFF
--- a/helper/hashcode/hashcode.go
+++ b/helper/hashcode/hashcode.go
@@ -1,6 +1,8 @@
 package hashcode
 
-import "hash/crc32"
+import (
+	"hash/crc32"
+)
 
 // String hashes a string to a unique hashcode.
 //
@@ -12,5 +14,6 @@ func String(s string) int {
 	if v < 0 {
 		return -v
 	}
+
 	return v
 }

--- a/helper/hashcode/hashcode.go
+++ b/helper/hashcode/hashcode.go
@@ -1,10 +1,16 @@
 package hashcode
 
-import (
-	"hash/crc32"
-)
+import "hash/crc32"
 
 // String hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
 func String(s string) int {
-	return int(crc32.ChecksumIEEE([]byte(s)))
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v < 0 {
+		return -v
+	}
+	return v
 }

--- a/helper/hashcode/hashcode_test.go
+++ b/helper/hashcode/hashcode_test.go
@@ -1,6 +1,8 @@
 package hashcode
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestString(t *testing.T) {
 	v := "hello, world"
@@ -16,8 +18,7 @@ func TestString(t *testing.T) {
 func TestString_positiveIndex(t *testing.T) {
 	ips := []string{"192.168.1.3", "192.168.1.5"}
 	for _, ip := range ips {
-		index := String(ip)
-		if index < 0 {
+		if index := String(ip); index < 0 {
 			t.Fatalf("Bad Index %#v for ip %s", index, ip)
 		}
 	}

--- a/helper/hashcode/hashcode_test.go
+++ b/helper/hashcode/hashcode_test.go
@@ -1,8 +1,6 @@
 package hashcode
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestString(t *testing.T) {
 	v := "hello, world"
@@ -10,7 +8,17 @@ func TestString(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		actual := String(v)
 		if actual != expected {
-			t.Fatalf("bad: %#v", actual)
+			t.Fatalf("bad: %#v\n\t%#v", actual, expected)
+		}
+	}
+}
+
+func TestString_positiveIndex(t *testing.T) {
+	ips := []string{"192.168.1.3", "192.168.1.5"}
+	for _, ip := range ips {
+		index := String(ip)
+		if index < 0 {
+			t.Fatalf("Bad Index %#v for ip %s", index, ip)
 		}
 	}
 }


### PR DESCRIPTION
When generating an int index for Set, we need to ensure that `hash.String` returns a positive integer.