### PR TITLE
provider/aws: Convert Network ACL and helper library to upstream aws-sdk-go

### DIFF
--- a/builtin/providers/aws/network_acl_entry_test.go
+++ b/builtin/providers/aws/network_acl_entry_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/ec2"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 )
 
 func Test_expandNetworkACLEntry(t *testing.T) {
@@ -29,26 +29,26 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 	}
 	expanded, _ := expandNetworkAclEntries(input, "egress")
 
-	expected := []ec2.NetworkACLEntry{
-		ec2.NetworkACLEntry{
+	expected := []*ec2.NetworkACLEntry{
+		&ec2.NetworkACLEntry{
 			Protocol: aws.String("6"),
 			PortRange: &ec2.PortRange{
-				From: aws.Integer(22),
-				To:   aws.Integer(22),
+				From: aws.Long(22),
+				To:   aws.Long(22),
 			},
 			RuleAction: aws.String("deny"),
-			RuleNumber: aws.Integer(1),
+			RuleNumber: aws.Long(1),
 			CIDRBlock:  aws.String("0.0.0.0/0"),
 			Egress:     aws.Boolean(true),
 		},
-		ec2.NetworkACLEntry{
+		&ec2.NetworkACLEntry{
 			Protocol: aws.String("6"),
 			PortRange: &ec2.PortRange{
-				From: aws.Integer(443),
-				To:   aws.Integer(443),
+				From: aws.Long(443),
+				To:   aws.Long(443),
 			},
 			RuleAction: aws.String("deny"),
-			RuleNumber: aws.Integer(2),
+			RuleNumber: aws.Long(2),
 			CIDRBlock:  aws.String("0.0.0.0/0"),
 			Egress:     aws.Boolean(true),
 		},
@@ -65,25 +65,25 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 
 func Test_flattenNetworkACLEntry(t *testing.T) {
 
-	apiInput := []ec2.NetworkACLEntry{
-		ec2.NetworkACLEntry{
+	apiInput := []*ec2.NetworkACLEntry{
+		&ec2.NetworkACLEntry{
 			Protocol: aws.String("tcp"),
 			PortRange: &ec2.PortRange{
-				From: aws.Integer(22),
-				To:   aws.Integer(22),
+				From: aws.Long(22),
+				To:   aws.Long(22),
 			},
 			RuleAction: aws.String("deny"),
-			RuleNumber: aws.Integer(1),
+			RuleNumber: aws.Long(1),
 			CIDRBlock:  aws.String("0.0.0.0/0"),
 		},
-		ec2.NetworkACLEntry{
+		&ec2.NetworkACLEntry{
 			Protocol: aws.String("tcp"),
 			PortRange: &ec2.PortRange{
-				From: aws.Integer(443),
-				To:   aws.Integer(443),
+				From: aws.Long(443),
+				To:   aws.Long(443),
 			},
 			RuleAction: aws.String("deny"),
-			RuleNumber: aws.Integer(2),
+			RuleNumber: aws.Long(2),
 			CIDRBlock:  aws.String("0.0.0.0/0"),
 		},
 	}
@@ -92,26 +92,26 @@ func Test_flattenNetworkACLEntry(t *testing.T) {
 	expected := []map[string]interface{}{
 		map[string]interface{}{
 			"protocol":   "tcp",
-			"from_port":  22,
-			"to_port":    22,
+			"from_port":  int64(22),
+			"to_port":    int64(22),
 			"cidr_block": "0.0.0.0/0",
 			"action":     "deny",
-			"rule_no":    1,
+			"rule_no":    int64(1),
 		},
 		map[string]interface{}{
 			"protocol":   "tcp",
-			"from_port":  443,
-			"to_port":    443,
+			"from_port":  int64(443),
+			"to_port":    int64(443),
 			"cidr_block": "0.0.0.0/0",
 			"action":     "deny",
-			"rule_no":    2,
+			"rule_no":    int64(2),
 		},
 	}
 
 	if !reflect.DeepEqual(flattened, expected) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			flattened[0],
+			flattened,
 			expected)
 	}
 

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -12,7 +12,7 @@ import (
 	// "github.com/hashicorp/terraform/helper/schema"
 )
 
-func TestAccAWSNetworkAclsWithEgressAndIngressRules(t *testing.T) {
+func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 	var networkAcl ec2.NetworkACL
 
 	resource.Test(t, resource.TestCase{
@@ -54,7 +54,7 @@ func TestAccAWSNetworkAclsWithEgressAndIngressRules(t *testing.T) {
 	})
 }
 
-func TestAccAWSNetworkAclsOnlyIngressRules(t *testing.T) {
+func TestAccAWSNetworkAcl_OnlyIngressRules(t *testing.T) {
 	var networkAcl ec2.NetworkACL
 
 	resource.Test(t, resource.TestCase{
@@ -85,7 +85,7 @@ func TestAccAWSNetworkAclsOnlyIngressRules(t *testing.T) {
 	})
 }
 
-func TestAccAWSNetworkAclsOnlyIngressRulesChange(t *testing.T) {
+func TestAccAWSNetworkAcl_OnlyIngressRulesChange(t *testing.T) {
 	var networkAcl ec2.NetworkACL
 
 	resource.Test(t, resource.TestCase{
@@ -139,7 +139,7 @@ func TestAccAWSNetworkAclsOnlyIngressRulesChange(t *testing.T) {
 	})
 }
 
-func TestAccAWSNetworkAclsOnlyEgressRules(t *testing.T) {
+func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 	var networkAcl ec2.NetworkACL
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Convert AWS Network ACL and helper library to upstream