### PR TITLE
providers/aws: iops in root device skipped when output state

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -482,6 +482,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		blockDevice["device_name"] = blockDevices[vol.VolumeId].DeviceName
 		blockDevice["volume_type"] = vol.VolumeType
 		blockDevice["volume_size"] = volSize
+		blockDevice["iops"] = vol.IOPS
 		blockDevice["delete_on_termination"] =
 			blockDevices[vol.VolumeId].DeleteOnTermination
 
@@ -494,7 +495,6 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 		blockDevice["snapshot_id"] = vol.SnapshotId
 		blockDevice["encrypted"] = vol.Encrypted
-		blockDevice["iops"] = vol.IOPS
 		nonRootBlockDevices = append(nonRootBlockDevices, blockDevice)
 	}
 	d.Set("block_device", nonRootBlockDevices)


### PR DESCRIPTION
After adding iops from #1103,  Root devices do not report correct IOPS value when using io1 volume.