### PR TITLE
Fix four acceptance tests so they now run successfully

### DIFF
--- a/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy_test.go
+++ b/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/service/elb"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -30,7 +31,7 @@ func TestAccAWSAppCookieStickinessPolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppCookieStickinessPolicy(
 						"aws_elb.lb",
-						"aws_app_cookie_stickiness_policy.bar",
+						"aws_app_cookie_stickiness_policy.foo",
 					),
 				),
 			},
@@ -80,7 +81,7 @@ func testAccCheckAppCookieStickinessPolicy(elbResource string, policyResource st
 const testAccAppCookieStickinessPolicyConfig = `
 resource "aws_elb" "lb" {
 	name = "test-lb"
-	availability_zones = ["us-east-1a"]
+	availability_zones = ["us-west-2a"]
 	listener {
 		instance_port = 8000
 		instance_protocol = "http"
@@ -90,17 +91,18 @@ resource "aws_elb" "lb" {
 }
 
 resource "aws_app_cookie_stickiness_policy" "foo" {
-	name = "foo_policy"
-	load_balancer = "${aws_elb.lb}"
+	name = "foo-policy"
+	load_balancer = "${aws_elb.lb.id}"
 	lb_port = 80
 	cookie_name = "MyAppCookie"
 }
 `
 
+// Change the cookie_name to "MyOtherAppCookie".
 const testAccAppCookieStickinessPolicyConfigUpdate = `
 resource "aws_elb" "lb" {
 	name = "test-lb"
-	availability_zones = ["us-east-1a"]
+	availability_zones = ["us-west-2a"]
 	listener {
 		instance_port = 8000
 		instance_protocol = "http"
@@ -110,16 +112,9 @@ resource "aws_elb" "lb" {
 }
 
 resource "aws_app_cookie_stickiness_policy" "foo" {
-	name = "foo_policy"
-	load_balancer = "${aws_elb.lb}"
+	name = "foo-policy"
+	load_balancer = "${aws_elb.lb.id}"
 	lb_port = 80
-	cookie_name = "MyAppCookie"
-}
-
-resource "aws_app_cookie_stickiness_policy" "bar" {
-	name = "bar_policy"
-	load_balancer = "${aws_elb.lb}"
-	lb_port = 80
-	cookie_name = "MyAppCookie"
+	cookie_name = "MyOtherAppCookie"
 }
 `

--- a/builtin/providers/aws/resource_aws_customer_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -25,10 +26,18 @@ func TestAccCustomerGateway(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCustomerGatewayUpdate,
+				Config: testAccCustomerGatewayConfigUpdateTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway(
-						"aws_customer_gateway.bar",
+						"aws_customer_gateway.foo",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCustomerGatewayConfigForceReplace,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGateway(
+						"aws_customer_gateway.foo",
 					),
 				),
 			},
@@ -82,29 +91,35 @@ const testAccCustomerGatewayConfig = `
 resource "aws_customer_gateway" "foo" {
 	bgp_asn = 60000
 	ip_address = "172.0.0.1"
-	type = ipsec.1
+	type = "ipsec.1"
 	tags {
 		Name = "foo-gateway"
 	}
 }
 `
 
-const testAccCustomerGatewayUpdate = `
+// Add the Another: "tag" tag.
+const testAccCustomerGatewayConfigUpdateTags = `
 resource "aws_customer_gateway" "foo" {
 	bgp_asn = 60000
 	ip_address = "172.0.0.1"
-	type = ipsec.1
+	type = "ipsec.1"
 	tags {
 		Name = "foo-gateway"
+		Another = "tag"
 	}
 }
+`
 
-resource "aws_customer_gateway" "bar" {
+// Change the ip_address.
+const testAccCustomerGatewayConfigForceReplace = `
+resource "aws_customer_gateway" "foo" {
 	bgp_asn = 60000
-	ip_address = "172.0.0.1"
-	type = ipsec.1
+	ip_address = "172.10.10.1"
+	type = "ipsec.1"
 	tags {
 		Name = "foo-gateway"
+		Another = "tag"
 	}
 }
 `

--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/awslabs/aws-sdk-go/service/elb"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSLBCookieStickinessPolicy(t *testing.T) {
+func TestAccAwsLBCookieStickinessPolicy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -30,7 +31,7 @@ func TestAccAWSLBCookieStickinessPolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBCookieStickinessPolicy(
 						"aws_elb.lb",
-						"aws_lb_cookie_stickiness_policy.bar",
+						"aws_lb_cookie_stickiness_policy.foo",
 					),
 				),
 			},
@@ -80,7 +81,7 @@ func testAccCheckLBCookieStickinessPolicy(elbResource string, policyResource str
 const testAccLBCookieStickinessPolicyConfig = `
 resource "aws_elb" "lb" {
 	name = "test-lb"
-	availability_zones = ["us-east-1a"]
+	availability_zones = ["us-west-2a"]
 	listener {
 		instance_port = 8000
 		instance_protocol = "http"
@@ -90,17 +91,18 @@ resource "aws_elb" "lb" {
 }
 
 resource "aws_lb_cookie_stickiness_policy" "foo" {
-	name = "foo_policy"
-	load_balancer = "${aws_elb.lb}"
+	name = "foo-policy"
+	load_balancer = "${aws_elb.lb.id}"
 	lb_port = 80
 	cookie_expiration_period = 600
 }
 `
 
+// Sets the cookie_expiration_period to 300s.
 const testAccLBCookieStickinessPolicyConfigUpdate = `
 resource "aws_elb" "lb" {
 	name = "test-lb"
-	availability_zones = ["us-east-1a"]
+	availability_zones = ["us-west-2a"]
 	listener {
 		instance_port = 8000
 		instance_protocol = "http"
@@ -110,16 +112,9 @@ resource "aws_elb" "lb" {
 }
 
 resource "aws_lb_cookie_stickiness_policy" "foo" {
-	name = "foo_policy"
-	load_balancer = "${aws_elb.lb}"
+	name = "foo-policy"
+	load_balancer = "${aws_elb.lb.id}"
 	lb_port = 80
-	cookie_expiration_period = 600
-}
-
-resource "aws_lb_cookie_stickiness_policy" "bar" {
-	name = "bar_policy"
-	load_balancer = "${aws_elb.lb}"
-	lb_port = 80
-	cookie_expiration_period = 600
+	cookie_expiration_period = 300
 }
 `

--- a/builtin/providers/aws/resource_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection_test.go
@@ -35,7 +35,7 @@ func TestAccAwsVpnConnection(t *testing.T) {
 						"aws_vpc.vpc",
 						"aws_vpn_gateway.vpn_gateway",
 						"aws_customer_gateway.customer_gateway",
-						"aws_vpn_connection.bar",
+						"aws_vpn_connection.foo",
 					),
 				),
 			},
@@ -85,18 +85,16 @@ func testAccAwsVpnConnection(
 }
 
 const testAccAwsVpnConnectionConfig = `
-resource "aws_vpc" "vpc" {
-	cidr_block = "10.0.0.0/16"
-}
-
 resource "aws_vpn_gateway" "vpn_gateway" {
-	vpc_id = "${aws_vpc.vpc.id}"
+	tags {
+		Name = "vpn_gateway"
+	}
 }
 
 resource "aws_customer_gateway" "customer_gateway" {
 	bgp_asn = 60000
-	ip_address = "172.0.0.1"
-	type = ipsec.1
+	ip_address = "178.0.0.1"
+	type = "ipsec.1"
 }
 
 resource "aws_vpn_connection" "foo" {
@@ -107,29 +105,21 @@ resource "aws_vpn_connection" "foo" {
 }
 `
 
+// Change static_routes_only to be false, forcing a refresh.
 const testAccAwsVpnConnectionConfigUpdate = `
-resource "aws_vpc" "vpc" {
-	cidr_block = "10.0.0.0/16"
-}
-
 resource "aws_vpn_gateway" "vpn_gateway" {
-	vpc_id = "${aws_vpc.vpc.id}"
+	tags {
+		Name = "vpn_gateway"
+	}
 }
 
 resource "aws_customer_gateway" "customer_gateway" {
 	bgp_asn = 60000
-	ip_address = "172.0.0.1"
-	type = ipsec.1
+	ip_address = "178.0.0.1"
+	type = "ipsec.1"
 }
 
 resource "aws_vpn_connection" "foo" {
-	vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
-	customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
-	type = "ipsec.1"
-	static_routes_only = true
-}
-
-resource "aws_vpn_connection" "bar" {
 	vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
 	customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
 	type = "ipsec.1"

--- a/website/source/docs/providers/aws/r/vpn_connection.html.markdown
+++ b/website/source/docs/providers/aws/r/vpn_connection.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_vpn_connection"
-sidebar_current: "docs-aws-vpn-connection"
+sidebar_current: "docs-aws-resource-vpn-connection"
 description: |-
   Provides a VPN connection connected to a VPC. These objects can be connected to customer gateways, and allow you to establish tunnels between your network and the VPC.
 ---


### PR DESCRIPTION
I was under the mistaken impression Travis CI was running acceptance tests on pull requests, and I wasn't in a position where I could run these locally. I fixed that local problem over the weekend, reran my recently submitted acceptance tests and realized they contained some bugs.

This PR fixes all of them, and they should all PASS now. Expect another PR from me later today adding `aws_vpn_connection_route` resources.