### PR TITLE
config: depends on cannot contain interpolations [GH-985]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -379,6 +379,17 @@ func (c *Config) Validate() error {
 
 		// Verify depends on points to resources that all exist
 		for _, d := range r.DependsOn {
+			// Check if we contain interpolations
+			rc, err := NewRawConfig(map[string]interface{}{
+				"value": d,
+			})
+			if err == nil && len(rc.Variables) > 0 {
+				errs = append(errs, fmt.Errorf(
+					"%s: depends on value cannot contain interpolations: %s",
+					n, d))
+				continue
+			}
+
 			if _, ok := resources[d]; !ok {
 				errs = append(errs, fmt.Errorf(
 					"%s: resource depends on non-existent resource '%s'",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,6 +109,13 @@ func TestConfigValidate_countVarInvalid(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_dependsOnVar(t *testing.T) {
+	c := testConfig(t, "validate-depends-on-var")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_dupModule(t *testing.T) {
 	c := testConfig(t, "validate-dup-module")
 	if err := c.Validate(); err == nil {

--- a/config/test-fixtures/validate-depends-on-var/main.tf
+++ b/config/test-fixtures/validate-depends-on-var/main.tf
@@ -1,0 +1,7 @@
+variable "foo" {
+    description = "bar"
+}
+
+resource aws_instance "web" {
+    depends_on = ["${var.foo}"]
+}


### PR DESCRIPTION
Fixes #985 

This would previously still fail validation since it wouldn't be a valid resource name, but this makes the error message clearer.