### PR TITLE
core: add prevent_destroy lifecycle flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,7 @@ type Resource struct {
 // to allow customized behavior
 type ResourceLifecycle struct {
 	CreateBeforeDestroy bool `hcl:"create_before_destroy"`
+	PreventDestroy      bool `hcl:"prevent_destroy"`
 }
 
 // Provisioner is a configured provisioner step on a resource.

--- a/terraform/eval_check_prevent_destroy.go
+++ b/terraform/eval_check_prevent_destroy.go
@@ -1,0 +1,32 @@
+package terraform
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/config"
+)
+
+// EvalPreventDestroy is an EvalNode implementation that returns an
+// error if a resource has PreventDestroy configured and the diff
+// would destroy the resource.
+type EvalCheckPreventDestroy struct {
+	Resource *config.Resource
+	Diff     **InstanceDiff
+}
+
+func (n *EvalCheckPreventDestroy) Eval(ctx EvalContext) (interface{}, error) {
+	if n.Diff == nil || *n.Diff == nil || n.Resource == nil {
+		return nil, nil
+	}
+
+	diff := *n.Diff
+	preventDestroy := n.Resource.Lifecycle.PreventDestroy
+
+	if diff.Destroy && preventDestroy {
+		return nil, fmt.Errorf(preventDestroyErrStr, n.Resource.Id())
+	}
+
+	return nil, nil
+}
+
+const preventDestroyErrStr = `%s: plan would destroy, but resource has prevent_destroy set. To avoid this error, either disable prevent_destroy, or change your config so the plan does not destroy this resource.`

--- a/terraform/test-fixtures/plan-prevent-destroy-bad/main.tf
+++ b/terraform/test-fixtures/plan-prevent-destroy-bad/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+  require_new = "yes"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/test-fixtures/plan-prevent-destroy-good/main.tf
+++ b/terraform/test-fixtures/plan-prevent-destroy-good/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "foo" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -263,6 +263,10 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 					Output:      &diff,
 					OutputState: &state,
 				},
+				&EvalCheckPreventDestroy{
+					Resource: n.Resource,
+					Diff:     &diff,
+				},
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
@@ -294,6 +298,10 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 					Info:   info,
 					State:  &state,
 					Output: &diff,
+				},
+				&EvalCheckPreventDestroy{
+					Resource: n.Resource,
+					Diff:     &diff,
 				},
 				&EvalWriteDiff{
 					Name: n.stateId(),

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -64,6 +64,10 @@ The `lifecycle` block allows the following keys to be set:
       instance is destroyed. As an example, this can be used to
       create an new DNS record before removing an old record.
 
+  * `prevent_destroy` (bool) - This flag provides extra protection against the
+      destruction of a given resource. When this is set to `true`, any plan
+      that includes a destroy of this resource will return an error message.
+
 -------------
 
 Within a resource, you can optionally have a **connection block**.


### PR DESCRIPTION
When the `prevent_destroy` flag is set on a resource, any plan that
would destroy that resource instead returns an error. This has the
effect of preventing the resource from being unexpectedly destroyed by
Terraform until the flag is removed from the config.