### PR TITLE
provider/aws: Fix issue with Route 53 and pre-existing, external Hosted zones

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -60,7 +60,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 
 func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
-	zone := d.Get("zone_id").(string)
+	zone := cleanZoneID(d.Get("zone_id").(string))
 
 	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(zone)})
 	if err != nil {
@@ -151,7 +151,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
 
-	zone := d.Get("zone_id").(string)
+	zone := cleanZoneID(d.Get("zone_id").(string))
 
 	// get expanded name
 	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(zone)})
@@ -200,7 +200,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
 
-	zone := d.Get("zone_id").(string)
+	zone := cleanZoneID(d.Get("zone_id").(string))
 	log.Printf("[DEBUG] Deleting resource records for zone: %s, name: %s",
 		zone, d.Get("name").(string))
 	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(zone)})

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -275,7 +275,7 @@ resource "aws_route53_zone" "main" {
 }
 
 resource "aws_route53_record" "default" {
-	zone_id = "${aws_route53_zone.main.zone_id}"
+	zone_id = "/hostedzone/${aws_route53_zone.main.zone_id}"
 	name = "subdomain"
 	type = "TXT"
 	ttl = "30"


### PR DESCRIPTION
Fixes #1405 by always cleaning the `zone_id` we use. If it's externally provided and users use the full ID `/hostedzone/xxxxx`, we weren't trimming the prefix off.