### PR TITLE
providers/aws: fix LCs being invalid in classic

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -278,10 +278,8 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		createLaunchConfigurationOpts.PlacementTenancy = aws.String(v.(string))
 	}
 
-	if v := d.Get("associate_public_ip_address"); v != nil {
+	if v, ok := d.GetOk("associate_public_ip_address"); ok {
 		createLaunchConfigurationOpts.AssociatePublicIPAddress = aws.Boolean(v.(bool))
-	} else {
-		createLaunchConfigurationOpts.AssociatePublicIPAddress = aws.Boolean(false)
 	}
 
 	if v, ok := d.GetOk("key_name"); ok {


### PR DESCRIPTION
Turns out AssociatePublicIPAddress was always being set, but the AWS
APIs don't like that when you're launching into EC2 Classic and return a
validation error at ASG launch time.

Fixes #1410