### PR TITLE
AWS/Route53Zone - create private hosted zone associated with VPC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ IMPROVEMENTS:
   * provider/aws: `aws_elasticache_cluster` add support for Tags [GH-1965]
   * provider/aws: `aws_s3_bucket` exports `hosted_zone_id` and `region` [GH-1865]
   * provider/aws: `aws_route53_record` exports `fqdn` [GH-1847]
+  * provider/aws: `aws_route53_hosted_zone` can create private hosted zones [GH-1526]
   * provider/google: `google_compute_instance` `scratch` attribute added [GH-1920]
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ IMPROVEMENTS:
   * provider/aws: `aws_elasticache_cluster` add support for Tags [GH-1965]
   * provider/aws: `aws_s3_bucket` exports `hosted_zone_id` and `region` [GH-1865]
   * provider/aws: `aws_route53_record` exports `fqdn` [GH-1847]
-  * provider/aws: `aws_route53_hosted_zone` can create private hosted zones [GH-1526]
+  * provider/aws: `aws_route53_zone` can create private hosted zones [GH-1526]
   * provider/google: `google_compute_instance` `scratch` attribute added [GH-1920]
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 
   * **New config function: `formatlist`** - Format lists in a similar way to `format`.
     Useful for creating URLs from a list of IPs. [GH-1829]
+  * **New resource: `aws_route53_zone_association`**
   * provider/aws: `aws_autoscaling_group` can wait for capacity in ELB
       via `min_elb_capacity` [GH-1970]
   * provider/aws: `aws_db_instances` supports `license_model` [GH-1966]

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -115,6 +115,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_network_interface":            resourceAwsNetworkInterface(),
 			"aws_proxy_protocol_policy":        resourceAwsProxyProtocolPolicy(),
 			"aws_route53_record":               resourceAwsRoute53Record(),
