### PR TITLE
Diff should be empty if the zero value is in the state

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -810,6 +810,9 @@ func (m schemaMap) diffString(
 		originalN = n
 		n = schema.StateFunc(n)
 	}
+	if n == nil {
+		n = schema.Type.Zero()
+	}
 	if err := mapstructure.WeakDecode(o, &os); err != nil {
 		return fmt.Errorf("%s: %s", k, err)
 	}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -1967,7 +1967,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #42 Set - Same as #47 but for sets
+		// #49 Set - Same as #47 but for sets
 		{
 			Schema: map[string]*Schema{
 				"route": &Schema{

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -1944,7 +1944,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err:  false,
 		},
 
-		// #48
+		// #48 - Zero value in state shouldn't result in diff
 		{
 			Schema: map[string]*Schema{
 				"port": &Schema{
@@ -1957,6 +1957,49 @@ func TestSchemaMap_Diff(t *testing.T) {
 			State: &terraform.InstanceState{
 				Attributes: map[string]string{
 					"port": "false",
+				},
+			},
+
+			Config: map[string]interface{}{},
+
+			Diff: nil,
+
+			Err: false,
+		},
+
+		// #42 Set - Same as #47 but for sets
+		{
+			Schema: map[string]*Schema{
+				"route": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"index": &Schema{
+								Type:     TypeInt,
+								Required: true,
+							},
+
+							"gateway": &Schema{
+								Type:     TypeSet,
+								Optional: true,
+								Elem:     &Schema{Type: TypeInt},
+								Set: func(a interface{}) int {
+									return a.(int)
+								},
+							},
+						},
+					},
+					Set: func(v interface{}) int {
+						m := v.(map[string]interface{})
+						return m["index"].(int)
+					},
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"route.#": "0",
 				},
 			},
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -1943,6 +1943,29 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Diff: nil,
 			Err:  false,
 		},
+
+		// #48
+		{
+			Schema: map[string]*Schema{
+				"port": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"port": "false",
+				},
+			},
+
+			Config: map[string]interface{}{},
+
+			Diff: nil,
+
+			Err: false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Fixes: #952 

If the zero value of a configuration is in the state and its not in the configuration, then it should not result in a diff since nothing is changing. See the test case for an example. 