### PR TITLE
Openstack resource docs

### DIFF
--- a/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
@@ -106,7 +106,7 @@ func resourceFWFirewallV1Read(d *schema.ResourceData, meta interface{}) error {
 	firewall, err := firewalls.Get(networkingClient, d.Id()).Extract()
 
 	if err != nil {
-		return CheckDeleted(d, err, "LB pool")
+		return CheckDeleted(d, err, "firewall")
 	}
 
 	d.Set("name", firewall.Name)

--- a/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
@@ -116,7 +116,7 @@ func resourceFWPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 	policy, err := policies.Get(networkingClient, d.Id()).Extract()
 
 	if err != nil {
-		return CheckDeleted(d, err, "LB pool")
+		return CheckDeleted(d, err, "FW policy")
 	}
 
 	d.Set("name", policy.Name)

--- a/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
@@ -125,7 +125,7 @@ func resourceFWRuleV1Read(d *schema.ResourceData, meta interface{}) error {
 	rule, err := rules.Get(networkingClient, d.Id()).Extract()
 
 	if err != nil {
-		return CheckDeleted(d, err, "LB pool")
+		return CheckDeleted(d, err, "FW rule")
 	}
 
 	d.Set("protocol", rule.Protocol)

--- a/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_compute_floatingip_v2"
-sidebar_current: "docs-openstack-resource-compute-secgroup-2"
+sidebar_current: "docs-openstack-resource-compute-floatingip-2"
 description: |-
   Manages a V2 floating IP resource within OpenStack Nova (compute).
 ---

--- a/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_floatingip_v2"
+sidebar_current: "docs-openstack-resource-compute-secgroup-2"
+description: |-
+  Manages a V2 floating IP resource within OpenStack Nova (compute).
+---
+
+# openstack\_compute\_floatingip_v2
+
+Manages a V2 floating IP resource within OpenStack Nova (compute)
+that can be used for compute instances.
+These are similar to Neutron (networking) floating IP resources,
+but only networking floating IPs can be used with load balancers.
+
+## Example Usage
+
+```
+resource "openstack_compute_floatingip_v2" "floatip_1" {
+  region = ""
+  pool = "public"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the V2 Compute client.
+    A Compute client is needed to create a floating IP that can be used with
+    a compute instance. If omitted, the `OS_REGION_NAME` environment variable
+    is used. Changing this creates a new floating IP (which may or may not
+    have a different address).
+
+* `pool` - (Required) The name of the pool from which to obtain the floating
+    IP. Changing this creates a new floating IP.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `pool` - See Argument Reference above.
+* `address` - The actual floating IP address itself.
+* `fixed_ip` - The fixed IP address corresponding to the floating IP.
+* `instance_id` - UUID of the compute instance associated with the floating IP.

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -47,8 +47,8 @@ The following arguments are supported:
 * `flavor_name` - (Optional; Required if `flavor_id` is empty) The name of the
     desired flavor for the server. Changing this resizes the existing server.
 
-* `floating_ip` - (Optional) A Floating IP that will be associated with the
-    Instance. The Floating IP must be provisioned already.
+* `floating_ip` - (Optional) A *Compute* Floating IP that will be associated
+    with the Instance. The Floating IP must be provisioned already.
 
 * `user_data` - (Optional) The user data to provide when launching the instance.
     Changing this creates a new server.

--- a/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_fw_firewall_v1"
+sidebar_current: "docs-openstack-resource-fw-firewall-1"
+description: |-
+  Manages a v1 firewall resource within OpenStack.
+---
+
+# openstack\_fw\_firewall_v1
+
+Manages a v1 firewall resource within OpenStack.
+
+## Example Usage
+
+```
+resource "openstack_fw_firewall_v1" "firewall_1" {
+  region = ""
+  name = "my-firewall"
+  policy_id = "${openstack_fw_policy_v1.policy_1.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the v1 networking client.
+    A networking client is needed to create a firewall. If omitted, the
+    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    firewall.
+
+* `policy_id` - (Required) The policy resource id for the firewall. Changing
+    this updates the `policy_id` of an existing firewall.
+
+* `name` - (Optional) A name for the firewall. Changing this
+    updates the `name` of an existing firewall.
+
+* `description` - (Required) A description for the firewall. Changing this
+    updates the `description` of an existing firewall.
+
+* `admin_state_up` - (Optional) Administrative up/down status for the firewall
+    (must be "true" or "false" if provided - defaults to "true").
+    Changing this updates the `admin_state_up` of an existing firewall.
+
+* `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants
+    to create a firewall for another tenant. Changing this creates a new
+    firewall.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `policy_id` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `admin_state_up` - See Argument Reference above.
+* `tenant_id` - See Argument Reference above.

--- a/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
@@ -13,6 +13,31 @@ Manages a v1 firewall resource within OpenStack.
 ## Example Usage
 
 ```
+resource "openstack_fw_rule_v1" "rule_1" {
+  name = "my-rule-1"
+  description = "drop TELNET traffic"
+  action = "deny"
+  protocol = "tcp"
+  destination_port = "23"
+  enabled = "true"
+}
+
+resource "openstack_fw_rule_v1" "rule_2" {
+  name = "my-rule-2"
+  description = "drop NTP traffic"
+  action = "deny"
+  protocol = "udp"
+  destination_port = "123"
+  enabled = "false"
+}
+
+resource "openstack_fw_policy_v1" "policy_1" {
+  region = ""
+  name = "my-policy"
+  rules = ["${openstack_fw_rule_v1.rule_1.id}",
+           "${openstack_fw_rule_v1.rule_2.id}"]
+}
+
 resource "openstack_fw_firewall_v1" "firewall_1" {
   region = ""
   name = "my-firewall"

--- a/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
@@ -13,6 +13,24 @@ Manages a v1 firewall policy resource within OpenStack.
 ## Example Usage
 
 ```
+resource "openstack_fw_rule_v1" "rule_1" {
+  name = "my-rule-1"
+  description = "drop TELNET traffic"
+  action = "deny"
+  protocol = "tcp"
+  destination_port = "23"
+  enabled = "true"
+}
+
+resource "openstack_fw_rule_v1" "rule_2" {
+  name = "my-rule-2"
+  description = "drop NTP traffic"
+  action = "deny"
+  protocol = "udp"
+  destination_port = "123"
+  enabled = "false"
+}
+
 resource "openstack_fw_policy_v1" "policy_1" {
   region = ""
   name = "my-policy"

--- a/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_fw_policy_v1"
+sidebar_current: "docs-openstack-resource-fw-policy-1"
+description: |-
+  Manages a v1 firewall policy resource within OpenStack.
+---
+
+# openstack\_fw\_policy_v1
+
+Manages a v1 firewall policy resource within OpenStack.
+
+## Example Usage
+
+```
+resource "openstack_fw_policy_v1" "policy_1" {
+  region = ""
+  name = "my-policy"
+  rules = ["${openstack_fw_rule_v1.rule_1.id}",
+           "${openstack_fw_rule_v1.rule_2.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the v1 networking client.
+    A networking client is needed to create a firewall policy. If omitted, the
+    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    firewall policy.
+
+* `name` - (Optional) A name for the firewall policy. Changing this
+    updates the `name` of an existing firewall policy.
+
+* `description` - (Optional) A description for the firewall policy. Changing
+    this updates the `description` of an existing firewall policy.
+
+* `rules` - (Optional) An array of one or more firewall rules that comprise
+    the policy. Changing this results in adding/removing rules from the
+    existing firewall policy.
+
+* `audited` - (Optional) Audit status of the firewall policy
+    (must be "true" or "false" if provided - defaults to "false").
+    This status is set to "false" whenever the firewall policy or any of its
+    rules are changed. Changing this updates the `audited` status of an existing
+    firewall policy.
+
+* `shared` - (Optional) Sharing status of the firewall policy (must be "true"
+    or "false" if provided - defaults to "false"). If this is "true" the policy
+    is visible to, and can be used in, firewalls in other tenants. Changing this
+    updates the `shared` status of an existing firewall policy.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `audited` - See Argument Reference above.
+* `shared` - See Argument Reference above.

--- a/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_fw_rule_v1"
-sidebar_current: "docs-openstack-resource-compute-rule-1"
+sidebar_current: "docs-openstack-resource-fw-rule-1"
 description: |-
   Manages a v1 firewall rule resource within OpenStack.
 ---
@@ -19,7 +19,7 @@ resource "openstack_fw_rule_v1" "rule_1" {
   action = "deny"
   protocol = "tcp"
   destination_port = "23"
-  enabled = "false"
+  enabled = "true"
 }
 ```
 

--- a/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
@@ -1,0 +1,90 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_fw_rule_v1"
+sidebar_current: "docs-openstack-resource-compute-rule-1"
+description: |-
+  Manages a v1 firewall rule resource within OpenStack.
+---
+
+# openstack\_fw\_rule_v1
+
+Manages a v1 firewall rule resource within OpenStack.
+
+## Example Usage
+
+```
+resource "openstack_fw_rule_v1" "rule_1" {
+  name = "my_rule"
+  description = "drop TELNET traffic"
+  action = "deny"
+  protocol = "tcp"
+  destination_port = "23"
+  enabled = "false"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the v1 Compute client.
+    A Compute client is needed to create a firewall rule. If omitted, the
+    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    firewall rule.
+
+* `name` - (Optional) A unique name for the firewall rule. Changing this
+    updates the `name` of an existing firewall rule.
+
+* `description` - (Optional) A description for the firewall rule. Changing this
+    updates the `description` of an existing firewall rule.
+
+* `protocol` - (Required) The protocol type on which the firewall rule operates.
+    Changing this updates the `protocol` of an existing firewall rule.
+
+* `action` - (Required) Action to be taken ( must be "allow" or "deny") when the
+    firewall rule matches. Changing this updates the `action` of an existing
+    firewall rule.
+
+* `ip_version` - (Optional) IP version, either 4 (default) or 6. Changing this
+    updates the `ip_version` of an existing firewall rule.
+
+* `source_ip_address` - (Optional) The source IP address on which the firewall
+    rule operates. Changing this updates the `source_ip_address` of an existing
+    firewall rule.
+
+* `destination_ip_address` - (Optional) The destination IP address on which the
+    firewall rule operates. Changing this updates the `destination_ip_address`
+    of an existing firewall rule.
+
+* `source_port` - (Optional) The source port on which the firewall
+    rule operates. Changing this updates the `source_port` of an existing
+    firewall rule.
+
+* `destination_port` - (Optional) The destination port on which the firewall
+    rule operates. Changing this updates the `destination_port` of an existing
+    firewall rule.
+
+* `enabled` - (Optional) Enabled status for the firewall rule (must be "true"
+    or "false" if provided - defaults to "true"). Changing this updates the
+    `enabled` status of an existing firewall rule.
+
+* `tenant_id` - (Optional) The owner of the firewall rule. Required if admin
+    wants to create a firewall rule for another tenant. Changing this creates a
+    new firewall rule.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `protocol` - See Argument Reference above.
+* `action` - See Argument Reference above.
+* `ip_version` - See Argument Reference above.
+* `source_ip_address` - See Argument Reference above.
+* `destination_ip_address` - See Argument Reference above.
+* `source_port` - See Argument Reference above.
+* `destination_port` - See Argument Reference above.
+* `enabled` - See Argument Reference above.
+* `tenant_id` - See Argument Reference above.

--- a/website/source/docs/providers/openstack/r/lb_vip_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_vip_v1.html.markdown
@@ -95,4 +95,6 @@ The following attributes are exported:
 * `description` - See Argument Reference above.
 * `persistence` - See Argument Reference above.
 * `conn_limit` - See Argument Reference above.
+* `floating_ip` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
+* `port_id` - Port UUID for this VIP at associated floating IP (if any).

--- a/website/source/docs/providers/openstack/r/lb_vip_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_vip_v1.html.markdown
@@ -65,8 +65,8 @@ The following arguments are supported:
     vip. Default is -1, meaning no limit. Changing this updates the conn_limit
     of the existing vip.
 
-* `floating_ip` - (Optional) A Floating IP that will be associated with the
-    vip. The Floating IP must be provisioned already.
+* `floating_ip` - (Optional) A *Networking* Floating IP that will be associated
+    with the vip. The Floating IP must be provisioned already.
 
 * `admin_state_up` - (Optional) The administrative state of the vip.
     Acceptable values are "true" and "false". Changing this value updates the

--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_networking_floatingip_v2"
-sidebar_current: "docs-openstack-resource-compute-secgroup-2"
+sidebar_current: "docs-openstack-resource-networking-floatingip-2"
 description: |-
   Manages a V2 floating IP resource within OpenStack Neutron (networking).
 ---

--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_floatingip_v2"
+sidebar_current: "docs-openstack-resource-compute-secgroup-2"
+description: |-
+  Manages a V2 floating IP resource within OpenStack Neutron (networking).
+---
+
+# openstack\_networking\_floatingip_v2
+
+Manages a V2 floating IP resource within OpenStack Neutron (networking)
+that can be used for load balancers.
+These are similar to Nova (compute) floating IP resources,
+but only compute floating IPs can be used with compute instances.
+
+## Example Usage
+
+```
+resource "openstack_networking_floatingip_v2" "floatip_1" {
+  region = ""
+  pool = "public"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the V2 Networking client.
+    A Networking client is needed to create a floating IP that can be used with
+    another networking resource, such as a load balancer. If omitted, the
+    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    floating IP (which may or may not have a different address).
+
+* `pool` - (Required) The name of the pool from which to obtain the floating
+    IP. Changing this creates a new floating IP.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `pool` - See Argument Reference above.
+* `address` - The actual floating IP address itself.

--- a/website/source/docs/providers/openstack/r/networking_router_interface_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_router_interface_v2.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_router_interface_v2"
+sidebar_current: "docs-openstack-resource-networking-router-interface-2"
+description: |-
+  Manages a V2 router interface resource within OpenStack.
+---
+
+# openstack\_networking\_router_interface_v2
+
+Manages a V2 router interface resource within OpenStack.
+
+## Example Usage
+
+```
+resource "openstack_networking_network_v2" "network_1" {
+  name = "tf_test_network"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+}
+
+resource "openstack_networking_router_v2" "router_1" {
+  region = ""
+  name = "my_router"
+  external_gateway = "f67f0d72-0ddf-11e4-9d95-e1f29f417e2f"
+}
+
+resource "openstack_networking_router_interface_v2" "router_interface_1" {
+  region = ""
+  router_id = "${openstack_networking_router_v2.router_1.id}"
+  subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the V2 networking client.
+    A networking client is needed to create a router. If omitted, the
+    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    router interface.
+
+* `router_id` - (Required) ID of the router this interface belongs to. Changing
+    this creates a new router interface.
+
+* `subnet_id` - (Required) ID of the subnet this interface connects to. Changing
+    this creates a new router interface.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `router_id` - See Argument Reference above.
+* `subnet_id` - See Argument Reference above.

--- a/website/source/docs/providers/openstack/r/networking_router_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_router_v2.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_router_v2"
+sidebar_current: "docs-openstack-resource-networking-router-2"
+description: |-
+  Manages a V2 router resource within OpenStack.
+---
+
+# openstack\_networking\_router_v2
+
+Manages a V2 router resource within OpenStack.
+
+## Example Usage
+
+```
+resource "openstack_networking_router_v2" "router_1" {
+  region = ""
+  name = "my_router"
+  external_gateway = "f67f0d72-0ddf-11e4-9d95-e1f29f417e2f"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the V2 networking client.
+    A networking client is needed to create a router. If omitted, the
+    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    router.
+
+* `name` - (Optional) A unique name for the router. Changing this
+    updates the `name` of an existing router.
+
+* `admin_state_up` - (Optional) Administrative up/down status for the router
+    (must be "true" or "false" if provided). Changing this updates the
+    `admin_state_up` of an existing router.
+
+* `external_gateway` - (Optional) The network UUID of an external gateway for
+    the router. A router with an external gateway is required if any compute
+    instances or load balancers will be using floating IPs. Changing this
+    updates the `external_gateway` of an existing router.
+
+* `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants
+    to create a router for another tenant. Changing this creates a new router.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `admin_state_up` - See Argument Reference above.
+* `external_gateway` - See Argument Reference above.
+* `tenant_id` - See Argument Reference above.


### PR DESCRIPTION
When trying to set up an OpenStack cloud using Terraform, I was having a lot of difficulty figuring out how to set up floating IPs, until I found an example on the net.  That's because there are nine OpenStack resource types that are not actually documented in the online docs (only in the source code).

This PR adds documentation for the missing nine; it is entirely untested, but I copied the boilerplate from other OpenStack resource types that were documented, and although it's possible I missed a sidebar reference in one of the new files, I did review them fairly thoroughly (and caught at least three cases).

I even added additional explanation for people who might be confused by the presence of two very similar but different floating IP resource types (one is for compute instances, the other for load balancers, and this is just the way OpenStack rolls, as warty as that is); no doubt it could be better, but this may prevent some obvious errors by users.

While documenting the OpenStack Firewall-as-a-Service resource types (my OpenStack cloud doesn't have them) from the master branch source, I noticed some copy-paste typos where the resource type name wasn't changed in a CheckDeleted call; I have included these as a separate commit in the same PR as this is a minor non-functional change that should still make the OpenStack resources more usable, but wasn't quite worth a separate PR.
