### PR TITLE
terraform: don't prune, but disable, inherited configs [GH-1447]

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -2258,6 +2258,29 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 	}
 }
 
+func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
+	m := testModule(t, "validate-module-pc-inherit-unused")
+	p := testProvider("aws")
+	c := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	p.ValidateFn = func(c *ResourceConfig) ([]string, []error) {
+		return nil, c.CheckSet([]string{"foo"})
+	}
+
+	w, e := c.Validate()
+	if len(w) > 0 {
+		t.Fatalf("bad: %#v", w)
+	}
+	if len(e) > 0 {
+		t.Fatalf("bad: %s", e)
+	}
+}
+
 func TestContext2Validate_orphans(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "validate-good")

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -33,6 +33,7 @@ type EvalContext interface {
 	// is used to store the provider configuration for inheritance lookups
 	// with ParentProviderConfig().
 	ConfigureProvider(string, *ResourceConfig) error
+	SetProviderConfig(string, *ResourceConfig) error
 	ParentProviderConfig(string) *ResourceConfig
 
 	// ProviderInput and SetProviderInput are used to configure providers

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -106,6 +106,15 @@ func (ctx *BuiltinEvalContext) ConfigureProvider(
 		return fmt.Errorf("Provider '%s' not initialized", n)
 	}
 
+	if err := ctx.SetProviderConfig(n, cfg); err != nil {
+		return nil
+	}
+
+	return p.Configure(cfg)
+}
+
+func (ctx *BuiltinEvalContext) SetProviderConfig(
+	n string, cfg *ResourceConfig) error {
 	providerPath := make([]string, len(ctx.Path())+1)
 	copy(providerPath, ctx.Path())
 	providerPath[len(providerPath)-1] = n
@@ -115,7 +124,7 @@ func (ctx *BuiltinEvalContext) ConfigureProvider(
 	ctx.ProviderConfigCache[PathCacheKey(providerPath)] = cfg
 	ctx.ProviderLock.Unlock()
 
-	return p.Configure(cfg)
+	return nil
 }
 
 func (ctx *BuiltinEvalContext) ProviderInput(n string) map[string]interface{} {

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -38,6 +38,10 @@ type MockEvalContext struct {
 	ConfigureProviderConfig *ResourceConfig
 	ConfigureProviderError  error
 
+	SetProviderConfigCalled bool
+	SetProviderConfigName   string
+	SetProviderConfigConfig *ResourceConfig
+
 	ParentProviderConfigCalled bool
 	ParentProviderConfigName   string
 	ParentProviderConfigConfig *ResourceConfig
@@ -105,6 +109,14 @@ func (c *MockEvalContext) ConfigureProvider(n string, cfg *ResourceConfig) error
 	c.ConfigureProviderName = n
 	c.ConfigureProviderConfig = cfg
 	return c.ConfigureProviderError
+}
+
+func (c *MockEvalContext) SetProviderConfig(
+	n string, cfg *ResourceConfig) error {
+	c.SetProviderConfigCalled = true
+	c.SetProviderConfigName = n
+	c.SetProviderConfigConfig = cfg
+	return nil
 }
 
 func (c *MockEvalContext) ParentProviderConfig(n string) *ResourceConfig {

--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -6,6 +6,17 @@ import (
 	"github.com/hashicorp/terraform/config"
 )
 
+// EvalSetProviderConfig sets the parent configuration for a provider
+// without configuring that provider, validating it, etc.
+type EvalSetProviderConfig struct {
+	Provider string
+	Config   **ResourceConfig
+}
+
+func (n *EvalSetProviderConfig) Eval(ctx EvalContext) (interface{}, error) {
+	return nil, ctx.SetProviderConfig(n.Provider, *n.Config)
+}
+
 // EvalBuildProviderConfig outputs a *ResourceConfig that is properly
 // merged with parents and inputs on top of what is configured in the file.
 type EvalBuildProviderConfig struct {

--- a/terraform/graph_config_node.go
+++ b/terraform/graph_config_node.go
@@ -209,6 +209,11 @@ func (n *GraphNodeConfigProvider) ProviderName() string {
 	return n.Provider.Name
 }
 
+// GraphNodeProvider implementation
+func (n *GraphNodeConfigProvider) ProviderConfig() *config.RawConfig {
+	return n.Provider.RawConfig
+}
+
 // GraphNodeDotter impl.
 func (n *GraphNodeConfigProvider) Dot(name string) string {
 	return fmt.Sprintf(

--- a/terraform/test-fixtures/validate-module-pc-inherit-unused/child/main.tf
+++ b/terraform/test-fixtures/validate-module-pc-inherit-unused/child/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "foo" {}

--- a/terraform/test-fixtures/validate-module-pc-inherit-unused/main.tf
+++ b/terraform/test-fixtures/validate-module-pc-inherit-unused/main.tf
@@ -1,0 +1,7 @@
+module "child" {
+    source = "./child"
+}
+
+provider "aws" {
+    foo = "set"
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -172,6 +172,10 @@ func (n *graphNodeDisabledProvider) EvalTree() EvalNode {
 	}
 }
 
+func (n *graphNodeDisabledProvider) Name() string {
+	return fmt.Sprintf("%s (disabled)", dag.VertexName(n.GraphNodeProvider))
+}
+
 type graphNodeMissingProvider struct {
 	ProviderNameValue string
 }

--- a/terraform/transform_provider_test.go
+++ b/terraform/transform_provider_test.go
@@ -217,6 +217,8 @@ provider.foo
 
 const testTransformDisableProviderBasicStr = `
 module.child
+  provider.aws (disabled)
+provider.aws (disabled)
 `
 
 const testTransformDisableProviderKeepStr = `


### PR DESCRIPTION
Fixes #1447 

This modifies my fix for #1380: we no longer _remove_ the provider nodes, but instead we replace them with disabled versions. The disabled version just sets the config for the parent lookup but doesn't do any validation.