### PR TITLE
ec2/config: Use provided region instead of hardcoding us-west-2

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -78,7 +78,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.ec2conn = ec2.New(creds, c.Region, nil)
 
 		client.iamconn = iam.New(creds, c.Region, nil)
-		client.ec2SDKconn = awsEC2.New(&awsSDK.Config{Region: "us-west-2"})
+		client.ec2SDKconn = awsEC2.New(&awsSDK.Config{Region: c.Region})
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
This fixes recently introduced issue via https://github.com/hashicorp/terraform/pull/1398

which effectively causes following:

```
* Error creating subnet: Value (eu-west-1c) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: us-west-2a, us-west-2b, us-west-2c.
```
in case you use any region except `us-west-2`.