### PR TITLE
provider/aws: Special case us-east-1 for S3 bucket creation

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -46,9 +46,14 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 	req := &s3.CreateBucketRequest{
 		Bucket: aws.String(bucket),
 		ACL:    aws.String(acl),
-		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
+	}
+
+	// Special case us-east-1 region and do not set the LocationConstraint.
+	// See "Request Elements: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
+	if awsRegion != "us-east-1" {
+		req.CreateBucketConfiguration = &s3.CreateBucketConfiguration{
 			LocationConstraint: aws.String(awsRegion),
-		},
+		}
 	}
 
 	_, err := s3conn.CreateBucket(req)


### PR DESCRIPTION
When creating buckets in S3, a `LocationConstraint` was introduced with `aws-sdk-go` in #1012 . 
It turns out that when creating a bucket in the `us-east-1` region, `us-east-1` is not a valid region constraint. 

The [Regions and Endpoints][1] outline that you don't need to specify a location constraint with `us-east-1`, and the URL can simply be `s3.amazonaws.com` as opposed to other regions like `s3-us-west-2.amazonaws.com`. 

This PR should fix #1012 



[1]: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region