### PR TITLE
Add quickdev option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ bin: generate
 dev: generate
 	@TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
+quickdev: generate
+	@TF_QUICKDEV=1 TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
+
 # test runs the unit tests and vets the code
 test: generate
 	TF_ACC= go test $(TEST) $(TESTARGS) -timeout=30s -parallel=4

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,9 +19,11 @@ GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd}
 
-# Install dependencies
-echo "==> Getting dependencies..."
-go get ./...
+# Install dependencies unless running in quick mode
+if [ "${TF_QUICKDEV}x" == "x" ]; then
+    echo "==> Getting dependencies..."
+    go get ./...
+fi
 
 # Delete the old dir
 echo "==> Removing old directory..."


### PR DESCRIPTION
This skips getting dependencies to make repeated builds a bit faster and less network-heavy