### PR TITLE
Bug: Prevent empty string to be used as default health_check_type

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -127,7 +127,6 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 
 	var autoScalingGroupOpts autoscaling.CreateAutoScalingGroupType
 	autoScalingGroupOpts.AutoScalingGroupName = aws.String(d.Get("name").(string))
-	autoScalingGroupOpts.HealthCheckType = aws.String(d.Get("health_check_type").(string))
 	autoScalingGroupOpts.LaunchConfigurationName = aws.String(d.Get("launch_configuration").(string))
 	autoScalingGroupOpts.MinSize = aws.Integer(d.Get("min_size").(int))
 	autoScalingGroupOpts.MaxSize = aws.Integer(d.Get("max_size").(int))
@@ -136,6 +135,10 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("default_cooldown"); ok {
 		autoScalingGroupOpts.DefaultCooldown = aws.Integer(v.(int))
+	}
+
+	if v, ok := d.GetOk("health_check"); ok && v.(string) != "" {
+		autoScalingGroupOpts.HealthCheckType = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("desired_capacity"); ok {


### PR DESCRIPTION
I guess this bug has been introduced along with swapping the AWS libraries.

If you run following sample template:

```ruby
provider "aws" {
  region = "eu-west-1"
}

resource "aws_launch_configuration" "foo" {
  name = "sample"
  image_id = "ami-8f0087f8"
  instance_type = "t1.micro"
}

resource "aws_autoscaling_group" "bar" {
  availability_zones = ["eu-west-1a"]
  name = "sample"
  max_size = 5
  min_size = 2

  launch_configuration = "${aws_launch_configuration.foo.name}"
}
```

you'll see following error:

```
Error creating Autoscaling Group: 1 validation error detected: Value '' at 'healthCheckType' failed to satisfy constraint: Member must have length greater than or equal to 1
```

The proposed change will only pass `health_check_type` to the underlying library if it's actually defined.

cc @catsby 