### PR TITLE
provider/aws: Convert AWS Route Table Association to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -87,7 +87,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  "ready",
-		Refresh: resourceAwsRouteTableStateRefreshFuncSDK(ec2conn, d.Id()),
+		Refresh: resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -102,7 +102,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	ec2conn := meta.(*AWSClient).awsEC2conn
 
-	rtRaw, _, err := resourceAwsRouteTableStateRefreshFuncSDK(ec2conn, d.Id())()
+	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id())()
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 
 	// First request the routing table since we'll have to disassociate
 	// all the subnets first.
-	rtRaw, _, err := resourceAwsRouteTableStateRefreshFuncSDK(ec2conn, d.Id())()
+	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id())()
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"ready"},
 		Target:  "",
-		Refresh: resourceAwsRouteTableStateRefreshFuncSDK(ec2conn, d.Id()),
+		Refresh: resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -291,9 +291,9 @@ func resourceAwsRouteTableHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-// resourceAwsRouteTableStateRefreshFuncSDK returns a resource.StateRefreshFunc that is used to watch
+// resourceAwsRouteTableStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
 // a RouteTable.
-func resourceAwsRouteTableStateRefreshFuncSDK(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+func resourceAwsRouteTableStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
 			RouteTableIDs: []string{id},

--- a/builtin/providers/aws/resource_aws_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_route_table_association.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mitchellh/goamz/ec2"
 )
 
 func resourceAwsRouteTableAssociation() *schema.Resource {
@@ -32,30 +33,31 @@ func resourceAwsRouteTableAssociation() *schema.Resource {
 }
 
 func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	log.Printf(
 		"[INFO] Creating route table association: %s => %s",
 		d.Get("subnet_id").(string),
 		d.Get("route_table_id").(string))
 
-	resp, err := ec2conn.AssociateRouteTable(
-		d.Get("route_table_id").(string),
-		d.Get("subnet_id").(string))
+	resp, err := ec2conn.AssociateRouteTable(&ec2.AssociateRouteTableRequest{
+		RouteTableID: aws.String(d.Get("route_table_id").(string)),
+		SubnetID:     aws.String(d.Get("subnet_id").(string)),
+	})
 
 	if err != nil {
 		return err
 	}
 
 	// Set the ID and return
-	d.SetId(resp.AssociationId)
+	d.SetId(*resp.AssociationID)
 	log.Printf("[INFO] Association ID: %s", d.Id())
 
 	return nil
 }
 
 func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	// Get the routing table that this association belongs to
 	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(
@@ -71,9 +73,9 @@ func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface
 	// Inspect that the association exists
 	found := false
 	for _, a := range rt.Associations {
-		if a.AssociationId == d.Id() {
+		if *a.RouteTableAssociationID == d.Id() {
 			found = true
-			d.Set("subnet_id", a.SubnetId)
+			d.Set("subnet_id", *a.SubnetID)
 			break
 		}
 	}
@@ -87,19 +89,21 @@ func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface
 }
 
 func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	log.Printf(
 		"[INFO] Creating route table association: %s => %s",
 		d.Get("subnet_id").(string),
 		d.Get("route_table_id").(string))
 
-	resp, err := ec2conn.ReassociateRouteTable(
-		d.Id(),
-		d.Get("route_table_id").(string))
+	req := &ec2.ReplaceRouteTableAssociationRequest{
+		AssociationID: aws.String(d.Id()),
+		RouteTableID:  aws.String(d.Get("route_table_id").(string)),
+	}
+	resp, err := ec2conn.ReplaceRouteTableAssociation(req)
 
 	if err != nil {
-		ec2err, ok := err.(*ec2.Error)
+		ec2err, ok := err.(aws.APIError)
 		if ok && ec2err.Code == "InvalidAssociationID.NotFound" {
 			// Not found, so just create a new one
 			return resourceAwsRouteTableAssociationCreate(d, meta)
@@ -109,18 +113,21 @@ func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	// Update the ID
-	d.SetId(resp.AssociationId)
+	d.SetId(*resp.NewAssociationID)
 	log.Printf("[INFO] Association ID: %s", d.Id())
 
 	return nil
 }
 
 func resourceAwsRouteTableAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	log.Printf("[INFO] Deleting route table association: %s", d.Id())
-	if _, err := ec2conn.DisassociateRouteTable(d.Id()); err != nil {
-		ec2err, ok := err.(*ec2.Error)
+	err := ec2conn.DisassociateRouteTable(&ec2.DisassociateRouteTableRequest{
+		AssociationID: aws.String(d.Id()),
+	})
+	if err != nil {
+		ec2err, ok := err.(aws.APIError)
 		if ok && ec2err.Code == "InvalidAssociationID.NotFound" {
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_route_table_association.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/aws-sdk-go/aws"
 	"github.com/hashicorp/aws-sdk-go/gen/ec2"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -136,30 +135,4 @@ func resourceAwsRouteTableAssociationDelete(d *schema.ResourceData, meta interfa
 	}
 
 	return nil
-}
-
-// TODO: remove this method when converting to aws-sdk-go
-// resourceAwsRouteTableStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
-// a RouteTable.
-func resourceAwsRouteTableStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeRouteTables([]string{id}, ec2.NewFilter())
-		if err != nil {
-			if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidRouteTableID.NotFound" {
-				resp = nil
-			} else {
-				log.Printf("Error on RouteTableStateRefresh: %s", err)
-				return nil, "", err
-			}
-		}
-
-		if resp == nil {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
-		}
-
-		rt := &resp.RouteTables[0]
-		return rt, "ready", nil
-	}
 }

--- a/builtin/providers/aws/resource_aws_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_association_test.go
@@ -64,7 +64,7 @@ func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
 		rt := resp.RouteTables[0]
 		if len(rt.Associations) > 0 {
 			return fmt.Errorf(
-				"route table %s has associations", rt.RouteTableID)
+				"route table %s has associations", *rt.RouteTableID)
 
 		}
 	}

