### PR TITLE
Fix network interface

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -671,7 +671,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				// Delete any accessConfig that currently exists in instNetworkInterface
 				for _, ac := range instNetworkInterface.AccessConfigs {
 					op, err := config.clientCompute.Instances.DeleteAccessConfig(
-						config.Project, zone, d.Id(), ac.Name, networkName).Do();
+						config.Project, zone, d.Id(), ac.Name, networkName).Do()
 					if err != nil {
 						return fmt.Errorf("Error deleting old access_config: %s", err)
 					}

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -671,7 +671,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				// Delete any accessConfig that currently exists in instNetworkInterface
 				for _, ac := range instNetworkInterface.AccessConfigs {
 					op, err := config.clientCompute.Instances.DeleteAccessConfig(
-						config.Project, zone, d.Id(), networkName, ac.Name).Do()
+						config.Project, zone, d.Id(), ac.Name, networkName).Do();
 					if err != nil {
 						return fmt.Errorf("Error deleting old access_config: %s", err)
 					}


### PR DESCRIPTION
The current code gives the following error:

* Error deleting old access_config: googleapi: Error 400: Invalid value for field 'networkInterfaceName': 'External NAT'.  Must be a valid network interface name (e.g. nic0, nic1), invalid

