### PR TITLE
provider/aws: Support S3 detailed ACL

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -26,7 +26,36 @@ func resourceAwsS3Bucket() *schema.Resource {
 
 			"acl": &schema.Schema{
 				Type:     schema.TypeString,
-				Default:  "private",
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"grant_full_control": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"grant_read": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"grant_read_acp": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"grant_write": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"grant_write_acp": &schema.Schema{
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -40,15 +69,40 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 	awsRegion := meta.(*AWSClient).region
 
-	// Get the bucket and acl
+	// Get the bucket, acl and grants
 	bucket := d.Get("bucket").(string)
 	acl := d.Get("acl").(string)
+	grant_full_control := d.Get("grant_full_control").(string)
+	grant_read := d.Get("grant_read").(string)
+	grant_read_acp := d.Get("grant_read_acp").(string)
+	grant_write := d.Get("grant_write").(string)
+	grant_write_acp := d.Get("grant_write_acp").(string)
 
 	log.Printf("[DEBUG] S3 bucket create: %s, ACL: %s", bucket, acl)
 
 	req := &s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 		ACL:    aws.String(acl),
+	}
+
+	if grant_full_control != "" {
+		req.GrantFullControl = aws.String(grant_full_control)
+	}
+
+	if grant_read != "" {
+		req.GrantRead = aws.String(grant_read)
+	}
+
+	if grant_read_acp != "" {
+		req.GrantReadACP = aws.String(grant_read_acp)
+	}
+
+	if grant_write != "" {
+		req.GrantWrite = aws.String(grant_write)
+	}
+
+	if grant_write_acp != "" {
+		req.GrantWriteACP = aws.String(grant_write_acp)
 	}
 
 	// Special case us-east-1 region and do not set the LocationConstraint.

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -24,7 +24,12 @@ resource "aws_s3_bucket" "b" {
 The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket.
-* `acl` - (Optional) The canned ACL to apply. Defaults to "private".
+* `acl` - (Optional) The canned ACL to apply.
+* `grant_full_control` - (Optional) The grantee which has full controll permission.
+* `grant_read` - (Optional) The grantee which has read permission.
+* `grant_read_acp` - (Optional) The grantee which has read ACP permission.
+* `grant_write` - (Optional) The grantee which has write permission.
+* `grant_write_acp` - (Optional) The grantee which has write ACP permission.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Currently [`aws_s3_bucket` resource](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html) supports only [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
In this PR, I added a support for [detailed bucket ACL](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), like `FULL_CONTROL`, `READ`, `READ_ACP`, `WRITE` and `WRITE_ACP`.

I added 5 arguments to `aws_s3_bucket` resource:

- `grant_full_control`
- `grant_read`
- `grant_read_acp`
- `grant_write`
- `grant_write_acp`

## Example

`s3.tf`

```go
resource "aws_s3_bucket" "hoge" {
  bucket = "dtan4-terraform-hoge"
  grant_read_acp = "emailAddress=\"dtanshi45@gmail.com\""
  grant_write = "emailAddress=\"dtanshi45@gmail.com\""
}
```

(generated) `terraform.tfstate`

```js
# terraform.tfstate

{
    "version": 1,
    "serial": 18,
    "modules": [
        {
            "path": [
                "root"
            ],
            "outputs": {},
            "resources": {
                "aws_s3_bucket.hoge": {
                    "type": "aws_s3_bucket",
                    "primary": {
                        "id": "dtan4-terraform-hoge",
                        "attributes": {
                            "bucket": "dtan4-terraform-hoge",
                            "grant_read_acp": "emailAddress=\"dtanshi45@gmail.com\"",
                            "grant_write": "emailAddress=\"dtanshi45@gmail.com\"",
                            "id": "dtan4-terraform-hoge"
                        }
                    }
                }
            }
        }
    ]
}
```