### PR TITLE
command: autoload terraform.tfvars.json as well [GH-1030]

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -346,6 +346,14 @@ func (m *Meta) process(args []string, vars bool) []string {
 			args[0] = "-" + m.autoKey
 			args[1] = DefaultVarsFilename
 		}
+
+		if _, err := os.Stat(DefaultVarsFilename + ".json"); err == nil {
+			m.autoKey = "var-file-default"
+			args = append(args, "", "")
+			copy(args[2:], args[0:])
+			args[0] = "-" + m.autoKey
+			args[1] = DefaultVarsFilename + ".json"
+		}
 	}
 
 	return args


### PR DESCRIPTION
Fixes #1030 

Simple change to autoload `terraform.tfvars.json` as well as `terraform.tfvars`. The latter takes priority in any conflicts, but both will be autoloaded. This doesn't affect #1084,  which is still a valid feature request.