### PR TITLE
providers/aws: handle empty instancestate in state migration

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_migrate.go
+++ b/builtin/providers/aws/resource_aws_instance_migrate.go
@@ -24,7 +24,13 @@ func resourceAwsInstanceMigrateState(
 }
 
 func migrateStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
 	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
 	// Delete old count
 	delete(is.Attributes, "block_device.#")
 

--- a/builtin/providers/aws/resource_aws_instance_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_instance_migrate_test.go
@@ -115,6 +115,7 @@ func TestAWSInstanceMigrateState(t *testing.T) {
 
 	for tn, tc := range cases {
 		is := &terraform.InstanceState{
+			ID:         "i-abc123",
 			Attributes: tc.Attributes,
 		}
 		is, err := resourceAwsInstanceMigrateState(
@@ -131,5 +132,28 @@ func TestAWSInstanceMigrateState(t *testing.T) {
 					tn, k, v, k, is.Attributes[k], is.Attributes)
 			}
 		}
+	}
+}
+
+func TestAWSInstanceMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta interface{}
+
+	// should handle nil
+	is, err := resourceAwsInstanceMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceAwsInstanceMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
 	}
 }

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -885,6 +885,10 @@ func (i *InstanceState) deepcopy() *InstanceState {
 	return n
 }
 
+func (s *InstanceState) Empty() bool {
+	return s == nil || s.ID == ""
+}
+
 func (s *InstanceState) Equal(other *InstanceState) bool {
 	// Short circuit some nil checks
 	if s == nil || other == nil {

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -366,6 +366,34 @@ func TestResourceStateTaint(t *testing.T) {
 	}
 }
 
+func TestInstanceStateEmpty(t *testing.T) {
+	cases := map[string]struct {
+		In     *InstanceState
+		Result bool
+	}{
+		"nil is empty": {
+			nil,
+			true,
+		},
+		"non-nil but without ID is empty": {
+			&InstanceState{},
+			true,
+		},
+		"with ID is not empty": {
+			&InstanceState{
+				ID: "i-abc123",
+			},
+			false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if tc.In.Empty() != tc.Result {
+			t.Fatalf("%q expected %#v to be empty: %#v", tn, tc.In, tc.Result)
+		}
+	}
+}
+
 func TestInstanceStateEqual(t *testing.T) {
 	cases := []struct {
 		Result   bool


### PR DESCRIPTION
fixes #1309