### PR TITLE
state/remote: allow https consul addresses

### DIFF
--- a/state/remote/consul.go
+++ b/state/remote/consul.go
@@ -20,6 +20,9 @@ func consulFactory(conf map[string]string) (Client, error) {
 	if addr, ok := conf["address"]; ok && addr != "" {
 		config.Address = addr
 	}
+	if scheme, ok := conf["scheme"]; ok && scheme != "" {
+		config.Scheme = scheme
+	}
 
 	client, err := consulapi.NewClient(config)
 	if err != nil {


### PR DESCRIPTION
Sending state over a cleartext protocol is bad in untrusted networks.
Expose `-backend-config="scheme=https"` and wire it through to the
Consul client.