### PR TITLE
security_groups field expects a list of Group Names, not Group IDs

### DIFF
--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -74,7 +74,9 @@ The `ingress` block supports:
 * `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be used with `security_groups`.
 * `from_port` - (Required) The start port.
 * `protocol` - (Required) The protocol.
-* `security_groups` - (Optional) List of security group IDs. Cannot be used with `cidr_blocks`.
+* `security_groups` - (Optional) List of security group Group Names if using
+    EC2-Classic or the default VPC, or Group IDs if using a non-default VPC.
+    Cannot be used with `cidr_blocks`.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this ingress rule.
 * `to_port` - (Required) The end range port.
@@ -84,7 +86,9 @@ The `egress` block supports:
 * `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be used with `security_groups`.
 * `from_port` - (Required) The start port.
 * `protocol` - (Required) The protocol.
-* `security_groups` - (Optional) List of security group IDs. Cannot be used with `cidr_blocks`.
+* `security_groups` - (Optional) List of security group Group Names if using
+    EC2-Classic or the default VPC, or Group IDs if using a non-default VPC.
+    Cannot be used with `cidr_blocks`.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this egress rule.
 * `to_port` - (Required) The end range port.


### PR DESCRIPTION
Currently, the docs incorrectly state that the security_groups field within ingress/egress blocks for the aws_security_group provider expect a "List of security group IDs". If you give it Group IDs as seen in the AWS console, it will fail with message `Error authorizing security group ingress rules: Unable to find group 'sg-197f565d'`. If you give it Group Names, it will succeed.

![screen shot 2015-04-09 at 2 42 43 pm](https://cloud.githubusercontent.com/assets/8631888/7075335/bb9017c0-dec6-11e4-9bc2-118a7d105ea2.png)