### PR TITLE
provider/aws: Convert AWS Network Interface to aws-sdk-go

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
 	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
+
+	awsSDK "github.com/awslabs/aws-sdk-go/aws"
+	awsEC2 "github.com/awslabs/aws-sdk-go/service/ec2"
 )
 
 type Config struct {
@@ -32,6 +35,7 @@ type AWSClient struct {
 	region          string
 	rdsconn         *rds.RDS
 	iamconn         *iam.IAM
+	ec2SDKconn      *awsEC2.EC2
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -74,6 +78,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.ec2conn = ec2.New(creds, c.Region, nil)
 
 		client.iamconn = iam.New(creds, c.Region, nil)
+		client.ec2SDKconn = awsEC2.New(&awsSDK.Config{Region: "us-west-2"})
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -51,15 +51,15 @@ func resourceAwsSubnet() *schema.Resource {
 }
 
 func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
-	createOpts := &ec2.CreateSubnetRequest{
+	createOpts := &ec2.CreateSubnetInput{
 		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
 		CIDRBlock:        aws.String(d.Get("cidr_block").(string)),
 		VPCID:            aws.String(d.Get("vpc_id").(string)),
 	}
 
-	resp, err := ec2conn.CreateSubnet(createOpts)
+	resp, err := conn.CreateSubnet(createOpts)
 
 	if err != nil {
 		return fmt.Errorf("Error creating subnet: %s", err)
@@ -75,7 +75,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  "available",
-		Refresh: SubnetStateRefreshFunc(ec2conn, *subnet.SubnetID),
+		Refresh: SubnetStateRefreshFunc(conn, *subnet.SubnetID),
 		Timeout: 10 * time.Minute,
 	}
 
@@ -91,10 +91,10 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
-	resp, err := ec2conn.DescribeSubnets(&ec2.DescribeSubnetsRequest{
-		SubnetIDs: []string{d.Id()},
+	resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		SubnetIDs: []*string{aws.String(d.Id())},
 	})
 
 	if err != nil {
@@ -109,39 +109,39 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	subnet := &resp.Subnets[0]
+	subnet := resp.Subnets[0]
 
 	d.Set("vpc_id", subnet.VPCID)
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("cidr_block", subnet.CIDRBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIPOnLaunch)
-	d.Set("tags", tagsToMap(subnet.Tags))
+	d.Set("tags", tagsToMapSDK(subnet.Tags))
 
 	return nil
 }
 
 func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	d.Partial(true)
 
-	if err := setTags(ec2conn, d); err != nil {
+	if err := setTagsSDK(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
 	}
 
 	if d.HasChange("map_public_ip_on_launch") {
-		modifyOpts := &ec2.ModifySubnetAttributeRequest{
+		modifyOpts := &ec2.ModifySubnetAttributeInput{
 			SubnetID: aws.String(d.Id()),
 			MapPublicIPOnLaunch: &ec2.AttributeBooleanValue{
-				aws.Boolean(d.Get("map_public_ip_on_launch").(bool)),
+				Value: aws.Boolean(d.Get("map_public_ip_on_launch").(bool)),
 			},
 		}
 
 		log.Printf("[DEBUG] Subnet modify attributes: %#v", modifyOpts)
 
-		err := ec2conn.ModifySubnetAttribute(modifyOpts)
+		_, err := conn.ModifySubnetAttribute(modifyOpts)
 
 		if err != nil {
 			return err
@@ -156,10 +156,10 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	log.Printf("[INFO] Deleting subnet: %s", d.Id())
-	req := &ec2.DeleteSubnetRequest{
+	req := &ec2.DeleteSubnetInput{
 		SubnetID: aws.String(d.Id()),
 	}
 
@@ -169,7 +169,7 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
-			err := ec2conn.DeleteSubnet(req)
+			_, err := conn.DeleteSubnet(req)
 			if err != nil {
 				if apiErr, ok := err.(aws.APIError); ok {
 					if apiErr.Code == "DependencyViolation" {
@@ -200,8 +200,8 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 // SubnetStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch a Subnet.
 func SubnetStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsRequest{
-			SubnetIDs: []string{id},
+		resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsInput{
+			SubnetIDs: []*string{aws.String(id)},
 		})
 		if err != nil {
 			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidSubnetID.NotFound" {
@@ -218,7 +218,7 @@ func SubnetStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc 
 			return nil, "", nil
 		}
 
-		subnet := &resp.Subnets[0]
+		subnet := resp.Subnets[0]
 		return subnet, *subnet.State, nil
 	}
 }

--- a/builtin/providers/aws/structure_sdk.go
+++ b/builtin/providers/aws/structure_sdk.go
@@ -1,0 +1,253 @@
+package aws
+
+import (
+	"strings"
+
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/elb"
+	"github.com/hashicorp/aws-sdk-go/gen/rds"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// Takes the result of flatmap.Expand for an array of listeners and
+// returns ELB API compatible objects
+func expandListenersSDK(configured []interface{}) ([]elb.Listener, error) {
+	listeners := make([]elb.Listener, 0, len(configured))
+
+	// Loop over our configured listeners and create
+	// an array of aws-sdk-go compatabile objects
+	for _, lRaw := range configured {
+		data := lRaw.(map[string]interface{})
+
+		l := elb.Listener{
+			InstancePort:     aws.Integer(data["instance_port"].(int)),
+			InstanceProtocol: aws.String(data["instance_protocol"].(string)),
+			LoadBalancerPort: aws.Integer(data["lb_port"].(int)),
+			Protocol:         aws.String(data["lb_protocol"].(string)),
+		}
+
+		if v, ok := data["ssl_certificate_id"]; ok {
+			l.SSLCertificateID = aws.String(v.(string))
+		}
+
+		listeners = append(listeners, l)
+	}
+
+	return listeners, nil
+}
+
+// Takes the result of flatmap.Expand for an array of ingress/egress
+// security group rules and returns EC2 API compatible objects
+func expandIPPermsSDK(
+	group ec2.SecurityGroup, configured []interface{}) []*ec2.IPPermission {
+	vpc := group.VPCID != nil
+
+	perms := make([]*ec2.IPPermission, len(configured))
+	for i, mRaw := range configured {
+		var perm ec2.IPPermission
+		m := mRaw.(map[string]interface{})
+
+		perm.FromPort = aws.Long(m["from_port"].(int64))
+		perm.ToPort = aws.Long(m["to_port"].(int64))
+		perm.IPProtocol = aws.String(m["protocol"].(string))
+
+		var groups []string
+		if raw, ok := m["security_groups"]; ok {
+			list := raw.(*schema.Set).List()
+			for _, v := range list {
+				groups = append(groups, v.(string))
+			}
+		}
+		if v, ok := m["self"]; ok && v.(bool) {
+			if vpc {
+				groups = append(groups, *group.GroupID)
+			} else {
+				groups = append(groups, *group.GroupName)
+			}
+		}
+
+		if len(groups) > 0 {
+			perm.UserIDGroupPairs = make([]*ec2.UserIDGroupPair, len(groups))
+			for i, name := range groups {
+				ownerId, id := "", name
+				if items := strings.Split(id, "/"); len(items) > 1 {
+					ownerId, id = items[0], items[1]
+				}
+
+				perm.UserIDGroupPairs[i] = &ec2.UserIDGroupPair{
+					GroupID: aws.String(id),
+					UserID:  aws.String(ownerId),
+				}
+				if !vpc {
+					perm.UserIDGroupPairs[i].GroupID = nil
+					perm.UserIDGroupPairs[i].GroupName = aws.String(id)
+					perm.UserIDGroupPairs[i].UserID = nil
+				}
+			}
+		}
+
+		if raw, ok := m["cidr_blocks"]; ok {
+			list := raw.([]interface{})
+			perm.IPRanges = make([]*ec2.IPRange, len(list))
+			for i, v := range list {
+				perm.IPRanges[i] = &ec2.IPRange{CIDRIP: aws.String(v.(string))}
+			}
+		}
+
+		perms[i] = &perm
+	}
+
+	return perms
+}
+
+// Takes the result of flatmap.Expand for an array of parameters and
+// returns Parameter API compatible objects
+func expandParametersSDK(configured []interface{}) ([]rds.Parameter, error) {
+	parameters := make([]rds.Parameter, 0, len(configured))
+
+	// Loop over our configured parameters and create
+	// an array of aws-sdk-go compatabile objects
+	for _, pRaw := range configured {
+		data := pRaw.(map[string]interface{})
+
+		p := rds.Parameter{
+			ApplyMethod:    aws.String(data["apply_method"].(string)),
+			ParameterName:  aws.String(data["name"].(string)),
+			ParameterValue: aws.String(data["value"].(string)),
+		}
+
+		parameters = append(parameters, p)
+	}
+
+	return parameters, nil
+}
+
+// Flattens a health check into something that flatmap.Flatten()
+// can handle
+func flattenHealthCheckSDK(check *elb.HealthCheck) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, 1)
+
+	chk := make(map[string]interface{})
+	chk["unhealthy_threshold"] = *check.UnhealthyThreshold
+	chk["healthy_threshold"] = *check.HealthyThreshold
+	chk["target"] = *check.Target
+	chk["timeout"] = *check.Timeout
+	chk["interval"] = *check.Interval
+
+	result = append(result, chk)
+
+	return result
+}
+
+// Flattens an array of UserSecurityGroups into a []string
+func flattenSecurityGroupsSDK(list []ec2.UserIDGroupPair) []string {
+	result := make([]string, 0, len(list))
+	for _, g := range list {
+		result = append(result, *g.GroupID)
+	}
+	return result
+}
+
+// Flattens an array of Instances into a []string
+func flattenInstancesSDK(list []elb.Instance) []string {
+	result := make([]string, 0, len(list))
+	for _, i := range list {
+		result = append(result, *i.InstanceID)
+	}
+	return result
+}
+
+// Expands an array of String Instance IDs into a []Instances
+func expandInstanceStringSDK(list []interface{}) []elb.Instance {
+	result := make([]elb.Instance, 0, len(list))
+	for _, i := range list {
+		result = append(result, elb.Instance{aws.String(i.(string))})
+	}
+	return result
+}
+
+// Flattens an array of Listeners into a []map[string]interface{}
+func flattenListenersSDK(list []elb.ListenerDescription) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		l := map[string]interface{}{
+			"instance_port":     *i.Listener.InstancePort,
+			"instance_protocol": strings.ToLower(*i.Listener.InstanceProtocol),
+			"lb_port":           *i.Listener.LoadBalancerPort,
+			"lb_protocol":       strings.ToLower(*i.Listener.Protocol),
+		}
+		// SSLCertificateID is optional, and may be nil
+		if i.Listener.SSLCertificateID != nil {
+			l["ssl_certificate_id"] = *i.Listener.SSLCertificateID
+		}
+		result = append(result, l)
+	}
+	return result
+}
+
+// Flattens an array of Parameters into a []map[string]interface{}
+func flattenParametersSDK(list []rds.Parameter) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		result = append(result, map[string]interface{}{
+			"name":  strings.ToLower(*i.ParameterName),
+			"value": strings.ToLower(*i.ParameterValue),
+		})
+	}
+	return result
+}
+
+// Takes the result of flatmap.Expand for an array of strings
+// and returns a []string
+func expandStringListSDK(configured []interface{}) []*string {
+	vs := make([]*string, 0, len(configured))
+	for _, v := range configured {
+		vs = append(vs, aws.String(v.(string)))
+	}
+	return vs
+}
+
+//Flattens an array of private ip addresses into a []string, where the elements returned are the IP strings e.g. "192.168.0.0"
+func flattenNetworkInterfacesPrivateIPAddessesSDK(dtos []*ec2.NetworkInterfacePrivateIPAddress) []string {
+	ips := make([]string, 0, len(dtos))
+	for _, v := range dtos {
+		ip := *v.PrivateIPAddress
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+//Flattens security group identifiers into a []string, where the elements returned are the GroupIDs
+func flattenGroupIdentifiersSDK(dtos []*ec2.GroupIdentifier) []string {
+	ids := make([]string, 0, len(dtos))
+	for _, v := range dtos {
+		group_id := *v.GroupID
+		ids = append(ids, group_id)
+	}
+	return ids
+}
+
+//Expands an array of IPs into a ec2 Private IP Address Spec
+func expandPrivateIPAddessesSDK(ips []interface{}) []*ec2.PrivateIPAddressSpecification {
+	dtos := make([]*ec2.PrivateIPAddressSpecification, 0, len(ips))
+	for i, v := range ips {
+		new_private_ip := &ec2.PrivateIPAddressSpecification{
+			PrivateIPAddress: aws.String(v.(string)),
+		}
+
+		new_private_ip.Primary = aws.Boolean(i == 0)
+
+		dtos = append(dtos, new_private_ip)
+	}
+	return dtos
+}
+
+//Flattens network interface attachment into a map[string]interface
+func flattenAttachmentSDK(a *ec2.NetworkInterfaceAttachment) map[string]interface{} {
+	att := make(map[string]interface{})
+	att["instance"] = *a.InstanceID
+	att["device_index"] = *a.DeviceIndex
+	att["attachment_id"] = *a.AttachmentID
+	return att
+}

--- a/builtin/providers/aws/structure_test_sdk.go
+++ b/builtin/providers/aws/structure_test_sdk.go
@@ -14,27 +14,27 @@ import (
 )
 
 // Returns test configuration
-// func testConf() map[string]string {
-// 	return map[string]string{
-// 		"listener.#":                   "1",
-// 		"listener.0.lb_port":           "80",
-// 		"listener.0.lb_protocol":       "http",
-// 		"listener.0.instance_port":     "8000",
-// 		"listener.0.instance_protocol": "http",
-// 		"availability_zones.#":         "2",
-// 		"availability_zones.0":         "us-east-1a",
-// 		"availability_zones.1":         "us-east-1b",
-// 		"ingress.#":                    "1",
-// 		"ingress.0.protocol":           "icmp",
-// 		"ingress.0.from_port":          "1",
-// 		"ingress.0.to_port":            "-1",
-// 		"ingress.0.cidr_blocks.#":      "1",
-// 		"ingress.0.cidr_blocks.0":      "0.0.0.0/0",
-// 		"ingress.0.security_groups.#":  "2",
-// 		"ingress.0.security_groups.0":  "sg-11111",
-// 		"ingress.0.security_groups.1":  "foo/sg-22222",
-// 	}
-// }
+func testConfSDK() map[string]string {
+	return map[string]string{
+		"listener.#":                   "1",
+		"listener.0.lb_port":           "80",
+		"listener.0.lb_protocol":       "http",
+		"listener.0.instance_port":     "8000",
+		"listener.0.instance_protocol": "http",
+		"availability_zones.#":         "2",
+		"availability_zones.0":         "us-east-1a",
+		"availability_zones.1":         "us-east-1b",
+		"ingress.#":                    "1",
+		"ingress.0.protocol":           "icmp",
+		"ingress.0.from_port":          "1",
+		"ingress.0.to_port":            "-1",
+		"ingress.0.cidr_blocks.#":      "1",
+		"ingress.0.cidr_blocks.0":      "0.0.0.0/0",
+		"ingress.0.security_groups.#":  "2",
+		"ingress.0.security_groups.0":  "sg-11111",
+		"ingress.0.security_groups.1":  "foo/sg-22222",
+	}
+}
 
 func TestExpandIPPermsSDK(t *testing.T) {
 	hash := func(v interface{}) int {
@@ -256,7 +256,7 @@ func TestFlattenHealthCheckSDK(t *testing.T) {
 }
 
 func TestExpandStringListSDK(t *testing.T) {
-	expanded := flatmap.Expand(testConf(), "availability_zones").([]interface{})
+	expanded := flatmap.Expand(testConfSDK(), "availability_zones").([]interface{})
 	stringList := expandStringList(expanded)
 	expected := []string{
 		"us-east-1a",

--- a/builtin/providers/aws/structure_test_sdk.go
+++ b/builtin/providers/aws/structure_test_sdk.go
@@ -1,0 +1,444 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/elb"
+	"github.com/hashicorp/aws-sdk-go/gen/rds"
+	"github.com/hashicorp/terraform/flatmap"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// Returns test configuration
+// func testConf() map[string]string {
+// 	return map[string]string{
+// 		"listener.#":                   "1",
+// 		"listener.0.lb_port":           "80",
+// 		"listener.0.lb_protocol":       "http",
+// 		"listener.0.instance_port":     "8000",
+// 		"listener.0.instance_protocol": "http",
+// 		"availability_zones.#":         "2",
+// 		"availability_zones.0":         "us-east-1a",
+// 		"availability_zones.1":         "us-east-1b",
+// 		"ingress.#":                    "1",
+// 		"ingress.0.protocol":           "icmp",
+// 		"ingress.0.from_port":          "1",
+// 		"ingress.0.to_port":            "-1",
+// 		"ingress.0.cidr_blocks.#":      "1",
+// 		"ingress.0.cidr_blocks.0":      "0.0.0.0/0",
+// 		"ingress.0.security_groups.#":  "2",
+// 		"ingress.0.security_groups.0":  "sg-11111",
+// 		"ingress.0.security_groups.1":  "foo/sg-22222",
+// 	}
+// }
+
+func TestExpandIPPermsSDK(t *testing.T) {
+	hash := func(v interface{}) int {
+		return hashcode.String(v.(string))
+	}
+
+	expanded := []interface{}{
+		map[string]interface{}{
+			"protocol":    "icmp",
+			"from_port":   1,
+			"to_port":     -1,
+			"cidr_blocks": []interface{}{"0.0.0.0/0"},
+			"security_groups": schema.NewSet(hash, []interface{}{
+				"sg-11111",
+				"foo/sg-22222",
+			}),
+		},
+		map[string]interface{}{
+			"protocol":  "icmp",
+			"from_port": 1,
+			"to_port":   -1,
+			"self":      true,
+		},
+	}
+	group := ec2.SecurityGroup{
+		GroupID: aws.String("foo"),
+		VPCID:   aws.String("bar"),
+	}
+	perms := expandIPPermsSDK(group, expanded)
+
+	expected := []ec2.IPPermission{
+		ec2.IPPermission{
+			IPProtocol: aws.String("icmp"),
+			FromPort:   aws.Long(1),
+			ToPort:     aws.Long(-1),
+			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("0.0.0.0/0")}},
+			UserIDGroupPairs: []*ec2.UserIDGroupPair{
+				&ec2.UserIDGroupPair{
+					UserID:  aws.String("foo"),
+					GroupID: aws.String("sg-22222"),
+				},
+				&ec2.UserIDGroupPair{
+					GroupID: aws.String("sg-22222"),
+				},
+			},
+		},
+		ec2.IPPermission{
+			IPProtocol: aws.String("icmp"),
+			FromPort:   aws.Long(1),
+			ToPort:     aws.Long(-1),
+			UserIDGroupPairs: []*ec2.UserIDGroupPair{
+				&ec2.UserIDGroupPair{
+					UserID: aws.String("foo"),
+				},
+			},
+		},
+	}
+
+	exp := expected[0]
+	perm := perms[0]
+
+	if *exp.FromPort != *perm.FromPort {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.FromPort,
+			*exp.FromPort)
+	}
+
+	if *exp.IPRanges[0].CIDRIP != *perm.IPRanges[0].CIDRIP {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.IPRanges[0].CIDRIP,
+			*exp.IPRanges[0].CIDRIP)
+	}
+
+	if *exp.UserIDGroupPairs[0].UserID != *perm.UserIDGroupPairs[0].UserID {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIDGroupPairs[0].UserID,
+			*exp.UserIDGroupPairs[0].UserID)
+	}
+
+}
+
+func TestExpandIPPerms_nonVPCSDK(t *testing.T) {
+	hash := func(v interface{}) int {
+		return hashcode.String(v.(string))
+	}
+
+	expanded := []interface{}{
+		map[string]interface{}{
+			"protocol":    "icmp",
+			"from_port":   1,
+			"to_port":     -1,
+			"cidr_blocks": []interface{}{"0.0.0.0/0"},
+			"security_groups": schema.NewSet(hash, []interface{}{
+				"sg-11111",
+				"foo/sg-22222",
+			}),
+		},
+		map[string]interface{}{
+			"protocol":  "icmp",
+			"from_port": 1,
+			"to_port":   -1,
+			"self":      true,
+		},
+	}
+	group := ec2.SecurityGroup{
+		GroupName: aws.String("foo"),
+	}
+	perms := expandIPPermsSDK(group, expanded)
+
+	expected := []ec2.IPPermission{
+		ec2.IPPermission{
+			IPProtocol: aws.String("icmp"),
+			FromPort:   aws.Long(1),
+			ToPort:     aws.Long(-1),
+			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("0.0.0.0/0")}},
+			UserIDGroupPairs: []*ec2.UserIDGroupPair{
+				&ec2.UserIDGroupPair{
+					GroupName: aws.String("sg-22222"),
+				},
+				&ec2.UserIDGroupPair{
+					GroupName: aws.String("sg-22222"),
+				},
+			},
+		},
+		ec2.IPPermission{
+			IPProtocol: aws.String("icmp"),
+			FromPort:   aws.Long(1),
+			ToPort:     aws.Long(-1),
+			UserIDGroupPairs: []*ec2.UserIDGroupPair{
+				&ec2.UserIDGroupPair{
+					GroupName: aws.String("foo"),
+				},
+			},
+		},
+	}
+
+	exp := expected[0]
+	perm := perms[0]
+
+	if *exp.FromPort != *perm.FromPort {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.FromPort,
+			*exp.FromPort)
+	}
+
+	if *exp.IPRanges[0].CIDRIP != *perm.IPRanges[0].CIDRIP {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.IPRanges[0].CIDRIP,
+			*exp.IPRanges[0].CIDRIP)
+	}
+}
+
+func TestExpandListenersSDK(t *testing.T) {
+	expanded := []interface{}{
+		map[string]interface{}{
+			"instance_port":     8000,
+			"lb_port":           80,
+			"instance_protocol": "http",
+			"lb_protocol":       "http",
+		},
+	}
+	listeners, err := expandListenersSDK(expanded)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	expected := elb.Listener{
+		InstancePort:     aws.Integer(8000),
+		LoadBalancerPort: aws.Integer(80),
+		InstanceProtocol: aws.String("http"),
+		Protocol:         aws.String("http"),
+	}
+
+	if !reflect.DeepEqual(listeners[0], expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			listeners[0],
+			expected)
+	}
+
+}
+
+func TestFlattenHealthCheckSDK(t *testing.T) {
+	cases := []struct {
+		Input  elb.HealthCheck
+		Output []map[string]interface{}
+	}{
+		{
+			Input: elb.HealthCheck{
+				UnhealthyThreshold: aws.Integer(10),
+				HealthyThreshold:   aws.Integer(10),
+				Target:             aws.String("HTTP:80/"),
+				Timeout:            aws.Integer(30),
+				Interval:           aws.Integer(30),
+			},
+			Output: []map[string]interface{}{
+				map[string]interface{}{
+					"unhealthy_threshold": 10,
+					"healthy_threshold":   10,
+					"target":              "HTTP:80/",
+					"timeout":             30,
+					"interval":            30,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenHealthCheckSDK(&tc.Input)
+		if !reflect.DeepEqual(output, tc.Output) {
+			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
+		}
+	}
+}
+
+func TestExpandStringListSDK(t *testing.T) {
+	expanded := flatmap.Expand(testConf(), "availability_zones").([]interface{})
+	stringList := expandStringList(expanded)
+	expected := []string{
+		"us-east-1a",
+		"us-east-1b",
+	}
+
+	if !reflect.DeepEqual(stringList, expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			stringList,
+			expected)
+	}
+
+}
+
+func TestExpandParametersSDK(t *testing.T) {
+	expanded := []interface{}{
+		map[string]interface{}{
+			"name":         "character_set_client",
+			"value":        "utf8",
+			"apply_method": "immediate",
+		},
+	}
+	parameters, err := expandParametersSDK(expanded)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	expected := rds.Parameter{
+		ParameterName:  aws.String("character_set_client"),
+		ParameterValue: aws.String("utf8"),
+		ApplyMethod:    aws.String("immediate"),
+	}
+
+	if !reflect.DeepEqual(parameters[0], expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			parameters[0],
+			expected)
+	}
+}
+
+func TestFlattenParametersSDK(t *testing.T) {
+	cases := []struct {
+		Input  []rds.Parameter
+		Output []map[string]interface{}
+	}{
+		{
+			Input: []rds.Parameter{
+				rds.Parameter{
+					ParameterName:  aws.String("character_set_client"),
+					ParameterValue: aws.String("utf8"),
+				},
+			},
+			Output: []map[string]interface{}{
+				map[string]interface{}{
+					"name":  "character_set_client",
+					"value": "utf8",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenParametersSDK(tc.Input)
+		if !reflect.DeepEqual(output, tc.Output) {
+			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
+		}
+	}
+}
+
+func TestExpandInstanceStringSDK(t *testing.T) {
+
+	expected := []elb.Instance{
+		elb.Instance{aws.String("test-one")},
+		elb.Instance{aws.String("test-two")},
+	}
+
+	ids := []interface{}{
+		"test-one",
+		"test-two",
+	}
+
+	expanded := expandInstanceStringSDK(ids)
+
+	if !reflect.DeepEqual(expanded, expected) {
+		t.Fatalf("Expand Instance String output did not match.\nGot:\n%#v\n\nexpected:\n%#v", expanded, expected)
+	}
+}
+
+func TestFlattenNetworkInterfacesPrivateIPAddessesSDK(t *testing.T) {
+	expanded := []*ec2.NetworkInterfacePrivateIPAddress{
+		&ec2.NetworkInterfacePrivateIPAddress{PrivateIPAddress: aws.String("192.168.0.1")},
+		&ec2.NetworkInterfacePrivateIPAddress{PrivateIPAddress: aws.String("192.168.0.2")},
+	}
+
+	result := flattenNetworkInterfacesPrivateIPAddessesSDK(expanded)
+
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected result had %d elements, but got %d", 2, len(result))
+	}
+
+	if result[0] != "192.168.0.1" {
+		t.Fatalf("expected ip to be 192.168.0.1, but was %s", result[0])
+	}
+
+	if result[1] != "192.168.0.2" {
+		t.Fatalf("expected ip to be 192.168.0.2, but was %s", result[1])
+	}
+}
+
+func TestFlattenGroupIdentifiersSDK(t *testing.T) {
+	expanded := []*ec2.GroupIdentifier{
+		&ec2.GroupIdentifier{GroupID: aws.String("sg-001")},
+		&ec2.GroupIdentifier{GroupID: aws.String("sg-002")},
+	}
+
+	result := flattenGroupIdentifiersSDK(expanded)
+
+	if len(result) != 2 {
+		t.Fatalf("expected result had %d elements, but got %d", 2, len(result))
+	}
+
+	if result[0] != "sg-001" {
+		t.Fatalf("expected id to be sg-001, but was %s", result[0])
+	}
+
+	if result[1] != "sg-002" {
+		t.Fatalf("expected id to be sg-002, but was %s", result[1])
+	}
+}
+
+func TestExpandPrivateIPAddessesSDK(t *testing.T) {
+
+	ip1 := "192.168.0.1"
+	ip2 := "192.168.0.2"
+	flattened := []interface{}{
+		ip1,
+		ip2,
+	}
+
+	result := expandPrivateIPAddessesSDK(flattened)
+
+	if len(result) != 2 {
+		t.Fatalf("expected result had %d elements, but got %d", 2, len(result))
+	}
+
+	if *result[0].PrivateIPAddress != "192.168.0.1" || !*result[0].Primary {
+		t.Fatalf("expected ip to be 192.168.0.1 and Primary, but got %v, %t", *result[0].PrivateIPAddress, *result[0].Primary)
+	}
+
+	if *result[1].PrivateIPAddress != "192.168.0.2" || *result[1].Primary {
+		t.Fatalf("expected ip to be 192.168.0.2 and not Primary, but got %v, %t", *result[1].PrivateIPAddress, *result[1].Primary)
+	}
+}
+
+func TestFlattenAttachmentSDK(t *testing.T) {
+	expanded := &ec2.NetworkInterfaceAttachment{
+		InstanceID:   aws.String("i-00001"),
+		DeviceIndex:  aws.Long(1),
+		AttachmentID: aws.String("at-002"),
+	}
+
+	result := flattenAttachmentSDK(expanded)
+
+	if result == nil {
+		t.Fatal("expected result to have value, but got nil")
+	}
+
+	if result["instance"] != "i-00001" {
+		t.Fatalf("expected instance to be i-00001, but got %s", result["instance"])
+	}
+
+	if result["device_index"] != 1 {
+		t.Fatalf("expected device_index to be 1, but got %d", result["device_index"])
+	}
+
+	if result["attachment_id"] != "at-002" {
+		t.Fatalf("expected attachment_id to be at-002, but got %s", result["attachment_id"])
+	}
+}

--- a/builtin/providers/aws/tags_sdk.go
+++ b/builtin/providers/aws/tags_sdk.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// tagsSchema returns the schema to use for tags.
+//
+// func tagsSchema() *schema.Schema {
+// 	return &schema.Schema{
+// 		Type:     schema.TypeMap,
+// 		Optional: true,
+// 	}
+// }
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsSDK(conn *ec2.EC2, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsSDK(tagsFromMapSDK(o), tagsFromMapSDK(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			_, err := conn.DeleteTags(&ec2.DeleteTagsInput{
+				Resources: []*string{aws.String(d.Id())},
+				Tags:      remove,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{aws.String(d.Id())},
+				Tags:      create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsSDK(oldTags, newTags []*ec2.Tag) ([]*ec2.Tag, []*ec2.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*ec2.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapSDK(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapSDK(m map[string]interface{}) []*ec2.Tag {
+	result := make([]*ec2.Tag, 0, len(m))
+	for k, v := range m {
+		result = append(result, &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapSDK(ts []*ec2.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		result[*t.Key] = *t.Value
+	}
+
+	return result
+}

--- a/builtin/providers/aws/tags_sdk_test.go
+++ b/builtin/providers/aws/tags_sdk_test.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDiffTagsSDK(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsSDK(tagsFromMapSDK(tc.Old), tagsFromMapSDK(tc.New))
+		cm := tagsToMapSDK(c)
+		rm := tagsToMapSDK(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// testAccCheckTags can be used to check the tags on a resource.
+func testAccCheckTagsSDK(
+	ts []*ec2.Tag, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m := tagsToMapSDK(ts)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("Missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("Extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Convert AWS Network Interface to aws-sdk-go, built off of #1398

Also adds sdk versions of structure, structure test