### PR TITLE
terraform: destroy node should not create

### DIFF
--- a/terraform/eval_diff_test.go
+++ b/terraform/eval_diff_test.go
@@ -1,0 +1,78 @@
+package terraform
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEvalFilterDiff(t *testing.T) {
+	ctx := new(MockEvalContext)
+
+	cases := []struct {
+		Node   *EvalFilterDiff
+		Input  *InstanceDiff
+		Output *InstanceDiff
+	}{
+		// With no settings, it returns an empty diff
+		{
+			&EvalFilterDiff{},
+			&InstanceDiff{Destroy: true},
+			&InstanceDiff{},
+		},
+
+		// Destroy
+		{
+			&EvalFilterDiff{Destroy: true},
+			&InstanceDiff{Destroy: false},
+			&InstanceDiff{Destroy: false},
+		},
+		{
+			&EvalFilterDiff{Destroy: true},
+			&InstanceDiff{Destroy: true},
+			&InstanceDiff{Destroy: true},
+		},
+		{
+			&EvalFilterDiff{Destroy: true},
+			&InstanceDiff{
+				Destroy: true,
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{},
+				},
+			},
+			&InstanceDiff{Destroy: true},
+		},
+		{
+			&EvalFilterDiff{Destroy: true},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{
+						RequiresNew: true,
+					},
+				},
+			},
+			&InstanceDiff{Destroy: true},
+		},
+		{
+			&EvalFilterDiff{Destroy: true},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{},
+				},
+			},
+			&InstanceDiff{Destroy: false},
+		},
+	}
+
+	for i, tc := range cases {
+		var output *InstanceDiff
+		tc.Node.Diff = &tc.Input
+		tc.Node.Output = &output
+		if _, err := tc.Node.Eval(ctx); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if !reflect.DeepEqual(output, tc.Output) {
+			t.Fatalf("bad: %d\n\n%#v", i, output)
+		}
+	}
+}

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -43,10 +43,9 @@ func (n *EvalReadState) Eval(ctx EvalContext) (interface{}, error) {
 		if idx < 0 {
 			idx = len(rs.Tainted) - 1
 		}
-
-		if idx < len(rs.Tainted) {
+		if idx >= 0 && idx < len(rs.Tainted) {
 			// Return the proper tainted resource
-			result = rs.Tainted[n.TaintedIndex]
+			result = rs.Tainted[idx]
 		}
 	}
 
@@ -56,6 +55,25 @@ func (n *EvalReadState) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	return result, nil
+}
+
+// EvalRequireState is an EvalNode implementation that early exits
+// if the state doesn't have an ID.
+type EvalRequireState struct {
+	State **InstanceState
+}
+
+func (n *EvalRequireState) Eval(ctx EvalContext) (interface{}, error) {
+	if n.State == nil {
+		return nil, EvalEarlyExitError{}
+	}
+
+	state := *n.State
+	if state == nil || state.ID == "" {
+		return nil, EvalEarlyExitError{}
+	}
+
+	return nil, nil
 }
 
 // EvalUpdateStateHook is an EvalNode implementation that calls the

--- a/terraform/eval_state_test.go
+++ b/terraform/eval_state_test.go
@@ -5,6 +5,47 @@ import (
 	"testing"
 )
 
+func TestEvalRequireState(t *testing.T) {
+	ctx := new(MockEvalContext)
+
+	cases := []struct {
+		State *InstanceState
+		Exit  bool
+	}{
+		{
+			nil,
+			true,
+		},
+		{
+			&InstanceState{},
+			true,
+		},
+		{
+			&InstanceState{ID: "foo"},
+			false,
+		},
+	}
+
+	var exitVal EvalEarlyExitError
+	for _, tc := range cases {
+		node := &EvalRequireState{State: &tc.State}
+		_, err := node.Eval(ctx)
+		if tc.Exit {
+			if err != exitVal {
+				t.Fatalf("should've exited: %#v", tc.State)
+			}
+
+			continue
+		}
+		if !tc.Exit && err != nil {
+			t.Fatalf("shouldn't exit: %#v", tc.State)
+		}
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+}
+
 func TestEvalUpdateStateHook(t *testing.T) {
 	mockHook := new(MockHook)
 


### PR DESCRIPTION
/cc @catsby @phinze: This is a doozy, but is a good example of the new refactor and how it comes into play in fixing bugs. 

@catsby ran into a "diffs not matching" error on an acceptance test. Little did I know it'd lead me down this rabbit hole. Basically what was going on was that the acceptance test did a create before destroy (wow!) and in create before destroy, the destroy nodes were actually _also_ doing the destroy. Shockingly, the Terraform core tests still passed. Still looking into how to make that not happen... but in the mean time, this PR.

Here are the major changes made in this:

* Destroy nodes now call a new eval node `EvalFilterDiff` to filter out only the _destroy_ part, and not the creation part. 

* Destroy nodes now call a new `EvalRequireState` to not call `Apply` on the provider if there isn't even a state to destroy.

* Regular nodes during apply now call `EvalWriteDiff` with a nil diff. This fixes an issue where during create-before-destroy, the creation was keeping the diff around (not writing nil diff), and the destroy node was doing a destroy then re-create. 

More comments inline in the code to better explain.