### PR TITLE
providers/aws: aws_elb incr. idle_timeout to 60s

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -84,7 +84,7 @@ func resourceAwsElb() *schema.Resource {
 			"idle_timeout": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  30,
+				Default:  60,
 			},
 
 			"connection_draining": &schema.Schema{

--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `listener` - (Required) A list of listener blocks. Listeners documented below.
 * `health_check` - (Optional) A health_check block. Health Check documented below.
 * `cross_zone_load_balancing` - (Optional) Enable cross-zone load balancing.
-* `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Default: 300.
+* `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Default: 60.
 * `connection_draining` - (Optional) Boolean to enable connection draining.
 * `connection_draining_timeout` - (Optional) The time in seconds to allow for connections to drain. 
 


### PR DESCRIPTION
per docs
http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-idle-timeout.html