### PR TITLE
helper/schema: validate unknown fields with computed values [GH-1507]

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1078,7 +1078,7 @@ func (m schemaMap) validateObject(
 	}
 
 	// Detect any extra/unknown keys and report those as errors.
-	raw, _ := c.Get(k)
+	raw, _ := c.GetRaw(k)
 	if m, ok := raw.(map[string]interface{}); ok {
 		for subk, _ := range m {
 			if _, ok := schema[subk]; !ok {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2933,6 +2933,27 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Err: true,
 		},
 
+		"Invalid/unknown field with computed value": {
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"foo": "${var.foo}",
+			},
+
+			Vars: map[string]string{
+				"var.foo": config.UnknownVariableValue,
+			},
+
+			Err: true,
+		},
+
 		"Computed field set": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{


### PR DESCRIPTION
Fixes #1507 

We have to use the raw value (non-interpolated) in order to find _all_ keys to validate. This will catch fields that have computed values that simply don't exist in the schema.