+			"aws_route53_zone_association":     resourceAwsRoute53ZoneAssociation(),
 			"aws_route53_zone":                 resourceAwsRoute53Zone(),
 			"aws_route_table_association":      resourceAwsRouteTableAssociation(),
 			"aws_route_table":                  resourceAwsRouteTable(),

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -38,6 +38,7 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"zone_id": &schema.Schema{
@@ -85,6 +86,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	zone := cleanZoneID(*resp.HostedZone.ID)
 	d.Set("zone_id", zone)
 	d.SetId(zone)
+	d.Set("vpc_region", req.VPC.VPCRegion)
 
 	// Wait until we are done initializing
 	wait := resource.StateChangeConf{

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -28,6 +28,18 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"vpc_region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"zone_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -52,6 +64,15 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 		Name:             aws.String(d.Get("name").(string)),
 		HostedZoneConfig: comment,
 		CallerReference:  aws.String(time.Now().Format(time.RFC3339Nano)),
+	}
+	if v := d.Get("vpc_id"); v != nil {
+		req.VPC = &route53.VPC{
+			VPCID:     aws.String(v.(string)),
+			VPCRegion: aws.String(meta.(*AWSClient).region),
+		}
+		if w := d.Get("vpc_region"); w != nil {
+			req.VPC.VPCRegion = aws.String(w.(string))
+		}
 	}
 
 	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", *req.Name)

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -119,7 +119,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	if zone.DelegationSet != nil {
+	if ! *zone.HostedZone.Config.PrivateZone {
 		ns := make([]string, len(zone.DelegationSet.NameServers))
 		for i := range zone.DelegationSet.NameServers {
 			ns[i] = *zone.DelegationSet.NameServers[i]
@@ -130,6 +130,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		}
 	} else {
 		d.Set("name_servers", nil);
+		//TODO Verify that the configure VPC is still associated
 	}
 
 	// get tags

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -121,7 +121,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	if ! *zone.HostedZone.Config.PrivateZone {
+	if !*zone.HostedZone.Config.PrivateZone {
 		ns := make([]string, len(zone.DelegationSet.NameServers))
 		for i := range zone.DelegationSet.NameServers {
 			ns[i] = *zone.DelegationSet.NameServers[i]
@@ -131,10 +131,10 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 			return fmt.Errorf("[DEBUG] Error setting name servers for: %s, error: %#v", d.Id(), err)
 		}
 	} else {
-		d.Set("name_servers", nil);
+		d.Set("name_servers", nil)
 		var associatedVPC *route53.VPC
 		for _, vpc := range zone.VPCs {
-			if (*vpc.VPCID == d.Get("vpc_id")) {
+			if *vpc.VPCID == d.Get("vpc_id") {
 				associatedVPC = vpc
 			}
 		}

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -74,6 +74,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 		if w := d.Get("vpc_region"); w != "" {
 			req.VPC.VPCRegion = aws.String(w.(string))
 		}
+		d.Set("vpc_region", req.VPC.VPCRegion)
 	}
 
 	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", *req.Name)
@@ -86,7 +87,6 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	zone := cleanZoneID(*resp.HostedZone.ID)
 	d.Set("zone_id", zone)
 	d.SetId(zone)
-	d.Set("vpc_region", req.VPC.VPCRegion)
 
 	// Wait until we are done initializing
 	wait := resource.StateChangeConf{

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -27,9 +27,9 @@ func resourceAwsRoute53ZoneAssociation() *schema.Resource {
 				Required: true,
 			},
 
-			"region": &schema.Schema{
+			"vpc_region": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"association_id": &schema.Schema{
@@ -47,9 +47,12 @@ func resourceAwsRoute53ZoneAssociationCreate(d *schema.ResourceData, meta interf
 		HostedZoneID: aws.String(d.Get("zone_id").(string)),
 		VPC: &route53.VPC{
 			VPCID:     aws.String(d.Get("vpc_id").(string)),
-			VPCRegion: aws.String(d.Get("region").(string)),
+			VPCRegion: aws.String(meta.(*AWSClient).region),
 		},
 		Comment: aws.String("Managed by Terraform"),
+	}
+	if w := d.Get("vpc_region"); w != nil {
+		req.VPC.VPCRegion = aws.String(w.(string))
 	}
 
 	log.Printf("[DEBUG] Associating Route53 Private Zone %s with VPC %s", *req.HostedZoneID, *req.VPC.VPCID)
@@ -106,9 +109,12 @@ func resourceAwsRoute53ZoneAssociationDelete(d *schema.ResourceData, meta interf
 		HostedZoneID: aws.String(d.Get("zone_id").(string)),
 		VPC: &route53.VPC{
 			VPCID:     aws.String(d.Get("vpc_id").(string)),
-			VPCRegion: aws.String(d.Get("region").(string)),
+			VPCRegion: aws.String(meta.(*AWSClient).region),
 		},
 		Comment: aws.String("Managed by Terraform"),
+	}
+	if w := d.Get("vpc_region"); w != nil {
+		req.VPC.VPCRegion = aws.String(w.(string))
 	}
 
 	_, err := r53.DisassociateVPCFromHostedZone(req)

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -59,7 +59,7 @@ func resourceAwsRoute53ZoneAssociationCreate(d *schema.ResourceData, meta interf
 	}
 
 	// Store association id
-	association_id := *resp.ChangeInfo.ID
+	association_id := cleanChangeID(*resp.ChangeInfo.ID)
 	d.Set("association_id", association_id)
 	d.SetId(association_id)
 

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -36,7 +36,6 @@ func resourceAwsRoute53ZoneAssociation() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
 		},
 	}
 }

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -51,7 +51,7 @@ func resourceAwsRoute53ZoneAssociationCreate(d *schema.ResourceData, meta interf
 		},
 		Comment: aws.String("Managed by Terraform"),
 	}
-	if w := d.Get("vpc_region"); w != nil {
+	if w := d.Get("vpc_region"); w != "" {
 		req.VPC.VPCRegion = aws.String(w.(string))
 	}
 
@@ -113,7 +113,7 @@ func resourceAwsRoute53ZoneAssociationDelete(d *schema.ResourceData, meta interf
 		},
 		Comment: aws.String("Managed by Terraform"),
 	}
-	if w := d.Get("vpc_region"); w != nil {
+	if w := d.Get("vpc_region"); w != "" {
 		req.VPC.VPCRegion = aws.String(w.(string))
 	}
 

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -1,0 +1,120 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
+)
+
+func resourceAwsRoute53ZoneAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53ZoneAssociationCreate,
+		Read:   resourceAwsRoute53ZoneAssociationRead,
+		Update: resourceAwsRoute53ZoneAssociationUpdate,
+		Delete: resourceAwsRoute53ZoneAssociationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"association_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsRoute53ZoneAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	r53 := meta.(*AWSClient).r53conn
+
+	req := &route53.AssociateVPCWithHostedZoneInput{
+		HostedZoneID: aws.String(d.Get("zone_id").(string)),
+		VPC: &route53.VPC{
+			VPCID:     aws.String(d.Get("vpc_id").(string)),
+			VPCRegion: aws.String(d.Get("region").(string)),
+		},
+		Comment: aws.String("Managed by Terraform"),
+	}
+
+	log.Printf("[DEBUG] Associating Route53 Private Zone %s with VPC %s", *req.HostedZoneID, *req.VPC.VPCID)
+	resp, err := r53.AssociateVPCWithHostedZone(req)
+	if err != nil {
+		return err
+	}
+
+	// Store association id
+	association_id := *resp.ChangeInfo.ID
+	d.Set("association_id", association_id)
+	d.SetId(association_id)
+
+	return resourceAwsRoute53ZoneAssociationUpdate(d, meta)
+}
+
+func resourceAwsRoute53ZoneAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	r53 := meta.(*AWSClient).r53conn
+	zone, err := r53.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(d.Id())})
+	if err != nil {
+		// Handle a deleted zone
+		if r53err, ok := err.(aws.APIError); ok && r53err.Code == "NoSuchHostedZone" {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	vpc_id := d.Get("vpc_id")
+
+	for i := range zone.VPCs {
+		if vpc_id == *zone.VPCs[i].VPCID {
+			// association is there, return
+			return nil
+		}
+	}
+
+	// no association found
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsRoute53ZoneAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAwsRoute53ZoneAssociationRead(d, meta)
+}
+
+func resourceAwsRoute53ZoneAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	r53 := meta.(*AWSClient).r53conn
+
+	log.Printf("[DEBUG] Deleting Route53 Private Zone (%s) association (ID: %s)",
+		d.Get("zone_id").(string), d.Id())
+
+	req := &route53.DisassociateVPCFromHostedZoneInput{
+		HostedZoneID: aws.String(d.Get("zone_id").(string)),
+		VPC: &route53.VPC{
+			VPCID:     aws.String(d.Get("vpc_id").(string)),
+			VPCRegion: aws.String(d.Get("region").(string)),
+		},
+		Comment: aws.String("Managed by Terraform"),
+	}
+
+	_, err := r53.DisassociateVPCFromHostedZone(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -34,6 +34,7 @@ func resourceAwsRoute53ZoneAssociation() *schema.Resource {
 			"vpc_region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 		},
@@ -55,7 +56,7 @@ func resourceAwsRoute53ZoneAssociationCreate(d *schema.ResourceData, meta interf
 		req.VPC.VPCRegion = aws.String(w.(string))
 	}
 
-	log.Printf("[DEBUG] Associating Route53 Private Zone %s with VPC %s", *req.HostedZoneID, *req.VPC.VPCID)
+	log.Printf("[DEBUG] Associating Route53 Private Zone %s with VPC %s with region %s", *req.HostedZoneID, *req.VPC.VPCID, *req.VPC.VPCRegion)
 	resp, err := r53.AssociateVPCWithHostedZone(req)
 	if err != nil {
 		return err

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -62,8 +62,8 @@ func testAccCheckRoute53ZoneAssociationExists(n string, zone *route53.HostedZone
 		}
 
 		exists := false
-		for i := range resp.VPCs {
-			if rs.Primary.Meta["vpc_id"] == *resp.VPCs[i].VPCID {
+		for _, vpc := range resp.VPCs {
+			if rs.Primary.Meta["vpc_id"] == *vpc.VPCID {
 				exists = true
 			}
 		}

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -45,9 +45,9 @@ func TestAccRoute53ZoneAssociationWithRegion(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
-		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroyWithProviders(&providers),
+		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRoute53ZoneAssociationRegionConfig,

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/awslabs/aws-sdk-go/aws"
@@ -22,7 +23,36 @@ func TestAccRoute53ZoneAssociation(t *testing.T) {
 			resource.TestStep{
 				Config: testAccRoute53ZoneAssociationConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneAssociationExists("aws_route53_zone_association.main", &zone),
+					testAccCheckRoute53ZoneAssociationExists("aws_route53_zone_association.foobar", &zone),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53ZoneAssociationWithRegion(t *testing.T) {
+	var zone route53.HostedZone
+
+	// record the initialized providers so that we can use them to
+	// check for the instances in each region
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"aws": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroyWithProviders(&providers),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53ZoneAssociationRegionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneAssociationExistsWithProviders("aws_route53_zone_association.foobar", &zone, &providers),
 				),
 			},
 		},
@@ -30,15 +60,43 @@ func TestAccRoute53ZoneAssociation(t *testing.T) {
 }
 
 func testAccCheckRoute53ZoneAssociationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).r53conn
+	return testAccCheckRoute53ZoneAssociationDestroyWithProvider(s, testAccProvider)
+}
+
+func testAccCheckRoute53ZoneAssociationDestroyWithProviders(providers *[]*schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, provider := range *providers {
+			if provider.Meta() == nil {
+				continue
+			}
+			if err := testAccCheckRoute53ZoneAssociationDestroyWithProvider(s, provider); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckRoute53ZoneAssociationDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	conn := provider.Meta().(*AWSClient).r53conn
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_zone" {
+		if rs.Type != "aws_route53_zone_association" {
 			continue
 		}
 
-		_, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
-		if err == nil {
-			return fmt.Errorf("Hosted zone still exists")
+		zone_id, vpc_id := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
+
+		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone_id)})
+		if err != nil {
+			exists := false
+			for _, vpc := range resp.VPCs {
+				if vpc_id == *vpc.VPCID {
+					exists = true
+				}
+			}
+			if exists {
+				return fmt.Errorf("VPC: %v is still associated to HostedZone: %v", vpc_id, zone_id)
+			}
 		}
 	}
 	return nil
@@ -46,34 +104,54 @@ func testAccCheckRoute53ZoneAssociationDestroy(s *terraform.State) error {
 
 func testAccCheckRoute53ZoneAssociationExists(n string, zone *route53.HostedZone) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
+		return testAccCheckRoute53ZoneAssociationExistsWithProvider(s, n, zone, testAccProvider)
+	}
+}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No hosted zone ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).r53conn
-		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
-		if err != nil {
-			return fmt.Errorf("Hosted zone err: %v", err)
-		}
-
-		exists := false
-		for _, vpc := range resp.VPCs {
-			if rs.Primary.Meta["vpc_id"] == *vpc.VPCID {
-				exists = true
+func testAccCheckRoute53ZoneAssociationExistsWithProviders(n string, zone *route53.HostedZone, providers *[]*schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, provider := range *providers {
+			if provider.Meta() == nil {
+				continue
+			}
+			if err := testAccCheckRoute53ZoneAssociationExistsWithProvider(s, n, zone, provider); err != nil {
+				return err
 			}
 		}
-		if !exists {
-			return fmt.Errorf("Hosted zone association not found")
-		}
-
-		*zone = *resp.HostedZone
 		return nil
 	}
+}
+
+func testAccCheckRoute53ZoneAssociationExistsWithProvider(s *terraform.State, n string, zone *route53.HostedZone, provider *schema.Provider) error {
+	rs, ok := s.RootModule().Resources[n]
+	if !ok {
+		return fmt.Errorf("Not found: %s", n)
+	}
+
+	if rs.Primary.ID == "" {
+		return fmt.Errorf("No zone association ID is set")
+	}
+
+	zone_id, vpc_id := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
+
+	conn := provider.Meta().(*AWSClient).r53conn
+	resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone_id)})
+	if err != nil {
+		return fmt.Errorf("Hosted zone err: %v", err)
+	}
+
+	exists := false
+	for _, vpc := range resp.VPCs {
+		if vpc_id == *vpc.VPCID {
+			exists = true
+		}
+	}
+	if !exists {
+		return fmt.Errorf("Hosted zone association not found")
+	}
+
+	*zone = *resp.HostedZone
+	return nil
 }
 
 const testAccRoute53ZoneAssociationConfig = `
@@ -97,5 +175,44 @@ resource "aws_route53_zone" "foo" {
 resource "aws_route53_zone_association" "foobar" {
 	zone_id = "${aws_route53_zone.foo.id}"
 	vpc_id  = "${aws_vpc.bar.id}"
+}
+`
+
+const testAccRoute53ZoneAssociationRegionConfig = `
+provider "aws" {
+	alias = "west"
+	region = "us-west-2"
+}
+
+provider "aws" {
+	alias = "east"
+	region = "us-east-1"
+}
+
+resource "aws_vpc" "foo" {
+	provider = "aws.west"
+	cidr_block = "10.6.0.0/16"
+	enable_dns_hostnames = true
+	enable_dns_support = true
+}
+
+resource "aws_vpc" "bar" {
+	provider = "aws.east"
+	cidr_block = "10.7.0.0/16"
+	enable_dns_hostnames = true
+	enable_dns_support = true
+}
+
+resource "aws_route53_zone" "foo" {
+	provider = "aws.west"
+	name = "foo.com"
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_route53_zone_association" "foobar" {
+	provider = "aws.west"
+	zone_id = "${aws_route53_zone.foo.id}"
+	vpc_id  = "${aws_vpc.bar.id}"
+	vpc_region = "us-east-1"
 }
 `

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -77,25 +77,25 @@ func testAccCheckRoute53ZoneAssociationExists(n string, zone *route53.HostedZone
 }
 
 const testAccRoute53ZoneAssociationConfig = `
-resource "aws_vpc" "mosakos" {
+resource "aws_vpc" "foo" {
 	cidr_block = "10.6.0.0/16"
-
 	enable_dns_hostnames = true
 	enable_dns_support = true
 }
 
-resource "aws_route53_zone" "main" {
-	name = "mosakos.com"
-
-	tags {
-		foo  = "bar"
-		Name = "tf-route53-tag-test"
-	}
+resource "aws_vpc" "bar" {
+	cidr_block = "10.7.0.0/16"
+	enable_dns_hostnames = true
+	enable_dns_support = true
 }
 
-resource "aws_route53_zone_association" "main" {
-	vpc_id  = "${aws_vpc.mosakos.id}"
-	zone_id = "${aws_route53_zone.main.id}"
-	region  = "us-west-2"
+resource "aws_route53_zone" "foo" {
+	name = "foo.com"
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_route53_zone_association" "foobar" {
+	zone_id = "${aws_route53_zone.foo.id}"
+	vpc_id  = "${aws_vpc.bar.id}"
 }
 `

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -1,0 +1,101 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/route53"
+)
+
+func TestAccRoute53ZoneAssociation(t *testing.T) {
+	var zone route53.HostedZone
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53ZoneAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneAssociationExists("aws_route53_zone_association.main", &zone),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRoute53ZoneAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).r53conn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_zone" {
+			continue
+		}
+
+		_, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
+		if err == nil {
+			return fmt.Errorf("Hosted zone still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckRoute53ZoneAssociationExists(n string, zone *route53.HostedZone) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No hosted zone ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).r53conn
+		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
+		if err != nil {
+			return fmt.Errorf("Hosted zone err: %v", err)
+		}
+
+		exists := false
+		for i := range resp.VPCs {
+			if rs.Primary.Meta["vpc_id"] == *resp.VPCs[i].VPCID {
+				exists = true
+			}
+		}
+		if !exists {
+			return fmt.Errorf("Hosted zone association not found")
+		}
+
+		*zone = *resp.HostedZone
+		return nil
+	}
+}
+
+const testAccRoute53ZoneAssociationConfig = `
+resource "aws_vpc" "mosakos" {
+	cidr_block = "10.6.0.0/16"
+
+	enable_dns_hostnames = true
+	enable_dns_support = true
+}
+
+resource "aws_route53_zone" "main" {
+	name = "mosakos.com"
+
+	tags {
+		foo  = "bar"
+		Name = "tf-route53-tag-test"
+	}
+}
+
+resource "aws_route53_zone_association" "main" {
+	vpc_id  = "${aws_vpc.mosakos.id}"
+	zone_id = "${aws_route53_zone.main.id}"
+	region  = "us-west-2"
+}
+`

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/awslabs/aws-sdk-go/service/route53"
 )
 
