### PR TITLE
OpenStack - Allow to disable HTTPS certificate check

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -56,6 +56,11 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Default:  "",
 			},
+			"insecure": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -93,6 +98,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		TenantName:       d.Get("tenant_name").(string),
 		DomainID:         d.Get("domain_id").(string),
 		DomainName:       d.Get("domain_name").(string),
+		Insecure:         d.Get("insecure").(bool),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/website/source/docs/providers/openstack/index.html.markdown
+++ b/website/source/docs/providers/openstack/index.html.markdown
@@ -57,6 +57,9 @@ The following arguments are supported:
 * `tenant_name` - (Optional) If omitted, the `OS_TENANT_NAME` environment
     variable is used.
 
+* `insecure` - (Optional) Explicitly allow the provider to perform
+    "insecure" SSL requests. If omitted, default value is `false`
+
 ## Testing
 
 In order to run the Acceptance Tests for development, the following environment


### PR DESCRIPTION
Currently, the provider does not work against HTTPS endpoints with self-signed certificate because there's no way to disable the certificate check.

```
Errors:

  * 1 error(s) occurred:

* Post https://openstack.net/identity/v2.0/tokens: x509: certificate is valid for , not openstack.net
```

This PR adds a provider config flag to allow to disable HTTPS certificate check.