### PR TITLE
remote-exec (ssh): chmod'ing right path

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -238,6 +238,11 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 				"machine: %s", err)
 	}
 	cmd.Wait()
+	if cmd.ExitStatus != 0 {
+		return fmt.Errorf(
+			"Error chmodding script file to 0777 in remote "+
+				"machine: exit status=%s", cmd.ExitStatus)
+	}
 
 	return nil
 }

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -230,7 +230,7 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	}
 
 	cmd := &remote.Cmd{
-		Command: fmt.Sprintf("chmod 0777 %s", c.connInfo.ScriptPath),
+		Command: fmt.Sprintf("chmod 0777 %s", path),
 	}
 	if err := c.Start(cmd); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
We pulled and built from terraform master today and noticed that a
refactoring introduced by #1483 broke our remote-exec
provisioner. Looking into it more it looks like it wasn't chmod'ing the
correct path. So we fixed that and added some additional checking on that.