### PR TITLE
terraform: merge provider configs before validate [GH-1282]

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -2505,6 +2505,9 @@ func TestContext2Input_provider(t *testing.T) {
 		actual = c.Config["foo"]
 		return nil
 	}
+	p.ValidateFn = func(c *ResourceConfig) ([]string, []error) {
+		return nil, c.CheckSet([]string{"foo"})
+	}
 
 	if err := ctx.Input(InputModeStd); err != nil {
 		t.Fatalf("err: %s", err)

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -5,6 +5,71 @@ import (
 	"testing"
 )
 
+func TestEvalBuildProviderConfig_impl(t *testing.T) {
+	var _ EvalNode = new(EvalBuildProviderConfig)
+}
+
+func TestEvalBuildProviderConfig(t *testing.T) {
+	config := testResourceConfig(t, map[string]interface{}{})
+	provider := "foo"
+
+	n := &EvalBuildProviderConfig{
+		Provider: provider,
+		Config:   &config,
+		Output:   &config,
+	}
+
+	ctx := &MockEvalContext{
+		ParentProviderConfigConfig: testResourceConfig(t, map[string]interface{}{
+			"foo": "bar",
+		}),
+		ProviderInputConfig: map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	if _, err := n.Eval(ctx); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := map[string]interface{}{
+		"foo": "bar",
+		"bar": "baz",
+	}
+	if !reflect.DeepEqual(config.Raw, expected) {
+		t.Fatalf("bad: %#v", config.Raw)
+	}
+}
+
+func TestEvalBuildProviderConfig_parentPriority(t *testing.T) {
+	config := testResourceConfig(t, map[string]interface{}{})
+	provider := "foo"
+
+	n := &EvalBuildProviderConfig{
+		Provider: provider,
+		Config:   &config,
+		Output:   &config,
+	}
+
+	ctx := &MockEvalContext{
+		ParentProviderConfigConfig: testResourceConfig(t, map[string]interface{}{
+			"foo": "bar",
+		}),
+		ProviderInputConfig: map[string]interface{}{
+			"foo": "baz",
+		},
+	}
+	if _, err := n.Eval(ctx); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := map[string]interface{}{
+		"foo": "bar",
+	}
+	if !reflect.DeepEqual(config.Raw, expected) {
+		t.Fatalf("bad: %#v", config.Raw)
+	}
+}
+
 func TestEvalConfigProvider_impl(t *testing.T) {
 	var _ EvalNode = new(EvalConfigProvider)
 }

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -57,20 +57,13 @@ RETURN:
 // EvalValidateProvider is an EvalNode implementation that validates
 // the configuration of a resource.
 type EvalValidateProvider struct {
-	ProviderName string
-	Provider     *ResourceProvider
-	Config       **ResourceConfig
+	Provider *ResourceProvider
+	Config   **ResourceConfig
 }
 
 func (n *EvalValidateProvider) Eval(ctx EvalContext) (interface{}, error) {
 	provider := *n.Provider
 	config := *n.Config
-
-	// Get the parent configuration if there is one
-	if parent := ctx.ParentProviderConfig(n.ProviderName); parent != nil {
-		merged := parent.raw.Merge(config.raw)
-		config = NewResourceConfig(merged)
-	}
 
 	warns, errs := provider.Validate(config)
 	if len(warns) == 0 && len(errs) == 0 {

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -44,10 +44,14 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 					Config: config,
 					Output: &resourceConfig,
 				},
+				&EvalBuildProviderConfig{
+					Provider: n,
+					Config:   &resourceConfig,
+					Output:   &resourceConfig,
+				},
 				&EvalValidateProvider{
-					ProviderName: n,
-					Provider:     &provider,
-					Config:       &resourceConfig,
+					Provider: &provider,
+					Config:   &resourceConfig,
 				},
 				&EvalConfigProvider{
 					Provider: n,


### PR DESCRIPTION
Fixes #1282

The validation function wasn't properly merging user inputs before validation, so they weren't being taken into account. For that matter, I discovered that module inherited keys weren't either. Fixed both.