### PR TITLE
providers: add template provider

### DIFF
--- a/builtin/bins/provider-template/main.go
+++ b/builtin/bins/provider-template/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/template"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: template.Provider,
+	})
+}

--- a/builtin/providers/template/provider.go
+++ b/builtin/providers/template/provider.go
@@ -1,0 +1,14 @@
+package template
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"template_file": resource(),
+		},
+	}
+}

--- a/builtin/providers/template/provider_test.go
+++ b/builtin/providers/template/provider_test.go
@@ -1,0 +1,13 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}

--- a/builtin/providers/template/resource.go
+++ b/builtin/providers/template/resource.go
@@ -1,0 +1,119 @@
+package template
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/config/lang"
+	"github.com/hashicorp/terraform/config/lang/ast"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resource() *schema.Resource {
+	return &schema.Resource{
+		Create: Create,
+		Read:   Read,
+		Update: Update,
+		Delete: Delete,
+		Exists: Exists,
+
+		Schema: map[string]*schema.Schema{
+			"filename": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "file to read template from",
+			},
+			"vars": &schema.Schema{
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Default:     make(map[string]interface{}),
+				Description: "variables to substitute",
+			},
+			"rendered": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Default:     nil,
+				Description: "rendered template",
+			},
+		},
+	}
+}
+
+func Create(d *schema.ResourceData, meta interface{}) error { return eval(d) }
+func Update(d *schema.ResourceData, meta interface{}) error { return eval(d) }
+func Read(d *schema.ResourceData, meta interface{}) error   { return nil }
+func Delete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+func Exists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	// Reload every time in case something has changed.
+	// This should be cheap, and cache invalidation is hard.
+	return false, nil
+}
+
+func eval(d *schema.ResourceData) error {
+	filename := d.Get("filename").(string)
+	vars := d.Get("vars").(map[string]interface{})
+
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	rendered, err := execute(string(buf), vars)
+	if err != nil {
+		return fmt.Errorf("failed to render %v: %v", filename, err)
+	}
+
+	d.Set("rendered", rendered)
+	d.SetId(hash(rendered))
+	return nil
+}
+
+// execute parses and executes a template using vars.
+func execute(s string, vars map[string]interface{}) (string, error) {
+	root, err := lang.Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	varmap := make(map[string]ast.Variable)
+	for k, v := range vars {
+		// As far as I can tell, v is always a string.
+		// If it's not, tell the user gracefully.
+		s, ok := v.(string)
+		if !ok {
+			return "", fmt.Errorf("unexpected type for variable %q: %T", k, v)
+		}
+		varmap[k] = ast.Variable{
+			Value: s,
+			Type:  ast.TypeString,
+		}
+	}
+
+	cfg := lang.EvalConfig{
+		GlobalScope: &ast.BasicScope{
+			VarMap:  varmap,
+			FuncMap: config.Funcs,
+		},
+	}
+
+	out, typ, err := lang.Eval(root, &cfg)
+	if err != nil {
+		return "", err
+	}
+	if typ != ast.TypeString {
+		return "", fmt.Errorf("unexpected output ast.Type: %v", typ)
+	}
+
+	return out.(string), nil
+}
+
+func hash(s string) string {
+	sha := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sha[:])[:20]
+}

--- a/builtin/providers/template/resource.go
+++ b/builtin/providers/template/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/config/lang"
 	"github.com/hashicorp/terraform/config/lang/ast"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mitchellh/go-homedir"
 )
 
 func resource() *schema.Resource {
@@ -35,7 +36,6 @@ func resource() *schema.Resource {
 			"rendered": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Default:     nil,
 				Description: "rendered template",
 			},
 		},
@@ -55,11 +55,18 @@ func Exists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	return false, nil
 }
 
