### PR TITLE
Provider/AWS: RDS - Avoid panics when DBName is not set

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -304,7 +304,11 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("name", *v.DBName)
+	if v.DBName != nil {
+		d.Set("name", *v.DBName)
+	} else {
+		d.Set("name", "")
+	}
 	d.Set("username", *v.MasterUsername)
 	d.Set("engine", *v.Engine)
 	d.Set("engine_version", *v.EngineVersion)


### PR DESCRIPTION
Hi,

I got this problem today: when a database instance is created in RDS service, the DBName attribute is optional. This means that RDS will not create database for you when the instance comes up.

The result of this is that when *Read function gets the attributes, it gets a null instead of DBName. Dereferencing it causes a panic.

cheers!
Michał