### PR TITLE
providers/aws: Convert AWS Internet Gateway to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/goamz/ec2"
 )
 
 func TestAccAWSInternetGateway(t *testing.T) {
@@ -20,8 +21,8 @@ func TestAccAWSInternetGateway(t *testing.T) {
 			return fmt.Errorf("IG B is not attached")
 		}
 
-		id1 := v.Attachments[0].VpcId
-		id2 := v2.Attachments[0].VpcId
+		id1 := v.Attachments[0].VPCID
+		id2 := v2.Attachments[0].VPCID
 		if id1 == id2 {
 			return fmt.Errorf("Both attachment IDs are the same")
 		}
@@ -104,8 +105,8 @@ func TestAccInternetGateway_tags(t *testing.T) {
 				Config: testAccCheckInternetGatewayConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
-					testAccCheckTags(&v.Tags, "foo", ""),
-					testAccCheckTags(&v.Tags, "bar", "baz"),
+					testAccCheckTagsSDK(&v.Tags, "foo", ""),
+					testAccCheckTagsSDK(&v.Tags, "bar", "baz"),
 				),
 			},
 		},
@@ -113,7 +114,7 @@ func TestAccInternetGateway_tags(t *testing.T) {
 }
 
 func testAccCheckInternetGatewayDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	ec2conn := testAccProvider.Meta().(*AWSClient).awsEC2conn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_internet_gateway" {
@@ -121,8 +122,9 @@ func testAccCheckInternetGatewayDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := conn.DescribeInternetGateways(
-			[]string{rs.Primary.ID}, ec2.NewFilter())
+		resp, err := ec2conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysRequest{
+			InternetGatewayIDs: []string{rs.Primary.ID},
+		})
 		if err == nil {
 			if len(resp.InternetGateways) > 0 {
 				return fmt.Errorf("still exists")
@@ -132,7 +134,7 @@ func testAccCheckInternetGatewayDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(*ec2.Error)
+		ec2err, ok := err.(aws.APIError)
 		if !ok {
 			return err
 		}
@@ -155,9 +157,10 @@ func testAccCheckInternetGatewayExists(n string, ig *ec2.InternetGateway) resour
 			return fmt.Errorf("No ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeInternetGateways(
-			[]string{rs.Primary.ID}, ec2.NewFilter())
+		ec2conn := testAccProvider.Meta().(*AWSClient).awsEC2conn
+		resp, err := ec2conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysRequest{
+			InternetGatewayIDs: []string{rs.Primary.ID},
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
:construction: 

This PR converts (part) of AWS Internet Gateway to `aws-sdk-go`. 
It is incomplete, the matching test file is not converted.

It's currently blocked by [this issue in aws-sdk-go][1].


[1]: https://github.com/awslabs/aws-sdk-go/issues/83#issuecomment-77044502