### PR TITLE
aws: Add support for Alias records into AWS Route 53

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -177,6 +177,11 @@ func resourceAwsElb() *schema.Resource {
 				Computed: true,
 			},
 
+			"zone_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -281,6 +286,7 @@ func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", *lb.LoadBalancerName)
 	d.Set("dns_name", *lb.DNSName)
+	d.Set("zone_id", *lb.CanonicalHostedZoneNameID)
 	d.Set("internal", *lb.Scheme == "internal")
 	d.Set("availability_zones", lb.AvailabilityZones)
 	d.Set("instances", flattenInstances(lb.Instances))

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -139,6 +139,57 @@ func TestAccRoute53Record_weighted(t *testing.T) {
 	})
 }
 
+func TestAccRoute53Record_alias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53ElbAliasRecord,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.elb_alias"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccRoute53AliasRecord,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.origin"),
+					testAccCheckRoute53RecordExists("aws_route53_record.alias"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_weighted_alias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53WeightedElbAliasRecord,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_live"),
+					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_dev"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccRoute53WeightedR53AliasRecord,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.green_origin"),
+					testAccCheckRoute53RecordExists("aws_route53_record.r53_weighted_alias_live"),
+					testAccCheckRoute53RecordExists("aws_route53_record.blue_origin"),
+					testAccCheckRoute53RecordExists("aws_route53_record.r53_weighted_alias_dev"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).r53conn
 	for _, rs := range s.RootModule().Resources {
@@ -323,5 +374,173 @@ resource "aws_route53_record" "www-live" {
   weight = 90
   set_identifier = "live"
   records = ["dev.notexample.com"]
+}
+`
+
+const testAccRoute53ElbAliasRecord = `
+resource "aws_route53_zone" "main" {
+  name = "notexample.com"
+}
+
+resource "aws_route53_record" "alias" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "A"
+
+  alias {
+  	zone_id = "${aws_elb.main.zone_id}"
+  	name = "${aws_elb.main.dns_name}"
+  	evaluate_target_health = true
+  }
+}
+
+resource "aws_elb" "main" {
+  name = "foobar-terraform-elb"
+  availability_zones = ["us-west-2a"]
+
+  listener {
+    instance_port = 80
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+`
+
+const testAccRoute53AliasRecord = `
+resource "aws_route53_zone" "main" {
+  name = "notexample.com"
+}
+
+resource "aws_route53_record" "origin" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "origin"
+  type = "A"
+  ttl = 5
+  records = ["127.0.0.1"]
+}
+
+resource "aws_route53_record" "alias" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "A"
+
+  alias {
+    zone_id = "${aws_route53_zone.main.zone_id}"
+    name = "${aws_route53_record.origin.name}.${aws_route53_zone.main.name}"
+    evaluate_target_health = true
+  }
+}
+`
+
+const testAccRoute53WeightedElbAliasRecord = `
+resource "aws_route53_zone" "main" {
+  name = "notexample.com"
+}
+
+resource "aws_elb" "live" {
+  name = "foobar-terraform-elb-live"
+  availability_zones = ["us-west-2a"]
+
+  listener {
+    instance_port = 80
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
+resource "aws_route53_record" "elb_weighted_alias_live" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "A"
+
+  weight = 90
+  set_identifier = "live"
+
+  alias {
+    zone_id = "${aws_elb.live.zone_id}"
+    name = "${aws_elb.live.dns_name}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_elb" "dev" {
+  name = "foobar-terraform-elb-dev"
+  availability_zones = ["us-west-2a"]
+
+  listener {
+    instance_port = 80
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
+resource "aws_route53_record" "elb_weighted_alias_dev" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "A"
+
+  weight = 10
+  set_identifier = "dev"
+
+  alias {
+    zone_id = "${aws_elb.dev.zone_id}"
+    name = "${aws_elb.dev.dns_name}"
+    evaluate_target_health = true
+  }
+}
+`
+
+const testAccRoute53WeightedR53AliasRecord = `
+resource "aws_route53_zone" "main" {
+  name = "notexample.com"
+}
+
+resource "aws_route53_record" "blue_origin" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "blue-origin"
+  type = "CNAME"
+  ttl = 5
+  records = ["v1.terraform.io"]
+}
+
+resource "aws_route53_record" "r53_weighted_alias_live" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "CNAME"
+
+  weight = 90
+  set_identifier = "blue"
+
+  alias {
+    zone_id = "${aws_route53_zone.main.zone_id}"
+    name = "${aws_route53_record.blue_origin.name}.${aws_route53_zone.main.name}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "green_origin" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "green-origin"
+  type = "CNAME"
+  ttl = 5
+  records = ["v2.terraform.io"]
+}
+
+resource "aws_route53_record" "r53_weighted_alias_dev" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "CNAME"
+
+  weight = 10
+  set_identifier = "green"
+
+  alias {
+    zone_id = "${aws_route53_zone.main.zone_id}"
+    name = "${aws_route53_record.green_origin.name}.${aws_route53_zone.main.name}"
+    evaluate_target_health = false
+  }
 }
 `

--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -96,3 +96,4 @@ The following attributes are exported:
 * `source_security_group` - The name of the security group that you can use as
   part of your inbound rules for your load balancer's back-end application
   instances.
+* `zone_id` - The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record)


### PR DESCRIPTION
This closes https://github.com/hashicorp/terraform/issues/747
Documentation attached.

Alias records (as documented) can be currently used in conjunction with
 - ELBs - one extra commit here is allowing it to happen by exposing `zone_id`
 - existing R53 records (works out of the box)
 - CloudFront distributions - see https://github.com/hashicorp/terraform/pull/1780#issuecomment-98403101
 - S3 buckets - see https://github.com/hashicorp/terraform/issues/1769

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=Route53Record' 2>/dev/null
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=Route53Record -timeout 45m
=== RUN TestAccRoute53Record
--- PASS: TestAccRoute53Record (260.16s)
=== RUN TestAccRoute53Record_txtSupport
--- PASS: TestAccRoute53Record_txtSupport (279.02s)
=== RUN TestAccRoute53Record_generatesSuffix
--- PASS: TestAccRoute53Record_generatesSuffix (269.83s)
=== RUN TestAccRoute53Record_wildcard
--- PASS: TestAccRoute53Record_wildcard (402.11s)
=== RUN TestAccRoute53Record_weighted
--- PASS: TestAccRoute53Record_weighted (266.97s)
=== RUN TestAccRoute53Record_alias
--- PASS: TestAccRoute53Record_alias (529.72s)
=== RUN TestAccRoute53Record_weighted_alias
--- PASS: TestAccRoute53Record_weighted_alias (521.43s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	2529.257s
```

### Example
```ruby
resource "aws_route53_zone" "main" {
  name = "notexample.com"
}

resource "aws_route53_record" "alias" {
  zone_id = "${aws_route53_zone.main.zone_id}"
  name = "www"
  type = "A"

  alias {
  	zone_id = "${aws_elb.main.zone_id}"
  	name = "${aws_elb.main.dns_name}"
  	evaluate_target_health = true
  }
}

resource "aws_elb" "main" {
  name = "foobar-terraform-elb"
  availability_zones = ["us-west-2a"]

  listener {
    instance_port = 80
    instance_protocol = "http"
    lb_port = 80
    lb_protocol = "http"
  }
}
```

Related PR: https://github.com/hashicorp/terraform/pull/1366. I hope I covered all the edge cases and conflicts (e.g. TTL).