### PR TITLE
provider/aws: Add env default for AWS_ACCOUNT_ID in VPC Peering connection

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -19,9 +19,10 @@ func resourceAwsVpcPeeringConnection() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"peer_owner_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("AWS_ACCOUNT_ID", nil),
 			},
 			"peer_vpc_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -68,11 +68,10 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_vpc" "bar" {
-    cidr_block = "10.0.1.0/16"
+    cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-    peer_owner_id = "12345"
     vpc_id = "${aws_vpc.foo.id}"
     peer_vpc_id = "${aws_vpc.bar.id}"
 }


### PR DESCRIPTION
- Provide a default value for `peer_owner_id`, so we don't have to hard code a valid `peer_owner_id`. 
- Fix the CIDR blocks so they don't overlap