### PR TITLE
provider/openstack: Allow Blank Region

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -111,3 +111,10 @@ func envDefaultFunc(k string) schema.SchemaDefaultFunc {
 		return nil, nil
 	}
 }
+
+func envDefaultFuncAllowMissing(k string) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		v := os.Getenv(k)
+		return v, nil
+	}
+}

--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -40,10 +40,9 @@ func testAccPreCheck(t *testing.T) {
 	}
 
 	v = os.Getenv("OS_REGION_NAME")
-	if v == "" {
-		t.Fatal("OS_REGION_NAME must be set for acceptance tests")
+	if v != "" {
+		OS_REGION_NAME = v
 	}
-	OS_REGION_NAME = v
 
 	v1 := os.Getenv("OS_IMAGE_ID")
 	v2 := os.Getenv("OS_IMAGE_NAME")

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -26,7 +26,7 @@ func resourceBlockStorageVolumeV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"size": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
@@ -20,7 +20,7 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 
 			"pool": &schema.Schema{

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -36,7 +36,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_compute_keypair_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_keypair_v2.go
@@ -19,7 +19,7 @@ func resourceComputeKeypairV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
@@ -23,7 +23,7 @@ func resourceComputeSecGroupV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
@@ -23,7 +23,7 @@ func resourceFWFirewallV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
@@ -23,7 +23,7 @@ func resourceFWPolicyV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
@@ -21,7 +21,7 @@ func resourceFWRuleV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
@@ -21,7 +21,7 @@ func resourceLBMonitorV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
@@ -24,7 +24,7 @@ func resourceLBPoolV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -61,7 +61,7 @@ func resourceLBPoolV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							ForceNew:    true,
-							DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+							DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 						},
 						"tenant_id": &schema.Schema{
 							Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
@@ -22,7 +22,7 @@ func resourceLBVipV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -21,7 +21,7 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"address": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_network_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2.go
@@ -21,7 +21,7 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
@@ -21,7 +21,7 @@ func resourceNetworkingRouterInterfaceV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"router_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -22,7 +22,7 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
@@ -22,7 +22,7 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"network_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/builtin/providers/openstack/resource_openstack_objectstorage_container_v1.go
@@ -20,7 +20,7 @@ func resourceObjectStorageContainerV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
When OS_REGION_NAME is not set, fall back to a blank string. This
will cause gophercloud to use the cloud's only region in
single-region clouds.

Fixes: #1441 