### PR TITLE
providers/dnsimple: default ttl to 3600

### DIFF
--- a/builtin/providers/dnsimple/resource_dnsimple_record.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record.go
@@ -49,6 +49,7 @@ func resourceDNSimpleRecord() *schema.Resource {
 			"ttl": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "3600",
 			},
 
 			"priority": &schema.Schema{


### PR DESCRIPTION
Since the field is optional and DNSimple defaults it to 3600 on their end, `terraform plan` currently will report `ttl: "3600" => ""`.