### PR TITLE
Convert AWS AutoScalingGroup to awslabs/aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -7,13 +7,14 @@ import (
 	"unicode"
 
 	"github.com/hashicorp/terraform/helper/multierror"
+	"github.com/mitchellh/goamz/autoscaling"
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/ec2"
 	"github.com/mitchellh/goamz/elb"
 	"github.com/mitchellh/goamz/rds"
 
 	awsGo "github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/autoscaling"
+	awsAutoScaling "github.com/awslabs/aws-sdk-go/gen/autoscaling"
 	"github.com/awslabs/aws-sdk-go/gen/route53"
 	"github.com/awslabs/aws-sdk-go/gen/s3"
 )
@@ -25,13 +26,14 @@ type Config struct {
 }
 
 type AWSClient struct {
-	ec2conn         *ec2.EC2
-	elbconn         *elb.ELB
-	autoscalingconn *autoscaling.AutoScaling
-	s3conn          *s3.S3
-	rdsconn         *rds.Rds
-	r53conn         *route53.Route53
-	region          string
+	ec2conn            *ec2.EC2
+	elbconn            *elb.ELB
+	autoscalingconn    *autoscaling.AutoScaling
+	s3conn             *s3.S3
+	rdsconn            *rds.Rds
+	r53conn            *route53.Route53
+	region             string
+	awsAutoScalingconn *awsAutoScaling.AutoScaling
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -64,6 +66,8 @@ func (c *Config) Client() (interface{}, error) {
 		client.ec2conn = ec2.New(auth, region)
 		log.Println("[INFO] Initializing ELB connection")
 		client.elbconn = elb.New(auth, region)
+		log.Println("[INFO] Initializing AutoScaling connection")
+		client.autoscalingconn = autoscaling.New(auth, region)
 		log.Println("[INFO] Initializing S3 connection")
 		client.s3conn = s3.New(creds, c.Region, nil)
 		log.Println("[INFO] Initializing RDS connection")
@@ -74,8 +78,8 @@ func (c *Config) Client() (interface{}, error) {
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		log.Println("[INFO] Initializing Route53 connection")
 		client.r53conn = route53.New(creds, "us-east-1", nil)
-		log.Println("[INFO] Initializing AutoScaling connection")
-		client.autoscalingconn = autoscaling.New(creds, c.Region, nil)
+		log.Println("[INFO] Initializing AWS Go AutoScaling connection")
+		client.awsAutoScalingconn = awsAutoScaling.New(creds, c.Region, nil)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -7,13 +7,13 @@ import (
 	"unicode"
 
 	"github.com/hashicorp/terraform/helper/multierror"
-	"github.com/mitchellh/goamz/autoscaling"
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/ec2"
 	"github.com/mitchellh/goamz/elb"
 	"github.com/mitchellh/goamz/rds"
 
 	awsGo "github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/gen/autoscaling"
 	"github.com/awslabs/aws-sdk-go/gen/route53"
 	"github.com/awslabs/aws-sdk-go/gen/s3"
 )
@@ -57,23 +57,25 @@ func (c *Config) Client() (interface{}, error) {
 		// store AWS region in client struct, for region specific operations such as
 		// bucket storage in S3
 		client.region = c.Region
+
 		creds := awsGo.Creds(c.AccessKey, c.SecretKey, "")
 
 		log.Println("[INFO] Initializing EC2 connection")
 		client.ec2conn = ec2.New(auth, region)
 		log.Println("[INFO] Initializing ELB connection")
 		client.elbconn = elb.New(auth, region)
-		log.Println("[INFO] Initializing AutoScaling connection")
-		client.autoscalingconn = autoscaling.New(auth, region)
 		log.Println("[INFO] Initializing S3 connection")
+		client.s3conn = s3.New(creds, c.Region, nil)
 		log.Println("[INFO] Initializing RDS connection")
 		client.rdsconn = rds.New(auth, region)
+
 		log.Println("[INFO] Initializing Route53 connection")
 		// aws-sdk-go uses v4 for signing requests, which requires all global
 		// endpoints to use 'us-east-1'.
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		client.r53conn = route53.New(creds, "us-east-1", nil)
-		client.s3conn = s3.New(creds, c.Region, nil)
+		log.Println("[INFO] Initializing AutoScaling connection")
+		client.autoscalingconn = autoscaling.New(creds, c.Region, nil)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -69,10 +69,10 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing RDS connection")
 		client.rdsconn = rds.New(auth, region)
 
-		log.Println("[INFO] Initializing Route53 connection")
 		// aws-sdk-go uses v4 for signing requests, which requires all global
 		// endpoints to use 'us-east-1'.
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
+		log.Println("[INFO] Initializing Route53 connection")
 		client.r53conn = route53.New(creds, "us-east-1", nil)
 		log.Println("[INFO] Initializing AutoScaling connection")
 		client.autoscalingconn = autoscaling.New(creds, c.Region, nil)

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -153,9 +153,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("vpc_zone_identifier"); ok && v.(*schema.Set).Len() > 0 {
 		exp := expandStringList(v.(*schema.Set).List())
-		log.Printf("\n\nexp:\n\t%#v\n\n", exp)
-		el := strings.Join(exp, ",")
-		autoScalingGroupOpts.VPCZoneIdentifier = aws.String(el)
+		autoScalingGroupOpts.VPCZoneIdentifier = aws.String(strings.Join(exp, ","))
 	}
 
 	if v, ok := d.GetOk("termination_policies"); ok && v.(*schema.Set).Len() > 0 {
@@ -185,15 +183,15 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("availability_zones", g.AvailabilityZones)
-	d.Set("default_cooldown", g.DefaultCooldown)
-	d.Set("desired_capacity", g.DesiredCapacity)
-	d.Set("health_check_grace_period", g.HealthCheckGracePeriod)
-	d.Set("health_check_type", g.HealthCheckType)
-	d.Set("launch_configuration", g.LaunchConfigurationName)
+	d.Set("default_cooldown", *g.DefaultCooldown)
+	d.Set("desired_capacity", *g.DesiredCapacity)
+	d.Set("health_check_grace_period", *g.HealthCheckGracePeriod)
+	d.Set("health_check_type", *g.HealthCheckType)
+	d.Set("launch_configuration", *g.LaunchConfigurationName)
 	d.Set("load_balancers", g.LoadBalancerNames)
-	d.Set("min_size", g.MinSize)
-	d.Set("max_size", g.MaxSize)
-	d.Set("name", g.AutoScalingGroupName)
+	d.Set("min_size", *g.MinSize)
+	d.Set("max_size", *g.MaxSize)
+	d.Set("name", *g.AutoScalingGroupName)
 	d.Set("vpc_zone_identifier", strings.Split(*g.VPCZoneIdentifier, ","))
 	d.Set("termination_policies", g.TerminationPolicies)
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -241,7 +243,7 @@ resource "aws_autoscaling_group" "bar" {
 }
 `
 
-const testAccAWSAutoScalingGroupConfigWithLoadBalancer = `
+var testAccAWSAutoScalingGroupConfigWithLoadBalancer = fmt.Sprintf(`
 resource "aws_elb" "bar" {
   name = "foobar-terraform-test"
   availability_zones = ["us-west-2a"]
@@ -262,7 +264,7 @@ resource "aws_launch_configuration" "foobar" {
 
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["us-west-2a"]
-  name = "foobar3-terraform-test"
+  name = "foobar3-terraform-test-%d"
   max_size = 5
   min_size = 2
   health_check_grace_period = 300
@@ -273,4 +275,4 @@ resource "aws_autoscaling_group" "bar" {
   launch_configuration = "${aws_launch_configuration.foobar.name}"
   load_balancers = ["${aws_elb.bar.name}"]
 }
-`
+`, rand.New(rand.NewSource(time.Now().UnixNano())).Intn(64))

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -2,9 +2,7 @@ package aws
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -243,7 +241,7 @@ resource "aws_autoscaling_group" "bar" {
 }
 `
 
-var testAccAWSAutoScalingGroupConfigWithLoadBalancer = fmt.Sprintf(`
+const testAccAWSAutoScalingGroupConfigWithLoadBalancer = `
 resource "aws_elb" "bar" {
   name = "foobar-terraform-test"
   availability_zones = ["us-west-2a"]
@@ -264,7 +262,7 @@ resource "aws_launch_configuration" "foobar" {
 
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["us-west-2a"]
-  name = "foobar3-terraform-test-%d"
+  name = "foobar3-terraform-test"
   max_size = 5
   min_size = 2
   health_check_grace_period = 300
@@ -275,4 +273,4 @@ resource "aws_autoscaling_group" "bar" {
   launch_configuration = "${aws_launch_configuration.foobar.name}"
   load_balancers = ["${aws_elb.bar.name}"]
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Intn(64))
+`

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/goamz/autoscaling"
+
+	_ "github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/gen/autoscaling"
 )
 
 func TestAccAWSAutoScalingGroup_basic(t *testing.T) {

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
-	_ "github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/autoscaling"
+	"github.com/mitchellh/goamz/autoscaling"
 )
 
 func TestAccAWSAutoScalingGroup_basic(t *testing.T) {


### PR DESCRIPTION
This PR converts AWS AutoScalingGroup to use `awslabs/aws-sdk-go`.

Because of light coupling with Launch Configurations, the test file keeps `mitchellh/goamz` as the ASG library for now, until I can convert the Launch Configurations resource. 