### PR TITLE
Fix connecting encrypted ebs volumes to aws_instances

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -397,6 +397,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			bd := v.(map[string]interface{})
 			ebs := &ec2.EBSBlockDevice{
 				DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
+				Encrypted:           aws.Boolean(bd["encrypted"].(bool)),
 			}
 
 			if v, ok := bd["snapshot_id"].(string); ok && v != "" {

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -473,6 +473,10 @@ const testAccInstanceConfigBlockDevices = `
 resource "aws_instance" "foo" {
 	# us-west-2
 	ami = "ami-55a7ea65"
+
+	# In order to attach an encrypted volume to an instance you need to have an
+	# m3.medium or larger. See "Supported Instance Types" in:
+	# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
 	instance_type = "m3.medium"
 
 	root_block_device {

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -123,6 +123,11 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 				fmt.Errorf("block device doesn't exist: /dev/sdc")
 			}
 
+			// Check if the encrypted block device exists
+			if _, ok := blockDevices["/dev/sdd"]; !ok {
+				fmt.Errorf("block device doesn't exist: /dev/sdd")
+			}
+
 			return nil
 		}
 	}
@@ -144,7 +149,7 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "root_block_device.0.volume_type", "gp2"),
 					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "ebs_block_device.#", "2"),
+						"aws_instance.foo", "ebs_block_device.#", "3"),
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "ebs_block_device.2576023345.device_name", "/dev/sdb"),
 					resource.TestCheckResourceAttr(
@@ -159,6 +164,12 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 						"aws_instance.foo", "ebs_block_device.2554893574.volume_type", "io1"),
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "ebs_block_device.2554893574.iops", "100"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "ebs_block_device.2634515331.device_name", "/dev/sdd"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "ebs_block_device.2634515331.encrypted", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "ebs_block_device.2634515331.volume_size", "12"),
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo", "ephemeral_block_device.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -462,7 +473,7 @@ const testAccInstanceConfigBlockDevices = `
 resource "aws_instance" "foo" {
 	# us-west-2
 	ami = "ami-55a7ea65"
-	instance_type = "m1.small"
+	instance_type = "m3.medium"
 
 	root_block_device {
 		volume_type = "gp2"
@@ -478,6 +489,14 @@ resource "aws_instance" "foo" {
 		volume_type = "io1"
 		iops = 100
 	}
+
+	# Encrypted ebs block device
+	ebs_block_device {
+		device_name = "/dev/sdd"
+		volume_size = 12
+		encrypted = true
+	}
+
 	ephemeral_block_device {
 		device_name = "/dev/sde"
 		virtual_name = "ephemeral0"


### PR DESCRIPTION
I found out, after working with `terraform` today that when you applied the `encrypted = true` option for a `ebs_block_device` in an `aws_instance` the encrypted option is completely ignored. This PR should fix that issue. I branched off of `v0.4.2`. I'm not sure what the proper protocol is for you guys, but I figured the change is small enough that it can be moved around and updated easily if we need to merge in the latest code. I just figured it'd be something for a `v0.4.3`.

All associated tests have been run.