### PR TITLE
providers/aws: aws_eip should not provide an empty PublicIp for describe calls

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -104,20 +104,20 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	assocIds := []*string{}
 	publicIps := []*string{}
+	req := &ec2.DescribeAddressesInput{}
+
 	if domain == "vpc" {
 		assocIds = []*string{aws.String(id)}
+		req = &ec2.DescribeAddressesInput{AllocationIDs: assocIds}
 	} else {
 		publicIps = []*string{aws.String(id)}
+		req = &ec2.DescribeAddressesInput{PublicIPs: publicIps}
 	}
 
 	log.Printf(
 		"[DEBUG] EIP describe configuration: %#v, %#v (domain: %s)",
 		assocIds, publicIps, domain)
 
-	req := &ec2.DescribeAddressesInput{
-		AllocationIDs: assocIds,
-		PublicIPs:     publicIps,
-	}
 	describeAddresses, err := ec2conn.DescribeAddresses(req)
 	if err != nil {
 		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidAllocationID.NotFound" {

--- a/builtin/providers/aws/resource_aws_eip_test.go
+++ b/builtin/providers/aws/resource_aws_eip_test.go
@@ -66,8 +66,7 @@ func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 		}
 
 		req := &ec2.DescribeAddressesInput{
-			AllocationIDs: []*string{},
-			PublicIPs:     []*string{aws.String(rs.Primary.ID)},
+			PublicIPs: []*string{aws.String(rs.Primary.ID)},
 		}
 		describe, err := conn.DescribeAddresses(req)
 
@@ -118,7 +117,6 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 		if strings.Contains(rs.Primary.ID, "eipalloc") {
 			req := &ec2.DescribeAddressesInput{
 				AllocationIDs: []*string{aws.String(rs.Primary.ID)},
-				PublicIPs:     []*string{},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {
@@ -133,8 +131,7 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 
 		} else {
 			req := &ec2.DescribeAddressesInput{
-				AllocationIDs: []*string{},
-				PublicIPs:     []*string{aws.String(rs.Primary.ID)},
+				PublicIPs: []*string{aws.String(rs.Primary.ID)},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {


### PR DESCRIPTION
When querying an EIP in VPC scope, `PublicIp` should not be provided in request or it yields;
```
* Error retrieving EIP: InvalidParameterValue: Invalid value '' for PublicIp. Not a valid IPv4 address.
```

Quite likely the acceptance tests will need an update as well.