### PR TITLE
Feature: Remote Modules

### DIFF
--- a/builtin/bins/provider-terraform/main.go
+++ b/builtin/bins/provider-terraform/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/terraform"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: terraform.Provider,
+	})
+}

--- a/builtin/bins/provider-terraform/main_test.go
+++ b/builtin/bins/provider-terraform/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/builtin/providers/terraform/provider.go
+++ b/builtin/providers/terraform/provider.go
@@ -9,7 +9,7 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"terraform_state": resourceState(),
+			"terraform_remote_state": resourceRemoteState(),
 		},
 	}
 }

--- a/builtin/providers/terraform/provider.go
+++ b/builtin/providers/terraform/provider.go
@@ -1,0 +1,15 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Provider returns a terraform.ResourceProvider.
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"terraform_state": resourceState(),
+		},
+	}
+}

--- a/builtin/providers/terraform/provider_test.go
+++ b/builtin/providers/terraform/provider_test.go
@@ -1,0 +1,31 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"terraform": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+}

--- a/builtin/providers/terraform/resource_state.go
+++ b/builtin/providers/terraform/resource_state.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/terraform/state/remote"
 )
 
-func resourceState() *schema.Resource {
+func resourceRemoteState() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceStateCreate,
-		Read:   resourceStateRead,
-		Delete: resourceStateDelete,
+		Create: resourceRemoteStateCreate,
+		Read:   resourceRemoteStateRead,
+		Delete: resourceRemoteStateDelete,
 
 		Schema: map[string]*schema.Schema{
 			"backend": &schema.Schema{
@@ -35,11 +35,11 @@ func resourceState() *schema.Resource {
 	}
 }
 
-func resourceStateCreate(d *schema.ResourceData, meta interface{}) error {
-	return resourceStateRead(d, meta)
+func resourceRemoteStateCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourceRemoteStateRead(d, meta)
 }
 
-func resourceStateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceRemoteStateRead(d *schema.ResourceData, meta interface{}) error {
 	backend := d.Get("backend").(string)
 	config := make(map[string]string)
 	for k, v := range d.Get("config").(map[string]interface{}) {
@@ -60,12 +60,17 @@ func resourceStateRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	var outputs map[string]string
+	if !state.State().Empty() {
+		outputs = state.State().RootModule().Outputs
+	}
+
 	d.SetId(time.Now().UTC().String())
-	d.Set("output", state.State().RootModule().Outputs)
+	d.Set("output", outputs)
 	return nil
 }
 
-func resourceStateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceRemoteStateDelete(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("")
 	return nil
 }

--- a/builtin/providers/terraform/resource_state.go
+++ b/builtin/providers/terraform/resource_state.go
@@ -1,0 +1,71 @@
+package terraform
+
+import (
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/state/remote"
+)
+
+func resourceState() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceStateCreate,
+		Read:   resourceStateRead,
+		Delete: resourceStateDelete,
+
+		Schema: map[string]*schema.Schema{
+			"backend": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"output": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceStateCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourceStateRead(d, meta)
+}
+
+func resourceStateRead(d *schema.ResourceData, meta interface{}) error {
+	backend := d.Get("backend").(string)
+	config := make(map[string]string)
+	for k, v := range d.Get("config").(map[string]interface{}) {
+		config[k] = v.(string)
+	}
+
+	// Create the client to access our remote state
+	log.Printf("[DEBUG] Initializing remote state client: %s", backend)
+	client, err := remote.NewClient(backend, config)
+	if err != nil {
+		return err
+	}
+
+	// Create the remote state itself and refresh it in order to load the state
+	log.Printf("[DEBUG] Loading remote state...")
+	state := &remote.State{Client: client}
+	if err := state.RefreshState(); err != nil {
+		return err
+	}
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("output", state.State().RootModule().Outputs)
+	return nil
+}
+
+func resourceStateDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/terraform/resource_state_test.go
+++ b/builtin/providers/terraform/resource_state_test.go
@@ -17,7 +17,7 @@ func TestAccState_basic(t *testing.T) {
 				Config: testAccState_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStateValue(
-						"terraform_state.foo", "foo", "bar"),
+						"terraform_remote_state.foo", "foo", "bar"),
 				),
 			},
 		},
@@ -45,7 +45,7 @@ func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
 }
 
 const testAccState_basic = `
-resource "terraform_state" "foo" {
+resource "terraform_remote_state" "foo" {
 	backend = "_local"
 
 	config {

--- a/builtin/providers/terraform/resource_state_test.go
+++ b/builtin/providers/terraform/resource_state_test.go
@@ -1,0 +1,54 @@
+package terraform
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccState_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccState_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue(
+						"terraform_state.foo", "foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[id]
+		if !ok {
+			return fmt.Errorf("Not found: %s", id)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		v := rs.Primary.Attributes["output."+name]
+		if v != value {
+			return fmt.Errorf(
+				"Value for %s is %s, not %s", name, v, value)
+		}
+
+		return nil
+	}
+}
+
+const testAccState_basic = `
+resource "terraform_state" "foo" {
+	backend = "_local"
+
+	config {
+		path = "./test-fixtures/basic.tfstate"
+	}
+}`


### PR DESCRIPTION
:construction: Work-in-progress.

This PR introduces a new feature to Terraform that we've internally called "remote modules." Remote modules are similar in spirit to normal modules: they are an abstraction to treat a set of resources like a black box, only accessing certain outputs from the module as a whole. The difference between normal and remote modules is that remote modules expect the resources they're containing to be created externally and beforehand, and are just accessing the resulting outputs, whereas normal modules create and manage the contained resources as part of the Terraform run.

**Note:** I'm not convinced remote modules is the best name, it just is what we've been calling it.

The practical use case: different teams can manage different infrastructures, but can share information about the infrastructures they're managing. Example: core IT can manage the VPC, security groups, subnets, etc. and an app team can consume those values to deploy their app within the shared VPC.

For implementation, this PR introduces a new provider and resource: `terraform_state`. This lets you access the outputs of any remote state (stored in any backend supported by Terraform's remote state system). 

I think this feature is core enough that it may deem some syntactic sugar to promote it to a 1st class feature. I stress that this should probably just be sugar: internally we should just convert it back to a resource and treat it as such. 

For now, here is how it looks like:

```
resource "terraform_state" "vpc" {
    backend = "atlas"
    config {
        path = "hashicorp/vpc-prod"
    }
}

resource "aws_instance" "foo" {
    # ...
    subnet_id = "${terraform_state.vpc.output.subnet_id}"
}
```