### PR TITLE
core: validate graph w/ diff during plan phase

### DIFF
--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -426,10 +426,13 @@ func (n *graphNodeResourceDestroy) destroyIncludePrimary(
 	// to include this resource.
 	prefix := n.Original.Resource.Id()
 
-	// If we're present in the diff proper, then keep it.
+	// If we're present in the diff proper, then keep it. We're looking
+	// only for resources in the diff that match our resource or a count-index
+	// of our resource that are marked for destroy.
 	if d != nil {
-		for k, _ := range d.Resources {
-			if strings.HasPrefix(k, prefix) {
+		for k, d := range d.Resources {
+			match := k == prefix || strings.HasPrefix(k, prefix+".")
+			if match && d.Destroy {
 				return true
 			}
 		}

--- a/terraform/transform_destroy_test.go
+++ b/terraform/transform_destroy_test.go
@@ -166,7 +166,7 @@ func TestPruneDestroyTransformer_diff(t *testing.T) {
 	actual := strings.TrimSpace(g.String())
 	expected := strings.TrimSpace(testTransformPruneDestroyBasicDiffStr)
 	if actual != expected {
-		t.Fatalf("bad:\n\n%s", actual)
+		t.Fatalf("expected:\n\n%s\n\nbad:\n\n%s", expected, actual)
 	}
 }
 
@@ -421,9 +421,7 @@ aws_instance.foo
 
 const testTransformPruneDestroyBasicDiffStr = `
 aws_instance.bar
-  aws_instance.bar (destroy)
   aws_instance.foo
-aws_instance.bar (destroy)
 aws_instance.foo
 `
 


### PR DESCRIPTION
This reimplements my prior attempt at nipping issues where a plan did
not yield the same cycle an apply did. My prior attempt was to have
ctx.Validate generate a "Verbose" worst-case graph. It turns out that
skipping PruneDestroyTransformer to generate this graph misses important
heuristics that prevent cycles by dropping destroy nodes that are
determined to be unused.

This resulted in Validate improperly failing in scenarios where these
heuristics would have broken the cycle.

We detected the problem during the work on #1781 and worked around the
issue by reverting to the non-Verbose graph in Validate.

This commit accomplishes the original goal in a better way - by
generating the full graph and checking it once Plan has calculated the
diff. This guarantees that any graph issue that would be caught by Apply
will be caught by Plan.