### PR TITLE
core: remove dead code from pre-deposed refactor

### DIFF
--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -560,19 +560,9 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 					Name:   n.ProvidedBy()[0],
 					Output: &provider,
 				},
-				&EvalIf{
-					If: func(ctx EvalContext) (bool, error) {
-						return n.Resource.Lifecycle.CreateBeforeDestroy, nil
-					},
-					Then: &EvalReadStateTainted{
-						Name:   n.stateId(),
-						Output: &state,
-						Index:  -1,
-					},
-					Else: &EvalReadState{
-						Name:   n.stateId(),
-						Output: &state,
-					},
+				&EvalReadState{
+					Name:   n.stateId(),
+					Output: &state,
 				},
 				&EvalRequireState{
 					State: &state,


### PR DESCRIPTION
CBD used to "borrow" the last slot of of the Tainted list in the State,
but as of #1078 it uses its own list. This seems like just a block of
old code that didn't get cleaned up from the refactor. Deposed resources
get their own destroy nodes, so they don't have to mess with the main
destroy node.