### PR TITLE
Bugfix: Add tags on AWS IG creation, not just on update

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -43,6 +43,11 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	d.SetId(*ig.InternetGatewayID)
 	log.Printf("[INFO] InternetGateway ID: %s", d.Id())
 
+	err = setTagsSDK(ec2conn, d)
+	if err != nil {
+		return err
+	}
+
 	// Attach the new gateway to the correct vpc
 	return resourceAwsInternetGatewayAttach(d, meta)
 }

--- a/builtin/providers/aws/resource_aws_internet_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway_test.go
@@ -98,6 +98,7 @@ func TestAccInternetGateway_tags(t *testing.T) {
 				Config: testAccCheckInternetGatewayConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
+					testAccCheckTagsSDK(&v.Tags, "foo", "bar"),
 				),
 			},
 


### PR DESCRIPTION
This is fixing #1102 