### PR TITLE
config: error in validation if module has self variable [GH-1609]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -309,9 +309,13 @@ func (c *Config) Validate() error {
 
 		// Check for invalid count variables
 		for _, v := range m.RawConfig.Variables {
-			if _, ok := v.(*CountVariable); ok {
+			switch v.(type) {
+			case *CountVariable:
 				errs = append(errs, fmt.Errorf(
 					"%s: count variables are only valid within resources", m.Name))
+			case *SelfVariable:
+				errs = append(errs, fmt.Errorf(
+					"%s: self variables are only valid within resources", m.Name))
 			}
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,6 +175,13 @@ func TestConfigValidate_moduleVarMap(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_moduleVarSelf(t *testing.T) {
+	c := testConfig(t, "validate-module-var-self")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should be invalid")
+	}
+}
+
 func TestConfigValidate_nil(t *testing.T) {
 	var c Config
 	if err := c.Validate(); err != nil {

--- a/config/test-fixtures/validate-module-var-self/main.tf
+++ b/config/test-fixtures/validate-module-var-self/main.tf
@@ -1,0 +1,4 @@
+module "foo" {
+    source = "./foo"
+    foo = "${self.bar}"
+}


### PR DESCRIPTION
Fixes #1609 

This adds validation so that self variables can't be used in modules. 