--- a/builtin/providers/aws/resource_aws_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_association_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/goamz/ec2"
 )
 
 func TestAccAWSRouteTableAssociation(t *testing.T) {
@@ -37,7 +38,7 @@ func TestAccAWSRouteTableAssociation(t *testing.T) {
 }
 
 func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	conn := testAccProvider.Meta().(*AWSClient).awsEC2conn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route_table_association" {
@@ -45,11 +46,12 @@ func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := conn.DescribeRouteTables(
-			[]string{rs.Primary.Attributes["route_table_Id"]}, ec2.NewFilter())
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
+			RouteTableIDs: []string{rs.Primary.Attributes["route_table_id"]},
+		})
 		if err != nil {
 			// Verify the error is what we want
-			ec2err, ok := err.(*ec2.Error)
+			ec2err, ok := err.(aws.APIError)
 			if !ok {
 				return err
 			}
@@ -62,7 +64,7 @@ func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
 		rt := resp.RouteTables[0]
 		if len(rt.Associations) > 0 {
 			return fmt.Errorf(
-				"route table %s has associations", rt.RouteTableId)
+				"route table %s has associations", rt.RouteTableID)
 
 		}
 	}
@@ -81,9 +83,10 @@ func testAccCheckRouteTableAssociationExists(n string, v *ec2.RouteTable) resour
 			return fmt.Errorf("No ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeRouteTables(
-			[]string{rs.Primary.Attributes["route_table_id"]}, ec2.NewFilter())
+		conn := testAccProvider.Meta().(*AWSClient).awsEC2conn
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
+			RouteTableIDs: []string{rs.Primary.Attributes["route_table_id"]},
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Migrate Route Table Association to `aws-sdk-go`, building off of #1170 

Restores the `resourceAwsRouteTableStateRefreshFunc ` func that was copied over for #1170