### PR TITLE
Enhance validation and tests around multi-provider

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -430,6 +430,15 @@ func (c *Config) Validate() error {
 			}
 		}
 
+		// Verify provider points to a provider that is configured
+		if r.Provider != "" {
+			if _, ok := providerSet[r.Provider]; !ok {
+				errs = append(errs, fmt.Errorf(
+					"%s: resource depends on non-configured provider '%s'",
+					n, r.Provider))
+			}
+		}
+
 		// Verify provisioners don't contain any splats
 		for _, p := range r.Provisioners {
 			// This validation checks that there are now splat variables

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -210,6 +210,13 @@ func TestConfigValidate_providerMulti(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_providerMultiGood(t *testing.T) {
+	c := testConfig(t, "validate-provider-multi-good")
+	if err := c.Validate(); err != nil {
+		t.Fatalf("should be valid: %s", err)
+	}
+}
+
 func TestConfigValidate_provConnSplatOther(t *testing.T) {
 	c := testConfig(t, "validate-prov-conn-splat-other")
 	if err := c.Validate(); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -203,6 +203,13 @@ func TestConfigValidate_pathVarInvalid(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_providerMulti(t *testing.T) {
+	c := testConfig(t, "validate-provider-multi")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_provConnSplatOther(t *testing.T) {
 	c := testConfig(t, "validate-prov-conn-splat-other")
 	if err := c.Validate(); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -217,6 +217,20 @@ func TestConfigValidate_providerMultiGood(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_providerMultiRefGood(t *testing.T) {
+	c := testConfig(t, "validate-provider-multi-ref-good")
+	if err := c.Validate(); err != nil {
+		t.Fatalf("should be valid: %s", err)
+	}
+}
+
+func TestConfigValidate_providerMultiRefBad(t *testing.T) {
+	c := testConfig(t, "validate-provider-multi-ref-bad")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_provConnSplatOther(t *testing.T) {
 	c := testConfig(t, "validate-prov-conn-splat-other")
 	if err := c.Validate(); err != nil {

--- a/config/test-fixtures/validate-provider-multi-good/main.tf
+++ b/config/test-fixtures/validate-provider-multi-good/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+    alias = "bar"
+}
+
+provider "aws" {
+    alias = "foo"
+}

--- a/config/test-fixtures/validate-provider-multi-ref-bad/main.tf
+++ b/config/test-fixtures/validate-provider-multi-ref-bad/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+    alias = "bar"
+}
+
+resource "aws_instance" "foo" {
+    provider = "aws.baz"
+}

--- a/config/test-fixtures/validate-provider-multi-ref-good/main.tf
+++ b/config/test-fixtures/validate-provider-multi-ref-good/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+    alias = "bar"
+}
+
+resource "aws_instance" "foo" {
+    provider = "aws.bar"
+}

--- a/config/test-fixtures/validate-provider-multi/main.tf
+++ b/config/test-fixtures/validate-provider-multi/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+    alias = "foo"
+}
+
+provider "aws" {
+    alias = "foo"
+}

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -610,6 +610,43 @@ func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_providerAliasMissing(t *testing.T) {
+	m := testModule(t, "apply-provider-alias-missing")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.foo": &ResourceState{
+						Type:     "aws_instance",
+						Provider: "aws.foo",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"require_new": "abc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: state,
+	})
+
+	if _, err := ctx.Plan(); err == nil {
+		t.Fatal("should err")
+	}
+}
+
 func TestContext2Plan_computed(t *testing.T) {
 	m := testModule(t, "plan-computed")
 	p := testProvider("aws")

--- a/terraform/test-fixtures/apply-provider-alias-missing/main.tf
+++ b/terraform/test-fixtures/apply-provider-alias-missing/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+	alias = "bar"
+}
+
+resource "aws_instance" "bar" {
+    foo = "bar"
+    provider = "aws.bar"
+}

--- a/terraform/test-fixtures/input-provider-multi/main.tf
+++ b/terraform/test-fixtures/input-provider-multi/main.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+    alias = "east"
+}
+
+resource "aws_instance" "foo" {
+    alias = "east"
+}
+
+resource "aws_instance" "bar" {}


### PR DESCRIPTION
This adds config validation and more tests around multi provider:

* Verify a provider with an alias is only configured once.
* Verify that resources that specify a provider are specifying a _configured_ provider.
* Verify that if the state contains a resource with a provider that doesn't exist in the config, it is an error.
* Verify the behavior of asking for input with multiple providers.