### PR TITLE
Track orphaned outputs in the graph [GH-1714]

### DIFF
--- a/terraform/eval_output.go
+++ b/terraform/eval_output.go
@@ -6,6 +6,34 @@ import (
 	"github.com/hashicorp/terraform/config"
 )
 
+// EvalDeleteOutput is an EvalNode implementation that deletes an output
+// from the state.
+type EvalDeleteOutput struct {
+	Name string
+}
+
+// TODO: test
+func (n *EvalDeleteOutput) Eval(ctx EvalContext) (interface{}, error) {
+	state, lock := ctx.State()
+	if state == nil {
+		return nil, nil
+	}
+
+	// Get a write lock so we can access this instance
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Look for the module state. If we don't have one, create it.
+	mod := state.ModuleByPath(ctx.Path())
+	if mod == nil {
+		return nil, nil
+	}
+
+	delete(mod.Outputs, n.Name)
+
+	return nil, nil
+}
+
 // EvalWriteOutput is an EvalNode implementation that writes the output
 // for the given name to the current state.
 type EvalWriteOutput struct {

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -95,6 +95,9 @@ func (b *BuiltinGraphBuilder) Steps() []GraphTransformer {
 			Targeting: (len(b.Targets) > 0),
 		},
 
+		// Output-related transformations
+		&AddOutputOrphanTransformer{State: b.State},
+
 		// Provider-related transformations
 		&MissingProviderTransformer{Providers: b.Providers},
 		&ProviderTransformer{},

--- a/terraform/graph_config_node.go
+++ b/terraform/graph_config_node.go
@@ -137,6 +137,10 @@ func (n *GraphNodeConfigOutput) ConfigType() GraphNodeConfigType {
 	return GraphNodeConfigTypeOutput
 }
 
+func (n *GraphNodeConfigOutput) OutputName() string {
+	return n.Output.Name
+}
+
 func (n *GraphNodeConfigOutput) DependableName() []string {
 	return []string{n.Name()}
 }

--- a/terraform/graph_config_node_test.go
+++ b/terraform/graph_config_node_test.go
@@ -41,6 +41,13 @@ func TestGraphNodeConfigModuleExpand(t *testing.T) {
 	}
 }
 
+func TestGraphNodeConfigOutput_impl(t *testing.T) {
+	var _ dag.Vertex = new(GraphNodeConfigOutput)
+	var _ dag.NamedVertex = new(GraphNodeConfigOutput)
+	var _ graphNodeConfig = new(GraphNodeConfigOutput)
+	var _ GraphNodeOutput = new(GraphNodeConfigOutput)
+}
+
 func TestGraphNodeConfigProvider_impl(t *testing.T) {
 	var _ dag.Vertex = new(GraphNodeConfigProvider)
 	var _ dag.NamedVertex = new(GraphNodeConfigProvider)

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -373,6 +373,13 @@ do_instance.foo:
   type = do_instance
 `
 
+const testTerraformApplyOutputOrphanStr = `
+<no state>
+Outputs:
+
+foo = bar
+`
+
 const testTerraformApplyProvisionerStr = `
 aws_instance.bar:
   ID = foo

--- a/terraform/test-fixtures/apply-output-orphan/main.tf
+++ b/terraform/test-fixtures/apply-output-orphan/main.tf
@@ -1,0 +1,1 @@
+output "foo" { value = "bar" }

--- a/terraform/test-fixtures/transform-orphan-output-basic/main.tf
+++ b/terraform/test-fixtures/transform-orphan-output-basic/main.tf
@@ -1,0 +1,1 @@
+output "foo" { value = "bar" }

--- a/terraform/transform_output.go
+++ b/terraform/transform_output.go
@@ -1,0 +1,59 @@
+package terraform
+
+import (
+	"fmt"
+)
+
+// GraphNodeOutput is an interface that nodes that are outputs must
+// implement. The OutputName returned is the name of the output key
+// that they manage.
+type GraphNodeOutput interface {
+	OutputName() string
+}
+
+// AddOutputOrphanTransformer is a transformer that adds output orphans
+// to the graph. Output orphans are outputs that are no longer in the
+// configuration and therefore need to be removed from the state.
+type AddOutputOrphanTransformer struct {
+	State *State
+}
+
+func (t *AddOutputOrphanTransformer) Transform(g *Graph) error {
+	// Get the state for this module. If we have no state, we have no orphans
+	state := t.State.ModuleByPath(g.Path)
+	if state == nil {
+		return nil
+	}
+
+	// Create the set of outputs we do have in the graph
+	found := make(map[string]struct{})
+	for _, v := range g.Vertices() {
+		on, ok := v.(GraphNodeOutput)
+		if !ok {
+			continue
+		}
+
+		found[on.OutputName()] = struct{}{}
+	}
+
+	// Go over all the outputs. If we don't have a graph node for it,
+	// create it. It doesn't need to depend on anything, since its just
+	// setting it empty.
+	for k, _ := range state.Outputs {
+		if _, ok := found[k]; ok {
+			continue
+		}
+
+		g.Add(&graphNodeOrphanOutput{OutputName: k})
+	}
+
+	return nil
+}
+
+type graphNodeOrphanOutput struct {
+	OutputName string
+}
+
+func (n *graphNodeOrphanOutput) Name() string {
+	return fmt.Sprintf("output.%s (orphan)", n.OutputName)
+}

--- a/terraform/transform_output.go
+++ b/terraform/transform_output.go
@@ -57,3 +57,12 @@ type graphNodeOrphanOutput struct {
 func (n *graphNodeOrphanOutput) Name() string {
 	return fmt.Sprintf("output.%s (orphan)", n.OutputName)
 }
+
+func (n *graphNodeOrphanOutput) EvalTree() EvalNode {
+	return &EvalOpFilter{
+		Ops: []walkOperation{walkApply, walkRefresh},
+		Node: &EvalDeleteOutput{
+			Name: n.OutputName,
+		},
+	}
+}

--- a/terraform/transform_output_test.go
+++ b/terraform/transform_output_test.go
@@ -1,0 +1,45 @@
+package terraform
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAddOutputOrphanTransformer(t *testing.T) {
+	mod := testModule(t, "transform-orphan-output-basic")
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: RootModulePath,
+				Outputs: map[string]string{
+					"foo": "bar",
+					"bar": "baz",
+				},
+			},
+		},
+	}
+
+	g := Graph{Path: RootModulePath}
+	{
+		tf := &ConfigTransformer{Module: mod}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	transform := &AddOutputOrphanTransformer{State: state}
+	if err := transform.Transform(&g); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformOrphanOutputBasicStr)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
+const testTransformOrphanOutputBasicStr = `
+output.bar (orphan)
+output.foo
+`


### PR DESCRIPTION
Fixes #1714 

This adds output orphans to the graph and their evaluation is to remove themselves. 

At first I was going to do this by simply at the end of Refresh/Apply going through and deleting them, but this code actually ended up being pretty gross and it was a lot easier to do in the graph. It also goes towards our goal of making the graph as verbose as possible so we can more strictly control ordering.