### PR TITLE
providers/heroku: empty config vars block shouldn't panic [GH-1211]

### DIFF
--- a/builtin/providers/heroku/resource_heroku_app.go
+++ b/builtin/providers/heroku/resource_heroku_app.go
@@ -358,14 +358,18 @@ func updateConfigVars(
 	vars := make(map[string]*string)
 
 	for _, v := range o {
-		for k, _ := range v.(map[string]interface{}) {
-			vars[k] = nil
+		if v != nil {
+			for k, _ := range v.(map[string]interface{}) {
+				vars[k] = nil
+			}
 		}
 	}
 	for _, v := range n {
-		for k, v := range v.(map[string]interface{}) {
-			val := v.(string)
-			vars[k] = &val
+		if v != nil {
+			for k, v := range v.(map[string]interface{}) {
+				val := v.(string)
+				vars[k] = &val
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #1211 

I think this might be a helper/schema improvement we can make too, but this guard doesn't hurt. Going to look into helper/schema separately.