### PR TITLE
providers/aws: private route53 zone support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ IMPROVEMENTS:
       change. This will lower the amount of state changing on things
       like refresh.
   * core: Autoload `terraform.tfvars.json` as well as `terraform.tfvars` [GH-1030]
+  * providers/aws: private route53 zone support [GH-607]
   * core: `.tf` files that start with a period are now ignored. [GH-1227]
   * command/remote-config: After enabling remote state, a `pull` is
       automatically done initially.


### PR DESCRIPTION
fixes #607 -- though, I didn't seem to need any upstream changes

Hand-verfied that creation of public and private zones work.

Note that `ForceNew` may not be required for updating the VPC on an already private zone, but updating a public zone to private isn't possible. I figured basic private zone support is better than no support. A future version might be able to change VPCs without creating a new zone.

VPC association may need to be used in future: http://docs.aws.amazon.com/Route53/latest/APIReference/API_AssociateVPCWithHostedZone.html

First terraform contribution, let me know if I've missed anything. I couldn't figure out a good way to validate the complex requirement at config time so I'd welcome input on that. Currently, not supplying both `vpc_id` and `vpc_region` will cause an error at apply time.