### PR TITLE
core: fix targeting with non-word chars

### DIFF
--- a/terraform/resource_address.go
+++ b/terraform/resource_address.go
@@ -77,9 +77,9 @@ func tokenizeResourceAddress(s string) (map[string]string, error) {
 	// string "aws_instance.web.tainted[1]"
 	re := regexp.MustCompile(`\A` +
 		// "aws_instance"
-		`(?P<type>\w+)\.` +
+		`(?P<type>[^.]+)\.` +
 		// "web"
-		`(?P<name>\w+)` +
+		`(?P<name>[^.[]+)` +
 		// "tainted" (optional, omission implies: "primary")
 		`(?:\.(?P<instance_type>\w+))?` +
 		// "1" (optional, omission implies: "0")

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -55,6 +55,15 @@ func TestParseResourceAddress(t *testing.T) {
 				Index:        -1,
 			},
 		},
+		"with a hyphen": {
+			Input: "aws_instance.foo-bar",
+			Expected: &ResourceAddress{
+				Type:         "aws_instance",
+				Name:         "foo-bar",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
Flips the regex strategy to capture everything that's _not_ the next
separator instead of whitelisting `\w`

fixes #1699