### PR TITLE
provider/google: compute template metadata to map

### DIFF
--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -126,12 +126,9 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 			},
 
 			"metadata": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeMap,
-				},
 			},
 
 			"network": &schema.Schema{


### PR DESCRIPTION
Needs to match instance, since shared processing helper functions are
used.

Closes #1665