### PR TITLE
helper/schema: GetChange shouldn't return true when no change

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -150,6 +150,9 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			m := route.(map[string]interface{})
 
 			// Delete the route as it no longer exists in the config
+			log.Printf(
+				"[INFO] Deleting route from %s: %s",
+				d.Id(), m["cidr_block"].(string))
 			_, err := ec2conn.DeleteRoute(
 				d.Id(), m["cidr_block"].(string))
 			if err != nil {
@@ -172,6 +175,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 				InstanceId:           m["instance_id"].(string),
 			}
 
+			log.Printf("[INFO] Creating route for %s: %#v", d.Id(), opts)
 			_, err := ec2conn.CreateRoute(&opts)
 			if err != nil {
 				return err

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -65,7 +65,7 @@ func (d *ResourceData) Get(key string) interface{} {
 // set and the new value is. This is common, for example, for boolean
 // fields which have a zero value of false.
 func (d *ResourceData) GetChange(key string) (interface{}, interface{}) {
-	o, n := d.getChange(key, getSourceState, getSourceDiff|getSourceExact)
+	o, n := d.getChange(key, getSourceState, getSourceDiff)
 	return o.Value, n.Value
 }
 

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1104,6 +1104,38 @@ func TestResourceDataHasChange(t *testing.T) {
 
 			Change: true,
 		},
+
+		// https://github.com/hashicorp/terraform/issues/927
+		{
+			Schema: map[string]*Schema{
+				"ports": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Elem:     &Schema{Type: TypeInt},
+					Set:      func(a interface{}) int { return a.(int) },
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"ports.#":  "1",
+					"ports.80": "80",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"tags.foo": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "bar",
+					},
+				},
+			},
+
+			Key: "ports",
+
+			Change: false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Fixes #927 

`GetChange` in helper/schema was just completely broken in some cases. This change seemed sketchy but nothing is failing and #927 is definitely fixed. I don't know why that `getSourceExact` was there before but I have a feeling it was likely due to weird behavior before my `FieldReader` refactor.