### PR TITLE
providers/aws: Convert Launch Configurations to awslabs/aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -7,14 +7,13 @@ import (
 	"unicode"
 
 	"github.com/hashicorp/terraform/helper/multierror"
-	"github.com/mitchellh/goamz/autoscaling"
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/ec2"
 	"github.com/mitchellh/goamz/elb"
 	"github.com/mitchellh/goamz/rds"
 
 	awsGo "github.com/awslabs/aws-sdk-go/aws"
-	awsAutoScaling "github.com/awslabs/aws-sdk-go/gen/autoscaling"
+	"github.com/awslabs/aws-sdk-go/gen/autoscaling"
 	"github.com/awslabs/aws-sdk-go/gen/route53"
 	"github.com/awslabs/aws-sdk-go/gen/s3"
 )
@@ -26,14 +25,13 @@ type Config struct {
 }
 
 type AWSClient struct {
-	ec2conn            *ec2.EC2
-	elbconn            *elb.ELB
-	autoscalingconn    *autoscaling.AutoScaling
-	s3conn             *s3.S3
-	rdsconn            *rds.Rds
-	r53conn            *route53.Route53
-	region             string
-	awsAutoScalingconn *awsAutoScaling.AutoScaling
+	ec2conn         *ec2.EC2
+	elbconn         *elb.ELB
+	autoscalingconn *autoscaling.AutoScaling
+	s3conn          *s3.S3
+	rdsconn         *rds.Rds
+	r53conn         *route53.Route53
+	region          string
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -67,7 +65,7 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing ELB connection")
 		client.elbconn = elb.New(auth, region)
 		log.Println("[INFO] Initializing AutoScaling connection")
-		client.autoscalingconn = autoscaling.New(auth, region)
+		client.autoscalingconn = autoscaling.New(creds, c.Region, nil)
 		log.Println("[INFO] Initializing S3 connection")
 		client.s3conn = s3.New(creds, c.Region, nil)
 		log.Println("[INFO] Initializing RDS connection")
@@ -78,8 +76,6 @@ func (c *Config) Client() (interface{}, error) {
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		log.Println("[INFO] Initializing Route53 connection")
 		client.r53conn = route53.New(creds, "us-east-1", nil)
-		log.Println("[INFO] Initializing AWS Go AutoScaling connection")
-		client.awsAutoScalingconn = awsAutoScaling.New(creds, c.Region, nil)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -123,7 +123,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 }
 
 func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).awsAutoScalingconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	var autoScalingGroupOpts autoscaling.CreateAutoScalingGroupType
 	autoScalingGroupOpts.AutoScalingGroupName = aws.String(d.Get("name").(string))
@@ -199,7 +199,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).awsAutoScalingconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	opts := autoscaling.UpdateAutoScalingGroupType{
 		AutoScalingGroupName: aws.String(d.Id()),
@@ -232,7 +232,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).awsAutoScalingconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	// Read the autoscaling group first. If it doesn't exist, we're done.
 	// We need the group in order to check if there are instances attached.
