### PR TITLE
command/push: read terraform.tfvars

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -24,7 +24,7 @@ func (c *PushCommand) Run(args []string) int {
 	var atlasAddress, atlasToken string
 	var archiveVCS, moduleUpload bool
 	var name string
-	args = c.Meta.process(args, false)
+	args = c.Meta.process(args, true)
 	cmdFlags := c.Meta.flagSet("push")
 	cmdFlags.StringVar(&atlasAddress, "atlas-address", "", "")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -176,6 +176,75 @@ func TestPush_inputPartial(t *testing.T) {
 	}
 }
 
+func TestPush_inputTfvars(t *testing.T) {
+	// Disable test mode so input would be asked and setup the
+	// input reader/writers.
+	test = false
+	defer func() { test = true }()
+	defaultInputReader = bytes.NewBufferString("nope\n")
+	defaultInputWriter = new(bytes.Buffer)
+
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
+	// Create remote state file, this should be pulled
+	conf, srv := testRemoteState(t, testState(), 200)
+	defer srv.Close()
+
+	// Persist local remote state
+	s := terraform.NewState()
+	s.Serial = 5
+	s.Remote = conf
+	testStateFileRemote(t, s)
+
+	// Path where the archive will be "uploaded" to
+	archivePath := testTempFile(t)
+	defer os.Remove(archivePath)
+
+	client := &mockPushClient{File: archivePath}
+	ui := new(cli.MockUi)
+	c := &PushCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+
+		client: client,
+	}
+
+	path := testFixturePath("push-tfvars")
+	args := []string{
+		"-var-file", path + "/terraform.tfvars",
+		path,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	actual := testArchiveStr(t, archivePath)
+	expected := []string{
+		".terraform/",
+		".terraform/terraform.tfstate",
+		"main.tf",
+		"terraform.tfvars",
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+
+	if client.UpsertOptions.Name != "foo" {
+		t.Fatalf("bad: %#v", client.UpsertOptions)
+	}
+
+	variables := map[string]string{
+		"foo": "bar",
+		"bar": "foo",
+	}
+	if !reflect.DeepEqual(client.UpsertOptions.Variables, variables) {
+		t.Fatalf("bad: %#v", client.UpsertOptions)
+	}
+}
+
 func TestPush_name(t *testing.T) {
 	tmp, cwd := testCwd(t)
 	defer testFixCwd(t, tmp, cwd)

--- a/command/test-fixtures/push-tfvars/main.tf
+++ b/command/test-fixtures/push-tfvars/main.tf
@@ -1,0 +1,8 @@
+variable "foo" {}
+variable "bar" {}
+
+resource "test_instance" "foo" {}
+
+atlas {
+    name = "foo"
+}

--- a/command/test-fixtures/push-tfvars/terraform.tfvars
+++ b/command/test-fixtures/push-tfvars/terraform.tfvars
@@ -1,0 +1,2 @@
+foo = "bar"
+bar = "foo"


### PR DESCRIPTION
This changes the "push" command to read `terraform.tfvars` before asking for variables. 

There is another weird "bug" I found here, which I can't remember if it was a bug or conscious decision, but I've decided to avoid it for now and we can look at it later: the "terraform.tfvars" has to be in pwd, not in the module path. I wonder if we want to load that, as well?