### PR TITLE
providers/aws: Convert AWS VPC Peering to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -5,9 +5,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mitchellh/goamz/ec2"
 )
 
 func resourceAwsVpcPeeringConnection() *schema.Resource {
@@ -40,23 +41,23 @@ func resourceAwsVpcPeeringConnection() *schema.Resource {
 }
 
 func resourceAwsVpcPeeringCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	// Create the vpc peering connection
-	createOpts := &ec2.CreateVpcPeeringConnection{
-		PeerOwnerId: d.Get("peer_owner_id").(string),
-		PeerVpcId:   d.Get("peer_vpc_id").(string),
-		VpcId:       d.Get("vpc_id").(string),
+	createOpts := &ec2.CreateVPCPeeringConnectionRequest{
+		PeerOwnerID: aws.String(d.Get("peer_owner_id").(string)),
+		PeerVPCID:   aws.String(d.Get("peer_vpc_id").(string)),
+		VPCID:       aws.String(d.Get("vpc_id").(string)),
 	}
 	log.Printf("[DEBUG] VpcPeeringCreate create config: %#v", createOpts)
-	resp, err := ec2conn.CreateVpcPeeringConnection(createOpts)
+	resp, err := ec2conn.CreateVPCPeeringConnection(createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating vpc peering connection: %s", err)
 	}
 
 	// Get the ID and store it
-	rt := &resp.VpcPeeringConnection
-	d.SetId(rt.VpcPeeringConnectionId)
+	rt := resp.VPCPeeringConnection
+	d.SetId(*rt.VPCPeeringConnectionID)
 	log.Printf("[INFO] Vpc Peering Connection ID: %s", d.Id())
 
 	// Wait for the vpc peering connection to become available
@@ -79,7 +80,7 @@ func resourceAwsVpcPeeringCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsVpcPeeringRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 	pcRaw, _, err := resourceAwsVpcPeeringConnectionStateRefreshFunc(ec2conn, d.Id())()
 	if err != nil {
 		return err
@@ -89,20 +90,20 @@ func resourceAwsVpcPeeringRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	pc := pcRaw.(*ec2.VpcPeeringConnection)
+	pc := pcRaw.(*ec2.VPCPeeringConnection)
 
-	d.Set("peer_owner_id", pc.AccepterVpcInfo.OwnerId)
-	d.Set("peer_vpc_id", pc.AccepterVpcInfo.VpcId)
-	d.Set("vpc_id", pc.RequesterVpcInfo.VpcId)
-	d.Set("tags", tagsToMap(pc.Tags))
+	d.Set("peer_owner_id", pc.AccepterVPCInfo.OwnerID)
+	d.Set("peer_vpc_id", pc.AccepterVPCInfo.VPCID)
+	d.Set("vpc_id", pc.RequesterVPCInfo.VPCID)
+	d.Set("tags", tagsToMapSDK(pc.Tags))
 
 	return nil
 }
 
 func resourceAwsVpcPeeringUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
-	if err := setTags(ec2conn, d); err != nil {
+	if err := setTagsSDK(ec2conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
@@ -112,9 +113,12 @@ func resourceAwsVpcPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsVpcPeeringDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
-	_, err := ec2conn.DeleteVpcPeeringConnection(d.Id())
+	_, err := ec2conn.DeleteVPCPeeringConnection(
+		&ec2.DeleteVPCPeeringConnectionRequest{
+			VPCPeeringConnectionID: aws.String(d.Id()),
+		})
 	return err
 }
 
@@ -123,9 +127,11 @@ func resourceAwsVpcPeeringDelete(d *schema.ResourceData, meta interface{}) error
 func resourceAwsVpcPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
-		resp, err := conn.DescribeVpcPeeringConnection([]string{id}, ec2.NewFilter())
+		resp, err := conn.DescribeVPCPeeringConnections(&ec2.DescribeVPCPeeringConnectionsRequest{
+			VPCPeeringConnectionIDs: []string{id},
+		})
 		if err != nil {
-			if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidVpcPeeringConnectionID.NotFound" {
+			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpcPeeringConnectionID.NotFound" {
 				resp = nil
 			} else {
 				log.Printf("Error on VpcPeeringConnectionStateRefresh: %s", err)
@@ -139,7 +145,7 @@ func resourceAwsVpcPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) r
 			return nil, "", nil
 		}
 
-		pc := &resp.VpcPeeringConnections[0]
+		pc := &resp.VPCPeeringConnections[0]
 
 		return pc, "ready", nil
 	}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/goamz/ec2"
 )
 
 func TestAccAWSVPCPeeringConnection_normal(t *testing.T) {
@@ -28,17 +28,20 @@ func TestAccAWSVPCPeeringConnection_normal(t *testing.T) {
 }
 
 func testAccCheckAWSVpcPeeringConnectionDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	conn := testAccProvider.Meta().(*AWSClient).awsEC2conn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_vpc_peering_connection" {
 			continue
 		}
 
-		describe, err := conn.DescribeVpcPeeringConnection([]string{rs.Primary.ID}, ec2.NewFilter())
+		describe, err := conn.DescribeVPCPeeringConnections(
+			&ec2.DescribeVPCPeeringConnectionsRequest{
+				VPCPeeringConnectionIDs: []string{rs.Primary.ID},
+			})
 
 		if err == nil {
-			if len(describe.VpcPeeringConnections) != 0 {
+			if len(describe.VPCPeeringConnections) != 0 {
 				return fmt.Errorf("vpc peering connection still exists")
 			}
 		}


### PR DESCRIPTION
Convert AWS VPC Peering resource to `aws-sdk-go`