### PR TITLE
providers/aws: go vet fixes in aws_subnet

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -68,10 +68,10 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	// Get the ID and store it
 	subnet := resp.Subnet
 	d.SetId(*subnet.SubnetID)
-	log.Printf("[INFO] Subnet ID: %s", subnet.SubnetID)
+	log.Printf("[INFO] Subnet ID: %s", *subnet.SubnetID)
 
 	// Wait for the Subnet to become available
-	log.Printf("[DEBUG] Waiting for subnet (%s) to become available", subnet.SubnetID)
+	log.Printf("[DEBUG] Waiting for subnet (%s) to become available", *subnet.SubnetID)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  "available",

--- a/builtin/providers/aws/resource_aws_subnet_test.go
+++ b/builtin/providers/aws/resource_aws_subnet_test.go
@@ -15,11 +15,11 @@ func TestAccAWSSubnet(t *testing.T) {
 
 	testCheck := func(*terraform.State) error {
 		if *v.CIDRBlock != "10.1.1.0/24" {
-			return fmt.Errorf("bad cidr: %s", v.CIDRBlock)
+			return fmt.Errorf("bad cidr: %s", *v.CIDRBlock)
 		}
 
 		if *v.MapPublicIPOnLaunch != true {
-			return fmt.Errorf("bad MapPublicIpOnLaunch: %t", v.MapPublicIPOnLaunch)
+			return fmt.Errorf("bad MapPublicIpOnLaunch: %t", *v.MapPublicIPOnLaunch)
 		}
 
 		return nil


### PR DESCRIPTION
Go vet was breaking on `master` with the following:

```
go tool vet -asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr .
builtin/providers/aws/resource_aws_subnet.go:71: arg subnet.SubnetID for printf verb %s of wrong type: github.com/hashicorp/aws-sdk-go/aws.StringValue
builtin/providers/aws/resource_aws_subnet.go:74: arg subnet.SubnetID for printf verb %s of wrong type: github.com/hashicorp/aws-sdk-go/aws.StringValue
builtin/providers/aws/resource_aws_subnet_test.go:18: arg v.CIDRBlock for printf verb %s of wrong type: github.com/hashicorp/aws-sdk-go/aws.StringValue
builtin/providers/aws/resource_aws_subnet_test.go:22: arg v.MapPublicIPOnLaunch for printf verb %t of wrong type: github.com/hashicorp/aws-sdk-go/aws.BooleanValue
```

Just needed a few extra derefs to make things happy again.