@@ -276,7 +276,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 func getAwsAutoscalingGroup(
 	d *schema.ResourceData,
 	meta interface{}) (*autoscaling.AutoScalingGroup, error) {
-	autoscalingconn := meta.(*AWSClient).awsAutoScalingconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	describeOpts := autoscaling.AutoScalingGroupNamesType{
 		AutoScalingGroupNames: []string{d.Id()},
@@ -307,7 +307,7 @@ func getAwsAutoscalingGroup(
 }
 
 func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).awsAutoScalingconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	// First, set the capacity to zero so the group will drain
 	log.Printf("[DEBUG] Reducing autoscaling group capacity to zero")

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -2,15 +2,17 @@ package aws
 
 import (
 	"crypto/sha1"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/gen/autoscaling"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mitchellh/goamz/autoscaling"
 )
 
 func resourceAwsLaunchConfiguration() *schema.Resource {
@@ -94,15 +96,26 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
-	var createLaunchConfigurationOpts autoscaling.CreateLaunchConfiguration
-	createLaunchConfigurationOpts.Name = d.Get("name").(string)
-	createLaunchConfigurationOpts.IamInstanceProfile = d.Get("iam_instance_profile").(string)
-	createLaunchConfigurationOpts.ImageId = d.Get("image_id").(string)
-	createLaunchConfigurationOpts.InstanceType = d.Get("instance_type").(string)
-	createLaunchConfigurationOpts.KeyName = d.Get("key_name").(string)
-	createLaunchConfigurationOpts.UserData = d.Get("user_data").(string)
-	createLaunchConfigurationOpts.AssociatePublicIpAddress = d.Get("associate_public_ip_address").(bool)
-	createLaunchConfigurationOpts.SpotPrice = d.Get("spot_price").(string)
+	var createLaunchConfigurationOpts autoscaling.CreateLaunchConfigurationType
+	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(d.Get("name").(string))
+	createLaunchConfigurationOpts.ImageID = aws.String(d.Get("image_id").(string))
+	createLaunchConfigurationOpts.InstanceType = aws.String(d.Get("instance_type").(string))
+
+	if v, ok := d.GetOk("user_data"); ok {
+		createLaunchConfigurationOpts.UserData = aws.String(base64.StdEncoding.EncodeToString([]byte(v.(string))))
+	}
+	if v, ok := d.GetOk("associate_public_ip_address"); ok {
+		createLaunchConfigurationOpts.AssociatePublicIPAddress = aws.Boolean(v.(bool))
+	}
+	if v, ok := d.GetOk("iam_instance_profile"); ok {
+		createLaunchConfigurationOpts.IAMInstanceProfile = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("key_name"); ok {
+		createLaunchConfigurationOpts.KeyName = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("spot_price"); ok {
+		createLaunchConfigurationOpts.SpotPrice = aws.String(v.(string))
+	}
 
 	if v, ok := d.GetOk("security_groups"); ok {
 		createLaunchConfigurationOpts.SecurityGroups = expandStringList(
@@ -110,7 +123,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	log.Printf("[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
-	_, err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
+	err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating launch configuration: %s", err)
 	}
@@ -128,8 +141,8 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
-	describeOpts := autoscaling.DescribeLaunchConfigurations{
-		Names: []string{d.Id()},
+	describeOpts := autoscaling.LaunchConfigurationNamesType{
+		LaunchConfigurationNames: []string{d.Id()},
 	}
 
 	log.Printf("[DEBUG] launch configuration describe configuration: %#v", describeOpts)
@@ -143,7 +156,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	}
 
 	// Verify AWS returned our launch configuration
-	if describConfs.LaunchConfigurations[0].Name != d.Id() {
+	if *describConfs.LaunchConfigurations[0].LaunchConfigurationName != d.Id() {
 		return fmt.Errorf(
 			"Unable to find launch configuration: %#v",
 			describConfs.LaunchConfigurations)
@@ -151,14 +164,28 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 
 	lc := describConfs.LaunchConfigurations[0]
 
-	d.Set("key_name", lc.KeyName)
-	d.Set("iam_instance_profile", lc.IamInstanceProfile)
-	d.Set("image_id", lc.ImageId)
-	d.Set("instance_type", lc.InstanceType)
-	d.Set("name", lc.Name)
-	d.Set("security_groups", lc.SecurityGroups)
-	d.Set("spot_price", lc.SpotPrice)
+	d.Set("key_name", *lc.KeyName)
+	d.Set("image_id", *lc.ImageID)
+	d.Set("instance_type", *lc.InstanceType)
+	d.Set("name", *lc.LaunchConfigurationName)
 
+	if lc.IAMInstanceProfile != nil {
+		d.Set("iam_instance_profile", *lc.IAMInstanceProfile)
+	} else {
+		d.Set("iam_instance_profile", nil)
+	}
+
+	if lc.SpotPrice != nil {
+		d.Set("spot_price", *lc.SpotPrice)
+	} else {
+		d.Set("spot_price", nil)
+	}
+
+	if lc.SecurityGroups != nil {
+		d.Set("security_groups", lc.SecurityGroups)
+	} else {
+		d.Set("security_groups", nil)
+	}
 	return nil
 }
 
@@ -166,10 +193,10 @@ func resourceAwsLaunchConfigurationDelete(d *schema.ResourceData, meta interface
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	log.Printf("[DEBUG] Launch Configuration destroy: %v", d.Id())
-	_, err := autoscalingconn.DeleteLaunchConfiguration(
-		&autoscaling.DeleteLaunchConfiguration{Name: d.Id()})
+	err := autoscalingconn.DeleteLaunchConfiguration(
+		&autoscaling.LaunchConfigurationNameType{LaunchConfigurationName: aws.String(d.Id())})
 	if err != nil {
-		autoscalingerr, ok := err.(*autoscaling.Error)
+		autoscalingerr, ok := err.(aws.APIError)
 		if ok && autoscalingerr.Code == "InvalidConfiguration.NotFound" {
 			return nil
 		}


### PR DESCRIPTION
This pull request converts AWS Launch Configuration over the `awslabs/aws-sdk-go`. It also upgrades ASG to remove `goamz` as well.

This conversion was trickier. 

I started by fully converting ASG over, because of some cross between the tests (ASG tests call `testAccCheckAWSLaunchConfigurationExists`, which was expecting old style `goamz` structs). 

After that, converting Launch Configurations involved more work, specifically regarding what I was sending to the API. I assume that's a difference in AWS APIs rather than something I'm doing wrong in other resources. 

Some callouts:

- `UserData`: needed to be Base64 encoded, or the API returned an error. There's already some data massaging going on in the `schema`, I'm not sure if that's redundant now with what I'm doing.
- things like `associate_public_ip_address`, `iam_instance_profile`, `key_name`, `spot_price` are all optional, but AWS was freaking out if anything empty was provided. `associate_public_ip_address`, for instance, is an optional boolean, but sending `false` caused it to complain about having an empty `VPCZoneIdentifier` field.
- `resource.TestCheckResourceAttrPtr` step in `testAccAWSAutoScalingGroupConfigUpdate` of the ASG test is throwing a nil pointer dereference error with the `lc.LaunchConfigurationName` attribute. I'm at a loss there. 