### PR TITLE
provider/aws: Fix route53 TXT record support

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -261,8 +261,15 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData) (*route53.Resource
 	recs := d.Get("records").(*schema.Set).List()
 	records := make([]route53.ResourceRecord, 0, len(recs))
 
+	typeStr := d.Get("type").(string)
 	for _, r := range recs {
-		records = append(records, route53.ResourceRecord{Value: aws.String(r.(string))})
+		switch typeStr {
+		case "TXT":
+			str := fmt.Sprintf("\"%s\"", r.(string))
+			records = append(records, route53.ResourceRecord{Value: aws.String(str)})
+		default:
+			records = append(records, route53.ResourceRecord{Value: aws.String(r.(string))})
+		}
 	}
 
 	rec := &route53.ResourceRecordSet{

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -28,6 +28,22 @@ func TestAccRoute53Record(t *testing.T) {
 	})
 }
 
+func TestAccRoute53Record_txtSupport(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53RecordConfigTXT,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRoute53Record_generatesSuffix(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -140,5 +156,19 @@ resource "aws_route53_record" "default" {
 	type = "A"
 	ttl = "30"
 	records = ["127.0.0.1", "127.0.0.27"]
+}
+`
+
+const testAccRoute53RecordConfigTXT = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_record" "default" {
+	zone_id = "${aws_route53_zone.main.zone_id}"
+	name = "subdomain"
+	type = "TXT"
+	ttl = "30"
+	records = ["lalalala"]
 }
 `


### PR DESCRIPTION
For `TXT` records, wrap them in double quotes `"` 

Fixes https://github.com/hashicorp/terraform/issues/455, but feels gross. 

Suggestions for improving this are most welcome. 