### PR TITLE
helper/schema: allow Schema attrs to be Deprecated/Removed

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -114,12 +114,20 @@ type Schema struct {
 	// NOTE: This currently does not work.
 	ComputedWhen []string
 
-	// When Deprecated is set, this field is deprecated.
+	// When Deprecated is set, this attribute is deprecated.
 	//
 	// A deprecated field still works, but will probably stop working in near
 	// future. This string is the message shown to the user with instructions on
 	// how to address the deprecation.
 	Deprecated string
+
+	// When Removed is set, this attribute has been removed from the schema
+	//
+	// Removed attributes can be left in the Schema to generate informative error
+	// messages for the user when they show up in resource configurations.
+	// This string is the message shown to the user with instructions on
+	// what do to about the removed attribute.
+	Removed string
 }
 
 // SchemaDefaultFunc is a function called to return a default value for
@@ -1089,6 +1097,11 @@ func (m schemaMap) validateType(
 	if schema.Deprecated != "" {
 		ws = append(ws, fmt.Sprintf(
 			"%q: [DEPRECATED] %s", k, schema.Deprecated))
+	}
+
+	if schema.Removed != "" {
+		es = append(es, fmt.Errorf(
+			"%q: [REMOVED] %s", k, schema.Removed))
 	}
 
 	return ws, es

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2584,11 +2584,11 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 
 func TestSchemaMap_Validate(t *testing.T) {
 	cases := map[string]struct {
-		Schema map[string]*Schema
-		Config map[string]interface{}
-		Vars   map[string]string
-		Warn   bool
-		Err    bool
+		Schema   map[string]*Schema
+		Config   map[string]interface{}
+		Vars     map[string]string
+		Err      bool
+		Warnings []string
 	}{
 		"Good": {
 			Schema: map[string]*Schema{
@@ -3019,6 +3019,83 @@ func TestSchemaMap_Validate(t *testing.T) {
 
 			Err: true,
 		},
+
+		"Deprecated attribute usage generates warning, but not error": {
+			Schema: map[string]*Schema{
+				"old_news": &Schema{
+					Type:       TypeString,
+					Optional:   true,
+					Deprecated: "please use 'new_news' instead",
+				},
+			},
+
+			Config: map[string]interface{}{
+				"old_news": "extra extra!",
+			},
+
+			Err: false,
+
+			Warnings: []string{
+				"\"old_news\": [DEPRECATED] please use 'new_news' instead",
+			},
+		},
+
+		"Deprecated generates no warnings if attr not used": {
+			Schema: map[string]*Schema{
+				"old_news": &Schema{
+					Type:       TypeString,
+					Optional:   true,
+					Deprecated: "please use 'new_news' instead",
+				},
+			},
+
+			Err: false,
+
+			Warnings: nil,
+		},
+
+		"Deprecated works with set/list type": {
+			Schema: map[string]*Schema{
+				"old_news": &Schema{
+					Type:       TypeSet,
+					Optional:   true,
+					Elem:       &Schema{Type: TypeString},
+					Deprecated: "please use 'new_news' instead",
+				},
+			},
+
+			Config: map[string]interface{}{
+				"old_news": []interface{}{"extra extra!"},
+			},
+
+			Err: false,
+
+			Warnings: []string{
+				"\"old_news\": [DEPRECATED] please use 'new_news' instead",
+			},
+		},
+
+		"Deprecated works with map type": {
+			Schema: map[string]*Schema{
+				"old_news": &Schema{
+					Type:       TypeMap,
+					Optional:   true,
+					Deprecated: "please use 'new_news' instead",
+				},
+			},
+
+			Config: map[string]interface{}{
+				"old_news": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+
+			Err: false,
+
+			Warnings: []string{
+				"\"old_news\": [DEPRECATED] please use 'new_news' instead",
+			},
+		},
 	}
 
 	for tn, tc := range cases {
@@ -3050,8 +3127,8 @@ func TestSchemaMap_Validate(t *testing.T) {
 			t.FailNow()
 		}
 
-		if (len(ws) > 0) != tc.Warn {
-			t.Fatalf("%q: ws: %#v", tn, ws)
+		if !reflect.DeepEqual(ws, tc.Warnings) {
+			t.Fatalf("%q: warnings:\n\nexpected: %#v\ngot:%#v", tn, tc.Warnings, ws)
 		}
 	}
 }


### PR DESCRIPTION
Deprecated fields show a customizable warning message to the user when
they are used in a Terraform config. This is a tool that provider
authors can use for user feedback as they evolve their Schemas.

Removed fields show a customizable error message to the user when they
are used in a Terraform config. This is a tool that provider authors can
use for user feedback as they evolve their Schemas.

fixes #957 