### PR TITLE
provider/aws: Fix refresh/plan issue with DB Param. Group name

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -106,7 +106,7 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Unable to find DB Subnet Group: %#v", describeResp.DBSubnetGroups)
 	}
 
-	d.Set("name", *subnetGroup.DBSubnetGroupName)
+	d.Set("name", d.Id())
 	d.Set("description", *subnetGroup.DBSubnetGroupDescription)
 
 	subnets := make([]string, 0, len(subnetGroup.Subnets))


### PR DESCRIPTION
This PR fixes #1750. We do the lookup check against AWS with lowercase, but store the `name` in the state file unmodified, so future checks don't show a change. 

This should be safe b/c of the block above, where we return early if `subnetGroup.DBSubnetGroupName` is `nil`.