### PR TITLE
Support session token in AWS credentials

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -32,6 +32,15 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["secret_key"],
 			},
 
+			"token": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"AWS_SESSION_TOKEN",
+				}, ""),
+				Description: descriptions["token"],
+			},
+
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -87,6 +96,9 @@ func init() {
 
 		"secret_key": "The secret key for API operations. You can retrieve this\n" +
 			"from the 'Security & Credentials' section of the AWS console.",
+
+		"token": "session token. A session token is only required if you are\n" +
+			"using temporary security credentials.",
 	}
 }
 
@@ -94,6 +106,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		AccessKey: d.Get("access_key").(string),
 		SecretKey: d.Get("secret_key").(string),
+		Token:     d.Get("token").(string),
 		Region:    d.Get("region").(string),
 	}
 


### PR DESCRIPTION
Session tokens are necessary to utilize temporary credentials.
http://docs.aws.amazon.com/STS/latest/UsingSTS/Welcome.html