### PR TITLE
get dependencies without installing them

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,10 +19,10 @@ GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd}
 
-# Install dependencies unless running in quick mode
+# Get dependencies unless running in quick mode
 if [ "${TF_QUICKDEV}x" == "x" ]; then
     echo "==> Getting dependencies..."
-    go get ./...
+    go get -d ./...
 fi
 
 # Delete the old dir


### PR DESCRIPTION
For now, make dev creates in ${MAIN_GOPATH}/bin/ files like 'provider-google' alongside with 'terraform-provider-google'.
If we decided to build plugins with custom names and install them manually with 'cp' command, it could make sense not to do it here.