### PR TITLE
Update header title to "Mailgun Provider"

### DIFF
--- a/website/source/docs/providers/mailgun/index.html.markdown
+++ b/website/source/docs/providers/mailgun/index.html.markdown
@@ -6,7 +6,7 @@ description: |-
   The Mailgun provider is used to interact with the resources supported by Mailgun. The provider needs to be configured with the proper credentials before it can be used.
 ---
 
-#  Provider
+# Mailgun Provider
 
 The Mailgun provider is used to interact with the
 resources supported by Mailgun. The provider needs to be configured


### PR DESCRIPTION
Update the Mailgun provider header title to "Mailgun Provider" so that it is consistent with the other provider pages.