### PR TITLE
providers/aws: final_snapshot_id isn't ForceNew

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -156,7 +156,6 @@ func resourceAwsDbInstance() *schema.Resource {
 			"final_snapshot_identifier": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"db_subnet_group_name": &schema.Schema{


### PR DESCRIPTION
Removing `ForceNew` from `final_snapshot_identifier` - it's a parameter
that's _only_ passed during the DeleteDBInstance API call, so it's perfectly
valid to change the attribute for an existing DB Instance.

fixes #1138