### PR TITLE
Add Providers link to nav when in resources

### DIFF
--- a/website/source/layouts/atlas.erb
+++ b/website/source/layouts/atlas.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-atlas-index") %>>
 				<a href="/docs/providers/atlas/index.html">Atlas Provider</a>
                 </li>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-aws-index") %>>
 				<a href="/docs/providers/aws/index.html">AWS Provider</a>
                 </li>

--- a/website/source/layouts/cloudflare.erb
+++ b/website/source/layouts/cloudflare.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-cloudflare-index") %>>
 				<a href="/docs/providers/cloudflare/index.html">CloudFlare Provider</a>
                 </li>

--- a/website/source/layouts/cloudstack.erb
+++ b/website/source/layouts/cloudstack.erb
@@ -6,6 +6,10 @@
                     <a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
                 <li<%= sidebar_current("docs-cloudstack-index") %>>
                     <a href="/docs/providers/cloudstack/index.html">CloudStack Provider</a>
                 </li>

--- a/website/source/layouts/consul.erb
+++ b/website/source/layouts/consul.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-consul-index") %>>
 				<a href="/docs/providers/consul/index.html">Consul Provider</a>
                 </li>

--- a/website/source/layouts/digitalocean.erb
+++ b/website/source/layouts/digitalocean.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-do-index") %>>
 				<a href="/docs/providers/do/index.html">DigitalOcean Provider</a>
                 </li>

--- a/website/source/layouts/dme.erb
+++ b/website/source/layouts/dme.erb
@@ -6,6 +6,10 @@
                 <a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
                 <li<%= sidebar_current("docs-dme-index") %>>
                 <a href="/docs/providers/dme/index.html">DNSMadeEasy Provider</a>
                 </li>

--- a/website/source/layouts/dnsimple.erb
+++ b/website/source/layouts/dnsimple.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-dnsimple-index") %>>
 				<a href="/docs/providers/dnsimple/index.html">DNSimple Provider</a>
                 </li>

--- a/website/source/layouts/docker.erb
+++ b/website/source/layouts/docker.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
 				</li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-docker-index") %>>
 					<a href="/docs/providers/docker/index.html">Docker Provider</a>
 				</li>

--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -6,6 +6,10 @@
 		<a href="/docs/index.html">&laquo; Documentation Home</a>
 		</li>
 
+        <li<%= sidebar_current("docs-providers") %>>
+          <a href="/docs/providers/index.html">Providers</a>
+        </li>
+
 		<li<%= sidebar_current("docs-google-index") %>>
 		<a href="/docs/providers/google/index.html">Google Provider</a>
 		</li>

--- a/website/source/layouts/heroku.erb
+++ b/website/source/layouts/heroku.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-heroku-index") %>>
 				<a href="/docs/providers/heroku/index.html">Heroku Provider</a>
                 </li>

--- a/website/source/layouts/mailgun.erb
+++ b/website/source/layouts/mailgun.erb
@@ -6,6 +6,10 @@
 				<a href="/docs/index.html">&laquo; Documentation Home</a>
                 </li>
 
+                <li<%= sidebar_current("docs-providers") %>>
+                  <a href="/docs/providers/index.html">Providers</a>
+                </li>
+
 				<li<%= sidebar_current("docs-mailgun-index") %>>
 				<a href="/docs/providers/mailgun/index.html">Mailgun Provider</a>
                 </li>

--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -6,6 +6,10 @@
           <a href="/docs/index.html">&laquo; Documentation Home</a>
         </li>
 
+        <li<%= sidebar_current("docs-providers") %>>
+          <a href="/docs/providers/index.html">Providers</a>
+        </li>
+
         <li<%= sidebar_current("docs-openstack-index") %>>
           <a href="/docs/providers/openstack/index.html">OpenStack Provider</a>
         </li>


### PR DESCRIPTION
![screenshot](http://cl.ly/image/460K28071a2p/Screen%20Shot%202015-04-23%20at%202.40.11%20PM.png)

While looking at resources in a provider, I found myself wanting to get back to the list of providers quite often.