### PR TITLE
provider/aws: Fix refresh issue in Route 53 hosted zone

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -83,7 +83,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 	_, err := r53.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(d.Id())})
 	if err != nil {
 		// Handle a deleted zone
-		if strings.Contains(err.Error(), "404") {
+		if r53err, ok := err.(aws.APIError); ok && r53err.Code == "NoSuchHostedZone" {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Change the error handling/detection to correctly determine no hosted zone
exists.

Basically fixes #1383 , pending a misunderstanding / miscommunication on what the behavior should actually be. 