### PR TITLE
switch to updated aws-sdk-go credentials

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/multierror"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/credentials"
 	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/awslabs/aws-sdk-go/service/elasticache"
@@ -61,7 +62,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.region = c.Region
 
 		log.Println("[INFO] Building AWS auth structure")
-		creds := aws.DetectCreds(c.AccessKey, c.SecretKey, c.Token)
+		creds := credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, c.Token)
 		awsConfig := &aws.Config{
 			Credentials: creds,
 			Region:      c.Region,

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/credentials"
 	"github.com/awslabs/aws-sdk-go/service/s3"
 )
 
@@ -32,16 +33,16 @@ func s3Factory(conf map[string]string) (Client, error) {
 	accessKeyId := conf["access_key"]
 	secretAccessKey := conf["secret_key"]
 
-	credentialsProvider := aws.DetectCreds(accessKeyId, secretAccessKey, "")
+	creds := credentials.NewStaticCredentials(accessKeyId, secretAccessKey, "")
 
 	// Make sure we got some sort of working credentials.
-	_, err := credentialsProvider.Credentials()
+	_, err := creds.Get()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to determine AWS credentials. Set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.\n(error was: %s)", err)
 	}
 
 	awsConfig := &aws.Config{
-		Credentials: credentialsProvider,
+		Credentials: creds,
 		Region:      regionName,
 	}
 	nativeClient := s3.New(awsConfig)

--- a/state/remote/s3_test.go
+++ b/state/remote/s3_test.go
@@ -51,7 +51,7 @@ func TestS3Factory(t *testing.T) {
 		t.Fatalf("Incorrect keyName was populated")
 	}
 
-	credentials, err := s3Client.nativeClient.Config.Credentials.Credentials()
+	credentials, err := s3Client.nativeClient.Config.Credentials.Get()
 	if err != nil {
 		t.Fatalf("Error when requesting credentials")
 	}
@@ -105,7 +105,7 @@ func TestS3Client(t *testing.T) {
 	if err != nil {
 		t.Skipf("Failed to create test S3 bucket, so skipping")
 	}
-	defer func () {
+	defer func() {
 		deleteBucketReq := &s3.DeleteBucketInput{
 			Bucket: &bucketName,
 		}


### PR DESCRIPTION
Seems aws-sdk-go has changed a bit..

*rant*, golang dependency management (or lack thereof) sucks, should we vendor deps? 

