### PR TITLE
helper/schema: allow set items with hyphens

### DIFF
--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2224,6 +2224,63 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			Err: false,
 		},
+
+		// #58 Set with hyphen keys
+		{
+			Schema: map[string]*Schema{
+				"route": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"index": &Schema{
+								Type:     TypeInt,
+								Required: true,
+							},
+
+							"gateway-name": &Schema{
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+					Set: func(v interface{}) int {
+						m := v.(map[string]interface{})
+						return m["index"].(int)
+					},
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"route": []map[string]interface{}{
+					map[string]interface{}{
+						"index":        "1",
+						"gateway-name": "hello",
+					},
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"route.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"route.1.index": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "1",
+					},
+					"route.1.gateway-name": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "hello",
+					},
+				},
+			},
+
+			Err: false,
+		},
 	}
 
 	for i, tc := range cases {

--- a/helper/schema/set.go
+++ b/helper/schema/set.go
@@ -123,6 +123,9 @@ func (s *Set) add(item interface{}) int {
 	s.once.Do(s.init)
 
 	code := s.F(item)
+	if code < 0 {
+		code *= -1
+	}
 	if _, ok := s.m[code]; !ok {
 		s.m[code] = item
 	}

--- a/helper/schema/set_test.go
+++ b/helper/schema/set_test.go
@@ -18,6 +18,20 @@ func TestSetAdd(t *testing.T) {
 	}
 }
 
+func TestSetAdd_negative(t *testing.T) {
+	// Since we don't allow negative hashes, this should just hash to the
+	// same thing...
+	s := &Set{F: testSetInt}
+	s.Add(-1)
+	s.Add(1)
+
+	expected := []interface{}{-1}
+	actual := s.List()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestSetContains(t *testing.T) {
 	s := &Set{F: testSetInt}
 	s.Add(5)


### PR DESCRIPTION
Fixes #1641

This fixes the way we replace "-" with "~" in computed sets to only consider the code. This allows set items with hyphens to work. They somewhat hilariously and sadly didn't work before.