### PR TITLE
providers: check for empty plan after each test step

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -230,6 +230,16 @@ func testStep(
 		}
 	}
 
+	// Verify that Plan is now empty and we don't have a perpetual diff issue
+	if p, err := ctx.Plan(); err != nil {
+		return state, fmt.Errorf("Error on follow-up plan: %s", err)
+	} else {
+		if p.Diff != nil && !p.Diff.Empty() {
+			return state, fmt.Errorf(
+				"After applying this step, the plan was not empty:\n\n%s", p)
+		}
+	}
+
 	return state, err
 }
 

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -18,6 +18,8 @@ func init() {
 
 func TestTest(t *testing.T) {
 	mp := testProvider()
+	mp.DiffReturn = nil
+
 	mp.ApplyReturn = &terraform.InstanceState{
 		ID: "foo",
 	}


### PR DESCRIPTION
Each acceptance test step plays a Refresh, Plan, Apply for a given
config. This adds a follow up Plan and fails the test if it does not
come back empty. This will catch issues with perpetual, unresolvable
diffs that crop up here and there.

This is going to cause a lot of our existing acceptance tests to fail -
too many to roll into a single PR. I think the best plan is to land this
in master and then fix the failures (each of which should be catching a
legitimate provider bug) one by one until we get the provider suites
back to green.