### PR TITLE
provider/openstack Compute Network Refactor

### DIFF
--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -63,4 +63,9 @@ func testAccPreCheck(t *testing.T) {
 	if v1 == "" && v2 == "" {
 		t.Fatal("OS_FLAVOR_ID or OS_FLAVOR_NAME must be set for acceptance tests")
 	}
+
+	v = os.Getenv("OS_NETWORK_NAME")
+	if v == "" {
+		t.Fatal("OS_NETWORK_NAME must be set for acceptance tests")
+	}
 }

--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -64,8 +64,8 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("OS_FLAVOR_ID or OS_FLAVOR_NAME must be set for acceptance tests")
 	}
 
-	v = os.Getenv("OS_NETWORK_NAME")
+	v = os.Getenv("OS_NETWORK_ID")
 	if v == "" {
-		t.Fatal("OS_NETWORK_NAME must be set for acceptance tests")
+		t.Fatal("OS_NETWORK_ID must be set for acceptance tests")
 	}
 }

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -818,7 +818,9 @@ func resourceInstanceAddresses(addresses map[string]interface{}) map[string]map[
 					addrs[n]["fixed_ip_v6"] = fmt.Sprintf("[%s]", address["addr"].(string))
 				}
 			}
-			addrs[n]["mac"] = address["OS-EXT-IPS-MAC:mac_addr"].(string)
+			if mac, ok := address["OS-EXT-IPS-MAC:mac_addr"]; ok {
+				addrs[n]["mac"] = mac.(string)
+			}
 		}
 	}
 

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -111,26 +111,31 @@ func resourceComputeInstanceV2() *schema.Resource {
 						"uuid": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"name": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"port": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"fixed_ip_v4": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"fixed_ip_v6": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"mac": &schema.Schema{
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -361,8 +366,8 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	hostv4 := server.AccessIPv4
 	hostv6 := server.AccessIPv6
 
-	addresses := resourceInstanceAddresses(server.Addresses)
 	networkDetails, err := resourceInstanceNetworks(computeClient, d)
+	addresses := resourceInstanceAddresses(server.Addresses)
 	if err != nil {
 		return err
 	}
@@ -423,6 +428,8 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 			}
 		}
 	}
+
+	log.Printf("[DEBUG] new networks: %+v", networks)
 
 	d.Set("network", networks)
 	d.Set("access_ip_v4", hostv4)
@@ -789,8 +796,6 @@ func resourceInstanceNetworks(computeClient *gophercloud.ServiceClient, d *schem
 			"fixed_ip_v4": rawMap["fixed_ip_v4"].(string),
 		}
 	}