-func TestAccRoute53ZoneAssociation(t *testing.T) {
+func TestAccRoute53ZoneAssociation_basic(t *testing.T) {
 	var zone route53.HostedZone
 
 	resource.Test(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccRoute53ZoneAssociation(t *testing.T) {
 	})
 }
 
-func TestAccRoute53ZoneAssociationWithRegion(t *testing.T) {
+func TestAccRoute53ZoneAssociation_region(t *testing.T) {
 	var zone route53.HostedZone
 
 	// record the initialized providers so that we can use them to

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -173,7 +173,7 @@ func testAccCheckRoute53ZoneAssociationExists(n string, zone *route53.GetHostedZ
 			}
 		}
 		if associatedVPC == nil {
-			return fmt.Errorf("VPC: %v is not associated to Zone: %v")
+			return fmt.Errorf("VPC: %v is not associated to Zone: %v", n, cleanZoneID(*zone.HostedZone.ID))
 		}
 		return nil
 	}

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -96,7 +96,7 @@ func TestAccRoute53PrivateZone(t *testing.T) {
 				Config: testAccRoute53PrivateZoneConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
-					testAccCheckRoute53ZoneAssociationExists("aws_vpc.main", &zone),
+					testAccCheckRoute53ZoneAssociatesWithVpc("aws_vpc.main", &zone),
 				),
 			},
 		},
