### PR TITLE
Bugfix: Save token that came from goamz + use it in go-sdk-aws

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -21,6 +21,7 @@ import (
 type Config struct {
 	AccessKey string
 	SecretKey string
+	Token     string
 	Region    string
 }
 
@@ -58,7 +59,7 @@ func (c *Config) Client() (interface{}, error) {
 		// bucket storage in S3
 		client.region = c.Region
 
-		creds := awsGo.Creds(c.AccessKey, c.SecretKey, "")
+		creds := awsGo.Creds(c.AccessKey, c.SecretKey, c.Token)
 
 		log.Println("[INFO] Initializing EC2 connection")
 		client.ec2conn = ec2.New(auth, region)
@@ -95,6 +96,7 @@ func (c *Config) AWSAuth() (aws.Auth, error) {
 		// Store the accesskey and secret that we got...
 		c.AccessKey = auth.AccessKey
 		c.SecretKey = auth.SecretKey
+		c.Token = auth.Token
 	}
 
 	return auth, err


### PR DESCRIPTION
Any requests with token will now fail as we're using `go-sdk-aws` and giving it hardcoded empty token.

Before https://github.com/hashicorp/terraform/pull/1049 gets the right shape & gets merged, this should do for the moment so it at least works as it was working before.