### PR TITLE
config: Add support for lists to concat

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -19,14 +19,14 @@ var Funcs map[string]ast.Function
 
 func init() {
 	Funcs = map[string]ast.Function{
+		"element":    interpolationFuncElement(),
 		"file":       interpolationFuncFile(),
 		"format":     interpolationFuncFormat(),
 		"formatlist": interpolationFuncFormatList(),
 		"join":       interpolationFuncJoin(),
-		"element":    interpolationFuncElement(),
+		"length":     interpolationFuncLength(),
 		"replace":    interpolationFuncReplace(),
 		"split":      interpolationFuncSplit(),
-		"length":     interpolationFuncLength(),
 
 		// Concat is a little useless now since we supported embeddded
 		// interpolations but we keep it around for backwards compat reasons.

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -19,6 +19,7 @@ var Funcs map[string]ast.Function
 
 func init() {
 	Funcs = map[string]ast.Function{
+		"concat":     interpolationFuncConcat(),
 		"element":    interpolationFuncElement(),
 		"file":       interpolationFuncFile(),
 		"format":     interpolationFuncFormat(),
@@ -27,10 +28,6 @@ func init() {
 		"length":     interpolationFuncLength(),
 		"replace":    interpolationFuncReplace(),
 		"split":      interpolationFuncSplit(),
-
-		// Concat is a little useless now since we supported embeddded
-		// interpolations but we keep it around for backwards compat reasons.
-		"concat": interpolationFuncConcat(),
 	}
 }
 
@@ -46,11 +43,32 @@ func interpolationFuncConcat() ast.Function {
 		VariadicType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
 			var b bytes.Buffer
-			for _, v := range args {
-				b.WriteString(v.(string))
+			var finalList []string
+
+			var isDeprecated = true
+
+			for _, arg := range args {
+				argument := arg.(string)
+
+				if len(argument) == 0 {
+					continue
+				}
+
+				if strings.Contains(argument, InterpSplitDelim) {
+					isDeprecated = false
+				}
+
+				finalList = append(finalList, argument)
+
+				// Deprecated concat behaviour
+				b.WriteString(argument)
 			}
 
-			return b.String(), nil
+			if isDeprecated {
+				return b.String(), nil
+			}
+
+			return strings.Join(finalList, InterpSplitDelim), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -532,12 +532,12 @@ func testFunction(t *testing.T, config testFunctionConfig) {
 	for i, tc := range config.Cases {
 		ast, err := lang.Parse(tc.Input)
 		if err != nil {
-			t.Fatalf("%d: err: %s", i, err)
+			t.Fatalf("Case #%d: input: %#v\nerr: %s", i, tc.Input, err)
 		}
 
 		out, _, err := lang.Eval(ast, langEvalConfig(config.Vars))
 		if (err != nil) != tc.Error {
-			t.Fatalf("%d: err: %s", i, err)
+			t.Fatalf("Case #%d:\ninput: %#v\nerr: %s", i, tc.Input, err)
 		}
 
 		if !reflect.DeepEqual(out, tc.Result) {

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -72,8 +72,8 @@ are documented below.
 
 The supported built-in functions are:
 
-  * `concat(args...)` - Concatenates the values of multiple arguments into
-      a single string.
+  * `concat(list1, list2)` - Combines two or more lists into a single list.
+     Example: `combine(aws_instance.db.*.tags.Name, aws_instance.web.*.tags.Name)`
 
   * `element(list, index)` - Returns a single element from a list
       at the given index. If the index is greater than the number of


### PR DESCRIPTION
The original intention was to satisfy @EvanKrall in this comment: https://github.com/hashicorp/terraform/pull/1495#issuecomment-91928215

but it turns out that lists are generally not a good idea for these cases as there's no way to uniquely identify each member of the list => when any member of the array is changed, many others will be changed too, because unique ID = `module.dns.dnsimple_record.foo.0` where `0` is not unique identifier and resource with that ID will change when you may not expect it to be changed.

In case of DNS records, it's a problem, because it will iterate over these resources `0..5` and try adding records that are already there.

It will only work well when changing/removing members from the end of the final list.

**Support for maps in variables** + `zip(keys, vals)` would be probably the way forward for case like this one.

So to sum it up, it probably won't solve that particular example, but I was thinking it may be useful elsewhere.

### Example
```ruby
${concat(aws_instance.db.*.tags.Name, aws_instance.web.*.tags.Name)}
```