### PR TITLE
aws: Add support for weighted Route53 records

### DIFF
--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -12,6 +12,8 @@ Provides a Route53 record resource.
 
 ## Example Usage
 
+### Simple routing policy
+
 ```
 resource "aws_route53_record" "www" {
    zone_id = "${aws_route53_zone.primary.zone_id}"
@@ -19,6 +21,30 @@ resource "aws_route53_record" "www" {
    type = "A"
    ttl = "300"
    records = ["${aws_eip.lb.public_ip}"]
+}
+```
+
+### Weighted routing policy
+See [AWS Route53 Developer Guide](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-weighted) for details.
+```
+resource "aws_route53_record" "www-dev" {
+  zone_id = "${aws_route53_zone.primary.zone_id}"
+  name = "www"
+  type = "CNAME"
+  ttl = "5"
+  weight = 10
+  set_identifier = "dev"
+  records = ["dev.example.com"]
+}
+
+resource "aws_route53_record" "www-live" {
+  zone_id = "${aws_route53_zone.primary.zone_id}"
+  name = "www"
+  type = "CNAME"
+  ttl = "5"
+  weight = 90
+  set_identifier = "live"
+  records = ["live.example.com"]
 }
 ```
 
@@ -31,6 +57,9 @@ The following arguments are supported:
 * `type` - (Required) The record type.
 * `ttl` - (Required) The TTL of the record.
 * `records` - (Required) A string list of records.
+* `weight` - (Optional) The weight of weighted record (0-255).
+* `set_identifier` - (Optional) Unique identifier to differentiate weighted
+  record from one another. Required for each weighted record.
 
 ## Attributes Reference
 


### PR DESCRIPTION
See #1155

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=Route53Record' 2>/dev/null
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=Route53Record -timeout 45m
=== RUN TestAccRoute53Record
--- PASS: TestAccRoute53Record (273.99s)
=== RUN TestAccRoute53Record_txtSupport
--- PASS: TestAccRoute53Record_txtSupport (263.21s)
=== RUN TestAccRoute53Record_generatesSuffix
--- PASS: TestAccRoute53Record_generatesSuffix (253.09s)
=== RUN TestAccRoute53Record_wildcard
--- PASS: TestAccRoute53Record_wildcard (403.83s)
=== RUN TestAccRoute53Record_weighted
--- PASS: TestAccRoute53Record_weighted (264.57s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1458.708s
```