### PR TITLE
config/module: storage path should be independent of system

### DIFF
--- a/command/module_storage.go
+++ b/command/module_storage.go
@@ -14,16 +14,16 @@ type uiModuleStorage struct {
 	Ui      cli.Ui
 }
 
-func (s *uiModuleStorage) Dir(source string) (string, bool, error) {
-	return s.Storage.Dir(source)
+func (s *uiModuleStorage) Dir(key string) (string, bool, error) {
+	return s.Storage.Dir(key)
 }
 
-func (s *uiModuleStorage) Get(source string, update bool) error {
+func (s *uiModuleStorage) Get(key string, source string, update bool) error {
 	updateStr := ""
 	if update {
 		updateStr = " (update)"
 	}
 
 	s.Ui.Output(fmt.Sprintf("Get: %s%s", source, updateStr))
-	return s.Storage.Get(source, update)
+	return s.Storage.Get(key, source, update)
 }

--- a/config/module/folder_storage.go
+++ b/config/module/folder_storage.go
@@ -16,8 +16,8 @@ type FolderStorage struct {
 }
 
 // Dir implements Storage.Dir
-func (s *FolderStorage) Dir(source string) (d string, e bool, err error) {
-	d = s.dir(source)
+func (s *FolderStorage) Dir(key string) (d string, e bool, err error) {
+	d = s.dir(key)
 	_, err = os.Stat(d)
 	if err == nil {
 		// Directory exists
@@ -59,7 +59,7 @@ func (s *FolderStorage) Get(key string, source string, update bool) error {
 
 // dir returns the directory name internally that we'll use to map to
 // internally.
-func (s *FolderStorage) dir(source string) string {
-	sum := md5.Sum([]byte(source))
+func (s *FolderStorage) dir(key string) string {
+	sum := md5.Sum([]byte(key))
 	return filepath.Join(s.StorageDir, hex.EncodeToString(sum[:]))
 }

--- a/config/module/folder_storage.go
+++ b/config/module/folder_storage.go
@@ -39,8 +39,8 @@ func (s *FolderStorage) Dir(source string) (d string, e bool, err error) {
 }
 
 // Get implements Storage.Get
-func (s *FolderStorage) Get(source string, update bool) error {
-	dir := s.dir(source)
+func (s *FolderStorage) Get(key string, source string, update bool) error {
+	dir := s.dir(key)
 	if !update {
 		if _, err := os.Stat(dir); err == nil {
 			// If the directory already exists, then we're done since

--- a/config/module/folder_storage_test.go
+++ b/config/module/folder_storage_test.go
@@ -24,14 +24,16 @@ func TestFolderStorage(t *testing.T) {
 		t.Fatal("should not exist")
 	}
 
+	key := "foo"
+
 	// We can get it
-	err = s.Get(module, false)
+	err = s.Get(key, module, false)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Now the module exists
-	dir, ok, err := s.Dir(module)
+	dir, ok, err := s.Dir(key)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/config/module/storage.go
+++ b/config/module/storage.go
@@ -9,17 +9,17 @@ type Storage interface {
 	Dir(string) (string, bool, error)
 
 	// Get will download and optionally update the given module.
-	Get(string, bool) error
+	Get(string, string, bool) error
 }
 
-func getStorage(s Storage, src string, mode GetMode) (string, bool, error) {
+func getStorage(s Storage, key string, src string, mode GetMode) (string, bool, error) {
 	// Get the module with the level specified if we were told to.
 	if mode > GetModeNone {
-		if err := s.Get(src, mode == GetModeUpdate); err != nil {
+		if err := s.Get(key, src, mode == GetModeUpdate); err != nil {
 			return "", false, err
 		}
 	}
 
 	// Get the directory where the module is.
-	return s.Dir(src)
+	return s.Dir(key)
 }

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -23,6 +23,7 @@ type Tree struct {
 	name     string
 	config   *config.Config
 	children map[string]*Tree
+	path     []string
 	lock     sync.RWMutex
 }
 
@@ -187,6 +188,11 @@ func (t *Tree) Load(s Storage, mode GetMode) error {
 			return fmt.Errorf(
 				"module %s: %s", m.Name, err)
 		}
+
+		// Set the path of this child
+		path := make([]string, len(t.path), len(t.path)+1)
+		copy(path, t.path)
+		children[m.Name].path = append(path, m.Name)
 	}
 
 	// Go through all the children and load them.
@@ -202,10 +208,19 @@ func (t *Tree) Load(s Storage, mode GetMode) error {
 	return nil
 }
 
+// Path is the full path to this tree.
+func (t *Tree) Path() []string {
+	return t.path
+}
+
 // String gives a nice output to describe the tree.
 func (t *Tree) String() string {
 	var result bytes.Buffer
-	result.WriteString(t.Name() + "\n")
+	path := strings.Join(t.path, ", ")
+	if path != "" {
+		path = fmt.Sprintf(" (path: %s)", path)
+	}
+	result.WriteString(t.Name() + path + "\n")
 
 	cs := t.Children()
 	if cs == nil {

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -153,6 +153,11 @@ func (t *Tree) Load(s Storage, mode GetMode) error {
 				"module %s: duplicated. module names must be unique", m.Name)
 		}
 
+		// Determine the path to this child
+		path := make([]string, len(t.path), len(t.path)+1)
+		copy(path, t.path)
+		path = append(path, m.Name)
+
 		// Split out the subdir if we have one
 		source, subDir := getDirSubdir(m.Source)
 
@@ -168,7 +173,9 @@ func (t *Tree) Load(s Storage, mode GetMode) error {
 		}
 
 		// Get the directory where this module is so we can load it
-		dir, ok, err := getStorage(s, source, mode)
+		key := strings.Join(path, ".")
+		key = "root." + key
+		dir, ok, err := getStorage(s, key, source, mode)
 		if err != nil {
 			return err
 		}
@@ -190,9 +197,7 @@ func (t *Tree) Load(s Storage, mode GetMode) error {
 		}
 
 		// Set the path of this child
-		path := make([]string, len(t.path), len(t.path)+1)
-		copy(path, t.path)
-		children[m.Name].path = append(path, m.Name)
+		children[m.Name].path = path
 	}
 
 	// Go through all the children and load them.

--- a/config/module/tree_gob.go
+++ b/config/module/tree_gob.go
@@ -22,6 +22,7 @@ func (t *Tree) GobDecode(bs []byte) error {
 	t.name = data.Name
 	t.config = data.Config
 	t.children = data.Children
+	t.path = data.Path
 
 	return nil
 }
@@ -31,6 +32,7 @@ func (t *Tree) GobEncode() ([]byte, error) {
 		Config:   t.config,
 		Children: t.children,
 		Name:     t.name,
+		Path:     t.path,
 	}
 
 	var buf bytes.Buffer
@@ -51,4 +53,5 @@ type treeGob struct {
 	Config   *config.Config
 	Children map[string]*Tree
 	Name     string
+	Path     []string
 }

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -18,6 +18,8 @@ func TestTreeChild(t *testing.T) {
 		t.Fatal("should not be nil")
 	} else if c.Name() != "root" {
 		t.Fatalf("bad: %#v", c.Name())
+	} else if !reflect.DeepEqual(c.Path(), []string(nil)) {
+		t.Fatalf("bad: %#v", c.Path())
 	}
 
 	// Should be able to get the root child
@@ -25,6 +27,8 @@ func TestTreeChild(t *testing.T) {
 		t.Fatal("should not be nil")
 	} else if c.Name() != "root" {
 		t.Fatalf("bad: %#v", c.Name())
+	} else if !reflect.DeepEqual(c.Path(), []string(nil)) {
+		t.Fatalf("bad: %#v", c.Path())
 	}
 
 	// Should be able to get the foo child
@@ -32,6 +36,8 @@ func TestTreeChild(t *testing.T) {
 		t.Fatal("should not be nil")
 	} else if c.Name() != "foo" {
 		t.Fatalf("bad: %#v", c.Name())
+	} else if !reflect.DeepEqual(c.Path(), []string{"foo"}) {
+		t.Fatalf("bad: %#v", c.Path())
 	}
 
 	// Should be able to get the nested child
@@ -39,6 +45,8 @@ func TestTreeChild(t *testing.T) {
 		t.Fatal("should not be nil")
 	} else if c.Name() != "bar" {
 		t.Fatalf("bad: %#v", c.Name())
+	} else if !reflect.DeepEqual(c.Path(), []string{"foo", "bar"}) {
+		t.Fatalf("bad: %#v", c.Path())
 	}
 }
 
@@ -274,16 +282,16 @@ func TestTreeValidate_requiredChildVar(t *testing.T) {
 
 const treeLoadStr = `
 root
-  foo
+  foo (path: foo)
 `
 
 const treeLoadParentStr = `
 root
-  a
-    b
+  a (path: a)
+    b (path: a, b)
 `
 const treeLoadSubdirStr = `
 root
-  foo
-    bar
+  foo (path: foo)
+    bar (path: foo, bar)
 `


### PR DESCRIPTION
This is a really important change to make copying entire `.terraform` directories work properly. Before, the hash in the `.terraform/modules` folder would be calculated based on the full URL of the source of the module. There are benefits to this:

  1. One copy per source
  2. When the source changes, `terraform` immediately notices.

The downside is that the paths aren't portable at all, which conflicts with `terraform push`. In this PR, I change the hash to be the hash of the "path" of the module: example "root.child.child2". This makes it portable, but makes it so that we have an exact 1:1 mapping of download of a module to folder. I don't think this optimization matters right now.

I think the proper long term solution is to have some sort of "module.lock" file that does this mapping for us so the hash doesn't matter at all. But for a 0.4.1 I wanted to minimize what is touched.

@phinze: Would appreciate some thoughts here and a review.