### PR TITLE
provider/aws: convert aws rds subnet to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -197,9 +197,7 @@ func resourceAwsDbSecurityGroupRetrieve(d *schema.ResourceData, meta interface{}
 
 	if len(resp.DBSecurityGroups) != 1 ||
 		*resp.DBSecurityGroups[0].DBSecurityGroupName != d.Id() {
-		if err != nil {
-			return nil, fmt.Errorf("Unable to find DB Security Group: %#v", resp.DBSecurityGroups)
-		}
+		return nil, fmt.Errorf("Unable to find DB Security Group: %#v", resp.DBSecurityGroups)
 	}
 
 	v := resp.DBSecurityGroups[0]


### PR DESCRIPTION
This completes the migration for AWS RDS to aws-sdk-go. 

If #1064 gets merged, I can update this to include changes to `config/aws.go` to completely replace `goamz/rds`