### PR TITLE
config: add reading from io.Reader

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -57,6 +58,22 @@ func TestConfigValidate_countInt(t *testing.T) {
 	c := testConfig(t, "validate-count-int")
 	if err := c.Validate(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestConfigValidate_countBadContext(t *testing.T) {
+	c := testConfig(t, "validate-count-bad-context")
+
+	err := c.Validate()
+
+	expected := []string{
+		"no_count_in_output: count variables are only valid within resources",
+		"no_count_in_module: count variables are only valid within resources",
+	}
+	for _, exp := range expected {
+		if !strings.Contains(err.Error(), exp) {
+			t.Fatalf("expected: %q,\nto contain: %q", err, exp)
+		}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -58,22 +57,6 @@ func TestConfigValidate_countInt(t *testing.T) {
 	c := testConfig(t, "validate-count-int")
 	if err := c.Validate(); err != nil {
 		t.Fatalf("err: %s", err)
-	}
-}
-
-func TestConfigValidate_countBadContext(t *testing.T) {
-	c := testConfig(t, "validate-count-bad-context")
-
-	err := c.Validate()
-
-	expected := []string{
-		"no_count_in_output: count variables are only valid within resources",
-		"no_count_in_module: count variables are only valid within resources",
-	}
-	for _, exp := range expected {
-		if !strings.Contains(err.Error(), exp) {
-			t.Fatalf("expected: %q,\nto contain: %q", err, exp)
-		}
 	}
 }
 
@@ -415,7 +398,7 @@ func TestVariableDefaultsMap(t *testing.T) {
 }
 
 func testConfig(t *testing.T, name string) *Config {
-	c, err := Load(filepath.Join(fixtureDir, name, "main.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, name, "main.tf"))
 	if err != nil {
 		t.Fatalf("file: %s\n\nerr: %s", name, err)
 	}

--- a/config/import_tree.go
+++ b/config/import_tree.go
@@ -17,20 +17,21 @@ type configurable interface {
 //
 // An importTree can be turned into a configTree.
 type importTree struct {
-	Path     string
-	Raw      configurable
+	Path string
+	Raw  configurable
+
+	// not used currently, just here for possible future features
 	Children []*importTree
 }
 
 // This is the function type that must be implemented by the configuration
-// file loader to turn a single file into a configurable and any additional
-// imports.
-type fileLoaderFunc func(path string) (configurable, []string, error)
+// file loader to turn a single file into a configurable.
+type fileLoaderFunc func(path string) (configurable, error)
 
-// loadTree takes a single file and loads the entire importTree for that
-// file. This function detects what kind of configuration file it is an
+// loadTreeFromFile takes a single file and loads the entire importTree for
+// that file. This function detects what kind of configuration file it is an
 // executes the proper fileLoaderFunc.
-func loadTree(root string) (*importTree, error) {
+func loadTreeFromFile(root string) (*importTree, error) {
 	var f fileLoaderFunc
 	switch ext(root) {
 	case ".tf":
@@ -46,25 +47,14 @@ func loadTree(root string) (*importTree, error) {
 			root)
 	}
 
-	c, imps, err := f(root)
+	c, err := f(root)
 	if err != nil {
 		return nil, err
 	}
 
-	children := make([]*importTree, len(imps))
-	for i, imp := range imps {
-		t, err := loadTree(imp)
-		if err != nil {
-			return nil, err
-		}
-
-		children[i] = t
-	}
-
 	return &importTree{
-		Path:     root,
-		Raw:      c,
-		Children: children,
+		Path: root,
+		Raw:  c,
 	}, nil
 }
 

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/hashicorp/hcl"
 	hclobj "github.com/hashicorp/hcl/hcl"
@@ -11,7 +13,6 @@ import (
 // hclConfigurable is an implementation of configurable that knows
 // how to turn HCL configuration into a *Config object.
 type hclConfigurable struct {
-	File   string
 	Object *hclobj.Object
 }
 
@@ -129,28 +130,25 @@ func (t *hclConfigurable) Config() (*Config, error) {
 	return config, nil
 }
 
-// loadFileHcl is a fileLoaderFunc that knows how to read HCL
+// loadReaderHcl
 // files and turn them into hclConfigurables.
-func loadFileHcl(root string) (configurable, []string, error) {
+func loadReaderHcl(r io.Reader) (configurable, error) {
 	var obj *hclobj.Object = nil
 
-	// Read the HCL file and prepare for parsing
-	d, err := ioutil.ReadFile(root)
+	// Read the HCL content and prepare for parsing
+	d, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"Error reading %s: %s", root, err)
+		return nil, fmt.Errorf("Error reading: %s", err)
 	}
 
 	// Parse it
 	obj, err = hcl.Parse(string(d))
 	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"Error parsing %s: %s", root, err)
+		return nil, fmt.Errorf("Error parsing: %s", err)
 	}
 
 	// Start building the result
 	result := &hclConfigurable{
-		File:   root,
 		Object: obj,
 	}
 
@@ -163,17 +161,14 @@ func loadFileHcl(root string) (configurable, []string, error) {
 			result.Object.Ref()
 			return result, nil, nil
 		}
-
 		if imports.Type() != libucl.ObjectTypeString {
 			imports.Close()
-
 			return nil, nil, fmt.Errorf(
 				"Error in %s: all 'import' declarations should be in the format\n"+
 					"`import \"foo\"` (Got type %s)",
 				root,
 				imports.Type())
 		}
-
 		// Gather all the import paths
 		importPaths := make([]string, 0, imports.Len())
 		iter := imports.Iterate(false)
@@ -184,17 +179,27 @@ func loadFileHcl(root string) (configurable, []string, error) {
 				dir := filepath.Dir(root)
 				path = filepath.Join(dir, path)
 			}
-
 			importPaths = append(importPaths, path)
 			imp.Close()
 		}
 		iter.Close()
 		imports.Close()
-
 		result.Object.Ref()
 	*/
 
-	return result, nil, nil
+	return result, nil
+}
+
+// loadFileHcl is a fileLoaderFunc that knows how to read HCL
+// files and turn them into hclConfigurables.
+func loadFileHcl(root string) (configurable, error) {
+	f, err := os.Open(root)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return loadReaderHcl(f)
 }
 
 // Given a handle to a HCL object, this transforms it into the Atlas

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -38,24 +38,96 @@ func TestIsEmptyDir_noConfigs(t *testing.T) {
 }
 
 func TestLoad_badType(t *testing.T) {
-	_, err := Load(filepath.Join(fixtureDir, "bad_type.tf.nope"))
+	_, err := LoadFile(filepath.Join(fixtureDir, "bad_type.tf.nope"))
 	if err == nil {
 		t.Fatal("should have error")
 	}
 }
 
-func TestLoadBasic(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "basic.tf"))
+func TestLoadReaderBasic(t *testing.T) {
+	const basicTf = `
+variable "foo" {
+    default = "bar"
+    description = "bar"
+}
+
+provider "aws" {
+  access_key = "foo"
+  secret_key = "bar"
+}
+
+provider "do" {
+  api_key = "${var.foo}"
+}
+
+resource "aws_security_group" "firewall" {
+    count = 5
+}
+
+resource aws_instance "web" {
+    ami = "${var.foo}"
+    security_groups = [
+        "foo",
+        "${aws_security_group.firewall.foo}"
+    ]
+
+    network_interface {
+        device_index = 0
+        description = "Main network interface"
+    }
+
+    provisioner "file" {
+        source = "foo"
+        destination = "bar"
+    }
+}
+
+resource "aws_instance" "db" {
+    security_groups = "${aws_security_group.firewall.*.id}"
+    VPC = "foo"
+
+    depends_on = ["aws_instance.web"]
+
+    provisioner "file" {
+        source = "foo"
+        destination = "bar"
+    }
+}
+
+output "web_ip" {
+    value = "${aws_instance.web.private_ip}"
+}
+
+atlas {
+    name = "mitchellh/foo"
+}
+	`
+
+	r := strings.NewReader(basicTf)
+	c, err := LoadReader(r)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if c == nil {
-		t.Fatal("config should not be nil")
+	loadBasic(c, t)
+}
+
+func TestLoadBasic(t *testing.T) {
+	c, err := LoadFile(filepath.Join(fixtureDir, "basic.tf"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
 
-	if c.Dir != "" {
+	if c != nil && c.Dir != "" {
 		t.Fatalf("bad: %#v", c.Dir)
+	}
+
+	loadBasic(c, t)
+}
+
+func loadBasic(c *Config, t *testing.T) {
+	if c == nil {
+		t.Fatal("config should not be nil")
 	}
 
 	expectedAtlas := &AtlasConfig{Name: "mitchellh/foo"}
@@ -82,10 +154,11 @@ func TestLoadBasic(t *testing.T) {
 	if actual != strings.TrimSpace(basicOutputsStr) {
 		t.Fatalf("bad:\n%s", actual)
 	}
+
 }
 
 func TestLoadBasic_empty(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "empty.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "empty.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -99,7 +172,7 @@ func TestLoadBasic_import(t *testing.T) {
 	// Skip because we disabled importing
 	t.Skip()
 
-	c, err := Load(filepath.Join(fixtureDir, "import.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "import.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -125,7 +198,7 @@ func TestLoadBasic_import(t *testing.T) {
 }
 
 func TestLoadBasic_json(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "basic.tf.json"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "basic.tf.json"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -165,7 +238,7 @@ func TestLoadBasic_json(t *testing.T) {
 }
 
 func TestLoadBasic_modules(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "modules.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "modules.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -185,7 +258,7 @@ func TestLoadBasic_modules(t *testing.T) {
 }
 
 func TestLoad_variables(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "variables.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "variables.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -304,7 +377,7 @@ func TestLoadDir_override(t *testing.T) {
 }
 
 func TestLoad_provisioners(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "provisioners.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "provisioners.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -320,7 +393,7 @@ func TestLoad_provisioners(t *testing.T) {
 }
 
 func TestLoad_connections(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "connection.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "connection.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -358,7 +431,7 @@ func TestLoad_connections(t *testing.T) {
 }
 
 func TestLoad_createBeforeDestroy(t *testing.T) {
-	c, err := Load(filepath.Join(fixtureDir, "create-before-destroy.tf"))
+	c, err := LoadFile(filepath.Join(fixtureDir, "create-before-destroy.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -48,7 +48,7 @@ func tempDir(t *testing.T) string {
 }
 
 func testConfig(t *testing.T, name string) *config.Config {
-	c, err := config.Load(filepath.Join(fixtureDir, name, "main.tf"))
+	c, err := config.LoadFile(filepath.Join(fixtureDir, name, "main.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
* Previously only reading from file was publicily available. Now we have
the new `LoadReader` function that reads the config directly from a
io.Reader stream. This is much more customizable as we can use anything
that satisfies the io.Reader.

* Changed `Load` to `LoadFile` (makes sense as we have also `LoadDir`).

* I've also changed the signature of `fileLoaderFunc` because currently
there is no support for sub imports . It's not used everywhere, so
returning multiple nil's is not good. The code for imports is commented
too.