### PR TITLE
Clean code (get rid of go vet errors)

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -336,7 +336,7 @@ func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) 
 	return resource.Retry(10*time.Minute, func() error {
 		g, err := getAwsAutoscalingGroup(d, meta)
 		if err != nil {
-			return resource.RetryError{err}
+			return resource.RetryError{Err: err}
 		}
 		if g == nil {
 			return nil

--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -42,7 +42,8 @@ func testAccCheckDBSubnetGroupDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := conn.DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroups{rs.Primary.ID})
+		resp, err := conn.DescribeDBSubnetGroups(
+			&rds.DescribeDBSubnetGroups{DBSubnetGroupName: rs.Primary.ID})
 		if err == nil {
 			if len(resp.DBSubnetGroups) > 0 {
 				return fmt.Errorf("still exist.")
@@ -76,7 +77,8 @@ func testAccCheckDBSubnetGroupExists(n string, v *rds.DBSubnetGroup) resource.Te
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).rdsconn
-		resp, err := conn.DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroups{rs.Primary.ID})
+		resp, err := conn.DescribeDBSubnetGroups(
+			&rds.DescribeDBSubnetGroups{DBSubnetGroupName: rs.Primary.ID})
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -219,7 +219,7 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 		if _, ok := err.(*ec2.Error); !ok {
-			return resource.RetryError{err}
+			return resource.RetryError{Err: err}
 		}
 
 		return err

--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -124,7 +124,7 @@ func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) 
 			return err // retry
 		}
 
-		return resource.RetryError{err}
+		return resource.RetryError{Err: err}
 	})
 }
 

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -268,10 +268,10 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 					return fmt.Errorf("Dependency violation: Cannot delete acl %s: %s", d.Id(), err)
 				}
 				_, err = ec2conn.ReplaceNetworkAclAssociation(association.NetworkAclAssociationId, defaultAcl.NetworkAclId)
-				return resource.RetryError{err}
+				return resource.RetryError{Err: err}
 			default:
 				// Any other error, we want to quit the retry loop immediately
-				return resource.RetryError{err}
+				return resource.RetryError{Err: err}
 			}
 		}
 		log.Printf("[Info] Deleted network ACL %s successfully", d.Id())

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -380,7 +380,7 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 				return err
 			default:
 				// Any other error, we want to quit the retry loop immediately
-				return resource.RetryError{err}
+				return resource.RetryError{Err: err}
 			}
 		}
 

--- a/command/remote.go
+++ b/command/remote.go
@@ -109,11 +109,9 @@ func (c *RemoteCommand) Run(args []string) int {
 	case !haveLocal && haveNonManaged:
 		// Enable remote state management
 		return c.enableRemoteState()
-
-	default:
-		panic("unhandled case")
 	}
-	return 0
+
+	panic("unhandled case")
 }
 
 // disableRemoteState is used to disable remote state management,

--- a/remote/atlas.go
+++ b/remote/atlas.go
@@ -213,10 +213,9 @@ func (c *AtlasRemoteClient) DeleteState() error {
 		return ErrInvalidAuth
 	case http.StatusInternalServerError:
 		return ErrRemoteInternal
-	default:
-		return fmt.Errorf("Unexpected HTTP response code %d", resp.StatusCode)
 	}
-	return nil
+
+	return fmt.Errorf("Unexpected HTTP response code %d", resp.StatusCode)
 }
 
 func (c *AtlasRemoteClient) url() *url.URL {


### PR DESCRIPTION
It may be wise to run `go vet` in the CI setup which checks every pull-request.

```
find . -name '*.go' -exec go vet {} \;
```
```
builtin/providers/aws/resource_aws_autoscaling_group.go:339: github.com/hashicorp/terraform/helper/resource.RetryError composite literal uses unkeyed fields
builtin/providers/aws/resource_aws_db_subnet_group_test.go:45: github.com/mitchellh/goamz/rds.DescribeDBSubnetGroups composite literal uses unkeyed fields
builtin/providers/aws/resource_aws_db_subnet_group_test.go:79: github.com/mitchellh/goamz/rds.DescribeDBSubnetGroups composite literal uses unkeyed fields
builtin/providers/aws/resource_aws_eip.go:222: github.com/hashicorp/terraform/helper/resource.RetryError composite literal uses unkeyed fields
builtin/providers/aws/resource_aws_internet_gateway.go:127: github.com/hashicorp/terraform/helper/resource.RetryError composite literal uses unkeyed fields
builtin/providers/aws/resource_aws_network_acl.go:271: github.com/hashicorp/terraform/helper/resource.RetryError composite literal uses unkeyed fields
builtin/providers/aws/resource_aws_network_acl.go:274: github.com/hashicorp/terraform/helper/resource.RetryError composite literal uses unkeyed fields
builtin/providers/aws/resource_aws_security_group.go:383: github.com/hashicorp/terraform/helper/resource.RetryError composite literal uses unkeyed fields
builtin/providers/heroku/resource_heroku_domain.go:46: unresolvable package for heroku.DomainCreateOpts literal
builtin/providers/heroku/resource_heroku_drain.go:46: unresolvable package for heroku.LogDrainCreateOpts literal
command/remote.go:116: unreachable code
remote/atlas.go:219: unreachable code
terraform/terraform_test.go:26: unreachable code
```