### PR TITLE
provider/aws: Convert Key Pair to upstream aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
 	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
+
+	awsSDK "github.com/awslabs/aws-sdk-go/aws"
+	awsEC2 "github.com/awslabs/aws-sdk-go/service/ec2"
 )
 
 type Config struct {
@@ -32,6 +35,7 @@ type AWSClient struct {
 	region          string
 	rdsconn         *rds.RDS
 	iamconn         *iam.IAM
+	ec2SDKconn      *awsEC2.EC2
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -74,6 +78,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.ec2conn = ec2.New(creds, c.Region, nil)
 
 		client.iamconn = iam.New(creds, c.Region, nil)
+		client.ec2SDKconn = awsEC2.New(&awsSDK.Config{Region: "us-west-2"})
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	awsSDK "github.com/awslabs/aws-sdk-go/aws"
-	awsEC2 "github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 )
 
 func resourceAwsKeyPair() *schema.Resource {
@@ -36,15 +36,15 @@ func resourceAwsKeyPair() *schema.Resource {
 }
 
 func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2SDKconn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	keyName := d.Get("key_name").(string)
 	publicKey := d.Get("public_key").(string)
-	req := &awsEC2.ImportKeyPairInput{
-		KeyName:           awsSDK.String(keyName),
+	req := &ec2.ImportKeyPairInput{
+		KeyName:           aws.String(keyName),
 		PublicKeyMaterial: []byte(publicKey),
 	}
-	resp, err := ec2conn.ImportKeyPair(req)
+	resp, err := conn.ImportKeyPair(req)
 	if err != nil {
 		return fmt.Errorf("Error import KeyPair: %s", err)
 	}
@@ -54,11 +54,11 @@ func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2SDKconn
-	req := &awsEC2.DescribeKeyPairsInput{
-		KeyNames: []*string{awsSDK.String(d.Id())},
+	conn := meta.(*AWSClient).ec2SDKconn
+	req := &ec2.DescribeKeyPairsInput{
+		KeyNames: []*string{aws.String(d.Id())},
 	}
-	resp, err := ec2conn.DescribeKeyPairs(req)
+	resp, err := conn.DescribeKeyPairs(req)
 	if err != nil {
 		return fmt.Errorf("Error retrieving KeyPair: %s", err)
 	}
@@ -75,10 +75,10 @@ func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2SDKconn
+	conn := meta.(*AWSClient).ec2SDKconn
 
-	_, err := ec2conn.DeleteKeyPair(&awsEC2.DeleteKeyPairInput{
-		KeyName: awsSDK.String(d.Id()),
+	_, err := conn.DeleteKeyPair(&ec2.DeleteKeyPairInput{
+		KeyName: aws.String(d.Id()),
 	})
 	return err
 }

--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -1,13 +1,12 @@
 package aws
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	awsSDK "github.com/awslabs/aws-sdk-go/aws"
+	awsEC2 "github.com/awslabs/aws-sdk-go/service/ec2"
 )
 
 func resourceAwsKeyPair() *schema.Resource {
@@ -37,13 +36,13 @@ func resourceAwsKeyPair() *schema.Resource {
 }
 
 func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).ec2SDKconn
 
 	keyName := d.Get("key_name").(string)
 	publicKey := d.Get("public_key").(string)
-	req := &ec2.ImportKeyPairRequest{
-		KeyName:           aws.String(keyName),
-		PublicKeyMaterial: []byte(base64.StdEncoding.EncodeToString([]byte(publicKey))),
+	req := &awsEC2.ImportKeyPairInput{
+		KeyName:           awsSDK.String(keyName),
+		PublicKeyMaterial: []byte(publicKey),
 	}
 	resp, err := ec2conn.ImportKeyPair(req)
 	if err != nil {
@@ -55,10 +54,9 @@ func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
-
-	req := &ec2.DescribeKeyPairsRequest{
-		KeyNames: []string{d.Id()},
+	ec2conn := meta.(*AWSClient).ec2SDKconn
+	req := &awsEC2.DescribeKeyPairsInput{
+		KeyNames: []*string{awsSDK.String(d.Id())},
 	}
 	resp, err := ec2conn.DescribeKeyPairs(req)
 	if err != nil {
@@ -77,10 +75,10 @@ func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	ec2conn := meta.(*AWSClient).ec2SDKconn
 
-	err := ec2conn.DeleteKeyPair(&ec2.DeleteKeyPairRequest{
-		KeyName: aws.String(d.Id()),
+	_, err := ec2conn.DeleteKeyPair(&awsEC2.DeleteKeyPairInput{
+		KeyName: awsSDK.String(d.Id()),
 	})
 	return err
 }

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -30,7 +30,7 @@ func TestAccAWSKeyPair_normal(t *testing.T) {
 }
 
 func testAccCheckAWSKeyPairDestroy(s *terraform.State) error {
-	ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	ec2SDKconn := testAccProvider.Meta().(*AWSClient).ec2SDKconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_key_pair" {
@@ -38,8 +38,8 @@ func testAccCheckAWSKeyPairDestroy(s *terraform.State) error {
 		}
 
 		// Try to find key pair
-		resp, err := ec2conn.DescribeKeyPairs(&ec2.DescribeKeyPairsRequest{
-			KeyNames: []string{rs.Primary.ID},
+		resp, err := ec2SDKconn.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{
+			KeyNames: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
 			if len(resp.KeyPairs) > 0 {
@@ -81,10 +81,10 @@ func testAccCheckAWSKeyPairExists(n string, res *ec2.KeyPairInfo) resource.TestC
 			return fmt.Errorf("No KeyPair name is set")
 		}
 
-		ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		ec2SDKconn := testAccProvider.Meta().(*AWSClient).ec2SDKconn
 
-		resp, err := ec2conn.DescribeKeyPairs(&ec2.DescribeKeyPairsRequest{
-			KeyNames: []string{rs.Primary.ID},
+		resp, err := ec2SDKconn.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{
+			KeyNames: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err != nil {
 			return err
@@ -94,7 +94,7 @@ func testAccCheckAWSKeyPairExists(n string, res *ec2.KeyPairInfo) resource.TestC
 			return fmt.Errorf("KeyPair not found")
 		}
 
-		*res = resp.KeyPairs[0]
+		*res = *resp.KeyPairs[0]
 
 		return nil
 	}


### PR DESCRIPTION
First of many PRs to get Terraform back to mainstream github.com/awslabs/aws-sdk-go .
Hopefully they will all be this trivial.

