### PR TITLE
provider/aws: Add tag support to ELB

### DIFF
--- a/builtin/providers/aws/tagsELB.go
+++ b/builtin/providers/aws/tagsELB.go
@@ -1,0 +1,94 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/elb"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsELB(conn *elb.ELB, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsELB(tagsFromMapELB(o), tagsFromMapELB(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]elb.TagKeyOnly, 0, len(remove))
+			for _, t := range remove {
+				k = append(k, elb.TagKeyOnly{Key: t.Key})
+			}
+			_, err := conn.RemoveTags(&elb.RemoveTagsInput{
+				LoadBalancerNames: []string{d.Get("name").(string)},
+				Tags:              k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.AddTags(&elb.AddTagsInput{
+				LoadBalancerNames: []string{d.Get("name").(string)},
+				Tags:              create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsELB(oldTags, newTags []elb.Tag) ([]elb.Tag, []elb.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []elb.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapELB(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapELB(m map[string]interface{}) []elb.Tag {
+	result := make([]elb.Tag, 0, len(m))
+	for k, v := range m {
+		result = append(result, elb.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapELB(ts []elb.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		result[*t.Key] = *t.Value
+	}
+
+	return result
+}

--- a/builtin/providers/aws/tagsELB_test.go
+++ b/builtin/providers/aws/tagsELB_test.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/aws-sdk-go/gen/elb"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDiffELBTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsELB(tagsFromMapELB(tc.Old), tagsFromMapELB(tc.New))
+		cm := tagsToMapELB(c)
+		rm := tagsToMapELB(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// testAccCheckTags can be used to check the tags on a resource.
+func testAccCheckELBTags(
+	ts *[]elb.Tag, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m := tagsToMapELB(*ts)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("Missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("Extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
This PR adds Tag support to Elastic Load Balancers, at the cost of a mostly duplicated `builtin/providers/aws/tags.go` file :frowning: 

Unfortunately, `aws-sdk-go` has a `Tag` struct declaration for each resource, instead of a common one, so we'll need versions of `tags.go` for each, unless we can manage to make `tags.go` more generic with our own `Tag` struct, and cast as needed, but that may be more work than worth it.