@@ -155,7 +155,7 @@ func testAccCheckRoute53ZoneExists(n string, zone *route53.GetHostedZoneOutput) 
 	}
 }
 
-func testAccCheckRoute53ZoneAssociationExists(n string, zone *route53.GetHostedZoneOutput) resource.TestCheckFunc {
+func testAccCheckRoute53ZoneAssociatesWithVpc(n string, zone *route53.GetHostedZoneOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -134,16 +134,18 @@ func testAccCheckRoute53ZoneExists(n string, zone *route53.HostedZone) resource.
 			return fmt.Errorf("Hosted zone err: %v", err)
 		}
 
-		sorted_ns := make([]string, len(resp.DelegationSet.NameServers))
-		for i, ns := range resp.DelegationSet.NameServers {
-			sorted_ns[i] = *ns
-		}
-		sort.Strings(sorted_ns)
-		for idx, ns := range sorted_ns {
-			attribute := fmt.Sprintf("name_servers.%d", idx)
-			dsns := rs.Primary.Attributes[attribute]
-			if dsns != ns {
-				return fmt.Errorf("Got: %v for %v, Expected: %v", dsns, attribute, ns)
+		if resp.DelegationSet != nil {
+			sorted_ns := make([]string, len(resp.DelegationSet.NameServers))
+			for i, ns := range resp.DelegationSet.NameServers {
+				sorted_ns[i] = *ns
+			}
+			sort.Strings(sorted_ns)
+			for idx, ns := range sorted_ns {
+				attribute := fmt.Sprintf("name_servers.%d", idx)
+				dsns := rs.Primary.Attributes[attribute]
+				if dsns != ns {
+					return fmt.Errorf("Got: %v for %v, Expected: %v", dsns, attribute, ns)
+				}
 			}
 		}
 

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -84,6 +84,24 @@ func TestAccRoute53Zone(t *testing.T) {
 	})
 }
 
+func TestAccRoute53PrivateZone(t *testing.T) {
+	var zone route53.HostedZone
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53PrivateZoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRoute53ZoneDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).r53conn
 	for _, rs := range s.RootModule().Resources {
@@ -165,5 +183,19 @@ resource "aws_route53_zone" "main" {
 		foo = "bar"
 		Name = "tf-route53-tag-test"
 	}
+}
+`
+
+const testAccRoute53PrivateZoneConfig = `
+resource "aws_vpc" "main" {
+	cidr_block = "172.29.0.0/24"
+	instance_tenancy = "default"
+	enable_dns_support = true
+	enable_dns_hostnames = true
+}
+
+resource "aws_route53_zone" "main" {
+	name = "hashicorp.com"
+	vpc_id = "${aws_vpc.main.id}"
 }
 `

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -119,9 +119,9 @@ func TestAccRoute53PrivateZoneWithRegion(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
-		CheckDestroy: testAccCheckRoute53ZoneDestroyWithProviders(&providers),
+		CheckDestroy:      testAccCheckRoute53ZoneDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRoute53PrivateZoneRegionConfig,
@@ -203,7 +203,7 @@ func testAccCheckRoute53ZoneExistsWithProvider(s *terraform.State, n string, zon
 		return fmt.Errorf("Hosted zone err: %v", err)
 	}
 
-	if ! *resp.HostedZone.Config.PrivateZone {
+	if !*resp.HostedZone.Config.PrivateZone {
 		sorted_ns := make([]string, len(resp.DelegationSet.NameServers))
 		for i, ns := range resp.DelegationSet.NameServers {
 			sorted_ns[i] = *ns

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -64,7 +64,7 @@ func TestCleanChangeID(t *testing.T) {
 	}
 }
 
-func TestAccRoute53Zone(t *testing.T) {
+func TestAccRoute53Zone_basic(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 	var td route53.ResourceTagSet
 
@@ -85,7 +85,7 @@ func TestAccRoute53Zone(t *testing.T) {
 	})
 }
 
-func TestAccRoute53PrivateZone(t *testing.T) {
+func TestAccRoute53Zone_private_basic(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
 	resource.Test(t, resource.TestCase{
@@ -104,7 +104,7 @@ func TestAccRoute53PrivateZone(t *testing.T) {
 	})
 }
 
-func TestAccRoute53PrivateZoneWithRegion(t *testing.T) {
+func TestAccRoute53Zone_private_region(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
 	// record the initialized providers so that we can use them to

--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -49,6 +49,10 @@ resource "aws_route53_record" "dev-ns" {
 }
 ```
 
+~> **NOTE:** The `name_servers` set is populated only for public Hosted Zones.
+Private Zones will contain any empty set since AWS does not return a `DelegationSet`
+for private Hosted Zones.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -63,5 +67,5 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `zone_id` - The Hosted Zone ID. This can be referenced by zone records.
-* `name_servers` - A list of name servers in a default delegation set.
+* `name_servers` - A list of name servers in a default delegation set. Support only for Public Hosted Zones.
   Find more about delegation sets in [AWS docs](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-reusable-delegation-sets.html).

--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -67,5 +67,5 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `zone_id` - The Hosted Zone ID. This can be referenced by zone records.
-* `name_servers` - A list of name servers in a default delegation set. Support only for Public Hosted Zones.
+* `name_servers` - A list of name servers in a default delegation set. Supported only for Public Hosted Zones.
   Find more about delegation sets in [AWS docs](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-reusable-delegation-sets.html).

--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `name` - (Required) This is the name of the hosted zone.
 * `tags` - (Optional) A mapping of tags to assign to the zone.
+* `vpc_id` - (Optional) The VPC to associate with a private hosted zone. Specifying `vpc_id` will create a private hosted zone.
+* `vpc_region` - (Optional) The VPC's region. Defaults to the region of the AWS provider.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/route53_zone_association.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone_association.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route53_zone_association"
+sidebar_current: "docs-aws-resource-route53-zone-association"
+description: |-
+  Provides a Route53 private Hosted Zone to VPC association resource.
+---
+
+# aws\_route53\_zone\_association
+
+Provides a Route53 private Hosted Zone to VPC association resource.
+
+## Example Usage
+
+```
+resource "aws_vpc" "primary" {
+  cidr_block = "10.6.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support = true
+}
+
+resource "aws_vpc" "secondary" {
+  cidr_block = "10.7.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support = true
+}
+
+resource "aws_route53_zone" "example" {
+  name = "example.com"
+  vpc_id = "${aws_vpc.primary.id}"
+}
+
+resource "aws_route53_zone_assocation" "secondary" {
+  zone_id = "${aws_route53_zone.example.id}"
+  vpc_id = "${aws_vpc.secondary.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required) The private hosted zone to associate.
+* `vpc_id` - (Required) The VPC to associate with the private hosted zone.
+* `vpc_region` - (Optional) The VPC's region. Defaults to the region of the AWS provider.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The calculated unique identifier for the association.
+* `zone_id` - The ID of the hosted zone for the association.
+* `vpc_id` - The ID of the VPC for the association.
+* `vpc_region` - The region in which the VPC identified by `vpc_id` was created.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -144,6 +144,10 @@
 							<a href="/docs/providers/aws/r/route53_zone.html">aws_route53_zone</a>
 						</li>
 
+						<li<%= sidebar_current("docs-aws-resource-route53-zone-association") %>>
+							<a href="/docs/providers/aws/r/route53_zone_association.html">aws_route53_zone_association</a>
+						</li>
+
 						<li<%= sidebar_current("docs-aws-resource-s3-bucket") %>>
 							<a href="/docs/providers/aws/r/s3_bucket.html">aws_s3_bucket</a>
 						</li>


### PR DESCRIPTION
Add ability to create a private Hosted Zone that is associated to a VPC. 
Currently only supports a single VPC at creation time. 

Future question is how to support multiple VPCs. Amazon uses a Associate/Disassociate request, however this is problematic since you must specify one (and only one) VPC during creation.

Alternatively, we could model it as a VPC Set and and use the first entry as the entry for creating and then associate the others.