### PR TITLE
Bugfix: Allow using deprecated security_groups in NI spec

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -371,6 +371,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			AssociatePublicIPAddress: aws.Boolean(associatePublicIPAddress),
 			DeviceIndex:              aws.Long(int64(0)),
 			SubnetID:                 aws.String(subnetID),
+			Groups:                   groups,
 		}
 
 		if v, ok := d.GetOk("private_ip"); ok {


### PR DESCRIPTION
Related to #1539 which made `security_groups` in some cases actually ineffective, not just deprecated :smile_cat: 

https://github.com/hashicorp/terraform/issues/1581 is still valid though, I believe user (and most users don't generally run terraform with `TF_LOG=1`) should be informed about this.