### PR TITLE
terraform: don't panic on input for bad default type [GH-1344]

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -175,6 +175,8 @@ func (c *Context) Input(mode InputMode) error {
 
 			v := m[n]
 			switch v.Type() {
+			case config.VariableTypeUnknown:
+				continue
 			case config.VariableTypeMap:
 				continue
 			case config.VariableTypeString:

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -2883,6 +2883,28 @@ func TestContext2Input(t *testing.T) {
 	}
 }
 
+func TestContext2Input_badVarDefault(t *testing.T) {
+	m := testModule(t, "input-bad-var-default")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	p.InputFn = func(i UIInput, c *ResourceConfig) (*ResourceConfig, error) {
+		c.Config["foo"] = "bar"
+		return c, nil
+	}
+
+	if err := ctx.Input(InputModeStd); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestContext2Input_provider(t *testing.T) {
 	m := testModule(t, "input-provider")
 	p := testProvider("aws")

--- a/terraform/test-fixtures/input-bad-var-default/main.tf
+++ b/terraform/test-fixtures/input-bad-var-default/main.tf
@@ -1,0 +1,5 @@
+variable "test" {
+    default {
+        l = [1, 2, 3]
+    }
+}


### PR DESCRIPTION
Fixes #1344 

On Input, we should ignore any invalid types. They get caught during validation later. This also avoids a panic. I believe the panic is correct in being there, but we didn't properly account for all possible default types.