### PR TITLE
provider/aws: Convert Route table and Route table association to upstream aws-sdk-go

### DIFF
--- a/builtin/providers/aws/resource_aws_main_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_main_route_table_association.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -40,18 +40,18 @@ func resourceAwsMainRouteTableAssociation() *schema.Resource {
 }
 
 func resourceAwsMainRouteTableAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 	vpcId := d.Get("vpc_id").(string)
 	routeTableId := d.Get("route_table_id").(string)
 
 	log.Printf("[INFO] Creating main route table association: %s => %s", vpcId, routeTableId)
 
-	mainAssociation, err := findMainRouteTableAssociation(ec2conn, vpcId)
+	mainAssociation, err := findMainRouteTableAssociation(conn, vpcId)
 	if err != nil {
 		return err
 	}
 
-	resp, err := ec2conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationRequest{
+	resp, err := conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{
 		AssociationID: mainAssociation.RouteTableAssociationID,
 		RouteTableID:  aws.String(routeTableId),
 	})
@@ -67,10 +67,10 @@ func resourceAwsMainRouteTableAssociationCreate(d *schema.ResourceData, meta int
 }
 
 func resourceAwsMainRouteTableAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	mainAssociation, err := findMainRouteTableAssociation(
-		ec2conn,
+		conn,
 		d.Get("vpc_id").(string))
 	if err != nil {
 		return err
@@ -88,13 +88,13 @@ func resourceAwsMainRouteTableAssociationRead(d *schema.ResourceData, meta inter
 // original_route_table_id - this needs to stay recorded as the AWS-created
 // table from VPC creation.
 func resourceAwsMainRouteTableAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 	vpcId := d.Get("vpc_id").(string)
 	routeTableId := d.Get("route_table_id").(string)
 
 	log.Printf("[INFO] Updating main route table association: %s => %s", vpcId, routeTableId)
 
-	resp, err := ec2conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationRequest{
+	resp, err := conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{
 		AssociationID: aws.String(d.Id()),
 		RouteTableID:  aws.String(routeTableId),
 	})
@@ -109,7 +109,7 @@ func resourceAwsMainRouteTableAssociationUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceAwsMainRouteTableAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 	vpcId := d.Get("vpc_id").(string)
 	originalRouteTableId := d.Get("original_route_table_id").(string)
 
@@ -117,7 +117,7 @@ func resourceAwsMainRouteTableAssociationDelete(d *schema.ResourceData, meta int
 		vpcId,
 		originalRouteTableId)
 
-	resp, err := ec2conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationRequest{
+	resp, err := conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{
 		AssociationID: aws.String(d.Id()),
 		RouteTableID:  aws.String(originalRouteTableId),
 	})
@@ -130,31 +130,31 @@ func resourceAwsMainRouteTableAssociationDelete(d *schema.ResourceData, meta int
 	return nil
 }
 
-func findMainRouteTableAssociation(ec2conn *ec2.EC2, vpcId string) (*ec2.RouteTableAssociation, error) {
-	mainRouteTable, err := findMainRouteTable(ec2conn, vpcId)
+func findMainRouteTableAssociation(conn *ec2.EC2, vpcId string) (*ec2.RouteTableAssociation, error) {
+	mainRouteTable, err := findMainRouteTable(conn, vpcId)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, a := range mainRouteTable.Associations {
 		if *a.Main {
-			return &a, nil
+			return a, nil
 		}
 	}
 	return nil, fmt.Errorf("Could not find main routing table association for VPC: %s", vpcId)
 }
 
-func findMainRouteTable(ec2conn *ec2.EC2, vpcId string) (*ec2.RouteTable, error) {
-	mainFilter := ec2.Filter{
-		aws.String("association.main"),
-		[]string{"true"},
+func findMainRouteTable(conn *ec2.EC2, vpcId string) (*ec2.RouteTable, error) {
+	mainFilter := &ec2.Filter{
+		Name:   aws.String("association.main"),
+		Values: []*string{aws.String("true")},
 	}
-	vpcFilter := ec2.Filter{
-		aws.String("vpc-id"),
-		[]string{vpcId},
+	vpcFilter := &ec2.Filter{
+		Name:   aws.String("vpc-id"),
+		Values: []*string{aws.String(vpcId)},
 	}
-	routeResp, err := ec2conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
-		Filters: []ec2.Filter{mainFilter, vpcFilter},
+	routeResp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{mainFilter, vpcFilter},
 	})
 	if err != nil {
 		return nil, err
@@ -165,5 +165,5 @@ func findMainRouteTable(ec2conn *ec2.EC2, vpcId string) (*ec2.RouteTable, error)
 			len(routeResp.RouteTables))
 	}
 
-	return &routeResp.RouteTables[0], nil
+	return routeResp.RouteTables[0], nil
 }

--- a/builtin/providers/aws/resource_aws_main_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_main_route_table_association_test.go
@@ -65,7 +65,7 @@ func testAccCheckMainRouteTableAssociation(
 			return fmt.Errorf("Not found: %s", vpcResource)
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		conn := testAccProvider.Meta().(*AWSClient).ec2SDKconn
 		mainAssociation, err := findMainRouteTableAssociation(conn, vpc.Primary.ID)
 		if err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -62,15 +62,15 @@ func resourceAwsRouteTable() *schema.Resource {
 }
 
 func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	// Create the routing table
-	createOpts := &ec2.CreateRouteTableRequest{
+	createOpts := &ec2.CreateRouteTableInput{
 		VPCID: aws.String(d.Get("vpc_id").(string)),
 	}
 	log.Printf("[DEBUG] RouteTable create config: %#v", createOpts)
 
-	resp, err := ec2conn.CreateRouteTable(createOpts)
+	resp, err := conn.CreateRouteTable(createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating route table: %s", err)
 	}
@@ -87,7 +87,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  "ready",
-		Refresh: resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id()),
+		Refresh: resourceAwsRouteTableStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -100,9 +100,9 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
-	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id())()
+	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(conn, d.Id())()
 	if err != nil {
 		return err
 	}
@@ -147,13 +147,13 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("route", route)
 
 	// Tags
-	d.Set("tags", tagsToMap(rt.Tags))
+	d.Set("tags", tagsToMapSDK(rt.Tags))
 
 	return nil
 }
 
 func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	// Check if the route set as a whole has changed
 	if d.HasChange("route") {
@@ -169,7 +169,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			log.Printf(
 				"[INFO] Deleting route from %s: %s",
 				d.Id(), m["cidr_block"].(string))
-			err := ec2conn.DeleteRoute(&ec2.DeleteRouteRequest{
+			_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
 				RouteTableID:         aws.String(d.Id()),
 				DestinationCIDRBlock: aws.String(m["cidr_block"].(string)),
 			})
@@ -186,7 +186,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 		for _, route := range nrs.List() {
 			m := route.(map[string]interface{})
 
-			opts := ec2.CreateRouteRequest{
+			opts := ec2.CreateRouteInput{
 				RouteTableID:           aws.String(d.Id()),
 				DestinationCIDRBlock:   aws.String(m["cidr_block"].(string)),
 				GatewayID:              aws.String(m["gateway_id"].(string)),
@@ -195,7 +195,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			}
 
 			log.Printf("[INFO] Creating route for %s: %#v", d.Id(), opts)
-			if err := ec2conn.CreateRoute(&opts); err != nil {
+			if _, err := conn.CreateRoute(&opts); err != nil {
 				return err
 			}
 
@@ -204,7 +204,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := setTags(ec2conn, d); err != nil {
+	if err := setTagsSDK(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
@@ -214,11 +214,11 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	// First request the routing table since we'll have to disassociate
 	// all the subnets first.
-	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id())()
+	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(conn, d.Id())()
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 	// Do all the disassociations
 	for _, a := range rt.Associations {
 		log.Printf("[INFO] Disassociating association: %s", *a.RouteTableAssociationID)
-		err := ec2conn.DisassociateRouteTable(&ec2.DisassociateRouteTableRequest{
+		_, err := conn.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
 			AssociationID: a.RouteTableAssociationID,
 		})
 		if err != nil {
@@ -240,7 +240,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 
 	// Delete the route table
 	log.Printf("[INFO] Deleting Route Table: %s", d.Id())
-	err = ec2conn.DeleteRouteTable(&ec2.DeleteRouteTableRequest{
+	_, err = conn.DeleteRouteTable(&ec2.DeleteRouteTableInput{
 		RouteTableID: aws.String(d.Id()),
 	})
 	if err != nil {
@@ -260,7 +260,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"ready"},
 		Target:  "",
-		Refresh: resourceAwsRouteTableStateRefreshFunc(ec2conn, d.Id()),
+		Refresh: resourceAwsRouteTableStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -296,8 +296,8 @@ func resourceAwsRouteTableHash(v interface{}) int {
 // a RouteTable.
 func resourceAwsRouteTableStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
-			RouteTableIDs: []string{id},
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			RouteTableIDs: []*string{aws.String(id)},
 		})
 		if err != nil {
 			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidRouteTableID.NotFound" {
@@ -314,7 +314,7 @@ func resourceAwsRouteTableStateRefreshFunc(conn *ec2.EC2, id string) resource.St
 			return nil, "", nil
 		}
 
-		rt := &resp.RouteTables[0]
+		rt := resp.RouteTables[0]
 		return rt, "ready", nil
 	}
 }

--- a/builtin/providers/aws/resource_aws_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_route_table_association.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -32,14 +32,14 @@ func resourceAwsRouteTableAssociation() *schema.Resource {
 }
 
 func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	log.Printf(
 		"[INFO] Creating route table association: %s => %s",
 		d.Get("subnet_id").(string),
 		d.Get("route_table_id").(string))
 
-	resp, err := ec2conn.AssociateRouteTable(&ec2.AssociateRouteTableRequest{
+	resp, err := conn.AssociateRouteTable(&ec2.AssociateRouteTableInput{
 		RouteTableID: aws.String(d.Get("route_table_id").(string)),
 		SubnetID:     aws.String(d.Get("subnet_id").(string)),
 	})
@@ -56,11 +56,11 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	// Get the routing table that this association belongs to
 	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(
-		ec2conn, d.Get("route_table_id").(string))()
+		conn, d.Get("route_table_id").(string))()
 	if err != nil {
 		return err
 	}
@@ -88,18 +88,18 @@ func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface
 }
 
 func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	log.Printf(
 		"[INFO] Creating route table association: %s => %s",
 		d.Get("subnet_id").(string),
 		d.Get("route_table_id").(string))
 
-	req := &ec2.ReplaceRouteTableAssociationRequest{
+	req := &ec2.ReplaceRouteTableAssociationInput{
 		AssociationID: aws.String(d.Id()),
 		RouteTableID:  aws.String(d.Get("route_table_id").(string)),
 	}
-	resp, err := ec2conn.ReplaceRouteTableAssociation(req)
+	resp, err := conn.ReplaceRouteTableAssociation(req)
 
 	if err != nil {
 		ec2err, ok := err.(aws.APIError)
@@ -119,10 +119,10 @@ func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceAwsRouteTableAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	ec2conn := meta.(*AWSClient).ec2conn
+	conn := meta.(*AWSClient).ec2SDKconn
 
 	log.Printf("[INFO] Deleting route table association: %s", d.Id())
-	err := ec2conn.DisassociateRouteTable(&ec2.DisassociateRouteTableRequest{
+	_, err := conn.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
 		AssociationID: aws.String(d.Id()),
 	})
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_association_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -38,7 +38,7 @@ func TestAccAWSRouteTableAssociation(t *testing.T) {
 }
 
 func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	conn := testAccProvider.Meta().(*AWSClient).ec2SDKconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route_table_association" {
@@ -46,8 +46,8 @@ func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
-			RouteTableIDs: []string{rs.Primary.Attributes["route_table_id"]},
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			RouteTableIDs: []*string{aws.String(rs.Primary.Attributes["route_table_id"])},
 		})
 		if err != nil {
 			// Verify the error is what we want
@@ -83,9 +83,9 @@ func testAccCheckRouteTableAssociationExists(n string, v *ec2.RouteTable) resour
 			return fmt.Errorf("No ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
-			RouteTableIDs: []string{rs.Primary.Attributes["route_table_id"]},
+		conn := testAccProvider.Meta().(*AWSClient).ec2SDKconn
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			RouteTableIDs: []*string{aws.String(rs.Primary.Attributes["route_table_id"])},
 		})
 		if err != nil {
 			return err
@@ -94,7 +94,7 @@ func testAccCheckRouteTableAssociationExists(n string, v *ec2.RouteTable) resour
 			return fmt.Errorf("RouteTable not found")
 		}
 
-		*v = resp.RouteTables[0]
+		*v = *resp.RouteTables[0]
 
 		if len(v.Associations) == 0 {
 			return fmt.Errorf("no associations")

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -18,7 +18,7 @@ func TestAccAWSRouteTable_normal(t *testing.T) {
 			return fmt.Errorf("bad routes: %#v", v.Routes)
 		}
 
-		routes := make(map[string]ec2.Route)
+		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
 			routes[*r.DestinationCIDRBlock] = r
 		}
@@ -38,7 +38,7 @@ func TestAccAWSRouteTable_normal(t *testing.T) {
 			return fmt.Errorf("bad routes: %#v", v.Routes)
 		}
 
-		routes := make(map[string]ec2.Route)
+		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
 			routes[*r.DestinationCIDRBlock] = r
 		}
@@ -90,7 +90,7 @@ func TestAccAWSRouteTable_instance(t *testing.T) {
 			return fmt.Errorf("bad routes: %#v", v.Routes)
 		}
 
-		routes := make(map[string]ec2.Route)
+		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
 			routes[*r.DestinationCIDRBlock] = r
 		}
@@ -134,7 +134,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				Config: testAccRouteTableConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-					testAccCheckTags(&route_table.Tags, "foo", "bar"),
+					testAccCheckTagsSDK(&route_table.Tags, "foo", "bar"),
 				),
 			},
 
@@ -142,8 +142,8 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				Config: testAccRouteTableConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-					testAccCheckTags(&route_table.Tags, "foo", ""),
-					testAccCheckTags(&route_table.Tags, "bar", "baz"),
+					testAccCheckTagsSDK(&route_table.Tags, "foo", ""),
+					testAccCheckTagsSDK(&route_table.Tags, "bar", "baz"),
 				),
 			},
 		},
@@ -151,7 +151,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 }
 
 func testAccCheckRouteTableDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	conn := testAccProvider.Meta().(*AWSClient).ec2SDKconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route_table" {
