### PR TITLE
terraform remote: fix for state files containing an upper case remote type

### DIFF
--- a/command/state.go
+++ b/command/state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/state"
@@ -208,7 +209,7 @@ func remoteState(
 	}
 
 	// Initialize the remote client based on the local state
-	client, err := remote.NewClient(local.Remote.Type, local.Remote.Config)
+	client, err := remote.NewClient(strings.ToLower(local.Remote.Type), local.Remote.Config)
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf(
 			"Error initializing remote driver '%s': {{err}}",


### PR DESCRIPTION
Terraform 0.3.7 saved the remote type in the state as it was passed on the command line. The current code expects lower case remote types. This error appears after a terraform upgrade to master:
````
$ terraform remote pull
Failed to read state: Error initializing remote driver 'Consul': unknown remote client type: Consul
````
This change makes state files created by older versions of terraform usable again.