### PR TITLE
providers/cloudflare: Better error message

### DIFF
--- a/builtin/providers/cloudflare/resource_cloudflare_record.go
+++ b/builtin/providers/cloudflare/resource_cloudflare_record.go
@@ -91,7 +91,7 @@ func resourceCloudFlareRecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	rec, err := client.RetrieveRecord(d.Get("domain").(string), d.Id())
 	if err != nil {
-		return fmt.Errorf("Couldn't find record: %s", err)
+		return fmt.Errorf("Couldn't find record ID (%s) for domain (%s): %s", d.Id(), d.Get("domain").(string), err)
 	}
 
 	d.Set("name", rec.Name)


### PR DESCRIPTION
Currently, if a record isn't found, we get an error like:

    Couldn't find record: Record not found

This change improves the error message to add more context:

    Couldn't find record ID (123456789) for domain (example.com): Record not found