### PR TITLE
Escape $GOPATH in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ cd /opt/go/src && ./all.bash
 mkdir -p /opt/gopath
 cat <<EOF >/etc/profile.d/gopath.sh
 export GOPATH="/opt/gopath"
-export PATH="/opt/go/bin:$GOPATH/bin:\$PATH"
+export PATH="/opt/go/bin:\$GOPATH/bin:\$PATH"
 EOF
 
 # Make sure the GOPATH is usable by vagrant


### PR DESCRIPTION
I think there is a missing escape in the Vagrantfile. Inside the VM I had to fix the /etc/profile.d/gopath.sh because it's contents were:

```
export GOPATH="/opt/gopath"
export PATH="/opt/go/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
```

BTW having a way to spin up a dev VM so easily made it a breeze to get hacking on Terraform! Great idea!