### PR TITLE
provider/aws: Convert Launch Configuration over to upstream

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/awslabs/aws-sdk-go/service/elb"
 	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
 	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/aws-sdk-go/gen/route53"
 	"github.com/hashicorp/aws-sdk-go/gen/s3"
 
 	awsSDK "github.com/awslabs/aws-sdk-go/aws"
-	awsASG "github.com/awslabs/aws-sdk-go/service/autoscaling"
+	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	awsEC2 "github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/awslabs/aws-sdk-go/service/rds"
@@ -31,7 +30,6 @@ type AWSClient struct {
 	ec2conn         *ec2.EC2
 	elbconn         *elb.ELB
 	autoscalingconn *autoscaling.AutoScaling
-	asgconn         *awsASG.AutoScaling
 	s3conn          *s3.S3
 	r53conn         *route53.Route53
 	region          string
@@ -72,8 +70,6 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing ELB SDK connection")
 		client.elbconn = elb.New(awsConfig)
 
-		log.Println("[INFO] Initializing AutoScaling connection")
-		client.autoscalingconn = autoscaling.New(creds, c.Region, nil)
 		log.Println("[INFO] Initializing S3 connection")
 		client.s3conn = s3.New(creds, c.Region, nil)
 
@@ -94,7 +90,7 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing IAM SDK Connection")
 		client.iamconn = iam.New(awsConfig)
 		log.Println("[INFO] Initializing AutoScaling SDK connection")
-		client.asgconn = awsASG.New(awsConfig)
+		client.autoscalingconn = autoscaling.New(awsConfig)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -125,7 +125,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 }
 
 func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	var autoScalingGroupOpts autoscaling.CreateAutoScalingGroupInput
 	autoScalingGroupOpts.AutoScalingGroupName = aws.String(d.Get("name").(string))
@@ -214,7 +214,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	opts := autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(d.Id()),
@@ -253,7 +253,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	// Read the autoscaling group first. If it doesn't exist, we're done.
 	// We need the group in order to check if there are instances attached.
@@ -302,7 +302,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 func getAwsAutoscalingGroup(
 	d *schema.ResourceData,
 	meta interface{}) (*autoscaling.AutoScalingGroup, error) {
-	autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	describeOpts := autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{aws.String(d.Id())},
@@ -333,7 +333,7 @@ func getAwsAutoscalingGroup(
 }
 
 func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) error {
-	autoscalingconn := meta.(*AWSClient).asgconn
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	// First, set the capacity to zero so the group will drain
 	log.Printf("[DEBUG] Reducing autoscaling group capacity to zero")

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/service/autoscaling"
-	hashiASG "github.com/hashicorp/aws-sdk-go/gen/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 	var group autoscaling.AutoScalingGroup
-	var lc hashiASG.LaunchConfiguration
+	var lc autoscaling.LaunchConfiguration
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -118,7 +117,7 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 	})
 }
 func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).asgconn
