### PR TITLE
providers/aws: if no public IP, use private IP for SSH by default

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -544,6 +544,11 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			"type": "ssh",
 			"host": *instance.PublicIPAddress,
 		})
+	} else if instance.PrivateIPAddress != nil {
+		d.SetConnInfo(map[string]string{
+			"type": "ssh",
+			"host": *instance.PrivateIPAddress,
+		})
 	}
 
 	// Set our attributes


### PR DESCRIPTION
Fixes #995 

This sets the private IP address as the default SSH address if it is available and the public IP is not.