### PR TITLE
providers/aws: derive instance root_block_device name

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -140,11 +140,9 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "root_block_device.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.1246122048.device_name", "/dev/sda1"),
+						"aws_instance.foo", "root_block_device.1023169747.volume_size", "11"),
 					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.1246122048.volume_size", "11"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.1246122048.volume_type", "gp2"),
+						"aws_instance.foo", "root_block_device.1023169747.volume_type", "gp2"),
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "ebs_block_device.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -467,7 +465,6 @@ resource "aws_instance" "foo" {
 	instance_type = "m1.small"
 
 	root_block_device {
-		device_name = "/dev/sda1"
 		volume_type = "gp2"
 		volume_size = 11
 	}

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -66,9 +66,6 @@ to understand the implications of using these attributes.
 
 The `root_block_device` mapping supports the following:
 
-* `device_name` - The name of the root device on the target instance. Must
-  match the root device as defined in the AMI. Defaults to `"/dev/sda1"`, which
-  is the typical root volume for Linux instances.
 * `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`,
   or `"io1"`. (Default: `"standard"`).
 * `volume_size` - (Optional) The size of the volume in gigabytes.


### PR DESCRIPTION
I was working on building a validation to check the user-provided
"device_name" for "root_block_device" on AWS Instances, when I realized
that if I can check it, I might as well just derive it automatically!

So that's what we do here - when you customize the details of the root
block device, device name is just comes from the selected AMI.