+	conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_autoscaling_group" {
@@ -225,7 +224,7 @@ func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.AutoScal
 			return fmt.Errorf("No AutoScaling Group ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).asgconn
+		conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
 
 		describeGroups, err := conn.DescribeAutoScalingGroups(
 			&autoscaling.DescribeAutoScalingGroupsInput{
@@ -247,7 +246,7 @@ func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.AutoScal
 	}
 }
 
-func testLaunchConfigurationName(n string, lc *hashiASG.LaunchConfiguration) resource.TestCheckFunc {
+func testLaunchConfigurationName(n string, lc *autoscaling.LaunchConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/aws-sdk-go/gen/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -245,7 +245,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 	ec2conn := meta.(*AWSClient).ec2conn
 
-	createLaunchConfigurationOpts := autoscaling.CreateLaunchConfigurationType{
+	createLaunchConfigurationOpts := autoscaling.CreateLaunchConfigurationInput{
 		LaunchConfigurationName: aws.String(d.Get("name").(string)),
 		ImageID:                 aws.String(d.Get("image_id").(string)),
 		InstanceType:            aws.String(d.Get("instance_type").(string)),
@@ -277,12 +277,12 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("security_groups"); ok {
-		createLaunchConfigurationOpts.SecurityGroups = expandStringList(
+		createLaunchConfigurationOpts.SecurityGroups = expandStringListSDK(
 			v.(*schema.Set).List(),
 		)
 	}
 
-	var blockDevices []autoscaling.BlockDeviceMapping
+	var blockDevices []*autoscaling.BlockDeviceMapping
 
 	if v, ok := d.GetOk("ebs_block_device"); ok {
 		vL := v.(*schema.Set).List()
@@ -297,7 +297,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
-				ebs.VolumeSize = aws.Integer(v)
+				ebs.VolumeSize = aws.Long(int64(v))
 			}
 
 			if v, ok := bd["volume_type"].(string); ok && v != "" {
@@ -305,10 +305,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			}
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Integer(v)
+				ebs.IOPS = aws.Long(int64(v))
 			}
 
-			blockDevices = append(blockDevices, autoscaling.BlockDeviceMapping{
+			blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 				DeviceName: aws.String(bd["device_name"].(string)),
 				EBS:        ebs,
 			})
@@ -319,7 +319,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			blockDevices = append(blockDevices, autoscaling.BlockDeviceMapping{
+			blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 				DeviceName:  aws.String(bd["device_name"].(string)),
 				VirtualName: aws.String(bd["virtual_name"].(string)),
 			})
@@ -338,7 +338,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
-				ebs.VolumeSize = aws.Integer(v)
+				ebs.VolumeSize = aws.Long(int64(v))
 			}
 
 			if v, ok := bd["volume_type"].(string); ok && v != "" {
@@ -346,11 +346,11 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			}
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Integer(v)
+				ebs.IOPS = aws.Long(int64(v))
 			}
 
 			if dn, err := fetchRootDeviceName(d.Get("image_id").(string), ec2conn); err == nil {
-				blockDevices = append(blockDevices, autoscaling.BlockDeviceMapping{
+				blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 					DeviceName: dn,
 					EBS:        ebs,
 				})
@@ -377,7 +377,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	log.Printf(
 		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
-	err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
+	_, err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating launch configuration: %s", err)
 	}
@@ -396,8 +396,8 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 	ec2conn := meta.(*AWSClient).ec2conn
 
-	describeOpts := autoscaling.LaunchConfigurationNamesType{
-		LaunchConfigurationNames: []string{d.Id()},
+	describeOpts := autoscaling.DescribeLaunchConfigurationsInput{
+		LaunchConfigurationNames: []*string{aws.String(d.Id())},
 	}
 
 	log.Printf("[DEBUG] launch configuration describe configuration: %#v", describeOpts)
@@ -429,7 +429,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	d.Set("spot_price", lc.SpotPrice)
 	d.Set("security_groups", lc.SecurityGroups)
 
-	if err := readLCBlockDevices(d, &lc, ec2conn); err != nil {
+	if err := readLCBlockDevices(d, lc, ec2conn); err != nil {
 		return err
 	}
 
@@ -440,8 +440,10 @@ func resourceAwsLaunchConfigurationDelete(d *schema.ResourceData, meta interface
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	log.Printf("[DEBUG] Launch Configuration destroy: %v", d.Id())
-	err := autoscalingconn.DeleteLaunchConfiguration(
-		&autoscaling.LaunchConfigurationNameType{LaunchConfigurationName: aws.String(d.Id())})
+	_, err := autoscalingconn.DeleteLaunchConfiguration(
+		&autoscaling.DeleteLaunchConfigurationInput{
+			LaunchConfigurationName: aws.String(d.Id()),
+		})
 	if err != nil {
 		autoscalingerr, ok := err.(aws.APIError)
 		if ok && autoscalingerr.Code == "InvalidConfiguration.NotFound" {

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/aws-sdk-go/aws"
-	"github.com/hashicorp/aws-sdk-go/gen/autoscaling"
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -107,8 +107,8 @@ func testAccCheckAWSLaunchConfigurationDestroy(s *terraform.State) error {
 		}
 
 		describe, err := conn.DescribeLaunchConfigurations(
-			&autoscaling.LaunchConfigurationNamesType{
-				LaunchConfigurationNames: []string{rs.Primary.ID},
+			&autoscaling.DescribeLaunchConfigurationsInput{
+				LaunchConfigurationNames: []*string{aws.String(rs.Primary.ID)},
 			})
 
 		if err == nil {
@@ -146,7 +146,7 @@ func testAccCheckAWSLaunchConfigurationAttributes(conf *autoscaling.LaunchConfig
 		}
 
 		// Map out the block devices by name, which should be unique.
-		blockDevices := make(map[string]autoscaling.BlockDeviceMapping)
+		blockDevices := make(map[string]*autoscaling.BlockDeviceMapping)
 		for _, blockDevice := range conf.BlockDeviceMappings {
 			blockDevices[*blockDevice.DeviceName] = blockDevice
 		}
@@ -188,8 +188,8 @@ func testAccCheckAWSLaunchConfigurationExists(n string, res *autoscaling.LaunchC
 
 		conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
 
-		describeOpts := autoscaling.LaunchConfigurationNamesType{
-			LaunchConfigurationNames: []string{rs.Primary.ID},
+		describeOpts := autoscaling.DescribeLaunchConfigurationsInput{
+			LaunchConfigurationNames: []*string{aws.String(rs.Primary.ID)},
 		}
 		describe, err := conn.DescribeLaunchConfigurations(&describeOpts)
 
@@ -202,7 +202,7 @@ func testAccCheckAWSLaunchConfigurationExists(n string, res *autoscaling.LaunchC
 			return fmt.Errorf("Launch Configuration Group not found")
 		}
 
-		*res = describe.LaunchConfigurations[0]
+		*res = *describe.LaunchConfigurations[0]
 
 		return nil
 	}


### PR DESCRIPTION
Converts Launch Configuration to upstream sdk, and removes extra ASG connection introduced in the ASG conversion PR