### PR TITLE
providers/aws: set LC ID after creation

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -364,23 +364,26 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		createLaunchConfigurationOpts.BlockDeviceMappings = blockDevices
 	}
 
+	var id string
 	if v, ok := d.GetOk("name"); ok {
 		createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(v.(string))
-		d.SetId(d.Get("name").(string))
+		id = v.(string)
 	} else {
 		hash := sha1.Sum([]byte(fmt.Sprintf("%#v", createLaunchConfigurationOpts)))
-		config_name := fmt.Sprintf("terraform-%s", base64.URLEncoding.EncodeToString(hash[:]))
-		log.Printf("[DEBUG] Computed Launch config name: %s", config_name)
-		createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(config_name)
-		d.SetId(config_name)
+		configName := fmt.Sprintf("terraform-%s", base64.URLEncoding.EncodeToString(hash[:]))
+		log.Printf("[DEBUG] Computed Launch config name: %s", configName)
+		createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(configName)
+		id = configName
 	}
 
-	log.Printf("[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
+	log.Printf(
+		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
 	err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating launch configuration: %s", err)
 	}
 
+	d.SetId(id)
 	log.Printf("[INFO] launch configuration ID: %s", d.Id())
 
 	// We put a Retry here since sometimes eventual consistency bites

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -366,15 +366,14 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	var id string
 	if v, ok := d.GetOk("name"); ok {
-		createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(v.(string))
 		id = v.(string)
 	} else {
 		hash := sha1.Sum([]byte(fmt.Sprintf("%#v", createLaunchConfigurationOpts)))
 		configName := fmt.Sprintf("terraform-%s", base64.URLEncoding.EncodeToString(hash[:]))
 		log.Printf("[DEBUG] Computed Launch config name: %s", configName)
-		createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(configName)
 		id = configName
 	}
+	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(id)
 
 	log.Printf(
 		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)


### PR DESCRIPTION
This is a pretty critical bug where the LC ID is set _before_ creation. In the case creation fails, it still sets the ID. The "critical" part of this bug comes from a very specific edge case we hit on our side:

1. Create LC with name "foo"
2. Create 2nd LC with name "foo" - error creating name conflict
3. Change 2nd LC name, apply
4. Result: LC "foo" deleted 

