### PR TITLE
provider/aws: fix EIPs on new upstream sdk

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -102,8 +102,8 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	domain := resourceAwsEipDomain(d)
 	id := d.Id()
 
-	assocIds := []*string{}
-	publicIps := []*string{}
+	var assocIds []*string
+	var publicIps []*string
 	if domain == "vpc" {
 		assocIds = []*string{aws.String(id)}
 	} else {

--- a/builtin/providers/aws/resource_aws_eip_test.go
+++ b/builtin/providers/aws/resource_aws_eip_test.go
@@ -66,8 +66,7 @@ func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 		}
 
 		req := &ec2.DescribeAddressesInput{
-			AllocationIDs: []*string{},
-			PublicIPs:     []*string{aws.String(rs.Primary.ID)},
+			PublicIPs: []*string{aws.String(rs.Primary.ID)},
 		}
 		describe, err := conn.DescribeAddresses(req)
 
@@ -118,7 +117,6 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 		if strings.Contains(rs.Primary.ID, "eipalloc") {
 			req := &ec2.DescribeAddressesInput{
 				AllocationIDs: []*string{aws.String(rs.Primary.ID)},
-				PublicIPs:     []*string{},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {
@@ -133,8 +131,7 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 
 		} else {
 			req := &ec2.DescribeAddressesInput{
-				AllocationIDs: []*string{},
-				PublicIPs:     []*string{aws.String(rs.Primary.ID)},
+				PublicIPs: []*string{aws.String(rs.Primary.ID)},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {


### PR DESCRIPTION
As we've seen elsewhere, the SDK now wants nils instead of empty arrays
for collections

fixes #1696

thanks @jstremick for pointing me in the right direction