@@ -159,8 +159,8 @@ func testAccCheckRouteTableDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
-			RouteTableIDs: []string{rs.Primary.ID},
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			RouteTableIDs: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
 			if len(resp.RouteTables) > 0 {
@@ -194,9 +194,9 @@ func testAccCheckRouteTableExists(n string, v *ec2.RouteTable) resource.TestChec
 			return fmt.Errorf("No ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesRequest{
-			RouteTableIDs: []string{rs.Primary.ID},
+		conn := testAccProvider.Meta().(*AWSClient).ec2SDKconn
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			RouteTableIDs: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err != nil {
 			return err
@@ -205,7 +205,7 @@ func testAccCheckRouteTableExists(n string, v *ec2.RouteTable) resource.TestChec
 			return fmt.Errorf("RouteTable not found")
 		}
 
-		*v = resp.RouteTables[0]
+		*v = *resp.RouteTables[0]
 
 		return nil
 	}
@@ -222,7 +222,7 @@ func _TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 			return fmt.Errorf("bad routes: %#v", v.Routes)
 		}
 
-		routes := make(map[string]ec2.Route)
+		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
 			routes[*r.DestinationCIDRBlock] = r
 		}


### PR DESCRIPTION
Converts both Route Table, Route Table Assoc, and Main Route Table Assoc. to upstream `aws-sdk-go`, so I don't have to duplicate the method they shared.