### PR TITLE
terraform: don't increment state if one is nil

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -224,6 +224,10 @@ func (s *State) IncrementSerialMaybe(other *State) {
 		return
 	}
 	if !s.Equal(other) {
+		if other.Serial > s.Serial {
+			s.Serial = other.Serial
+		}
+
 		s.Serial++
 	}
 }

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -214,6 +214,15 @@ func (s *State) DeepCopy() *State {
 // IncrementSerialMaybe increments the serial number of this state
 // if it different from the other state.
 func (s *State) IncrementSerialMaybe(other *State) {
+	if s == nil {
+		return
+	}
+	if other == nil {
+		return
+	}
+	if s.Serial > other.Serial {
+		return
+	}
 	if !s.Equal(other) {
 		s.Serial++
 	}

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -178,6 +178,40 @@ func TestStateEqual(t *testing.T) {
 	}
 }
 
+func TestStateIncrementSerialMaybe(t *testing.T) {
+	cases := map[string]struct {
+		S1, S2 *State
+		Serial int64
+	}{
+		"S2 is nil": {
+			&State{},
+			nil,
+			0,
+		},
+		"S2 is identical": {
+			&State{},
+			&State{},
+			0,
+		},
+		"S2 is different": {
+			&State{},
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{Path: rootModulePath},
+				},
+			},
+			1,
+		},
+	}
+
+	for name, tc := range cases {
+		tc.S1.IncrementSerialMaybe(tc.S2)
+		if tc.S1.Serial != tc.Serial {
+			t.Fatalf("Bad: %s\nGot: %d", name, tc.S1.Serial)
+		}
+	}
+}
+
 func TestResourceStateEqual(t *testing.T) {
 	cases := []struct {
 		Result   bool

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -202,6 +202,16 @@ func TestStateIncrementSerialMaybe(t *testing.T) {
 			},
 			1,
 		},
+		"S1 serial is higher": {
+			&State{Serial: 5},
+			&State{
+				Serial: 3,
+				Modules: []*ModuleState{
+					&ModuleState{Path: rootModulePath},
+				},
+			},
+			5,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
Fixes #1297 

When remote config was enabled, we were incorrectly adding 1 right away to the state. This was causing issues where our local state was always one behind. We now only increment the serial if we're equal or less than the other.