### PR TITLE
config: provisioner splat vars can only reference other resources

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -385,6 +385,26 @@ func (c *Config) Validate() error {
 					n, d))
 			}
 		}
+
+		// Verify provisioners don't contain any splats
+		for _, p := range r.Provisioners {
+			// This validation checks that there are now splat variables
+			// referencing ourself. This currently is not allowed.
+
+			for _, v := range p.ConnInfo.Variables {
+				rv, ok := v.(*ResourceVariable)
+				if !ok {
+					continue
+				}
+
+				if rv.Multi && rv.Index == -1 && rv.Type == r.Type && rv.Name == r.Name {
+					errs = append(errs, fmt.Errorf(
+						"%s: connection info cannot contain splat variable "+
+							"referencing itself", n))
+					break
+				}
+			}
+		}
 	}
 
 	for source, vs := range vars {

--- a/config/config.go
+++ b/config/config.go
@@ -404,6 +404,20 @@ func (c *Config) Validate() error {
 					break
 				}
 			}
+
+			for _, v := range p.RawConfig.Variables {
+				rv, ok := v.(*ResourceVariable)
+				if !ok {
+					continue
+				}
+
+				if rv.Multi && rv.Index == -1 && rv.Type == r.Type && rv.Name == r.Name {
+					errs = append(errs, fmt.Errorf(
+						"%s: connection info cannot contain splat variable "+
+							"referencing itself", n))
+					break
+				}
+			}
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -193,6 +193,20 @@ func TestConfigValidate_provConnSplatSelf(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_provSplatOther(t *testing.T) {
+	c := testConfig(t, "validate-prov-splat-other")
+	if err := c.Validate(); err != nil {
+		t.Fatalf("should be valid: %s", err)
+	}
+}
+
+func TestConfigValidate_provSplatSelf(t *testing.T) {
+	c := testConfig(t, "validate-prov-splat-self")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_unknownThing(t *testing.T) {
 	c := testConfig(t, "validate-unknownthing")
 	if err := c.Validate(); err == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -179,6 +179,13 @@ func TestConfigValidate_pathVarInvalid(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_provConnSplatOther(t *testing.T) {
+	c := testConfig(t, "validate-prov-conn-splat-other")
+	if err := c.Validate(); err != nil {
+		t.Fatalf("should be valid: %s", err)
+	}
+}
+
 func TestConfigValidate_provConnSplatSelf(t *testing.T) {
 	c := testConfig(t, "validate-prov-conn-splat-self")
 	if err := c.Validate(); err == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -179,6 +179,13 @@ func TestConfigValidate_pathVarInvalid(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_provConnSplatSelf(t *testing.T) {
+	c := testConfig(t, "validate-prov-conn-splat-self")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_unknownThing(t *testing.T) {
 	c := testConfig(t, "validate-unknownthing")
 	if err := c.Validate(); err == nil {

--- a/config/test-fixtures/validate-prov-conn-splat-other/main.tf
+++ b/config/test-fixtures/validate-prov-conn-splat-other/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "foo" {}
+
+resource "aws_instance" "bar" {
+    connection {
+        host = "${element(aws_instance.foo.*.private_ip, 0)}"
+    }
+
+    provisioner "local-exec" {}
+}

--- a/config/test-fixtures/validate-prov-conn-splat-self/main.tf
+++ b/config/test-fixtures/validate-prov-conn-splat-self/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "bar" {
+    connection {
+        host = "${element(aws_instance.bar.*.private_ip, 0)}"
+    }
+
+    provisioner "local-exec" {}
+}

--- a/config/test-fixtures/validate-prov-splat-other/main.tf
+++ b/config/test-fixtures/validate-prov-splat-other/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {}
+
+resource "aws_instance" "bar" {
+    provisioner "local-exec" {
+        command = "${element(aws_instance.foo.*.private_ip, 0)}"
+    }
+}

--- a/config/test-fixtures/validate-prov-splat-self/main.tf
+++ b/config/test-fixtures/validate-prov-splat-self/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {}
+
+resource "aws_instance" "bar" {
+    provisioner "local-exec" {
+        command = "${element(aws_instance.bar.*.private_ip, 0)}"
+    }
+}


### PR DESCRIPTION
Fixes #868 
Fixes #795 

This adds validation so that connection info and provisioners that use splats (`${resource.name.*.property}`) can only reference _other_ resources, not themselves. 