### PR TITLE
Add support for multiple credential providers via aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
@@ -39,6 +40,7 @@ type AWSClient struct {
 }
 
 func (c *Config) loadAndValidate(providerCode string) (interface{}, error) {
+	c.tryLoadingDeprecatedEnvVars()
 	credsProvider, err := c.getCredsProvider(providerCode)
 	if err != nil {
 		return nil, err
@@ -51,6 +53,19 @@ func (c *Config) loadAndValidate(providerCode string) (interface{}, error) {
 	c.Provider = credsProvider
 
 	return c.Client()
+}
+
+func (c *Config) tryLoadingDeprecatedEnvVars() {
+	// Backward compatibility
+	if c.Token == "" {
+		c.Token = os.Getenv("AWS_SECURITY_TOKEN")
+	}
+	if c.CredentialsFilePath == "" {
+		c.CredentialsFilePath = os.Getenv("AWS_CREDENTIAL_FILE")
+	}
+	if c.CredentialsFileProfile == "" {
+		c.CredentialsFileProfile = os.Getenv("AWS_PROFILE")
+	}
 }
 
 func (c *Config) getCredsProvider(providerCode string) (aws.CredentialsProvider, error) {

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -54,9 +54,9 @@ func (c *Config) Client() (interface{}, error) {
 		client.region = c.Region
 
 		log.Println("[INFO] Building AWS auth structure")
-		creds := aws.DetectCreds(c.AccessKey, c.SecretKey, c.Token)
+		credsProvider := aws.DetectCreds(c.AccessKey, c.SecretKey, c.Token)
 		awsConfig := &aws.Config{
-			Credentials: creds,
+			Credentials: credsProvider,
 			Region:      c.Region,
 		}
 
@@ -82,10 +82,9 @@ func (c *Config) Client() (interface{}, error) {
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		log.Println("[INFO] Initializing Route 53 connection")
 		client.r53conn = route53.New(&aws.Config{
-			Credentials: creds,
+			Credentials: credsProvider,
 			Region:      "us-east-1",
 		})
-
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
The new library already brings in the functionality, so I just took the advantage of it and gave it a higher priority as in the current state `goamz` was loading everything the same old way and then passing these credentials as _static_ into `aws-sdk-go`.

I first wanted to write some tests for this, but I'm finding it really hard to mock [the calls of remote API](https://github.com/awslabs/aws-sdk-go/blob/master/aws/auth.go#L203-209) in `aws-sdk-go` as it doesn't have any similar argument for passing mocked http client instance [like each API part](https://github.com/awslabs/aws-sdk-go/blob/master/gen/s3/s3.go#L31) has.

Either way, I guess we may want to maintain the **"backward compatibility"** with the way `goamz` loads credentials, especially because the new library doesn't support following (so far):

 - `AWS_CREDENTIAL_FILE` - we could pass a filename into [`ProfileCreds`](https://github.com/awslabs/aws-sdk-go/blob/master/aws/auth.go#L130) and use that one instead `DetectCreds` if the variable exists
 - the same applies to `AWS_PROFILE` - same solution, `profile` parameter
 - the library does not support older naming convention of variables:
   - `AWS_ACCESS_KEY`
   - `AWS_SECRET_KEY `
   - `AWS_SECURITY_TOKEN`

Both `AWS_CREDENTIAL_FILE` & `AWS_PROFILE` should probably be raised as an issue and/or pull request in the `aws-sdk-go` library as well in the meantime I guess as it's pretty standard variable used by some other tools like AWS CLI.

I can add that compatibility layer into this PR too, I just first want to know what your thoughts are and if you actually want such layer there.

cc @catsby 

Related to:
#866 #266 #801