### PR TITLE
core: module targeting

### DIFF
--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -19,6 +19,8 @@ type GraphNodeConfigResource struct {
 
 	// Used during DynamicExpand to target indexes
 	Targets []ResourceAddress
+
+	Path []string
 }
 
 func (n *GraphNodeConfigResource) ConfigType() GraphNodeConfigType {
@@ -174,7 +176,7 @@ func (n *GraphNodeConfigResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 // GraphNodeAddressable impl.
 func (n *GraphNodeConfigResource) ResourceAddress() *ResourceAddress {
 	return &ResourceAddress{
-		// Indicates no specific index; will match on other three fields
+		Path:         n.Path[1:],
 		Index:        -1,
 		InstanceType: TypePrimary,
 		Name:         n.Resource.Name,

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -64,6 +64,46 @@ func TestParseResourceAddress(t *testing.T) {
 				Index:        -1,
 			},
 		},
+		"in a module": {
+			Input: "module.child.aws_instance.foo",
+			Expected: &ResourceAddress{
+				Path:         []string{"child"},
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+		},
+		"nested modules": {
+			Input: "module.a.module.b.module.forever.aws_instance.foo",
+			Expected: &ResourceAddress{
+				Path:         []string{"a", "b", "forever"},
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+		},
+		"just a module": {
+			Input: "module.a",
+			Expected: &ResourceAddress{
+				Path:         []string{"a"},
+				Type:         "",
+				Name:         "",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+		},
+		"just a nested module": {
+			Input: "module.a.module.b",
+			Expected: &ResourceAddress{
+				Path:         []string{"a", "b"},
+				Type:         "",
+				Name:         "",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+		},
 	}
 
 	for tn, tc := range cases {
@@ -203,6 +243,57 @@ func TestResourceAddressEquals(t *testing.T) {
 				Index:        1,
 			},
 			Expect: false,
+		},
+		"module address matches address of resource inside module": {
+			Address: &ResourceAddress{
+				Path:         []string{"a", "b"},
+				Type:         "",
+				Name:         "",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+			Other: &ResourceAddress{
+				Path:         []string{"a", "b"},
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        0,
+			},
+			Expect: true,
+		},
+		"module address doesn't match resource outside module": {
+			Address: &ResourceAddress{
+				Path:         []string{"a", "b"},
+				Type:         "",
+				Name:         "",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+			Other: &ResourceAddress{
+				Path:         []string{"a"},
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        0,
+			},
+			Expect: false,
+		},
+		"nil path vs empty path should match": {
+			Address: &ResourceAddress{
+				Path:         []string{},
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        -1,
+			},
+			Other: &ResourceAddress{
+				Path:         nil,
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        0,
+			},
+			Expect: true,
 		},
 	}
 

--- a/terraform/test-fixtures/apply-targeted-module-resource/child/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-resource/child/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+    num = "2"
+}
+
+resource "aws_instance" "bar" {
+    num = "2"
+}

--- a/terraform/test-fixtures/apply-targeted-module-resource/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-resource/main.tf
@@ -1,0 +1,7 @@
+module "child" {
+    source = "./child"
+}
+
+resource "aws_instance" "bar" {
+    foo = "bar"
+}

--- a/terraform/test-fixtures/apply-targeted-module/child/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module/child/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+    num = "2"
+}
+
+resource "aws_instance" "bar" {
+    num = "2"
+}

--- a/terraform/test-fixtures/apply-targeted-module/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module/main.tf
@@ -1,0 +1,11 @@
+module "child" {
+    source = "./child"
+}
+
+resource "aws_instance" "foo" {
+    foo = "bar"
+}
+
+resource "aws_instance" "bar" {
+    foo = "bar"
+}

--- a/terraform/transform_config.go
+++ b/terraform/transform_config.go
@@ -55,7 +55,10 @@ func (t *ConfigTransformer) Transform(g *Graph) error {
 
 	// Write all the resources out
 	for _, r := range config.Resources {
-		nodes = append(nodes, &GraphNodeConfigResource{Resource: r})
+		nodes = append(nodes, &GraphNodeConfigResource{
+			Resource: r,
+			Path:     g.Path,
+		})
 	}
 
 	// Write all the modules out

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -44,6 +44,7 @@ func (t *ResourceCountTransformer) Transform(g *Graph) error {
 		var node dag.Vertex = &graphNodeExpandedResource{
 			Index:    index,
 			Resource: t.Resource,
+			Path:     g.Path,
 		}
 		if t.Destroy {
 			node = &graphNodeExpandedResourceDestroy{
@@ -93,6 +94,7 @@ func (t *ResourceCountTransformer) nodeIsTargeted(node dag.Vertex) bool {
 type graphNodeExpandedResource struct {
 	Index    int
 	Resource *config.Resource
+	Path     []string
 }
 
 func (n *graphNodeExpandedResource) Name() string {
@@ -112,8 +114,8 @@ func (n *graphNodeExpandedResource) ResourceAddress() *ResourceAddress {
 		index = 0
 	}
 	return &ResourceAddress{
-		Index: index,
-		// TODO: kjkjkj
+		Path:         n.Path[1:],
+		Index:        index,
 		InstanceType: TypePrimary,
 		Name:         n.Resource.Name,
 		Type:         n.Resource.Type,

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -1,6 +1,10 @@
 package terraform
 
-import "github.com/hashicorp/terraform/dag"
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/dag"
+)
 
 // TargetsTransformer is a GraphTransformer that, when the user specifies a
 // list of resources to target, limits the graph to only those resources and
@@ -30,6 +34,7 @@ func (t *TargetsTransformer) Transform(g *Graph) error {
 		for _, v := range g.Vertices() {
 			if _, ok := v.(GraphNodeAddressable); ok {
 				if !targetedNodes.Include(v) {
+					log.Printf("[DEBUG] Removing %s, filtered by targeting.", v)
 					g.Remove(v)
 				}
 			}

--- a/website/source/docs/internals/resource-addressing.html.markdown
+++ b/website/source/docs/internals/resource-addressing.html.markdown
@@ -10,19 +10,34 @@ description: |-
 # Resource Addressing
 
 A __Resource Address__ is a string that references a specific resource in a
-larger infrastructure. The syntax of a resource address is:
+larger infrastructure. An address is made up of two parts:
 
 ```
-<resource_type>.<resource_name>[optional fields]
+[module path][resource spec]
 ```
 
-Required fields:
+__Module path__:
+
+A module path addresses a module within the tree of modules. It takes the form:
+
+```
+module.A.module.B.module.C...
+```
+
+Multiple modules in a path indicate nesting. If a module path is specified
+without a resource spec, the address applies to every resource within the
+module. If the module path is omitted, this addresses the root module.
+
+__Resource spec__:
+
+A resource spec addresses a specific resource in the config. It takes the form:
+
+```
+resource_type.resource_name[N]
+```
 
  * `resource_type` - Type of the resource being addressed.
  * `resource_name` - User-defined name of the resource.
-
-Optional fields may include:
-
  * `[N]` - where `N` is a `0`-based index into a resource with multiple
    instances specified by the `count` meta-parameter. Omitting an index when
    addressing a resource where `count > 1` means that the address references


### PR DESCRIPTION
Adds the ability to target resources within modules, like:

module.mymod.aws_instance.foo

And the ability to target all resources inside a module, like:

module.mymod

Closes #1434