+var readfile func(string) ([]byte, error) = ioutil.ReadFile // testing hook
+
 func eval(d *schema.ResourceData) error {
 	filename := d.Get("filename").(string)
 	vars := d.Get("vars").(map[string]interface{})
 
-	buf, err := ioutil.ReadFile(filename)
+	path, err := homedir.Expand(filename)
+	if err != nil {
+		return err
+	}
+
+	buf, err := readfile(path)
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/template/resource_test.go
+++ b/builtin/providers/template/resource_test.go
@@ -1,0 +1,58 @@
+package template
+
+import (
+	"fmt"
+	"testing"
+
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testProviders = map[string]terraform.ResourceProvider{
+	"template": Provider(),
+}
+
+func TestTemplateRendering(t *testing.T) {
+	var cases = []struct {
+		vars     string
+		template string
+		want     string
+	}{
+		{`{}`, `ABC`, `ABC`},
+		{`{a="foo"}`, `${a}`, `foo`},
+		{`{a="hello"}`, `${replace(a, "ello", "i")}`, `hi`},
+		{`{}`, `${1+2+3}`, `6`},
+	}
+
+	for _, tt := range cases {
+		r.Test(t, r.TestCase{
+			PreCheck: func() {
+				readfile = func(string) ([]byte, error) {
+					return []byte(tt.template), nil
+				}
+			},
+			Providers: testProviders,
+			Steps: []r.TestStep{
+				r.TestStep{
+					Config: `
+resource "template_file" "t0" {
+	filename = "mock"
+	vars = ` + tt.vars + `
+}
+output "rendered" {
+    value = "${template_file.t0.rendered}"
+}
+`,
+					Check: func(s *terraform.State) error {
+						got := s.RootModule().Outputs["rendered"]
+						if tt.want != got {
+							return fmt.Errorf("template:\n%s\nvars:\n%s\ngot:\n%s\nwant:\n%s\n", tt.template, tt.vars, got, tt.want)
+						}
+						return nil
+					},
+					TransientResource: true,
+				},
+			},
+		})
+	}
+}

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -75,6 +75,12 @@ type TestStep struct {
 
 	// Destroy will create a destroy plan if set to true.
 	Destroy bool
+
+	// TransientResource indicates that resources created as part
+	// of this test step are temporary and might be recreated anew
+	// with every planning step. This should only be set for
+	// pseudo-resources, like the null resource or templates.
+	TransientResource bool
 }
 
 // Test performs an acceptance test on a resource.
@@ -260,7 +266,7 @@ func testStep(
 	if p, err := ctx.Plan(); err != nil {
 		return state, fmt.Errorf("Error on second follow-up plan: %s", err)
 	} else {
-		if p.Diff != nil && !p.Diff.Empty() {
+		if p.Diff != nil && !p.Diff.Empty() && !step.TransientResource {
 			return state, fmt.Errorf(
 				"After applying this step and refreshing, the plan was not empty:\n\n%s", p)
 		}

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -114,3 +114,33 @@ The supported built-in functions are:
       back into a list. This is useful for pushing lists through module
       outputs since they currently only support string values.
       Example: `split(",", module.amod.server_ids)`
+
+## Templates
+
+Long strings can be managed using templates. Templates are [resources](/docs/configuration/resources.html) defined by a filename and some variables to use during interpolation. They have a computed `rendered` attribute containing the result.
+
+A template resource looks like:
+
+```
+resource "template_file" "example" {
+    filename = "template.txt"
+    vars {
+        hello = "goodnight"
+        world = "moon"
+    }
+}
+
+output "rendered" {
+    value = "${template_file.example.rendered}"
+}
+```
+
+Assuming `template.txt` looks like this:
+
+```
+${hello} ${world}!
+```
+
+Then the rendered value would be `goodnight moon!`.
+
+You may use any of the built-in functions in your template.

--- a/website/source/docs/configuration/providers.html.md
+++ b/website/source/docs/configuration/providers.html.md
@@ -9,7 +9,7 @@ description: |-
 # Provider Configuration
 
 Providers are responsible in Terraform for managing the lifecycle
-of a [resource](/docs/configuration/resource.html): create,
+of a [resource](/docs/configuration/resources.html): create,
 read, update, delete.
 
 Every resource in Terraform is mapped to a provider based


### PR DESCRIPTION
Fixes #215.

This PR is an initial pass, so that I can get early feedback. At a minimum, it lacks website/documentation updates, but I want to do that last, after the code has stabilized and the barns have been painted.

Sample `example.tf`:

```
variable "key" {
    default = "hello"
}

variable "filename" {
    default = "template.txt"
}

resource "template_file" "sample" {
    filename = "${var.filename}"
    vars {
        hello = "${var.key}"
        world = "${replace(var.key, "ello", "i")}"
    }
}

output "rendered" {
    value = "${template_file.sample.rendered}"
}
```

Sample `template.txt`:

```
Hello: ${hello}
World: ${world}
Addition: ${1+2+3}
```

Output:

```
$ terraform apply
var.filename
  Default: template.txt
  Enter a value: 

var.key
  Default: hello
  Enter a value: 

template_file.sample: Creating...
  filename:   "" => "template.txt"
  rendered:   "" => "<computed>"
  vars.#:     "0" => "2"
  vars.hello: "" => "hello"
  vars.world: "" => "hi"
template_file.sample: Creation complete

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate

Outputs:

  rendered = Hello: hello
World: hi
Addition: 6
```

And everything shows up nicely for historical purposes in [`terraform.tfstate`](https://gist.github.com/josharian/1a1db45eadf5ba926f2f).
