### PR TITLE
command/output: don't panic if no root module in state [GH-1263]

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -39,7 +39,7 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	state := stateStore.State()
-	if len(state.RootModule().Outputs) == 0 {
+	if state.Empty() || len(state.RootModule().Outputs) == 0 {
 		c.Ui.Error(fmt.Sprintf(
 			"The state file has no outputs defined. Define an output\n" +
 				"in your configuration with the `output` directive and re-run\n" +

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -142,6 +142,27 @@ func TestOutput_noArgs(t *testing.T) {
 	}
 }
 
+func TestOutput_noState(t *testing.T) {
+	originalState := &terraform.State{}
+	statePath := testStateFile(t, originalState)
+
+	ui := new(cli.MockUi)
+	c := &OutputCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"foo",
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+}
+
 func TestOutput_noVars(t *testing.T) {
 	originalState := &terraform.State{
 		Modules: []*terraform.ModuleState{


### PR DESCRIPTION
Fixes #1263 

The output command should error and not panic if the state itself is empty.