### PR TITLE
Heroku returns config_vars for addon as string array.

### DIFF
--- a/builtin/providers/heroku/resource_heroku_addon.go
+++ b/builtin/providers/heroku/resource_heroku_addon.go
@@ -114,7 +114,12 @@ func resourceHerokuAddonRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", addon.Name)
 	d.Set("plan", plan)
 	d.Set("provider_id", addon.ProviderID)
-	d.Set("config_vars", []interface{}{addon.ConfigVars})
+
+	configVarsMap := make(map[string]interface{})
+	for i := range addon.ConfigVars {
+		configVarsMap[addon.ConfigVars[i]] = addon.ConfigVars[i]
+	}
+	d.Set("config_vars", []interface{}{configVarsMap})
 
 	return nil
 }


### PR DESCRIPTION
our schema says []map[string]interface{} which results in no data being saved in state after provisioning. I am switching this to save the array in a form {config_variable => config_variable}. Or course if we don't feel a huge need to be backwards compatible, it would be more convenient to change the schema accordingly.