### PR TITLE
terraform: fix provider config inheritance during input

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -2927,6 +2927,35 @@ func TestContext2Input_providerVars(t *testing.T) {
 	}
 }
 
+func TestContext2Input_providerVarsModuleInherit(t *testing.T) {
+	input := new(MockUIInput)
+	m := testModule(t, "input-provider-with-vars-and-module")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		UIInput: input,
+	})
+
+	p.InputFn = func(i UIInput, c *ResourceConfig) (*ResourceConfig, error) {
+		if errs := c.CheckSet([]string{"access_key"}); len(errs) > 0 {
+			return c, errs[0]
+		}
+		return c, nil
+	}
+	p.ConfigureFn = func(c *ResourceConfig) error {
+		return nil
+	}
+
+	if err := ctx.Input(InputModeStd); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestContext2Input_varOnly(t *testing.T) {
 	input := new(MockUIInput)
 	m := testModule(t, "input-provider-vars")

--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -96,7 +96,7 @@ func (n *EvalGetProvider) Eval(ctx EvalContext) (interface{}, error) {
 type EvalInputProvider struct {
 	Name     string
 	Provider *ResourceProvider
-	Config   *config.RawConfig
+	Config   **ResourceConfig
 }
 
 func (n *EvalInputProvider) Eval(ctx EvalContext) (interface{}, error) {
@@ -105,8 +105,7 @@ func (n *EvalInputProvider) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, nil
 	}
 
-	rc := NewResourceConfig(n.Config)
-	rc.Config = make(map[string]interface{})
+	rc := *n.Config
 
 	// Wrap the input into a namespace
 	input := &PrefixUIInput{

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -22,10 +22,19 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 					Name:   n,
 					Output: &provider,
 				},
+				&EvalInterpolate{
+					Config: config,
+					Output: &resourceConfig,
+				},
+				&EvalBuildProviderConfig{
+					Provider: n,
+					Config:   &resourceConfig,
+					Output:   &resourceConfig,
+				},
 				&EvalInputProvider{
 					Name:     n,
 					Provider: &provider,
-					Config:   config,
+					Config:   &resourceConfig,
 				},
 			},
 		},

--- a/terraform/test-fixtures/input-provider-with-vars-and-module/child/main.tf
+++ b/terraform/test-fixtures/input-provider-with-vars-and-module/child/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "foo" { }

--- a/terraform/test-fixtures/input-provider-with-vars-and-module/main.tf
+++ b/terraform/test-fixtures/input-provider-with-vars-and-module/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  access_key = "abc123"
+}
+
+module "child" {
+  source = "./child"
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -151,7 +151,7 @@ func (n *graphNodeDisabledProvider) EvalTree() EvalNode {
 	var resourceConfig *ResourceConfig
 
 	return &EvalOpFilter{
-		Ops: []walkOperation{walkValidate, walkRefresh, walkPlan, walkApply},
+		Ops: []walkOperation{walkInput, walkValidate, walkRefresh, walkPlan, walkApply},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalInterpolate{


### PR DESCRIPTION
The provider config was not being properly merged across module
boundaries during the Input walk over the graph, so when a provider was
configured at the top level, resources in modules could improperly
trigger a request for input for a provider attribute that's already
defined.