### PR TITLE
config: add module raw configs to InterpolatedConfigs [GH-1448]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -570,6 +570,11 @@ func (c *Config) InterpolatedVariables() map[string][]InterpolatedVariable {
 // a human-friendly source.
 func (c *Config) rawConfigs() map[string]*RawConfig {
 	result := make(map[string]*RawConfig)
+	for _, m := range c.Modules {
+		source := fmt.Sprintf("module '%s'", m.Name)
+		result[source] = m.RawConfig
+	}
+
 	for _, pc := range c.ProviderConfigs {
 		source := fmt.Sprintf("provider config '%s'", pc.Name)
 		result[source] = pc.RawConfig

--- a/config/module/test-fixtures/validate-bad-output-to-module/child/main.tf
+++ b/config/module/test-fixtures/validate-bad-output-to-module/child/main.tf
@@ -1,0 +1,1 @@
+variable "memory" { default = "foo" }

--- a/config/module/test-fixtures/validate-bad-output-to-module/main.tf
+++ b/config/module/test-fixtures/validate-bad-output-to-module/main.tf
@@ -1,0 +1,8 @@
+module "child" {
+    source = "./child"
+}
+
+module "child2" {
+    source = "./child"
+    memory = "${module.child.memory_max}"
+}

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -224,6 +224,18 @@ func TestTreeValidate_badChildOutput(t *testing.T) {
 	}
 }
 
+func TestTreeValidate_badChildOutputToModule(t *testing.T) {
+	tree := NewTree("", testConfig(t, "validate-bad-output-to-module"))
+
+	if err := tree.Load(testStorage(t), GetModeGet); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := tree.Validate(); err == nil {
+		t.Fatal("should error")
+	}
+}
+
 func TestTreeValidate_badChildVar(t *testing.T) {
 	tree := NewTree("", testConfig(t, "validate-bad-var"))
 


### PR DESCRIPTION
Fixes #1448 

We just weren't tracking the module raw configuration for the function called on config to return all the interpolations. Once we added this, the validation all worked. The validation was already there.