### PR TITLE
Perform Transitive Reduction on Graph

### DIFF
--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -3,6 +3,7 @@ package dag
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -45,6 +46,44 @@ func TestAcyclicGraphRoot_multiple(t *testing.T) {
 
 	if _, err := g.Root(); err == nil {
 		t.Fatal("should error")
+	}
+}
+
+func TestAyclicGraphTransReduction(t *testing.T) {
+	var g AcyclicGraph
+	g.Add(1)
+	g.Add(2)
+	g.Add(3)
+	g.Connect(BasicEdge(1, 2))
+	g.Connect(BasicEdge(1, 3))
+	g.Connect(BasicEdge(2, 3))
+	g.TransitiveReduction()
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testGraphTransReductionStr)
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+func TestAyclicGraphTransReduction_more(t *testing.T) {
+	var g AcyclicGraph
+	g.Add(1)
+	g.Add(2)
+	g.Add(3)
+	g.Add(4)
+	g.Connect(BasicEdge(1, 2))
+	g.Connect(BasicEdge(1, 3))
+	g.Connect(BasicEdge(1, 4))
+	g.Connect(BasicEdge(2, 3))
+	g.Connect(BasicEdge(2, 4))
+	g.Connect(BasicEdge(3, 4))
+	g.TransitiveReduction()
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testGraphTransReductionMoreStr)
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
 	}
 }
 
@@ -156,3 +195,21 @@ func TestAcyclicGraphWalk_error(t *testing.T) {
 
 	t.Fatalf("bad: %#v", visits)
 }
+
+const testGraphTransReductionStr = `
+1
+  2
+2
+  3
+3
+`
+
+const testGraphTransReductionMoreStr = `
+1
+  2
+2
+  3
+3
+  4
+4
+`

--- a/dag/set.go
+++ b/dag/set.go
@@ -36,6 +36,20 @@ func (s *Set) Include(v interface{}) bool {
 	return ok
 }
 
+// Intersection computes the set intersection with other.
+func (s *Set) Intersection(other *Set) *Set {
+	result := new(Set)
+	if other != nil {
+		for _, v := range s.m {
+			if other.Include(v) {
+				result.Add(v)
+			}
+		}
+	}
+
+	return result
+}
+
 // Len is the number of items in the set.
 func (s *Set) Len() int {
 	if s == nil {

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -109,5 +109,9 @@ func (b *BuiltinGraphBuilder) Steps() []GraphTransformer {
 
 		// Make sure we create one root
 		&RootTransformer{},
+
+		// Perform the transitive reduction to make our graph a bit
+		// more sane if possible (it usually is possible).
+		&TransitiveReductionTransformer{},
 	}
 }

--- a/terraform/graph_builder_test.go
+++ b/terraform/graph_builder_test.go
@@ -129,7 +129,6 @@ aws_instance.db (destroy tainted)
   aws_instance.web (destroy tainted)
 aws_instance.web
   aws_instance.db
-  aws_instance.web (destroy tainted)
 aws_instance.web (destroy tainted)
   provider.aws
 provider.aws

--- a/terraform/graph_builder_test.go
+++ b/terraform/graph_builder_test.go
@@ -125,14 +125,11 @@ const testBasicGraphBuilderStr = `
 const testBuiltinGraphBuilderBasicStr = `
 aws_instance.db
   aws_instance.db (destroy tainted)
-  provider.aws
 aws_instance.db (destroy tainted)
   aws_instance.web (destroy tainted)
-  provider.aws
 aws_instance.web
   aws_instance.db
   aws_instance.web (destroy tainted)
-  provider.aws
 aws_instance.web (destroy tainted)
   provider.aws
 provider.aws

--- a/terraform/test-fixtures/transform-trans-reduce-basic/main.tf
+++ b/terraform/test-fixtures/transform-trans-reduce-basic/main.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "A" {}
+
+resource "aws_instance" "B" {
+    A = "${aws_instance.A.id}"
+}
+
+resource "aws_instance" "C" {
+    A = "${aws_instance.A.id}"
+    B = "${aws_instance.B.id}"
+}

--- a/terraform/transform_transitive_reduction.go
+++ b/terraform/transform_transitive_reduction.go
@@ -1,0 +1,20 @@
+package terraform
+
+// TransitiveReductionTransformer is a GraphTransformer that performs
+// finds the transitive reduction of the graph. For a definition of
+// transitive reduction, see Wikipedia.
+type TransitiveReductionTransformer struct{}
+
+func (t *TransitiveReductionTransformer) Transform(g *Graph) error {
+	// If the graph isn't valid, skip the transitive reduction.
+	// We don't error here because Terraform itself handles graph
+	// validation in a better way, or we assume it does.
+	if err := g.Validate(); err != nil {
+		return nil
+	}
+
+	// Do it
+	g.TransitiveReduction()
+
+	return nil
+}

--- a/terraform/transform_transitive_reduction_test.go
+++ b/terraform/transform_transitive_reduction_test.go
@@ -1,0 +1,39 @@
+package terraform
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTransitiveReductionTransformer(t *testing.T) {
+	mod := testModule(t, "transform-trans-reduce-basic")
+
+	g := Graph{Path: RootModulePath}
+	{
+		tf := &ConfigTransformer{Module: mod}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &TransitiveReductionTransformer{}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformTransReduceBasicStr)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
+const testTransformTransReduceBasicStr = `
+aws_instance.A
+aws_instance.B
+  aws_instance.A
+aws_instance.C
+  aws_instance.B
+`


### PR DESCRIPTION
This adds a new transformer to perform a [transitive reduction](http://en.wikipedia.org/wiki/Transitive_reduction) on the graph. We make some pretty edge-y graphs, and this should help simplify them considerably for debugging. The changes made in this PR:

* Add `*AcyclicGraph.TransitiveReduction()` to perform the actual transitive reduction

* Add `TransitiveReductionTransformer` that does the transitive reduction transform

