### PR TITLE
aws: re-introduce support for AWS_SECURITY_TOKEN

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -38,6 +38,7 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"AWS_SESSION_TOKEN",
+					"AWS_SECURITY_TOKEN",
 				}, ""),
 				Description: descriptions["token"],
 			},


### PR DESCRIPTION
This re-enables support for the AWS_SECURITY_TOKEN environmental variable for AWS session tokens.