### PR TITLE
Doc home link goes back to providers from resource

### DIFF
--- a/website/source/layouts/atlas.erb
+++ b/website/source/layouts/atlas.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-atlas-index") %>>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-aws-index") %>>

--- a/website/source/layouts/cloudflare.erb
+++ b/website/source/layouts/cloudflare.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-cloudflare-index") %>>

--- a/website/source/layouts/cloudstack.erb
+++ b/website/source/layouts/cloudstack.erb
@@ -3,7 +3,7 @@
         <div class="docs-sidebar hidden-print affix-top" role="complementary">
             <ul class="nav docs-sidenav">
                 <li<%= sidebar_current("docs-home") %>>
-                    <a href="/docs/index.html">&laquo; Documentation Home</a>
+                    <a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
                 <li<%= sidebar_current("docs-cloudstack-index") %>>

--- a/website/source/layouts/consul.erb
+++ b/website/source/layouts/consul.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-consul-index") %>>

--- a/website/source/layouts/digitalocean.erb
+++ b/website/source/layouts/digitalocean.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-do-index") %>>

--- a/website/source/layouts/dme.erb
+++ b/website/source/layouts/dme.erb
@@ -3,7 +3,7 @@
         <div class="docs-sidebar hidden-print affix-top" role="complementary">
             <ul class="nav docs-sidenav">
                 <li<%= sidebar_current("docs-home") %>>
-                <a href="/docs/index.html">&laquo; Documentation Home</a>
+                <a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
                 <li<%= sidebar_current("docs-dme-index") %>>

--- a/website/source/layouts/dnsimple.erb
+++ b/website/source/layouts/dnsimple.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-dnsimple-index") %>>

--- a/website/source/layouts/docker.erb
+++ b/website/source/layouts/docker.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
 				</li>
 
 				<li<%= sidebar_current("docs-docker-index") %>>

--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -3,7 +3,7 @@
 	<div class="docs-sidebar hidden-print affix-top" role="complementary">
 	<ul class="nav docs-sidenav">
 		<li<%= sidebar_current("docs-home") %>>
-		<a href="/docs/index.html">&laquo; Documentation Home</a>
+		<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
 		</li>
 
 		<li<%= sidebar_current("docs-google-index") %>>

--- a/website/source/layouts/heroku.erb
+++ b/website/source/layouts/heroku.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-heroku-index") %>>

--- a/website/source/layouts/mailgun.erb
+++ b/website/source/layouts/mailgun.erb
@@ -3,7 +3,7 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/index.html">&laquo; Documentation Home</a>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
                 </li>
 
 				<li<%= sidebar_current("docs-mailgun-index") %>>

--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -3,7 +3,7 @@
     <div class="docs-sidebar hidden-print affix-top" role="complementary">
       <ul class="nav docs-sidenav">
         <li<%= sidebar_current("docs-home") %>>
-          <a href="/docs/index.html">&laquo; Documentation Home</a>
+          <a href="/docs/providers/index.html">&laquo; Documentation Home</a>
         </li>
 
         <li<%= sidebar_current("docs-openstack-index") %>>


### PR DESCRIPTION
Changes the "Documentation Home" link in the sidebar to go back to the
list of providers instead of all the way back to the documentation home
page.

[#1659]