### PR TITLE
provider/aws: Convert AWS Network ACL to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -2,11 +2,14 @@ package aws
 
 import (
 	"fmt"
-	"github.com/mitchellh/goamz/ec2"
+	"strconv"
+
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 )
 
-func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.NetworkAclEntry, error) {
-	entries := make([]ec2.NetworkAclEntry, 0, len(configured))
+func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.NetworkACLEntry, error) {
+	entries := make([]ec2.NetworkACLEntry, 0, len(configured))
 	for _, eRaw := range configured {
 		data := eRaw.(map[string]interface{})
 		protocol := data["protocol"].(string)
@@ -15,16 +18,16 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.
 			return nil, fmt.Errorf("Invalid Protocol %s for rule %#v", protocol, data)
 		}
 		p := extractProtocolInteger(data["protocol"].(string))
-		e := ec2.NetworkAclEntry{
-			Protocol: p,
-			PortRange: ec2.PortRange{
-				From: data["from_port"].(int),
-				To:   data["to_port"].(int),
+		e := ec2.NetworkACLEntry{
+			Protocol: aws.String(strconv.Itoa(p)),
+			PortRange: &ec2.PortRange{
+				From: aws.Integer(data["from_port"].(int)),
+				To:   aws.Integer(data["to_port"].(int)),
 			},
-			Egress:     (entryType == "egress"),
-			RuleAction: data["action"].(string),
-			RuleNumber: data["rule_no"].(int),
-			CidrBlock:  data["cidr_block"].(string),
+			Egress:     aws.Boolean((entryType == "egress")),
+			RuleAction: aws.String(data["action"].(string)),
+			RuleNumber: aws.Integer(data["rule_no"].(int)),
+			CIDRBlock:  aws.String(data["cidr_block"].(string)),
 		}
 		entries = append(entries, e)
 	}
@@ -33,17 +36,17 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]ec2.
 
 }
 
