### PR TITLE
Gce update instance template tests

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -7,11 +7,10 @@ import (
 	"net/http"
 	"os"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
+	"google.golang.org/api/compute/v1"
 )
 
 // Config is the configuration structure used to instantiate the Google

--- a/builtin/providers/google/disk_type.go
+++ b/builtin/providers/google/disk_type.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"code.google.com/p/google-api-go-client/compute/v1"
+	"google.golang.org/api/compute/v1"
 )
 
 // readDiskType finds the disk type with the given name.

--- a/builtin/providers/google/operation.go
+++ b/builtin/providers/google/operation.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
+	"google.golang.org/api/compute/v1"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 

--- a/builtin/providers/google/resource_compute_address.go
+++ b/builtin/providers/google/resource_compute_address.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeAddress() *schema.Resource {

--- a/builtin/providers/google/resource_compute_address_test.go
+++ b/builtin/providers/google/resource_compute_address_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeAddress_basic(t *testing.T) {

--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeDisk() *schema.Resource {

--- a/builtin/providers/google/resource_compute_disk_test.go
+++ b/builtin/providers/google/resource_compute_disk_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeDisk_basic(t *testing.T) {

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -6,10 +6,10 @@ import (
 	"sort"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeFirewall() *schema.Resource {

--- a/builtin/providers/google/resource_compute_firewall_test.go
+++ b/builtin/providers/google/resource_compute_firewall_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeFirewall_basic(t *testing.T) {

--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeForwardingRule() *schema.Resource {

--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeHttpHealthCheck() *schema.Resource {

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeInstance() *schema.Resource {

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeInstanceTemplate() *schema.Resource {

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeInstanceTemplate_basic(t *testing.T) {

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -65,7 +65,7 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "debian-7-wheezy-v20140814", true, true),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "foo_existing_disk", false, false),
+					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
 				),
 			},
 		},
@@ -252,6 +252,14 @@ resource "google_compute_instance_template" "foobar" {
 }`
 
 const testAccComputeInstanceTemplate_disks = `
+resource "google_compute_disk" "foobar" {
+	name = "terraform-test-foobar"
+	image = "debian-7-wheezy-v20140814"
+	size = 10
+	type = "pd-ssd"
+	zone = "us-central1-a"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "terraform-test"
 	machine_type = "n1-standard-1"
@@ -263,9 +271,8 @@ resource "google_compute_instance_template" "foobar" {
 	}
 
 	disk {
-		source = "foo_existing_disk"
+		source = "terraform-test-foobar"
 		auto_delete = false
-		boot = false
 	}
 
 	network {

--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeInstance_basic_deprecated_network(t *testing.T) {

--- a/builtin/providers/google/resource_compute_network.go
+++ b/builtin/providers/google/resource_compute_network.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeNetwork() *schema.Resource {

--- a/builtin/providers/google/resource_compute_network_test.go
+++ b/builtin/providers/google/resource_compute_network_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeNetwork_basic(t *testing.T) {

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeRoute() *schema.Resource {

--- a/builtin/providers/google/resource_compute_route_test.go
+++ b/builtin/providers/google/resource_compute_route_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeRoute_basic(t *testing.T) {

--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/google-api-go-client/compute/v1"
-	"code.google.com/p/google-api-go-client/googleapi"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeTargetPool() *schema.Resource {


### PR DESCRIPTION
Disk resources for Instance Templates are now required to exist when the template is created.