### PR TITLE
provider/aws: Convert Route 53 Zone resource to use awslabs/aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mitchellh/goamz/route53"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/gen/route53"
 )
 
 func resourceAwsRoute53Zone() *schema.Resource {
@@ -32,20 +34,23 @@ func resourceAwsRoute53Zone() *schema.Resource {
 }
 
 func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).route53
+	r53 := meta.(*AWSClient).r53conn
 
+	comment := &route53.HostedZoneConfig{Comment: aws.String("Managed by Terraform")}
 	req := &route53.CreateHostedZoneRequest{
-		Name:    d.Get("name").(string),
-		Comment: "Managed by Terraform",
+		Name:             aws.String(d.Get("name").(string)),
+		HostedZoneConfig: comment,
+		CallerReference:  aws.String(time.Now().Format(time.RFC3339Nano)),
 	}
-	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", req.Name)
+
+	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", *req.Name)
 	resp, err := r53.CreateHostedZone(req)
 	if err != nil {
 		return err
 	}
 
 	// Store the zone_id
-	zone := route53.CleanZoneID(resp.HostedZone.ID)
+	zone := cleanZoneID(*resp.HostedZone.ID)
 	d.Set("zone_id", zone)
 	d.SetId(zone)
 
@@ -57,7 +62,10 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 		Timeout:    10 * time.Minute,
 		MinTimeout: 2 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
-			return resourceAwsRoute53Wait(r53, resp.ChangeInfo.ID)
+			changeRequest := &route53.GetChangeRequest{
+				ID: aws.String(cleanChangeID(*resp.ChangeInfo.ID)),
+			}
+			return resourceAwsGoRoute53Wait(r53, changeRequest)
 		},
 	}
 	_, err = wait.WaitForState()
@@ -68,9 +76,8 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).route53
-
-	_, err := r53.GetHostedZone(d.Id())
+	r53 := meta.(*AWSClient).r53conn
+	_, err := r53.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(d.Id())})
 	if err != nil {
 		// Handle a deleted zone
 		if strings.Contains(err.Error(), "404") {
@@ -84,11 +91,11 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).route53
+	r53 := meta.(*AWSClient).r53conn
 
 	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",
 		d.Get("name").(string), d.Id())
-	_, err := r53.DeleteHostedZone(d.Id())
+	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneRequest{ID: aws.String(d.Id())})
 	if err != nil {
 		return err
 	}
@@ -96,11 +103,29 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-// resourceAwsRoute53Wait checks the status of a change
-func resourceAwsRoute53Wait(r53 *route53.Route53, ref string) (result interface{}, state string, err error) {
+func resourceAwsGoRoute53Wait(r53 *route53.Route53, ref *route53.GetChangeRequest) (result interface{}, state string, err error) {
+
 	status, err := r53.GetChange(ref)
 	if err != nil {
 		return nil, "UNKNOWN", err
 	}
-	return true, status, nil
+	return true, *status.ChangeInfo.Status, nil
+}
+
+// cleanChangeID is used to remove the leading /change/
+func cleanChangeID(ID string) string {
+	return cleanPrefix(ID, "/change/")
+}
+
+// cleanZoneID is used to remove the leading /hostedzone/
+func cleanZoneID(ID string) string {
+	return cleanPrefix(ID, "/hostedzone/")
+}
+
+// cleanPrefix removes a string prefix from an ID
+func cleanPrefix(ID, prefix string) string {
+	if strings.HasPrefix(ID, prefix) {
+		ID = strings.TrimPrefix(ID, prefix)
+	}
+	return ID
 }


### PR DESCRIPTION
:construction: This is a work in progress :construction: 

This commit updates the Route 53 Zone resource to use AWS Labs aws-sdk-go
library instead of mitchellh/goamz.

This is meant as a spike to begin converting resources one by one to the new
library.

It's rough, I'll comment inline on things I wasn't sure on.