### PR TITLE
core: failing test for a bad module cycle

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -2443,6 +2443,26 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 	}
 }
 
+func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
+	m := testModule(t, "validate-module-deps-cycle")
+	p := testProvider("aws")
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	w, e := ctx.Validate()
+
+	if len(w) > 0 {
+		t.Fatalf("expected no warnings, got: %s", w)
+	}
+	if len(e) > 0 {
+		t.Fatalf("expected no errors, got: %s", e)
+	}
+}
+
 func TestContext2Validate_moduleProviderInherit(t *testing.T) {
 	m := testModule(t, "validate-module-pc-inherit")
 	p := testProvider("aws")

--- a/terraform/test-fixtures/validate-module-deps-cycle/a/main.tf
+++ b/terraform/test-fixtures/validate-module-deps-cycle/a/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "a" { }
+
+output "output" {
+  value = "${aws_instance.a.id}"
+}

--- a/terraform/test-fixtures/validate-module-deps-cycle/b/main.tf
+++ b/terraform/test-fixtures/validate-module-deps-cycle/b/main.tf
@@ -1,0 +1,4 @@
+variable "input" {}
+resource "aws_instance" "b" {
+  name = "${var.input}"
+}

--- a/terraform/test-fixtures/validate-module-deps-cycle/main.tf
+++ b/terraform/test-fixtures/validate-module-deps-cycle/main.tf
@@ -1,0 +1,8 @@
+module "a" {
+  source = "./a"
+}
+
+module "b" {
+  source = "./b"
+  input = "${module.a.output}"
+}


### PR DESCRIPTION
passing output of one module into input of the following module results
in a cycle