### PR TITLE
config/module: validate config to load [GH-1439]

### DIFF
--- a/config/module/test-fixtures/invalid/main.tf
+++ b/config/module/test-fixtures/invalid/main.tf
@@ -1,0 +1,3 @@
+module "foo" {
+    source = "${path.cwd}"
+}

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -140,6 +140,12 @@ func (t *Tree) Load(s Storage, mode GetMode) error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	// The configuration must be valid to load modules
+	if err := t.config.Validate(); err != nil {
+		return fmt.Errorf(
+			"configuration must be valid to load modules. error: %s", err)
+	}
+
 	// Reset the children if we have any
 	t.children = nil
 

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -102,6 +102,22 @@ func TestTreeLoad_duplicate(t *testing.T) {
 	}
 }
 
+func TestTreeLoad_invalid(t *testing.T) {
+	storage := testStorage(t)
+	tree := NewTree("", testConfig(t, "invalid"))
+
+	if tree.Loaded() {
+		t.Fatal("should not be loaded")
+	}
+
+	// This should get things
+	if err := tree.Load(storage, GetModeGet); err == nil {
+		t.Fatalf("should error")
+	} else if !strings.Contains(err.Error(), "interpolations") {
+		t.Fatalf("bad: %s", err)
+	}
+}
+
 func TestTreeLoad_parentRef(t *testing.T) {
 	storage := testStorage(t)
 	tree := NewTree("", testConfig(t, "basic-parent"))
@@ -200,18 +216,6 @@ func TestTreeName(t *testing.T) {
 	}
 }
 
-func TestTreeValidate_badChild(t *testing.T) {
-	tree := NewTree("", testConfig(t, "validate-child-bad"))
-
-	if err := tree.Load(testStorage(t), GetModeGet); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	if err := tree.Validate(); err == nil {
-		t.Fatal("should error")
-	}
-}
-
 func TestTreeValidate_badChildOutput(t *testing.T) {
 	tree := NewTree("", testConfig(t, "validate-bad-output"))
 
@@ -226,18 +230,6 @@ func TestTreeValidate_badChildOutput(t *testing.T) {
 
 func TestTreeValidate_badChildVar(t *testing.T) {
 	tree := NewTree("", testConfig(t, "validate-bad-var"))
-
-	if err := tree.Load(testStorage(t), GetModeGet); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	if err := tree.Validate(); err == nil {
-		t.Fatal("should error")
-	}
-}
-
-func TestTreeValidate_badRoot(t *testing.T) {
-	tree := NewTree("", testConfig(t, "validate-root-bad"))
 
 	if err := tree.Load(testStorage(t), GetModeGet); err != nil {
 		t.Fatalf("err: %s", err)

--- a/terraform/test-fixtures/apply-provisioner-compute/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-compute/main.tf
@@ -1,3 +1,5 @@
+variable "value" {}
+
 resource "aws_instance" "foo" {
     num = "2"
     compute = "dynamical"

--- a/terraform/test-fixtures/apply-provisioner-conninfo/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-conninfo/main.tf
@@ -1,3 +1,5 @@
+variable "value" {}
+
 resource "aws_instance" "foo" {
     num = "2"
     compute = "dynamical"

--- a/terraform/test-fixtures/graph-missing-deps/main.tf
+++ b/terraform/test-fixtures/graph-missing-deps/main.tf
@@ -1,5 +1,0 @@
-resource "aws_instance" "db" {}
-
-resource "aws_instance" "web" {
-    foo = "${aws_instance.lb.id}"
-}

--- a/terraform/test-fixtures/plan-count-zero/main.tf
+++ b/terraform/test-fixtures/plan-count-zero/main.tf
@@ -4,5 +4,5 @@ resource "aws_instance" "foo" {
 }
 
 resource "aws_instance" "bar" {
-    foo = "${aws_instance.foo.*.foo}"
+    foo = ["${aws_instance.foo.*.foo}"]
 }

--- a/terraform/test-fixtures/plan-module-provider-defaults-var/main.tf
+++ b/terraform/test-fixtures/plan-module-provider-defaults-var/main.tf
@@ -1,3 +1,5 @@
+variable "foo" {}
+
 module "child" {
     source = "./child"
 }

--- a/terraform/test-fixtures/plan-var-multi-count-one/main.tf
+++ b/terraform/test-fixtures/plan-var-multi-count-one/main.tf
@@ -5,5 +5,5 @@ resource "aws_instance" "foo" {
 }
 
 resource "aws_instance" "bar" {
-    foo = "${aws_instance.foo.*.num}"
+    foo = ["${aws_instance.foo.*.num}"]
 }

--- a/terraform/test-fixtures/transform-targets-destroy/main.tf
+++ b/terraform/test-fixtures/transform-targets-destroy/main.tf
@@ -14,5 +14,5 @@ resource "aws_instance" "metoo" {
 }
 
 resource "aws_elb" "me" {
-  instances = "${aws_instance.me.*.id}"
+  instances = ["${aws_instance.me.*.id}"]
 }

--- a/terraform/transform_config_test.go
+++ b/terraform/transform_config_test.go
@@ -86,14 +86,6 @@ func TestConfigTransformer_outputs(t *testing.T) {
 	}
 }
 
-func TestConfigTransformer_errMissingDeps(t *testing.T) {
-	g := Graph{Path: RootModulePath}
-	tf := &ConfigTransformer{Module: testModule(t, "graph-missing-deps")}
-	if err := tf.Transform(&g); err == nil {
-		t.Fatalf("err: %s", err)
-	}
-}
-
 const testGraphBasicStr = `
 aws_instance.web
   aws_security_group.firewall


### PR DESCRIPTION
Fixes #1439 (via validation)

Turns out we _do_ validate that module sources contain no interpolations, but loading modules doesn't check if the configuration is valid. This changes `config/module` to require that the configuration be valid to load child modules.