### PR TITLE
helper/schema: empty map in state should not compute map

### DIFF
--- a/helper/schema/field_reader_map.go
+++ b/helper/schema/field_reader_map.go
@@ -56,10 +56,11 @@ func (r *MapFieldReader) readMap(k string) (FieldReadResult, error) {
 	prefix := k + "."
 	r.Map.Range(func(k, v string) bool {
 		if strings.HasPrefix(k, prefix) {
+			resultSet = true
+
 			key := k[len(prefix):]
 			if key != "#" {
 				result[key] = v
-				resultSet = true
 			}
 		}
 

--- a/helper/schema/field_reader_map_test.go
+++ b/helper/schema/field_reader_map_test.go
@@ -49,11 +49,14 @@ func TestMapFieldReader(t *testing.T) {
 func TestMapFieldReader_extra(t *testing.T) {
 	r := &MapFieldReader{
 		Schema: map[string]*Schema{
-			"mapDel": &Schema{Type: TypeMap},
+			"mapDel":   &Schema{Type: TypeMap},
+			"mapEmpty": &Schema{Type: TypeMap},
 		},
 
 		Map: BasicMapReader(map[string]string{
 			"mapDel": "",
+
+			"mapEmpty.#": "0",
 		}),
 	}
 
@@ -66,6 +69,14 @@ func TestMapFieldReader_extra(t *testing.T) {
 	}{
 		"mapDel": {
 			[]string{"mapDel"},
+			map[string]interface{}{},
+			true,
+			false,
+			false,
+		},
+
+		"mapEmpty": {
+			[]string{"mapEmpty"},
 			map[string]interface{}{},
 			true,
 			false,

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2201,6 +2201,29 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			Err: false,
 		},
+
+		// #57 - Computed map without config that's known to be empty does not
+		//       generate diff
+		{
+			Schema: map[string]*Schema{
+				"tags": &Schema{
+					Type:     TypeMap,
+					Computed: true,
+				},
+			},
+
+			Config: nil,
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"tags.#": "0",
+				},
+			},
+
+			Diff: nil,
+
+			Err: false,
+		},
 	}
 
 	for i, tc := range cases {

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -134,6 +134,15 @@ func (c *ResourceConfig) Get(k string) (interface{}, bool) {
 	return c.get(k, c.Raw)
 }
 
+// GetRaw looks up a configuration value by key and returns the value,
+// from the raw, uninterpolated config.
+//
+// The second return value is true if the get was successful. Get will
+// not succeed if the value is being computed.
+func (c *ResourceConfig) GetRaw(k string) (interface{}, bool) {
+	return c.get(k, c.Raw)
+}
+
 // IsComputed returns whether the given key is computed or not.
 func (c *ResourceConfig) IsComputed(k string) bool {
 	_, ok := c.get(k, c.Config)


### PR DESCRIPTION
Fixes #1607

This makes it so that having an empty map in the state (`map.# = 0`) and a computed map element in the schema, that the diff should be empty.