### PR TITLE
Ignore hidden files when autoloading *.tf per Unix conventions

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -187,7 +187,7 @@ func dirFiles(dir string) ([]string, []string, error) {
 // provided file name is a temporary file for the following editors:
 // emacs or vim.
 func isTemporaryFile(name string) bool {
-	return strings.HasSuffix(name, "~") || // vim
-		strings.HasPrefix(name, ".#") || // emacs
+	return strings.HasPrefix(name, ".") || // Unix-like hidden files
+		strings.HasSuffix(name, "~") || // vim
 		(strings.HasPrefix(name, "#") && strings.HasSuffix(name, "#")) // emacs
 }


### PR DESCRIPTION
As discussed in https://github.com/hashicorp/terraform/issues/1084#issuecomment-82682071 I'm submitting this as a separate PR.

Any objections why not do this?