### PR TITLE
aws/s3_bucket: Add missing argument for Errorf

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -90,7 +90,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		} else {
 			// some of the AWS SDK's errors can be empty strings, so let's add
 			// some additional context.
-			return fmt.Errorf("error reading S3 bucket \"%s\": %#v", d.Id())
+			return fmt.Errorf("error reading S3 bucket \"%s\": %#v", d.Id(), err)
 		}
 	}
 


### PR DESCRIPTION
This is fixing following vet error:

```
builtin/providers/aws/resource_aws_s3_bucket.go:93: missing argument for Errorf("%#v"): format reads arg 2, have only 1 args

Vet found suspicious constructs. Please check the reported constructs
```