### PR TITLE
provider/aws: Fix issue with updating VPC Security Group IDs for an Instance

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -316,6 +316,10 @@ func TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						"aws_instance.foo_instance", &v),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo_instance", "security_groups.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo_instance", "vpc_security_group_ids.#", "1"),
 				),
 			},
 		},


### PR DESCRIPTION
Currently, we aren't correctly setting the ids, and are setting both
`security_groups` and `vpc_security_group_ids` in the state. As a result, we really only use
the former, but the latter never goes away in the state file :frowning: 

We also don't actually update the remote security groups in the `update` method.

This PR fixes both issues, correctly reading `security_groups` vs.
`vpc_security_group_ids` and allows users to update the latter without
destroying the Instance when in a VPC.

Should fix #1611