### PR TITLE
providers/aws: add iops to block devices

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -186,6 +186,13 @@ func resourceAwsInstance() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
+
+						"iops": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
 					},
 				},
 				Set: resourceAwsInstanceBlockDevicesHash,
@@ -227,6 +234,13 @@ func resourceAwsInstance() *schema.Resource {
 
 						"volume_type": &schema.Schema{
 							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"iops": &schema.Schema{
+							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
@@ -312,6 +326,9 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 			if v, ok := bd["encrypted"].(bool); ok {
 				runOpts.BlockDevices[i].Encrypted = v
+			}
+			if v, ok := bd["iops"].(int); ok {
+				runOpts.BlockDevices[i].IOPS = int64(v)
 			}
 		}
 	}
@@ -477,6 +494,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 		blockDevice["snapshot_id"] = vol.SnapshotId
 		blockDevice["encrypted"] = vol.Encrypted
+		blockDevice["iops"] = vol.IOPS
 		nonRootBlockDevices = append(nonRootBlockDevices, blockDevice)
 	}
 	d.Set("block_device", nonRootBlockDevices)

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -88,6 +88,11 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 				fmt.Errorf("block device doesn't exist: /dev/sdb")
 			}
 
+			// Check if the third block device exists.
+			if _, ok := blockDevices["/dev/sdc"]; !ok {
+				fmt.Errorf("block device doesn't exist: /dev/sdc")
+			}
+
 			return nil
 		}
 	}
@@ -114,11 +119,22 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "root_block_device.0.volume_type", "gp2"),
 					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "block_device.#", "1"),
+						"aws_instance.foo", "block_device.#", "2"),
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "block_device.172787947.device_name", "/dev/sdb"),
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "block_device.172787947.volume_size", "9"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "block_device.172787947.iops", "0"),
+					// Check provisioned SSD device
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "block_device.3336996981.volume_type", "io1"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "block_device.3336996981.device_name", "/dev/sdc"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "block_device.3336996981.volume_size", "10"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "block_device.3336996981.iops", "100"),
 					testCheck(),
 				),
 			},
@@ -390,6 +406,12 @@ resource "aws_instance" "foo" {
 	block_device {
 		device_name = "/dev/sdb"
 		volume_size = 9
+	}
+	block_device {
+		device_name = "/dev/sdc"
+		volume_size = 10
+		volume_type = "io1"
+		iops = 100
 	}
 }
 `

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -58,6 +58,8 @@ Each `block_device` supports the following:
 * `snapshot_id` - (Optional) The Snapshot ID to mount.
 * `volume_type` - (Optional) The type of volume. Can be standard, gp2, or io1. Defaults to standard.
 * `volume_size` - (Optional) The size of the volume in gigabytes.
+* `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
+    volume_type of "io1".
 * `delete_on_termination` - (Optional) Should the volume be destroyed on instance termination (defaults true).
 * `encrypted` - (Optional) Should encryption be enabled (defaults false).
 
@@ -68,6 +70,8 @@ The `root_block_device` mapping supports the following:
   is the typical root volume for Linux instances.
 * `volume_type` - (Optional) The type of volume. Can be standard, gp2, or io1. Defaults to standard.
 * `volume_size` - (Optional) The size of the volume in gigabytes.
+* `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
+    volume_type of "io1".
 * `delete_on_termination` - (Optional) Should the volume be destroyed on instance termination (defaults true).
 
 ## Attributes Reference


### PR DESCRIPTION
Normal AWS instances support io1 volume type at block devices which require IOPS property. This changes add IOPS to block_device scheme.