-func flattenNetworkAclEntries(list []ec2.NetworkAclEntry) []map[string]interface{} {
+func flattenNetworkAclEntries(list []ec2.NetworkACLEntry) []map[string]interface{} {
 	entries := make([]map[string]interface{}, 0, len(list))
 
 	for _, entry := range list {
 		entries = append(entries, map[string]interface{}{
-			"from_port":  entry.PortRange.From,
-			"to_port":    entry.PortRange.To,
-			"action":     entry.RuleAction,
-			"rule_no":    entry.RuleNumber,
-			"protocol":   extractProtocolString(entry.Protocol),
-			"cidr_block": entry.CidrBlock,
+			"from_port":  *entry.PortRange.From,
+			"to_port":    *entry.PortRange.To,
+			"action":     *entry.RuleAction,
+			"rule_no":    *entry.RuleNumber,
+			"protocol":   *entry.Protocol,
+			"cidr_block": *entry.CIDRBlock,
 		})
 	}
 	return entries

--- a/builtin/providers/aws/network_acl_entry_test.go
+++ b/builtin/providers/aws/network_acl_entry_test.go
@@ -31,7 +31,7 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 
 	expected := []ec2.NetworkACLEntry{
 		ec2.NetworkACLEntry{
-			Protocol: aws.String("tcp"),
+			Protocol: aws.String("6"),
 			PortRange: &ec2.PortRange{
 				From: aws.Integer(22),
 				To:   aws.Integer(22),
@@ -40,13 +40,9 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 			RuleNumber: aws.Integer(1),
 			CIDRBlock:  aws.String("0.0.0.0/0"),
 			Egress:     aws.Boolean(true),
-			ICMPTypeCode: &ec2.ICMPTypeCode{
-				Code: aws.Integer(0),
-				Type: aws.Integer(0),
-			},
 		},
 		ec2.NetworkACLEntry{
-			Protocol: aws.String("tcp"),
+			Protocol: aws.String("6"),
 			PortRange: &ec2.PortRange{
 				From: aws.Integer(443),
 				To:   aws.Integer(443),
@@ -55,10 +51,6 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 			RuleNumber: aws.Integer(2),
 			CIDRBlock:  aws.String("0.0.0.0/0"),
 			Egress:     aws.Boolean(true),
-			ICMPTypeCode: &ec2.ICMPTypeCode{
-				Code: aws.Integer(0),
-				Type: aws.Integer(0),
-			},
 		},
 	}
 

--- a/builtin/providers/aws/network_acl_entry_test.go
+++ b/builtin/providers/aws/network_acl_entry_test.go
@@ -4,10 +4,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mitchellh/goamz/ec2"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 )
 
-func Test_expandNetworkAclEntry(t *testing.T) {
+func Test_expandNetworkACLEntry(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"protocol":   "tcp",
@@ -28,30 +29,36 @@ func Test_expandNetworkAclEntry(t *testing.T) {
 	}
 	expanded, _ := expandNetworkAclEntries(input, "egress")
 
-	expected := []ec2.NetworkAclEntry{
-		ec2.NetworkAclEntry{
-			Protocol: 6,
-			PortRange: ec2.PortRange{
-				From: 22,
-				To:   22,
+	expected := []ec2.NetworkACLEntry{
+		ec2.NetworkACLEntry{
+			Protocol: aws.String("tcp"),
+			PortRange: &ec2.PortRange{
+				From: aws.Integer(22),
+				To:   aws.Integer(22),
 			},
-			RuleAction: "deny",
-			RuleNumber: 1,
-			CidrBlock:  "0.0.0.0/0",
-			Egress:     true,
-			IcmpCode:   ec2.IcmpCode{Code: 0, Type: 0},
+			RuleAction: aws.String("deny"),
+			RuleNumber: aws.Integer(1),
+			CIDRBlock:  aws.String("0.0.0.0/0"),
+			Egress:     aws.Boolean(true),
+			ICMPTypeCode: &ec2.ICMPTypeCode{
+				Code: aws.Integer(0),
+				Type: aws.Integer(0),
+			},
 		},
-		ec2.NetworkAclEntry{
-			Protocol: 6,
-			PortRange: ec2.PortRange{
-				From: 443,
-				To:   443,
+		ec2.NetworkACLEntry{
+			Protocol: aws.String("tcp"),
+			PortRange: &ec2.PortRange{
+				From: aws.Integer(443),
+				To:   aws.Integer(443),
 			},
-			RuleAction: "deny",
-			RuleNumber: 2,
-			CidrBlock:  "0.0.0.0/0",
-			Egress:     true,
-			IcmpCode:   ec2.IcmpCode{Code: 0, Type: 0},
+			RuleAction: aws.String("deny"),
+			RuleNumber: aws.Integer(2),
+			CIDRBlock:  aws.String("0.0.0.0/0"),
+			Egress:     aws.Boolean(true),
+			ICMPTypeCode: &ec2.ICMPTypeCode{
+				Code: aws.Integer(0),
+				Type: aws.Integer(0),
+			},
 		},
 	}
 
@@ -64,28 +71,28 @@ func Test_expandNetworkAclEntry(t *testing.T) {
 
 }
 
-func Test_flattenNetworkAclEntry(t *testing.T) {
+func Test_flattenNetworkACLEntry(t *testing.T) {
 
-	apiInput := []ec2.NetworkAclEntry{
-		ec2.NetworkAclEntry{
-			Protocol: 6,
-			PortRange: ec2.PortRange{
-				From: 22,
-				To:   22,
+	apiInput := []ec2.NetworkACLEntry{
+		ec2.NetworkACLEntry{
+			Protocol: aws.String("tcp"),
+			PortRange: &ec2.PortRange{
+				From: aws.Integer(22),
+				To:   aws.Integer(22),
 			},
-			RuleAction: "deny",
-			RuleNumber: 1,
-			CidrBlock:  "0.0.0.0/0",
+			RuleAction: aws.String("deny"),
+			RuleNumber: aws.Integer(1),
+			CIDRBlock:  aws.String("0.0.0.0/0"),
 		},
-		ec2.NetworkAclEntry{
-			Protocol: 6,
-			PortRange: ec2.PortRange{
-				From: 443,
-				To:   443,
+		ec2.NetworkACLEntry{
+			Protocol: aws.String("tcp"),
+			PortRange: &ec2.PortRange{
+				From: aws.Integer(443),
+				To:   aws.Integer(443),
 			},
-			RuleAction: "deny",
-			RuleNumber: 2,
-			CidrBlock:  "0.0.0.0/0",
+			RuleAction: aws.String("deny"),
+			RuleNumber: aws.Integer(2),
+			CIDRBlock:  aws.String("0.0.0.0/0"),
 		},
 	}
 	flattened := flattenNetworkAclEntries(apiInput)

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -6,10 +6,11 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mitchellh/goamz/ec2"
 )
 
 func resourceAwsNetworkAcl() *schema.Resource {
@@ -108,32 +109,34 @@ func resourceAwsNetworkAcl() *schema.Resource {
 
 func resourceAwsNetworkAclCreate(d *schema.ResourceData, meta interface{}) error {
 
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	// Create the Network Acl
-	createOpts := &ec2.CreateNetworkAcl{
-		VpcId: d.Get("vpc_id").(string),
+	createOpts := &ec2.CreateNetworkACLRequest{
+		VPCID: aws.String(d.Get("vpc_id").(string)),
 	}
 
 	log.Printf("[DEBUG] Network Acl create config: %#v", createOpts)
-	resp, err := ec2conn.CreateNetworkAcl(createOpts)
+	resp, err := ec2conn.CreateNetworkACL(createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating network acl: %s", err)
 	}
 
 	// Get the ID and store it
-	networkAcl := &resp.NetworkAcl
-	d.SetId(networkAcl.NetworkAclId)
-	log.Printf("[INFO] Network Acl ID: %s", networkAcl.NetworkAclId)
+	networkAcl := resp.NetworkACL
+	d.SetId(*networkAcl.NetworkACLID)
+	log.Printf("[INFO] Network Acl ID: %s", *networkAcl.NetworkACLID)
 
 	// Update rules and subnet association once acl is created
 	return resourceAwsNetworkAclUpdate(d, meta)
 }
 
 func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
-	resp, err := ec2conn.NetworkAcls([]string{d.Id()}, ec2.NewFilter())
+	resp, err := ec2conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsRequest{
+		NetworkACLIDs: []string{d.Id()},
+	})
 
 	if err != nil {
 		return err
@@ -142,29 +145,29 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	networkAcl := &resp.NetworkAcls[0]
-	var ingressEntries []ec2.NetworkAclEntry
-	var egressEntries []ec2.NetworkAclEntry
+	networkAcl := &resp.NetworkACLs[0]
+	var ingressEntries []ec2.NetworkACLEntry
+	var egressEntries []ec2.NetworkACLEntry
 
 	// separate the ingress and egress rules
-	for _, e := range networkAcl.EntrySet {
-		if e.Egress == true {
+	for _, e := range networkAcl.Entries {
+		if *e.Egress == true {
 			egressEntries = append(egressEntries, e)
 		} else {
 			ingressEntries = append(ingressEntries, e)
 		}
 	}
 
-	d.Set("vpc_id", networkAcl.VpcId)
+	d.Set("vpc_id", networkAcl.VPCID)
 	d.Set("ingress", ingressEntries)
 	d.Set("egress", egressEntries)
-	d.Set("tags", tagsToMap(networkAcl.Tags))
+	d.Set("tags", tagsToMapSDK(networkAcl.Tags))
 
 	return nil
 }
 
 func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 	d.Partial(true)
 
 	if d.HasChange("ingress") {
@@ -190,13 +193,16 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("Failed to update acl %s with subnet %s: %s", d.Id(), newSubnet, err)
 		}
-		_, err = ec2conn.ReplaceNetworkAclAssociation(association.NetworkAclAssociationId, d.Id())
+		_, err = ec2conn.ReplaceNetworkACLAssociation(&ec2.ReplaceNetworkACLAssociationRequest{
+			AssociationID: association.NetworkACLAssociationID,
+			NetworkACLID:  aws.String(d.Id()),
+		})
 		if err != nil {
 			return err
 		}
 	}
 
-	if err := setTags(ec2conn, d); err != nil {
+	if err := setTagsSDK(ec2conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
@@ -226,7 +232,11 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, ec2conn *
 	}
 	for _, remove := range toBeDeleted {
 		// Delete old Acl
-		_, err := ec2conn.DeleteNetworkAclEntry(d.Id(), remove.RuleNumber, remove.Egress)
+		err := ec2conn.DeleteNetworkACLEntry(&ec2.DeleteNetworkACLEntryRequest{
+			NetworkACLID: aws.String(d.Id()),
+			RuleNumber:   remove.RuleNumber,
+			Egress:       remove.Egress,
+		})
 		if err != nil {
 			return fmt.Errorf("Error deleting %s entry: %s", entryType, err)
 		}
@@ -238,7 +248,15 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, ec2conn *
 	}
 	for _, add := range toBeCreated {
 		// Add new Acl entry
-		_, err := ec2conn.CreateNetworkAclEntry(d.Id(), &add)
+		err := ec2conn.CreateNetworkACLEntry(&ec2.CreateNetworkACLEntryRequest{
+			NetworkACLID: aws.String(d.Id()),
+			CIDRBlock:    add.CIDRBlock,
+			Egress:       add.Egress,
+			PortRange:    add.PortRange,
+			Protocol:     add.Protocol,
+			RuleAction:   add.RuleAction,
+			RuleNumber:   add.RuleNumber,
+		})
 		if err != nil {
 			return fmt.Errorf("Error creating %s entry: %s", entryType, err)
 		}
@@ -247,12 +265,15 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, ec2conn *
 }
 
 func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).awsEC2conn
 
 	log.Printf("[INFO] Deleting Network Acl: %s", d.Id())
 	return resource.Retry(5*time.Minute, func() error {
-		if _, err := ec2conn.DeleteNetworkAcl(d.Id()); err != nil {
-			ec2err := err.(*ec2.Error)
+		err := ec2conn.DeleteNetworkACL(&ec2.DeleteNetworkACLRequest{
+			NetworkACLID: aws.String(d.Id()),
+		})
+		if err != nil {
+			ec2err := err.(aws.APIError)
 			switch ec2err.Code {
 			case "InvalidNetworkAclID.NotFound":
 				return nil
@@ -267,7 +288,10 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 				if err != nil {
 					return fmt.Errorf("Dependency violation: Cannot delete acl %s: %s", d.Id(), err)
 				}
-				_, err = ec2conn.ReplaceNetworkAclAssociation(association.NetworkAclAssociationId, defaultAcl.NetworkAclId)
+				_, err = ec2conn.ReplaceNetworkACLAssociation(&ec2.ReplaceNetworkACLAssociationRequest{
+					AssociationID: association.NetworkACLAssociationID,
+					NetworkACLID:  defaultAcl.NetworkACLID,
+				})
 				return resource.RetryError{Err: err}
 			default:
 				// Any other error, we want to quit the retry loop immediately
@@ -296,30 +320,43 @@ func resourceAwsNetworkAclEntryHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func getDefaultNetworkAcl(vpc_id string, ec2conn *ec2.EC2) (defaultAcl *ec2.NetworkAcl, err error) {
-	filter := ec2.NewFilter()
-	filter.Add("default", "true")
-	filter.Add("vpc-id", vpc_id)
-
-	resp, err := ec2conn.NetworkAcls([]string{}, filter)
+func getDefaultNetworkAcl(vpc_id string, ec2conn *ec2.EC2) (defaultAcl *ec2.NetworkACL, err error) {
+	resp, err := ec2conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsRequest{
+		NetworkACLIDs: []string{},
+		Filters: []ec2.Filter{
+			ec2.Filter{
+				Name:   aws.String("default"),
+				Values: []string{"true"},
+			},
+			ec2.Filter{
+				Name:   aws.String("vpc-id"),
+				Values: []string{vpc_id},
+			},
+		},
+	})
 
 	if err != nil {
 		return nil, err
 	}
-	return &resp.NetworkAcls[0], nil
+	return &resp.NetworkACLs[0], nil
 }
 
-func findNetworkAclAssociation(subnetId string, ec2conn *ec2.EC2) (networkAclAssociation *ec2.NetworkAclAssociation, err error) {
-	filter := ec2.NewFilter()
-	filter.Add("association.subnet-id", subnetId)
-
-	resp, err := ec2conn.NetworkAcls([]string{}, filter)
+func findNetworkAclAssociation(subnetId string, ec2conn *ec2.EC2) (networkAclAssociation *ec2.NetworkACLAssociation, err error) {
+	resp, err := ec2conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsRequest{
+		NetworkACLIDs: []string{},
+		Filters: []ec2.Filter{
+			ec2.Filter{
+				Name:   aws.String("association.subnet-id"),
+				Values: []string{subnetId},
+			},
+		},
+	})
 
 	if err != nil {
 		return nil, err
 	}
-	for _, association := range resp.NetworkAcls[0].AssociationSet {
-		if association.SubnetId == subnetId {
+	for _, association := range resp.NetworkACLs[0].Associations {
+		if *association.SubnetID == subnetId {
 			return &association, nil
 		}
 	}

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -184,7 +184,6 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 }
 
 func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
-	// log.Printf("\n@@@\nEnter Destroy func\n@@@\n")
 	conn := testAccProvider.Meta().(*AWSClient).awsEC2conn
 
 	for _, rs := range s.RootModule().Resources {
@@ -198,26 +197,21 @@ func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
 		})
 		if err == nil {
 			if len(resp.NetworkACLs) > 0 && *resp.NetworkACLs[0].NetworkACLID == rs.Primary.ID {
-				// log.Printf("\n@@@\nDestroy func err: still exists\n@@@\n")
 				return fmt.Errorf("Network Acl (%s) still exists.", rs.Primary.ID)
 			}
 
-			// log.Printf("\n@@@\nDestroy func err: found something, but returning nil\n@@@\n")
 			return nil
 		}
 
 		ec2err, ok := err.(aws.APIError)
 		if !ok {
-			// log.Printf("\n@@@\nDestroy func err: aws err:%#v\n@@@\n", err)
 			return err
 		}
 		// Confirm error code is what we want
 		if ec2err.Code != "InvalidNetworkAclID.NotFound" {
-			// log.Printf("\n@@@\nDestroy func err: not found aws err:%#v\n@@@\n", err)
 			return err
 		}
 	}
-	// log.Printf("\n@@@\nDestroy func err: end return\n@@@\n")
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -24,29 +24,29 @@ func TestAccAWSNetworkAclsWithEgressAndIngressRules(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.580214135.protocol", "tcp"),
+						"aws_network_acl.bar", "ingress.3409203205.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.580214135.rule_no", "1"),
+						"aws_network_acl.bar", "ingress.3409203205.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.580214135.from_port", "80"),
+						"aws_network_acl.bar", "ingress.3409203205.from_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.580214135.to_port", "80"),
+						"aws_network_acl.bar", "ingress.3409203205.to_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.580214135.action", "allow"),
+						"aws_network_acl.bar", "ingress.3409203205.action", "allow"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.580214135.cidr_block", "10.3.10.3/18"),
+						"aws_network_acl.bar", "ingress.3409203205.cidr_block", "10.3.10.3/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.1730430240.protocol", "tcp"),
+						"aws_network_acl.bar", "egress.2579689292.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.1730430240.rule_no", "2"),
+						"aws_network_acl.bar", "egress.2579689292.rule_no", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.1730430240.from_port", "443"),
+						"aws_network_acl.bar", "egress.2579689292.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.1730430240.to_port", "443"),
+						"aws_network_acl.bar", "egress.2579689292.to_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.1730430240.cidr_block", "10.3.2.3/18"),
+						"aws_network_acl.bar", "egress.2579689292.cidr_block", "10.3.2.3/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.1730430240.action", "allow"),
+						"aws_network_acl.bar", "egress.2579689292.action", "allow"),
 				),
 			},
 		},
@@ -157,7 +157,7 @@ func TestAccAWSNetworkAclsOnlyEgressRules(t *testing.T) {
 	})
 }
 
-func TestAccNetworkAcl_SubnetChange(t *testing.T) {
+func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -67,17 +67,17 @@ func TestAccAWSNetworkAclsOnlyIngressRules(t *testing.T) {
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					// testAccCheckSubnetAssociation("aws_network_acl.foos", "aws_subnet.blob"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.protocol", "tcp"),
+						"aws_network_acl.foos", "ingress.2750166237.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.rule_no", "1"),
+						"aws_network_acl.foos", "ingress.2750166237.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.from_port", "0"),
+						"aws_network_acl.foos", "ingress.2750166237.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.to_port", "22"),
+						"aws_network_acl.foos", "ingress.2750166237.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.action", "deny"),
+						"aws_network_acl.foos", "ingress.2750166237.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.cidr_block", "10.2.2.3/18"),
+						"aws_network_acl.foos", "ingress.2750166237.cidr_block", "10.2.2.3/18"),
 				),
 			},
 		},
@@ -98,21 +98,21 @@ func TestAccAWSNetworkAclsOnlyIngressRulesChange(t *testing.T) {
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					testIngressRuleLength(&networkAcl, 2),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.protocol", "tcp"),
+						"aws_network_acl.foos", "ingress.37211640.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.rule_no", "1"),
+						"aws_network_acl.foos", "ingress.37211640.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.from_port", "0"),
+						"aws_network_acl.foos", "ingress.37211640.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.to_port", "22"),
+						"aws_network_acl.foos", "ingress.37211640.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.action", "deny"),
+						"aws_network_acl.foos", "ingress.37211640.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.cidr_block", "10.2.2.3/18"),
+						"aws_network_acl.foos", "ingress.37211640.cidr_block", "10.2.2.3/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2438803013.from_port", "443"),
+						"aws_network_acl.foos", "ingress.2750166237.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2438803013.rule_no", "2"),
+						"aws_network_acl.foos", "ingress.2750166237.rule_no", "2"),
 				),
 			},
 			resource.TestStep{
@@ -121,17 +121,17 @@ func TestAccAWSNetworkAclsOnlyIngressRulesChange(t *testing.T) {
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					testIngressRuleLength(&networkAcl, 1),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.protocol", "tcp"),
+						"aws_network_acl.foos", "ingress.37211640.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.rule_no", "1"),
+						"aws_network_acl.foos", "ingress.37211640.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.from_port", "0"),
+						"aws_network_acl.foos", "ingress.37211640.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.to_port", "22"),
+						"aws_network_acl.foos", "ingress.37211640.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.action", "deny"),
+						"aws_network_acl.foos", "ingress.37211640.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.3697634361.cidr_block", "10.2.2.3/18"),
+						"aws_network_acl.foos", "ingress.37211640.cidr_block", "10.2.2.3/18"),
 				),
 			},
 		},
