### PR TITLE
Don't error when reading s3 bucket with no tags

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -88,14 +88,12 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	resp, err := s3conn.GetBucketTagging(&s3.GetBucketTaggingRequest{
-		Bucket: aws.String(d.Id()),
-	})
+	tagSet, err := getTagSetS3(s3conn, d.Id())
 	if err != nil {
 		return err
 	}
 
-	if err := d.Set("tags", tagsToMapS3(resp.TagSet)); err != nil {
+	if err := d.Set("tags", tagsToMapS3(tagSet)); err != nil {
 		return err
 	}
 

--- a/builtin/providers/aws/s3_tags.go
+++ b/builtin/providers/aws/s3_tags.go
@@ -110,3 +110,22 @@ func tagsToMapS3(ts []s3.Tag) map[string]string {
 
 	return result
 }
+
+// return a slice of s3 tags associated with the given s3 bucket. Essentially
+// s3.GetBucketTagging, except returns an empty slice instead of an error when
+// there are no tags.
+func getTagSetS3(s3conn *s3.S3, bucket string) ([]s3.Tag, error) {
+	request := &s3.GetBucketTaggingRequest{
+		Bucket: aws.String(bucket),
+	}
+
+	response, err := s3conn.GetBucketTagging(request)
+	if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "NoSuchTagSet" {
+		// There is no tag set associated with the bucket.
+		return []s3.Tag{}, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return response.TagSet, nil
+}


### PR DESCRIPTION
s3.GetBucketTagging returns an error if there are no tags associated
with a bucket. Consequently, any configuration with a tagless s3 bucket
would fail with an error, "the TagSet does not exist".

Handle that error more appropriately, interpreting it as an empty set of
tags.