### PR TITLE
provider/aws: Remove goamz/rds

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -10,11 +10,10 @@ import (
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/ec2"
 	"github.com/mitchellh/goamz/elb"
-	"github.com/mitchellh/goamz/rds"
 
 	awsGo "github.com/hashicorp/aws-sdk-go/aws"
 	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
-	awsRDS "github.com/hashicorp/aws-sdk-go/gen/rds"
+	"github.com/hashicorp/aws-sdk-go/gen/rds"
 	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
 )
@@ -30,10 +29,9 @@ type AWSClient struct {
 	elbconn         *elb.ELB
 	autoscalingconn *autoscaling.AutoScaling
 	s3conn          *s3.S3
-	rdsconn         *rds.Rds
 	r53conn         *route53.Route53
 	region          string
-	awsRDSconn      *awsRDS.RDS
+	rdsconn         *rds.RDS
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -71,15 +69,13 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing S3 connection")
 		client.s3conn = s3.New(creds, c.Region, nil)
 		log.Println("[INFO] Initializing RDS connection")
-		client.rdsconn = rds.New(auth, region)
+		client.rdsconn = rds.New(creds, c.Region, nil)
 
 		// aws-sdk-go uses v4 for signing requests, which requires all global
 		// endpoints to use 'us-east-1'.
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		log.Println("[INFO] Initializing Route53 connection")
 		client.r53conn = route53.New(creds, "us-east-1", nil)
-		log.Println("[INFO] Initializing AWS Go RDS connection")
-		client.awsRDSconn = awsRDS.New(creds, c.Region, nil)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -185,7 +185,7 @@ func resourceAwsDbInstance() *schema.Resource {
 }
 
 func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).awsRDSconn
+	conn := meta.(*AWSClient).rdsconn
 	opts := rds.CreateDBInstanceMessage{
 		AllocatedStorage:     aws.Integer(d.Get("allocated_storage").(int)),
 		DBInstanceClass:      aws.String(d.Get("instance_class").(string)),
@@ -347,7 +347,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).awsRDSconn
+	conn := meta.(*AWSClient).rdsconn
 
 	log.Printf("[DEBUG] DB Instance destroy: %v", d.Id())
 
