### PR TITLE
providers/aws: fix a few more bugs in launch configs

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -474,6 +474,9 @@ func readLCBlockDevices(d *schema.ResourceData, lc *autoscaling.LaunchConfigurat
 	if err := d.Set("ebs_block_device", ibds["ebs"]); err != nil {
 		return err
 	}
+	if err := d.Set("ephemeral_block_device", ibds["ephemeral"]); err != nil {
+		return err
+	}
 	if ibds["root"] != nil {
 		if err := d.Set("root_block_device", []interface{}{ibds["root"]}); err != nil {
 			return err
@@ -489,12 +492,13 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 	map[string]interface{}, error) {
 	blockDevices := make(map[string]interface{})
 	blockDevices["ebs"] = make([]map[string]interface{}, 0)
+	blockDevices["ephemeral"] = make([]map[string]interface{}, 0)
 	blockDevices["root"] = nil
 	if len(lc.BlockDeviceMappings) == 0 {
 		return nil, nil
 	}
 	rootDeviceName, err := fetchRootDeviceName(d.Get("image_id").(string), ec2conn)
-	if err == nil {
+	if err != nil {
 		return nil, err
 	}
 	for _, bdm := range lc.BlockDeviceMappings {
@@ -503,7 +507,7 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 			bd["delete_on_termination"] = *bdm.EBS.DeleteOnTermination
 		}
 		if bdm.EBS != nil && bdm.EBS.VolumeSize != nil {
-			bd["volume_size"] = bdm.EBS.VolumeSize
+			bd["volume_size"] = *bdm.EBS.VolumeSize
 		}
 		if bdm.EBS != nil && bdm.EBS.VolumeType != nil {
 			bd["volume_type"] = *bdm.EBS.VolumeType
@@ -511,16 +515,21 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 		if bdm.EBS != nil && bdm.EBS.IOPS != nil {
 			bd["iops"] = *bdm.EBS.IOPS
 		}
-		if bdm.DeviceName != nil && bdm.DeviceName == rootDeviceName {
+		if bdm.DeviceName != nil && *bdm.DeviceName == *rootDeviceName {
 			blockDevices["root"] = bd
 		} else {
 			if bdm.DeviceName != nil {
 				bd["device_name"] = *bdm.DeviceName
 			}
-			if bdm.EBS != nil && bdm.EBS.SnapshotID != nil {
-				bd["snapshot_id"] = *bdm.EBS.SnapshotID
+			if bdm.VirtualName != nil {
+				bd["virtual_name"] = *bdm.VirtualName
+				blockDevices["ephemeral"] = append(blockDevices["ephemeral"].([]map[string]interface{}), bd)
+			} else {
+				if bdm.EBS != nil && bdm.EBS.SnapshotID != nil {
+					bd["snapshot_id"] = *bdm.EBS.SnapshotID
+				}
+				blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
 			}
-			blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
 		}
 	}
 	return blockDevices, nil


### PR DESCRIPTION
These bugs were found by additional check added in #1443

 * Reversed nil err check meant that block devices were broken :(
 * Fixing the err check revealed a few missed pointer derefs
 * Unlike instances, ephemeral block devices do come back in
   `BlockDeviceMappings` from `DescribeLaunchConfigurations` calls, so
   we need to recognize them and filter them properly. Even though
   they're not set as computed, I'm doing a `d.Set` since it doesn't
   hurt and it gives us the benefit of basic drift detection.