### PR TITLE
Support for multiple providers of the same type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type Module struct {
 // resource provider.
 type ProviderConfig struct {
 	Name      string
+	Alias     string
 	RawConfig *RawConfig
 }
 
@@ -75,6 +76,7 @@ type Resource struct {
 	RawCount     *RawConfig
 	RawConfig    *RawConfig
 	Provisioners []*Provisioner
+	Provider     string
 	DependsOn    []string
 	Lifecycle    ResourceLifecycle
 }

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -325,13 +325,13 @@ func loadOutputsHcl(os *hclobj.Object) ([]*Output, error) {
 // LoadProvidersHcl recurses into the given HCL object and turns
 // it into a mapping of provider configs.
 func loadProvidersHcl(os *hclobj.Object) ([]*ProviderConfig, error) {
-	objects := make(map[string]*hclobj.Object)
+	var objects []*hclobj.Object
 
 	// Iterate over all the "provider" blocks and get the keys along with
 	// their raw configuration objects. We'll parse those later.
 	for _, o1 := range os.Elem(false) {
 		for _, o2 := range o1.Elem(true) {
-			objects[o2.Key] = o2
+			objects = append(objects, o2)
 		}
 	}
 
@@ -341,23 +341,38 @@ func loadProvidersHcl(os *hclobj.Object) ([]*ProviderConfig, error) {
 
 	// Go through each object and turn it into an actual result.
 	result := make([]*ProviderConfig, 0, len(objects))
-	for n, o := range objects {
+	for _, o := range objects {
 		var config map[string]interface{}
 
 		if err := hcl.DecodeObject(&config, o); err != nil {
 			return nil, err
 		}
 
+		delete(config, "alias")
+
 		rawConfig, err := NewRawConfig(config)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"Error reading config for provider config %s: %s",
-				n,
+				o.Key,
 				err)
 		}
 
+		// If we have an alias field, then add those in
+		var alias string
+		if a := o.Get("alias", false); a != nil {
+			err := hcl.DecodeObject(&alias, a)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Error reading alias for provider[%s]: %s",
+					o.Key,
+					err)
+			}
+		}
+
 		result = append(result, &ProviderConfig{
-			Name:      n,
+			Name:      o.Key,
+			Alias:     alias,
 			RawConfig: rawConfig,
 		})
 	}
@@ -417,6 +432,7 @@ func loadResourcesHcl(os *hclobj.Object) ([]*Resource, error) {
 			delete(config, "count")
 			delete(config, "depends_on")
 			delete(config, "provisioner")
+			delete(config, "provider")
 			delete(config, "lifecycle")
 
 			rawConfig, err := NewRawConfig(config)
@@ -488,6 +504,19 @@ func loadResourcesHcl(os *hclobj.Object) ([]*Resource, error) {
 				}
 			}
 
+			// If we have a provider, then parse it out
+			var provider string
+			if o := obj.Get("provider", false); o != nil {
+				err := hcl.DecodeObject(&provider, o)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"Error reading provider for %s[%s]: %s",
+						t.Key,
+						k,
+						err)
+				}
+			}
+
 			// Check if the resource should be re-created before
 			// destroying the existing instance
 			var lifecycle ResourceLifecycle
