### PR TITLE
provisioner/file: expand ~ in source

### DIFF
--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/config"
 	helper "github.com/hashicorp/terraform/helper/ssh"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/go-homedir"
 )
 
 type ResourceProvisioner struct{}
@@ -33,6 +34,11 @@ func (p *ResourceProvisioner) Apply(
 	src, ok := sRaw.(string)
 	if !ok {
 		return fmt.Errorf("Unsupported 'source' type! Must be string.")
+	}
+
+	src, err = homedir.Expand(src)
+	if err != nil {
+		return err
 	}
 
 	dRaw := c.Config["destination"]


### PR DESCRIPTION
closes #1559

tested manually, since a unit test would be sort of annoying to write.
:)