### PR TITLE
provider/cloudstack: updating the docs so they represent the added `managed` feature

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
@@ -191,10 +191,10 @@ func resourceCloudStackPortForwardRead(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	// If this is a managed firewall, add all unknown rules into a single dummy rule
+	// If this is a managed resource, add all unknown forwards to dummy forwards
 	managed := d.Get("managed").(bool)
 	if managed {
-		// Get all the rules from the running environment
+		// Get all the forwards from the running environment
 		p := cs.Firewall.NewListPortForwardingRulesParams()
 		p.SetIpaddressid(d.Id())
 		p.SetListall(true)
@@ -220,7 +220,7 @@ func resourceCloudStackPortForwardRead(d *schema.ResourceData, meta interface{})
 		}
 
 		for uuid, _ := range uuids {
-			// Make a dummy forward to hold all unknown UUIDs
+			// Make a dummy forward to hold the unknown UUID
 			forward := map[string]interface{}{
 				"protocol":        "N/A",
 				"private_port":    0,
@@ -229,7 +229,7 @@ func resourceCloudStackPortForwardRead(d *schema.ResourceData, meta interface{})
 				"uuid":            uuid,
 			}
 
-			// Add the dummy forward to the rules set
+			// Add the dummy forward to the forwards set
 			forwards.Add(forward)
 		}
 	}

--- a/website/source/docs/providers/cloudstack/r/port_forward.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/port_forward.html.markdown
@@ -32,6 +32,10 @@ The following arguments are supported:
 * `ipaddress` - (Required) The IP address for which to create the port forwards.
     Changing this forces a new resource to be created.
 
+* `managed` - (Optional) USE WITH CAUTION! If enabled all the port forwards for
+    this IP address will be managed by this resource. This means it will delete
+    all port forwards that are not in your config! (defaults false)
+
 * `forward` - (Required) Can be specified multiple times. Each forward block supports
     fields documented below.
 


### PR DESCRIPTION
Adding info about the `managed` option for port forwards…