@@ -508,6 +537,7 @@ func loadResourcesHcl(os *hclobj.Object) ([]*Resource, error) {
 				RawCount:     countConfig,
 				RawConfig:    rawConfig,
 				Provisioners: provisioners,
+				Provider:     provider,
 				DependsOn:    dependsOn,
 				Lifecycle:    lifecycle,
 			})

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -35,7 +35,8 @@ type TestCase struct {
 	PreCheck func()
 
 	// Provider is the ResourceProvider that will be under test.
-	Providers map[string]terraform.ResourceProvider
+	Providers         map[string]terraform.ResourceProvider
+	ProviderFactories map[string]terraform.ResourceProviderFactory
 
 	// CheckDestroy is called after the resource is finally destroyed
 	// to allow the tester to test that the resource is truly gone.
@@ -102,9 +103,12 @@ func Test(t TestT, c TestCase) {
 	}
 
 	// Build our context options that we can
-	ctxProviders := make(map[string]terraform.ResourceProviderFactory)
-	for k, p := range c.Providers {
-		ctxProviders[k] = terraform.ResourceProviderFactoryFixed(p)
+	ctxProviders := c.ProviderFactories
+	if ctxProviders == nil {
+		ctxProviders = make(map[string]terraform.ResourceProviderFactory)
+		for k, p := range c.Providers {
+			ctxProviders[k] = terraform.ResourceProviderFactoryFixed(p)
+		}
 	}
 	opts := terraform.ContextOpts{Providers: ctxProviders}
 

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -3057,6 +3057,39 @@ func TestContext2Apply(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_providerAlias(t *testing.T) {
+	m := testModule(t, "apply-provider-alias")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	mod := state.RootModule()
+	if len(mod.Resources) < 2 {
+		t.Fatalf("bad: %#v", mod.Resources)
+	}
+
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(testTerraformApplyProviderAliasStr)
+	if actual != expected {
+		t.Fatalf("bad: \n%s", actual)
+	}
+}
+
 func TestContext2Apply_emptyModule(t *testing.T) {
 	m := testModule(t, "apply-empty-module")
 	p := testProvider("aws")

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform/config"
@@ -68,9 +69,11 @@ func (ctx *BuiltinEvalContext) InitProvider(n string) (ResourceProvider, error) 
 	ctx.ProviderLock.Lock()
 	defer ctx.ProviderLock.Unlock()
 
-	f, ok := ctx.Providers[n]
+	typeName := strings.SplitN(n, ".", 2)[0]
+
+	f, ok := ctx.Providers[typeName]
 	if !ok {
-		return nil, fmt.Errorf("Provider '%s' not found", n)
+		return nil, fmt.Errorf("Provider '%s' not found", typeName)
 	}
 
 	p, err := f()

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -154,12 +154,13 @@ func (n *EvalUpdateStateHook) Eval(ctx EvalContext) (interface{}, error) {
 type EvalWriteState struct {
 	Name         string
 	ResourceType string
+	Provider     string
 	Dependencies []string
 	State        **InstanceState
 }
 
 func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
-	return writeInstanceToState(ctx, n.Name, n.ResourceType, n.Dependencies,
+	return writeInstanceToState(ctx, n.Name, n.ResourceType, n.Provider, n.Dependencies,
 		func(rs *ResourceState) error {
 			rs.Primary = *n.State
 			return nil
@@ -172,6 +173,7 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 type EvalWriteStateTainted struct {
 	Name         string
 	ResourceType string
+	Provider     string
 	Dependencies []string
 	State        **InstanceState
 	// Index indicates which instance in the Tainted list to target, or -1 to append.
@@ -181,7 +183,7 @@ type EvalWriteStateTainted struct {
 // EvalWriteStateTainted is an EvalNode implementation that writes the
 // one of the tainted InstanceStates for a specific resource out of the state.
 func (n *EvalWriteStateTainted) Eval(ctx EvalContext) (interface{}, error) {
-	return writeInstanceToState(ctx, n.Name, n.ResourceType, n.Dependencies,
+	return writeInstanceToState(ctx, n.Name, n.ResourceType, n.Provider, n.Dependencies,
 		func(rs *ResourceState) error {
 			if n.Index == -1 {
 				rs.Tainted = append(rs.Tainted, *n.State)
@@ -198,6 +200,7 @@ func (n *EvalWriteStateTainted) Eval(ctx EvalContext) (interface{}, error) {
 type EvalWriteStateDeposed struct {
 	Name         string
 	ResourceType string
+	Provider     string
 	Dependencies []string
 	State        **InstanceState
 	// Index indicates which instance in the Deposed list to target, or -1 to append.
@@ -205,7 +208,7 @@ type EvalWriteStateDeposed struct {
 }
 
 func (n *EvalWriteStateDeposed) Eval(ctx EvalContext) (interface{}, error) {
-	return writeInstanceToState(ctx, n.Name, n.ResourceType, n.Dependencies,
+	return writeInstanceToState(ctx, n.Name, n.ResourceType, n.Provider, n.Dependencies,
 		func(rs *ResourceState) error {
 			if n.Index == -1 {
 				rs.Deposed = append(rs.Deposed, *n.State)
@@ -225,6 +228,7 @@ func writeInstanceToState(
 	ctx EvalContext,
 	resourceName string,
 	resourceType string,
+	provider string,
 	dependencies []string,
 	writerFn func(*ResourceState) error,
 ) (*InstanceState, error) {
@@ -252,6 +256,7 @@ func writeInstanceToState(
 	}
 	rs.Type = resourceType
 	rs.Dependencies = dependencies
+	rs.Provider = provider
 
 	if err := writerFn(rs); err != nil {
 		return nil, err

--- a/terraform/graph_config_node_test.go
+++ b/terraform/graph_config_node_test.go
@@ -58,6 +58,36 @@ func TestGraphNodeConfigProvider_ProviderName(t *testing.T) {
 	}
 }
 
+func TestGraphNodeConfigProvider_ProviderName_alias(t *testing.T) {
+	n := &GraphNodeConfigProvider{
+		Provider: &config.ProviderConfig{Name: "foo", Alias: "bar"},
+	}
+
+	if v := n.ProviderName(); v != "foo.bar" {
+		t.Fatalf("bad: %#v", v)
+	}
+}
+
+func TestGraphNodeConfigProvider_Name(t *testing.T) {
+	n := &GraphNodeConfigProvider{
+		Provider: &config.ProviderConfig{Name: "foo"},
+	}
+
+	if v := n.Name(); v != "provider.foo" {
+		t.Fatalf("bad: %#v", v)
+	}
+}
+
+func TestGraphNodeConfigProvider_Name_alias(t *testing.T) {
+	n := &GraphNodeConfigProvider{
+		Provider: &config.ProviderConfig{Name: "foo", Alias: "bar"},
+	}
+
+	if v := n.Name(); v != "provider.foo.bar" {
+		t.Fatalf("bad: %#v", v)
+	}
+}
+
 func TestGraphNodeConfigResource_impl(t *testing.T) {
 	var _ dag.Vertex = new(GraphNodeConfigResource)
 	var _ dag.NamedVertex = new(GraphNodeConfigResource)
@@ -72,6 +102,16 @@ func TestGraphNodeConfigResource_ProvidedBy(t *testing.T) {
 	}
 
 	if v := n.ProvidedBy(); v[0] != "aws" {
+		t.Fatalf("bad: %#v", v)
+	}
+}
+
+func TestGraphNodeConfigResource_ProvidedBy_alias(t *testing.T) {
+	n := &GraphNodeConfigResource{
+		Resource: &config.Resource{Type: "aws_instance", Provider: "aws.bar"},
+	}
+
+	if v := n.ProvidedBy(); v[0] != "aws.bar" {
 		t.Fatalf("bad: %#v", v)
 	}
 }

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -182,6 +182,18 @@ aws_instance.foo:
   type = aws_instance
 `
 
+const testTerraformApplyProviderAliasStr = `
+aws_instance.bar:
+  ID = foo
+  provider = aws.bar
+  foo = bar
+  type = aws_instance
+aws_instance.foo:
+  ID = foo
+  num = 2
+  type = aws_instance
+`
+
 const testTerraformApplyEmptyModuleStr = `
 <no state>
 Outputs:

--- a/terraform/test-fixtures/apply-provider-alias/main.tf
+++ b/terraform/test-fixtures/apply-provider-alias/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+	alias = "bar"
+}
+
+resource "aws_instance" "foo" {
+    num = "2"
+}
+
+resource "aws_instance" "bar" {
+    foo = "bar"
+    provider = "aws.bar"
+}

--- a/terraform/test-fixtures/graph-provider-alias/main.tf
+++ b/terraform/test-fixtures/graph-provider-alias/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+}
+
+provider "aws" {
+    alias = "foo"
+}
+
+provider "aws" {
+    alias = "bar"
+}

--- a/terraform/transform_config_test.go
+++ b/terraform/transform_config_test.go
@@ -86,6 +86,20 @@ func TestConfigTransformer_outputs(t *testing.T) {
 	}
 }
 
+func TestConfigTransformer_providerAlias(t *testing.T) {
+	g := Graph{Path: RootModulePath}
+	tf := &ConfigTransformer{Module: testModule(t, "graph-provider-alias")}
+	if err := tf.Transform(&g); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testGraphProviderAliasStr)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
 func TestConfigTransformer_errMissingDeps(t *testing.T) {
 	g := Graph{Path: RootModulePath}
 	tf := &ConfigTransformer{Module: testModule(t, "graph-missing-deps")}
@@ -125,4 +139,10 @@ const testGraphOutputsStr = `
 aws_instance.foo
 output.foo
   aws_instance.foo
+`
+
+const testGraphProviderAliasStr = `
+provider.aws
+provider.aws.bar
+provider.aws.foo
 `

--- a/terraform/transform_deposed.go
+++ b/terraform/transform_deposed.go
@@ -40,6 +40,7 @@ func (t *DeposedTransformer) Transform(g *Graph) error {
 				Index:        i,
 				ResourceName: k,
 				ResourceType: rs.Type,
+				Provider:     rs.Provider,
 			})
 		}
 	}
@@ -52,6 +53,7 @@ type graphNodeDeposedResource struct {
 	Index        int
 	ResourceName string
 	ResourceType string
+	Provider     string
 }
 
 func (n *graphNodeDeposedResource) Name() string {
@@ -59,7 +61,7 @@ func (n *graphNodeDeposedResource) Name() string {
 }
 
 func (n *graphNodeDeposedResource) ProvidedBy() []string {
-	return []string{resourceProvider(n.ResourceName)}
+	return []string{resourceProvider(n.ResourceName, n.Provider)}
 }
 
 // GraphNodeEvalable impl.
@@ -96,6 +98,7 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 				&EvalWriteStateDeposed{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					Provider:     n.Provider,
 					State:        &state,
 					Index:        n.Index,
 				},
@@ -138,6 +141,7 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 				&EvalWriteStateDeposed{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					Provider:     n.Provider,
 					State:        &state,
 					Index:        n.Index,
 				},

--- a/terraform/transform_orphan.go
+++ b/terraform/transform_orphan.go
@@ -89,6 +89,7 @@ func (t *OrphanTransformer) Transform(g *Graph) error {
 			resourceVertexes[i] = g.Add(&graphNodeOrphanResource{
 				ResourceName: k,
 				ResourceType: rs.Type,
+				Provider:     rs.Provider,
 				dependentOn:  rs.Dependencies,
 			})
 		}
@@ -162,6 +163,7 @@ func (n *graphNodeOrphanModule) Expand(b GraphBuilder) (GraphNodeSubgraph, error
 type graphNodeOrphanResource struct {
 	ResourceName string
 	ResourceType string
+	Provider     string
 
 	dependentOn []string
 }
@@ -179,7 +181,7 @@ func (n *graphNodeOrphanResource) Name() string {
 }
 
 func (n *graphNodeOrphanResource) ProvidedBy() []string {
-	return []string{resourceProvider(n.ResourceName)}
+	return []string{resourceProvider(n.ResourceName, n.Provider)}
 }
 
 // GraphNodeEvalable impl.
@@ -215,6 +217,7 @@ func (n *graphNodeOrphanResource) EvalTree() EvalNode {
 				&EvalWriteState{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					Provider:     n.Provider,
 					Dependencies: n.DependentOn(),
 					State:        &state,
 				},
@@ -272,6 +275,7 @@ func (n *graphNodeOrphanResource) EvalTree() EvalNode {
 				&EvalWriteState{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					Provider:     n.Provider,
 					Dependencies: n.DependentOn(),
 					State:        &state,
 				},

--- a/terraform/transform_orphan_test.go
+++ b/terraform/transform_orphan_test.go
@@ -342,6 +342,13 @@ func TestGraphNodeOrphanResource_ProvidedBy(t *testing.T) {
 	}
 }
 
+func TestGraphNodeOrphanResource_ProvidedBy_alias(t *testing.T) {
+	n := &graphNodeOrphanResource{ResourceName: "aws_instance.foo", Provider: "aws.bar"}
+	if v := n.ProvidedBy(); v[0] != "aws.bar" {
+		t.Fatalf("bad: %#v", v)
+	}
+}
+
 const testTransformOrphanBasicStr = `
 aws_instance.db (orphan)
 aws_instance.web

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -140,7 +140,7 @@ func (n *graphNodeExpandedResource) DependentOn() []string {
 
 // GraphNodeProviderConsumer
 func (n *graphNodeExpandedResource) ProvidedBy() []string {
-	return []string{resourceProvider(n.Resource.Type)}
+	return []string{resourceProvider(n.Resource.Type, n.Resource.Provider)}
 }
 
 // GraphNodeEvalable impl.
@@ -230,6 +230,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					Provider:     n.Resource.Provider,
 					Dependencies: n.DependentOn(),
 					State:        &state,
 				},
@@ -266,6 +267,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					Provider:     n.Resource.Provider,
 					Dependencies: n.DependentOn(),
 					State:        &state,
 				},
@@ -408,6 +410,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					Provider:     n.Resource.Provider,
 					Dependencies: n.DependentOn(),
 					State:        &state,
 				},
@@ -451,6 +454,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 							&EvalWriteStateTainted{
 								Name:         n.stateId(),
 								ResourceType: n.Resource.Type,
+								Provider:     n.Resource.Provider,
 								Dependencies: n.DependentOn(),
 								State:        &state,
 								Index:        -1,
@@ -468,6 +472,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 					Else: &EvalWriteState{
 						Name:         n.stateId(),
 						ResourceType: n.Resource.Type,
+						Provider:     n.Resource.Provider,
 						Dependencies: n.DependentOn(),
 						State:        &state,
 					},
@@ -588,6 +593,7 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					Provider:     n.Resource.Provider,
 					Dependencies: n.DependentOn(),
 					State:        &state,
 				},

--- a/terraform/transform_tainted.go
+++ b/terraform/transform_tainted.go
@@ -45,6 +45,7 @@ func (t *TaintedTransformer) Transform(g *Graph) error {
 				Index:        i,
 				ResourceName: k,
 				ResourceType: rs.Type,
+				Provider:     rs.Provider,
 			})
 		}
 	}
@@ -57,6 +58,7 @@ type graphNodeTaintedResource struct {
 	Index        int
 	ResourceName string
 	ResourceType string
+	Provider     string
 }
 
 func (n *graphNodeTaintedResource) Name() string {
@@ -64,7 +66,7 @@ func (n *graphNodeTaintedResource) Name() string {
 }
 
 func (n *graphNodeTaintedResource) ProvidedBy() []string {
-	return []string{resourceProvider(n.ResourceName)}
+	return []string{resourceProvider(n.ResourceName, n.Provider)}
 }
 
 // GraphNodeEvalable impl.
@@ -101,6 +103,7 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 				&EvalWriteStateTainted{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					Provider:     n.Provider,
 					State:        &state,
 					Index:        n.Index,
 				},
@@ -138,6 +141,7 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 				&EvalWriteStateTainted{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					Provider:     n.Provider,
 					State:        &state,
 					Index:        n.Index,
 				},

--- a/terraform/transform_tainted_test.go
+++ b/terraform/transform_tainted_test.go
@@ -58,6 +58,13 @@ func TestGraphNodeTaintedResource_ProvidedBy(t *testing.T) {
 	}
 }
 
+func TestGraphNodeTaintedResource_ProvidedBy_alias(t *testing.T) {
+	n := &graphNodeTaintedResource{ResourceName: "aws_instance.foo", Provider: "aws.bar"}
+	if v := n.ProvidedBy(); v[0] != "aws.bar" {
+		t.Fatalf("bad: %#v", v)
+	}
+}
+
 const testTransformTaintedBasicStr = `
 aws_instance.web
 aws_instance.web (tainted #1)

--- a/terraform/util.go
+++ b/terraform/util.go
@@ -47,7 +47,11 @@ func (s Semaphore) Release() {
 }
 
 // resourceProvider returns the provider name for the given type.
-func resourceProvider(t string) string {
+func resourceProvider(t, alias string) string {
+	if alias != "" {
+		return alias
+	}
+
 	idx := strings.IndexRune(t, '_')
 	if idx == -1 {
 		return ""


### PR DESCRIPTION
This is incomplete, but I'm submitting to start getting feedback. This will enable support for #451.

Adds an "alias" field to the provider which allows creating multiple instances
of a provider under different names. This provides support for configurations
such as multiple AWS providers for different regions. In each resource, the
provider can be set with the "provider" field.

Known issues:
- [x] input prompts for missing config keys aren't being propagated, so you still get a key error during validation (opened a new issue since it turned out to be broken in master: #1282)
- [x] needs more tests

Tentatively, the config syntax looks like this:

```
provider "aws" {
    alias = "asia"
    region = "ap-northeast-1"
}

provider "aws" {
    alias = "us"
    region = "us-west-1"
}

resource "aws_instance" "foo" {
    provider = "aws.asia"
}

resource "aws_instance" "bar" {
    provider = "aws.us"
}
```

(thanks to Cisco Cloud for sponsoring development)