### PR TITLE
state/remote: add undocumented file backend for remote state

### DIFF
--- a/state/remote/file.go
+++ b/state/remote/file.go
@@ -1,0 +1,64 @@
+package remote
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+)
+
+func fileFactory(conf map[string]string) (Client, error) {
+	path, ok := conf["path"]
+	if !ok {
+		return nil, fmt.Errorf("missing 'path' configuration")
+	}
+
+	return &FileClient{
+		Path: path,
+	}, nil
+}
+
+// FileClient is a remote client that stores data locally on disk.
+// This is only used for development reasons to test remote state... locally.
+type FileClient struct {
+	Path string
+}
+
+func (c *FileClient) Get() (*Payload, error) {
+	var buf bytes.Buffer
+	f, err := os.Open(c.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(&buf, f); err != nil {
+		return nil, err
+	}
+
+	md5 := md5.Sum(buf.Bytes())
+	return &Payload{
+		Data: buf.Bytes(),
+		MD5:  md5[:],
+	}, nil
+}
+
+func (c *FileClient) Put(data []byte) error {
+	f, err := os.Create(c.Path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(data)
+	return err
+}
+
+func (c *FileClient) Delete() error {
+	return os.Remove(c.Path)
+}

--- a/state/remote/file_test.go
+++ b/state/remote/file_test.go
@@ -1,0 +1,29 @@
+package remote
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestFileClient_impl(t *testing.T) {
+	var _ Client = new(FileClient)
+}
+
+func TestFileClient(t *testing.T) {
+	tf, err := ioutil.TempFile("", "tf")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	tf.Close()
+	defer os.Remove(tf.Name())
+
+	client, err := fileFactory(map[string]string{
+		"path": tf.Name(),
+	})
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	testClient(t, client)
+}

--- a/state/remote/remote.go
+++ b/state/remote/remote.go
@@ -39,4 +39,7 @@ var BuiltinClients = map[string]Factory{
 	"atlas":  atlasFactory,
 	"consul": consulFactory,
 	"http":   httpFactory,
+
+	// This is used for development purposes only.
+	"_local": fileFactory,
 }


### PR DESCRIPTION
This adds a `_local` backend to the remote state. This is used for development so that the remote state machinery can be enabled while it is actually only being synced to another local file. 

Unit tests continue to use a mock HTTP server. This is mostly for devs doing manual testing locally to perhaps try to repro bugs or whatnot.