### PR TITLE
helper/schema: allow pointer values to ResourceData.Set

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -143,9 +143,16 @@ func (d *ResourceData) Set(key string, value interface{}) error {
 	// simplify the interface.
 	reflectVal := reflect.ValueOf(value)
 	if reflectVal.Kind() == reflect.Ptr {
-		reflectVal = reflect.Indirect(reflectVal)
-		if reflectVal.Kind() != reflect.Struct {
-			value = reflectVal.Interface()
+		if reflectVal.IsNil() {
+			// If the pointer is nil, then the value is just nil
+			value = nil
+		} else {
+			// Otherwise, we dereference the pointer as long as its not
+			// a pointer to a struct, since struct pointers are allowed.
+			reflectVal = reflect.Indirect(reflectVal)
+			if reflectVal.Kind() != reflect.Struct {
+				value = reflectVal.Interface()
+			}
 		}
 	}
 

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -137,6 +137,18 @@ func (d *ResourceData) Partial(on bool) {
 // will be returned.
 func (d *ResourceData) Set(key string, value interface{}) error {
 	d.once.Do(d.init)
+
+	// If the value is a pointer to a non-struct, get its value and
+	// use that. This allows Set to take a pointer to primitives to
+	// simplify the interface.
+	reflectVal := reflect.ValueOf(value)
+	if reflectVal.Kind() == reflect.Ptr {
+		reflectVal = reflect.Indirect(reflectVal)
+		if reflectVal.Kind() != reflect.Struct {
+			value = reflectVal.Interface()
+		}
+	}
+
 	return d.setWriter.WriteField(strings.Split(key, "."), value)
 }
 

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1178,6 +1178,8 @@ func TestResourceDataHasChange(t *testing.T) {
 }
 
 func TestResourceDataSet(t *testing.T) {
+	var testNilPtr *string
+
 	cases := []struct {
 		Schema   map[string]*Schema
 		State    *terraform.InstanceState
@@ -1649,7 +1651,7 @@ func TestResourceDataSet(t *testing.T) {
 			Diff: nil,
 
 			Key:   "availability_zone",
-			Value: nil,
+			Value: testNilPtr,
 
 			GetKey:   "availability_zone",
 			GetValue: "",

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1588,6 +1588,72 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ratios",
 			GetValue: []interface{}{1.0, 2.2, 5.5},
 		},
+
+		// #13: Basic pointer
+		{
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "availability_zone",
+			Value: testPtrTo("foo"),
+
+			GetKey:   "availability_zone",
+			GetValue: "foo",
+		},
+
+		// #14: Basic nil value
+		{
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "availability_zone",
+			Value: testPtrTo(nil),
+
+			GetKey:   "availability_zone",
+			GetValue: "",
+		},
+
+		// #15: Basic nil pointer
+		{
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "availability_zone",
+			Value: nil,
+
+			GetKey:   "availability_zone",
+			GetValue: "",
+		},
 	}
 
 	for i, tc := range cases {
@@ -2787,4 +2853,8 @@ func TestResourceDataSetId_override(t *testing.T) {
 	if actual.ID != "foo" {
 		t.Fatalf("bad: %#v", actual)
 	}
+}
+
+func testPtrTo(raw interface{}) interface{} {
+	return &raw
 }


### PR DESCRIPTION
Broader fix for #1100 

/cc @catsby @phinze 

This allows pointer values to be sent to `ResourceData.Set`. This should simplify things immensely with libraries that return point values to primitives. Instead of sending a `string`, you can just use `*string` and `ResourceData` does the right thing. 

Clint, this would let you do this: `d.Set("name", thing.Name)` instead of `d.Set("name", *thing.Name)`. 

This isn't just for aesthetics: this protects against panic scenarios as was seen in #1100. 

Thoughts?