### PR TITLE
provider/aws: allow assocation of EIP to ENI

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -31,6 +31,12 @@ func resourceAwsEip() *schema.Resource {
 				Optional: true,
 			},
 
+			"network_interface": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"instance"},
+			},
+
 			"allocation_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -114,10 +120,14 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		"[DEBUG] EIP describe configuration: %#v, %#v (domain: %s)",
 		assocIds, publicIps, domain)
 
-	req := &ec2.DescribeAddressesInput{
-		AllocationIDs: assocIds,
-		PublicIPs:     publicIps,
+	req := &ec2.DescribeAddressesInput{}
+
+	if domain == "vpc" {
+		req.AllocationIDs = []*string{aws.String(id)}
+	} else {
+		req.PublicIPs = []*string{aws.String(id)}
 	}
+
 	describeAddresses, err := ec2conn.DescribeAddresses(req)
 	if err != nil {
 		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidAllocationID.NotFound" {
@@ -141,6 +151,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("association_id", address.AssociationID)
 	d.Set("instance", address.InstanceID)
+	d.Set("network_interface", address.NetworkInterfaceID)
 	d.Set("private_ip", address.PrivateIPAddress)
 	d.Set("public_ip", address.PublicIP)
 
@@ -152,9 +163,13 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	domain := resourceAwsEipDomain(d)
 
-	// Only register with an instance if we have one
-	if v, ok := d.GetOk("instance"); ok {
-		instanceId := v.(string)
+	// Associate to instance or interface if specified
+	v_instance, ok_instance := d.GetOk("instance")
+	v_interface, ok_interface := d.GetOk("network_interface")
+
+	if ok_instance || ok_interface {
+		instanceId := v_instance.(string)
+		networkInterfaceId := v_interface.(string)
 
 		assocOpts := &ec2.AssociateAddressInput{
 			InstanceID: aws.String(instanceId),
@@ -164,16 +179,16 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 		// more unique ID conditionals
 		if domain == "vpc" {
 			assocOpts = &ec2.AssociateAddressInput{
-				InstanceID:   aws.String(instanceId),
-				AllocationID: aws.String(d.Id()),
-				PublicIP:     aws.String(""),
+				NetworkInterfaceID: aws.String(networkInterfaceId),
+				InstanceID:         aws.String(instanceId),
+				AllocationID:       aws.String(d.Id()),
 			}
 		}
 
 		log.Printf("[DEBUG] EIP associate configuration: %#v (domain: %v)", assocOpts, domain)
 		_, err := ec2conn.AssociateAddress(assocOpts)
 		if err != nil {
-			return fmt.Errorf("Failure associating instances: %s", err)
+			return fmt.Errorf("Failure associating EIP: %s", err)
 		}
 	}
 
@@ -191,8 +206,8 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	// If we are attached to an instance, detach first.
-	if d.Get("instance").(string) != "" {
+	// If we are attached to an instance or interface, detach first.
+	if d.Get("instance").(string) != "" || d.Get("association_id").(string) != "" {
 		log.Printf("[DEBUG] Disassociating EIP: %s", d.Id())
 		var err error
 		switch resourceAwsEipDomain(d) {

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -123,7 +123,6 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	describeAddresses, err := ec2conn.DescribeAddresses(req)
 	if err != nil {
 		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidAllocationID.NotFound" {
-			log.Printf("[DEBUG] EIP describe configuration: %#v", req)
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Adds a new attribute 'network_interface' to the 'aws_eip' resource.

Resolves #1468