### PR TITLE
Revert "provider/aws: Fix dependency violation with subnets and security groups"

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -128,8 +128,6 @@ func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) 
 		switch ec2err.Code {
 		case "InvalidInternetGatewayID.NotFound":
 			return nil
-		case "DependencyViolation":
-			return err // retry
 		}
 
 		return resource.RetryError{Err: err}
@@ -232,10 +230,11 @@ func detachIGStateRefreshFunc(conn *ec2.EC2, instanceID, vpcID string) resource.
 					return nil, "Not Found", err
 				} else if ec2err.Code == "Gateway.NotAttached" {
 					return "detached", "detached", nil
-				} else if ec2err.Code == "DependencyViolation" {
-					return nil, "detaching", nil
 				}
 			}
+
+			log.Printf("Error on detachIGStateRefreshFunc: %#v", err)
+			return nil, "", err
 		}
 		// DetachInternetGateway only returns an error, so if it's nil, assume we're
 		// detached


### PR DESCRIPTION
This reverts commit 3d8005729d3e307535ea505c63fc238aae7beb87.

Rationale: There is no guarantee that waiting will resolve the
DependencyViolation. It's possible, perhaps likely, that the thing
preventing the subnet deletion was created by some other means -- by
another user, by a dynamic application, in another manifest, or that it
was created by this manifest but for some other reason failed to be
deleted.

In these cases, the retry behavior makes the user wait 5 minutes only to
receive the misleading error:

Error deleting subnet: timeout while waiting for state to become
'destroyed'

The obvious response to this is to try again, which yields another 5
minutes of waiting.

The previous behavior was to fail quickly with an error which exactly
described the problem. While this is mildly annoying, it's at least
apparent what is happening.

The situation the original commit was intended to address could be more
elegantly addressed by:

  - running Terraform a second time, or
  - explicitly declaring dependencies via the `depends_on` attribute.