### PR TITLE
providers/aws: Add ElastiCache replication group support

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -93,6 +93,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ebs_volume":                   resourceAwsEbsVolume(),
 			"aws_eip":                          resourceAwsEip(),
 			"aws_elasticache_cluster":          resourceAwsElasticacheCluster(),
+			"aws_elasticache_replication_group":resourceAwsElasticacheReplicationGroup(),
 			"aws_elasticache_security_group":   resourceAwsElasticacheSecurityGroup(),
 			"aws_elasticache_subnet_group":     resourceAwsElasticacheSubnetGroup(),
 			"aws_elb":                          resourceAwsElb(),

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsElasticacheReplicationGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsElasticacheReplicationGroupCreate,
+		Read:   resourceAwsElasticacheReplicationGroupRead,
+		Update: resourceAwsElasticacheReplicationGroupUpdate,
+		Delete: resourceAwsElasticacheReplicationGroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"replication_group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cache_node_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"automatic_failover": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"num_cache_clusters": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+			"parameter_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"engine": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "redis",
+			},
+			"engine_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	replicationGroupId := d.Get("replication_group_id").(string)
+	description := d.Get("description").(string)
+	cacheNodeType := d.Get("cache_node_type").(string)
+	automaticFailover := d.Get("automatic_failover").(bool)
+	numCacheClusters := d.Get("num_cache_clusters").(int)
+	parameterGroupName := d.Get("parameter_group_name").(string)
+	engine := d.Get("engine").(string)
+	engineVersion := d.Get("engine_version").(string)
+
+	req := &elasticache.CreateReplicationGroupInput{
+		ReplicationGroupID:		aws.String(replicationGroupId),
+		ReplicationGroupDescription:	aws.String(description),
+		CacheNodeType:            	aws.String(cacheNodeType),
+		AutomaticFailoverEnabled: 	aws.Boolean(automaticFailover),
+		NumCacheClusters:         	aws.Long(int64(numCacheClusters)),
+		CacheParameterGroupName:	aws.String(parameterGroupName),
+		Engine:				aws.String(engine),
+		EngineVersion:			aws.String(engineVersion),
+	}
+
+	_, err := conn.CreateReplicationGroup(req)
+	if err != nil {
+		return fmt.Errorf("Error creating Elasticache replication group: %s", err)
+	}
+
+	d.SetId(replicationGroupId)
+
+	return nil
+}
+
+func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	req := &elasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupID: aws.String(d.Id()),
+	}
+
+	res, err := conn.DescribeReplicationGroups(req)
+	if err != nil {
+		return err
+	}
+
+	if len(res.ReplicationGroups) == 1 {
+		c := res.ReplicationGroups[0]
+		d.Set("replication_group_id", c.ReplicationGroupID)
+		d.Set("description", c.Description)
+		d.Set("automatic_failover", c.AutomaticFailover)
+	}
+
+	return nil
+}
+
+func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	req := &elasticache.ModifyReplicationGroupInput{
+		ApplyImmediately:   aws.Boolean(true),
+		ReplicationGroupID: aws.String(d.Id()),
+	}
+
+	if d.HasChange("description") {
+		description := d.Get("description").(string)
+		req.ReplicationGroupDescription = aws.String(description)
+	}
+
+	if d.HasChange("automatic_failover") {
+		automaticFailover := d.Get("automatic_failover").(bool)
+		req.AutomaticFailoverEnabled = aws.Boolean(automaticFailover)
+	}
+
+	_, err := conn.ModifyReplicationGroup(req)
+	if err != nil {
+		d.Partial(true)
+		return fmt.Errorf("Error updating Elasticache replication group: %s", err)
+	}
+
+	return resourceAwsElasticacheReplicationGroupRead(d, meta)
+}
+
+func resourceAwsElasticacheReplicationGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	req := &elasticache.DeleteReplicationGroupInput{
+		ReplicationGroupID: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteReplicationGroupRequest(req)
+	if err != nil {
+		return fmt.Errorf("Error deleting Elasticache replication group: %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -97,9 +97,9 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		Pending:    pending,
 		Target:     "available",
 		Refresh:    ReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
-		Timeout:    20 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Timeout:    15 * time.Minute,
+		Delay:      20 * time.Second,
+		MinTimeout: 5 * time.Second,
 	}
 
 	log.Printf("[DEBUG] Waiting for state to become available: %v", d.Id())
@@ -178,9 +178,9 @@ func resourceAwsElasticacheReplicationGroupDelete(d *schema.ResourceData, meta i
 		Pending:    []string{"creating", "available", "deleting"},
 		Target:     "",
 		Refresh:    ReplicationGroupStateRefreshFunc(conn, d.Id(), "", []string{}),
-		Timeout:    20 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Timeout:    15 * time.Minute,
+		Delay:      20 * time.Second,
+		MinTimeout: 5 * time.Second,
 	}
 
 	_, sterr := stateConf.WaitForState()
@@ -200,7 +200,7 @@ func ReplicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replication
 		if err != nil {
 			apierr := err.(aws.APIError)
 			log.Printf("[DEBUG] message: %v, code: %v", apierr.Message, apierr.Code)
-			if apierr.Message == fmt.Sprintf("ReplicationGroup not found: %v", replicationGroupID) {
+			if apierr.Code == "ReplicationGroupNotFoundFault" {
 				log.Printf("[DEBUG] Detect deletion")
 				return nil, "", nil
 			}

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -40,6 +40,7 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  1,
+				ForceNew: true,
 			},
 			"parameter_group_name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -141,14 +142,9 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 
-	req := &elasticache.ModifyReplicationGroupInput{
+	req := &elasticache.ModifyReplicationGroupInput {
 		ApplyImmediately:   aws.Boolean(true),
 		ReplicationGroupID: aws.String(d.Id()),
-	}
-
-	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		req.ReplicationGroupDescription = aws.String(description)
 	}
 
 	if d.HasChange("automatic_failover") {
@@ -156,9 +152,18 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 		req.AutomaticFailoverEnabled = aws.Boolean(automaticFailover)
 	}
 
+	if d.HasChange("description") {
+		description := d.Get("description").(string)
+		req.ReplicationGroupDescription = aws.String(description)
+	}
+
+	if d.HasChange("engine_version") {
+		engine_version := d.Get("engine_version").(string)
+		req.EngineVersion = aws.String(engine_version)
+	}
+
 	_, err := conn.ModifyReplicationGroup(req)
 	if err != nil {
-		d.Partial(true)
 		return fmt.Errorf("Error updating Elasticache replication group: %s", err)
 	}
 

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"log"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSEcacheReplicationGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcacheReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcacheReplicationGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcacheReplicationGroupExists("aws_elasticache_replication_group.bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEcacheReplicationGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elasticache_replication_group" {
+			continue
+		}
+		res, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
+			ReplicationGroupID: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+		if len(res.ReplicationGroups) > 0 {
+			return fmt.Errorf("still exist.")
+		}
+	}
+	return nil
+}
+
+func testAccCheckAWSEcacheReplicationGroupExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		log.Printf("[???] Checking for: %s", rs.Primary.ID)
+		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+		res, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
+			ReplicationGroupID: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("CacheReplicationGroup error: %v", err)
+		}
+
+		if len(res.ReplicationGroups) != 1 ||
+			*res.ReplicationGroups[0].ReplicationGroupID != rs.Primary.ID {
+				log.Printf("[???] Rep group not found %s", res)
+			return fmt.Errorf("Replication group not found")
+		}
+		log.Printf("[???] Rep group found")
+		return nil
+	}
+}
+
+var testAccAWSEcacheReplicationGroupConfig = fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "bar" {
+    replication_group_id = "tf-repgrp-%03d"
+    cache_node_type = "cache.m1.small"
+    num_cache_clusters = 2
+    description = "tf-test-replication-group-descr"
+}
+`, genRandInt())

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -54,7 +54,6 @@ func testAccCheckAWSEcacheReplicationGroupExists(n string) resource.TestCheckFun
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		log.Printf("[???] Checking for: %s", rs.Primary.ID)
 		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
 		res, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
 			ReplicationGroupID: aws.String(rs.Primary.ID),
@@ -66,10 +65,9 @@ func testAccCheckAWSEcacheReplicationGroupExists(n string) resource.TestCheckFun
 
 		if len(res.ReplicationGroups) != 1 ||
 			*res.ReplicationGroups[0].ReplicationGroupID != rs.Primary.ID {
-				log.Printf("[???] Rep group not found %s", res)
 			return fmt.Errorf("Replication group not found")
 		}
-		log.Printf("[???] Rep group found")
+		log.Printf("[DEBUG] Rep group found")
 		return nil
 	}
 }


### PR DESCRIPTION
This my first pass at adding replication group support -- the only Amazon sanctioned way of creating increased-availabilty Redis clusters with ElastiCache.