### PR TITLE
command: when setting up state, only write back if local is newer

### DIFF
--- a/command/state.go
+++ b/command/state.go
@@ -231,10 +231,20 @@ func remoteState(
 				"Error reloading remote state: {{err}}", err)
 		}
 		switch cache.RefreshResult() {
+		// All the results below can be safely ignored since it means the
+		// pull was successful in some way. Noop = nothing happened.
+		// Init = both are empty. UpdateLocal = local state was older and
+		// updated.
+		//
+		// We don't have to do anything, the pull was successful.
 		case state.CacheRefreshNoop:
 		case state.CacheRefreshInit:
-		case state.CacheRefreshLocalNewer:
 		case state.CacheRefreshUpdateLocal:
+
+		// Our local state has a higher serial number than remote, so we
+		// want to explicitly sync the remote side with our local so that
+		// the remote gets the latest serial number.
+		case state.CacheRefreshLocalNewer:
 			// Write our local state out to the durable storage to start.
 			if err := cache.WriteState(local); err != nil {
 				return nil, errwrap.Wrapf(

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -344,6 +344,10 @@ func (r *RemoteState) Equals(other *RemoteState) bool {
 	return true
 }
 
+func (r *RemoteState) GoString() string {
+	return fmt.Sprintf("*%#v", *r)
+}
+
 // ModuleState is used to track all the state relevant to a single
 // module. Previous to Terraform 0.3, all state belonged to the "root"
 // module.


### PR DESCRIPTION
Fixes #1318 

This was probably introduced during #1028 by myself. 

When we setup the state that all the commands use, we were incorrectly updating the remote state on `CacheRefreshUpdateLocal` which even just looking at it from an english perspective doesn't make any sense. We actually want to update when it is `CacheRefreshLocalNewer` which says that the local state is newer than the remote state, so we sync.