### PR TITLE
helper/schema: ensure ForceNew set when Update is not

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -84,6 +84,7 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 			"associate_public_ip_address": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 				Default:  false,
 			},
 
@@ -96,6 +97,7 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 			"ebs_optimized": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 				Default:  false,
 			},
 

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -75,6 +75,7 @@ func resourceComputeRoute() *schema.Resource {
 			"tags": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set: func(v interface{}) int {
 					return hashcode.String(v.(string))


### PR DESCRIPTION
If a given resource does not define an `Update` function, then all of
its attributes must be specified as `ForceNew`, lest Applys fail with
"doesn't support update" like #1367.

This is something we can detect automatically, so this adds a check for
it when we validate provider implementations.