### PR TITLE
providers/aws: check allocationId only if it's vpc, fixes #1345

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -130,7 +130,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Verify AWS returned our EIP
 	if len(describeAddresses.Addresses) != 1 ||
-		*describeAddresses.Addresses[0].AllocationID != id ||
+		(domain == "vpc" && *describeAddresses.Addresses[0].AllocationID != id) ||
 		*describeAddresses.Addresses[0].PublicIP != id {
 		if err != nil {
 			return fmt.Errorf("Unable to find EIP: %#v", describeAddresses.Addresses)


### PR DESCRIPTION
EIP with VPC only returns an allocationID. However, for standard we need
to lookup for PublicIP. When we use an example for standard EC2 instance
(here `t1.micro`):

```
resource "aws_instance" "example" {
    ami = "ami-25773a24"
    instance_type = "t1.micro"
}

resource "aws_eip" "ip" {
    instance = "${aws_instance.example.id}"
}

```

then in this case, allocationID will be nil, but publicIP will be non
nil (which is used later for association the IP).  So check for
allocationId only if it's of domain `VPC`.