### PR TITLE
provider/aws: Fix DB Subnet refresh issue

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -79,6 +79,11 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 	describeResp, err := rdsconn.DescribeDBSubnetGroups(&describeOpts)
 	if err != nil {
+		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "DBSubnetGroupNotFoundFault" {
+			// Update state to indicate the db subnet no longer exists.
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes #496 by updating the `read` function to mark the resource as deleted if not found. 