### PR TITLE
Revert "Merge pull request #804 from PeoplePerHour/f-aws-elb-subnet"

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -73,6 +73,7 @@ func resourceAwsElb() *schema.Resource {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				ForceNew: true,
 				Computed: true,
 				Set: func(v interface{}) int {
 					return hashcode.String(v.(string))

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -88,42 +88,6 @@ func TestAccAWSELB_InstanceAttaching(t *testing.T) {
 	})
 }
 
-func TestAccAWSELB_AddSubnet(t *testing.T) {
-	var conf elb.LoadBalancer
-
-	testCheckSubnetsAdded := func(count int) resource.TestCheckFunc {
-		return func(*terraform.State) error {
-			if len(conf.Subnets) != count {
-				return fmt.Errorf("subnet count does not match")
-			}
-			return nil
-		}
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSELBDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSELBConfigVPC,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
-					testAccCheckAWSELBAttributes(&conf),
-				),
-			},
-
-			resource.TestStep{
-				Config: testAccAWSELBAddSubnets,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
-					testCheckSubnetsAdded(2),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSELB_HealthCheck(t *testing.T) {
 	var conf elb.LoadBalancer
 
@@ -346,64 +310,6 @@ resource "aws_instance" "foo" {
 	# us-west-2
 	ami = "ami-043a5034"
 	instance_type = "t1.micro"
-}
-`
-const testAccAWSELBConfigVPC = `
-resource "aws_elb" "bar" {
-  vpc_id = "${aws_vpc.foobar.id}"
-  name = "foobar-terraform-test"
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
-
-  listener {
-    instance_port = 8000
-    instance_protocol = "http"
-    lb_port = 80
-    lb_protocol = "http"
-  }
-
-  subnets = ["${aws_subnet.baz.id}"]
-
-}
-
-resource "aws_subnet" "baz" {
-  vpc_id = "${aws_vpc.foobar.id}"
-  cidr_block = "10.0.69.0/24"
-}
-
-resource "aws_vpc" "foobar" {
-  cidr_block = "10.0.0.0/16"
-}
-`
-
-const testAccAWSELBAddSubnets = `
-resource "aws_elb" "bar" {
-  vpc_id = "${aws_vpc.foobar.id}"
-  name = "foobar-terraform-test"
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
-
-  listener {
-    instance_port = 8000
-    instance_protocol = "http"
-    lb_port = 80
-    lb_protocol = "http"
-  }
-
-  subnets = ["${aws_subnet.baz.id}",
-             "${aws_subnet.foo.id}"]
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.foobar.id}"
-  cidr_block = "10.0.68.0/24"
-}
-
-resource "aws_subnet" "baz" {
-  vpc_id = "${aws_vpc.foobar.id}"
-  cidr_block = "10.0.69.0/24"
-}
-
-resource "aws_vpc" "foobar" {
-  cidr_block = "10.0.0.0/16"
 }
 `
 


### PR DESCRIPTION
Unfortunately, the acceptance tests here were improperly passing, and
allowing Subnet updates on ELBs is not as straightfoward as simply
removing `ForceNew`.

Subnets on ELBs need to be managed by two explicit API calls:

 * `AttachLoadBalancerToSubnets` - http://bit.ly/elbattachsubnet
 * `DetachLoadBalanceFromSubnets` - http://bit.ly/elbdetachsubnet

We'll need to circle back and use these APIs to explicitly add support.

This fixes the failure of `TestAccAWSELB_AddSubnet` by removing the
test.

This reverts commit 61e91017befb8b61e394776c53abbb675ac09f14, reversing
changes made to 49b3afe45201a56bd154517cf1a9a4c753156659.