### PR TITLE
Fixes #1535

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -320,12 +320,12 @@ func resourceAwsSecurityGroupRuleHash(v interface{}) int {
 func resourceAwsSecurityGroupIPPermGather(d *schema.ResourceData, permissions []*ec2.IPPermission) []map[string]interface{} {
 	ruleMap := make(map[string]map[string]interface{})
 	for _, perm := range permissions {
-		var fromPort, toPort *int64
+		var fromPort, toPort int64
 		if v := perm.FromPort; v != nil {
-			fromPort = v
+			fromPort = *v
 		}
 		if v := perm.ToPort; v != nil {
-			toPort = v
+			toPort = *v
 		}
 
 		k := fmt.Sprintf("%s-%d-%d", *perm.IPProtocol, fromPort, toPort)


### PR DESCRIPTION
For some reason when the pointer where the other way the rules where not refreshing correctly. Differences weren't being found.