### PR TITLE
providers/aws: add root_block_device to aws_instance

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
   launch the instance with.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `block_device` - (Optional) A list of block devices to add. Their keys are documented below.
+* `root_block_device` - (Optional) Customize details about the root block
+  device of the instance. Available keys are documented below.
 
 Each `block_device` supports the following:
 
@@ -58,6 +60,15 @@ Each `block_device` supports the following:
 * `volume_size` - (Optional) The size of the volume in gigabytes.
 * `delete_on_termination` - (Optional) Should the volume be destroyed on instance termination (defaults true).
 * `encrypted` - (Optional) Should encryption be enabled (defaults false).
+
+The `root_block_device` mapping supports the following:
+
+* `device_name` - The name of the root device on the target instance. Must
+  match the root device as defined in the AMI. Defaults to "/dev/sda1", which
+  is the typical root volume for Linux instances.
+* `volume_type` - (Optional) The type of volume. Can be standard, gp2, or io1. Defaults to standard.
+* `volume_size` - (Optional) The size of the volume in gigabytes.
+* `delete_on_termination` - (Optional) Should the volume be destroyed on instance termination (defaults true).
 
 ## Attributes Reference
 


### PR DESCRIPTION
AWS provides a single `BlockDeviceMapping` to manage three different
kinds of block devices:

 (a) The root volume
 (b) Ephemeral storage
 (c) Additional EBS volumes

Each of these types has slightly different semantics [1].

(a) The root volume is defined by the AMI; it can only be customized
with `volume_size`, `volume_type`, and `delete_on_termination`.

(b) Ephemeral storage is made available based on instance type [2]. It's
attached automatically if _no_ block device mappings are specified, and
must otherwise be defined with block device mapping entries that contain
only DeviceName set to a device like "/dev/sdX" and VirtualName set to
"ephemeralN".

(c) Additional EBS volumes are controlled by mappings that omit
`virtual_name` and can specify `volume_size`, `volume_type`,
`delete_on_termination`, `snapshot_id`, and `encryption`.

After deciding to ignore root block devices to fix #859, we had users
with configurations that were attempting to manage the root block device chime
in on #913.

Terraform does not have the primitives to be able to properly handle a
single collection of resources that is partially managed and partially
computed, so our strategy here is to break out logical sub-resources for
Terraform and hide the BlockDeviceMapping inside the provider
implementation.

Now (a) is supported by the `root_block_device` sub-resource, and (b)
and (c) are still both merged together under `block_device`, though I
have yet to see ephemeral block devices working properly.

Looking into possibly separating out `ephemeral_block_device` and
`ebs_block_device` sub-resources as well, which seem like the logical
next step. We'll wait until the next big release for this, though, since
it will break backcompat.

[1] http://bit.ly/ec2bdmap
[2] http://bit.ly/instancestorebytype

Fixes #913