### PR TITLE
terraform: module inputs/vars can be non-strings [GH-819]

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -3298,6 +3298,35 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 	}
 }
 
+// GH-819
+func TestContext2Apply_moduleBool(t *testing.T) {
+	m := testModule(t, "apply-module-bool")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	if _, err := ctx.Plan(nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(testTerraformApplyModuleBoolStr)
+	if actual != expected {
+		t.Fatalf("bad: \n%s", actual)
+	}
+}
+
 func TestContext2Apply_multiProvider(t *testing.T) {
 	m := testModule(t, "apply-multi-provider")
 	p := testProvider("aws")

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -231,7 +231,12 @@ func (s *State) String() string {
 
 		s := bufio.NewScanner(strings.NewReader(mStr))
 		for s.Scan() {
-			buf.WriteString(fmt.Sprintf("  %s\n", s.Text()))
+			text := s.Text()
+			if text != "" {
+				text = "  " + text
+			}
+
+			buf.WriteString(fmt.Sprintf("%s\n", text))
 		}
 	}
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -285,6 +285,22 @@ module.child:
     type = aws_instance
 `
 
+const testTerraformApplyModuleBoolStr = `
+aws_instance.bar:
+  ID = foo
+  foo = 1
+  type = aws_instance
+
+  Dependencies:
+    module.child
+
+module.child:
+  <no state>
+  Outputs:
+
+  leader = 1
+`
+
 const testTerraformApplyMultiProviderStr = `
 aws_instance.bar:
   ID = foo

--- a/terraform/test-fixtures/apply-module-bool/child/main.tf
+++ b/terraform/test-fixtures/apply-module-bool/child/main.tf
@@ -1,0 +1,7 @@
+variable "leader" {
+    default = false
+}
+
+output "leader" {
+    value = "${var.leader}"
+}

--- a/terraform/test-fixtures/apply-module-bool/main.tf
+++ b/terraform/test-fixtures/apply-module-bool/main.tf
@@ -1,0 +1,8 @@
+module "child" {
+    source = "./child"
+    leader = true
+}
+
+resource "aws_instance" "bar" {
+    foo = "${module.child.leader}"
+}


### PR DESCRIPTION
Fixes #819 

This allows module variables to be non-string types. We currently just do a mapstructure weak decode to a string, but as we introduce more typing throughout core, this should just end up working. And for now, this works since we weak decode back to the normal type at some point.