### PR TITLE
Increase aws/Route53 record creation timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -138,7 +138,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		Delay:      30 * time.Second,
 		Pending:    []string{"PENDING"},
 		Target:     "INSYNC",
-		Timeout:    10 * time.Minute,
+		Timeout:    30 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
 			changeRequest := &route53.GetChangeRequest{


### PR DESCRIPTION
I'm getting following error when trying to create Route53 record sets:

```
aws_route53_record.db: Error: 1 error(s) occurred:

* timeout while waiting for state to become 'INSYNC'
```

The current timeout is 10 mins which may not be enough, so this modification is IMO necessary, although I'd rather see #1124 being solved in long-term.