### PR TITLE
changing route53_zone.name_servers back to list

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -34,12 +33,9 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			},
 
 			"name_servers": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
-				Set: func(v interface{}) int {
-					return hashcode.String(v.(string))
-				},
 			},
 
 			"tags": tagsSchema(),

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -101,6 +102,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 	for i := range zone.DelegationSet.NameServers {
 		ns[i] = *zone.DelegationSet.NameServers[i]
 	}
+	sort.Strings(ns)
 	if err := d.Set("name_servers", ns); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting name servers for: %s, error: %#v", d.Id(), err)
 	}

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -115,10 +116,15 @@ func testAccCheckRoute53ZoneExists(n string, zone *route53.HostedZone) resource.
 			return fmt.Errorf("Hosted zone err: %v", err)
 		}
 
-		for idx, ns := range resp.DelegationSet.NameServers {
+		sorted_ns := make([]string, len(resp.DelegationSet.NameServers))
+		for i, ns := range resp.DelegationSet.NameServers {
+			sorted_ns[i] = *ns
+		}
+		sort.Strings(sorted_ns)
+		for idx, ns := range sorted_ns {
 			attribute := fmt.Sprintf("name_servers.%d", idx)
 			dsns := rs.Primary.Attributes[attribute]
-			if dsns != *ns {
+			if dsns != ns {
 				return fmt.Errorf("Got: %v for %v, Expected: %v", dsns, attribute, ns)
 			}
 		}

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -116,8 +115,8 @@ func testAccCheckRoute53ZoneExists(n string, zone *route53.HostedZone) resource.
 			return fmt.Errorf("Hosted zone err: %v", err)
 		}
 
-		for _, ns := range resp.DelegationSet.NameServers {
-			attribute := fmt.Sprintf("name_servers.%d", hashcode.String(*ns))
+		for idx, ns := range resp.DelegationSet.NameServers {
+			attribute := fmt.Sprintf("name_servers.%d", idx)
 			dsns := rs.Primary.Attributes[attribute]
 			if dsns != *ns {
 				return fmt.Errorf("Got: %v for %v, Expected: %v", dsns, attribute, ns)


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/pull/1525 and https://github.com/hashicorp/terraform/pull/1573, I had to change the computed `name_servers` attribute back to a list so the values could be referenced elsewhere as they are in the docs. Until we can reference set elements correctly, this was about the only way I could think of to get it to work. I've verified that the name servers are returned from the AWS API are in a consistent ordering as well.

```
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	140.474s
```