### PR TITLE
provider/aws: Fix issue in Security Groups with empty IPRanges

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -93,9 +93,8 @@ func expandIPPerms(
 
 		if raw, ok := m["cidr_blocks"]; ok {
 			list := raw.([]interface{})
-			perm.IPRanges = make([]*ec2.IPRange, len(list))
-			for i, v := range list {
-				perm.IPRanges[i] = &ec2.IPRange{CIDRIP: aws.String(v.(string))}
+			for _, v := range list {
+				perm.IPRanges = append(perm.IPRanges, &ec2.IPRange{CIDRIP: aws.String(v.(string))})
 			}
 		}
 


### PR DESCRIPTION
Either a change in the API, or how the `aws-sdk-go` library handles things (since moving to upstream), has caused a break in creating Security Groups with `self` or just a `security_groups` attribute, as demonstrated in #1600.

This PR changes the behavior to not allocate an empty slice of `[]*ec2.IPRange` if there are no `cidr_blocks` present. As a result, we correctly send an `IPPermission` struct with `[]*ec2.IPRange(nil)` in this situation.

Fixes #1600