### PR TITLE
Add docker container network settings to output attribute

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -108,6 +108,26 @@ func resourceDockerContainer() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      stringSetHash,
 			},
+
+      "ip_address": &schema.Schema{
+        Type:     schema.TypeString,
+        Computed: true,
+      },
+
+      "ip_prefix_length": &schema.Schema{
+        Type:     schema.TypeInt,
+        Computed: true,
+      },
+
+      "gateway": &schema.Schema{
+        Type:     schema.TypeString,
+        Computed: true,
+      },
+
+      "bridge": &schema.Schema{
+        Type:     schema.TypeString,
+        Computed: true,
+      },
 		},
 	}
 }

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -134,6 +134,12 @@ func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error
 		return resourceDockerContainerDelete(d, meta)
 	}
 
+  // Read Network Settings
+  d.Set("ip_address", container.NetworkSettings.IPAddress)
+  d.Set("ip_prefix_length", container.NetworkSettings.IPPrefixLen)
+  d.Set("gateway", container.NetworkSettings.Gateway)
+  d.Set("bridge", container.NetworkSettings.Bridge)
+
 	return nil
 }
 


### PR DESCRIPTION
Allow to reference docker network settings (`IPAddress, IPPrefixLen, Gateway, Bridge`) in terraform-files.
e.g.:
```
${docker_container.NAME.ip_address}
```
