### PR TITLE
helper/ssh: add random number to upload path for script [GH-1545]

### DIFF
--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -213,11 +213,13 @@ func (p *ResourceProvisioner) runScripts(
 		go p.copyOutput(o, errR, errDoneCh)
 
 		err := retryFunc(conf.TimeoutVal, func() error {
-			if err := comm.Upload(conf.ScriptPath, script); err != nil {
+			remotePath := conf.RemotePath()
+
+			if err := comm.Upload(remotePath, script); err != nil {
 				return fmt.Errorf("Failed to upload script: %v", err)
 			}
 			cmd = &helper.RemoteCmd{
-				Command: fmt.Sprintf("chmod 0777 %s", conf.ScriptPath),
+				Command: fmt.Sprintf("chmod 0777 %s", remotePath),
 			}
 			if err := comm.Start(cmd); err != nil {
 				return fmt.Errorf(
@@ -227,7 +229,7 @@ func (p *ResourceProvisioner) runScripts(
 			cmd.Wait()
 
 			cmd = &helper.RemoteCmd{
-				Command: conf.ScriptPath,
+				Command: remotePath,
 				Stdout:  outW,
 				Stderr:  errW,
 			}

--- a/helper/ssh/provisioner.go
+++ b/helper/ssh/provisioner.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -25,7 +28,7 @@ const (
 
 	// DefaultScriptPath is used as the path to copy the file to
 	// for remote execution if not provided otherwise.
-	DefaultScriptPath = "/tmp/script.sh"
+	DefaultScriptPath = "/tmp/script_%RAND%.sh"
 
 	// DefaultTimeout is used if there is no timeout given
 	DefaultTimeout = 5 * time.Minute
@@ -44,6 +47,12 @@ type SSHConfig struct {
 	Timeout    string
 	ScriptPath string        `mapstructure:"script_path"`
 	TimeoutVal time.Duration `mapstructure:"-"`
+}
+
+func (c *SSHConfig) RemotePath() string {
+	return strings.Replace(
+		c.ScriptPath, "%RAND%",
+		strconv.FormatInt(int64(rand.Int31()), 10), -1)
 }
 
 // VerifySSH is used to verify the ConnInfo is usable by remote-exec

--- a/helper/ssh/provisioner_test.go
+++ b/helper/ssh/provisioner_test.go
@@ -1,10 +1,40 @@
 package ssh
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func TestSSHConfig_RemotePath(t *testing.T) {
+	cases := []struct {
+		Input   string
+		Pattern string
+	}{
+		{
+			"/tmp/script.sh",
+			`^/tmp/script\.sh$`,
+		},
+		{
+			"/tmp/script_%RAND%.sh",
+			`^/tmp/script_(\d+)\.sh$`,
+		},
+	}
+
+	for _, tc := range cases {
+		config := &SSHConfig{ScriptPath: tc.Input}
+		output := config.RemotePath()
+
+		match, err := regexp.Match(tc.Pattern, []byte(output))
+		if err != nil {
+			t.Fatalf("bad: %s\n\nerr: %s", tc.Input, err)
+		}
+		if !match {
+			t.Fatalf("bad: %s\n\n%s", tc.Input, output)
+		}
+	}
+}
 
 func TestResourceProvider_verifySSH(t *testing.T) {
 	r := &terraform.InstanceState{


### PR DESCRIPTION
Fixes #1545 

This makes the default remote path include a random number. There are no backwards incompatibilities here. It was an edge case found by #1545 that if you have multiple `remote-exec` in parallel (possible by targeting other remote hosts from multiple resources), then the scripts would collide.