-
-	d.Set("network", newNetworks)
 
 	log.Printf("[DEBUG] networks: %+v", newNetworks)
 

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -332,20 +332,6 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 
 	hostv4 := server.AccessIPv4
 	if hostv4 == "" {
-		if publicAddressesRaw, ok := server.Addresses["public"]; ok {
-			publicAddresses := publicAddressesRaw.([]interface{})
-			for _, paRaw := range publicAddresses {
-				pa := paRaw.(map[string]interface{})
-				if pa["version"].(float64) == 4 {
-					hostv4 = pa["addr"].(string)
-					break
-				}
-			}
-		}
-	}
-
-	// If no host found, just get the first IPv4 we find
-	if hostv4 == "" {
 		for _, networkAddresses := range server.Addresses {
 			for _, element := range networkAddresses.([]interface{}) {
 				address := element.(map[string]interface{})
@@ -360,20 +346,6 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	log.Printf("hostv4: %s", hostv4)
 
 	hostv6 := server.AccessIPv6
-	if hostv6 == "" {
-		if publicAddressesRaw, ok := server.Addresses["public"]; ok {
-			publicAddresses := publicAddressesRaw.([]interface{})
-			for _, paRaw := range publicAddresses {
-				pa := paRaw.(map[string]interface{})
-				if pa["version"].(float64) == 6 {
-					hostv6 = fmt.Sprintf("[%s]", pa["addr"].(string))
-					break
-				}
-			}
-		}
-	}
-
-	// If no hostv6 found, just get the first IPv6 we find
 	if hostv6 == "" {
 		for _, networkAddresses := range server.Addresses {
 			for _, element := range networkAddresses.([]interface{}) {

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -115,7 +115,11 @@ func resourceComputeInstanceV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"fixed_ip": &schema.Schema{
+						"fixed_ip_v4": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"fixed_ip_v6": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -691,7 +695,7 @@ func resourceInstanceNetworksV2(d *schema.ResourceData) []servers.Network {
 		networks[i] = servers.Network{
 			UUID:    rawMap["uuid"].(string),
 			Port:    rawMap["port"].(string),
-			FixedIP: rawMap["fixed_ip"].(string),
+			FixedIP: rawMap["fixed_ip_v4"].(string),
 		}
 	}
 	return networks

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -13,14 +13,13 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/flavors"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/images"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
-	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
-	"github.com/rackspace/gophercloud/openstack/networking/v2/ports"
 	"github.com/rackspace/gophercloud/pagination"
 )
 
@@ -76,7 +75,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
-                        "user_data": &schema.Schema{
+			"user_data": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -291,18 +290,8 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	}
 	floatingIP := d.Get("floating_ip").(string)
 	if floatingIP != "" {
-		networkingClient, err := config.networkingV2Client(d.Get("region").(string))
-		if err != nil {
-			return fmt.Errorf("Error creating OpenStack compute client: %s", err)
-		}
-
-		allFloatingIPs, err := getFloatingIPs(networkingClient)
-		if err != nil {
-			return fmt.Errorf("Error listing OpenStack floating IPs: %s", err)
-		}
-		err = assignFloatingIP(networkingClient, extractFloatingIPFromIP(allFloatingIPs, floatingIP), server.ID)
-		if err != nil {
-			return fmt.Errorf("Error assigning floating IP to OpenStack compute instance: %s", err)
+		if err := floatingip.Associate(computeClient, server.ID, floatingIP).ExtractErr(); err != nil {
+			return fmt.Errorf("Error associating floating IP: %s", err)
 		}
 	}
 
@@ -553,20 +542,20 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("floating_ip") {
-		floatingIP := d.Get("floating_ip").(string)
-		if floatingIP != "" {
-			networkingClient, err := config.networkingV2Client(d.Get("region").(string))
-			if err != nil {
-				return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+		oldFIP, newFIP := d.GetChange("floating_ip")
+		log.Printf("[DEBUG] Old Floating IP: %v", oldFIP)
+		log.Printf("[DEBUG] New Floating IP: %v", newFIP)
+		if oldFIP.(string) != "" {
+			log.Printf("[DEBUG] Attemping to disassociate %s from %s", oldFIP, d.Id())
+			if err := floatingip.Disassociate(computeClient, d.Id(), oldFIP.(string)).ExtractErr(); err != nil {
+				return fmt.Errorf("Error disassociating Floating IP during update: %s", err)
 			}
+		}
 
-			allFloatingIPs, err := getFloatingIPs(networkingClient)
-			if err != nil {
-				return fmt.Errorf("Error listing OpenStack floating IPs: %s", err)
-			}
-			err = assignFloatingIP(networkingClient, extractFloatingIPFromIP(allFloatingIPs, floatingIP), d.Id())
-			if err != nil {
-				fmt.Errorf("Error assigning floating IP to OpenStack compute instance: %s", err)
+		if newFIP.(string) != "" {
+			log.Printf("[DEBUG] Attemping to associate %s to %s", newFIP, d.Id())
+			if err := floatingip.Associate(computeClient, d.Id(), newFIP.(string)).ExtractErr(); err != nil {
+				return fmt.Errorf("Error associating Floating IP during update: %s", err)
 			}
 		}
 	}
@@ -757,75 +746,6 @@ func resourceInstanceBlockDeviceV2(d *schema.ResourceData, bd map[string]interfa
 	}
 
 	return bfvOpts
-}
-
-func extractFloatingIPFromIP(ips []floatingips.FloatingIP, IP string) *floatingips.FloatingIP {
-	for _, floatingIP := range ips {
-		if floatingIP.FloatingIP == IP {
-			return &floatingIP
-		}
-	}
-	return nil
-}
-
-func assignFloatingIP(networkingClient *gophercloud.ServiceClient, floatingIP *floatingips.FloatingIP, instanceID string) error {
-	portID, err := getInstancePortID(networkingClient, instanceID)
-	if err != nil {
-		return err
-	}
-	return floatingips.Update(networkingClient, floatingIP.ID, floatingips.UpdateOpts{
-		PortID: portID,
-	}).Err
-}
-
-func getInstancePortID(networkingClient *gophercloud.ServiceClient, instanceID string) (string, error) {
-	pager := ports.List(networkingClient, ports.ListOpts{
-		DeviceID: instanceID,
-	})
-
-	var portID string
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		portList, err := ports.ExtractPorts(page)
-		if err != nil {
-			return false, err
-		}
-		for _, port := range portList {
-			portID = port.ID
-			return false, nil
-		}
-		return true, nil
-	})
-
-	if err != nil {
-		return "", err
-	}
-
-	if portID == "" {
-		return "", fmt.Errorf("Cannot find port for instance %s", instanceID)
-	}
-
-	return portID, nil
-}
-
-func getFloatingIPs(networkingClient *gophercloud.ServiceClient) ([]floatingips.FloatingIP, error) {
-	pager := floatingips.List(networkingClient, floatingips.ListOpts{})
-
-	ips := []floatingips.FloatingIP{}
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		floatingipList, err := floatingips.ExtractFloatingIPs(page)
-		if err != nil {
-			return false, err
-		}
-		for _, f := range floatingipList {
-			ips = append(ips, f)
-		}
-		return true, nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-	return ips, nil
 }
 
 func getImageID(client *gophercloud.ServiceClient, d *schema.ResourceData) (string, error) {

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -106,6 +106,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"uuid": &schema.Schema{

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -382,7 +382,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	// Loop through all networks and addresses,
 	// merge relevant address details.
 	if len(networkDetails) == 0 {
-		for _, n := range addresses {
+		for netName, n := range addresses {
 			if floatingIP, ok := n["floating_ip"]; ok {
 				hostv4 = floatingIP.(string)
 			} else {
@@ -396,7 +396,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 			}
 
 			networks[0] = map[string]interface{}{
-				"name":        n,
+				"name":        netName,
 				"fixed_ip_v4": n["fixed_ip_v4"],
 				"fixed_ip_v6": n["fixed_ip_v6"],
 				"mac":         n["mac"],

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -2,12 +2,14 @@ package openstack
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/pagination"
@@ -47,6 +49,40 @@ func TestAccComputeV2Instance_volumeAttach(t *testing.T) {
 					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeV2Instance_floatingIPAttach(t *testing.T) {
+	var instance servers.Server
+	var fip floatingip.FloatingIP
+	var testAccComputeV2Instance_floatingIPAttach = fmt.Sprintf(`
+		resource "openstack_compute_floatingip_v2" "myip" {
+		}
+
+		resource "openstack_compute_instance_v2" "foo" {
+			name = "terraform-test"
+			floating_ip = "${openstack_compute_floatingip_v2.myip.address}"
+
+			network {
+				name = "%s"
+			}
+		}`,
+		os.Getenv("OS_NETWORK_NAME"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_floatingIPAttach,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FloatingIPExists(t, "openstack_compute_floatingip_v2.myip", &fip),
+					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
+					testAccCheckComputeV2InstanceFloatingIPAttach(&instance, &fip),
 				),
 			},
 		},
@@ -156,6 +192,18 @@ func testAccCheckComputeV2InstanceVolumeAttachment(
 		}
 
 		return fmt.Errorf("Volume not found: %s", volume.ID)
+	}
+}
+
+func testAccCheckComputeV2InstanceFloatingIPAttach(
+	instance *servers.Server, fip *floatingip.FloatingIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if fip.InstanceID == instance.ID {
+			return nil
+		}
+
+		return fmt.Errorf("Floating IP %s was not attached to instance %s", fip.ID, instance.ID)
+
 	}
 }
 

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -17,6 +17,17 @@ import (
 
 func TestAccComputeV2Instance_basic(t *testing.T) {
 	var instance servers.Server
+	var testAccComputeV2Instance_basic = fmt.Sprintf(`
+		resource "openstack_compute_instance_v2" "foo" {
+			name = "terraform-test"
+			network {
+				uuid = "%s"
+			}
+			metadata {
+				foo = "bar"
+			}
+		}`,
+		os.Getenv("OS_NETWORK_ID"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -206,16 +217,6 @@ func testAccCheckComputeV2InstanceFloatingIPAttach(
 
 	}
 }
-
-var testAccComputeV2Instance_basic = fmt.Sprintf(`
-	resource "openstack_compute_instance_v2" "foo" {
-		region = "%s"
-		name = "terraform-test"
-		metadata {
-			foo = "bar"
-		}
-	}`,
-	OS_REGION_NAME)
 
 var testAccComputeV2Instance_volumeAttach = fmt.Sprintf(`
   resource "openstack_blockstorage_volume_v1" "myvol" {

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -67,10 +67,10 @@ func TestAccComputeV2Instance_floatingIPAttach(t *testing.T) {
 			floating_ip = "${openstack_compute_floatingip_v2.myip.address}"
 
 			network {
-				name = "%s"
+				uuid = "%s"
 			}
 		}`,
-		os.Getenv("OS_NETWORK_NAME"))
+		os.Getenv("OS_NETWORK_ID"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2_test.go
@@ -2,11 +2,13 @@ package openstack
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
+	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 )
 
@@ -22,6 +24,40 @@ func TestAccNetworkingV2FloatingIP_basic(t *testing.T) {
 				Config: testAccNetworkingV2FloatingIP_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2FloatingIPExists(t, "openstack_networking_floatingip_v2.foo", &floatingIP),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2FloatingIP_attach(t *testing.T) {
+	var instance servers.Server
+	var fip floatingips.FloatingIP
+	var testAccNetworkV2FloatingIP_attach = fmt.Sprintf(`
+    resource "openstack_networking_floatingip_v2" "myip" {
+    }
+
+    resource "openstack_compute_instance_v2" "foo" {
+      name = "terraform-test"
+      floating_ip = "${openstack_networking_floatingip_v2.myip.address}"
+
+      network {
+        uuid = "%s"
+      }
+    }`,
+		os.Getenv("OS_NETWORK_ID"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2FloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkV2FloatingIP_attach,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2FloatingIPExists(t, "openstack_networking_floatingip_v2.myip", &fip),
+					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
+					testAccCheckNetworkingV2InstanceFloatingIPAttach(&instance, &fip),
 				),
 			},
 		},
@@ -81,11 +117,28 @@ func testAccCheckNetworkingV2FloatingIPExists(t *testing.T, n string, kp *floati
 	}
 }
 
+func testAccCheckNetworkingV2InstanceFloatingIPAttach(
+	instance *servers.Server, fip *floatingips.FloatingIP) resource.TestCheckFunc {
+
+	// When Neutron is used, the Instance sometimes does not know its floating IP until some time
+	// after the attachment happened. This can be anywhere from 2-20 seconds. Because of that delay,
+	// the test usually completes with failure.
+	// However, the Fixed IP is known on both sides immediately, so that can be used as a bridge
+	// to ensure the two are now related.
+	// I think a better option is to introduce some state changing config in the actual resource.
+	return func(s *terraform.State) error {
+		for _, networkAddresses := range instance.Addresses {
+			for _, element := range networkAddresses.([]interface{}) {
+				address := element.(map[string]interface{})
+				if address["OS-EXT-IPS:type"] == "fixed" && address["addr"] == fip.FixedIP {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("Floating IP %+v was not attached to instance %+v", fip, instance)
+	}
+}
+
 var testAccNetworkingV2FloatingIP_basic = `
   resource "openstack_networking_floatingip_v2" "foo" {
-  }
-
-  resource "openstack_compute_instance_v2" "bar" {
-	name = "terraform-acc-floating-ip-test"
-	floating_ip = "${openstack_networking_floatingip_v2.foo.address}"
   }`


### PR DESCRIPTION
The following are a series of changes that I was working on during the OpenStack provider development. Unfortunately these changes did not make it for the initial merge.

I have a lot of notes and comments scattered across previous PRs, but in an attempt to start fresh, I'll try to lay everything out here.

First, to make sure everyone is on the same page, I want to define some areas:

* Floating IP: Analogous to an Elastic IP in AWS
* Neutron: An OpenStack Network service that is decoupled from the Compute service (Nova)
* nova-network: The original network service that is integrated in Compute (Nova)

Neutron, nova-network, and Nova:

nova-network is sometimes labelled as "legacy". While it's true it was previously deprecated, the deprecation status was removed [some time ago](http://docs.openstack.org/openstack-ops/content/nova-network-deprecation.html). As recently as [last week](http://thread.gmane.org/gmane.comp.cloud.openstack.devel/49558) there are still no plans to deprecate nova-network. The recent user survey shows that [30% of OpenStack clouds use nova-network](http://thread.gmane.org/gmane.comp.cloud.openstack.devel/49558/focus=49631). 

The reason I'm placing so much emphasis on this is because if Terraform is going to officially support OpenStack, nova-network should be considered a peer to Neutron for the foreseeable future. Calling it "legacy" is the same as saying Neutron is still in development.

Supporting two network services can definitely cause headaches, but fortunately, the areas where Nova and Neutron cross paths are taken care of naturally through the Nova API. A lot of this was already done with this provider, but the one area that was left untouched was Floating IPs.

During the development of this provider, Floating IP support was [initially added](https://github.com/jrperritt/terraform/pull/1/files) using the Neutron API. This was because gophercloud did not support Floating IPs through the Nova API. While this worked for Neutron-based clouds, it prevented anyone running nova-network from using Floating IPs.

gophercloud was patched to support floating IPs via the Nova API and I set out to remedy Terraform. Along the way I learned that the Nova API can also handle the allocation, deallocation, association, and disassociation of Neutron-based Floating IPs.

There are areas in OpenStack where it makes sense to strictly use the Neutron API with Floating IPs. This is why two Floating IP resources exist (a networking and compute one). However, when it comes to working solely with Compute, the Compute API can be used regardless of the underlying network service. This holds true for Neutron Security Groups as well which has always used the Nova API.

References:

* #924 (search for `os-floating-ips`)
* [prior PR comment](https://github.com/jrperritt/terraform/pull/18#issuecomment-83321212)

So, there's the history. 

Now, for the commits included, here's what each one is doing:

* ea228ad: Simply swaps the Neutron-only APIs out for `os-floating-ips`. As per the commit message, it works with both network systems but has one drawback (will discuss later). At a minimum, this is the only commit that needs merged and a lot of nova-network users will be very happy. But not just that, it gets rid of a lot of Neutron code that is already handled by Nova. I'd be happy to simply submit this single commit as a PR. 
* 3ebe55c: Checking for a network called "public" is only beneficial when the cloud actually has a network called "public". If checks like this should be enabled, might as well have other checks for networks called "default", "external", "provider", "internet", and the myriad of other names I've come across.
* ad1bfce: IPv6 is a real thing!
* 9a12fb0: The ability to specify anything by something other than a UUID only makes a better end-user experience.
* 58af3cb: The network information available to the instance is available from two different locations: the instance itself and the networks the instance is attached to. This commit attempts to make sense of all of that and combine the information where appropriate. You'll see a much more detailed result of `terraform show` with this patch.
* c6a81c5: I meant this patch. :)
* b6f524a: It looks as though MAC addresses aren't available on Nebula-based OpenStack clouds.
* e605f31 and 2c83073: Typos and cleanup
* 173a215: updated acceptance test. It looks a little strange because the environment variables aren't actually making it to the acceptance tests. References:
  * #924 (search `_NAME`)
  * https://github.com/jrperritt/terraform/pull/11

The Drawback

I mentioned a drawback. With Neutron environments, when specifying multiple networks, the network that will receive the floating IP attachment _must_ be the first network specified in the `instance` resource. #1342 has a similar drawback, but it looks like it would be the last network?

I have a patch into gophercloud to remedy this, and I also have the corresponding terraform code ready, too, but I want to wait until gophercloud is patched.

Other References

* https://github.com/jrperritt/terraform/pull/23 has some examples using both nova-network and Neutron.
* https://github.com/jrperritt/terraform/pull/18 was a first attempt at this but tried to use both the Neutron API for Neutron clouds and Nova API for nova-network clouds. I really don't recommend going this route. The actual Nova API already supports Neutron connectivity and I kept seeing timing issues in Neutron clouds where the instance would not know its Floating IP for a few seconds after Terraform returned, requiring a refresh before everything appeared. I have not seen these timing issues by using just the Nova API.
* https://github.com/jrperritt/terraform/pull/12 Further discussion, and links to even further discussion.

So that's my case! I apologize for being overly verbose. It seems a little silly for a single feature of Floating IPs, but since this is a new audience, I wanted to lay everything out. 

I'd love to get some feedback -- especially if there are mistakes. I'm in no way saying this is all perfect and without error, but I've been working with this issue, trying different ways of solving it, digging into code, and testing on multiple clouds for six weeks now.