### PR TITLE
A partial fix the "-1" protocol problem in AWS security groups

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -406,8 +406,14 @@ func resourceAwsSecurityGroupUpdateRules(
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		remove := expandIPPerms(group, os.Difference(ns).List())
-		add := expandIPPerms(group, ns.Difference(os).List())
+		remove, err := expandIPPerms(group, os.Difference(ns).List())
+		if err != nil {
+			return err
+		}
+		add, err := expandIPPerms(group, ns.Difference(os).List())
+		if err != nil {
+			return err
+		}
 
 		// TODO: We need to handle partial state better in the in-between
 		// in this update.

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -142,6 +142,47 @@ func TestAccAWSSecurityGroup_vpc(t *testing.T) {
 	})
 }
 
+func TestAccAWSSecurityGroup_vpcNegOneIngress(t *testing.T) {
+	var group ec2.SecurityGroup
+
+	testCheck := func(*terraform.State) error {
+		if *group.VPCID == "" {
+			return fmt.Errorf("should have vpc ID")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupConfigVpcNegOneIngress,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupAttributesNegOneProtocol(&group),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "name", "terraform_acceptance_test_example"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "description", "Used in the terraform acceptance tests"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.956249133.protocol", "-1"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.956249133.from_port", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.956249133.to_port", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.956249133.cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.956249133.cidr_blocks.0", "10.0.0.0/8"),
+					testCheck,
+				),
+			},
+		},
+	})
+}
 func TestAccAWSSecurityGroup_MultiIngress(t *testing.T) {
 	var group ec2.SecurityGroup
 
@@ -283,6 +324,37 @@ func testAccCheckAWSSecurityGroupAttributes(group *ec2.SecurityGroup) resource.T
 			FromPort:   aws.Long(80),
 			ToPort:     aws.Long(8000),
 			IPProtocol: aws.String("tcp"),
+			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("10.0.0.0/8")}},
+		}
+
+		if *group.GroupName != "terraform_acceptance_test_example" {
+			return fmt.Errorf("Bad name: %s", *group.GroupName)
+		}
+
+		if *group.Description != "Used in the terraform acceptance tests" {
+			return fmt.Errorf("Bad description: %s", *group.Description)
+		}
+
+		if len(group.IPPermissions) == 0 {
+			return fmt.Errorf("No IPPerms")
+		}
+
+		// Compare our ingress
+		if !reflect.DeepEqual(group.IPPermissions[0], p) {
+			return fmt.Errorf(
+				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+				group.IPPermissions[0],
+				p)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSecurityGroupAttributesNegOneProtocol(group *ec2.SecurityGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		p := &ec2.IPPermission{
+			IPProtocol: aws.String("-1"),
 			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("10.0.0.0/8")}},
 		}
 
