### PR TITLE
Update docs for Route53 + S3 bucket

### DIFF
--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -26,6 +26,7 @@ resource "aws_route53_record" "www" {
 
 ### Weighted routing policy
 See [AWS Route53 Developer Guide](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-weighted) for details.
+
 ```
 resource "aws_route53_record" "www-dev" {
   zone_id = "${aws_route53_zone.primary.zone_id}"

--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -29,6 +29,10 @@ resource "aws_route53_zone" "main" {
 
 resource "aws_route53_zone" "dev" {
   name = "dev.example.com"
+
+  tags {
+    Environment = "dev"
+  }
 }
 
 resource "aws_route53_record" "dev-ns" {
@@ -37,10 +41,10 @@ resource "aws_route53_record" "dev-ns" {
     type = "NS"
     ttl = "30"
     records = [
-        "${aws_route53_zone.dev.delegation_set_name_servers.0}",
-        "${aws_route53_zone.dev.delegation_set_name_servers.1}",
-        "${aws_route53_zone.dev.delegation_set_name_servers.2}",
-        "${aws_route53_zone.dev.delegation_set_name_servers.3}"
+        "${aws_route53_zone.dev.name_servers.0}",
+        "${aws_route53_zone.dev.name_servers.1}",
+        "${aws_route53_zone.dev.name_servers.2}",
+        "${aws_route53_zone.dev.name_servers.3}"
     ]
 }
 ```
@@ -50,10 +54,12 @@ resource "aws_route53_record" "dev-ns" {
 The following arguments are supported:
 
 * `name` - (Required) This is the name of the hosted zone.
+* `tags` - (Optional) A mapping of tags to assign to the zone.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `zone_id` - The Hosted Zone ID. This can be referenced by zone records.
-
+* `name_servers` - A list of name servers in a default delegation set.
+  Find more about delegation sets in [AWS docs](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-reusable-delegation-sets.html).

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -16,6 +16,11 @@ Provides a S3 bucket resource.
 resource "aws_s3_bucket" "b" {
     bucket = "my_tf_test_bucket"
     acl = "private"
+
+    tags {
+        Name = "My bucket"
+        Environment = "Dev"
+    }
 }
 ```
 
@@ -25,6 +30,7 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket.
 * `acl` - (Optional) The canned ACL to apply. Defaults to "private".
+* `tags` - (Optional) A mapping of tags to assign to the bucket.
 
 ## Attributes Reference
 


### PR DESCRIPTION
There's a bug I brought into the docs page ( :expressionless: ) - missing newline which causes markdown to not display code block as code block.

I'm also updating some bits as the docs were out of date - missing some of the great work @catsby has done with tags.

There's [an issue with `route53_zone.name_servers` generally](https://github.com/hashicorp/terraform/pull/1633) which makes it actually impossible to reference name servers the way it's described in docs (zero-based indexes), I'm just fixing wrong name here.