### PR TITLE
terraform: when pruning destroy, only match exact nodes, or exact counts

### DIFF
--- a/terraform/graph_config_node.go
+++ b/terraform/graph_config_node.go
@@ -555,20 +555,25 @@ func (n *graphNodeResourceDestroy) destroyIncludePrimary(
 	// decreases to "1".
 	if s != nil {
 		for k, v := range s.Resources {
-			if !strings.HasPrefix(k, prefix) {
+			// Ignore exact matches
+			if k == prefix {
+				continue
+			}
+
+			// Ignore anything that doesn't have a "." afterwards so that
+			// we only get our own resource and any counts on it.
+			if !strings.HasPrefix(k, prefix+".") {
 				continue
 			}
 
 			// Ignore exact matches and the 0'th index. We only care
 			// about if there is a decrease in count.
-			if k == prefix {
-				continue
-			}
 			if k == prefix+".0" {
 				continue
 			}
 
 			if v.Primary != nil {
+				println("FUCK: " + prefix + " ; " + k)
 				return true
 			}
 		}

--- a/terraform/graph_config_node.go
+++ b/terraform/graph_config_node.go
@@ -573,7 +573,6 @@ func (n *graphNodeResourceDestroy) destroyIncludePrimary(
 			}
 
 			if v.Primary != nil {
-				println("FUCK: " + prefix + " ; " + k)
 				return true
 			}
 		}

--- a/terraform/test-fixtures/transform-destroy-prefix/main.tf
+++ b/terraform/test-fixtures/transform-destroy-prefix/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {}
+
+resource "aws_instance" "foo-bar" {}

--- a/terraform/transform_destroy_test.go
+++ b/terraform/transform_destroy_test.go
@@ -299,6 +299,56 @@ func TestPruneDestroyTransformer_countState(t *testing.T) {
 	}
 }
 
+func TestPruneDestroyTransformer_prefixMatch(t *testing.T) {
+	mod := testModule(t, "transform-destroy-prefix")
+
+	diff := &Diff{}
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: RootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.foo-bar.0": &ResourceState{
+						Primary: &InstanceState{ID: "foo"},
+					},
+
+					"aws_instance.foo-bar.1": &ResourceState{
+						Primary: &InstanceState{ID: "foo"},
+					},
+				},
+			},
+		},
+	}
+
+	g := Graph{Path: RootModulePath}
+	{
+		tf := &ConfigTransformer{Module: mod}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		tf := &DestroyTransformer{}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		tf := &PruneDestroyTransformer{Diff: diff, State: state}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformPruneDestroyPrefixStr)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
 func TestPruneDestroyTransformer_tainted(t *testing.T) {
 	mod := testModule(t, "transform-destroy-basic")
 
@@ -397,6 +447,13 @@ const testTransformPruneDestroyCountStateStr = `
 aws_instance.bar
   aws_instance.foo
 aws_instance.foo
+`
+
+const testTransformPruneDestroyPrefixStr = `
+aws_instance.foo
+aws_instance.foo-bar
+  aws_instance.foo-bar (destroy)
+aws_instance.foo-bar (destroy)
 `
 
 const testTransformPruneDestroyTaintedStr = `


### PR DESCRIPTION
This fixes an issue where the Terraform prune destroy transform was invalidly keeping the destroy node around for things that didn't need it. Example: if you had a resource "foo" and "foo-bar" and "foo-bar" needed to be kept around, it'd also keep "foo" because of the way prefix checking was before.