### PR TITLE
provider/aws: Convert Route 53 Zone, Record to upstream

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -7,9 +7,9 @@ import (
 	"github.com/hashicorp/terraform/helper/multierror"
 
 	"github.com/awslabs/aws-sdk-go/service/elb"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/hashicorp/aws-sdk-go/aws"
 	"github.com/hashicorp/aws-sdk-go/gen/ec2"
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
 
 	awsSDK "github.com/awslabs/aws-sdk-go/aws"
@@ -73,16 +73,8 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing S3 connection")
 		client.s3conn = s3.New(creds, c.Region, nil)
 
-		// aws-sdk-go uses v4 for signing requests, which requires all global
-		// endpoints to use 'us-east-1'.
-		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
-		log.Println("[INFO] Initializing Route53 connection")
-		client.r53conn = route53.New(creds, "us-east-1", nil)
 		log.Println("[INFO] Initializing EC2 Connection")
 		client.ec2conn = ec2.New(creds, c.Region, nil)
-
-		log.Println("[INFO] Initializing EC2 SDK Connection")
-		client.ec2SDKconn = awsEC2.New(awsConfig)
 
 		log.Println("[INFO] Initializing RDS SDK Connection")
 		client.rdsconn = rds.New(awsConfig)
@@ -91,6 +83,19 @@ func (c *Config) Client() (interface{}, error) {
 		client.iamconn = iam.New(awsConfig)
 		log.Println("[INFO] Initializing AutoScaling SDK connection")
 		client.autoscalingconn = autoscaling.New(awsConfig)
+
+		log.Println("[INFO] Initializing EC2 SDK Connection")
+		client.ec2SDKconn = awsEC2.New(awsConfig)
+
+		// aws-sdk-go uses v4 for signing requests, which requires all global
+		// endpoints to use 'us-east-1'.
+		// See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
+		log.Println("[INFO] Initializing Route 53 SDK connection")
+		client.r53conn = route53.New(&awsSDK.Config{
+			Credentials: sdkCreds,
+			Region:      "us-east-1",
+		})
+
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/route53"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func resourceAwsRoute53Record() *schema.Resource {
@@ -74,7 +74,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).r53conn
 	zone := cleanZoneID(d.Get("zone_id").(string))
 
-        zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
 	if err != nil {
 		return err
 	}
@@ -90,15 +90,15 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	// operation happening at the same time.
 	changeBatch := &route53.ChangeBatch{
 		Comment: aws.String("Managed by Terraform"),
-                Changes: []*route53.Change{
-                        &route53.Change{
+		Changes: []*route53.Change{
+			&route53.Change{
 				Action:            aws.String("UPSERT"),
 				ResourceRecordSet: rec,
 			},
 		},
 	}
 
-        req := &route53.ChangeResourceRecordSetsInput{
+	req := &route53.ChangeResourceRecordSetsInput{
 		HostedZoneID: aws.String(cleanZoneID(*zoneRecord.HostedZone.ID)),
 		ChangeBatch:  changeBatch,
 	}
@@ -133,7 +133,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-        changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo
+	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo
 
 	// Generate an ID
 	d.SetId(fmt.Sprintf("%s_%s_%s", zone, d.Get("name").(string), d.Get("type").(string)))
@@ -146,7 +146,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		Timeout:    30 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
-                        changeRequest := &route53.GetChangeInput{
+			changeRequest := &route53.GetChangeInput{
 				ID: aws.String(cleanChangeID(*changeInfo.ID)),
 			}
 			return resourceAwsGoRoute53Wait(conn, changeRequest)
@@ -166,13 +166,13 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	zone := cleanZoneID(d.Get("zone_id").(string))
 
 	// get expanded name
-        zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
 	if err != nil {
 		return err
 	}
 	en := expandRecordName(d.Get("name").(string), *zoneRecord.HostedZone.Name)
 
-        lopts := &route53.ListResourceRecordSetsInput{
+	lopts := &route53.ListResourceRecordSetsInput{
 		HostedZoneID:    aws.String(cleanZoneID(zone)),
 		StartRecordName: aws.String(en),
 		StartRecordType: aws.String(d.Get("type").(string)),
@@ -218,7 +218,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	zone := cleanZoneID(d.Get("zone_id").(string))
 	log.Printf("[DEBUG] Deleting resource records for zone: %s, name: %s",
 		zone, d.Get("name").(string))
-        zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
 	if err != nil {
 		return err
 	}
@@ -231,15 +231,15 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	// Create the new records
 	changeBatch := &route53.ChangeBatch{
 		Comment: aws.String("Deleted by Terraform"),
-                Changes: []*route53.Change{
-                        &route53.Change{
+		Changes: []*route53.Change{
+			&route53.Change{
 				Action:            aws.String("DELETE"),
 				ResourceRecordSet: rec,
 			},
 		},
 	}
 
-        req := &route53.ChangeResourceRecordSetsInput{
+	req := &route53.ChangeResourceRecordSetsInput{
 		HostedZoneID: aws.String(cleanZoneID(zone)),
 		ChangeBatch:  changeBatch,
 	}

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func resourceAwsRoute53Record() *schema.Resource {
@@ -74,7 +74,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).r53conn
 	zone := cleanZoneID(d.Get("zone_id").(string))
 
-	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(zone)})
+        zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
 	if err != nil {
 		return err
 	}
@@ -90,15 +90,15 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	// operation happening at the same time.
 	changeBatch := &route53.ChangeBatch{
 		Comment: aws.String("Managed by Terraform"),
-		Changes: []route53.Change{
-			route53.Change{
+                Changes: []*route53.Change{
+                        &route53.Change{
 				Action:            aws.String("UPSERT"),
 				ResourceRecordSet: rec,
 			},
 		},
 	}
 
-	req := &route53.ChangeResourceRecordSetsRequest{
+        req := &route53.ChangeResourceRecordSetsInput{
 		HostedZoneID: aws.String(cleanZoneID(*zoneRecord.HostedZone.ID)),
 		ChangeBatch:  changeBatch,
 	}
@@ -133,7 +133,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsResponse).ChangeInfo
+        changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo
 
 	// Generate an ID
 	d.SetId(fmt.Sprintf("%s_%s_%s", zone, d.Get("name").(string), d.Get("type").(string)))
@@ -146,7 +146,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		Timeout:    30 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
-			changeRequest := &route53.GetChangeRequest{
+                        changeRequest := &route53.GetChangeInput{
 				ID: aws.String(cleanChangeID(*changeInfo.ID)),
 			}
 			return resourceAwsGoRoute53Wait(conn, changeRequest)
@@ -166,13 +166,13 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	zone := cleanZoneID(d.Get("zone_id").(string))
 
 	// get expanded name
-	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(zone)})
+        zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
 	if err != nil {
 		return err
 	}
 	en := expandRecordName(d.Get("name").(string), *zoneRecord.HostedZone.Name)
 
-	lopts := &route53.ListResourceRecordSetsRequest{
+        lopts := &route53.ListResourceRecordSetsInput{
 		HostedZoneID:    aws.String(cleanZoneID(zone)),
 		StartRecordName: aws.String(en),
 		StartRecordType: aws.String(d.Get("type").(string)),
@@ -218,7 +218,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	zone := cleanZoneID(d.Get("zone_id").(string))
 	log.Printf("[DEBUG] Deleting resource records for zone: %s, name: %s",
 		zone, d.Get("name").(string))
-	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(zone)})
+        zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
 	if err != nil {
 		return err
 	}
@@ -231,15 +231,15 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	// Create the new records
 	changeBatch := &route53.ChangeBatch{
 		Comment: aws.String("Deleted by Terraform"),
-		Changes: []route53.Change{
-			route53.Change{
+                Changes: []*route53.Change{
+                        &route53.Change{
 				Action:            aws.String("DELETE"),
 				ResourceRecordSet: rec,
 			},
 		},
 	}
 
-	req := &route53.ChangeResourceRecordSetsRequest{
+        req := &route53.ChangeResourceRecordSetsInput{
 		HostedZoneID: aws.String(cleanZoneID(zone)),
 		ChangeBatch:  changeBatch,
 	}

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	route53 "github.com/hashicorp/aws-sdk-go/gen/route53"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func TestCleanRecordName(t *testing.T) {
@@ -134,7 +134,7 @@ func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 		name := parts[1]
 		rType := parts[2]
 
-		lopts := &route53.ListResourceRecordSetsRequest{
+                lopts := &route53.ListResourceRecordSetsInput{
 			HostedZoneID:    aws.String(cleanZoneID(zone)),
 			StartRecordName: aws.String(name),
 			StartRecordType: aws.String(rType),
@@ -174,7 +174,7 @@ func testAccCheckRoute53RecordExists(n string) resource.TestCheckFunc {
 
 		en := expandRecordName(name, "notexample.com")
 
-		lopts := &route53.ListResourceRecordSetsRequest{
+                lopts := &route53.ListResourceRecordSetsInput{
 			HostedZoneID:    aws.String(cleanZoneID(zone)),
 			StartRecordName: aws.String(en),
 			StartRecordType: aws.String(rType),

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/route53"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func TestCleanRecordName(t *testing.T) {
@@ -134,7 +134,7 @@ func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 		name := parts[1]
 		rType := parts[2]
 
-                lopts := &route53.ListResourceRecordSetsInput{
+		lopts := &route53.ListResourceRecordSetsInput{
 			HostedZoneID:    aws.String(cleanZoneID(zone)),
 			StartRecordName: aws.String(name),
 			StartRecordType: aws.String(rType),
@@ -174,7 +174,7 @@ func testAccCheckRoute53RecordExists(n string) resource.TestCheckFunc {
 
 		en := expandRecordName(name, "notexample.com")
 
-                lopts := &route53.ListResourceRecordSetsInput{
+		lopts := &route53.ListResourceRecordSetsInput{
 			HostedZoneID:    aws.String(cleanZoneID(zone)),
 			StartRecordName: aws.String(en),
 			StartRecordType: aws.String(rType),

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func resourceAwsRoute53Zone() *schema.Resource {
@@ -40,7 +40,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	r53 := meta.(*AWSClient).r53conn
 
 	comment := &route53.HostedZoneConfig{Comment: aws.String("Managed by Terraform")}
-	req := &route53.CreateHostedZoneRequest{
+        req := &route53.CreateHostedZoneInput{
 		Name:             aws.String(d.Get("name").(string)),
 		HostedZoneConfig: comment,
 		CallerReference:  aws.String(time.Now().Format(time.RFC3339Nano)),
@@ -65,7 +65,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 		Timeout:    10 * time.Minute,
 		MinTimeout: 2 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
-			changeRequest := &route53.GetChangeRequest{
+                        changeRequest := &route53.GetChangeInput{
 				ID: aws.String(cleanChangeID(*resp.ChangeInfo.ID)),
 			}
 			return resourceAwsGoRoute53Wait(r53, changeRequest)
@@ -80,7 +80,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
 	r53 := meta.(*AWSClient).r53conn
-	_, err := r53.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(d.Id())})
+        _, err := r53.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(d.Id())})
 	if err != nil {
 		// Handle a deleted zone
 		if r53err, ok := err.(aws.APIError); ok && r53err.Code == "NoSuchHostedZone" {
@@ -91,7 +91,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	// get tags
-	req := &route53.ListTagsForResourceRequest{
+        req := &route53.ListTagsForResourceInput{
 		ResourceID:   aws.String(d.Id()),
 		ResourceType: aws.String("hostedzone"),
 	}
@@ -101,7 +101,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	var tags []route53.Tag
+        var tags []*route53.Tag
 	if resp.ResourceTagSet != nil {
 		tags = resp.ResourceTagSet.Tags
 	}
@@ -130,7 +130,7 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",
 		d.Get("name").(string), d.Id())
-	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneRequest{ID: aws.String(d.Id())})
+        _, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{ID: aws.String(d.Id())})
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceAwsGoRoute53Wait(r53 *route53.Route53, ref *route53.GetChangeRequest) (result interface{}, state string, err error) {
+func resourceAwsGoRoute53Wait(r53 *route53.Route53, ref *route53.GetChangeInput) (result interface{}, state string, err error) {
 
 	status, err := r53.GetChange(ref)
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/route53"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func resourceAwsRoute53Zone() *schema.Resource {
@@ -40,7 +40,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	r53 := meta.(*AWSClient).r53conn
 
 	comment := &route53.HostedZoneConfig{Comment: aws.String("Managed by Terraform")}
-        req := &route53.CreateHostedZoneInput{
+	req := &route53.CreateHostedZoneInput{
 		Name:             aws.String(d.Get("name").(string)),
 		HostedZoneConfig: comment,
 		CallerReference:  aws.String(time.Now().Format(time.RFC3339Nano)),
@@ -65,7 +65,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 		Timeout:    10 * time.Minute,
 		MinTimeout: 2 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
-                        changeRequest := &route53.GetChangeInput{
+			changeRequest := &route53.GetChangeInput{
 				ID: aws.String(cleanChangeID(*resp.ChangeInfo.ID)),
 			}
 			return resourceAwsGoRoute53Wait(r53, changeRequest)
@@ -80,7 +80,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
 	r53 := meta.(*AWSClient).r53conn
-        _, err := r53.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(d.Id())})
+	_, err := r53.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(d.Id())})
 	if err != nil {
 		// Handle a deleted zone
 		if r53err, ok := err.(aws.APIError); ok && r53err.Code == "NoSuchHostedZone" {
@@ -91,7 +91,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	// get tags
-        req := &route53.ListTagsForResourceInput{
+	req := &route53.ListTagsForResourceInput{
 		ResourceID:   aws.String(d.Id()),
 		ResourceType: aws.String("hostedzone"),
 	}
@@ -101,7 +101,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-        var tags []*route53.Tag
+	var tags []*route53.Tag
 	if resp.ResourceTagSet != nil {
 		tags = resp.ResourceTagSet.Tags
 	}
@@ -130,7 +130,7 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",
 		d.Get("name").(string), d.Id())
-        _, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{ID: aws.String(d.Id())})
+	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{ID: aws.String(d.Id())})
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func TestCleanPrefix(t *testing.T) {
@@ -90,7 +90,7 @@ func testAccCheckRoute53ZoneDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(rs.Primary.ID)})
+                _, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
 		if err == nil {
 			return fmt.Errorf("Hosted zone still exists")
 		}
@@ -110,7 +110,7 @@ func testAccCheckRoute53ZoneExists(n string, zone *route53.HostedZone) resource.
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).r53conn
-		resp, err := conn.GetHostedZone(&route53.GetHostedZoneRequest{ID: aws.String(rs.Primary.ID)})
+                resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
 		if err != nil {
 			return fmt.Errorf("Hosted zone err: %v", err)
 		}
@@ -124,7 +124,7 @@ func testAccLoadTagsR53(zone *route53.HostedZone, td *route53.ResourceTagSet) re
 		conn := testAccProvider.Meta().(*AWSClient).r53conn
 
 		zone := cleanZoneID(*zone.ID)
-		req := &route53.ListTagsForResourceRequest{
+                req := &route53.ListTagsForResourceInput{
 			ResourceID:   aws.String(zone),
 			ResourceType: aws.String("hostedzone"),
 		}

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/route53"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 )
 
 func TestCleanPrefix(t *testing.T) {
@@ -90,7 +90,7 @@ func testAccCheckRoute53ZoneDestroy(s *terraform.State) error {
 			continue
 		}
 
-                _, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
+		_, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
 		if err == nil {
 			return fmt.Errorf("Hosted zone still exists")
 		}
@@ -110,7 +110,7 @@ func testAccCheckRoute53ZoneExists(n string, zone *route53.HostedZone) resource.
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).r53conn
-                resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
+		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
 		if err != nil {
 			return fmt.Errorf("Hosted zone err: %v", err)
 		}
@@ -124,7 +124,7 @@ func testAccLoadTagsR53(zone *route53.HostedZone, td *route53.ResourceTagSet) re
 		conn := testAccProvider.Meta().(*AWSClient).r53conn
 
 		zone := cleanZoneID(*zone.ID)
-                req := &route53.ListTagsForResourceInput{
+		req := &route53.ListTagsForResourceInput{
 			ResourceID:   aws.String(zone),
 			ResourceType: aws.String("hostedzone"),
 		}

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1,14 +1,12 @@
 package aws
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/aws-sdk-go/aws"
 	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/aws-sdk-go/gen/elb"
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -252,30 +250,4 @@ func flattenAttachment(a *ec2.NetworkInterfaceAttachment) map[string]interface{}
 	att["device_index"] = *a.DeviceIndex
 	att["attachment_id"] = *a.AttachmentID
 	return att
-}
-
-func flattenResourceRecords(recs []route53.ResourceRecord) []string {
-	strs := make([]string, 0, len(recs))
-	for _, r := range recs {
-		if r.Value != nil {
-			s := strings.Replace(*r.Value, "\"", "", 2)
-			strs = append(strs, s)
-		}
-	}
-	return strs
-}
-
-func expandResourceRecords(recs []interface{}, typeStr string) []route53.ResourceRecord {
-	records := make([]route53.ResourceRecord, 0, len(recs))
-	for _, r := range recs {
-		s := r.(string)
-		switch typeStr {
-		case "TXT":
-			str := fmt.Sprintf("\"%s\"", s)
-			records = append(records, route53.ResourceRecord{Value: aws.String(str)})
-		default:
-			records = append(records, route53.ResourceRecord{Value: aws.String(s)})
-		}
-	}
-	return records
 }

--- a/builtin/providers/aws/structure_sdk_test.go
+++ b/builtin/providers/aws/structure_sdk_test.go
@@ -4,10 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/awslabs/aws-sdk-go/service/elb"
 	"github.com/awslabs/aws-sdk-go/service/rds"
-	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -440,5 +441,26 @@ func TestFlattenAttachmentSDK(t *testing.T) {
 
 	if result["attachment_id"] != "at-002" {
 		t.Fatalf("expected attachment_id to be at-002, but got %s", result["attachment_id"])
+	}
+}
+
+func TestFlattenResourceRecords(t *testing.T) {
+	expanded := []*route53.ResourceRecord{
+		&route53.ResourceRecord{
+			Value: aws.String("127.0.0.1"),
+		},
+		&route53.ResourceRecord{
+			Value: aws.String("127.0.0.3"),
+		},
+	}
+
+	result := flattenResourceRecords(expanded)
+
+	if result == nil {
+		t.Fatal("expected result to have value, but got nil")
+	}
+
+	if len(result) != 2 {
+		t.Fatal("expected result to have value, but got nil")
 	}
 }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -8,7 +8,6 @@ import (
 	ec2 "github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/aws-sdk-go/gen/elb"
 	"github.com/hashicorp/aws-sdk-go/gen/rds"
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -441,26 +440,5 @@ func TestFlattenAttachment(t *testing.T) {
 
 	if result["attachment_id"] != "at-002" {
 		t.Fatalf("expected attachment_id to be at-002, but got %s", result["attachment_id"])
-	}
-}
-
-func TestFlattenResourceRecords(t *testing.T) {
-	expanded := []route53.ResourceRecord{
-		route53.ResourceRecord{
-			Value: aws.String("127.0.0.1"),
-		},
-		route53.ResourceRecord{
-			Value: aws.String("127.0.0.3"),
-		},
-	}
-
-	result := flattenResourceRecords(expanded)
-
-	if result == nil {
-		t.Fatal("expected result to have value, but got nil")
-	}
-
-	if len(result) != 2 {
-		t.Fatal("expected result to have value, but got nil")
 	}
 }

--- a/builtin/providers/aws/tags_route53.go
+++ b/builtin/providers/aws/tags_route53.go
@@ -3,8 +3,8 @@ package aws
 import (
 	"log"
 
-        "github.com/awslabs/aws-sdk-go/aws"
-        "github.com/awslabs/aws-sdk-go/service/route53"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -18,21 +18,21 @@ func setTagsR53(conn *route53.Route53, d *schema.ResourceData) error {
 		create, remove := diffTagsR53(tagsFromMapR53(o), tagsFromMapR53(n))
 
 		// Set tags
-                r := make([]*string, len(remove))
+		r := make([]*string, len(remove))
 		for i, t := range remove {
-                        r[i] = t.Key
+			r[i] = t.Key
 		}
 		log.Printf("[DEBUG] Changing tags: \n\tadding: %#v\n\tremoving:%#v", create, remove)
-                req := &route53.ChangeTagsForResourceInput{
-                        ResourceID:   aws.String(d.Id()),
-                        ResourceType: aws.String("hostedzone"),
-                }
+		req := &route53.ChangeTagsForResourceInput{
+			ResourceID:   aws.String(d.Id()),
+			ResourceType: aws.String("hostedzone"),
+		}
 
-                if len(create) > 0 {
-                        req.AddTags = create
-                }
-                if len(r) > 0 {
-                        req.RemoveTagKeys = r
+		if len(create) > 0 {
+			req.AddTags = create
+		}
+		if len(r) > 0 {
+			req.RemoveTagKeys = r
 		}
 
 		_, err := conn.ChangeTagsForResource(req)
@@ -55,7 +55,7 @@ func diffTagsR53(oldTags, newTags []*route53.Tag) ([]*route53.Tag, []*route53.Ta
 	}
 
 	// Build the list of what to remove
-        var remove []*route53.Tag
+	var remove []*route53.Tag
 	for _, t := range oldTags {
 		old, ok := create[*t.Key]
 		if !ok || old != *t.Value {
@@ -69,9 +69,9 @@ func diffTagsR53(oldTags, newTags []*route53.Tag) ([]*route53.Tag, []*route53.Ta
 
 // tagsFromMap returns the tags for the given map of data.
 func tagsFromMapR53(m map[string]interface{}) []*route53.Tag {
-        result := make([]*route53.Tag, 0, len(m))
+	result := make([]*route53.Tag, 0, len(m))
 	for k, v := range m {
-                result = append(result, &route53.Tag{
+		result = append(result, &route53.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v.(string)),
 		})

--- a/builtin/providers/aws/tags_route53.go
+++ b/builtin/providers/aws/tags_route53.go
@@ -3,8 +3,8 @@ package aws
 import (
 	"log"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
+        "github.com/awslabs/aws-sdk-go/aws"
+        "github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -18,16 +18,21 @@ func setTagsR53(conn *route53.Route53, d *schema.ResourceData) error {
 		create, remove := diffTagsR53(tagsFromMapR53(o), tagsFromMapR53(n))
 
 		// Set tags
-		r := make([]string, len(remove))
+                r := make([]*string, len(remove))
 		for i, t := range remove {
-			r[i] = *t.Key
+                        r[i] = t.Key
 		}
 		log.Printf("[DEBUG] Changing tags: \n\tadding: %#v\n\tremoving:%#v", create, remove)
-		req := &route53.ChangeTagsForResourceRequest{
-			AddTags:       create,
-			RemoveTagKeys: r,
-			ResourceID:    aws.String(d.Id()),
-			ResourceType:  aws.String("hostedzone"),
+                req := &route53.ChangeTagsForResourceInput{
+                        ResourceID:   aws.String(d.Id()),
+                        ResourceType: aws.String("hostedzone"),
+                }
+
+                if len(create) > 0 {
+                        req.AddTags = create
+                }
+                if len(r) > 0 {
+                        req.RemoveTagKeys = r
 		}
 
 		_, err := conn.ChangeTagsForResource(req)
@@ -42,7 +47,7 @@ func setTagsR53(conn *route53.Route53, d *schema.ResourceData) error {
 // diffTags takes our tags locally and the ones remotely and returns
 // the set of tags that must be created, and the set of tags that must
 // be destroyed.
-func diffTagsR53(oldTags, newTags []route53.Tag) ([]route53.Tag, []route53.Tag) {
+func diffTagsR53(oldTags, newTags []*route53.Tag) ([]*route53.Tag, []*route53.Tag) {
 	// First, we're creating everything we have
 	create := make(map[string]interface{})
 	for _, t := range newTags {
@@ -50,7 +55,7 @@ func diffTagsR53(oldTags, newTags []route53.Tag) ([]route53.Tag, []route53.Tag) 
 	}
 
 	// Build the list of what to remove
-	var remove []route53.Tag
+        var remove []*route53.Tag
 	for _, t := range oldTags {
 		old, ok := create[*t.Key]
 		if !ok || old != *t.Value {
@@ -63,10 +68,10 @@ func diffTagsR53(oldTags, newTags []route53.Tag) ([]route53.Tag, []route53.Tag) 
 }
 
 // tagsFromMap returns the tags for the given map of data.
-func tagsFromMapR53(m map[string]interface{}) []route53.Tag {
-	result := make([]route53.Tag, 0, len(m))
+func tagsFromMapR53(m map[string]interface{}) []*route53.Tag {
+        result := make([]*route53.Tag, 0, len(m))
 	for k, v := range m {
-		result = append(result, route53.Tag{
+                result = append(result, &route53.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v.(string)),
 		})
@@ -76,7 +81,7 @@ func tagsFromMapR53(m map[string]interface{}) []route53.Tag {
 }
 
 // tagsToMap turns the list of tags into a map.
-func tagsToMapR53(ts []route53.Tag) map[string]string {
+func tagsToMapR53(ts []*route53.Tag) map[string]string {
 	result := make(map[string]string)
 	for _, t := range ts {
 		result[*t.Key] = *t.Value

--- a/builtin/providers/aws/tags_route53_test.go
+++ b/builtin/providers/aws/tags_route53_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-        "github.com/awslabs/aws-sdk-go/service/route53"
+	"github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -63,7 +63,7 @@ func TestDiffTagsR53(t *testing.T) {
 
 // testAccCheckTags can be used to check the tags on a resource.
 func testAccCheckTagsR53(
-        ts *[]*route53.Tag, key string, value string) resource.TestCheckFunc {
+	ts *[]*route53.Tag, key string, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		m := tagsToMapR53(*ts)
 		v, ok := m[key]

--- a/builtin/providers/aws/tags_route53_test.go
+++ b/builtin/providers/aws/tags_route53_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/aws-sdk-go/gen/route53"
+        "github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -63,7 +63,7 @@ func TestDiffTagsR53(t *testing.T) {
 
 // testAccCheckTags can be used to check the tags on a resource.
 func testAccCheckTagsR53(
-	ts *[]route53.Tag, key string, value string) resource.TestCheckFunc {
+        ts *[]*route53.Tag, key string, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		m := tagsToMapR53(*ts)
 		v, ok := m[key]


### PR DESCRIPTION
- Converts both Route 53 Zone and Records to upstream aws-sdk-go. 
- Converts helper tag library
- Moves a Route 53 only method from `structure.go` to `structure_sdk.go`, but without the `SDK` suffix since Route53 is the only resource that uses it

- [x] Acceptance tests ~~are running~~ passed