@@ -385,7 +385,7 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 
 func resourceAwsBbInstanceRetrieve(
 	d *schema.ResourceData, meta interface{}) (*rds.DBInstance, error) {
-	conn := meta.(*AWSClient).awsRDSconn
+	conn := meta.(*AWSClient).rdsconn
 
 	opts := rds.DescribeDBInstancesMessage{
 		DBInstanceIdentifier: aws.String(d.Id()),

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -47,7 +47,7 @@ func TestAccAWSDBInstance(t *testing.T) {
 }
 
 func testAccCheckAWSDBInstanceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).awsRDSconn
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_db_instance" {
@@ -110,7 +110,7 @@ func testAccCheckAWSDBInstanceExists(n string, v *rds.DBInstance) resource.TestC
 			return fmt.Errorf("No DB Instance ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).awsRDSconn
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 		opts := rds.DescribeDBInstancesMessage{
 			DBInstanceIdentifier: aws.String(rs.Primary.ID),

--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -72,7 +72,7 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 }
 
 func resourceAwsDbParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	rdsconn := meta.(*AWSClient).awsRDSconn
+	rdsconn := meta.(*AWSClient).rdsconn
 
 	createOpts := rds.CreateDBParameterGroupMessage{
 		DBParameterGroupName:   aws.String(d.Get("name").(string)),
@@ -99,7 +99,7 @@ func resourceAwsDbParameterGroupCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
-	rdsconn := meta.(*AWSClient).awsRDSconn
+	rdsconn := meta.(*AWSClient).rdsconn
 
 	describeOpts := rds.DescribeDBParameterGroupsMessage{
 		DBParameterGroupName: aws.String(d.Id()),
@@ -136,7 +136,7 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
-	rdsconn := meta.(*AWSClient).awsRDSconn
+	rdsconn := meta.(*AWSClient).rdsconn
 
 	d.Partial(true)
 
@@ -193,7 +193,7 @@ func resourceAwsDbParameterGroupDelete(d *schema.ResourceData, meta interface{})
 func resourceAwsDbParameterGroupDeleteRefreshFunc(
 	d *schema.ResourceData,
 	meta interface{}) resource.StateRefreshFunc {
-	rdsconn := meta.(*AWSClient).awsRDSconn
+	rdsconn := meta.(*AWSClient).rdsconn
 
 	return func() (interface{}, string, error) {
 

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -106,7 +106,7 @@ func TestAccAWSDBParameterGroupOnly(t *testing.T) {
 }
 
 func testAccCheckAWSDBParameterGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).awsRDSconn
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_db_parameter_group" {
@@ -169,7 +169,7 @@ func testAccCheckAWSDBParameterGroupExists(n string, v *rds.DBParameterGroup) re
 			return fmt.Errorf("No DB Parameter Group ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).awsRDSconn
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 		opts := rds.DescribeDBParameterGroupsMessage{
 			DBParameterGroupName: aws.String(rs.Primary.ID),

--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -70,7 +70,7 @@ func resourceAwsDbSecurityGroup() *schema.Resource {
 }
 
 func resourceAwsDbSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).awsRDSconn
+	conn := meta.(*AWSClient).rdsconn
 
 	var err error
 	var errs []error
@@ -160,7 +160,7 @@ func resourceAwsDbSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceAwsDbSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).awsRDSconn
+	conn := meta.(*AWSClient).rdsconn
 
 	log.Printf("[DEBUG] DB Security Group destroy: %v", d.Id())
 
@@ -181,7 +181,7 @@ func resourceAwsDbSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceAwsDbSecurityGroupRetrieve(d *schema.ResourceData, meta interface{}) (*rds.DBSecurityGroup, error) {
-	conn := meta.(*AWSClient).awsRDSconn
+	conn := meta.(*AWSClient).rdsconn
 
 	opts := rds.DescribeDBSecurityGroupsMessage{
 		DBSecurityGroupName: aws.String(d.Id()),
@@ -197,9 +197,7 @@ func resourceAwsDbSecurityGroupRetrieve(d *schema.ResourceData, meta interface{}
 
 	if len(resp.DBSecurityGroups) != 1 ||
 		*resp.DBSecurityGroups[0].DBSecurityGroupName != d.Id() {
-		if err != nil {
-			return nil, fmt.Errorf("Unable to find DB Security Group: %#v", resp.DBSecurityGroups)
-		}
+		return nil, fmt.Errorf("Unable to find DB Security Group: %#v", resp.DBSecurityGroups)
 	}
 
 	v := resp.DBSecurityGroups[0]

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -38,7 +38,7 @@ func TestAccAWSDBSecurityGroup(t *testing.T) {
 }
 
 func testAccCheckAWSDBSecurityGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).awsRDSconn
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_db_security_group" {
@@ -113,7 +113,7 @@ func testAccCheckAWSDBSecurityGroupExists(n string, v *rds.DBSecurityGroup) reso
 			return fmt.Errorf("No DB Security Group ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).awsRDSconn
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 		opts := rds.DescribeDBSecurityGroupsMessage{
 			DBSecurityGroupName: aws.String(rs.Primary.ID),

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -5,10 +5,11 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/rds"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mitchellh/goamz/rds"
 )
 
 func resourceAwsDbSubnetGroup() *schema.Resource {
@@ -52,10 +53,10 @@ func resourceAwsDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) er
 		subnetIds[i] = subnetId.(string)
 	}
 
-	createOpts := rds.CreateDBSubnetGroup{
-		DBSubnetGroupName:        d.Get("name").(string),
-		DBSubnetGroupDescription: d.Get("description").(string),
-		SubnetIds:                subnetIds,
+	createOpts := rds.CreateDBSubnetGroupMessage{
+		DBSubnetGroupName:        aws.String(d.Get("name").(string)),
+		DBSubnetGroupDescription: aws.String(d.Get("description").(string)),
+		SubnetIDs:                subnetIds,
 	}
 
 	log.Printf("[DEBUG] Create DB Subnet Group: %#v", createOpts)
@@ -64,7 +65,7 @@ func resourceAwsDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating DB Subnet Group: %s", err)
 	}
 
-	d.SetId(createOpts.DBSubnetGroupName)
+	d.SetId(*createOpts.DBSubnetGroupName)
 	log.Printf("[INFO] DB Subnet Group ID: %s", d.Id())
 	return resourceAwsDbSubnetGroupRead(d, meta)
 }
@@ -72,8 +73,8 @@ func resourceAwsDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
 
-	describeOpts := rds.DescribeDBSubnetGroups{
-		DBSubnetGroupName: d.Id(),
+	describeOpts := rds.DescribeDBSubnetGroupsMessage{
+		DBSubnetGroupName: aws.String(d.Id()),
 	}
 
 	describeResp, err := rdsconn.DescribeDBSubnetGroups(&describeOpts)
@@ -82,12 +83,20 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if len(describeResp.DBSubnetGroups) != 1 ||
-		describeResp.DBSubnetGroups[0].Name != d.Id() {
+		*describeResp.DBSubnetGroups[0].DBSubnetGroupName != d.Id() {
+		return fmt.Errorf("Unable to find DB Subnet Group: %#v", describeResp.DBSubnetGroups)
 	}
 
-	d.Set("name", describeResp.DBSubnetGroups[0].Name)
-	d.Set("description", describeResp.DBSubnetGroups[0].Description)
-	d.Set("subnet_ids", describeResp.DBSubnetGroups[0].SubnetIds)
+	subnetGroup := describeResp.DBSubnetGroups[0]
+
+	d.Set("name", *subnetGroup.DBSubnetGroupName)
+	d.Set("description", *subnetGroup.DBSubnetGroupDescription)
+
+	subnets := make([]string, 0, len(subnetGroup.Subnets))
+	for _, s := range subnetGroup.Subnets {
+		subnets = append(subnets, *s.SubnetIdentifier)
+	}
+	d.Set("subnet_ids", subnets)
 
 	return nil
 }
@@ -111,12 +120,12 @@ func resourceAwsDbSubnetGroupDeleteRefreshFunc(
 
 	return func() (interface{}, string, error) {
 
-		deleteOpts := rds.DeleteDBSubnetGroup{
-			DBSubnetGroupName: d.Id(),
+		deleteOpts := rds.DeleteDBSubnetGroupMessage{
+			DBSubnetGroupName: aws.String(d.Id()),
 		}
 
-		if _, err := rdsconn.DeleteDBSubnetGroup(&deleteOpts); err != nil {
-			rdserr, ok := err.(*rds.Error)
+		if err := rdsconn.DeleteDBSubnetGroup(&deleteOpts); err != nil {
+			rdserr, ok := err.(aws.APIError)
 			if !ok {
 				return d, "error", err
 			}

--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/goamz/rds"
+
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/rds"
 )
 
 func TestAccAWSDBSubnetGroup(t *testing.T) {
@@ -43,7 +45,7 @@ func testAccCheckDBSubnetGroupDestroy(s *terraform.State) error {
 
 		// Try to find the resource
 		resp, err := conn.DescribeDBSubnetGroups(
-			&rds.DescribeDBSubnetGroups{DBSubnetGroupName: rs.Primary.ID})
+			&rds.DescribeDBSubnetGroupsMessage{DBSubnetGroupName: aws.String(rs.Primary.ID)})
 		if err == nil {
 			if len(resp.DBSubnetGroups) > 0 {
 				return fmt.Errorf("still exist.")
@@ -53,7 +55,7 @@ func testAccCheckDBSubnetGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		rdserr, ok := err.(*rds.Error)
+		rdserr, ok := err.(aws.APIError)
 		if !ok {
 			return err
 		}
@@ -78,7 +80,7 @@ func testAccCheckDBSubnetGroupExists(n string, v *rds.DBSubnetGroup) resource.Te
 
 		conn := testAccProvider.Meta().(*AWSClient).rdsconn
 		resp, err := conn.DescribeDBSubnetGroups(
-			&rds.DescribeDBSubnetGroups{DBSubnetGroupName: rs.Primary.ID})
+			&rds.DescribeDBSubnetGroupsMessage{DBSubnetGroupName: aws.String(rs.Primary.ID)})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This completes the move from `goamz/rds` to `hashicorp/aws-sdk-go`.

Based off of #1067 , so the diff looks duplicated. We'll wait to merge that one first.