### PR TITLE
providers/aws: add _cluster to aws_elasticache

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -83,7 +83,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_db_security_group":            resourceAwsDbSecurityGroup(),
 			"aws_db_subnet_group":              resourceAwsDbSubnetGroup(),
 			"aws_ebs_volume":                   resourceAwsEbsVolume(),
-			"aws_elasticache":                  resourceAwsElasticache(),
+			"aws_elasticache_cluster":          resourceAwsElasticacheCluster(),
 			"aws_elasticache_subnet_group":     resourceAwsElasticacheSubnetGroup(),
 			"aws_elasticache_security_group":   resourceAwsElasticacheSecurityGroup(),
 			"aws_eip":                          resourceAwsEip(),

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -12,11 +12,11 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func resourceAwsElasticache() *schema.Resource {
+func resourceAwsElasticacheCluster() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAwsElasticacheCreate,
-		Read:   resourceAwsElasticacheRead,
-		Delete: resourceAwsElasticacheDelete,
+		Create: resourceAwsElasticacheClusterCreate,
+		Read:   resourceAwsElasticacheClusterRead,
+		Delete: resourceAwsElasticacheClusterDelete,
 
 		Schema: map[string]*schema.Schema{
 			"cluster_id": &schema.Schema{
@@ -84,7 +84,7 @@ func resourceAwsElasticache() *schema.Resource {
 	}
 }
 
-func resourceAwsElasticacheCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 
 	clusterId := d.Get("cluster_id").(string)
@@ -140,7 +140,7 @@ func resourceAwsElasticacheCreate(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceAwsElasticacheRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 	req := &elasticache.DescribeCacheClustersInput{
 		CacheClusterID: aws.String(d.Id()),
@@ -170,7 +170,7 @@ func resourceAwsElasticacheRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceAwsElasticacheDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsElasticacheClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 
 	req := &elasticache.DeleteCacheClusterInput{


### PR DESCRIPTION
This AWS calls the actual resources "Cache Clusters" so it seems like
this name makes more sense.

Verified all Elasticache acc tests pass.

/cc @tmtk75 for review