### PR TITLE
Support for AWS Placement Group

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -47,6 +47,13 @@ func resourceAwsInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"placement_group": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"instance_type": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -318,6 +325,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	placement := &ec2.Placement{
 		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
+		GroupName:        aws.String(d.Get("placement_group").(string)),
 	}
 
 	if hasSubnet {

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -21,6 +21,10 @@ func TestAccAWSInstance_normal(t *testing.T) {
 			return fmt.Errorf("bad availability zone: %#v", *v.Placement.AvailabilityZone)
 		}
 
+		if *v.Placement.GroupName != "terraform-placement-group" {
+			return fmt.Errorf("bad placement group name: %#v", *v.Placement.GroupName)
+		}
+
 		if len(v.SecurityGroups) == 0 {
 			return fmt.Errorf("no security groups: %#v", v.SecurityGroups)
 		}
@@ -451,6 +455,7 @@ resource "aws_instance" "foo" {
 	# us-west-2
 	ami = "ami-4fccb37f"
 	availability_zone = "us-west-2a"
+	placement_group = "terraform-placement-group"
 
 	instance_type = "m1.small"
 	security_groups = ["${aws_security_group.tf_test_foo.name}"]

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -31,6 +31,7 @@ The following arguments are supported:
 
 * `ami` - (Required) The AMI to use for the instance.
 * `availability_zone` - (Optional) The AZ to start the instance in.
+* `placement_group` - (Optional) The Placement Group to start the instance in.
 * `ebs_optimized` - (Optional) If true, the launched EC2 instance will be
      EBS-optimized.
 * `instance_type` - (Required) The type of instance to start
@@ -125,6 +126,7 @@ The following attributes are exported:
 
 * `id` - The instance ID.
 * `availability_zone` - The availability zone of the instance.
+* `placement_group` - The placement group of the instance.
 * `key_name` - The key name of the instance
 * `private_dns` - The Private DNS name of the instance
 * `private_ip` - The private IP address.


### PR DESCRIPTION
- add placement_group for aws instance
- update test and document

tested in my test setup, this launches instance into the right placement group.