### PR TITLE
Expose parallelism semaphore in the cli ui as -parallelism=#

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -38,6 +38,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		cmdFlags.BoolVar(&destroyForce, "force", false, "force")
 	}
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
+	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
@@ -93,9 +94,10 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	// Build the context based on the arguments given
 	ctx, planned, err := c.Context(contextOpts{
-		Destroy:   c.Destroy,
-		Path:      configPath,
-		StatePath: c.Meta.statePath,
+		Destroy:     c.Destroy,
+		Path:        configPath,
+		StatePath:   c.Meta.statePath,
+		Parallelism: c.Meta.parallelism,
 	})
 	if err != nil {
 		c.Ui.Error(err.Error())
@@ -304,6 +306,8 @@ Options:
   -input=true            Ask for input for variables if not directly set.
 
   -no-color              If specified, output won't contain any color.
+
+  -parallelism=#         Limit the number of concurrent operations.
 
   -refresh=true          Update state prior to checking for differences. This
                          has no effect if a plan file is given to apply.

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -58,6 +58,82 @@ func TestApply(t *testing.T) {
 	}
 }
 
+func TestApply_parallelism1(t *testing.T) {
+	statePath := testTempFile(t)
+
+	ui := new(cli.MockUi)
+	p := testProvider()
+	pr := new(terraform.MockResourceProvisioner)
+
+	pr.ApplyFn = func(*terraform.InstanceState, *terraform.ResourceConfig) error {
+		time.Sleep(time.Second)
+		return nil
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-parallelism=1",
+		testFixturePath("parallelism"),
+	}
+
+	c := &ApplyCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfigWithShell(p, pr),
+			Ui:          ui,
+		},
+	}
+
+	start := time.Now()
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+	elapsed := time.Since(start).Seconds()
+
+	// This test should take exactly two seconds, plus some minor amount of execution time.
+	if elapsed < 2 || elapsed > 2.2 {
+		t.Fatalf("bad: %f\n\n%s", elapsed, ui.ErrorWriter.String())
+	}
+
+}
+
+func TestApply_parallelism2(t *testing.T) {
+	statePath := testTempFile(t)
+
+	ui := new(cli.MockUi)
+	p := testProvider()
+	pr := new(terraform.MockResourceProvisioner)
+
+	pr.ApplyFn = func(*terraform.InstanceState, *terraform.ResourceConfig) error {
+		time.Sleep(time.Second)
+		return nil
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-parallelism=2",
+		testFixturePath("parallelism"),
+	}
+
+	c := &ApplyCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfigWithShell(p, pr),
+			Ui:          ui,
+		},
+	}
+
+	start := time.Now()
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+	elapsed := time.Since(start).Seconds()
+
+	// This test should take exactly one second, plus some minor amount of execution time.
+	if elapsed < 1 || elapsed > 1.2 {
+		t.Fatalf("bad: %f\n\n%s", elapsed, ui.ErrorWriter.String())
+	}
+
+}
+
 func TestApply_configInvalid(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -52,6 +52,21 @@ func testCtxConfig(p terraform.ResourceProvider) *terraform.ContextOpts {
 	}
 }
 
