### PR TITLE
providers/aws: fix aws_instance source_dest_check

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -491,9 +491,9 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	modify := false
 	opts := new(ec2.ModifyInstance)
 
-	if v, ok := d.GetOk("source_dest_check"); ok {
-		opts.SourceDestCheck = v.(bool)
+	if d.HasChange("source_dest_check") {
 		opts.SetSourceDestCheck = true
+		opts.SourceDestCheck = d.Get("source_dest_check").(bool)
 		modify = true
 	}
 


### PR DESCRIPTION
Was relying on old behavior of GetOk and therefore never properly seeing
a change from true -> false.

This fixes the acceptance test failure of
`TestAccAWSInstance_sourceDestCheck`.