### PR TITLE
provider/aws: Update ARN in instanceProfileReadResult

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_instance_profile.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile.go
@@ -189,6 +189,9 @@ func instanceProfileReadResult(d *schema.ResourceData, result *iam.InstanceProfi
 	if err := d.Set("name", result.InstanceProfileName); err != nil {
 		return err
 	}
+	if err := d.Set("arn", result.ARN); err != nil {
+		return err
+	}
 	if err := d.Set("path", result.Path); err != nil {
 		return err
 	}


### PR DESCRIPTION
I found that `arn` attribute in `aws_iam_instance_profile` is not available after a resource is created.