### PR TITLE
Vpc security group ids

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -101,7 +101,7 @@ func resourceAwsInstance() *schema.Resource {
 				},
 			},
 
-			"vpc_security_groups_ids": &schema.Schema{
+			"vpc_security_group_ids": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -293,9 +293,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v := d.Get("security_groups"); v != nil {
 		if runOpts.SubnetId != "" {
-			log.Printf(
-				"[WARN] Deprecated. Attempting to use 'security_groups' within a VPC instance. Use 'vpc_security_group_ids' instead."
-			)
+			log.Printf("[WARN] Deprecated. Attempting to use 'security_groups' within a VPC instance. Use 'vpc_security_group_ids' instead.")
 		}
 
 		for _, v := range v.(*schema.Set).List() {

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -459,7 +459,6 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	// we use IDs if we're in a VPC. However, if we previously had an
 	// all-name list of security groups, we use names. Or, if we had any
 	// IDs, we use IDs.
-	// TODO: check the VPC ID instead?
 	useID := instance.SubnetId != ""
 	// Deprecated: vpc security groups should be defined in vpc_security_group_ids
 	if v := d.Get("security_groups"); v != nil {
@@ -481,7 +480,12 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		for i, sg := range instance.SecurityGroups {
 			sgs[i] = sg.Id
 		}
-		d.Set("vpc_security_group_ids", sgs)
+		// Keep some backward compatibility. The user is warned on creation.
+		if d.Get("security_groups") != nil {
+			d.Set("security_groups", sgs)
+		} else {
+			d.Set("vpc_security_group_ids", sgs)
+		}
 	} else {
 		for i, sg := range instance.SecurityGroups {
 			sgs[i] = sg.Name

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -101,6 +101,16 @@ func resourceAwsInstance() *schema.Resource {
 				},
 			},
 
+			"vpc_security_groups_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set: func(v interface{}) int {
+					return hashcode.String(v.(string))
+				},
+			},
+
 			"public_dns": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -282,15 +292,33 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v := d.Get("security_groups"); v != nil {
+		if runOpts.SubnetId != "" {
+			log.Printf(
+				"[WARN] Deprecated. Attempting to use 'security_groups' within a VPC instance. Use 'vpc_security_group_ids' instead."
+			)
+		}
+
 		for _, v := range v.(*schema.Set).List() {
 			str := v.(string)
 
 			var g ec2.SecurityGroup
+			// Deprecated, stop using the subnet ID here
 			if runOpts.SubnetId != "" {
 				g.Id = str
 			} else {
 				g.Name = str
 			}
+
+			runOpts.SecurityGroups = append(runOpts.SecurityGroups, g)
+		}
+	}
+
+	if v := d.Get("vpc_security_group_ids"); v != nil {
+		for _, v := range v.(*schema.Set).List() {
+			str := v.(string)
+
+			var g ec2.SecurityGroup
+			g.Id = str
 
 			runOpts.SecurityGroups = append(runOpts.SecurityGroups, g)
 		}
@@ -431,7 +459,9 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	// we use IDs if we're in a VPC. However, if we previously had an
 	// all-name list of security groups, we use names. Or, if we had any
 	// IDs, we use IDs.
+	// TODO: check the VPC ID instead?
 	useID := instance.SubnetId != ""
+	// Deprecated: vpc security groups should be defined in vpc_security_group_ids
 	if v := d.Get("security_groups"); v != nil {
 		match := false
 		for _, v := range v.(*schema.Set).List() {
@@ -446,14 +476,18 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Build up the security groups
 	sgs := make([]string, len(instance.SecurityGroups))
-	for i, sg := range instance.SecurityGroups {
-		if useID {
+
+	if useID {
+		for i, sg := range instance.SecurityGroups {
 			sgs[i] = sg.Id
-		} else {
+		}
+		d.Set("vpc_security_group_ids", sgs)
+	} else {
+		for i, sg := range instance.SecurityGroups {
 			sgs[i] = sg.Name
 		}
+		d.Set("security_groups", sgs)
 	}
-	d.Set("security_groups", sgs)
 
 	blockDevices := make(map[string]ec2.BlockDevice)
 	for _, bd := range instance.BlockDevices {

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -34,9 +34,9 @@ The following arguments are supported:
      EBS-optimized.
 * `instance_type` - (Required) The type of instance to start
 * `key_name` - (Optional) The key name to use for the instance.
-* `security_groups` - (Optional) A list of security group IDs or names to associate with.
-   If you are within a non-default VPC, you'll need to use the security group ID. Otherwise,
-   for EC2 and the default VPC, use the security group name.
+* `security_groups` - (Optional) A list of security group names to associate with.
+   If you are within a non-default VPC, you'll need to use `vpc_security_group_ids` instead.
+* `vpc_security_group_ids` - (Optional) A list of security group IDs to associate with.
 * `subnet_id` - (Optional) The VPC Subnet ID to launch in.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.
 * `private_ip` - (Optional) Private IP address to associate with the
@@ -86,4 +86,5 @@ The following attributes are exported:
 * `public_dns` - The public DNS name of the instance
 * `public_ip` - The public IP address.
 * `security_groups` - The associated security groups.
+* `vpc_security_group_ids` - The associated security groups in non-default VPC.
 * `subnet_id` - The VPC subnet ID.


### PR DESCRIPTION
In a VPC environment the security groups on instances can be changed without having to recreate the instance.

The current `security_groups` parameter forces the recreation of the instance. To allow VPC users to change their configuration, a different parameter can be used (`vpc_security_groups_ids`, which matches the model we have in `aws_db_instance`).

This PR adds the said parameter

Should be a first step to fix #749