### PR TITLE
helper/resource: fix accidentaly swallowing of acctest step errors

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -235,8 +235,8 @@ func testStep(
 
 	// Check! Excitement!
 	if step.Check != nil {
-		if err = step.Check(state); err != nil {
-			err = fmt.Errorf("Check failed: %s", err)
+		if err := step.Check(state); err != nil {
+			return state, fmt.Errorf("Check failed: %s", err)
 		}
 	}
 


### PR DESCRIPTION
With #1757 I unwittingly reused an err variable, causing all test check
errors to be swallowed. -_-