### PR TITLE
provider/aws: Convert AWS DB Security Group to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -275,9 +275,13 @@ func resourceAwsDbSecurityGroupStateRefreshFunc(
 			return nil, "", err
 		}
 
-		st := flattenEC2SecurityGroupStatuses(v.EC2SecurityGroups)
-		ip := flattenIPRangeStatuses(v.IPRanges)
-		statuses := append(st, ip...)
+		statuses := make([]string, 0, len(v.EC2SecurityGroups)+len(v.IPRanges))
+		for _, ec2g := range v.EC2SecurityGroups {
+			statuses = append(statuses, *ec2g.Status)
+		}
+		for _, ips := range v.IPRanges {
+			statuses = append(statuses, *ips.Status)
+		}
 
 		for _, stat := range statuses {
 			// Not done

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -81,9 +81,13 @@ func testAccCheckAWSDBSecurityGroupAttributes(group *rds.DBSecurityGroup) resour
 			return fmt.Errorf("bad cidr: %#v", group.IPRanges)
 		}
 
-		ipSt := flattenIPRangeStatuses(group.IPRanges)
-		if ipSt[0] != "authorized" {
-			return fmt.Errorf("bad status: %#v", ipSt)
+		statuses := make([]string, 0, len(group.IPRanges))
+		for _, ips := range group.IPRanges {
+			statuses = append(statuses, *ips.Status)
+		}
+
+		if statuses[0] != "authorized" {
+			return fmt.Errorf("bad status: %#v", statuses)
 		}
 
 		if *group.DBSecurityGroupName != "secgroup-terraform" {

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -27,7 +27,7 @@ func TestAccAWSDBSecurityGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_security_group.bar", "description", "just cuz"),
 					resource.TestCheckResourceAttr(
-						"aws_db_security_group.bar", "ingress.0.cidr", "10.0.0.1/24"),
+                                                "aws_db_security_group.bar", "ingress.3363517775.cidr", "10.0.0.1/24"),
 					resource.TestCheckResourceAttr(
 						"aws_db_security_group.bar", "ingress.#", "1"),
 				),

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -27,7 +27,7 @@ func TestAccAWSDBSecurityGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_security_group.bar", "description", "just cuz"),
 					resource.TestCheckResourceAttr(
-                                                "aws_db_security_group.bar", "ingress.3363517775.cidr", "10.0.0.1/24"),
+						"aws_db_security_group.bar", "ingress.3363517775.cidr", "10.0.0.1/24"),
 					resource.TestCheckResourceAttr(
 						"aws_db_security_group.bar", "ingress.#", "1"),
 				),

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -207,21 +207,3 @@ func expandStringList(configured []interface{}) []string {
 	}
 	return vs
 }
-
-// Flattens an array of DBSecurityGroups into a []string
-func flattenEC2SecurityGroupStatuses(list []rds.EC2SecurityGroup) []string {
-	result := make([]string, 0, len(list))
-	for _, i := range list {
-		result = append(result, *i.Status)
-	}
-	return result
-}
-
-// Flattens an array of IPRanges into a []string
-func flattenIPRangeStatuses(list []rds.IPRange) []string {
-	result := make([]string, 0, len(list))
-	for _, i := range list {
-		result = append(result, *i.Status)
-	}
-	return result
-}

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -207,3 +207,21 @@ func expandStringList(configured []interface{}) []string {
 	}
 	return vs
 }
+
+// Flattens an array of DBSecurityGroups into a []string
+func flattenEC2SecurityGroupStatuses(list []rds.EC2SecurityGroup) []string {
+	result := make([]string, 0, len(list))
+	for _, i := range list {
+		result = append(result, *i.Status)
+	}
+	return result
+}
+
+// Flattens an array of IPRanges into a []string
+func flattenIPRangeStatuses(list []rds.IPRange) []string {
+	result := make([]string, 0, len(list))
+	for _, i := range list {
+		result = append(result, *i.Status)
+	}
+	return result
+}


### PR DESCRIPTION
Start of conversion for AWS DB Security Group to aws-sdk-go. 

 