+func testCtxConfigWithShell(p terraform.ResourceProvider, pr terraform.ResourceProvisioner) *terraform.ContextOpts {
+	return &terraform.ContextOpts{
+		Providers: map[string]terraform.ResourceProviderFactory{
+			"test": func() (terraform.ResourceProvider, error) {
+				return p, nil
+			},
+		},
+		Provisioners: map[string]terraform.ResourceProvisionerFactory{
+			"shell": func() (terraform.ResourceProvisioner, error) {
+				return pr, nil
+			},
+		},
+	}
+}
+
 func testModule(t *testing.T, name string) *module.Tree {
 	mod, err := module.NewTreeModule("", filepath.Join(fixtureDir, name))
 	if err != nil {

--- a/command/meta.go
+++ b/command/meta.go
@@ -59,9 +59,13 @@ type Meta struct {
 	//
 	// backupPath is used to backup the state file before writing a modified
 	// version. It defaults to stateOutPath + DefaultBackupExtention
+	//
+	// parallelism is used to control the number of concurrent operations
+	// allowed when walking the graph
 	statePath    string
 	stateOutPath string
 	backupPath   string
+	parallelism  int
 }
 
 // initStatePaths is used to initialize the default values for
@@ -151,6 +155,7 @@ func (m *Meta) Context(copts contextOpts) (*terraform.Context, bool, error) {
 	}
 
 	opts.Module = mod
+	opts.Parallelism = copts.Parallelism
 	opts.State = state.State()
 	ctx := terraform.NewContext(opts)
 	return ctx, false, nil
@@ -429,4 +434,7 @@ type contextOpts struct {
 
 	// Set to true when running a destroy plan/apply.
 	Destroy bool
+
+	// Number of concurrent operations allowed
+	Parallelism int
 }

--- a/command/plan.go
+++ b/command/plan.go
@@ -27,6 +27,7 @@ func (c *PlanCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
 	c.addModuleDepthFlag(cmdFlags, &moduleDepth)
 	cmdFlags.StringVar(&outPath, "out", "", "path")
+	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
@@ -54,9 +55,10 @@ func (c *PlanCommand) Run(args []string) int {
 	}
 
 	ctx, _, err := c.Context(contextOpts{
-		Destroy:   destroy,
-		Path:      path,
-		StatePath: c.Meta.statePath,
+		Destroy:     destroy,
+		Path:        path,
+		StatePath:   c.Meta.statePath,
+		Parallelism: c.Meta.parallelism,
 	})
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -18,6 +18,7 @@ func (c *RefreshCommand) Run(args []string) int {
 
 	cmdFlags := c.Meta.flagSet("refresh")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -78,8 +79,9 @@ func (c *RefreshCommand) Run(args []string) int {
 
 	// Build the context based on the arguments given
 	ctx, _, err := c.Context(contextOpts{
-		Path:      configPath,
-		StatePath: c.Meta.statePath,
+		Path:        configPath,
+		StatePath:   c.Meta.statePath,
+		Parallelism: c.Meta.parallelism,
 	})
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/test-fixtures/parallelism/main.tf
+++ b/command/test-fixtures/parallelism/main.tf
@@ -1,0 +1,13 @@
+resource "test_instance" "foo1" {
+	ami = "bar"
+
+	// shell has been configured to sleep for one second
+	provisioner "shell" {}
+}
+
+resource "test_instance" "foo2" {
+	ami = "bar"
+
+	// shell has been configured to sleep for one second
+	provisioner "shell" {}
+}


### PR DESCRIPTION
:mega:  **This is a WIP. Feedback appreciated.**  :mega:

**Why**
There are a couple of use cases I can came up with below but in general this semaphore was available within Terraform core but wasn't exposed up to the UI. I think fundamentally that if there's a configurable that it should be exposed to the end user.

**Use Cases**

*Rate Limiting*
For example, if you're hitting the AWS rate limit you will be able to limit the parallelism to perhaps avoid hitting the limit. There are other proposals for putting limits on individual providers but for now this will allow you to change from the default parallelism of 10 things at a time.

*Safely Rolling Stateful Services*
Consider a "clustered by default" stateful datastore that has a replication factor (i.e hdfs, cassandra, riak, elasticsearch). If you have a need to roll the whole cluster then create before destroy isn't enough. Whereas the nodes may have come up, the data may not be entirely replicated before the destroys begin. Doing a `terraform apply -parallelism=1` gets us half of the way there by slowing down the process so that replication can occur properly. 

The other part is a blocking script in a pre-destroy provisioner that checks to see if blocks have been sufficiently replicated before allowing the next destroy to occur. That will be my next PR and @phinze and I talked through the design as far as what can be done with the current internals.

**TODO**
- [x] `terraform apply -parallelism=n`
- [x] `terraform destroy -parallelism=n`
- [x] `terraform plan -parallelism=n`
- [x] `terraform refresh -parallelism=n`
- [x] apply test written
- [ ] destroy test written
- [ ] plan test written
- [ ] refresh test written
