### PR TITLE
config: Add length to built-in functions

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -23,6 +23,7 @@ func init() {
 		"element": interpolationFuncElement(),
 		"replace": interpolationFuncReplace(),
 		"split":   interpolationFuncSplit(),
+		"length":  interpolationFuncLength(),
 
 		// Concat is a little useless now since we supported embeddded
 		// interpolations but we keep it around for backwards compat reasons.
@@ -128,6 +129,28 @@ func interpolationFuncReplace() ast.Function {
 			}
 
 			return strings.Replace(s, search, replace, -1), nil
+		},
+	}
+}
+
+func interpolationFuncLength() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeInt,
+		Variadic:   false,
+		Callback: func(args []interface{}) (interface{}, error) {
+			if !strings.Contains(args[0].(string), InterpSplitDelim) {
+				return len(args[0].(string)), nil
+			}
+
+			var list []string
+			for _, arg := range args {
+				parts := strings.Split(arg.(string), InterpSplitDelim)
+				for _, part := range parts {
+					list = append(list, part)
+				}
+			}
+			return len(list), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -183,6 +183,66 @@ func TestInterpolateFuncReplace(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncLength(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			// Raw strings
+			{
+				`${length("")}`,
+				"0",
+				false,
+			},
+			{
+				`${length("a")}`,
+				"1",
+				false,
+			},
+			{
+				`${length(" ")}`,
+				"1",
+				false,
+			},
+			{
+				`${length(" a ,")}`,
+				"4",
+				false,
+			},
+			{
+				`${length("aaa")}`,
+				"3",
+				false,
+			},
+
+			// Lists
+			{
+				`${length(split(",", "a"))}`,
+				"1",
+				false,
+			},
+			{
+				`${length(split(",", "foo,"))}`,
+				"2",
+				false,
+			},
+			{
+				`${length(split(",", ",foo,"))}`,
+				"3",
+				false,
+			},
+			{
+				`${length(split(",", "foo,bar"))}`,
+				"2",
+				false,
+			},
+			{
+				`${length(split(".", "one.two.three.four.five"))}`,
+				"5",
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncSplit(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
@@ -195,6 +255,35 @@ func TestInterpolateFuncSplit(t *testing.T) {
 			{
 				`${split(",", "foo")}`,
 				"foo",
+				false,
+			},
+
+			{
+				`${split(",", ",,,")}`,
+				fmt.Sprintf(
+					"%s%s%s",
+					InterpSplitDelim,
+					InterpSplitDelim,
+					InterpSplitDelim),
+				false,
+			},
+
+			{
+				`${split(",", "foo,")}`,
+				fmt.Sprintf(
+					"%s%s",
+					"foo",
+					InterpSplitDelim),
+				false,
+			},
+
+			{
+				`${split(",", ",foo,")}`,
+				fmt.Sprintf(
+					"%s%s%s",
+					InterpSplitDelim,
+					"foo",
+					InterpSplitDelim),
 				false,
 			},
 


### PR DESCRIPTION
Related issue: #1389

I would really welcome some feedback regarding expected use-cases of this function - i.e. see the test cases and input/output.

I've taken certain assumptions about edge cases like **empty members** and **strings** generally.

1. Some people may expect `${length(split(",one,"))}` to return `3`, but I can't think of any real use case for empty strings here, so `${length(split(",one,"))}` = `1`
2. Some people may expect `${length("string")}` to return `6` instead of `1`. <del>I could try and search for `InterpSplitDelim` and if it's not there, just treat the input as string.</del> done.

Once you'll be happy with the behaviour, I can add some docs too (and describe the behaviour there as well).

I'm not entirely sure @mitchellh will want to see this implemented before a real support for arrays.