### PR TITLE
provider/aws: Fix issue when creating ELB with no tags

### DIFF
--- a/builtin/providers/aws/tagsELB.go
+++ b/builtin/providers/aws/tagsELB.go
@@ -72,7 +72,7 @@ func diffTagsELB(oldTags, newTags []*elb.Tag) ([]*elb.Tag, []*elb.Tag) {
 
 // tagsFromMap returns the tags for the given map of data.
 func tagsFromMapELB(m map[string]interface{}) []*elb.Tag {
-	result := make([]*elb.Tag, 0, len(m))
+	var result []*elb.Tag
 	for k, v := range m {
 		result = append(result, &elb.Tag{
 			Key:   aws.String(k),


### PR DESCRIPTION
The ELB API does not like when you send it a slice of `*elb.Tag` with length greater than 0, but no actual elements in it. Basically. 