### PR TITLE
Add vpc_peering docs to sidebar

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -95,6 +95,10 @@
                     <li<%= sidebar_current("docs-aws-resource-vpc") %>>
 					<a href="/docs/providers/aws/r/vpc.html">aws_vpc</a>
                     </li>
+
+                    <li<%= sidebar_current("docs-aws-resource-vpc-peering") %>>
+					<a href="/docs/providers/aws/r/vpc_peering.html">aws_vpc_peering</a>
+                    </li>
 				</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
This resource is already documented, but there is actually no link pointing to that page.