### PR TITLE
provider/aws: Fix issue in updating Route 53 records on refresh/read.

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -269,18 +269,8 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 
 func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (*route53.ResourceRecordSet, error) {
 	recs := d.Get("records").(*schema.Set).List()
-	records := make([]route53.ResourceRecord, 0, len(recs))
 
-	typeStr := d.Get("type").(string)
-	for _, r := range recs {
-		switch typeStr {
-		case "TXT":
-			str := fmt.Sprintf("\"%s\"", r.(string))
-			records = append(records, route53.ResourceRecord{Value: aws.String(str)})
-		default:
-			records = append(records, route53.ResourceRecord{Value: aws.String(r.(string))})
-		}
-	}
+	records := expandResourceRecords(recs, d.Get("type").(string))
 
 	// get expanded name
 	en := expandRecordName(d.Get("name").(string), zoneName)

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -186,7 +186,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 
 		err := d.Set("records", flattenResourceRecords(record.ResourceRecords))
 		if err != nil {
-			log.Printf("[DEBUG] Error setting records for: %s, error: %#v", en, err)
+			return fmt.Errorf("[DEBUG] Error setting records for: %s, error: %#v", en, err)
 		}
 		d.Set("ttl", record.TTL)
 

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -184,7 +184,10 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 
 		found = true
 
-		d.Set("records", record.ResourceRecords)
+		err := d.Set("records", flattenResourceRecords(record.ResourceRecords))
+		if err != nil {
+			log.Printf("[DEBUG] Error setting records for: %s, error: %#v", en, err)
+		}
 		d.Set("ttl", record.TTL)
 
 		break

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/aws-sdk-go/gen/elb"
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
+	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -250,4 +251,12 @@ func flattenAttachment(a *ec2.NetworkInterfaceAttachment) map[string]interface{}
 	att["device_index"] = *a.DeviceIndex
 	att["attachment_id"] = *a.AttachmentID
 	return att
+}
+
+func flattenResourceRecords(recs []route53.ResourceRecord) []string {
+	strs := make([]string, 0, len(recs))
+	for _, r := range recs {
+		strs = append(strs, *r.Value)
+	}
+	return strs
 }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -8,6 +8,7 @@ import (
 	ec2 "github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/aws-sdk-go/gen/elb"
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
+	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -440,5 +441,26 @@ func TestFlattenAttachment(t *testing.T) {
 
 	if result["attachment_id"] != "at-002" {
 		t.Fatalf("expected attachment_id to be at-002, but got %s", result["attachment_id"])
+	}
+}
+
+func TestFlattenResourceRecords(t *testing.T) {
+	expanded := []route53.ResourceRecord{
+		route53.ResourceRecord{
+			Value: aws.String("127.0.0.1"),
+		},
+		route53.ResourceRecord{
+			Value: aws.String("127.0.0.3"),
+		},
+	}
+
+	result := flattenResourceRecords(expanded)
+
+	if result == nil {
+		t.Fatal("expected result to have value, but got nil")
+	}
+
+	if len(result) != 2 {
+		t.Fatal("expected result to have value, but got nil")
 	}
 }


### PR DESCRIPTION
Route 53 records were silently erroring out when saving the records returned
from AWS, because they weren't being presented as an array of strings like we
expected.

This PR Introduces `flattenResourceRecords` to `structure.go`, used to flatten `[]route53.ResourceRecord` into an array of strings and correctly update the local state of records. We also no longer silently ignore this error.

This basically fixes #1413, in such that the local state is updated, and subsequent applying of `destroy` will actually destroy the record. 