### PR TITLE
terraform: return value for resource interpolation on refresh

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -193,7 +193,7 @@ func (i *Interpolater) valueResourceVar(
 	result map[string]ast.Variable) error {
 	// If we're computing all dynamic fields, then module vars count
 	// and we mark it as computed.
-	if i.Operation == walkValidate || i.Operation == walkRefresh {
+	if i.Operation == walkValidate {
 		result[n] = ast.Variable{
 			Value: config.UnknownVariableValue,
 			Type:  ast.TypeString,
@@ -353,6 +353,14 @@ func (i *Interpolater) computeResourceVariable(
 	}
 
 MISSING:
+	// If the operation is refresh, it isn't an error for a value to
+	// be unknown. Instead, we return that the value is computed so
+	// that the graph can continue to refresh other nodes. It doesn't
+	// matter because the config isn't interpolated anyways.
+	if i.Operation == walkRefresh {
+		return config.UnknownVariableValue, nil
+	}
+
 	return "", fmt.Errorf(
 		"Resource '%s' does not have attribute '%s' "+
 			"for variable '%s'",

--- a/terraform/test-fixtures/refresh-output/main.tf
+++ b/terraform/test-fixtures/refresh-output/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "web" {}
+
+output "foo" {
+    value = "${aws_instance.web.foo}"
+}


### PR DESCRIPTION
Fixes #1369 

Instead of returning UnknownVariableValue every time, attempt to return
the real value. If we don't find it, return unknown value. This fixes
removing outputs from state on refresh.