### PR TITLE
providers/aws: fix DNS options on VPC

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -185,13 +185,13 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 	// Turn on partial mode
 	d.Partial(true)
 	vpcid := d.Id()
-	modifyOpts := &ec2.ModifyVPCAttributeRequest{
-		VPCID: &vpcid,
-	}
 	if d.HasChange("enable_dns_hostnames") {
 		val := d.Get("enable_dns_hostnames").(bool)
-		modifyOpts.EnableDNSHostnames = &ec2.AttributeBooleanValue{
-			Value: &val,
+		modifyOpts := &ec2.ModifyVPCAttributeRequest{
+			VPCID: &vpcid,
+			EnableDNSHostnames: &ec2.AttributeBooleanValue{
+				Value: &val,
+			},
 		}
 
 		log.Printf(
@@ -205,9 +205,12 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("enable_dns_support") {
-		val := d.Get("enable_dns_hostnames").(bool)
-		modifyOpts.EnableDNSSupport = &ec2.AttributeBooleanValue{
-			Value: &val,
+		val := d.Get("enable_dns_support").(bool)
+		modifyOpts := &ec2.ModifyVPCAttributeRequest{
+			VPCID: &vpcid,
+			EnableDNSSupport: &ec2.AttributeBooleanValue{
+				Value: &val,
+			},
 		}
 
 		log.Printf(

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -2,11 +2,12 @@ package aws
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/aws-sdk-go/aws"
 	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"testing"
 )
 
 func TestAccVpc_basic(t *testing.T) {
@@ -184,6 +185,26 @@ func testAccCheckVpcExists(n string, vpc *ec2.VPC) resource.TestCheckFunc {
 	}
 }
 
+// https://github.com/hashicorp/terraform/issues/1301
+func TestAccVpc_bothDnsOptionsSet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcConfig_BothDnsOptions,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_vpc.bar", "enable_dns_hostnames", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.bar", "enable_dns_support", "true"),
+				),
+			},
+		},
+	})
+}
+
 const testAccVpcConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
@@ -221,5 +242,14 @@ resource "aws_vpc" "bar" {
 	instance_tenancy = "dedicated"
 
 	cidr_block = "10.2.0.0/16"
+}
+`
+
+const testAccVpcConfig_BothDnsOptions = `
+resource "aws_vpc" "bar" {
+	cidr_block = "10.2.0.0/16"
+
+	enable_dns_hostnames = true
+	enable_dns_support = true
 }
 `


### PR DESCRIPTION
One typo on a `d.Get` and reuse of the request object was making it sad.

Now it is happy!

fixes #1301