### PR TITLE
providers/aws: Convert AWS Subnet to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
 	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
+
+	awsEC2 "github.com/hashicorp/aws-sdk-go/gen/ec2"
 )
 
 type Config struct {
@@ -27,6 +29,7 @@ type Config struct {
 
 type AWSClient struct {
 	ec2conn         *ec2.EC2
+	awsEC2conn      *awsEC2.EC2
 	elbconn         *elb.ELB
 	autoscalingconn *autoscaling.AutoScaling
 	s3conn          *s3.S3
@@ -77,6 +80,8 @@ func (c *Config) Client() (interface{}, error) {
 		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		log.Println("[INFO] Initializing Route53 connection")
 		client.r53conn = route53.New(creds, "us-east-1", nil)
+		log.Println("[INFO] Initializing AWS-GO EC2 Connection")
+		client.awsEC2conn = awsEC2.New(creds, c.Region, nil)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/tags_sdk.go
+++ b/builtin/providers/aws/tags_sdk.go
@@ -1,0 +1,106 @@
+package aws
+
+// TODO: Clint: consolidate tags and tags_sdk
+// tags_sdk and tags_sdk_test are used only for transition to aws-sdk-go
+// and will replace tags and tags_test when the transition to aws-sdk-go/ec2 is
+// complete
+
+import (
+	"log"
+
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// tagsSchema returns the schema to use for tags.
+//
+// TODO: uncomment this when we replace the original tags.go
+//
+// func tagsSchema() *schema.Schema {
+// 	return &schema.Schema{
+// 		Type:     schema.TypeMap,
+// 		Optional: true,
+// 	}
+// }
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsSDK(conn *ec2.EC2, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsSDK(tagsFromMapSDK(o), tagsFromMapSDK(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			err := conn.DeleteTags(&ec2.DeleteTagsRequest{
+				Resources: []string{d.Id()},
+				Tags:      remove,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			err := conn.CreateTags(&ec2.CreateTagsRequest{
+				Resources: []string{d.Id()},
+				Tags:      create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsSDK(oldTags, newTags []ec2.Tag) ([]ec2.Tag, []ec2.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []ec2.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapSDK(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapSDK(m map[string]interface{}) []ec2.Tag {
+	result := make([]ec2.Tag, 0, len(m))
+	for k, v := range m {
+		result = append(result, ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapSDK(ts []ec2.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		result[*t.Key] = *t.Value
+	}
+
+	return result
+}

--- a/builtin/providers/aws/tags_sdk_test.go
+++ b/builtin/providers/aws/tags_sdk_test.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDiffTagsSDK(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsSDK(tagsFromMapSDK(tc.Old), tagsFromMapSDK(tc.New))
+		cm := tagsToMapSDK(c)
+		rm := tagsToMapSDK(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// testAccCheckTags can be used to check the tags on a resource.
+func testAccCheckTagsSDK(
+	ts *[]ec2.Tag, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m := tagsToMapSDK(*ts)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("Missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("Extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
This PR converts AWS Subnet to use `aws-sdk-go`. 
Because EC2 covers so many things, and many resources still use `goamz/ec2`, I duplicated the `tags.go` and `tags_test.go` to `*_sdk.go` files that use `aws-sdk-go/ec2` instead of `goamz/ec2`. I felt that was simpler than duplicating them all in the same file. We can replace the former with the latter when all resources are using `aws-sdk-go/ec2`. 