### PR TITLE
Refresh state for deleted s3 bucket correctly

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -85,7 +85,13 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		Bucket: aws.String(d.Id()),
 	})
 	if err != nil {
-		return err
+		if awsError, ok := err.(aws.APIError); ok && awsError.StatusCode == 404 {
+			d.SetId("")
+		} else {
+			// some of the AWS SDK's errors can be empty strings, so let's add
+			// some additional context.
+			return fmt.Errorf("error reading S3 bucket \"%s\": %#v", d.Id())
+		}
 	}
 
 	tagSet, err := getTagSetS3(s3conn, d.Id())


### PR DESCRIPTION
If reading an S3 bucket's state, and that bucket has been deleted, don't
fail with a 404 error. Instead, update the state to reflect that the
bucket does not exist. Fixes #1574.