### PR TITLE
Floating IP support for LBaaS Virtual IP

### DIFF
--- a/website/source/docs/providers/openstack/r/lb_vip_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_vip_v1.html.markdown
@@ -65,6 +65,9 @@ The following arguments are supported:
     vip. Default is -1, meaning no limit. Changing this updates the conn_limit
     of the existing vip.
 
+* `floating_ip` - (Optional) A Floating IP that will be associated with the
+    vip. The Floating IP must be provisioned already.
+
 * `admin_state_up` - (Optional) The administrative state of the vip.
     Acceptable values are "true" and "false". Changing this value updates the
     state of the existing vip.


### PR DESCRIPTION
Currently, it is not possible to assign a floating IP to a LB virtual IP. This PR adds a `floating_ip` attribute to the `openstack_lb_vip_v1` resource.