### PR TITLE
Set variables from env vars

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -11,6 +11,12 @@ import (
 	"github.com/hashicorp/terraform/config/module"
 )
 
+const (
+	// VarEnvPrefix is the prefix of variables that are read from
+	// the environment to set variables here.
+	VarEnvPrefix = "TF_VAR_"
+)
+
 // Interpolater is the structure responsible for determining the values
 // for interpolations such as `aws_instance.foo.bar`.
 type Interpolater struct {
@@ -43,6 +49,11 @@ func (i *Interpolater) Values(
 		}
 		for _, v := range mod.Config().Variables {
 			for k, val := range v.DefaultsMap() {
+				envKey := VarEnvPrefix + strings.TrimPrefix(k, "var.")
+				if v := os.Getenv(envKey); v != "" {
+					val = v
+				}
+
 				result[k] = ast.Variable{
 					Value: val,
 					Type:  ast.TypeString,

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -47,6 +47,14 @@ func tempDir(t *testing.T) string {
 	return dir
 }
 
+// tempEnv lets you temporarily set an environment variable. It returns
+// the old value that should be set via a defer.
+func tempEnv(t *testing.T, k string, v string) string {
+	old := os.Getenv(k)
+	os.Setenv(k, v)
+	return old
+}
+
 func testConfig(t *testing.T, name string) *config.Config {
 	c, err := config.Load(filepath.Join(fixtureDir, name, "main.tf"))
 	if err != nil {
@@ -618,6 +626,13 @@ aws_instance.foo:
   ID = foo
   bar = baz
   num = 2
+  type = aws_instance
+`
+
+const testTerraformApplyVarsEnvStr = `
+aws_instance.bar:
+  ID = foo
+  foo = baz
   type = aws_instance
 `
 

--- a/terraform/test-fixtures/apply-vars-env/main.tf
+++ b/terraform/test-fixtures/apply-vars-env/main.tf
@@ -1,0 +1,7 @@
+variable "ami" {
+    default = "foo"
+}
+
+resource "aws_instance" "bar" {
+    foo = "${var.ami}"
+}

--- a/website/source/docs/configuration/variables.html.md
+++ b/website/source/docs/configuration/variables.html.md
@@ -90,6 +90,25 @@ The usage of maps, strings, etc. is documented fully in the
 [interpolation syntax](/docs/configuration/interpolation.html)
 page.
 
+## Environment Variables
+
+Environment variables can be used to set the value of a variable.
+The key of the environment variable must be `TF_VAR_name` and the value
+is the value of the variable.
+
+For example, given the configuration below:
+
+```
+variable "image" {}
+```
+
+The variable can be set via an environment variable:
+
+```
+$ TF_VAR_image=foo terraform apply
+...
+```
+
 ## Syntax
 
 The full syntax is:

--- a/website/source/intro/getting-started/variables.html.md
+++ b/website/source/intro/getting-started/variables.html.md
@@ -53,14 +53,16 @@ the AWS provider with the given variables.
 
 ## Assigning Variables
 
-There are three ways to assign variables.
+There are multiple ways to assign variables. Below is also the order
+in which variable values are chosen. If they're found in an option first
+below, then the options below are ignored.
 
-First, if you execute `terraform plan` or apply without doing
+**UI Input:** If you execute `terraform plan` or apply without doing
 anything, Terraform will ask you to input the variables interactively.
 These variables are not saved, but provides a nice user experience for
 getting started with Terraform.
 
-For another option, you can set it directly on the command-line with the
+**Command-line flags:** You can set it directly on the command-line with the
 `-var` flag. Any command in Terraform that inspects the configuration
 accepts this flag, such as `apply`, `plan`, and `refresh`:
 
@@ -74,7 +76,7 @@ $ terraform plan \
 Once again, setting variables this way will not save them, and they'll
 have to be input repeatedly as commands are executed.
 
-The third way, and the way to persist variable values, is to create
+**From a file:** To persist variable values, create
 a file and assign variables within this file. Create a file named
 "terraform.tfvars" with the following contents:
 
@@ -88,6 +90,10 @@ Terraform automatically loads it to populate variables. If the file is
 named something else, you can use the `-var-file` flag directly to
 specify a file. These files are the same syntax as Terraform configuration
 files. And like Terraform configuration files, these files can also be JSON.
+
+**From environment variables:** Terraform will read environment variables
+in the form of `TF_VAR_name` to find the value for a variable. For example,
+the `TF_VAR_access_key` variable can be set to set the `access_key` variable.
 
 We recommend using the "terraform.tfvars" file, and ignoring it from
 version control.


### PR DESCRIPTION
Fixes #62 (enough for now, at least)

This makes it so that you can set the env var `TF_VAR_name` to set the variable with the name "name". 

In the future, we'd still like to add `${env.NAME}` syntax to the configuration, but the way we'd like to do that represents significantly more engineering effort. This is a nice stop-gap solution to support env vars for configuration that is simple to implement. And it isn't mutually exclusive to `env.NAME` interpolations: we'll keep both when we implement them.

I've found this style of configuration to be very useful in automation environments.