### PR TITLE
Allow me to do math on variables

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -23,6 +23,7 @@ func init() {
 		"element": interpolationFuncElement(),
 		"replace": interpolationFuncReplace(),
 		"split":   interpolationFuncSplit(),
+		"to_int":  interpolationFuncToint(),
 
 		// Concat is a little useless now since we supported embeddded
 		// interpolations but we keep it around for backwards compat reasons.
@@ -187,6 +188,26 @@ func interpolationFuncElement() ast.Function {
 
 			v := list[index%len(list)]
 			return v, nil
+		},
+	}
+}
+
+// interpolationFuncToint implements the "toint" function that
+// takes a string and returns an integer, so that you can do math operations
+// on it.
+func interpolationFuncToint() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeInt,
+		Variadic:   false,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			i, err := strconv.Atoi(s)
+			if err != nil {
+				return -1, fmt.Errorf(
+					"invalid value to convert to int: %s", s)
+			}
+			return i, nil
 		},
 	}
 }

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -109,3 +109,7 @@ The supported built-in functions are:
       back into a list. This is useful for pushing lists through module
       outputs since they currently only support string values.
       Example: `split(",", module.amod.server_ids)`
+
+  * `to_int(string)` - Turns a string into an integer. This is useful for
+     passing integer values (for example the max_size_ of an ASG) from
+     variables or calls to the lookup() function which return string values.


### PR DESCRIPTION
I want to be able to make a module which generates ASGs of the same min and desired size, but with a max size of the desired size+1, and I want to be able to pass the size in as a variable (i.e. a string), however math only works on ints.

Therefore I wrote a toint function, to allow me to be able to write code like this:

    max_size = "${toint(var.cluster_size)+1}"

Full example:
https://github.com/bobtfish/terraform-aws-coreos-kubernates-cluster/blob/master/nodes.tf#L28

I'm not sure if this is the right way forward (it'd be nice if we were to implicitly convert strings to ints), but it appears to work for my use-case right now, and was trivial to implement, so I thought I'd share it to prompt some discussion :)