@@ -183,6 +183,7 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 }
 
 func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
+	// log.Printf("\n@@@\nEnter Destroy func\n@@@\n")
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
 	for _, rs := range s.RootModule().Resources {
@@ -194,21 +195,26 @@ func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
 		resp, err := conn.NetworkAcls([]string{rs.Primary.ID}, ec2.NewFilter())
 		if err == nil {
 			if len(resp.NetworkAcls) > 0 && resp.NetworkAcls[0].NetworkAclId == rs.Primary.ID {
+				// log.Printf("\n@@@\nDestroy func err: still exists\n@@@\n")
 				return fmt.Errorf("Network Acl (%s) still exists.", rs.Primary.ID)
 			}
 
+			// log.Printf("\n@@@\nDestroy func err: found something, but returning nil\n@@@\n")
 			return nil
 		}
 
 		ec2err, ok := err.(*ec2.Error)
 		if !ok {
+			// log.Printf("\n@@@\nDestroy func err: aws err:%#v\n@@@\n", err)
 			return err
 		}
 		// Confirm error code is what we want
 		if ec2err.Code != "InvalidNetworkAclID.NotFound" {
+			// log.Printf("\n@@@\nDestroy func err: not found aws err:%#v\n@@@\n", err)
 			return err
 		}
 	}
+	// log.Printf("\n@@@\nDestroy func err: end return\n@@@\n")
 
 	return nil
 }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
@@ -61,8 +60,6 @@ func TestExpandIPPerms(t *testing.T) {
 		},
 	}
 	perms := expandIPPerms("foo", expanded)
-
-	log.Printf("wtf is perms:\n%#v", perms)
 
 	expected := []awsEC2.IPPermission{
 		awsEC2.IPPermission{


### PR DESCRIPTION
Convert AWS Network ACL to `aws-sdk-go`