### PR TITLE
config: bare splat variables should not be allowed in provisioners

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -465,6 +465,13 @@ func (c *Config) rawConfigs() map[string]*RawConfig {
 		source := fmt.Sprintf("resource '%s'", rc.Id())
 		result[source+" count"] = rc.RawCount
 		result[source+" config"] = rc.RawConfig
+
+		for i, p := range rc.Provisioners {
+			subsource := fmt.Sprintf(
+				"%s provisioner %s (#%d)",
+				source, p.Type, i+1)
+			result[subsource] = p.RawConfig
+		}
 	}
 
 	for _, o := range c.Outputs {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -249,6 +249,13 @@ func TestConfigValidate_varMultiNonSlice(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_varMultiNonSliceProvisioner(t *testing.T) {
+	c := testConfig(t, "validate-var-multi-non-slice-provisioner")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_varMultiFunctionCall(t *testing.T) {
 	c := testConfig(t, "validate-var-multi-func")
 	if err := c.Validate(); err != nil {

--- a/config/test-fixtures/validate-var-multi-non-slice-provisioner/main.tf
+++ b/config/test-fixtures/validate-var-multi-non-slice-provisioner/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "foo" {
+    count = 3
+}
+
+resource "aws_instance" "bar" {
+    provisioner "local-exec" {
+        foo = "${aws_instance.foo.*.id}"
+    }
+}


### PR DESCRIPTION
Fixes #636 

This validates that bare splats aren't allowed in provisioner configurations either (we already verify top-level config). They CAN use `${join(",", splat)}` etc., it just can't be `${splat}` directly.