### PR TITLE
provider/aws: Convert S3 Bucket to awslabs/aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -12,10 +12,10 @@ import (
 	"github.com/mitchellh/goamz/ec2"
 	"github.com/mitchellh/goamz/elb"
 	"github.com/mitchellh/goamz/rds"
-	"github.com/mitchellh/goamz/s3"
 
 	awsGo "github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/gen/route53"
+	"github.com/awslabs/aws-sdk-go/gen/s3"
 )
 
 type Config struct {
@@ -31,6 +31,7 @@ type AWSClient struct {
 	s3conn          *s3.S3
 	rdsconn         *rds.Rds
 	r53conn         *route53.Route53
+	region          string
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -53,6 +54,11 @@ func (c *Config) Client() (interface{}, error) {
 	}
 
 	if len(errs) == 0 {
+		// store AWS region in client struct, for region specific operations such as
+		// bucket storage in S3
+		client.region = c.Region
+		creds := awsGo.Creds(c.AccessKey, c.SecretKey, "")
+
 		log.Println("[INFO] Initializing EC2 connection")
 		client.ec2conn = ec2.New(auth, region)
 		log.Println("[INFO] Initializing ELB connection")
@@ -60,16 +66,14 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing AutoScaling connection")
 		client.autoscalingconn = autoscaling.New(auth, region)
 		log.Println("[INFO] Initializing S3 connection")
-		client.s3conn = s3.New(auth, region)
 		log.Println("[INFO] Initializing RDS connection")
 		client.rdsconn = rds.New(auth, region)
 		log.Println("[INFO] Initializing Route53 connection")
-		creds := awsGo.Creds(c.AccessKey, c.SecretKey, "")
-
 		// aws-sdk-go uses v4 for signing requests, which requires all global
 		// endpoints to use 'us-east-1'.
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		client.r53conn = route53.New(creds, "us-east-1", nil)
+		client.s3conn = s3.New(creds, c.Region, nil)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -5,7 +5,9 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mitchellh/goamz/s3"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/gen/s3"
 )
 
 func resourceAwsS3Bucket() *schema.Resource {
@@ -33,14 +35,23 @@ func resourceAwsS3Bucket() *schema.Resource {
 
 func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
+	awsRegion := meta.(*AWSClient).region
 
 	// Get the bucket and acl
 	bucket := d.Get("bucket").(string)
 	acl := d.Get("acl").(string)
 
 	log.Printf("[DEBUG] S3 bucket create: %s, ACL: %s", bucket, acl)
-	s3Bucket := s3conn.Bucket(bucket)
-	err := s3Bucket.PutBucket(s3.ACL(acl))
+
+	req := &s3.CreateBucketRequest{
+		Bucket: aws.String(bucket),
+		ACL:    aws.String(acl),
+		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
+			LocationConstraint: aws.String(awsRegion),
+		},
+	}
+
+	_, err := s3conn.CreateBucket(req)
 	if err != nil {
 		return fmt.Errorf("Error creating S3 bucket: %s", err)
 	}
@@ -54,12 +65,12 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
-	bucket := s3conn.Bucket(d.Id())
-	resp, err := bucket.Head("/")
+	err := s3conn.HeadBucket(&s3.HeadBucketRequest{
+		Bucket: aws.String(d.Id()),
+	})
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 	return nil
 }
 
@@ -67,7 +78,11 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
 	log.Printf("[DEBUG] S3 Delete Bucket: %s", d.Id())
-	bucket := s3conn.Bucket(d.Id())
-
-	return bucket.DelBucket()
+	err := s3conn.DeleteBucket(&s3.DeleteBucketRequest{
+		Bucket: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This converts the S3 Bucket resource to `awslabs/aws-sdk-go`, removing `goamz/s3`