### PR TITLE
RFC for making launch configuration names computed.

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -24,7 +24,8 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -122,13 +123,23 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			v.(*schema.Set).List())
 	}
 
+	if v, ok := d.GetOk("name"); ok {
+		createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(v.(string))
+		d.SetId(d.Get("name").(string))
+	} else {
+		hash := sha1.Sum([]byte(fmt.Sprintf("%#v", createLaunchConfigurationOpts)))
+		config_name := fmt.Sprintf("terraform-%s", base64.URLEncoding.EncodeToString(hash[:]))
+		log.Printf("[DEBUG] Computed Launch config name: %s", config_name)
+		createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(config_name)
+		d.SetId(config_name)
+	}
+
 	log.Printf("[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
 	err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating launch configuration: %s", err)
 	}
 
-	d.SetId(d.Get("name").(string))
 	log.Printf("[INFO] launch configuration ID: %s", d.Id())
 
 	// We put a Retry here since sometimes eventual consistency bites

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -45,6 +45,16 @@ func TestAccAWSLaunchConfiguration(t *testing.T) {
 						"aws_launch_configuration.bar", "spot_price", "0.01"),
 				),
 			},
+
+			resource.TestStep{
+				Config: testAccAWSLaunchConfigurationNoNameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
+					testAccCheckAWSLaunchConfigurationAttributes(&conf),
+					resource.TestCheckResourceAttr(
+						"aws_launch_configuration.bar", "name", "terraform-foo"), // FIXME - This should fail?!?!?
+				),
+			},
 		},
 	})
 }
@@ -151,5 +161,14 @@ resource "aws_launch_configuration" "bar" {
   user_data = "foobar-user-data"
   associate_public_ip_address = true
   spot_price = "0.01"
+}
+`
+
+const testAccAWSLaunchConfigurationNoNameConfig = `
+resource "aws_launch_configuration" "bar" {
+   image_id = "ami-21f78e12"
+   instance_type = "t1.micro"
+   user_data = "foobar-user-data-change"
+   associate_public_ip_address = false
 }
 `


### PR DESCRIPTION
Currently, terraform has trouble with launch configuration changes, as you need to make a new launch config to make any changes, however you can't do this as the 'name' field needs to be unique, and if the existing launch config is attached to an ASG then it can't be removed until it's replaced.

Issue #532 is relevant here also.

This patch allows terraform to generate the name for launch configs, which allows you to have something like this:

    resource "aws_launch_configuration" "example" {
        ....
        lifecycle {
            create_before_destroy = true
        }
    }

    resource "aws_autoscaling_group" "example" {
       ....
      launch_configuration = "${aws_launch_configuration.example.name}"
    }

and when some configuration for the 'example' launch configuration is changed, terraform will do the right thing, i.e. create a new launch config, re-associate the ASG with the new launch config, and then delete the old launch config.

This appears to work for me, however I tried adding some tests for this functionality, which expectedly don't fail, I'm not sure what I'm doing wrong?