### PR TITLE
provider/aws: Detect creds in AWS config

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -58,7 +58,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.region = c.Region
 
 		log.Println("[INFO] Building AWS auth structure")
-		creds := aws.Creds(c.AccessKey, c.SecretKey, c.Token)
+		creds := aws.DetectCreds(c.AccessKey, c.SecretKey, c.Token)
 
 		log.Println("[INFO] Initializing ELB connection")
 		client.elbconn = elb.New(creds, c.Region, nil)
@@ -76,9 +76,13 @@ func (c *Config) Client() (interface{}, error) {
 		client.r53conn = route53.New(creds, "us-east-1", nil)
 		log.Println("[INFO] Initializing EC2 Connection")
 		client.ec2conn = ec2.New(creds, c.Region, nil)
-
 		client.iamconn = iam.New(creds, c.Region, nil)
-		client.ec2SDKconn = awsEC2.New(&awsSDK.Config{Region: c.Region})
+
+		sdkCreds := awsSDK.DetectCreds(c.AccessKey, c.SecretKey, c.Token)
+		client.ec2SDKconn = awsEC2.New(&awsSDK.Config{
+			Credentials: sdkCreds,
+			Region:      c.Region,
+		})
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
Try detecting credentials, if they aren't magically supplied in the environment or Amazons special `~/.aws/credentials` location 

This _should_ fix #1466. 
Probably. 

Summary:
For resources using the upstream `awslabs/aws-sdk-go`, I fell through to their default `DetectCreds` setup, which always picked up my ENV vars during dev and running the test suites. If none of that is in place, and you don't have the creds elsewhere, TF never shared them with the library, so :frowning: 