### PR TITLE
provider/aws: Convert AWS ASG to upstream aws-sdk-go

### DIFF
--- a/builtin/providers/aws/autoscaling_tags.go
+++ b/builtin/providers/aws/autoscaling_tags.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -61,23 +61,23 @@ func setAutoscalingTags(conn *autoscaling.AutoScaling, d *schema.ResourceData) e
 			autoscalingTagsFromMap(o, resourceID),
 			autoscalingTagsFromMap(n, resourceID),
 			resourceID)
-		create := autoscaling.CreateOrUpdateTagsType{
+                create := autoscaling.CreateOrUpdateTagsInput{
 			Tags: c,
 		}
-		remove := autoscaling.DeleteTagsType{
+                remove := autoscaling.DeleteTagsInput{
 			Tags: r,
 		}
 
 		// Set tags
 		if len(r) > 0 {
 			log.Printf("[DEBUG] Removing autoscaling tags: %#v", r)
-			if err := conn.DeleteTags(&remove); err != nil {
+                        if _, err := conn.DeleteTags(&remove); err != nil {
 				return err
 			}
 		}
 		if len(c) > 0 {
 			log.Printf("[DEBUG] Creating autoscaling tags: %#v", c)
-			if err := conn.CreateOrUpdateTags(&create); err != nil {
+                        if _, err := conn.CreateOrUpdateTags(&create); err != nil {
 				return err
 			}
 		}
@@ -89,7 +89,7 @@ func setAutoscalingTags(conn *autoscaling.AutoScaling, d *schema.ResourceData) e
 // diffTags takes our tags locally and the ones remotely and returns
 // the set of tags that must be created, and the set of tags that must
 // be destroyed.
-func diffAutoscalingTags(oldTags, newTags []autoscaling.Tag, resourceID string) ([]autoscaling.Tag, []autoscaling.Tag) {
+func diffAutoscalingTags(oldTags, newTags []*autoscaling.Tag, resourceID string) ([]*autoscaling.Tag, []*autoscaling.Tag) {
 	// First, we're creating everything we have
 	create := make(map[string]interface{})
 	for _, t := range newTags {
@@ -101,7 +101,7 @@ func diffAutoscalingTags(oldTags, newTags []autoscaling.Tag, resourceID string) 
 	}
 
 	// Build the list of what to remove
-	var remove []autoscaling.Tag
+        var remove []*autoscaling.Tag
 	for _, t := range oldTags {
 		old, ok := create[*t.Key].(map[string]interface{})
 
@@ -115,11 +115,11 @@ func diffAutoscalingTags(oldTags, newTags []autoscaling.Tag, resourceID string) 
 }
 
 // tagsFromMap returns the tags for the given map of data.
-func autoscalingTagsFromMap(m map[string]interface{}, resourceID string) []autoscaling.Tag {
-	result := make([]autoscaling.Tag, 0, len(m))
+func autoscalingTagsFromMap(m map[string]interface{}, resourceID string) []*autoscaling.Tag {
+        result := make([]*autoscaling.Tag, 0, len(m))
 	for k, v := range m {
 		attr := v.(map[string]interface{})
-		result = append(result, autoscaling.Tag{
+                result = append(result, &autoscaling.Tag{
 			Key:               aws.String(k),
 			Value:             aws.String(attr["value"].(string)),
 			PropagateAtLaunch: aws.Boolean(attr["propagate_at_launch"].(bool)),
@@ -132,7 +132,7 @@ func autoscalingTagsFromMap(m map[string]interface{}, resourceID string) []autos
 }
 
 // autoscalingTagsToMap turns the list of tags into a map.
-func autoscalingTagsToMap(ts []autoscaling.Tag) map[string]interface{} {
+func autoscalingTagsToMap(ts []*autoscaling.Tag) map[string]interface{} {
 	tags := make(map[string]interface{})
 	for _, t := range ts {
 		tag := map[string]interface{}{
@@ -146,9 +146,9 @@ func autoscalingTagsToMap(ts []autoscaling.Tag) map[string]interface{} {
 }
 
 // autoscalingTagDescriptionsToMap turns the list of tags into a map.
-func autoscalingTagDescriptionsToMap(ts []autoscaling.TagDescription) map[string]map[string]interface{} {
+func autoscalingTagDescriptionsToMap(ts *[]*autoscaling.TagDescription) map[string]map[string]interface{} {
 	tags := make(map[string]map[string]interface{})
-	for _, t := range ts {
+        for _, t := range *ts {
 		tag := map[string]interface{}{
 			"value":               *t.Value,
 			"propagate_at_launch": *t.PropagateAtLaunch,

--- a/builtin/providers/aws/autoscaling_tags.go
+++ b/builtin/providers/aws/autoscaling_tags.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/autoscaling"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -61,23 +61,23 @@ func setAutoscalingTags(conn *autoscaling.AutoScaling, d *schema.ResourceData) e
 			autoscalingTagsFromMap(o, resourceID),
 			autoscalingTagsFromMap(n, resourceID),
 			resourceID)
-                create := autoscaling.CreateOrUpdateTagsInput{
+		create := autoscaling.CreateOrUpdateTagsInput{
 			Tags: c,
 		}
-                remove := autoscaling.DeleteTagsInput{
+		remove := autoscaling.DeleteTagsInput{
 			Tags: r,
 		}
 
 		// Set tags
 		if len(r) > 0 {
 			log.Printf("[DEBUG] Removing autoscaling tags: %#v", r)
-                        if _, err := conn.DeleteTags(&remove); err != nil {
+			if _, err := conn.DeleteTags(&remove); err != nil {
 				return err
 			}
 		}
 		if len(c) > 0 {
 			log.Printf("[DEBUG] Creating autoscaling tags: %#v", c)
-                        if _, err := conn.CreateOrUpdateTags(&create); err != nil {
+			if _, err := conn.CreateOrUpdateTags(&create); err != nil {
 				return err
 			}
 		}
@@ -101,7 +101,7 @@ func diffAutoscalingTags(oldTags, newTags []*autoscaling.Tag, resourceID string)
 	}
 
 	// Build the list of what to remove
-        var remove []*autoscaling.Tag
+	var remove []*autoscaling.Tag
 	for _, t := range oldTags {
 		old, ok := create[*t.Key].(map[string]interface{})
 
@@ -116,10 +116,10 @@ func diffAutoscalingTags(oldTags, newTags []*autoscaling.Tag, resourceID string)
 
 // tagsFromMap returns the tags for the given map of data.
 func autoscalingTagsFromMap(m map[string]interface{}, resourceID string) []*autoscaling.Tag {
-        result := make([]*autoscaling.Tag, 0, len(m))
+	result := make([]*autoscaling.Tag, 0, len(m))
 	for k, v := range m {
 		attr := v.(map[string]interface{})
-                result = append(result, &autoscaling.Tag{
+		result = append(result, &autoscaling.Tag{
 			Key:               aws.String(k),
 			Value:             aws.String(attr["value"].(string)),
 			PropagateAtLaunch: aws.Boolean(attr["propagate_at_launch"].(bool)),
@@ -148,7 +148,7 @@ func autoscalingTagsToMap(ts []*autoscaling.Tag) map[string]interface{} {
 // autoscalingTagDescriptionsToMap turns the list of tags into a map.
 func autoscalingTagDescriptionsToMap(ts *[]*autoscaling.TagDescription) map[string]map[string]interface{} {
 	tags := make(map[string]map[string]interface{})
-        for _, t := range *ts {
+	for _, t := range *ts {
 		tag := map[string]interface{}{
 			"value":               *t.Value,
 			"propagate_at_launch": *t.PropagateAtLaunch,

--- a/builtin/providers/aws/autoscaling_tags_test.go
+++ b/builtin/providers/aws/autoscaling_tags_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-        "github.com/awslabs/aws-sdk-go/service/autoscaling"
+	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -93,9 +93,9 @@ func TestDiffAutoscalingTags(t *testing.T) {
 
 // testAccCheckTags can be used to check the tags on a resource.
 func testAccCheckAutoscalingTags(
-        ts *[]*autoscaling.TagDescription, key string, expected map[string]interface{}) resource.TestCheckFunc {
+	ts *[]*autoscaling.TagDescription, key string, expected map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-                m := autoscalingTagDescriptionsToMap(ts)
+		m := autoscalingTagDescriptionsToMap(ts)
 		v, ok := m[key]
 		if !ok {
 			return fmt.Errorf("Missing tag: %s", key)
@@ -112,7 +112,7 @@ func testAccCheckAutoscalingTags(
 
 func testAccCheckAutoscalingTagNotExists(ts *[]*autoscaling.TagDescription, key string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-                m := autoscalingTagDescriptionsToMap(ts)
+		m := autoscalingTagDescriptionsToMap(ts)
 		if _, ok := m[key]; ok {
 			return fmt.Errorf("Tag exists when it should not: %s", key)
 		}

--- a/builtin/providers/aws/autoscaling_tags_test.go
+++ b/builtin/providers/aws/autoscaling_tags_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
+        "github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -93,9 +93,9 @@ func TestDiffAutoscalingTags(t *testing.T) {
 
 // testAccCheckTags can be used to check the tags on a resource.
 func testAccCheckAutoscalingTags(
-	ts *[]autoscaling.TagDescription, key string, expected map[string]interface{}) resource.TestCheckFunc {
+        ts *[]*autoscaling.TagDescription, key string, expected map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		m := autoscalingTagDescriptionsToMap(*ts)
+                m := autoscalingTagDescriptionsToMap(ts)
 		v, ok := m[key]
 		if !ok {
 			return fmt.Errorf("Missing tag: %s", key)
@@ -110,9 +110,9 @@ func testAccCheckAutoscalingTags(
 	}
 }
 
-func testAccCheckAutoscalingTagNotExists(ts *[]autoscaling.TagDescription, key string) resource.TestCheckFunc {
+func testAccCheckAutoscalingTagNotExists(ts *[]*autoscaling.TagDescription, key string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		m := autoscalingTagDescriptionsToMap(*ts)
+                m := autoscalingTagDescriptionsToMap(ts)
 		if _, ok := m[key]; ok {
 			return fmt.Errorf("Tag exists when it should not: %s", key)
 		}

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
 
 	awsSDK "github.com/awslabs/aws-sdk-go/aws"
+	awsASG "github.com/awslabs/aws-sdk-go/service/autoscaling"
 	awsEC2 "github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/awslabs/aws-sdk-go/service/rds"
@@ -30,6 +31,7 @@ type AWSClient struct {
 	ec2conn         *ec2.EC2
 	elbconn         *elb.ELB
 	autoscalingconn *autoscaling.AutoScaling
+	asgconn         *awsASG.AutoScaling
 	s3conn          *s3.S3
 	r53conn         *route53.Route53
 	region          string
@@ -91,6 +93,8 @@ func (c *Config) Client() (interface{}, error) {
 
 		log.Println("[INFO] Initializing IAM SDK Connection")
 		client.iamconn = iam.New(awsConfig)
+		log.Println("[INFO] Initializing AutoScaling SDK connection")
+		client.asgconn = awsASG.New(awsConfig)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/autoscaling"
 )
 
 func resourceAwsAutoscalingGroup() *schema.Resource {
@@ -125,14 +125,14 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 }
 
 func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).autoscalingconn
+        autoscalingconn := meta.(*AWSClient).asgconn
 
-	var autoScalingGroupOpts autoscaling.CreateAutoScalingGroupType
+        var autoScalingGroupOpts autoscaling.CreateAutoScalingGroupInput
 	autoScalingGroupOpts.AutoScalingGroupName = aws.String(d.Get("name").(string))
 	autoScalingGroupOpts.LaunchConfigurationName = aws.String(d.Get("launch_configuration").(string))
-	autoScalingGroupOpts.MinSize = aws.Integer(d.Get("min_size").(int))
-	autoScalingGroupOpts.MaxSize = aws.Integer(d.Get("max_size").(int))
-	autoScalingGroupOpts.AvailabilityZones = expandStringList(
+        autoScalingGroupOpts.MinSize = aws.Long(int64(d.Get("min_size").(int)))
+        autoScalingGroupOpts.MaxSize = aws.Long(int64(d.Get("max_size").(int)))
+        autoScalingGroupOpts.AvailabilityZones = expandStringListSDK(
 		d.Get("availability_zones").(*schema.Set).List())
 
 	if v, ok := d.GetOk("tag"); ok {
@@ -141,7 +141,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("default_cooldown"); ok {
-		autoScalingGroupOpts.DefaultCooldown = aws.Integer(v.(int))
+                autoScalingGroupOpts.DefaultCooldown = aws.Long(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("health_check_type"); ok && v.(string) != "" {
@@ -149,30 +149,34 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("desired_capacity"); ok {
-		autoScalingGroupOpts.DesiredCapacity = aws.Integer(v.(int))
+                autoScalingGroupOpts.DesiredCapacity = aws.Long(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("health_check_grace_period"); ok {
-		autoScalingGroupOpts.HealthCheckGracePeriod = aws.Integer(v.(int))
+                autoScalingGroupOpts.HealthCheckGracePeriod = aws.Long(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("load_balancers"); ok && v.(*schema.Set).Len() > 0 {
-		autoScalingGroupOpts.LoadBalancerNames = expandStringList(
+                autoScalingGroupOpts.LoadBalancerNames = expandStringListSDK(
 			v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("vpc_zone_identifier"); ok && v.(*schema.Set).Len() > 0 {
-		exp := expandStringList(v.(*schema.Set).List())
-		autoScalingGroupOpts.VPCZoneIdentifier = aws.String(strings.Join(exp, ","))
+                exp := expandStringListSDK(v.(*schema.Set).List())
+                strs := make([]string, len(exp))
+                for _, s := range exp {
+                        strs = append(strs, *s)
+                }
+                autoScalingGroupOpts.VPCZoneIdentifier = aws.String(strings.Join(strs, ","))
 	}
 
 	if v, ok := d.GetOk("termination_policies"); ok && v.(*schema.Set).Len() > 0 {
-		autoScalingGroupOpts.TerminationPolicies = expandStringList(
+                autoScalingGroupOpts.TerminationPolicies = expandStringListSDK(
 			v.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group create configuration: %#v", autoScalingGroupOpts)
-	err := autoscalingconn.CreateAutoScalingGroup(&autoScalingGroupOpts)
+        _, err := autoscalingconn.CreateAutoScalingGroup(&autoScalingGroupOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating Autoscaling Group: %s", err)
 	}
@@ -210,14 +214,14 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).autoscalingconn
+        autoscalingconn := meta.(*AWSClient).asgconn
 
-	opts := autoscaling.UpdateAutoScalingGroupType{
+        opts := autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(d.Id()),
 	}
 
 	if d.HasChange("desired_capacity") {
-		opts.DesiredCapacity = aws.Integer(d.Get("desired_capacity").(int))
+                opts.DesiredCapacity = aws.Long(int64(d.Get("desired_capacity").(int)))
 	}
 
 	if d.HasChange("launch_configuration") {
@@ -225,11 +229,11 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("min_size") {
-		opts.MinSize = aws.Integer(d.Get("min_size").(int))
+                opts.MinSize = aws.Long(int64(d.Get("min_size").(int)))
 	}
 
 	if d.HasChange("max_size") {
-		opts.MaxSize = aws.Integer(d.Get("max_size").(int))
+                opts.MaxSize = aws.Long(int64(d.Get("max_size").(int)))
 	}
 
 	if err := setAutoscalingTags(autoscalingconn, d); err != nil {
@@ -239,7 +243,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group update configuration: %#v", opts)
-	err := autoscalingconn.UpdateAutoScalingGroup(&opts)
+        _, err := autoscalingconn.UpdateAutoScalingGroup(&opts)
 	if err != nil {
 		d.Partial(true)
 		return fmt.Errorf("Error updating Autoscaling group: %s", err)
@@ -249,7 +253,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).autoscalingconn
+        autoscalingconn := meta.(*AWSClient).asgconn
 
 	// Read the autoscaling group first. If it doesn't exist, we're done.
 	// We need the group in order to check if there are instances attached.
@@ -268,7 +272,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group destroy: %v", d.Id())
-	deleteopts := autoscaling.DeleteAutoScalingGroupType{AutoScalingGroupName: aws.String(d.Id())}
+        deleteopts := autoscaling.DeleteAutoScalingGroupInput{AutoScalingGroupName: aws.String(d.Id())}
 
 	// You can force an autoscaling group to delete
 	// even if it's in the process of scaling a resource.
@@ -279,7 +283,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 		deleteopts.ForceDelete = aws.Boolean(true)
 	}
 
-	if err := autoscalingconn.DeleteAutoScalingGroup(&deleteopts); err != nil {
+        if _, err := autoscalingconn.DeleteAutoScalingGroup(&deleteopts); err != nil {
 		autoscalingerr, ok := err.(aws.APIError)
 		if ok && autoscalingerr.Code == "InvalidGroup.NotFound" {
 			return nil
@@ -298,10 +302,10 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 func getAwsAutoscalingGroup(
 	d *schema.ResourceData,
 	meta interface{}) (*autoscaling.AutoScalingGroup, error) {
-	autoscalingconn := meta.(*AWSClient).autoscalingconn
+        autoscalingconn := meta.(*AWSClient).asgconn
 
-	describeOpts := autoscaling.AutoScalingGroupNamesType{
-		AutoScalingGroupNames: []string{d.Id()},
+        describeOpts := autoscaling.DescribeAutoScalingGroupsInput{
+                AutoScalingGroupNames: []*string{aws.String(d.Id())},
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group describe configuration: %#v", describeOpts)
@@ -319,7 +323,7 @@ func getAwsAutoscalingGroup(
 	// Search for the autoscaling group
 	for idx, asc := range describeGroups.AutoScalingGroups {
 		if *asc.AutoScalingGroupName == d.Id() {
-			return &describeGroups.AutoScalingGroups[idx], nil
+                        return describeGroups.AutoScalingGroups[idx], nil
 		}
 	}
 
@@ -329,17 +333,17 @@ func getAwsAutoscalingGroup(
 }
 
 func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).autoscalingconn
+        autoscalingconn := meta.(*AWSClient).asgconn
 
 	// First, set the capacity to zero so the group will drain
 	log.Printf("[DEBUG] Reducing autoscaling group capacity to zero")
-	opts := autoscaling.UpdateAutoScalingGroupType{
+        opts := autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(d.Id()),
-		DesiredCapacity:      aws.Integer(0),
-		MinSize:              aws.Integer(0),
-		MaxSize:              aws.Integer(0),
+                DesiredCapacity:      aws.Long(0),
+                MinSize:              aws.Long(0),
+                MaxSize:              aws.Long(0),
 	}
-	if err := autoscalingconn.UpdateAutoScalingGroup(&opts); err != nil {
+        if _, err := autoscalingconn.UpdateAutoScalingGroup(&opts); err != nil {
 		return fmt.Errorf("Error setting capacity to zero to drain: %s", err)
 	}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/autoscaling"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 )
 
 func resourceAwsAutoscalingGroup() *schema.Resource {
@@ -125,14 +125,14 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 }
 
 func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{}) error {
-        autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).asgconn
 
-        var autoScalingGroupOpts autoscaling.CreateAutoScalingGroupInput
+	var autoScalingGroupOpts autoscaling.CreateAutoScalingGroupInput
 	autoScalingGroupOpts.AutoScalingGroupName = aws.String(d.Get("name").(string))
 	autoScalingGroupOpts.LaunchConfigurationName = aws.String(d.Get("launch_configuration").(string))
-        autoScalingGroupOpts.MinSize = aws.Long(int64(d.Get("min_size").(int)))
-        autoScalingGroupOpts.MaxSize = aws.Long(int64(d.Get("max_size").(int)))
-        autoScalingGroupOpts.AvailabilityZones = expandStringListSDK(
+	autoScalingGroupOpts.MinSize = aws.Long(int64(d.Get("min_size").(int)))
+	autoScalingGroupOpts.MaxSize = aws.Long(int64(d.Get("max_size").(int)))
+	autoScalingGroupOpts.AvailabilityZones = expandStringListSDK(
 		d.Get("availability_zones").(*schema.Set).List())
 
 	if v, ok := d.GetOk("tag"); ok {
@@ -141,7 +141,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("default_cooldown"); ok {
-                autoScalingGroupOpts.DefaultCooldown = aws.Long(int64(v.(int)))
+		autoScalingGroupOpts.DefaultCooldown = aws.Long(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("health_check_type"); ok && v.(string) != "" {
@@ -149,34 +149,34 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("desired_capacity"); ok {
-                autoScalingGroupOpts.DesiredCapacity = aws.Long(int64(v.(int)))
+		autoScalingGroupOpts.DesiredCapacity = aws.Long(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("health_check_grace_period"); ok {
-                autoScalingGroupOpts.HealthCheckGracePeriod = aws.Long(int64(v.(int)))
+		autoScalingGroupOpts.HealthCheckGracePeriod = aws.Long(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("load_balancers"); ok && v.(*schema.Set).Len() > 0 {
-                autoScalingGroupOpts.LoadBalancerNames = expandStringListSDK(
+		autoScalingGroupOpts.LoadBalancerNames = expandStringListSDK(
 			v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("vpc_zone_identifier"); ok && v.(*schema.Set).Len() > 0 {
-                exp := expandStringListSDK(v.(*schema.Set).List())
-                strs := make([]string, len(exp))
-                for _, s := range exp {
-                        strs = append(strs, *s)
-                }
-                autoScalingGroupOpts.VPCZoneIdentifier = aws.String(strings.Join(strs, ","))
+		exp := expandStringListSDK(v.(*schema.Set).List())
+		strs := make([]string, len(exp))
+		for _, s := range exp {
+			strs = append(strs, *s)
+		}
+		autoScalingGroupOpts.VPCZoneIdentifier = aws.String(strings.Join(strs, ","))
 	}
 
 	if v, ok := d.GetOk("termination_policies"); ok && v.(*schema.Set).Len() > 0 {
-                autoScalingGroupOpts.TerminationPolicies = expandStringListSDK(
+		autoScalingGroupOpts.TerminationPolicies = expandStringListSDK(
 			v.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group create configuration: %#v", autoScalingGroupOpts)
-        _, err := autoscalingconn.CreateAutoScalingGroup(&autoScalingGroupOpts)
+	_, err := autoscalingconn.CreateAutoScalingGroup(&autoScalingGroupOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating Autoscaling Group: %s", err)
 	}
@@ -214,14 +214,14 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{}) error {
-        autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).asgconn
 
-        opts := autoscaling.UpdateAutoScalingGroupInput{
+	opts := autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(d.Id()),
 	}
 
 	if d.HasChange("desired_capacity") {
-                opts.DesiredCapacity = aws.Long(int64(d.Get("desired_capacity").(int)))
+		opts.DesiredCapacity = aws.Long(int64(d.Get("desired_capacity").(int)))
 	}
 
 	if d.HasChange("launch_configuration") {
@@ -229,11 +229,11 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("min_size") {
-                opts.MinSize = aws.Long(int64(d.Get("min_size").(int)))
+		opts.MinSize = aws.Long(int64(d.Get("min_size").(int)))
 	}
 
 	if d.HasChange("max_size") {
-                opts.MaxSize = aws.Long(int64(d.Get("max_size").(int)))
+		opts.MaxSize = aws.Long(int64(d.Get("max_size").(int)))
 	}
 
 	if err := setAutoscalingTags(autoscalingconn, d); err != nil {
@@ -243,7 +243,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group update configuration: %#v", opts)
-        _, err := autoscalingconn.UpdateAutoScalingGroup(&opts)
+	_, err := autoscalingconn.UpdateAutoScalingGroup(&opts)
 	if err != nil {
 		d.Partial(true)
 		return fmt.Errorf("Error updating Autoscaling group: %s", err)
@@ -253,7 +253,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{}) error {
-        autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).asgconn
 
 	// Read the autoscaling group first. If it doesn't exist, we're done.
 	// We need the group in order to check if there are instances attached.
@@ -272,7 +272,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group destroy: %v", d.Id())
-        deleteopts := autoscaling.DeleteAutoScalingGroupInput{AutoScalingGroupName: aws.String(d.Id())}
+	deleteopts := autoscaling.DeleteAutoScalingGroupInput{AutoScalingGroupName: aws.String(d.Id())}
 
 	// You can force an autoscaling group to delete
 	// even if it's in the process of scaling a resource.
@@ -283,7 +283,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 		deleteopts.ForceDelete = aws.Boolean(true)
 	}
 
-        if _, err := autoscalingconn.DeleteAutoScalingGroup(&deleteopts); err != nil {
+	if _, err := autoscalingconn.DeleteAutoScalingGroup(&deleteopts); err != nil {
 		autoscalingerr, ok := err.(aws.APIError)
 		if ok && autoscalingerr.Code == "InvalidGroup.NotFound" {
 			return nil
@@ -302,10 +302,10 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 func getAwsAutoscalingGroup(
 	d *schema.ResourceData,
 	meta interface{}) (*autoscaling.AutoScalingGroup, error) {
-        autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).asgconn
 
-        describeOpts := autoscaling.DescribeAutoScalingGroupsInput{
-                AutoScalingGroupNames: []*string{aws.String(d.Id())},
+	describeOpts := autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String(d.Id())},
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group describe configuration: %#v", describeOpts)
@@ -323,7 +323,7 @@ func getAwsAutoscalingGroup(
 	// Search for the autoscaling group
 	for idx, asc := range describeGroups.AutoScalingGroups {
 		if *asc.AutoScalingGroupName == d.Id() {
-                        return describeGroups.AutoScalingGroups[idx], nil
+			return describeGroups.AutoScalingGroups[idx], nil
 		}
 	}
 
@@ -333,17 +333,17 @@ func getAwsAutoscalingGroup(
 }
 
 func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) error {
-        autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).asgconn
 
 	// First, set the capacity to zero so the group will drain
 	log.Printf("[DEBUG] Reducing autoscaling group capacity to zero")
-        opts := autoscaling.UpdateAutoScalingGroupInput{
+	opts := autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(d.Id()),
-                DesiredCapacity:      aws.Long(0),
-                MinSize:              aws.Long(0),
-                MaxSize:              aws.Long(0),
+		DesiredCapacity:      aws.Long(0),
+		MinSize:              aws.Long(0),
+		MaxSize:              aws.Long(0),
 	}
-        if _, err := autoscalingconn.UpdateAutoScalingGroup(&opts); err != nil {
+	if _, err := autoscalingconn.UpdateAutoScalingGroup(&opts); err != nil {
 		return fmt.Errorf("Error setting capacity to zero to drain: %s", err)
 	}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -5,15 +5,16 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/autoscaling"
+        hashiASG "github.com/hashicorp/aws-sdk-go/gen/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 	var group autoscaling.AutoScalingGroup
-	var lc autoscaling.LaunchConfiguration
+        var lc hashiASG.LaunchConfiguration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,7 +99,7 @@ func TestAccAWSAutoScalingGroup_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSAutoScalingGroupWithLoadBalancer(t *testing.T) {
+func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 	var group autoscaling.AutoScalingGroup
 
 	resource.Test(t, resource.TestCase{
@@ -117,7 +118,7 @@ func TestAccAWSAutoScalingGroupWithLoadBalancer(t *testing.T) {
 	})
 }
 func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
+        conn := testAccProvider.Meta().(*AWSClient).asgconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_autoscaling_group" {
@@ -126,8 +127,8 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 
 		// Try to find the Group
 		describeGroups, err := conn.DescribeAutoScalingGroups(
-			&autoscaling.AutoScalingGroupNamesType{
-				AutoScalingGroupNames: []string{rs.Primary.ID},
+                        &autoscaling.DescribeAutoScalingGroupsInput{
+                                AutoScalingGroupNames: []*string{aws.String(rs.Primary.ID)},
 			})
 
 		if err == nil {
@@ -152,7 +153,7 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 
 func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if group.AvailabilityZones[0] != "us-west-2a" {
+                if *group.AvailabilityZones[0] != "us-west-2a" {
 			return fmt.Errorf("Bad availability_zones: %s", group.AvailabilityZones[0])
 		}
 
@@ -184,7 +185,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGro
 			return fmt.Errorf("Bad launch configuration name: %s", *group.LaunchConfigurationName)
 		}
 
-		t := autoscaling.TagDescription{
+                t := &autoscaling.TagDescription{
 			Key:               aws.String("Foo"),
 			Value:             aws.String("foo-bar"),
 			PropagateAtLaunch: aws.Boolean(true),
@@ -205,7 +206,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGro
 
 func testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if group.LoadBalancerNames[0] != "foobar-terraform-test" {
+                if *group.LoadBalancerNames[0] != "foobar-terraform-test" {
 			return fmt.Errorf("Bad load_balancers: %s", group.LoadBalancerNames[0])
 		}
 
@@ -224,12 +225,12 @@ func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.AutoScal
 			return fmt.Errorf("No AutoScaling Group ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
+                conn := testAccProvider.Meta().(*AWSClient).asgconn
 
-		describeOpts := autoscaling.AutoScalingGroupNamesType{
-			AutoScalingGroupNames: []string{rs.Primary.ID},
-		}
-		describeGroups, err := conn.DescribeAutoScalingGroups(&describeOpts)
+                describeGroups, err := conn.DescribeAutoScalingGroups(
+                        &autoscaling.DescribeAutoScalingGroupsInput{
+                                AutoScalingGroupNames: []*string{aws.String(rs.Primary.ID)},
+                        })
 
 		if err != nil {
 			return err
@@ -240,13 +241,13 @@ func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.AutoScal
 			return fmt.Errorf("AutoScaling Group not found")
 		}
 
-		*group = describeGroups.AutoScalingGroups[0]
+                *group = *describeGroups.AutoScalingGroups[0]
 
 		return nil
 	}
 }
 
-func testLaunchConfigurationName(n string, lc *autoscaling.LaunchConfiguration) resource.TestCheckFunc {
+func testLaunchConfigurationName(n string, lc *hashiASG.LaunchConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -5,16 +5,16 @@ import (
 	"reflect"
 	"testing"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/autoscaling"
-        hashiASG "github.com/hashicorp/aws-sdk-go/gen/autoscaling"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/autoscaling"
+	hashiASG "github.com/hashicorp/aws-sdk-go/gen/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 	var group autoscaling.AutoScalingGroup
-        var lc hashiASG.LaunchConfiguration
+	var lc hashiASG.LaunchConfiguration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -118,7 +118,7 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 	})
 }
 func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
-        conn := testAccProvider.Meta().(*AWSClient).asgconn
+	conn := testAccProvider.Meta().(*AWSClient).asgconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_autoscaling_group" {
@@ -127,8 +127,8 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 
 		// Try to find the Group
 		describeGroups, err := conn.DescribeAutoScalingGroups(
-                        &autoscaling.DescribeAutoScalingGroupsInput{
-                                AutoScalingGroupNames: []*string{aws.String(rs.Primary.ID)},
+			&autoscaling.DescribeAutoScalingGroupsInput{
+				AutoScalingGroupNames: []*string{aws.String(rs.Primary.ID)},
 			})
 
 		if err == nil {
@@ -153,7 +153,7 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 
 func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-                if *group.AvailabilityZones[0] != "us-west-2a" {
+		if *group.AvailabilityZones[0] != "us-west-2a" {
 			return fmt.Errorf("Bad availability_zones: %s", group.AvailabilityZones[0])
 		}
 
@@ -185,7 +185,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGro
 			return fmt.Errorf("Bad launch configuration name: %s", *group.LaunchConfigurationName)
 		}
 
-                t := &autoscaling.TagDescription{
+		t := &autoscaling.TagDescription{
 			Key:               aws.String("Foo"),
 			Value:             aws.String("foo-bar"),
 			PropagateAtLaunch: aws.Boolean(true),
@@ -206,7 +206,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGro
 
 func testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-                if *group.LoadBalancerNames[0] != "foobar-terraform-test" {
+		if *group.LoadBalancerNames[0] != "foobar-terraform-test" {
 			return fmt.Errorf("Bad load_balancers: %s", group.LoadBalancerNames[0])
 		}
 
@@ -225,12 +225,12 @@ func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.AutoScal
 			return fmt.Errorf("No AutoScaling Group ID is set")
 		}
 
-                conn := testAccProvider.Meta().(*AWSClient).asgconn
+		conn := testAccProvider.Meta().(*AWSClient).asgconn
 
-                describeGroups, err := conn.DescribeAutoScalingGroups(
-                        &autoscaling.DescribeAutoScalingGroupsInput{
-                                AutoScalingGroupNames: []*string{aws.String(rs.Primary.ID)},
-                        })
+		describeGroups, err := conn.DescribeAutoScalingGroups(
+			&autoscaling.DescribeAutoScalingGroupsInput{
+				AutoScalingGroupNames: []*string{aws.String(rs.Primary.ID)},
+			})
 
 		if err != nil {
 			return err
@@ -241,7 +241,7 @@ func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.AutoScal
 			return fmt.Errorf("AutoScaling Group not found")
 		}
 
-                *group = *describeGroups.AutoScalingGroups[0]
+		*group = *describeGroups.AutoScalingGroups[0]
 
 		return nil
 	}

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -154,7 +154,7 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *group.AvailabilityZones[0] != "us-west-2a" {
-			return fmt.Errorf("Bad availability_zones: %s", group.AvailabilityZones[0])
+			return fmt.Errorf("Bad availability_zones: %#v", group.AvailabilityZones[0])
 		}
 
 		if *group.AutoScalingGroupName != "foobar3-terraform-test" {
@@ -207,7 +207,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGro
 func testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *group.LoadBalancerNames[0] != "foobar-terraform-test" {
-			return fmt.Errorf("Bad load_balancers: %s", group.LoadBalancerNames[0])
+			return fmt.Errorf("Bad load_balancers: %#v", group.LoadBalancerNames[0])
 		}
 
 		return nil


### PR DESCRIPTION
Converts AWS ASG resource and companion tag library. 