### PR TITLE
provider/aws: Fix issue in AWS AutoScaling Group and health_check_type

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -137,7 +137,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 		autoScalingGroupOpts.DefaultCooldown = aws.Integer(v.(int))
 	}
 
-	if v, ok := d.GetOk("health_check"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("health_check_type"); ok && v.(string) != "" {
 		autoScalingGroupOpts.HealthCheckType = aws.String(v.(string))
 	}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -130,7 +130,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGro
 		}
 
 		if *group.HealthCheckType != "ELB" {
-			return fmt.Errorf("Bad health_check_type: %s", *group.HealthCheckType)
+			return fmt.Errorf("Bad health_check_type,\nexpected: %s\ngot: %s", "ELB", *group.HealthCheckType)
 		}
 
 		if *group.HealthCheckGracePeriod != 300 {


### PR DESCRIPTION
Fixes #1259 where AWS AutoScaling Group was not getting `health_check_type` set correctly. 