### PR TITLE
provider/aws: Convert AWS Key Pair to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -1,9 +1,13 @@
 package aws
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 )
 
 func resourceAwsKeyPair() *schema.Resource {
@@ -33,42 +37,50 @@ func resourceAwsKeyPair() *schema.Resource {
 }
 
 func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	keyName := d.Get("key_name").(string)
 	publicKey := d.Get("public_key").(string)
-	resp, err := ec2conn.ImportKeyPair(keyName, publicKey)
+	req := &ec2.ImportKeyPairRequest{
+		KeyName:           aws.String(keyName),
+		PublicKeyMaterial: []byte(base64.StdEncoding.EncodeToString([]byte(publicKey))),
+	}
+	resp, err := ec2conn.ImportKeyPair(req)
 	if err != nil {
 		return fmt.Errorf("Error import KeyPair: %s", err)
 	}
 
-	d.SetId(resp.KeyName)
-
+	d.SetId(*resp.KeyName)
 	return nil
 }
 
 func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
-	resp, err := ec2conn.KeyPairs([]string{d.Id()}, nil)
+	req := &ec2.DescribeKeyPairsRequest{
+		KeyNames: []string{d.Id()},
+	}
+	resp, err := ec2conn.DescribeKeyPairs(req)
 	if err != nil {
 		return fmt.Errorf("Error retrieving KeyPair: %s", err)
 	}
 
-	for _, keyPair := range resp.Keys {
-		if keyPair.Name == d.Id() {
-			d.Set("key_name", keyPair.Name)
-			d.Set("fingerprint", keyPair.Fingerprint)
+	for _, keyPair := range resp.KeyPairs {
+		if *keyPair.KeyName == d.Id() {
+			d.Set("key_name", keyPair.KeyName)
+			d.Set("fingerprint", keyPair.KeyFingerprint)
 			return nil
 		}
 	}
 
-	return fmt.Errorf("Unable to find key pair within: %#v", resp.Keys)
+	return fmt.Errorf("Unable to find key pair within: %#v", resp.KeyPairs)
 }
 
 func resourceAwsKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
-	_, err := ec2conn.DeleteKeyPair(d.Id())
+	err := ec2conn.DeleteKeyPair(&ec2.DeleteKeyPairRequest{
+		KeyName: aws.String(d.Id()),
+	})
 	return err
 }


### PR DESCRIPTION
This PR converts AWS KeyPair over to aws-sdk-go.
It's built off of https://github.com/hashicorp/aws-sdk-go/pull/3 which applies a patch fix for a panic.