### PR TITLE
core: avoid diff mismatch on NewRemoved fields during -/+

### DIFF
--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -168,6 +168,34 @@ func TestAccComputeInstance_update_deprecated_network(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_forceNewAndChangeMetadata(t *testing.T) {
+	var instance compute.Instance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstance_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						"google_compute_instance.foobar", &instance),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeInstance_forceNewAndChangeMetadata,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						"google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceMetadata(
+						&instance, "qux", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_update(t *testing.T) {
 	var instance compute.Instance
 
@@ -429,6 +457,30 @@ resource "google_compute_instance" "foobar" {
 
 	metadata {
 		foo = "bar"
+	}
+}`
+
+// Update zone to ForceNew, and change metadata k/v entirely
+// Generates diff mismatch
+const testAccComputeInstance_forceNewAndChangeMetadata = `
+resource "google_compute_instance" "foobar" {
+	name = "terraform-test"
+	machine_type = "n1-standard-1"
+	zone = "us-central1-a"
+	zone = "us-central1-b"
+	tags = ["baz"]
+
+	disk {
+		image = "debian-7-wheezy-v20140814"
+	}
+
+	network_interface {
+		network = "default"
+		access_config { }
+	}
+
+	metadata {
+		qux = "true"
 	}
 }`
 

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -407,6 +407,12 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 
 		_, ok := d2.Attributes[k]
 		if !ok {
+			// If there's no new attribute, and the old diff expected the attribute
+			// to be removed, that's just fine.
+			if diffOld.NewRemoved {
+				continue
+			}
+
 			// No exact match, but maybe this is a set containing computed
 			// values. So check if there is an approximate hash in the key
 			// and if so, try to match the key.


### PR DESCRIPTION
fixes #1508

In a DESTROY/CREATE scenario, the plan diff will be run against the
state of the old instance, while the apply diff will be run against an
empty state (because the state is cleared when the destroy node does its
thing.)

For complex attributes, this can result in keys that seem to disappear
between the two diffs, when in reality everything is working just fine.

Same() needs to take into account this scenario by analyzing NewRemoved
and treating as "Same" a diff that does indeed have that key removed.