### PR TITLE
Only increment serial on state change

### DIFF
--- a/state/cache.go
+++ b/state/cache.go
@@ -104,6 +104,8 @@ func (s *CacheState) RefreshState() error {
 			s.refreshResult = CacheRefreshNoop
 			return err
 		}
+
+		cached = durable
 	}
 
 	s.state = cached

--- a/state/cache.go
+++ b/state/cache.go
@@ -19,7 +19,7 @@ type CacheState struct {
 
 // StateReader impl.
 func (s *CacheState) State() *terraform.State {
-	return s.state
+	return s.state.DeepCopy()
 }
 
 // WriteState will write and persist the state to the cache.

--- a/state/inmem.go
+++ b/state/inmem.go
@@ -10,7 +10,7 @@ type InmemState struct {
 }
 
 func (s *InmemState) State() *terraform.State {
-	return s.state
+	return s.state.DeepCopy()
 }
 
 func (s *InmemState) RefreshState() error {

--- a/state/inmem.go
+++ b/state/inmem.go
@@ -18,6 +18,7 @@ func (s *InmemState) RefreshState() error {
 }
 
 func (s *InmemState) WriteState(state *terraform.State) error {
+	state.IncrementSerialMaybe(s.state)
 	s.state = state
 	return nil
 }

--- a/state/local.go
+++ b/state/local.go
@@ -28,7 +28,7 @@ func (s *LocalState) SetState(state *terraform.State) {
 
 // StateReader impl.
 func (s *LocalState) State() *terraform.State {
-	return s.state
+	return s.state.DeepCopy()
 }
 
 // WriteState for LocalState always persists the state as well.

--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -18,7 +18,7 @@ type State struct {
 
 // StateReader impl.
 func (s *State) State() *terraform.State {
-	return s.state
+	return s.state.DeepCopy()
 }
 
 // StateWriter impl.

--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -13,7 +13,7 @@ import (
 type State struct {
 	Client Client
 
-	state *terraform.State
+	state, readState *terraform.State
 }
 
 // StateReader impl.
@@ -43,11 +43,14 @@ func (s *State) RefreshState() error {
 	}
 
 	s.state = state
+	s.readState = state
 	return nil
 }
 
 // StatePersister impl.
 func (s *State) PersistState() error {
+	s.state.IncrementSerialMaybe(s.readState)
+
 	var buf bytes.Buffer
 	if err := terraform.WriteState(s.state, &buf); err != nil {
 		return err

--- a/state/remote/state_test.go
+++ b/state/remote/state_test.go
@@ -7,8 +7,11 @@ import (
 )
 
 func TestState(t *testing.T) {
-	s := &State{Client: new(InmemClient)}
-	s.WriteState(state.TestStateInitial())
+	s := &State{
+		Client:    new(InmemClient),
+		state:     state.TestStateInitial(),
+		readState: state.TestStateInitial(),
+	}
 	if err := s.PersistState(); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/state/testing.go
+++ b/state/testing.go
@@ -28,7 +28,7 @@ func TestState(t *testing.T, s interface{}) {
 	current := TestStateInitial()
 
 	// Check that the initial state is correct
-	if state := reader.State(); !reflect.DeepEqual(state, current) {
+	if state := reader.State(); !current.Equal(state) {
 		t.Fatalf("not initial: %#v\n\n%#v", state, current)
 	}
 
@@ -45,7 +45,7 @@ func TestState(t *testing.T, s interface{}) {
 			t.Fatalf("err: %s", err)
 		}
 
-		if actual := reader.State(); !reflect.DeepEqual(actual, current) {
+		if actual := reader.State(); !actual.Equal(current) {
 			t.Fatalf("bad: %#v\n\n%#v", actual, current)
 		}
 	}
@@ -65,7 +65,7 @@ func TestState(t *testing.T, s interface{}) {
 
 		// Just set the serials the same... Then compare.
 		actual := reader.State()
-		if !reflect.DeepEqual(actual, current) {
+		if !actual.Equal(current) {
 			t.Fatalf("bad: %#v\n\n%#v", actual, current)
 		}
 	}
@@ -106,6 +106,12 @@ func TestState(t *testing.T, s interface{}) {
 
 		if reader.State().Serial <= serial {
 			t.Fatalf("bad: expected %d, got %d", serial, reader.State().Serial)
+		}
+
+		// Check that State() returns a copy
+		reader.State().Serial++
+		if reflect.DeepEqual(reader.State(), current) {
+			t.Fatal("State() should return a copy")
 		}
 	}
 }

--- a/state/testing.go
+++ b/state/testing.go
@@ -28,9 +28,7 @@ func TestState(t *testing.T, s interface{}) {
 	current := TestStateInitial()
 
 	// Check that the initial state is correct
-	state := reader.State()
-	current.Serial = state.Serial
-	if !reflect.DeepEqual(state, current) {
+	if state := reader.State(); !reflect.DeepEqual(state, current) {
 		t.Fatalf("not initial: %#v\n\n%#v", state, current)
 	}
 
@@ -67,9 +65,47 @@ func TestState(t *testing.T, s interface{}) {
 
 		// Just set the serials the same... Then compare.
 		actual := reader.State()
-		actual.Serial = current.Serial
 		if !reflect.DeepEqual(actual, current) {
 			t.Fatalf("bad: %#v\n\n%#v", actual, current)
+		}
+	}
+
+	// If we can write and persist then verify that the serial
+	// is only implemented on change.
+	writer, writeOk := s.(StateWriter)
+	persister, persistOk := s.(StatePersister)
+	if writeOk && persistOk {
+		// Same serial
+		serial := current.Serial
+		if err := writer.WriteState(current); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if err := persister.PersistState(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if reader.State().Serial != serial {
+			t.Fatalf("bad: expected %d, got %d", serial, reader.State().Serial)
+		}
+
+		// Change the serial
+		currentCopy := *current
+		current = &currentCopy
+		current.Modules = []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path:    []string{"root", "somewhere"},
+				Outputs: map[string]string{"serialCheck": "true"},
+			},
+		}
+		if err := writer.WriteState(current); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if err := persister.PersistState(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if reader.State().Serial <= serial {
+			t.Fatalf("bad: expected %d, got %d", serial, reader.State().Serial)
 		}
 	}
 }

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -224,7 +224,7 @@ func (c *Context) Apply() (*State, error) {
 	defer c.releaseRun(v)
 
 	// Copy our own state
-	c.state = c.state.deepcopy()
+	c.state = c.state.DeepCopy()
 
 	// Do the walk
 	_, err := c.walk(walkApply)
@@ -264,7 +264,7 @@ func (c *Context) Plan(opts *PlanOpts) (*Plan, error) {
 			c.state = &State{}
 			c.state.init()
 		} else {
-			c.state = old.deepcopy()
+			c.state = old.DeepCopy()
 		}
 		defer func() {
 			c.state = old
@@ -299,7 +299,7 @@ func (c *Context) Refresh() (*State, error) {
 	defer c.releaseRun(v)
 
 	// Copy our own state
-	c.state = c.state.deepcopy()
+	c.state = c.state.DeepCopy()
 
 	// Do the walk
 	if _, err := c.walk(walkRefresh); err != nil {

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -188,6 +188,26 @@ func (s *State) Equal(other *State) bool {
 	return true
 }
 
+// DeepCopy performs a deep copy of the state structure and returns
+// a new structure.
+func (s *State) DeepCopy() *State {
+	if s == nil {
+		return nil
+	}
+	n := &State{
+		Version: s.Version,
+		Serial:  s.Serial,
+		Modules: make([]*ModuleState, 0, len(s.Modules)),
+	}
+	for _, mod := range s.Modules {
+		n.Modules = append(n.Modules, mod.deepcopy())
+	}
+	if s.Remote != nil {
+		n.Remote = s.Remote.deepcopy()
+	}
+	return n
+}
+
 // IncrementSerialMaybe increments the serial number of this state
 // if it different from the other state.
 func (s *State) IncrementSerialMaybe(other *State) {
@@ -207,24 +227,6 @@ func (s *State) init() {
 		root.init()
 		s.Modules = []*ModuleState{root}
 	}
-}
-
-func (s *State) deepcopy() *State {
-	if s == nil {
-		return nil
-	}
-	n := &State{
-		Version: s.Version,
-		Serial:  s.Serial,
-		Modules: make([]*ModuleState, 0, len(s.Modules)),
-	}
-	for _, mod := range s.Modules {
-		n.Modules = append(n.Modules, mod.deepcopy())
-	}
-	if s.Remote != nil {
-		n.Remote = s.Remote.deepcopy()
-	}
-	return n
 }
 
 // prune is used to remove any resources that are no longer required

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -172,6 +172,9 @@ func (s *State) Equal(other *State) bool {
 	}
 
 	// If any of the modules are not equal, then this state isn't equal
+	if len(s.Modules) != len(other.Modules) {
+		return false
+	}
 	for _, m := range s.Modules {
 		// This isn't very optimal currently but works.
 		otherM := other.ModuleByPath(m.Path)

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -161,6 +161,11 @@ func (s *State) RootModule() *ModuleState {
 
 // Equal tests if one state is equal to another.
 func (s *State) Equal(other *State) bool {
+	// If one is nil, we do a direct check
+	if s == nil || other == nil {
+		return s == other
+	}
+
 	// If the versions are different, they're certainly not equal
 	if s.Version != other.Version {
 		return false
@@ -181,6 +186,14 @@ func (s *State) Equal(other *State) bool {
 	}
 
 	return true
+}
+
+// IncrementSerialMaybe increments the serial number of this state
+// if it different from the other state.
+func (s *State) IncrementSerialMaybe(other *State) {
+	if !s.Equal(other) {
+		s.Serial++
+	}
 }
 
 func (s *State) init() {
@@ -950,9 +963,6 @@ func WriteState(d *State, dst io.Writer) error {
 
 	// Ensure the version is set
 	d.Version = StateVersion
-
-	// Always increment the serial number
-	d.Serial++
 
 	// Encode the data in a human-friendly way
 	data, err := json.MarshalIndent(d, "", "    ")

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -537,15 +537,6 @@ func TestReadWriteState(t *testing.T) {
 		t.Fatalf("bad version number: %d", state.Version)
 	}
 
-	// Verify the serial number is incremented
-	if state.Serial != 10 {
-		t.Fatalf("bad serial: %d", state.Serial)
-	}
-
-	// Remove the changes or the checksum will fail
-	state.Version = 0
-	state.Serial = 9
-
 	// Checksum after the write
 	chksumAfter := checksumStruct(t, state)
 	if chksumAfter != chksum {
@@ -556,10 +547,6 @@ func TestReadWriteState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	// Verify the changes came through
-	state.Version = StateVersion
-	state.Serial = 10
 
 	// ReadState should not restore sensitive information!
 	mod := state.RootModule()

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -116,6 +116,19 @@ func TestStateEqual(t *testing.T) {
 		Result   bool
 		One, Two *State
 	}{
+		// Nils
+		{
+			false,
+			nil,
+			&State{Version: 2},
+		},
+
+		{
+			true,
+			nil,
+			nil,
+		},
+
 		// Different versions
 		{
 			false,
@@ -157,6 +170,9 @@ func TestStateEqual(t *testing.T) {
 
 	for i, tc := range cases {
 		if tc.One.Equal(tc.Two) != tc.Result {
+			t.Fatalf("Bad: %d\n\n%s\n\n%s", i, tc.One.String(), tc.Two.String())
+		}
+		if tc.Two.Equal(tc.One) != tc.Result {
 			t.Fatalf("Bad: %d\n\n%s\n\n%s", i, tc.One.String(), tc.Two.String())
 		}
 	}


### PR DESCRIPTION
Fixes #380 

* `terraform.WriteState` no longer _ever_ increments the serial. 

* `*State.IncrementSerialMaybe` can be called to increment the serial if its not equal to another State.

* The contract of a `state.State` implementation has been modified to require the serial to be changed when the state change, and to _not change_ when the state does not change. The common test harness tests this. 

* `state.State.State()` is required to return a _copy_ of the state. The test harness also verifies this. This contract is required so that we can't request a state, modify it, call `PersistState()` can get a change with the same serial.

The only sketchy thing here is that before we _knew_ the serial was incrementing, and now it seems like we depend on a secondary package (`state`) to properly increment. However, the thing that makes this safe is that the common testing harness that is exposed publicly verifies this behavior, and all states use this test harness (`state.TestState`).