### PR TITLE
providers/aws: chain credentials

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -62,7 +62,16 @@ func (c *Config) Client() (interface{}, error) {
 		client.region = c.Region
 
 		log.Println("[INFO] Building AWS auth structure")
-		creds := credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, c.Token)
+		creds := credentials.NewChainCredentials([]credentials.Provider{
+			&credentials.StaticProvider{Value: credentials.Value{
+				AccessKeyID:     c.AccessKey,
+				SecretAccessKey: c.SecretKey,
+				SessionToken:    c.Token,
+			}},
+			&credentials.EnvProvider{},
+			&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
+			&credentials.EC2RoleProvider{},
+		})
 		awsConfig := &aws.Config{
 			Credentials: creds,
 			Region:      c.Region,


### PR DESCRIPTION
Fixes #1804 

This chains more credential providers in addition to static so that we can properly pick up things from the environment, shared files, etc.

NOTE: It'd be really awesome if we could test this somehow, but I still look at it and I'm not sure how yet. :(