### PR TITLE
provider/aws: Fix issue with ignoring the 'self' attribute of a Security Group rule

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -285,6 +285,7 @@ func resourceAwsSecurityGroupRuleHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%s-", m["protocol"].(string)))
+	buf.WriteString(fmt.Sprintf("%t-", m["self"].(bool)))
 
 	// We need to make sure to sort the strings below so that we always
 	// generate the same hash code no matter what is in the set.


### PR DESCRIPTION
Fix issue where we ignored the `self` attribute of a security group rule.

**To reproduce:**

1) `plan` and `apply` the config below:

```
provider "aws" {
  region = "us-west-2"
}

resource "aws_security_group" "tf_test_self" {
  name = "tf_test_self"
  description = "tf_test_self"
  vpc_id = "<a vpc id>"

  ingress {
    from_port = 0
    to_port = 65535
    protocol = "tcp"
    self = true
  }

  tags {
    Name = "tf_test_self"
  }
}
```

2) After successfully creating, remove `self = true` from the `ingress` block
3) Run `plan` again

**Expected:**

_A diff_

**Actual:**

_nope-nope-nope_

Discovered while investigating #508, so credit to them for discovery :smile: 