### PR TITLE
unique identifier helper for resources / generate AWS security group names

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -364,16 +364,13 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		createLaunchConfigurationOpts.BlockDeviceMappings = blockDevices
 	}
 
-	var id string
+	var lcName string
 	if v, ok := d.GetOk("name"); ok {
-		id = v.(string)
+		lcName = v.(string)
 	} else {
-		hash := sha1.Sum([]byte(fmt.Sprintf("%#v", createLaunchConfigurationOpts)))
-		configName := fmt.Sprintf("terraform-%s", base64.URLEncoding.EncodeToString(hash[:]))
-		log.Printf("[DEBUG] Computed Launch config name: %s", configName)
-		id = configName
+		lcName = resource.UniqueId()
 	}
-	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(id)
+	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(lcName)
 
 	log.Printf(
 		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
@@ -382,7 +379,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating launch configuration: %s", err)
 	}
 
-	d.SetId(id)
+	d.SetId(lcName)
 	log.Printf("[INFO] launch configuration ID: %s", d.Id())
 
 	// We put a Retry here since sometimes eventual consistency bites

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -31,7 +31,8 @@ func resourceAwsSecurityGroup() *schema.Resource {
 
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"vpc_id": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
@@ -178,6 +179,33 @@ func TestAccAWSSecurityGroup_Change(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupAttributesChanged(&group),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroup_generatedName(t *testing.T) {
+	var group ec2.SecurityGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
+					func(s *terraform.State) error {
+						if group.GroupName == nil {
+							return fmt.Errorf("bad: No SG name")
+						}
+						if !strings.HasPrefix(*group.GroupName, "terraform-") {
+							return fmt.Errorf("No terraform- prefix: %s", *group.GroupName)
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -516,5 +544,22 @@ resource "aws_security_group" "foo" {
   tags {
     bar = "baz"
   }
+}
+`
+
+const testAccAWSSecurityGroupConfig_generatedName = `
+resource "aws_security_group" "web" {
+  description = "Used in the terraform acceptance tests"
+
+  ingress {
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+
+	tags {
+		Name = "tf-acc-test"
+	}
 }
 `

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -197,6 +197,8 @@ func TestAccAWSSecurityGroup_generatedName(t *testing.T) {
 				Config: testAccAWSSecurityGroupConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "description", "Managed by Terraform"),
 					func(s *terraform.State) error {
 						if group.GroupName == nil {
 							return fmt.Errorf("bad: No SG name")
@@ -549,8 +551,6 @@ resource "aws_security_group" "foo" {
 
 const testAccAWSSecurityGroupConfig_generatedName = `
 resource "aws_security_group" "web" {
-  description = "Used in the terraform acceptance tests"
-
   ingress {
     protocol = "tcp"
     from_port = 80

--- a/helper/resource/id.go
+++ b/helper/resource/id.go
@@ -12,14 +12,30 @@ const UniqueIdPrefix = `terraform-`
 // Helper for a resource to generate a unique identifier
 //
 // This uses a simple RFC 4122 v4 UUID with some basic cosmetic filters
-// applied (remove padding, downcase) to help distinguishing visually between
-// identifiers.
+// applied (base32, remove padding, downcase) to make visually distinguishing
+// identifiers easier.
 func UniqueId() string {
-	var uuid [16]byte
-	rand.Read(uuid[:])
 	return fmt.Sprintf("%s%s", UniqueIdPrefix,
 		strings.ToLower(
 			strings.Replace(
-				base32.StdEncoding.EncodeToString(uuid[:]),
+				base32.StdEncoding.EncodeToString(uuidV4()),
 				"=", "", -1)))
+}
+
+func uuidV4() []byte {
+	var uuid [16]byte
+
+	// Set all the other bits to randomly (or pseudo-randomly) chosen
+	// values.
+	rand.Read(uuid[:])
+
+	// Set the two most significant bits (bits 6 and 7) of the
+	// clock_seq_hi_and_reserved to zero and one, respectively.
+	uuid[8] = (uuid[8] | 0x80) & 0x8f
+
+	// Set the four most significant bits (bits 12 through 15) of the
+	// time_hi_and_version field to the 4-bit version number from Section 4.1.3.
+	uuid[6] = (uuid[6] | 0x40) & 0x4f
+
+	return uuid[:]
 }

--- a/helper/resource/id.go
+++ b/helper/resource/id.go
@@ -1,0 +1,25 @@
+package resource
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"fmt"
+	"strings"
+)
+
+const UniqueIdPrefix = `terraform-`
+
+// Helper for a resource to generate a unique identifier
+//
+// This uses a simple RFC 4122 v4 UUID with some basic cosmetic filters
+// applied (remove padding, downcase) to help distinguishing visually between
+// identifiers.
+func UniqueId() string {
+	var uuid [16]byte
+	rand.Read(uuid[:])
+	return fmt.Sprintf("%s%s", UniqueIdPrefix,
+		strings.ToLower(
+			strings.Replace(
+				base32.StdEncoding.EncodeToString(uuid[:]),
+				"=", "", -1)))
+}

--- a/helper/resource/id_test.go
+++ b/helper/resource/id_test.go
@@ -1,0 +1,25 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUniqueId(t *testing.T) {
+	iterations := 10000
+	ids := make(map[string]struct{})
+	var id string
+	for i := 0; i < iterations; i++ {
+		id = UniqueId()
+
+		if _, ok := ids[id]; ok {
+			t.Fatalf("Got duplicated id! %s", id)
+		}
+
+		if !strings.HasPrefix(id, "terraform-") {
+			t.Fatalf("Unique ID didn't have terraform- prefix! %s", id)
+		}
+
+		ids[id] = struct{}{}
+	}
+}


### PR DESCRIPTION
Provider resources can use `resource.UniqueId()` when they need an identifier generated for any attribute.

Switch AWS Launch Configurations to use the new helper.

Used the new helper to support generated AWS Security Group names.