### PR TITLE
providers/aws: S3 bucket website support

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -220,7 +220,7 @@ func resourceAwsS3BucketWebsiteDelete(s3conn *s3.S3, d *schema.ResourceData) err
 func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (string, error) {
 	// If the bucket doesn't have a website configuration, return an empty
 	// endpoint
-	if len(d.Get("website").([]interface{})) == 0 {
+	if _, ok := d.GetOk("website"); !ok {
 		return "", nil
 	}
 

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -240,7 +240,8 @@ func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (string, error) {
 		region = *location.LocationConstraint
 	}
 
-	// Default to us-east-1 if the bucket doesn't have a region
+	// Default to us-east-1 if the bucket doesn't have a region:
+	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
 	if region == "" {
 		region = "us-east-1"
 	}

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -129,10 +129,15 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	})
 	var websites []map[string]interface{}
 	if err == nil {
-		websites = append(websites, map[string]interface{}{
-			"index_document": *ws.IndexDocument.Suffix,
-			"error_document": *ws.ErrorDocument.Key,
-		})
+		w := make(map[string]interface{})
+
+		w["index_document"] = *ws.IndexDocument.Suffix
+
+		if v := ws.ErrorDocument; v != nil {
+			w["error_document"] = *v.Key
+		}
+
+		websites = append(websites, w)
 	}
 	if err := d.Set("website", websites); err != nil {
 		return err

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -123,6 +123,21 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	// Read the website configuration
+	ws, err := s3conn.GetBucketWebsite(&s3.GetBucketWebsiteInput{
+		Bucket: aws.String(d.Id()),
+	})
+	var websites []map[string]interface{}
+	if err == nil {
+		websites = append(websites, map[string]interface{}{
+			"index_document": *ws.IndexDocument.Suffix,
+			"error_document": *ws.ErrorDocument.Key,
+		})
+	}
+	if err := d.Set("website", websites); err != nil {
+		return err
+	}
+
 	// Add website_endpoint as an output
 	endpoint, err := websiteEndpoint(s3conn, d)
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -217,11 +217,11 @@ func resourceAwsS3BucketWebsiteDelete(s3conn *s3.S3, d *schema.ResourceData) err
 	return nil
 }
 
-func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (endpoint string, err error) {
+func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (string, error) {
 	// If the bucket doesn't have a website configuration, return an empty
 	// endpoint
 	if len(d.Get("website").([]interface{})) == 0 {
-		return
+		return "", nil
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -233,7 +233,7 @@ func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (endpoint string, er
 		},
 	)
 	if err != nil {
-		return
+		return "", err
 	}
 	var region string
 	if location.LocationConstraint != nil {
@@ -245,7 +245,7 @@ func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (endpoint string, er
 		region = "us-east-1"
 	}
 
-	endpoint = fmt.Sprintf("%s.s3-website-%s.amazonaws.com", bucket, region)
+	endpoint := fmt.Sprintf("%s.s3-website-%s.amazonaws.com", bucket, region)
 
-	return
+	return endpoint, nil
 }

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -90,7 +90,8 @@ resource "aws_s3_bucket" "website" {
 	bucket = "tf-test-bucket-website-%d"
 	acl = "public-read"
 
-	website = true
-	index_document = "index.html"
+	website {
+		index_document = "index.html"
+	}
 }
 `, rand.New(rand.NewSource(time.Now().UnixNano())).Int())

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -23,6 +23,8 @@ func TestAccAWSS3Bucket(t *testing.T) {
 				Config: testAccAWSS3BucketConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "website_endpoint", ""),
 				),
 			},
 		},
@@ -41,6 +43,8 @@ func TestAccAWSS3BucketWebsite(t *testing.T) {
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketWebsite(
 						"aws_s3_bucket.bucket", "index.html", ""),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint),
 				),
 			},
 			resource.TestStep{
@@ -49,6 +53,8 @@ func TestAccAWSS3BucketWebsite(t *testing.T) {
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketWebsite(
 						"aws_s3_bucket.bucket", "index.html", "error.html"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint),
 				),
 			},
 			resource.TestStep{
@@ -57,6 +63,8 @@ func TestAccAWSS3BucketWebsite(t *testing.T) {
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketWebsite(
 						"aws_s3_bucket.bucket", "", ""),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "website_endpoint", ""),
 				),
 			},
 		},
@@ -142,13 +150,14 @@ func testAccCheckAWSS3BucketWebsite(n string, indexDoc string, errorDoc string) 
 
 // These need a bit of randomness as the name can only be used once globally
 // within AWS
-var d = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+var testAccWebsiteEndpoint = fmt.Sprintf("tf-test-bucket-%d.s3-website-us-east-1.amazonaws.com", randInt)
 var testAccAWSS3BucketConfig = fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
 	bucket = "tf-test-bucket-%d"
 	acl = "public-read"
 }
-`, d)
+`, randInt)
 
 var testAccAWSS3BucketWebsiteConfig = fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
@@ -159,7 +168,7 @@ resource "aws_s3_bucket" "bucket" {
 		index_document = "index.html"
 	}
 }
-`, d)
+`, randInt)
 
 var testAccAWSS3BucketWebsiteConfigWithError = fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
@@ -171,4 +180,4 @@ resource "aws_s3_bucket" "bucket" {
 		error_document = "error.html"
 	}
 }
-`, d)
+`, randInt)

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -23,7 +23,13 @@ func TestAccAWSS3Bucket(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSS3BucketConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bar"),
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSS3BucketWebsiteConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.website"),
 				),
 			},
 		},
@@ -70,11 +76,21 @@ func testAccCheckAWSS3BucketExists(n string) resource.TestCheckFunc {
 	}
 }
 
-// This needs a bit of randoness as the name can only be
-// used once globally within AWS
+// These need a bit of randoness as the name can only be used once globally
+// within AWS
 var testAccAWSS3BucketConfig = fmt.Sprintf(`
