### PR TITLE
bug: AWS EIP (dis)association fails on non-EC2-Classic accounts

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -185,7 +185,7 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 
 	// If we are attached to an instance, detach first.
 	if d.Get("instance").(string) != "" {
-		log.Printf("[DEBUG] Disassociating EIP: %s", d.Id())
+		log.Printf("[DEBUG] Disassociating EIP %s from %s", d.Id(), d.Get("instance"))
 		var err error
 		switch resourceAwsEipDomain(d) {
 		case "vpc":
@@ -224,9 +224,11 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 		if _, ok := err.(aws.APIError); !ok {
+			log.Printf("[DEBUG] AWS error when releasing EIP: %#v", err)
 			return resource.RetryError{Err: err}
 		}
 
+		log.Printf("[DEBUG] Error when releasing EIP: %#v", err)
 		return err
 	})
 }

--- a/builtin/providers/aws/resource_aws_eip_test.go
+++ b/builtin/providers/aws/resource_aws_eip_test.go
@@ -66,8 +66,7 @@ func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 		}
 
 		req := &ec2.DescribeAddressesInput{
-			AllocationIDs: []*string{},
-			PublicIPs:     []*string{aws.String(rs.Primary.ID)},
+			PublicIPs: []*string{aws.String(rs.Primary.ID)},
 		}
 		describe, err := conn.DescribeAddresses(req)
 
@@ -118,7 +117,6 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 		if strings.Contains(rs.Primary.ID, "eipalloc") {
 			req := &ec2.DescribeAddressesInput{
 				AllocationIDs: []*string{aws.String(rs.Primary.ID)},
-				PublicIPs:     []*string{},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {
@@ -133,8 +131,7 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 
 		} else {
 			req := &ec2.DescribeAddressesInput{
-				AllocationIDs: []*string{},
-				PublicIPs:     []*string{aws.String(rs.Primary.ID)},
+				PublicIPs: []*string{aws.String(rs.Primary.ID)},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {


### PR DESCRIPTION
As @pmoust mentioned in #1596 

### Test plan

All tested in a fresh new account (no EC2 Classic), it may need some testing in EC2 Classic too, but I don't have access to any.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=EIP' 2>/dev/null
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=EIP -timeout 45m
=== RUN TestAccAWSEIP_normal
--- PASS: TestAccAWSEIP_normal (2.25s)
=== RUN TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (256.66s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	258.929s
```

---- 
### `15b68fe`
_I'm happy to send 15b68fe as a separate PR, but it depends on the other commits as it's changing the same file._

#### How to replicate
```ruby
resource "aws_vpc" "default" {
  cidr_block = "10.10.0.0/16"
}

resource "aws_subnet" "public" {
  vpc_id = "${aws_vpc.default.id}"
  cidr_block = "10.10.1.0/24"
  availability_zone = "us-east-1c"
}

resource "aws_instance" "web" {
  ami = "ami-323b195a"
  availability_zone = "us-east-1c"
  instance_type = "t2.small"
  key_name = "coreos-test"
  subnet_id = "${aws_subnet.public.id}"
  associate_public_ip_address = true
}

resource "aws_eip" "lb" {
  instance = "${aws_instance.web.id}"
  vpc = true
}
```
Output (that's still valid):
```
* Failure associating instances: Gateway.NotAttached: Network vpc-7c9abd19 is not attached to any internet gateway
```
`destroy`:
```
* MissingParameter: Either public IP or association id must be specified
```

The instance ID is saved to state file even though the API request ends up in error, which then results in trying to remove association which doesn't actually exist = corrupted state.