### PR TITLE
provider/aws: allow int for network acl entry [GH-1435]

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -13,11 +13,15 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2
 	for _, eRaw := range configured {
 		data := eRaw.(map[string]interface{})
 		protocol := data["protocol"].(string)
-		_, ok := protocolIntegers()[protocol]
-		if !ok {
-			return nil, fmt.Errorf("Invalid Protocol %s for rule %#v", protocol, data)
+		p, err := strconv.Atoi(protocol)
+		if err != nil {
+			var ok bool
+			p, ok = protocolIntegers()[protocol]
+			if !ok {
+				return nil, fmt.Errorf("Invalid Protocol %s for rule %#v", protocol, data)
+			}
 		}
-		p := extractProtocolInteger(data["protocol"].(string))
+
 		e := &ec2.NetworkACLEntry{
 			Protocol: aws.String(strconv.Itoa(p)),
 			PortRange: &ec2.PortRange{
@@ -50,19 +54,6 @@ func flattenNetworkAclEntries(list []*ec2.NetworkACLEntry) []map[string]interfac
 
 	return entries
 
-}
-
-func extractProtocolInteger(protocol string) int {
-	return protocolIntegers()[protocol]
-}
-
-func extractProtocolString(protocol int) string {
-	for key, value := range protocolIntegers() {
-		if value == protocol {
-			return key
-		}
-	}
-	return ""
 }
 
 func protocolIntegers() map[string]int {

--- a/builtin/providers/aws/network_acl_entry_test.go
+++ b/builtin/providers/aws/network_acl_entry_test.go
@@ -26,6 +26,14 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 			"action":     "deny",
 			"rule_no":    2,
 		},
+		map[string]interface{}{
+			"protocol":   "-1",
+			"from_port":  443,
+			"to_port":    443,
+			"cidr_block": "0.0.0.0/0",
+			"action":     "deny",
+			"rule_no":    2,
+		},
 	}
 	expanded, _ := expandNetworkAclEntries(input, "egress")
 
@@ -43,6 +51,17 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 		},
 		&ec2.NetworkACLEntry{
 			Protocol: aws.String("6"),
+			PortRange: &ec2.PortRange{
+				From: aws.Long(443),
+				To:   aws.Long(443),
+			},
+			RuleAction: aws.String("deny"),
+			RuleNumber: aws.Long(2),
+			CIDRBlock:  aws.String("0.0.0.0/0"),
+			Egress:     aws.Boolean(true),
+		},
+		&ec2.NetworkACLEntry{
+			Protocol: aws.String("-1"),
 			PortRange: &ec2.PortRange{
 				From: aws.Long(443),
 				To:   aws.Long(443),


### PR DESCRIPTION
Fixes #1435 

Allow pure protocol integers for network ACL protocols.