### PR TITLE
core: [refactor] pull Deposed out of Tainted list

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -3845,6 +3845,136 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
+	m := testModule(t, "apply-multi-depose-create-before-destroy")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ps := map[string]ResourceProviderFactory{"aws": testProviderFuncFixed(p)}
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.web": &ResourceState{
+						Type:    "aws_instance",
+						Primary: &InstanceState{ID: "foo"},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Module:    m,
+		Providers: ps,
+		State:     state,
+	})
+	createdInstanceId := "bar"
+	// Create works
+	createFunc := func(is *InstanceState) (*InstanceState, error) {
+		return &InstanceState{ID: createdInstanceId}, nil
+	}
+	// Destroy starts broken
+	destroyFunc := func(is *InstanceState) (*InstanceState, error) {
+		return is, fmt.Errorf("destroy failed")
+	}
+	p.ApplyFn = func(info *InstanceInfo, is *InstanceState, id *InstanceDiff) (*InstanceState, error) {
+		if id.Destroy {
+			return destroyFunc(is)
+		} else {
+			return createFunc(is)
+		}
+	}
+
+	if _, err := ctx.Plan(nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Destroy is broken, so even though CBD successfully replaces the instance,
+	// we'll have to save the Deposed instance to destroy later
+	state, err := ctx.Apply()
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	checkStateString(t, state, `
+aws_instance.web: (1 deposed)
+  ID = bar
+  Deposed ID 1 = foo
+	`)
+
+	createdInstanceId = "baz"
+	ctx = testContext2(t, &ContextOpts{
+		Module:    m,
+		Providers: ps,
+		State:     state,
+	})
+
+	if _, err := ctx.Plan(nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// We're replacing the primary instance once again. Destroy is _still_
+	// broken, so the Deposed list gets longer
+	state, err = ctx.Apply()
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	checkStateString(t, state, `
+aws_instance.web: (2 deposed)
+  ID = baz
+  Deposed ID 1 = foo
+  Deposed ID 2 = bar
+	`)
+
+	// Destroy partially fixed!
+	destroyFunc = func(is *InstanceState) (*InstanceState, error) {
+		if is.ID == "foo" || is.ID == "baz" {
+			return nil, nil
+		} else {
+			return is, fmt.Errorf("destroy partially failed")
+		}
+	}
+
+	createdInstanceId = "qux"
+	if _, err := ctx.Plan(nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	state, err = ctx.Apply()
+	// Expect error because 1/2 of Deposed destroys failed
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// foo and baz are now gone, bar sticks around
+	checkStateString(t, state, `
+aws_instance.web: (1 deposed)
+  ID = qux
+  Deposed ID 1 = bar
+	`)
+
+	// Destroy working fully!
+	destroyFunc = func(is *InstanceState) (*InstanceState, error) {
+		return nil, nil
+	}
+
+	createdInstanceId = "quux"
+	if _, err := ctx.Plan(nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	state, err = ctx.Apply()
+	if err != nil {
+		t.Fatal("should not have error:", err)
+	}
+
+	// And finally the state is clean
+	checkStateString(t, state, `
+aws_instance.web:
+  ID = quux
+	`)
+}
+
 func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 	m := testModule(t, "apply-provisioner-resource-ref")
 	p := testProvider("aws")
@@ -5341,6 +5471,15 @@ func testProvider(prefix string) *MockResourceProvider {
 func testProvisioner() *MockResourceProvisioner {
 	p := new(MockResourceProvisioner)
 	return p
+}
+
+func checkStateString(t *testing.T, state *State, expected string) {
+	actual := strings.TrimSpace(state.String())
+	expected = strings.TrimSpace(expected)
+
+	if actual != expected {
+		t.Fatalf("state does not match! actual:\n%s\n\nexpected:\n%s", actual, expected)
+	}
 }
 
 const testContextGraph = `

--- a/terraform/eval_error.go
+++ b/terraform/eval_error.go
@@ -1,0 +1,16 @@
+package terraform
+
+// EvalReturnError is an EvalNode implementation that returns an
+// error if it is present.
+//
+// This is useful for scenarios where an error has been captured by
+// another EvalNode (like EvalApply) for special EvalTree-based error
+// handling, and that handling has completed, so the error should be
+// returned normally.
+type EvalReturnError struct {
+	Error *error
+}
+
+func (n *EvalReturnError) Eval(ctx EvalContext) (interface{}, error) {
+	return nil, *n.Error
+}

--- a/terraform/eval_error.go
+++ b/terraform/eval_error.go
@@ -12,5 +12,9 @@ type EvalReturnError struct {
 }
 
 func (n *EvalReturnError) Eval(ctx EvalContext) (interface{}, error) {
+	if n.Error == nil {
+		return nil, nil
+	}
+
 	return nil, *n.Error
 }

--- a/terraform/eval_if.go
+++ b/terraform/eval_if.go
@@ -3,7 +3,8 @@ package terraform
 // EvalIf is an EvalNode that is a conditional.
 type EvalIf struct {
 	If   func(EvalContext) (bool, error)
-	Node EvalNode
+	Then EvalNode
+	Else EvalNode
 }
 
 // TODO: test
@@ -14,7 +15,11 @@ func (n *EvalIf) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	if yes {
-		return EvalRaw(n.Node, ctx)
+		return EvalRaw(n.Then, ctx)
+	} else {
+		if n.Else != nil {
+			return EvalRaw(n.Else, ctx)
+		}
 	}
 
 	return nil, nil

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -56,6 +56,9 @@ func (n *EvalReadStateDeposed) Eval(ctx EvalContext) (interface{}, error) {
 	})
 }
 
+// Does the bulk of the work for the various flavors of ReadState eval nodes.
+// Each node just provides a function to get from the ResourceState to the
+// InstanceState, and this takes care of all the plumbing.
 func readInstanceFromState(
 	ctx EvalContext,
 	resourceName string,
@@ -138,17 +141,12 @@ func (n *EvalUpdateStateHook) Eval(ctx EvalContext) (interface{}, error) {
 // EvalWriteState is an EvalNode implementation that reads the
 // InstanceState for a specific resource out of the state.
 type EvalWriteState struct {
-	Name                string
-	ResourceType        string
-	Dependencies        []string
-	State               **InstanceState
-	Tainted             *bool
-	TaintedIndex        int
-	TaintedClearPrimary bool
-	Deposed             bool
+	Name         string
+	ResourceType string
+	Dependencies []string
+	State        **InstanceState
 }
 
-// TODO: test
 func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 	state, lock := ctx.State()
 	if state == nil {
@@ -175,22 +173,119 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 	rs.Type = n.ResourceType
 	rs.Dependencies = n.Dependencies
 
-	if n.Tainted != nil && *n.Tainted {
-		if n.TaintedIndex != -1 {
-			rs.Tainted[n.TaintedIndex] = *n.State
-		} else {
-			rs.Tainted = append(rs.Tainted, *n.State)
-		}
+	rs.Primary = *n.State
 
-		if n.TaintedClearPrimary {
-			rs.Primary = nil
-		}
-	} else if n.Deposed {
-		rs.Deposed = *n.State
-	} else {
-		// Set the primary state
-		rs.Primary = *n.State
+	return nil, nil
+}
+
+type EvalWriteStateTainted struct {
+	Name         string
+	ResourceType string
+	Dependencies []string
+	State        **InstanceState
+	TaintedIndex int
+}
+
+func (n *EvalWriteStateTainted) Eval(ctx EvalContext) (interface{}, error) {
+	state, lock := ctx.State()
+	if state == nil {
+		return nil, fmt.Errorf("cannot write state to nil state")
 	}
+
+	// Get a write lock so we can access this instance
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Look for the module state. If we don't have one, create it.
+	mod := state.ModuleByPath(ctx.Path())
+	if mod == nil {
+		mod = state.AddModule(ctx.Path())
+	}
+
+	// Look for the resource state.
+	rs := mod.Resources[n.Name]
+	if rs == nil {
+		rs = &ResourceState{}
+		rs.init()
+		mod.Resources[n.Name] = rs
+	}
+	rs.Type = n.ResourceType
+	rs.Dependencies = n.Dependencies
+
+	if n.TaintedIndex == -1 {
+		rs.Tainted = append(rs.Tainted, *n.State)
+	} else {
+		rs.Tainted[n.TaintedIndex] = *n.State
+	}
+
+	return nil, nil
+}
+
+type EvalWriteStateDeposed struct {
+	Name         string
+	ResourceType string
+	Dependencies []string
+	State        **InstanceState
+}
+
+func (n *EvalWriteStateDeposed) Eval(ctx EvalContext) (interface{}, error) {
+	state, lock := ctx.State()
+	if state == nil {
+		return nil, fmt.Errorf("cannot write state to nil state")
+	}
+
+	// Get a write lock so we can access this instance
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Look for the module state. If we don't have one, create it.
+	mod := state.ModuleByPath(ctx.Path())
+	if mod == nil {
+		mod = state.AddModule(ctx.Path())
+	}
+
+	// Look for the resource state.
+	rs := mod.Resources[n.Name]
+	if rs == nil {
+		rs = &ResourceState{}
+		rs.init()
+		mod.Resources[n.Name] = rs
+	}
+	rs.Type = n.ResourceType
+	rs.Dependencies = n.Dependencies
+
+	rs.Deposed = *n.State
+
+	return nil, nil
+}
+
+// EvalClearPrimaryState is an EvalNode implementation that clears the primary
+// instance from a resource state.
+type EvalClearPrimaryState struct {
+	Name string
+}
+
+func (n *EvalClearPrimaryState) Eval(ctx EvalContext) (interface{}, error) {
+	state, lock := ctx.State()
+
+	// Get a read lock so we can access this instance
+	lock.RLock()
+	defer lock.RUnlock()
+
+	// Look for the module state. If we don't have one, then it doesn't matter.
+	mod := state.ModuleByPath(ctx.Path())
+	if mod == nil {
+		return nil, nil
+	}
+
+	// Look for the resource state. If we don't have one, then it is okay.
+	rs := mod.Resources[n.Name]
+	if rs == nil {
+		return nil, nil
+	}
+
+	// Clear primary from the resource state
+	rs.Primary = nil
 
 	return nil, nil
 }

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -22,7 +22,8 @@ func (n *EvalReadState) Eval(ctx EvalContext) (interface{}, error) {
 type EvalReadStateTainted struct {
 	Name   string
 	Output **InstanceState
-	// Index indicates which instance in the Tainted list to target, or -1 for the last item.
+	// Index indicates which instance in the Tainted list to target, or -1 for
+	// the last item.
 	Index int
 }
 
@@ -46,7 +47,8 @@ func (n *EvalReadStateTainted) Eval(ctx EvalContext) (interface{}, error) {
 type EvalReadStateDeposed struct {
 	Name   string
 	Output **InstanceState
-	// Index indicates which instance in the Deposed list to target, or -1 for the last item.
+	// Index indicates which instance in the Deposed list to target, or -1 for
+	// the last item.
 	Index int
 }
 
@@ -72,7 +74,7 @@ func readInstanceFromState(
 	ctx EvalContext,
 	resourceName string,
 	output **InstanceState,
-	reader func(*ResourceState) (*InstanceState, error),
+	readerFn func(*ResourceState) (*InstanceState, error),
 ) (*InstanceState, error) {
 	state, lock := ctx.State()
 
@@ -93,7 +95,7 @@ func readInstanceFromState(
 	}
 
 	// Use the delegate function to get the instance state from the resource state
-	is, err := reader(rs)
+	is, err := readerFn(rs)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +226,7 @@ func writeInstanceToState(
 	resourceName string,
 	resourceType string,
 	dependencies []string,
-	writer func(*ResourceState) error,
+	writerFn func(*ResourceState) error,
 ) (*InstanceState, error) {
 	state, lock := ctx.State()
 	if state == nil {
@@ -251,7 +253,7 @@ func writeInstanceToState(
 	rs.Type = resourceType
 	rs.Dependencies = dependencies
 
-	if err := writer(rs); err != nil {
+	if err := writerFn(rs); err != nil {
 		return nil, err
 	}
 
@@ -361,8 +363,9 @@ func (n *EvalUndeposeState) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	// Undepose
-	rs.Primary = rs.Deposed[len(rs.Deposed)-1]
-	rs.Deposed = rs.Deposed[:len(rs.Deposed)-1]
+	idx := len(rs.Deposed) - 1
+	rs.Primary = rs.Deposed[idx]
+	rs.Deposed[idx] = nil
 
 	return nil, nil
 }

--- a/terraform/eval_state_test.go
+++ b/terraform/eval_state_test.go
@@ -97,21 +97,24 @@ func TestEvalReadState(t *testing.T) {
 				},
 			},
 			Node: &EvalReadStateTainted{
-				Name:         "aws_instance.bar",
-				Output:       &output,
-				TaintedIndex: 0,
+				Name:   "aws_instance.bar",
+				Output: &output,
+				Index:  0,
 			},
 			ExpectedInstanceId: "i-abc123",
 		},
 		"ReadStateDeposed gets deposed instance": {
 			Resources: map[string]*ResourceState{
 				"aws_instance.bar": &ResourceState{
-					Deposed: &InstanceState{ID: "i-abc123"},
+					Deposed: []*InstanceState{
+						&InstanceState{ID: "i-abc123"},
+					},
 				},
 			},
 			Node: &EvalReadStateDeposed{
 				Name:   "aws_instance.bar",
 				Output: &output,
+				Index:  0,
 			},
 			ExpectedInstanceId: "i-abc123",
 		},
@@ -187,7 +190,7 @@ func TestEvalWriteStateTainted(t *testing.T) {
 		Name:         "restype.resname",
 		ResourceType: "restype",
 		State:        &is,
-		TaintedIndex: -1,
+		Index:        -1,
 	}
 	_, err := node.Eval(ctx)
 	if err != nil {
@@ -195,7 +198,7 @@ func TestEvalWriteStateTainted(t *testing.T) {
 	}
 
 	rs := state.ModuleByPath(ctx.Path()).Resources["restype.resname"]
-	if len(rs.Tainted) == 1 && rs.Tainted[0].ID != "i-abc123" {
+	if len(rs.Tainted) != 1 || rs.Tainted[0].ID != "i-abc123" {
 		t.Fatalf("expected tainted instance to have ID 'i-abc123': %#v", rs)
 	}
 }
@@ -212,6 +215,7 @@ func TestEvalWriteStateDeposed(t *testing.T) {
 		Name:         "restype.resname",
 		ResourceType: "restype",
 		State:        &is,
+		Index:        -1,
 	}
 	_, err := node.Eval(ctx)
 	if err != nil {
@@ -219,7 +223,7 @@ func TestEvalWriteStateDeposed(t *testing.T) {
 	}
 
 	rs := state.ModuleByPath(ctx.Path()).Resources["restype.resname"]
-	if rs.Deposed == nil || rs.Deposed.ID != "i-abc123" {
+	if len(rs.Deposed) != 1 || rs.Deposed[0].ID != "i-abc123" {
 		t.Fatalf("expected deposed instance to have ID 'i-abc123': %#v", rs)
 	}
 }

--- a/terraform/eval_state_test.go
+++ b/terraform/eval_state_test.go
@@ -169,13 +169,10 @@ func TestEvalWriteState(t *testing.T) {
 		t.Fatalf("Got err: %#v", err)
 	}
 
-	rs := state.ModuleByPath(ctx.Path()).Resources["restype.resname"]
-	if rs.Type != "restype" {
-		t.Fatalf("expected type 'restype': %#v", rs)
-	}
-	if rs.Primary.ID != "i-abc123" {
-		t.Fatalf("expected primary instance to have ID 'i-abc123': %#v", rs)
-	}
+	checkStateString(t, state, `
+restype.resname:
+  ID = i-abc123
+	`)
 }
 
 func TestEvalWriteStateTainted(t *testing.T) {
@@ -197,10 +194,11 @@ func TestEvalWriteStateTainted(t *testing.T) {
 		t.Fatalf("Got err: %#v", err)
 	}
 
-	rs := state.ModuleByPath(ctx.Path()).Resources["restype.resname"]
-	if len(rs.Tainted) != 1 || rs.Tainted[0].ID != "i-abc123" {
-		t.Fatalf("expected tainted instance to have ID 'i-abc123': %#v", rs)
-	}
+	checkStateString(t, state, `
+restype.resname: (1 tainted)
+  ID = <not created>
+  Tainted ID 1 = i-abc123
+	`)
 }
 
 func TestEvalWriteStateDeposed(t *testing.T) {
@@ -222,8 +220,9 @@ func TestEvalWriteStateDeposed(t *testing.T) {
 		t.Fatalf("Got err: %#v", err)
 	}
 
-	rs := state.ModuleByPath(ctx.Path()).Resources["restype.resname"]
-	if len(rs.Deposed) != 1 || rs.Deposed[0].ID != "i-abc123" {
-		t.Fatalf("expected deposed instance to have ID 'i-abc123': %#v", rs)
-	}
+	checkStateString(t, state, `
+restype.resname: (1 deposed)
+  ID = <not created>
+  Deposed ID 1 = i-abc123
+	`)
 }

--- a/terraform/graph_config_node.go
+++ b/terraform/graph_config_node.go
@@ -293,24 +293,16 @@ func (n *GraphNodeConfigResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 			View:  n.Resource.Id(),
 		})
 
-		if n.Resource.Lifecycle.CreateBeforeDestroy {
-			// If we're only destroying tainted resources, then we only
-			// want to find tainted resources and destroy them here.
-			steps = append(steps, &TaintedTransformer{
-				State:          state,
-				View:           n.Resource.Id(),
-				Deposed:        n.Resource.Lifecycle.CreateBeforeDestroy,
-				DeposedInclude: true,
-			})
-		}
+		steps = append(steps, &DeposedTransformer{
+			State: state,
+			View:  n.Resource.Id(),
+		})
 	case DestroyTainted:
 		// If we're only destroying tainted resources, then we only
 		// want to find tainted resources and destroy them here.
 		steps = append(steps, &TaintedTransformer{
-			State:          state,
-			View:           n.Resource.Id(),
-			Deposed:        n.Resource.Lifecycle.CreateBeforeDestroy,
-			DeposedInclude: false,
+			State: state,
+			View:  n.Resource.Id(),
 		})
 	}
 

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -658,8 +658,10 @@ type ResourceState struct {
 	// Primary is Deposed to get it out of the way for the replacement Primary to
 	// be created by Apply. If the replacement Primary creates successfully, the
 	// Deposed instance is cleaned up. If there were problems creating the
-	// replacement, we mark the replacement as Tainted and Undepose the former
-	// Primary.
+	// replacement, the instance remains in the Deposed list so it can be
+	// destroyed in a future run. Functionally, Deposed instances are very
+	// similar to Tainted instances in that Terraform is only tracking them in
+	// order to remember to destroy them.
 	Deposed []*InstanceState `json:"deposed,omitempty"`
 }
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -443,9 +443,9 @@ aws_instance.bar:
 `
 
 const testTerraformApplyErrorDestroyCreateBeforeDestroyStr = `
-aws_instance.bar: (1 tainted)
+aws_instance.bar: (1 deposed)
   ID = foo
-  Tainted ID 1 = bar
+  Deposed ID 1 = bar
 `
 
 const testTerraformApplyErrorPartialStr = `

--- a/terraform/test-fixtures/apply-multi-depose-create-before-destroy/main.tf
+++ b/terraform/test-fixtures/apply-multi-depose-create-before-destroy/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "web" {
+    // require_new is a special attribute recognized by testDiffFn that forces
+    // a new resource on every apply
+    require_new = "yes"
+    lifecycle {
+        create_before_destroy = true
+    }
+}

--- a/terraform/transform_deposed.go
+++ b/terraform/transform_deposed.go
@@ -2,7 +2,7 @@ package terraform
 
 import "fmt"
 
-// DeposedTransformer is a GraphTransformer that adds tainted resources
+// DeposedTransformer is a GraphTransformer that adds deposed resources
 // to the graph.
 type DeposedTransformer struct {
 	// State is the global state. We'll automatically find the correct

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -406,7 +406,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 								ResourceType: n.Resource.Type,
 								Dependencies: n.DependentOn(),
 								State:        &state,
-								TaintedIndex: -1,
+								Index:        -1,
 							},
 							&EvalIf{
 								If: func(ctx EvalContext) (bool, error) {
@@ -513,9 +513,9 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 						return n.Resource.Lifecycle.CreateBeforeDestroy, nil
 					},
 					Then: &EvalReadStateTainted{
-						Name:         n.stateId(),
-						Output:       &state,
-						TaintedIndex: -1,
+						Name:   n.stateId(),
+						Output: &state,
+						Index:  -1,
 					},
 					Else: &EvalReadState{
 						Name:   n.stateId(),

--- a/terraform/transform_tainted.go
+++ b/terraform/transform_tainted.go
@@ -71,7 +71,6 @@ func (n *graphNodeTaintedResource) ProvidedBy() []string {
 func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 	var provider ResourceProvider
 	var state *InstanceState
-	tainted := true
 
 	seq := &EvalSequence{Nodes: make([]EvalNode, 0, 5)}
 
@@ -99,11 +98,10 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 					State:    &state,
 					Output:   &state,
 				},
-				&EvalWriteState{
+				&EvalWriteStateTainted{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
 					State:        &state,
-					Tainted:      &tainted,
 					TaintedIndex: n.Index,
 				},
 			},
@@ -137,11 +135,10 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 					Provider: &provider,
 					Output:   &state,
 				},
-				&EvalWriteState{
+				&EvalWriteStateTainted{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
 					State:        &state,
-					Tainted:      &tainted,
 					TaintedIndex: n.Index,
 				},
 				&EvalUpdateStateHook{},

--- a/terraform/transform_tainted.go
+++ b/terraform/transform_tainted.go
@@ -88,9 +88,9 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 					Output: &provider,
 				},
 				&EvalReadStateTainted{
-					Name:         n.ResourceName,
-					TaintedIndex: n.Index,
-					Output:       &state,
+					Name:   n.ResourceName,
+					Index:  n.Index,
+					Output: &state,
 				},
 				&EvalRefresh{
 					Info:     info,
@@ -102,7 +102,7 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
 					State:        &state,
-					TaintedIndex: n.Index,
+					Index:        n.Index,
 				},
 			},
 		},
@@ -119,9 +119,9 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 					Output: &provider,
 				},
 				&EvalReadStateTainted{
-					Name:         n.ResourceName,
-					TaintedIndex: n.Index,
-					Output:       &state,
+					Name:   n.ResourceName,
+					Index:  n.Index,
+					Output: &state,
 				},
 				&EvalDiffDestroy{
 					Info:   info,
@@ -139,7 +139,7 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
 					State:        &state,
-					TaintedIndex: n.Index,
+					Index:        n.Index,
 				},
 				&EvalUpdateStateHook{},
 			},


### PR DESCRIPTION
This is the promised follow up to #1069.

This has us tracking Deposed as a fully separate concept from Tainted in the state, with its own graph transformer and everything.

We also move from single `Eval{Read,Write}State` nodes with lots of parameters to lots of targeted `EvalNodes` that are individually simpler.