### PR TITLE
providers/aws: network_acl, remove blank filter

### DIFF
--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -342,7 +342,6 @@ func getDefaultNetworkAcl(vpc_id string, conn *ec2.EC2) (defaultAcl *ec2.Network
 
 func findNetworkAclAssociation(subnetId string, conn *ec2.EC2) (networkAclAssociation *ec2.NetworkACLAssociation, err error) {
 	resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
-		NetworkACLIDs: []*string{},
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
 				Name:   aws.String("association.subnet-id"),


### PR DESCRIPTION
The upstream behavior here changed, and the request needs a `nil`
instead of an empty slice to indicate that we _don't_ want to filter on
Network ACL IDs.

fixes #1634