### PR TITLE
aws.erb: It's "docs", not "doc". Oops.

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -57,7 +57,7 @@
 							<a href="/docs/providers/aws/r/launch_config.html">aws_launch_configuration</a>
 						</li>
 
-						<li<%= sidebar_current("doc-aws-resource-lb-cookie-stickiness-policy") %>>
+						<li<%= sidebar_current("docs-aws-resource-lb-cookie-stickiness-policy") %>>
 							<a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
 						</li>
 


### PR DESCRIPTION
This was my bad. I introduced this in `30f8fd73` but couldn't test the docs (the Vagrantfile doesn't work for me).