### PR TITLE
terraform: catch scenario where both "foo" and "foo.0" are in state

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -829,6 +829,64 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 	}
 }
 
+// https://github.com/PeoplePerHour/terraform/pull/11
+//
+// This tests a case where both a "resource" and "resource.0" are in
+// the state file, which apparently is a reasonable backwards compatibility
+// concern found in the above 3rd party repo.
+func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
+	m := testModule(t, "plan-count-inc")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	s := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.foo": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo":  "foo",
+								"type": "aws_instance",
+							},
+						},
+					},
+					"aws_instance.foo.0": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo":  "foo",
+								"type": "aws_instance",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: s,
+	})
+
+	plan, err := ctx.Plan(nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(testTerraformPlanCountIncreaseFromOneCorruptedStr)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestContext2Plan_destroy(t *testing.T) {
 	m := testModule(t, "plan-destroy")
 	p := testProvider("aws")

--- a/terraform/eval_count.go
+++ b/terraform/eval_count.go
@@ -41,10 +41,18 @@ func (n *EvalCountFixZeroOneBoundary) Eval(ctx EvalContext) (interface{}, error)
 	}
 
 	// Look for the resource state. If we don't have one, then it is okay.
-	if rs, ok := mod.Resources[hunt]; ok {
-		mod.Resources[replace] = rs
-		delete(mod.Resources, hunt)
+	rs, ok := mod.Resources[hunt]
+	if !ok {
+		return nil, nil
 	}
+
+	// If the replacement key exists, we just keep both
+	if _, ok := mod.Resources[replace]; ok {
+		return nil, nil
+	}
+
+	mod.Resources[replace] = rs
+	delete(mod.Resources, hunt)
 
 	return nil, nil
 }

--- a/terraform/graph_config_node.go
+++ b/terraform/graph_config_node.go
@@ -481,6 +481,14 @@ func (n *graphNodeResourceDestroy) DestroyInclude(d *ModuleDiff, s *ModuleState)
 				return true
 			}
 		}
+
+		// If we're in the state as _both_ "foo" and "foo.0", then
+		// keep it, since we treat the latter as an orphan.
+		_, okOne := s.Resources[prefix]
+		_, okTwo := s.Resources[prefix+".0"]
+		if okOne && okTwo {
+			return true
+		}
 	}
 
 	return false

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/sha1"
 	"encoding/gob"
 	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -66,6 +68,14 @@ func testModule(t *testing.T, name string) *module.Tree {
 	}
 
 	return mod
+}
+
+func testStringMatch(t *testing.T, s fmt.Stringer, expected string) {
+	actual := strings.TrimSpace(s.String())
+	expected = strings.TrimSpace(expected)
+	if actual != expected {
+		t.Fatalf("Actual\n\n%s\n\nExpected:\n\n%s", actual, expected)
+	}
 }
 
 func testProviderFuncFixed(rp ResourceProvider) ResourceProviderFactory {
@@ -243,6 +253,29 @@ const testTerraformApplyCountDecToOneStr = `
 aws_instance.foo:
   ID = bar
   foo = foo
+  type = aws_instance
+`
+
+const testTerraformApplyCountDecToOneCorruptedStr = `
+aws_instance.foo:
+  ID = bar
+  foo = foo
+  type = aws_instance
+`
+
+const testTerraformApplyCountDecToOneCorruptedPlanStr = `
+DIFF:
+
+DESTROY: aws_instance.foo.0
+
+STATE:
+
+aws_instance.foo:
+  ID = bar
+  foo = foo
+  type = aws_instance
+aws_instance.foo.0:
+  ID = baz
   type = aws_instance
 `
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -829,6 +829,32 @@ aws_instance.foo.0:
   type = aws_instance
 `
 
+const testTerraformPlanCountIncreaseFromOneCorruptedStr = `
+DIFF:
+
+CREATE: aws_instance.bar
+  foo:  "" => "bar"
+  type: "" => "aws_instance"
+DESTROY: aws_instance.foo
+CREATE: aws_instance.foo.1
+  foo:  "" => "foo"
+  type: "" => "aws_instance"
+CREATE: aws_instance.foo.2
+  foo:  "" => "foo"
+  type: "" => "aws_instance"
+
+STATE:
+
+aws_instance.foo:
+  ID = bar
+  foo = foo
+  type = aws_instance
+aws_instance.foo.0:
+  ID = bar
+  foo = foo
+  type = aws_instance
+`
+
 const testTerraformPlanDestroyStr = `
 DIFF:
 

--- a/terraform/test-fixtures/apply-count-dec-one/main.tf
+++ b/terraform/test-fixtures/apply-count-dec-one/main.tf
@@ -1,7 +1,3 @@
 resource "aws_instance" "foo" {
     foo = "foo"
 }
-
-resource "aws_instance" "bar" {
-    foo = "bar"
-}


### PR DESCRIPTION
Fixes #1047 (cc @pmoust)

I'm not sure _what caused this_, but it seems that there is a possibility in the state to have both a `type.name` and `type.name.0` to be present. If both of these are present, we experience some very bizarre behavior. In 0.3.7 and prior, it appears we just assume `type.name` is the valid resource to use, and the `type.name.0` value is completely ignored. There seems to be no way to do anything with it (including remove it) short of modifying the state.

This PR causes the `type.name.0` to behave as an orphan in the case both are present and `count = 1`. While in theory it is possible that either are the one you want, I think in practice we should remove the `.0` resource because it appears that this is how 0.3.7 behaved by completely ignoring it (therefore not destroying it but also not using its values for any dependent resources).

The fix here is pretty simple:

* In the `PruneDestroyTransform`, we must _not prune_ the destroy node if we see this scenario.

* In the `FixZeroOneBoundary` eval node, we must not override and therefore mask the value if we see that both the hunt and replace exist. This will cause both to remain and the orphan transform to pick it up later.

I don't think its possible going currently in master and going forward to ever persist a state with both, so this situation must be a backwards compat possibility.

To be clear, here is the before/after:

* **0.3.7 and before**: the `type.name.0` value is always completely ignored. It is not treated as an orphan, attributes are not reference-able, it is in the state but never affects plans/applies in any way. It is as if it isn't there.

* **master prior to this patch**: the `type.name.0` value is always used, and `type.name` is completely ignored. The inverse of 0.3.7 and before. But likewise, `type.name` is therefore never fixable.

* **master after this patch**: `type.name.0` is treated as an orphan, `type.name` is used. We chose this route because 0.3.7 use `type.name` so we should use those values for BC reasons.