### PR TITLE
aws: Allow defining blacklist/whitelist of account IDs

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -41,6 +42,26 @@ func Provider() terraform.ResourceProvider {
 				}, nil),
 				Description:  descriptions["region"],
 				InputDefault: "us-east-1",
+			},
+
+			"allowed_account_ids": &schema.Schema{
+				Type:          schema.TypeSet,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				ConflictsWith: []string{"forbidden_account_ids"},
+				Set: func(v interface{}) int {
+					return hashcode.String(v.(string))
+				},
+			},
+
+			"forbidden_account_ids": &schema.Schema{
+				Type:          schema.TypeSet,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				ConflictsWith: []string{"allowed_account_ids"},
+				Set: func(v interface{}) int {
+					return hashcode.String(v.(string))
+				},
 			},
 		},
 
@@ -95,6 +116,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		AccessKey: d.Get("access_key").(string),
 		SecretKey: d.Get("secret_key").(string),
 		Region:    d.Get("region").(string),
+	}
+
+	if v, ok := d.GetOk("allowed_account_ids"); ok {
+		config.AllowedAccountIds = v.(*schema.Set).List()
+	}
+
+	if v, ok := d.GetOk("forbidden_account_ids"); ok {
+		config.ForbiddenAccountIds = v.(*schema.Set).List()
 	}
 
 	return config.Client()

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -384,6 +384,8 @@ func (m schemaMap) Input(
 			fallthrough
 		case TypeFloat:
 			fallthrough
+		case TypeSet:
+			continue
 		case TypeString:
 			value, err = m.inputString(input, k, v)
 		default:

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2555,6 +2555,66 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
+		// Conflicting attributes cannot be required
+		{
+			map[string]*Schema{
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Required: true,
+				},
+				"whitelist": &Schema{
+					Type:          TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{"blacklist"},
+				},
+			},
+			true,
+		},
+
+		// Attribute with conflicts cannot be required
+		{
+			map[string]*Schema{
+				"whitelist": &Schema{
+					Type:          TypeBool,
+					Required:      true,
+					ConflictsWith: []string{"blacklist"},
+				},
+			},
+			true,
+		},
+
+		// ConflictsWith cannot be used w/ Computed
+		{
+			map[string]*Schema{
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Computed: true,
+				},
+				"whitelist": &Schema{
+					Type:          TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{"blacklist"},
+				},
+			},
+			true,
+		},
+
+		// ConflictsWith cannot be used w/ ComputedWhen
+		{
+			map[string]*Schema{
+				"blacklist": &Schema{
+					Type:         TypeBool,
+					ComputedWhen: []string{"foor"},
+				},
+				"whitelist": &Schema{
+					Type:          TypeBool,
+					Required:      true,
+					ConflictsWith: []string{"blacklist"},
+				},
+			},
+			true,
+		},
+
 		// Sub-resource invalid
 		{
 			map[string]*Schema{
@@ -2594,7 +2654,10 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 	for i, tc := range cases {
 		err := schemaMap(tc.In).InternalValidate()
 		if (err != nil) != tc.Err {
-			t.Fatalf("%d: bad: %s\n\n%#v", i, err, tc.In)
+			if tc.Err {
+				t.Fatalf("%d: Expected error did not occur:\n\n%#v", i, tc.In)
+			}
+			t.Fatalf("%d: Unexpected error occured:\n\n%#v", i, tc.In)
 		}
 	}
 
@@ -3102,6 +3165,74 @@ func TestSchemaMap_Validate(t *testing.T) {
 			},
 
 			Err: false,
+		},
+
+		"Conflicting attributes generate error": {
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeString,
+					Optional: true,
+				},
+				"blacklist": &Schema{
+					Type:          TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"whitelist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist": "white-val",
+				"blacklist": "black-val",
+			},
+
+			Err: true,
+			Errors: []error{
+				fmt.Errorf("\"blacklist\": conflicts with whitelist (\"white-val\")"),
+			},
+		},
+
+		"Required attribute & undefined conflicting optional are good": {
+			Schema: map[string]*Schema{
+				"required_att": &Schema{
+					Type:     TypeString,
+					Required: true,
+				},
+				"optional_att": &Schema{
+					Type:          TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"required_att"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"required_att": "required-val",
+			},
+
+			Err: false,
+		},
+
+		"Required conflicting attribute & defined optional generate error": {
+			Schema: map[string]*Schema{
+				"required_att": &Schema{
+					Type:     TypeString,
+					Required: true,
+				},
+				"optional_att": &Schema{
+					Type:          TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"required_att"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"required_att": "required-val",
+				"optional_att": "optional-val",
+			},
+
+			Err: true,
+			Errors: []error{
+				fmt.Errorf("\"optional_att\": conflicts with required_att (\"required-val\")"),
+			},
 		},
 	}
 

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -22,6 +22,9 @@ provider "aws" {
     access_key = "${var.aws_access_key}"
     secret_key = "${var.aws_secret_key}"
     region = "us-east-1"
+
+    # Not run this in live account
+    forbidden_account_ids = ["1234567890"]
 }
 
 # Create a web server
@@ -42,6 +45,14 @@ The following arguments are supported in the `provider` block:
 
 * `region` - (Required) This is the AWS region. It must be provided, but
   it can also be sourced from the `AWS_DEFAULT_REGION` environment variables.
+
+* `allowed_account_ids` - (Optional) List of allowed AWS account IDs (whitelist)
+  to prevent you mistakenly using a wrong one (and end up destroying live environment).
+  Conflicts with `forbidden_account_ids`.
+
+* `forbidden_account_ids` - (Optional) List of forbidden AWS account IDs (blacklist)
+  to prevent you mistakenly using a wrong one (and end up destroying live environment).
+  Conflicts with `allowed_account_ids`.
 
 In addition to the above parameters, the `AWS_SECURITY_TOKEN` environmental
 variable can be set to set an MFA token.


### PR DESCRIPTION
:exclamation:  Directly depends on #1594 which should be reviewed & merged separately first.

Closes https://github.com/hashicorp/terraform/issues/1063

This should prevent people (including me) from doing stupid things by simply adding a following line to the provider config:

```ruby
provider "aws" {
    forbidden_account_ids = ["1234567890"] # live account id
}
```
or taking the other approach - whitelisting IDs:
```ruby
provider "aws" {
    allowed_account_ids = ["1234567890"] # dev account id
}
```
------

btw. When I was looking at the API response structure, I realised the next step/feature could be `allow_root_accounts = true/false` if `Path = /` can help identifying root accounts... but it may not be always accurate, so it would require some further investigation.

```
$ aws iam get-user
{
    "User": {
        "UserName": "username", 
        "PasswordLastUsed": "2015-02-26T18:40:08Z", 
        "CreateDate": "2015-02-01T13:40:42Z", 
        "UserId": "AAAABBBCCC1234567890", 
        "Path": "/", 
        "Arn": "arn:aws:iam::1111111111111:user/username"
    }
}
```