### PR TITLE
Fixing a small vet warning introduced by PR #1796

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -229,8 +229,11 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 		return err
 	}
 
+	var stdout, stderr bytes.Buffer
 	cmd := &remote.Cmd{
 		Command: fmt.Sprintf("chmod 0777 %s", path),
+		Stdout:  &stdout,
+		Stderr:  &stderr,
 	}
 	if err := c.Start(cmd); err != nil {
 		return fmt.Errorf(
@@ -241,7 +244,7 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	if cmd.ExitStatus != 0 {
 		return fmt.Errorf(
 			"Error chmodding script file to 0777 in remote "+
-				"machine: exit status=%s", cmd.ExitStatus)
+				"machine: %s %s", stdout.String(), stderr.String())
 	}
 
 	return nil

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -244,7 +244,7 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	if cmd.ExitStatus != 0 {
 		return fmt.Errorf(
 			"Error chmodding script file to 0777 in remote "+
-				"machine: %s %s", stdout.String(), stderr.String())
+				"machine %d: %s %s", cmd.ExitStatus, stdout.String(), stderr.String())
 	}
 
 	return nil


### PR DESCRIPTION
While fixing the vet warning also tried to improve any feedback by showing the actual output/error instead of just the error code.

While testing this I noticed only adding stderr output is not enough as not all error info is send to stderr, but sometimes also to stdout.