### PR TITLE
Make Google Instance disk attribute all ForceNew. Fix #608.

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -54,11 +54,13 @@ func resourceComputeInstance() *schema.Resource {
 						"disk": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 
 						"image": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 
 						"type": &schema.Schema{
@@ -70,6 +72,7 @@ func resourceComputeInstance() *schema.Resource {
 						"auto_delete": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
There is no code in Update to handle these cases.  It's nontrivial to implement updating disks because of limitations of Terraform's model (first element of the list is special).  We need to discuss the best way to move forward but in the short term marking them all as ForceNew seems reasonable.