### PR TITLE
aws/rds: Let aws_db_instance.*.address to be actually address

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -324,7 +324,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("parameter_group_name", *v.DBParameterGroups[0].DBParameterGroupName)
 	}
 
-	d.Set("address", *v.Endpoint.Port)
+	d.Set("address", *v.Endpoint.Address)
 	d.Set("endpoint", fmt.Sprintf("%s:%d", *v.Endpoint.Address, *v.Endpoint.Port))
 	d.Set("status", *v.DBInstanceStatus)
 	d.Set("storage_encrypted", *v.StorageEncrypted)


### PR DESCRIPTION
I believe this was just a mistake/typo while converting the resource to use the `aws-sdk-go` recently.

cc @catsby 