### PR TITLE
adding storage_encrypted as an optional parameter

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -50,6 +50,12 @@ func resourceAwsDbInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"storage_encrypted": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"allocated_storage": &schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
@@ -195,6 +201,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		MasterUserPassword:   aws.String(d.Get("password").(string)),
 		Engine:               aws.String(d.Get("engine").(string)),
 		EngineVersion:        aws.String(d.Get("engine_version").(string)),
+		StorageEncrypted:     aws.Boolean(d.Get("storage_encrypted").(bool)),
 	}
 
 	if attr, ok := d.GetOk("storage_type"); ok {
@@ -320,6 +327,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("address", *v.Endpoint.Port)
 	d.Set("endpoint", fmt.Sprintf("%s:%d", *v.Endpoint.Address, *v.Endpoint.Port))
 	d.Set("status", *v.DBInstanceStatus)
+	d.Set("storage_encrypted", *v.StorageEncrypted)
 
 	// Create an empty schema.Set to hold all vpc security group ids
 	ids := &schema.Set{


### PR DESCRIPTION
This provides support for encryption at rest in AWS using the default key.