### PR TITLE
provider/aws: Change Route 53 record to allow resource updates

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -18,6 +18,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsRoute53RecordCreate,
 		Read:   resourceAwsRoute53RecordRead,
+		Update: resourceAwsRoute53RecordUpdate,
 		Delete: resourceAwsRoute53RecordDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -42,20 +43,31 @@ func resourceAwsRoute53Record() *schema.Resource {
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"records": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Required: true,
-				ForceNew: true,
 				Set: func(v interface{}) int {
 					return hashcode.String(v.(string))
 				},
 			},
 		},
 	}
+}
+
+func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	// Route 53 supports CREATE, DELETE, and UPSERT actions. We use UPSERT, and
+	// AWS dynamically determins if a record should be created or updated.
+	// Amazon Route 53 can update an existing resource record set only when all
+	// of the following values match: Name, Type
+	// (and SetIdentifier, which we don't use yet).
+	// See http://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets_Requests.html#change-rrsets-request-action
+	//
+	// Because we use UPSERT, for resouce update here we simply fall through to
+	// our resource create function.
+	return resourceAwsRoute53RecordCreate(d, meta)
 }
 
 func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -59,7 +59,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 
 func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	// Route 53 supports CREATE, DELETE, and UPSERT actions. We use UPSERT, and
-	// AWS dynamically determins if a record should be created or updated.
+	// AWS dynamically determines if a record should be created or updated.
 	// Amazon Route 53 can update an existing resource record set only when all
 	// of the following values match: Name, Type
 	// (and SetIdentifier, which we don't use yet).


### PR DESCRIPTION
This removes `ForceNew` from `records` and `ttl`, and introduces a
`resourceAwsRoute53RecordUpdate` function. The `resourceAwsRoute53RecordUpdate`
falls through to the `resourceAwsRoute53RecordCreate` function, which utilizes
AWS `UPSERT` behavior and diffs for us.

`Name` and `Type` are used by AWS in the `UPSERT`, so only records with matching
`name` and `type` can be updated. Others are created as new, so we leave the
`ForceNew` behavior here.