### PR TITLE
Fix issue with Network interfaces and an instance-level security groups

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -292,6 +292,17 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	subnet, hasSubnet := d.GetOk("subnet_id")
 	subnetID := subnet.(string)
 
+	var groups []string
+	if v := d.Get("security_groups"); v != nil {
+		// Security group names.
+		// For a nondefault VPC, you must use security group IDs instead.
+		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
+		for _, v := range v.(*schema.Set).List() {
+			str := v.(string)
+			groups = append(groups, str)
+		}
+	}
+
 	if hasSubnet && associatePublicIPAddress {
 		// If we have a non-default VPC / Subnet specified, we can flag
 		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
@@ -310,6 +321,10 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			ni.PrivateIPAddress = aws.String(v.(string))
 		}
 
+		if len(groups) > 0 {
+			ni.Groups = groups
+		}
+
 		runOpts.NetworkInterfaces = []ec2.InstanceNetworkInterfaceSpecification{ni}
 	} else {
 		if subnetID != "" {
@@ -319,27 +334,16 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("private_ip"); ok {
 			runOpts.PrivateIPAddress = aws.String(v.(string))
 		}
-	}
-
-	if v, ok := d.GetOk("key_name"); ok {
-		runOpts.KeyName = aws.String(v.(string))
-	}
-
-	if v := d.Get("security_groups"); v != nil {
-		// Security group names.
-		// For a nondefault VPC, you must use security group IDs instead.
-		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
-		var groups []string
-		for _, v := range v.(*schema.Set).List() {
-			str := v.(string)
-			groups = append(groups, str)
-		}
 		if runOpts.SubnetID != nil &&
 			*runOpts.SubnetID != "" {
 			runOpts.SecurityGroupIDs = groups
 		} else {
 			runOpts.SecurityGroups = groups
 		}
+	}
+
+	if v, ok := d.GetOk("key_name"); ok {
+		runOpts.KeyName = aws.String(v.(string))
 	}
 
 	blockDevices := make([]interface{}, 0)

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -556,7 +556,6 @@ resource "aws_instance" "foo" {
 const testAccInstanceNetworkInstanceSecurityGroups = `
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
-	depends_on = ["aws_eip.foo_eip"]
 }
 
 resource "aws_vpc" "foo" {
@@ -590,10 +589,12 @@ resource "aws_instance" "foo_instance" {
   security_groups = ["${aws_security_group.tf_test_foo.id}"]
   subnet_id = "${aws_subnet.foo.id}"
   associate_public_ip_address = true
+	depends_on = ["aws_internet_gateway.gw"]
 }
 
 resource "aws_eip" "foo_eip" {
   instance = "${aws_instance.foo_instance.id}"
   vpc = true
+	depends_on = ["aws_internet_gateway.gw"]
 }
 `

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -207,6 +207,25 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 	})
 }
 
+func TestAccInstance_NetworkInstanceSecurityGroups(t *testing.T) {
+	var v ec2.Instance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceNetworkInstanceSecurityGroups,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(
+						"aws_instance.foo_instance", &v),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_tags(t *testing.T) {
 	var v ec2.Instance
 
@@ -531,5 +550,46 @@ resource "aws_instance" "foo" {
 	subnet_id = "${aws_subnet.foo.id}"
 	associate_public_ip_address = true
 	private_ip = "10.1.1.42"
+}
+`
+
+const testAccInstanceNetworkInstanceSecurityGroups = `
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_security_group" "tf_test_foo" {
+  name = "tf_test_foo"
+  description = "foo"
+  vpc_id="${aws_vpc.foo.id}"
+
+  ingress {
+    protocol = "icmp"
+    from_port = -1
+    to_port = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_subnet" "foo" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_instance" "foo_instance" {
+  ami = "ami-21f78e11"
+  instance_type = "t1.micro"
+  security_groups = ["${aws_security_group.tf_test_foo.id}"]
+  subnet_id = "${aws_subnet.foo.id}"
+  associate_public_ip_address = true
+}
+
+resource "aws_eip" "foo_eip" {
+  instance = "${aws_instance.foo_instance.id}"
+  vpc = true
 }
 `

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -556,10 +556,14 @@ resource "aws_instance" "foo" {
 const testAccInstanceNetworkInstanceSecurityGroups = `
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
+	depends_on = ["aws_eip.foo_eip"]
 }
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "tf-network-test"
+	}
 }
 
 resource "aws_security_group" "tf_test_foo" {

--- a/website/source/docs/providers/aws/r/internet_gateway.html.markdown
+++ b/website/source/docs/providers/aws/r/internet_gateway.html.markdown
@@ -29,6 +29,11 @@ The following arguments are supported:
 * `vpc_id` - (Required) The VPC ID to create in.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+-> **Note:** When using Internet Gateways with AWS Instances or Elastic IPs,
+it is recommended to denote that they depend on the Internet Gateway created,
+via the `depends_on` attribute:  
+`depends_on = ["aws_internet_gateway.gw"]`.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/source/docs/providers/aws/r/internet_gateway.html.markdown
+++ b/website/source/docs/providers/aws/r/internet_gateway.html.markdown
@@ -29,10 +29,17 @@ The following arguments are supported:
 * `vpc_id` - (Required) The VPC ID to create in.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
--> **Note:** When using Internet Gateways with AWS Instances or Elastic IPs,
-it is recommended to denote that they depend on the Internet Gateway created,
-via the `depends_on` attribute:  
-`depends_on = ["aws_internet_gateway.gw"]`.
+-> **Note:** It's recommended to denote that the AWS Instance or Elastic IP depends on the Internet Gateway. For example:  
+
+
+    resource "aws_internet_gateway" "gw" {
+      vpc_id = "${aws_vpc.main.id}"
+    }
+
+    resource "aws_instance" "foo" {  
+      depends_on = ["aws_internet_gateway.gw"]  
+    }
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
This should fix #1188, pending current acceptance tests and a new one to account for the issue there.

The configuration I tested:

```
provider "aws" {
  region="us-west-2"
}

resource "aws_vpc" "foo" {
  cidr_block = "10.1.0.0/16"
}

resource "aws_security_group" "tf_test_foo" {
  name = "tf_test_foo"
  description = "foo"
  vpc_id="${aws_vpc.foo.id}"

  ingress {
    protocol = "icmp"
    from_port = -1
    to_port = -1
    cidr_blocks = ["0.0.0.0/0"]
  }
}

resource "aws_subnet" "foo" {
  cidr_block = "10.1.1.0/24"
  vpc_id = "${aws_vpc.foo.id}"
}

resource "aws_instance" "nat" {
  ami = "ami-21f78e11"
  instance_type = "t1.micro"
  security_groups = ["${aws_security_group.tf_test_foo.id}"]
  subnet_id = "${aws_subnet.foo.id}"
  associate_public_ip_address = true
  source_dest_check = false
  tags {
    Name = "testing-vpc-subnet-things"
  }
}
```