### PR TITLE
provider/aws: Fix encoding bug with AWS Instance

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"bytes"
 	"crypto/sha1"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -258,7 +259,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	// Figure out user data
 	userData := ""
 	if v := d.Get("user_data"); v != nil {
-		userData = v.(string)
+		userData = base64.StdEncoding.EncodeToString([]byte(v.(string)))
 	}
 
 	placement := &ec2.Placement{

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -392,7 +392,7 @@ resource "aws_instance" "foo" {
 
 	instance_type = "m1.small"
 	security_groups = ["${aws_security_group.tf_test_foo.name}"]
-	user_data = "foo"
+	user_data = "foo:-with-character's"
 }
 `
 


### PR DESCRIPTION
`user_data` wasn't being properly encoded in AWS Instance. 
This wasn't caught because our acceptance tests didn't include anything that wasn't already valid base64.

This PR fixes the encoding, and updates an acceptance test to introduce an otherwise failing case.

Fixes #1196 