### PR TITLE
helper/ssh: update import location

### DIFF
--- a/helper/ssh/communicator.go
+++ b/helper/ssh/communicator.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 )
 
 // RemoteCmd represents a remote command being prepared or run.

--- a/helper/ssh/communicator_test.go
+++ b/helper/ssh/communicator_test.go
@@ -4,7 +4,7 @@ package ssh
 
 import (
 	"bytes"
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"fmt"
 	"net"
 	"testing"

--- a/helper/ssh/password.go
+++ b/helper/ssh/password.go
@@ -1,7 +1,7 @@
 package ssh
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"log"
 )
 

--- a/helper/ssh/password_test.go
+++ b/helper/ssh/password_test.go
@@ -1,7 +1,7 @@
 package ssh
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"reflect"
 	"testing"
 )

--- a/helper/ssh/provisioner.go
+++ b/helper/ssh/provisioner.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"


### PR DESCRIPTION
go's ssh package now lives canonically at `golang.org/x/crypto/ssh`

see https://godoc.org/golang.org/x/crypto/ssh

closes #1179