### PR TITLE
provider/aws: Fix type mismatch issue with AWS RDS

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -349,7 +349,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	arn, err := buildRDSARN(d, meta)
 	if err != nil {
 		name := "<empty>"
-		if v.DBName != "" {
+		if v.DBName != nil && *v.DBName != "" {
 			name = *v.DBName
 		}
 


### PR DESCRIPTION
Fix type mismatch (`aws.StringValue` vs `string).
Running acc. tests...