### PR TITLE
Makefile: tweak updatedeps to catch test-only deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ updatedeps:
 	go get -u github.com/mitchellh/gox
 	go get -u golang.org/x/tools/cmd/stringer
 	go list ./... \
-		| xargs go list -f '{{join .Deps "\n"}}' \
+		| xargs go list -f '{{join .Deps "\n"}}' -f '{{ join .TestImports "\n" }}' \
+		| xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' \
 		| grep -v github.com/hashicorp/terraform \
 		| sort -u \
 		| xargs go get -f -u -v


### PR DESCRIPTION
With the WinRM provider we had our first test-only dependency ->
`winrmtest`. This caused us to realized that `updatedeps` did not catch
test only deps.

This tweaks the process to include test dependencies, while also adding
a wee optimization I learned about while I poked around the `go list`
docs.