### PR TITLE
providers/docker: default cert_path to non-nil so input isn't asked [GH-1432]

### DIFF
--- a/builtin/providers/docker/provider.go
+++ b/builtin/providers/docker/provider.go
@@ -20,7 +20,7 @@ func Provider() terraform.ResourceProvider {
 			"cert_path": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("DOCKER_CERT_PATH", nil),
+				DefaultFunc: schema.EnvDefaultFunc("DOCKER_CERT_PATH", ""),
 				Description: "Path to directory with Docker TLS config",
 			},
 		},

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2322,6 +2322,24 @@ func TestSchemaMap_Input(t *testing.T) {
 			Err: false,
 		},
 
+		"input ignored when default function returns an empty string": {
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Default:  "",
+					Optional: true,
+				},
+			},
+
+			Input: map[string]string{
+				"availability_zone": "bar",
+			},
+
+			Result: map[string]interface{}{},
+
+			Err: false,
+		},
+
 		"input used when default function returns nil": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{


### PR DESCRIPTION
Fixes #1432 

If the default of an optional field goes to `nil`, then input is asked. We change this to `""` so that input isn't asked.