### PR TITLE
config/lang: support math on variables through implicits

### DIFF
--- a/config/lang/eval_test.go
+++ b/config/lang/eval_test.go
@@ -135,6 +135,40 @@ func TestEval(t *testing.T) {
 		},
 
 		{
+			"foo ${bar+1}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: "41",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+			false,
+			"foo 42",
+			ast.TypeString,
+		},
+
+		{
+			"foo ${bar+baz}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: "41",
+						Type:  ast.TypeString,
+					},
+					"baz": ast.Variable{
+						Value: "1",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+			false,
+			"foo 42",
+			ast.TypeString,
+		},
+
+		{
 			"foo ${rand()}",
 			&ast.BasicScope{
 				FuncMap: map[string]ast.Function{


### PR DESCRIPTION
Fixes #1381 

We always meant for conversion to the correct numeric type to be implicit. There is an edge case though if the first operand to math ops is not a primitive: the type inference doesn't work. This fixes that issue.