### PR TITLE
Use an AMI id that exists so the first example copypasted will work

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -59,7 +59,7 @@ provider "aws" {
 }
 
 resource "aws_instance" "example" {
-	ami = "ami-408c7f28"
+	ami = "ami-5189a661"
 	instance_type = "t1.micro"
 }
 ```
@@ -111,7 +111,7 @@ $ terraform plan
 ...
 
 + aws_instance.example
-    ami:               "" => "ami-408c7f28"
+    ami:               "" => "ami-5189a661"
     availability_zone: "" => "<computed>"
     instance_type:     "" => "t1.micro"
     key_name:          "" => "<computed>"
@@ -148,7 +148,7 @@ since Terraform waits for the EC2 instance to become available.
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-408c7f28"
+  ami:           "" => "ami-5189a661"
   instance_type: "" => "t1.micro"
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
@@ -172,7 +172,7 @@ You can inspect the state using `terraform show`:
 $ terraform show
 aws_instance.example:
   id = i-e60900cd
-  ami = ami-408c7f28
+  ami = ami-5189a661
   availability_zone = us-east-1c
   instance_type = t1.micro
   key_name =


### PR DESCRIPTION
The example AMI id has probably been deleted because it was very old. It would be good (mainly for beginners) if the first example you hit works if you copypaste it straight from the getting started guide.