### PR TITLE
command: add env var equivalent to -input arg

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/state"
@@ -165,11 +166,26 @@ func (m *Meta) DataDir() string {
 	return dataDir
 }
 
+const (
+	// InputModeEnvVar is the environment variable that, if set to "false" or
+	// "0", causes terraform commands to behave as if the `-input=false` flag was
+	// specified.
+	InputModeEnvVar = "TF_INPUT"
+)
+
 // InputMode returns the type of input we should ask for in the form of
 // terraform.InputMode which is passed directly to Context.Input.
 func (m *Meta) InputMode() terraform.InputMode {
 	if test || !m.input {
 		return 0
+	}
+
+	if envVar := os.Getenv(InputModeEnvVar); envVar != "" {
+		if v, err := strconv.ParseBool(envVar); err == nil {
+			if !v {
+				return 0
+			}
+		}
 	}
 
 	var mode terraform.InputMode

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -70,6 +70,40 @@ func TestMetaInputMode(t *testing.T) {
 	}
 }
 
+func TestMetaInputMode_envVar(t *testing.T) {
+	test = false
+	defer func() { test = true }()
+	old := os.Getenv(InputModeEnvVar)
+	defer os.Setenv(InputModeEnvVar, old)
+
+	m := new(Meta)
+	args := []string{}
+
+	fs := m.flagSet("foo")
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	off := terraform.InputMode(0)
+	on := terraform.InputModeStd | terraform.InputModeVarUnset
+	cases := []struct {
+		EnvVar   string
+		Expected terraform.InputMode
+	}{
+		{"false", off},
+		{"0", off},
+		{"true", on},
+		{"1", on},
+	}
+
+	for _, tc := range cases {
+		os.Setenv(InputModeEnvVar, tc.EnvVar)
+		if m.InputMode() != tc.Expected {
+			t.Fatalf("expected InputMode: %#v, got: %#v", tc.Expected, m.InputMode())
+		}
+	}
+}
+
 func TestMetaInputMode_disable(t *testing.T) {
 	test = false
 	defer func() { test = true }()


### PR DESCRIPTION
Setting TF_INPUT has the equivalent effect of setting the flag.
I got sick of specifying this when iterating on TF config locally.