### PR TITLE
Remove Security Group owner_id argument from document

### DIFF
--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -67,7 +67,6 @@ The following arguments are supported:
       egress rule. Each egress block supports fields documented below.
       VPC only.
 * `vpc_id` - (Optional) The VPC ID.
-* `owner_id` - (Optional) The AWS Owner ID.
 
 The `ingress` block supports:
 


### PR DESCRIPTION
Currently, [Security Group resource document](https://www.terraform.io/docs/providers/aws/r/db_instance.html) describes that `owner_id` argument is supported argument.
However, [in the source code](https://github.com/hashicorp/terraform/blob/eadc44d5f790dcd17677751efe908572d892c958/builtin/providers/aws/resource_aws_security_group.go#L134-L137), this `owner_id` is defined as computed-only field.

I met this error by `terraform apply`: 

```
Errors:

  * aws_security_group.hoge: "owner_id": this field cannot be set
```

with this `main.tf`: 

```
resource "aws_security_group" "hoge" {
    name        = "hoge"
    description = "Group for hoge"
    owner_id    = "012345678901"

    ingress {
        from_port       = 22
        to_port         = 22
        protocol        = "tcp"
        cidr_blocks     = ["0.0.0.0/0"]
    }

    egress {
        from_port       = 0
        to_port         = 0
        protocol        = "-1"
        cidr_blocks     = ["0.0.0.0/0"]
    }
}
```

In this pull request, I removed `owner_id` argument from document.