### PR TITLE
OpenStack provider - Bugfix on floating IP assignment

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_v2_test.go
@@ -81,6 +81,11 @@ func testAccCheckComputeV2FloatingIPExists(t *testing.T, n string, kp *floatingi
 	}
 }
 
-var testAccComputeV2FloatingIP_basic = fmt.Sprintf(`
+var testAccComputeV2FloatingIP_basic = `
   resource "openstack_compute_floatingip_v2" "foo" {
-  }`)
+  }
+
+  resource "openstack_compute_instance_v2" "bar" {
+	name = "terraform-acc-floating-ip-test"
+	floating_ip = "${openstack_compute_floatingip_v2.foo.address}"
+  }`

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -28,9 +28,10 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Computed: true,
 			},
 			"pool": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: envDefaultFunc("OS_POOL_NAME"),
 			},
 		},
 	}

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2_test.go
@@ -81,9 +81,11 @@ func testAccCheckNetworkingV2FloatingIPExists(t *testing.T, n string, kp *floati
 	}
 }
 
-var testAccNetworkingV2FloatingIP_basic = fmt.Sprintf(`
+var testAccNetworkingV2FloatingIP_basic = `
   resource "openstack_networking_floatingip_v2" "foo" {
-    region = "%s"
-    pool = "%s"
-    }`,
-	OS_REGION_NAME, OS_POOL_NAME)
+  }
+
+  resource "openstack_compute_instance_v2" "bar" {
+	name = "terraform-acc-floating-ip-test"
+	floating_ip = "${openstack_networking_floatingip_v2.foo.address}"
+  }`


### PR DESCRIPTION
The `getFirstNetworkID` does not work correctly because the first
network is not always the private network of the instance.

As long as the `GET /networks` gives a list containing also public
networks we don't have any guarantee that the first network is the
one we want. Furthermore, with a loop over the network list we are
not able to determine which network is the one we want.

Instead of retrieving the network ID and then finding the port ID,
it's better to basically take the first port ID of the instance.