### PR TITLE
provider/aws: attach existing EC2 volumes

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -247,6 +247,39 @@ func resourceAwsInstance() *schema.Resource {
 				},
 			},
 
+			"volume": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"volume_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+            "attached": &schema.Schema{
+              Type:     schema.TypeBool,
+              Computed: true,
+            },
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", m["volume_id"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+
+
 			"root_block_device": &schema.Schema{
 				// TODO: This is a set because we don't support singleton
 				//       sub-resources today. We'll enforce that the set only ever has
@@ -536,6 +569,36 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			"type": "ssh",
 			"host": *instance.PublicIPAddress,
 		})
+	}
+
+  // Attach volumes
+	if v, ok := d.GetOk("volume"); ok {
+		vL := v.(*schema.Set).List()
+		for _, v := range vL {
+			vol := v.(map[string]interface{})
+
+			if v, ok := vol["attached"].(bool); ok && v {
+        // Already attached
+        break
+			}
+
+			attach := &ec2.AttachVolumeInput {
+				InstanceID: instance.InstanceID,
+        Device: aws.String(vol["device_name"].(string)),
+        VolumeID: aws.String(vol["volume_id"].(string)),
+			}
+
+      _, err := conn.AttachVolume(attach)
+      if err != nil {
+        return fmt.Errorf("Error attaching volume: %s", err)
+      }
+
+	    vol["attached"] = true 
+
+		}
+    if err := d.Set("volume", v); err != nil {
+      return err
+    }
 	}
 
 	// Set our attributes

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -264,10 +264,10 @@ func resourceAwsInstance() *schema.Resource {
 							Required: true,
 						},
 
-            "attached": &schema.Schema{
-              Type:     schema.TypeBool,
-              Computed: true,
-            },
+						"attached": &schema.Schema{
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 				Set: func(v interface{}) int {
@@ -571,34 +571,34 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		})
 	}
 
-  // Attach volumes
+	// Attach volumes
 	if v, ok := d.GetOk("volume"); ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
 			vol := v.(map[string]interface{})
 
 			if v, ok := vol["attached"].(bool); ok && v {
-        // Already attached
-        break
+				// Already attached
+				break
 			}
 
 			attach := &ec2.AttachVolumeInput {
 				InstanceID: instance.InstanceID,
-        Device: aws.String(vol["device_name"].(string)),
-        VolumeID: aws.String(vol["volume_id"].(string)),
+				Device: aws.String(vol["device_name"].(string)),
+				VolumeID: aws.String(vol["volume_id"].(string)),
 			}
 
-      _, err := conn.AttachVolume(attach)
-      if err != nil {
-        return fmt.Errorf("Error attaching volume: %s", err)
-      }
+			_, err := conn.AttachVolume(attach)
+			if err != nil {
+				return fmt.Errorf("Error attaching volume: %s", err)
+			}
 
-	    vol["attached"] = true 
+			vol["attached"] = true
 
 		}
-    if err := d.Set("volume", v); err != nil {
-      return err
-    }
+		if err := d.Set("volume", v); err != nil {
+			return err
+		}
 	}
 
 	// Set our attributes

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -114,6 +114,24 @@ resources cannot be automatically detected by Terraform. After making updates
 to block device configuration, resource recreation can be manually triggered by
 using the [`taint` command](/docs/commands/taint.html).
 
+<a id="volumes"></a>
+## Volumes
+
+Each `volume` attribute mounts an existing AWS volume to the instance. Volumes
+must exist in the same availability zone as the instance.
+
+The `volume` mapping supports the following:
+
+* `device_name` - The name of the block device to mount on the instance.
+* `volume_id` - The id of the volume.
+
+Modifying any of the `volume` settings requires resource replacement.
+
+~> **NOTE:** Currently, changes to `volume` configuration of _existing_
+resources cannot be automatically detected by Terraform. After making updates
+to block device configuration, resource recreation can be manually triggered by
+using the [`taint` command](/docs/commands/taint.html).
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Allows existing EC2 volumes to be attached to instances.

A few notes:

* This is part of the aws_instance resource instead of its own resource in order to make the volume available to the instance before provisioning.  There may be better ways to accomplish this goal.
* Acceptance tests are not included as I was unsure of the proper way to set up and tear down volumes before and after the test.  Any input on this would be appreciated.  I would be more than happy to add them.
* I am a go and terraform newbie, so any general feedback is welcome.