### PR TITLE
provider/aws: Convert EIP to use upstream aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
 	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
+
+	awsSDK "github.com/awslabs/aws-sdk-go/aws"
+	awsEC2 "github.com/awslabs/aws-sdk-go/service/ec2"
 )
 
 type Config struct {
@@ -32,6 +35,7 @@ type AWSClient struct {
 	region          string
 	rdsconn         *rds.RDS
 	iamconn         *iam.IAM
+	ec2SDKconn      *awsEC2.EC2
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -74,6 +78,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.ec2conn = ec2.New(creds, c.Region, nil)
 
 		client.iamconn = iam.New(creds, c.Region, nil)
+		client.ec2SDKconn = awsEC2.New(&awsSDK.Config{Region: "us-west-2"})
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -51,15 +51,15 @@ func resourceAwsSubnet() *schema.Resource {
 }
 
 func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
-	createOpts := &ec2.CreateSubnetRequest{
+	createOpts := &ec2.CreateSubnetInput{
 		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
 		CIDRBlock:        aws.String(d.Get("cidr_block").(string)),
 		VPCID:            aws.String(d.Get("vpc_id").(string)),
 	}
 
-	resp, err := ec2conn.CreateSubnet(createOpts)
+	resp, err := conn.CreateSubnet(createOpts)
 
 	if err != nil {
 		return fmt.Errorf("Error creating subnet: %s", err)
@@ -75,7 +75,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  "available",
-		Refresh: SubnetStateRefreshFunc(ec2conn, *subnet.SubnetID),
+		Refresh: SubnetStateRefreshFunc(conn, *subnet.SubnetID),
 		Timeout: 10 * time.Minute,
 	}
 
@@ -91,10 +91,10 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
-	resp, err := ec2conn.DescribeSubnets(&ec2.DescribeSubnetsRequest{
-		SubnetIDs: []string{d.Id()},
+	resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		SubnetIDs: []*string{aws.String(d.Id())},
 	})
 
 	if err != nil {
@@ -109,39 +109,39 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	subnet := &resp.Subnets[0]
+	subnet := resp.Subnets[0]
 
 	d.Set("vpc_id", subnet.VPCID)
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("cidr_block", subnet.CIDRBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIPOnLaunch)
-	d.Set("tags", tagsToMap(subnet.Tags))
+	d.Set("tags", tagsToMapSDK(subnet.Tags))
 
 	return nil
 }
 
 func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	d.Partial(true)
 
-	if err := setTags(ec2conn, d); err != nil {
+	if err := setTagsSDK(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
 	}
 
 	if d.HasChange("map_public_ip_on_launch") {
-		modifyOpts := &ec2.ModifySubnetAttributeRequest{
+		modifyOpts := &ec2.ModifySubnetAttributeInput{
 			SubnetID: aws.String(d.Id()),
 			MapPublicIPOnLaunch: &ec2.AttributeBooleanValue{
-				aws.Boolean(d.Get("map_public_ip_on_launch").(bool)),
+				Value: aws.Boolean(d.Get("map_public_ip_on_launch").(bool)),
 			},
 		}
 
 		log.Printf("[DEBUG] Subnet modify attributes: %#v", modifyOpts)
 
-		err := ec2conn.ModifySubnetAttribute(modifyOpts)
+		_, err := conn.ModifySubnetAttribute(modifyOpts)
 
 		if err != nil {
 			return err
@@ -156,10 +156,10 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	log.Printf("[INFO] Deleting subnet: %s", d.Id())
-	req := &ec2.DeleteSubnetRequest{
+	req := &ec2.DeleteSubnetInput{
 		SubnetID: aws.String(d.Id()),
 	}
 
@@ -169,7 +169,7 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
-			err := ec2conn.DeleteSubnet(req)
+			_, err := conn.DeleteSubnet(req)
 			if err != nil {
 				if apiErr, ok := err.(aws.APIError); ok {
 					if apiErr.Code == "DependencyViolation" {
@@ -200,8 +200,8 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 // SubnetStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch a Subnet.
 func SubnetStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsRequest{
-			SubnetIDs: []string{id},
+		resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsInput{
+			SubnetIDs: []*string{aws.String(id)},
 		})
 		if err != nil {
 			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidSubnetID.NotFound" {
@@ -218,7 +218,7 @@ func SubnetStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc 
 			return nil, "", nil
 		}
 
-		subnet := &resp.Subnets[0]
+		subnet := resp.Subnets[0]
 		return subnet, *subnet.State, nil
 	}
 }

--- a/builtin/providers/aws/tags_sdk.go
+++ b/builtin/providers/aws/tags_sdk.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// tagsSchema returns the schema to use for tags.
+//
+// func tagsSchema() *schema.Schema {
+// 	return &schema.Schema{
+// 		Type:     schema.TypeMap,
+// 		Optional: true,
+// 	}
+// }
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsSDK(conn *ec2.EC2, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsSDK(tagsFromMapSDK(o), tagsFromMapSDK(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			_, err := conn.DeleteTags(&ec2.DeleteTagsInput{
+				Resources: []*string{aws.String(d.Id())},
+				Tags:      remove,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{aws.String(d.Id())},
+				Tags:      create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsSDK(oldTags, newTags []*ec2.Tag) ([]*ec2.Tag, []*ec2.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*ec2.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapSDK(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapSDK(m map[string]interface{}) []*ec2.Tag {
+	result := make([]*ec2.Tag, 0, len(m))
+	for k, v := range m {
+		result = append(result, &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapSDK(ts []*ec2.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		result[*t.Key] = *t.Value
+	}
+
+	return result
+}

--- a/builtin/providers/aws/tags_sdk_test.go
+++ b/builtin/providers/aws/tags_sdk_test.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDiffTagsSDK(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsSDK(tagsFromMapSDK(tc.Old), tagsFromMapSDK(tc.New))
+		cm := tagsToMapSDK(c)
+		rm := tagsToMapSDK(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// testAccCheckTags can be used to check the tags on a resource.
+func testAccCheckTagsSDK(
+	ts []*ec2.Tag, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m := tagsToMapSDK(ts)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("Missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("Extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Convert EIP to use upstream aws-sdk-go. Builds off of #1398