### PR TITLE
docs: fill out all provider env var configuration

### DIFF
--- a/website/source/docs/providers/atlas/index.html.markdown
+++ b/website/source/docs/providers/atlas/index.html.markdown
@@ -35,7 +35,9 @@ resource "atlas_artifact" "web" {
 The following arguments are supported:
 
 * `address` - (Optional) Atlas server endpoint. Defaults to public Atlas.
-  This is only required when using an on-premise deployment of Atlas.
+  This is only required when using an on-premise deployment of Atlas. This can
+  also be specified with the `ATLAS_ADDRESS` shell environment variable.
 
-* `token` - (Required) API token
+* `token` - (Required) API token. This can also be specified with the
+  `ATLAS_TOKEN` shell environment variable.
 

--- a/website/source/docs/providers/cloudflare/index.html.markdown
+++ b/website/source/docs/providers/cloudflare/index.html.markdown
@@ -33,7 +33,7 @@ resource "cloudflare_record" "www" {
 
 The following arguments are supported:
 
-* `email` - (Required) The email associated with the account
-* `token` - (Required) The Cloudflare API token
-
-
+* `email` - (Required) The email associated with the account. This can also be
+  specified with the `CLOUDFLARE_EMAIL` shell environment variable.
+* `token` - (Required) The Cloudflare API token. This can also be specified
+  with the `CLOUDFLARE_TOKEN` shell environment variable.

--- a/website/source/docs/providers/dme/index.html.markdown
+++ b/website/source/docs/providers/dme/index.html.markdown
@@ -35,7 +35,10 @@ resource "dme_record" "www" {
 
 The following arguments are supported:
 
-* `akey` - (Required) The DNSMadeEasy API key
-* `skey` - (Required) The DNSMadeEasy Secret key
+* `akey` - (Required) The DNSMadeEasy API key. This can also be specified with
+  the `DME_AKEY` shell environment variable.
+* `skey` - (Required) The DNSMadeEasy Secret key. This can also be specified
+  with the `DME_SKEY` shell environment variable.
 * `usesandbox` - (Optional) If true, the DNSMadeEasy sandbox will be
-  used
+  used. This can also be specified with the `DME_USESANDBOX` shell environment
+  variable.

--- a/website/source/docs/providers/do/index.html.markdown
+++ b/website/source/docs/providers/do/index.html.markdown
@@ -32,5 +32,6 @@ resource "digitalocean_droplet" "web" {
 
 The following arguments are supported:
 
-* `token` - (Required) This is the DO API token.
+* `token` - (Required) This is the DO API token. This can also be specified
+  with the `DIGITALOCEAN_TOKEN` shell environment variable.
 

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -39,10 +39,14 @@ The following keys can be used to configure the provider.
   retrieving this file are below.  The _account file_ can be "" if you
   are running terraform from a GCE instance with a properly-configured [Compute
   Engine Service Account](https://cloud.google.com/compute/docs/authentication).
+  This can also be specified with the `GOOGLE_ACCOUNT_FILE` shell environment
+  variable.
 
-* `project` - (Required) The ID of the project to apply any resources to.
+* `project` - (Required) The ID of the project to apply any resources to.  This
+  can also be specified with the `GOOGLE_PROJECT` shell environment variable.
 
-* `region` - (Required) The region to operate under.
+* `region` - (Required) The region to operate under. This can also be specified
+  with the `GOOGLE_REGION` shell environment variable.
 
 ## Authentication JSON File
 


### PR DESCRIPTION
I find env vars a lot easier to use in day-to-day practice, so it's
probably a good idea to let the users have that benefit too!