### PR TITLE
312 route 53 default record name

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -71,7 +71,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	// and keep AWS happy.
 	recordName := d.Get("name").(string)
 	zoneName := strings.Trim(zoneRecord.HostedZone.Name, ".")
-	if ok := strings.HasSuffix(recordName, zoneName); !ok {
+	if !strings.HasSuffix(recordName, zoneName) {
 		d.Set("name", strings.Join([]string{recordName, zoneName}, "."))
 	}
 

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -59,6 +59,22 @@ func resourceAwsRoute53Record() *schema.Resource {
 func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).route53
 
+	zone := d.Get("zone_id").(string)
+
+	zoneRecord, err := conn.GetHostedZone(zone)
+	if err != nil {
+		return err
+	}
+
+	// Check if the current record name contains the zone suffix.
+	// If it does not, add the zone name to form a fully qualified name
+	// and keep AWS happy.
+	recordName := d.Get("name").(string)
+	zoneName := strings.Trim(zoneRecord.HostedZone.Name, ".")
+	if ok := strings.HasSuffix(recordName, zoneName); !ok {
+		d.Set("name", strings.Join([]string{recordName, zoneName}, "."))
+	}
+
 	// Get the record
 	rec, err := resourceAwsRoute53RecordBuildSet(d)
 	if err != nil {
@@ -77,7 +93,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 			},
 		},
 	}
-	zone := d.Get("zone_id").(string)
+
 	log.Printf("[DEBUG] Creating resource records for zone: %s, name: %s",
 		zone, d.Get("name").(string))
 

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -26,6 +26,22 @@ func TestAccRoute53Record(t *testing.T) {
 	})
 }
 
+func TestAccRoute53Record_generatesSuffix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53RecordConfigSuffix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).route53
 	for _, rs := range s.RootModule().Resources {
@@ -95,6 +111,20 @@ resource "aws_route53_zone" "main" {
 resource "aws_route53_record" "default" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "www.notexample.com"
+	type = "A"
+	ttl = "30"
+	records = ["127.0.0.1", "127.0.0.27"]
+}
+`
+
+const testAccRoute53RecordConfigSuffix = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_record" "default" {
+	zone_id = "${aws_route53_zone.main.zone_id}"
+	name = "subdomain"
 	type = "A"
 	ttl = "30"
 	records = ["127.0.0.1", "127.0.0.27"]

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -60,7 +60,7 @@ type Schema struct {
 	//
 	// If Required is true above, then Default cannot be set. DefaultFunc
 	// can be set with Required. If the DefaultFunc returns nil, then there
-	// will no default and the user will be asked to fill it in.
+	// will be no default and the user will be asked to fill it in.
 	//
 	// If either of these is set, then the user won't be asked for input
 	// for this key if the default is not nil.


### PR DESCRIPTION
First pass at fixing #312.
This will allow AWS Route53 Records to simply specify a subdomain and not the fully qualified name:

Given a zone:
```
resource "aws_route53_zone" "main" {
  name = "example.com"
}
```

this change then supports the current:

```
resource "aws_route53_record" "www" {
  [...]
  name = "www.example.com"
  [...]
}
```
and shorter:
```
resource "aws_route53_record" "www" {
  [...]
  name = "www"
  [...]
}
```

both result in a Route53 record with name `www.example.com`.