-resource "aws_s3_bucket" "bar" {
+resource "aws_s3_bucket" "bucket" {
 	bucket = "tf-test-bucket-%d"
 	acl = "public-read"
+}
+`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+
+var testAccAWSS3BucketWebsiteConfig = fmt.Sprintf(`
+resource "aws_s3_bucket" "website" {
+	bucket = "tf-test-bucket-website-%d"
+	acl = "public-read"
+
+	website = true
+	index_document = "index.html"
 }
 `, rand.New(rand.NewSource(time.Now().UnixNano())).Int())

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -12,6 +12,8 @@ Provides a S3 bucket resource.
 
 ## Example Usage
 
+### Private Bucket w/ Tags
+
 ```
 resource "aws_s3_bucket" "b" {
     bucket = "my_tf_test_bucket"
@@ -24,6 +26,20 @@ resource "aws_s3_bucket" "b" {
 }
 ```
 
+### Static Website Hosting
+
+```
+resource "aws_s3_bucket" "b" {
+    bucket = "s3-website-test.hashicorp.com"
+    acl = "public-read"
+
+    website {
+        index_document = "index.html"
+        error_document = "error.html"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -31,10 +47,16 @@ The following arguments are supported:
 * `bucket` - (Required) The name of the bucket.
 * `acl` - (Optional) The [canned ACL](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Defaults to "private".
 * `tags` - (Optional) A mapping of tags to assign to the bucket.
+* `website` - (Optional) A website object (documented below).
+
+The website object supports the following:
+
+* `index_document` - (Required) Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
+* `error_document` - (Optional) An absolute path to the document to return in case of a 4XX error.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The name of the bucket
-
+* `id` - The name of the bucket.
+* `website_endpoint` - The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.


### PR DESCRIPTION
* [x] Create/update/destroy
* [x] index/error document
* [x] Computed endpoint
* [x] Multi-region support
* [x] Docs

```go
provider "aws" { region = "us-east-1" }

resource "aws_s3_bucket" "default" {
  bucket = "tf.justincampbel.me"
  acl = "public-read"

  website {
    index_document = "index.html"
    error_document = "error.html"
  }
}

output "dns_name" { value = "${aws_s3_bucket.default.website_endpoint}" }
// "tf.justincampbell.me.s3-website-us-east-1.amazonaws.com"
```