### PR TITLE
schema.Schema: Enforce "readonly" attributes with a ReadOnly field.

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -92,6 +92,13 @@ type Schema struct {
 	ForceNew  bool
 	StateFunc SchemaStateFunc
 
+	// If the following field is set to `true`, this attribute can't be set
+	// in the configuration file by the user. It can only be set by
+	// terraform itself after reading a remote API. This is an appropriate
+	// setting for data coming back from a provider that users might want
+	// to output, but which they cannot change.
+	ReadOnly bool
+
 	// The following fields are only set for a TypeList or TypeSet Type.
 	//
 	// Elem must be either a *Schema or a *Resource only if the Type is
@@ -1153,6 +1160,11 @@ func (m schemaMap) validateType(
 		ws, es = m.validateMap(k, raw, schema, c)
 	default:
 		ws, es = m.validatePrimitive(k, raw, schema, c)
+	}
+
+	if schema.ReadOnly {
+		es = append(es, fmt.Errorf(
+			"%q: This field is readonly and cannot be set by users", k))
 	}
 
 	if schema.Deprecated != "" {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3335,6 +3335,39 @@ func TestSchemaMap_Validate(t *testing.T) {
 				fmt.Errorf("\"optional_att\": conflicts with required_att (\"required-val\")"),
 			},
 		},
+
+		"Readonly attribute is set by user": {
+			Schema: map[string]*Schema{
+				"readonly_att": &Schema{
+					Type:     TypeString,
+					ReadOnly: true,
+					Required: true,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"readonly_att": "user-set-val",
+			},
+
+			Err: true,
+			Errors: []error{
+				fmt.Errorf("\"readonly_att\": This field is readonly and cannot be set by users"),
+			},
+		},
+
+		"Readonly attribute with no config is OK": {
+			Schema: map[string]*Schema{
+				"readonly_att": &Schema{
+					Type:     TypeString,
+					ReadOnly: true,
+					Optional: true,
+				},
+			},
+
+			Config: nil,
+
+			Err: false,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
Providers frequently return useful resource data to terraform on read,
which we want to store locally in the state file. Right now, nothing
prevents a user from setting those values in a configuration, other
than the fact that most of them aren't documented. The ReadOnly field
enforces RO attributes.

When a field is marked `ReadOnly: true`, terraform will error if a user
attempts to apply it from a configuration file. It will not error if
terraform itself provides the value during a resource read.

@phinze -- I think this implements what you and I discussed in #terraform-tool. I haven't retrofit any resources to use this particular quality, although my (still in progress) work on AWS VPN Connections could leverage it easily assuming it passes muster and hits master.