### PR TITLE
[Bugfix] aws/rds: Expect no DBName in the API response

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -305,7 +305,10 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("name", *v.DBName)
+	if v.DBName != nil {
+		d.Set("name", *v.DBName)
+	}
+
 	d.Set("username", *v.MasterUsername)
 	d.Set("engine", *v.Engine)
 	d.Set("engine_version", *v.EngineVersion)


### PR DESCRIPTION
Terraform will crash if you don't provide **optional** `name` for `aws_db_instance`.

The assumption that this parameter should be optional is correct, but then we cannot expect the name to be returned from the API response either, otherwise it will effectively try to dereference a variable pointing to `nil` = crash.

Here's a simple example for demonstration
```ruby
provider "aws" {
  region = "eu-west-1"
}

resource "aws_db_instance" "default" {
  identifier = "mydb-rds-5"
  allocated_storage = 10
  engine = "mysql"
  engine_version = "5.6.21b"
  instance_class = "db.t2.micro"
  username = "foo"
  password = "barbarbar"
}
```

This is what you'll get:

```
aws_db_instance.default: Creating...
  address:                 "" => "<computed>"
  allocated_storage:       "" => "10"
  availability_zone:       "" => "<computed>"
  backup_retention_period: "" => "1"
  backup_window:           "" => "<computed>"
  endpoint:                "" => "<computed>"
  engine:                  "" => "mysql"
  engine_version:          "" => "5.6.21b"
  identifier:              "" => "mydb-rds-5"
  instance_class:          "" => "db.t2.micro"
  maintenance_window:      "" => "<computed>"
  multi_az:                "" => "<computed>"
  parameter_group_name:    "" => "<computed>"
  password:                "" => "barbarbar"
  port:                    "" => "<computed>"
  status:                  "" => "<computed>"
  storage_type:            "" => "<computed>"
  username:                "" => "foo"
aws_db_instance.default: Error: 1 error(s) occurred:

* unexpected EOF
panic: runtime error: invalid memory address or nil pointer dereference
2015/03/02 23:17:04 terraform-provider-aws: [signal 0xb code=0x1 addr=0x0 pc=0x4bf8b]
2015/03/02 23:17:04 terraform-provider-aws: 
2015/03/02 23:17:04 terraform-provider-aws: goroutine 42 [running]:
2015/03/02 23:17:04 terraform-provider-aws: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsDbInstanceRead(0xc2080521e0, 0x427a60, 0xc208164340, 0x0, 0x0)
2015/03/02 23:17:04 terraform-provider-aws: 	/Users/radek/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_db_instance.go:308 +0xfbb
2015/03/02 23:17:04 terraform-provider-aws: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsDbInstanceCreate(0xc2080521e0, 0x427a60, 0xc208164340, 0x0, 0x0)
2015/03/02 23:17:04 terraform-provider-aws: 	/Users/radek/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_db_instance.go:294 +0x21c9
...
```