@@ -473,6 +545,24 @@ resource "aws_security_group" "web" {
 }
 `
 
+const testAccAWSSecurityGroupConfigVpcNegOneIngress = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_security_group" "web" {
+	name = "terraform_acceptance_test_example"
+	description = "Used in the terraform acceptance tests"
+	vpc_id = "${aws_vpc.foo.id}"
+
+	ingress {
+		protocol = "-1"
+		from_port = 0
+		to_port = 0
+		cidr_blocks = ["10.0.0.0/8"]
+	}
+}
+`
 const testAccAWSSecurityGroupConfigMultiIngress = `
 resource "aws_security_group" "worker" {
   name = "terraform_acceptance_test_example_1"

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -64,7 +64,10 @@ func TestexpandIPPerms(t *testing.T) {
 		GroupID: aws.String("foo"),
 		VPCID:   aws.String("bar"),
 	}
-	perms := expandIPPerms(group, expanded)
+	perms, err := expandIPPerms(group, expanded)
+	if err != nil {
+		t.Fatalf("error expanding perms: %v", err)
+	}
 
 	expected := []ec2.IPPermission{
 		ec2.IPPermission{
@@ -120,6 +123,100 @@ func TestexpandIPPerms(t *testing.T) {
 
 }
 
+func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
+	hash := func(v interface{}) int {
+		return hashcode.String(v.(string))
+	}
+
+	expanded := []interface{}{
+		map[string]interface{}{
+			"protocol":    "-1",
+			"from_port":   0,
+			"to_port":     0,
+			"cidr_blocks": []interface{}{"0.0.0.0/0"},
+			"security_groups": schema.NewSet(hash, []interface{}{
+				"sg-11111",
+				"foo/sg-22222",
+			}),
+		},
+	}
+	group := &ec2.SecurityGroup{
+		GroupID: aws.String("foo"),
+		VPCID:   aws.String("bar"),
+	}
+
+	perms, err := expandIPPerms(group, expanded)
+	if err != nil {
+		t.Fatalf("error expanding perms: %v", err)
+	}
+
+	expected := []ec2.IPPermission{
+		ec2.IPPermission{
+			IPProtocol: aws.String("-1"),
+			FromPort:   aws.Long(int64(0)),
+			ToPort:     aws.Long(int64(0)),
+			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("0.0.0.0/0")}},
+			UserIDGroupPairs: []*ec2.UserIDGroupPair{
+				&ec2.UserIDGroupPair{
+					UserID:  aws.String("foo"),
+					GroupID: aws.String("sg-22222"),
+				},
+				&ec2.UserIDGroupPair{
+					GroupID: aws.String("sg-22222"),
+				},
+			},
+		},
+	}
+
+	exp := expected[0]
+	perm := perms[0]
+
+	if *exp.FromPort != *perm.FromPort {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.FromPort,
+			*exp.FromPort)
+	}
+
+	if *exp.IPRanges[0].CIDRIP != *perm.IPRanges[0].CIDRIP {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.IPRanges[0].CIDRIP,
+			*exp.IPRanges[0].CIDRIP)
+	}
+
+	if *exp.UserIDGroupPairs[0].UserID != *perm.UserIDGroupPairs[0].UserID {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIDGroupPairs[0].UserID,
+			*exp.UserIDGroupPairs[0].UserID)
+	}
+
+	// Now test the error case. This *should* error when either from_port
+	// or to_port is not zero, but protocal is "-1".
+	errorCase := []interface{}{
+		map[string]interface{}{
+			"protocol":    "-1",
+			"from_port":   0,
+			"to_port":     65535,
+			"cidr_blocks": []interface{}{"0.0.0.0/0"},
+			"security_groups": schema.NewSet(hash, []interface{}{
+				"sg-11111",
+				"foo/sg-22222",
+			}),
+		},
+	}
+	securityGroups := &ec2.SecurityGroup{
+		GroupID: aws.String("foo"),
+		VPCID:   aws.String("bar"),
+	}
+
+	_, expandErr := expandIPPerms(securityGroups, errorCase)
+	if expandErr == nil {
+		t.Fatal("expandIPPerms should have errored!")
+	}
+}
+
 func TestExpandIPPerms_nonVPC(t *testing.T) {
 	hash := func(v interface{}) int {
 		return hashcode.String(v.(string))
@@ -146,7 +243,10 @@ func TestExpandIPPerms_nonVPC(t *testing.T) {
 	group := &ec2.SecurityGroup{
 		GroupName: aws.String("foo"),
 	}
-	perms := expandIPPerms(group, expanded)
+	perms, err := expandIPPerms(group, expanded)
+	if err != nil {
+		t.Fatalf("error expanding perms: %v", err)
+	}
 
 	expected := []ec2.IPPermission{
 		ec2.IPPermission{

--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -73,7 +73,8 @@ The `ingress` block supports:
 
 * `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be used with `security_groups`.
 * `from_port` - (Required) The start port.
-* `protocol` - (Required) The protocol.
+* `protocol` - (Required) The protocol. If you select a protocol of
+"-1", you must specify a "from_port" and "to_port" equal to 0.
 * `security_groups` - (Optional) List of security group Group Names if using
     EC2-Classic or the default VPC, or Group IDs if using a non-default VPC.
     Cannot be used with `cidr_blocks`.
@@ -85,7 +86,8 @@ The `egress` block supports:
 
 * `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be used with `security_groups`.
 * `from_port` - (Required) The start port.
-* `protocol` - (Required) The protocol.
+* `protocol` - (Required) The protocol. If you select a protocol of
+"-1", you must specify a "from_port" and "to_port" equal to 0.
 * `security_groups` - (Optional) List of security group Group Names if using
     EC2-Classic or the default VPC, or Group IDs if using a non-default VPC.
     Cannot be used with `cidr_blocks`.


### PR DESCRIPTION
This addresses, but does not completely close, #1177, and probably a few other issues if you go rooting around.

The core problem is this -- every time a provider discards or appends additional configuration data not captured by the terraform config file on API read, it'll result in a hashing error. It crops up twice for AWS security groups. First, `protocol = "-1"` rules don't record ports in AWS, meaning resources applied with ports and that protocol will always be out of hash-sync when reading the rules back down. Second, egress rules get a default `0.0.0.0/0` rule that isn't necessarily present in the local config file. That behavior is discussed in #1765.

This patch solves the first problem by forcing the user to explicitly declare `to_port = 0` and `from_port = 0` if passing `protocol = -1`. The logic is confined to `expandIPPerms` and is pretty straightforward. The patch also includes a slew of new testing, but notably not egress tests because they cannot pass.

There is no fix for the egress problem in this PR, but I did discover a (crappy) workaround. If users declare an '0.0.0.0/0' egress rule and runs `terraform apply`, AWS will error, claiming the rule is a duplicate, but record everything with the proper hash. Run `terraform apply` again, and terraform will run without error. Users can then remove the '0.0.0.0/0' egress rule, if that is their intent, and be completely in sync.