### PR TITLE
Adding CRUD support for Customer Gateway for AWS VPC.

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -67,6 +67,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_subnet":                       resourceAwsSubnet(),
 			"aws_vpc":                          resourceAwsVpc(),
 			"aws_vpc_peering_connection":       resourceAwsVpcPeeringConnection(),
+			"aws_customer_gateway":         	resourceAwsCustomerGateway(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/aws/resource_customer_gateway.go
+++ b/builtin/providers/aws/resource_customer_gateway.go
@@ -1,0 +1,126 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mitchellh/goamz/ec2"
+)
+
+func resourceAwsCustomerGateway() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCustomerGatewayCreate,
+		Read:   resourceAwsCustomerGatewayRead,
+		Update: resourceAwsCustomerGatewayUpdate,
+		Delete: resourceAwsCustomerGatewayDelete,
+
+		Schema: map[string]*schema.Schema{
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bgp_asn": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default: 65000,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	createOpts := &ec2.CreateCustomerGateway{
+		Type:            d.Get("type").(string),
+		IpAddress:       d.Get("ip_address").(string),
+		BgpAsn:          d.Get("bgp_asn").(int),
+	}
+
+	// Create the gateway
+	log.Printf("[DEBUG] Creating customer gateway")
+	resp, err := ec2conn.CreateCustomerGateway(createOpts)
+
+	if err != nil {
+		return fmt.Errorf("Error creating customer gateway: %s", err)
+	}
+
+	// Get the ID and store it
+	customerGateway := &resp.CustomerGateway
+	log.Printf("[INFO] CustomerGateway ID: %s", customerGateway.CustomerGatewayId)
+	d.SetId(customerGateway.CustomerGatewayId)
+
+	return resourceAwsCustomerGatewayUpdate(d, meta)
+}
+
+func resourceAwsCustomerGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+	d.Partial(true)
+
+	if err := setTags(ec2conn, d); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsCustomerGatewayRead(d, meta)
+}
+
+func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	resp, err := ec2conn.DescribeCustomerGateways([]string{d.Id()}, ec2.NewFilter())
+
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return nil
+	}
+
+	customerGateway := &resp.CustomerGateways[0]
+
+	d.Set("type", customerGateway.Type)
+	d.Set("ip_address", customerGateway.IpAddress)
+	d.Set("bgp_asn", customerGateway.BgpAsn)
+	d.Set("tags", tagsToMap(customerGateway.Tags))
+	return nil
+}
+
+
+func resourceAwsCustomerGatewayDelete(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+
+	log.Printf("[INFO] Deleting Customer Gateway: %s", d.Id())
+
+	return resource.Retry(5*time.Minute, func() error {
+			_, err := ec2conn.DeleteCustomerGateway(d.Id())
+			if err != nil {
+				ec2err, ok := err.(*ec2.Error)
+				if !ok {
+					return err
+				}
+
+				switch ec2err.Code {
+				case "InvalidCustomerGatewayID.NotFound":
+					return nil
+				default:
+					return resource.RetryError{err}
+				}
+			}
+
+			log.Printf("[Info] Deleted customer gateway %s successfully", d.Id())
+			return nil
+	})
+
+}

--- a/builtin/providers/aws/resource_customer_gateway_test.go
+++ b/builtin/providers/aws/resource_customer_gateway_test.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/goamz/ec2"
+)
+
+func TestAccAWSCustomerGateway(t *testing.T) {
+	var customerGateway ec2.CustomerGateway
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCustomerGatewayDestroy,
+		Steps: []resource.TestStep {
+			resource.TestStep{
+				Config: testAccCustomerGatewayConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGatewayExists("aws_customer_gateway.foo", &customerGateway),
+					resource.TestCheckResourceAttr("aws_customer_gateway.foo", "bgp_asn", "65000"),
+					testAccCheckTags(&customerGateway.Tags, "bar", "baz"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCustomerGateway_delete(t *testing.T) {
+	var customerGateway ec2.CustomerGateway
+
+	testDeleted := func(r string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			_, ok := s.RootModule().Resources[r]
+			if ok {
+				return fmt.Errorf("Customer Gateway %q should have been deleted", r)
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCustomerGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep {
+				Config: testAccCustomerGatewayConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGatewayExists("aws_customer_gateway.foo", &customerGateway)),
+			},
+			resource.TestStep{
+				Config: testAccNoCustomerGatewayConfig,
+				Check:  resource.ComposeTestCheckFunc(
+					testDeleted("aws_customer_gateway.foo")),
+			},
+		},
+	})
+}
+
+func testAccCheckCustomerGatewayDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_customer_gateway" {
+			continue
+		}
+
+		// Try to find the resource
+		resp, err := conn.DescribeCustomerGateways(
+			[]string{rs.Primary.ID}, ec2.NewFilter())
+		if err == nil {
+			if len(resp.CustomerGateways) > 0 {
+				return fmt.Errorf("still exist.")
+			}
+
+			return nil
+		}
+
+		// Verify the error is what we want
+		ec2err, ok := err.(*ec2.Error)
+		if !ok {
+			return err
+		}
+		if ec2err.Code != "InvalidCustomerGatewayID.NotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCustomerGatewayExists(n string, customerGateway *ec2.CustomerGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		resp, err := conn.DescribeCustomerGateways(
+			[]string{rs.Primary.ID}, ec2.NewFilter())
+		if err != nil {
+			return err
+		}
+		if len(resp.CustomerGateways) == 0 {
+			return fmt.Errorf("Customer Gateway not found")
+		}
+
+		*customerGateway = resp.CustomerGateways[0]
+
+		return nil
+	}
+}
+
+const testAccCustomerGatewayConfig = `
+resource "aws_customer_gateway" "foo" {
+	bgp_asn = 65000
+	ip_address = "182.72.16.113"
+	type = "ipsec.1"
+	tags {
+		bar = "baz"
+	}
+}
+`
+const testAccNoCustomerGatewayConfig = ``
+


### PR DESCRIPTION
This solves part of #551. AWS makes bgp_asn compulsory in its API. This is used for a dynamic gateway. However, if you want to create a static gateway, you need to pass a dummy bgp_asn. Hence, I have made bgp_asn field optional and given it a default value of 65000.