### PR TITLE
Add Network ACL tags document

### DIFF
--- a/website/source/docs/providers/aws/r/network_acl.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl.html.markdown
@@ -16,7 +16,7 @@ to your security groups in order to add an additional layer of security to your 
 ```
 resource "aws_network_acl" "main" {
 	vpc_id = "${aws_vpc.main.id}"
-	egress = {
+	egress {
 		protocol = "tcp"
 		rule_no = 2
 		action = "allow"
@@ -25,7 +25,7 @@ resource "aws_network_acl" "main" {
 		to_port = 443
 	}
 
-	ingress = {
+	ingress {
 		protocol = "tcp"
 		rule_no = 1
 		action = "allow"
@@ -34,7 +34,7 @@ resource "aws_network_acl" "main" {
 		to_port = 80
 	}
 
-	tags = {
+	tags {
 		Name = "main"
 	}
 }

--- a/website/source/docs/providers/aws/r/network_acl.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl.html.markdown
@@ -33,6 +33,10 @@ resource "aws_network_acl" "main" {
 		from_port = 80
 		to_port = 80
 	}
+
+	tags = {
+		Name = "main"
+	}
 }
 ```
 
@@ -44,6 +48,7 @@ The following arguments are supported:
 * `subnet_id` - (Optional) The ID of the associated subnet.
 * `ingress` - (Optional) Specifies an ingress rule. Parameters defined below.
 * `egress` - (Optional) Specifies an egress rule. Parameters defined below.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Both `egress` and `ingress` support the following keys:
 


### PR DESCRIPTION
`tags` argument of aws_network_acl is [currently undocumented](https://www.terraform.io/docs/providers/aws/r/network_acl.html). I added it.