### PR TITLE
terraform: copy RawConfigs to avoid races

### DIFF
--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"encoding/gob"
+	"sync"
 
 	"github.com/hashicorp/terraform/config/lang"
 	"github.com/hashicorp/terraform/config/lang/ast"
@@ -31,6 +32,7 @@ type RawConfig struct {
 	Interpolations []ast.Node
 	Variables      map[string]InterpolatedVariable
 
+	lock        sync.Mutex
 	config      map[string]interface{}
 	unknownKeys []string
 }
@@ -46,6 +48,19 @@ func NewRawConfig(raw map[string]interface{}) (*RawConfig, error) {
 	return result, nil
 }
 
+// Copy returns a copy of this RawConfig, uninterpolated.
+func (r *RawConfig) Copy() *RawConfig {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	result, err := NewRawConfig(r.Raw)
+	if err != nil {
+		panic("copy failed: " + err.Error())
+	}
+
+	return result
+}
+
 // Value returns the value of the configuration if this configuration
 // has a Key set. If this does not have a Key set, nil will be returned.
 func (r *RawConfig) Value() interface{} {
@@ -55,6 +70,8 @@ func (r *RawConfig) Value() interface{} {
 		}
 	}
 
+	r.lock.Lock()
+	defer r.lock.Unlock()
 	return r.Raw[r.Key]
 }
 
@@ -81,6 +98,9 @@ func (r *RawConfig) Config() map[string]interface{} {
 //
 // If a variable key is missing, this will panic.
 func (r *RawConfig) Interpolate(vs map[string]ast.Variable) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	config := langEvalConfig(vs)
 	return r.interpolate(func(root ast.Node) (string, error) {
 		// We detect the variables again and check if the value of any
@@ -119,6 +139,9 @@ func (r *RawConfig) Interpolate(vs map[string]ast.Variable) error {
 // values in this config) and returns a new config. The original config
 // is not modified.
 func (r *RawConfig) Merge(other *RawConfig) *RawConfig {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	// Merge the raw configurations
 	raw := make(map[string]interface{})
 	for k, v := range r.Raw {
@@ -252,6 +275,9 @@ func (r *RawConfig) GobDecode(b []byte) error {
 // tree of interpolated variables is recomputed on decode, since it is
 // referentially transparent.
 func (r *RawConfig) GobEncode() ([]byte, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	data := gobRawConfig{
 		Key: r.Key,
 		Raw: r.Raw,

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -58,6 +58,7 @@ func (r *RawConfig) Copy() *RawConfig {
 		panic("copy failed: " + err.Error())
 	}
 
+	result.Key = r.Key
 	return result
 }
 

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -171,7 +171,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 		Output: &provider,
 	})
 	vseq.Nodes = append(vseq.Nodes, &EvalInterpolate{
-		Config:   n.Resource.RawConfig,
+		Config:   n.Resource.RawConfig.Copy(),
 		Resource: resource,
 		Output:   &resourceConfig,
 	})
@@ -189,7 +189,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 			Name:   p.Type,
 			Output: &provisioner,
 		}, &EvalInterpolate{
-			Config:   p.RawConfig,
+			Config:   p.RawConfig.Copy(),
 			Resource: resource,
 			Output:   &resourceConfig,
 		}, &EvalValidateProvisioner{
@@ -243,7 +243,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalInterpolate{
-					Config:   n.Resource.RawConfig,
+					Config:   n.Resource.RawConfig.Copy(),
 					Resource: resource,
 					Output:   &resourceConfig,
 				},
@@ -354,7 +354,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 				},
 
 				&EvalInterpolate{
-					Config:   n.Resource.RawConfig,
+					Config:   n.Resource.RawConfig.Copy(),
 					Resource: resource,
 					Output:   &resourceConfig,
 				},


### PR DESCRIPTION
Fixes #1416 probably

This adds a `Copy` method to `*config.RawConfig` that performs a parallel-safe copy. The reason this is necessary is because `*config.RawConfig.Interpolate` has a slight race in the way it reads from and writes to `r.config` at the same time. 

While I couldn't come up with a test case to prove it, I'm very confident this is what caused #1416. The key there being that in his repro, one of them _isn't interpolated at all_. I think this is because it wrote `r.config` properly but then another interpolation overwrote it with a raw version, and interpolation didnt' see those values.

I can't be 100% sure. I couldn't reproduce the bug, but looking over the code this was the only shared state that I could find anywhere. 