### PR TITLE
provider/aws: Remove default egress rule from Security Group on creation

### DIFF
--- a/builtin/providers/aws/resource_aws_network_interface_test.go
+++ b/builtin/providers/aws/resource_aws_network_interface_test.go
@@ -181,6 +181,13 @@ resource "aws_security_group" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   description = "foo"
   name = "foo"  
+
+        egress {
+                from_port = 0
+                to_port = 0
+                protocol = "tcp"
+                cidr_blocks = ["10.0.0.0/16"]
+        }
 }
 
 resource "aws_network_interface" "bar" {

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -148,12 +148,12 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	securityGroupOpts := &ec2.CreateSecurityGroupInput{}
 
-	if v := d.Get("vpc_id"); v != nil {
+        if v := d.Get("vpc_id"); v != nil {
                 if len(d.Get("egress").(*schema.Set).List()) == 0 {
-                        return fmt.Errorf("Error creating Security Group: Security groups inside a VPC require an egress rule. See https://terraform.io/why.html")
+                        return fmt.Errorf("Error creating Security Group: Security groups inside a VPC require an egress rule. See http://localhost:4567/docs/providers/aws/r/security_group.html for more information.")
                 }
 
-		securityGroupOpts.VPCID = aws.String(v.(string))
+                securityGroupOpts.VPCID = aws.String(v.(string))
 	}
 
 	if v := d.Get("description"); v != nil {

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -148,13 +148,9 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 
         securityGroupOpts := &ec2.CreateSecurityGroupInput{}
 
-        if v, ok := d.GetOk("vpc_id"); ok {
-                if len(d.Get("egress").(*schema.Set).List()) == 0 {
-                        return fmt.Errorf("Error creating Security Group: Security groups inside a VPC require an egress rule. See http://terraform.io/docs/providers/aws/r/security_group.html for more information.")
-                }
-
+        if v := d.Get("vpc_id"); v != nil {
                 securityGroupOpts.VPCID = aws.String(v.(string))
-	}
+        }
 
 	if v := d.Get("description"); v != nil {
 		securityGroupOpts.Description = aws.String(v.(string))

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -150,7 +150,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 
         if v := d.Get("vpc_id"); v != nil {
                 if len(d.Get("egress").(*schema.Set).List()) == 0 {
-                        return fmt.Errorf("Error creating Security Group: Security groups inside a VPC require an egress rule. See http://localhost:4567/docs/providers/aws/r/security_group.html for more information.")
+                        return fmt.Errorf("Error creating Security Group: Security groups inside a VPC require an egress rule. See http://terraform.io/docs/providers/aws/r/security_group.html for more information.")
                 }
 
                 securityGroupOpts.VPCID = aws.String(v.(string))
@@ -194,6 +194,35 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 			"Error waiting for Security Group (%s) to become available: %s",
 			d.Id(), err)
 	}
+
+        // AWS defaults all Security Groups to have an ALLOW ALL egress rule. Here we
+        // revoke that rule, so users don't unknowningly have/use it.
+        if v := d.Get("vpc_id"); v != nil {
+                log.Printf("[DEBUG] Revoking default egress rule for Security Group for %s", d.Id())
+
+                req := &ec2.RevokeSecurityGroupEgressInput{
+                        GroupID: createResp.GroupID,
+                        IPPermissions: []*ec2.IPPermission{
+                                &ec2.IPPermission{
+                                        FromPort: aws.Long(int64(0)),
+                                        ToPort:   aws.Long(int64(0)),
+                                        IPRanges: []*ec2.IPRange{
+                                                &ec2.IPRange{
+                                                        CIDRIP: aws.String("0.0.0.0/0"),
+                                                },
+                                        },
+                                        IPProtocol: aws.String("-1"),
+                                },
+                        },
+                }
+
+                if _, err = conn.RevokeSecurityGroupEgress(req); err != nil {
+                        return fmt.Errorf(
+                                "Error revoking default egress rule for Security Group (%s): %s",
+                                d.Id(), err)
+                }
+
+        }
 
 	return resourceAwsSecurityGroupUpdate(d, meta)
 }
@@ -408,29 +437,12 @@ func resourceAwsSecurityGroupUpdateRules(
 		}
 
 		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+                ns := n.(*schema.Set)
 
-		remove := expandIPPerms(group, os.Difference(ns).List())
+                remove := expandIPPerms(group, os.Difference(ns).List())
+                add := expandIPPerms(group, ns.Difference(os).List())
 
-                if len(remove) == 0 && len(os.List()) == 0 && ruleset == "egress" {
-                        // For new Security groups, a default Egress rule is created. Here we add
-                        // the equivelent IPPermission struct for removal, so that only the
-                        // supplied egress rules exist in the security group.
-                        remove = append(remove, &ec2.IPPermission{
-                                FromPort: aws.Long(int64(0)),
-                                ToPort:   aws.Long(int64(0)),
-                                IPRanges: []*ec2.IPRange{
-                                        &ec2.IPRange{
-                                                CIDRIP: aws.String("0.0.0.0/0"),
-                                        },
-                                },
-                                IPProtocol: aws.String("-1"),
-                        })
-                }
-
-		add := expandIPPerms(group, ns.Difference(os).List())
-
-		// TODO: We need to handle partial state better in the in-between
+                // TODO: We need to handle partial state better in the in-between
 		// in this update.
 
 		// TODO: It'd be nicer to authorize before removing, but then we have

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -146,11 +146,11 @@ func resourceAwsSecurityGroup() *schema.Resource {
 func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-        securityGroupOpts := &ec2.CreateSecurityGroupInput{}
+	securityGroupOpts := &ec2.CreateSecurityGroupInput{}
 
-        if v := d.Get("vpc_id"); v != nil {
-                securityGroupOpts.VPCID = aws.String(v.(string))
-        }
+	if v := d.Get("vpc_id"); v != nil {
+		securityGroupOpts.VPCID = aws.String(v.(string))
+	}
 
 	if v := d.Get("description"); v != nil {
 		securityGroupOpts.Description = aws.String(v.(string))
@@ -186,42 +186,42 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		Timeout: 1 * time.Minute,
 	}
 
-        resp, err := stateConf.WaitForState()
-        if err != nil {
+	resp, err := stateConf.WaitForState()
+	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for Security Group (%s) to become available: %s",
 			d.Id(), err)
 	}
 
-        // AWS defaults all Security Groups to have an ALLOW ALL egress rule. Here we
-        // revoke that rule, so users don't unknowningly have/use it.
-        group := resp.(*ec2.SecurityGroup)
-        if group.VPCID != nil && *group.VPCID != "" {
-                log.Printf("[DEBUG] Revoking default egress rule for Security Group for %s", d.Id())
+	// AWS defaults all Security Groups to have an ALLOW ALL egress rule. Here we
+	// revoke that rule, so users don't unknowningly have/use it.
+	group := resp.(*ec2.SecurityGroup)
+	if group.VPCID != nil && *group.VPCID != "" {
+		log.Printf("[DEBUG] Revoking default egress rule for Security Group for %s", d.Id())
 
-                req := &ec2.RevokeSecurityGroupEgressInput{
-                        GroupID: createResp.GroupID,
-                        IPPermissions: []*ec2.IPPermission{
-                                &ec2.IPPermission{
-                                        FromPort: aws.Long(int64(0)),
-                                        ToPort:   aws.Long(int64(0)),
-                                        IPRanges: []*ec2.IPRange{
-                                                &ec2.IPRange{
-                                                        CIDRIP: aws.String("0.0.0.0/0"),
-                                                },
-                                        },
-                                        IPProtocol: aws.String("-1"),
-                                },
-                        },
-                }
+		req := &ec2.RevokeSecurityGroupEgressInput{
+			GroupID: createResp.GroupID,
+			IPPermissions: []*ec2.IPPermission{
+				&ec2.IPPermission{
+					FromPort: aws.Long(int64(0)),
+					ToPort:   aws.Long(int64(0)),
+					IPRanges: []*ec2.IPRange{
+						&ec2.IPRange{
+							CIDRIP: aws.String("0.0.0.0/0"),
+						},
+					},
+					IPProtocol: aws.String("-1"),
+				},
+			},
+		}
 
-                if _, err = conn.RevokeSecurityGroupEgress(req); err != nil {
-                        return fmt.Errorf(
-                                "Error revoking default egress rule for Security Group (%s): %s",
-                                d.Id(), err)
-                }
+		if _, err = conn.RevokeSecurityGroupEgress(req); err != nil {
+			return fmt.Errorf(
+				"Error revoking default egress rule for Security Group (%s): %s",
+				d.Id(), err)
+		}
 
-        }
+	}
 
 	return resourceAwsSecurityGroupUpdate(d, meta)
 }
@@ -436,12 +436,12 @@ func resourceAwsSecurityGroupUpdateRules(
 		}
 
 		os := o.(*schema.Set)
-                ns := n.(*schema.Set)
+		ns := n.(*schema.Set)
 
-                remove := expandIPPerms(group, os.Difference(ns).List())
-                add := expandIPPerms(group, ns.Difference(os).List())
+		remove := expandIPPerms(group, os.Difference(ns).List())
+		add := expandIPPerms(group, ns.Difference(os).List())
 
-                // TODO: We need to handle partial state better in the in-between
+		// TODO: We need to handle partial state better in the in-between
 		// in this update.
 
 		// TODO: It'd be nicer to authorize before removing, but then we have

--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -63,9 +63,8 @@ The following arguments are supported:
 * `description` - (Required) The security group description.
 * `ingress` - (Optional) Can be specified multiple times for each
    ingress rule. Each ingress block supports fields documented below.
-* `egress` - (Optional) Can be specified multiple times for each
+* `egress` - (Required, VPC only) Can be specified multiple times for each
       egress rule. Each egress block supports fields documented below.
-      VPC only.
 * `vpc_id` - (Optional) The VPC ID.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -92,6 +91,20 @@ The `egress` block supports:
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this egress rule.
 * `to_port` - (Required) The end range port.
+
+~> **NOTE on Egress rules:** By default, AWS creates an `ALLOW ALL` egress rule when creating a
+new Security Group inside of a VPC. When creating a new Security
+Group inside a VPC, **Terraform will remove this default rule**, and require you
+specifically re-create it if you desire that rule. We feel this leads to fewer
+surprises in terms of controlling your egress rules. If you desire this rule to
+be in place, you can use this `egress` block:
+
+    egress {
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      cidr_block = "0.0.0.0/0"
+    }
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 * `description` - (Required) The security group description.
 * `ingress` - (Optional) Can be specified multiple times for each
    ingress rule. Each ingress block supports fields documented below.
-* `egress` - (Required, VPC only) Can be specified multiple times for each
+* `egress` - (Optional, VPC only) Can be specified multiple times for each
       egress rule. Each egress block supports fields documented below.
 * `vpc_id` - (Optional) The VPC ID.
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
Security Groups in a VPC receive a default `egress` rule to permit all. This causes some issues though, as it's implicit, and causes errors if people try to add a duplicate rule. It also triggers a new plan if you _do_ specify an `egress` rule, as we interpret that as needing to remove the old one. 

This PR changes two things:

- by default, if you specify an `egress` rule, we delete the default ALLOW ALL rule
- ~~**you must now specify an `egress` rule when creating a Security Group inside a VPC**~~ reneged 

Refs #1177 
Fixes #1169, #1631
Probably fixes #1299 