### PR TITLE
provider/aws: Fix issue finding db subnets

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -103,16 +103,22 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-1"
+	}
 }
 
 resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-2"
+	}
 }
 
 resource "aws_db_subnet_group" "foo" {
-	name = "foo"
+	name = "FOO"
 	description = "foo description"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 }


### PR DESCRIPTION
AWS seems to lower case DB Subnet Group names, causing a failure in TF if your
name isn't all lower case.

This PR covers:

- lower casing both our saved ID and the name we get back from AWS, and then makes the comparison. 
- range over all db subnets returned to look for the one in question
- changes the test to use upper case