### PR TITLE
helper/resource: don't fail test on config warnings

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -209,13 +209,16 @@ func testStep(
 	opts.Destroy = step.Destroy
 	ctx := terraform.NewContext(&opts)
 	if ws, es := ctx.Validate(); len(ws) > 0 || len(es) > 0 {
-		estrs := make([]string, len(es))
-		for i, e := range es {
-			estrs[i] = e.Error()
+		if len(es) > 0 {
+			estrs := make([]string, len(es))
+			for i, e := range es {
+				estrs[i] = e.Error()
+			}
+			return state, fmt.Errorf(
+				"Configuration is invalid.\n\nWarnings: %#v\n\nErrors: %#v",
+				ws, estrs)
 		}
-		return state, fmt.Errorf(
-			"Configuration is invalid.\n\nWarnings: %#v\n\nErrors: %#v",
-			ws, estrs)
+		log.Printf("[WARN] Config warnings: %#v", ws)
 	}
 
 	// Refresh!


### PR DESCRIPTION
AccTests like TestAccComputeInstance_basic_deprecated_network were
failing early on "invalid config" when we are explictly testing behavior
that we know generates warnings.