### PR TITLE
Bug: Fix missing values for keys containing periods.

### DIFF
--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -118,40 +118,49 @@ func (r *ConfigFieldReader) readMap(k string) (FieldReadResult, error) {
 	switch m := mraw.(type) {
 	case []interface{}:
 		for i, innerRaw := range m {
-			for ik, _ := range innerRaw.(map[string]interface{}) {
+			for ik, iv := range innerRaw.(map[string]interface{}) {
 				key := fmt.Sprintf("%s.%d.%s", k, i, ik)
 				if r.Config.IsComputed(key) {
 					computed = true
 					break
 				}
 
-				v, _ := r.Config.Get(key)
-				result[ik] = v
+				if v, ok := r.Config.Get(key); ok {
+					result[ik] = v
+				} else {
+					result[ik] = iv
+				}
 			}
 		}
 	case []map[string]interface{}:
 		for i, innerRaw := range m {
-			for ik, _ := range innerRaw {
+			for ik, iv := range innerRaw {
 				key := fmt.Sprintf("%s.%d.%s", k, i, ik)
 				if r.Config.IsComputed(key) {
 					computed = true
 					break
 				}
 
-				v, _ := r.Config.Get(key)
-				result[ik] = v
+				if v, ok := r.Config.Get(key); ok {
+					result[ik] = v
+				} else {
+					result[ik] = iv
+				}
 			}
 		}
 	case map[string]interface{}:
-		for ik, _ := range m {
+		for ik, iv := range m {
 			key := fmt.Sprintf("%s.%s", k, ik)
 			if r.Config.IsComputed(key) {
 				computed = true
 				break
 			}
 
-			v, _ := r.Config.Get(key)
-			result[ik] = v
+			if v, ok := r.Config.Get(key); ok {
+				result[ik] = v
+			} else {
+				result[ik] = iv
+			}
 		}
 	default:
 		panic(fmt.Sprintf("unknown type: %#v", mraw))

--- a/helper/schema/field_reader_config_test.go
+++ b/helper/schema/field_reader_config_test.go
@@ -153,14 +153,16 @@ func TestConfigFieldReader_ComputedMap(t *testing.T) {
 			[]string{"map"},
 			FieldReadResult{
 				Value: map[string]interface{}{
-					"foo": "bar",
+					"foo":     "bar",
+					"bam.bam": "baz",
 				},
 				Exists:   true,
 				Computed: false,
 			},
 			testConfig(t, map[string]interface{}{
 				"map": map[string]interface{}{
-					"foo": "bar",
+					"foo":     "bar",
+					"bam.bam": "baz",
 				},
 			}),
 			false,


### PR DESCRIPTION
This fixes an issue causing map containing keys with periods to ignore their values. The behavior change was introduced by commit fa934d9 which added supported for computed map detection in FieldReaderConfig.

I'm not sure this is the "best" fix since but it seems to do the right thing by falling back to the pre-fa934d9 behavior. My manual testing and the updated test seems correct. FWIW, I spent a little bit of time looking through the code and noticed there are a few assumptions joining/splitting/replacing on "magic" characters. I think this type of logic is also the source of other subtle issues when interpolating and retrieving keys/values (see: https://github.com/hashicorp/terraform/issues/1641).