### PR TITLE
Rename "The The" so that they can play songs again

### DIFF
--- a/command/remote_push.go
+++ b/command/remote_push.go
@@ -90,5 +90,5 @@ Options:
 }
 
 func (c *RemotePushCommand) Synopsis() string {
-	return "Uploads the the local state to the remote server"
+	return "Uploads the local state to the remote server"
 }

--- a/contrib/zsh-completion/_terraform
+++ b/contrib/zsh-completion/_terraform
@@ -10,7 +10,7 @@ _terraform_cmds=(
     'output:Read an output from a state file'
     'plan:Generate and show an execution plan'
     'pull:Refreshes the local state copy from the remote server'
-    'push:Uploads the the local state to the remote server'
+    'push:Uploads the local state to the remote server'
     'refresh:Update local state file against real resources'
     'remote:Configures remote state management'
     'taint:Manualy forcing a destroy and recreate on the next plan/apply'

--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -103,7 +103,7 @@ func addrToSchema(addr []string, schemaMap map[string]*Schema) []*Schema {
 				return nil
 			}
 
-			// If we only have one more thing and the the next thing
+			// If we only have one more thing and the next thing
 			// is a #, then we're accessing the index which is always
 			// an int.
 			if len(addr) > 0 && addr[0] == "#" {

--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -72,7 +72,7 @@ determines if the ELB exists in a VPC or in EC2-classic.
 Listeners support the following:
 
 * `instance_port` - (Required) The port on the instance to route to
-* `instance_protocol` - (Required) The the protocol to use to the instance.
+* `instance_protocol` - (Required) The protocol to use to the instance.
 * `lb_port` - (Required) The port to listen on for the load balancer
 * `lb_protocol` - (Required) The protocol to listen on.
 * `ssl_certificate_id` - (Optional) The id of an SSL certificate you have uploaded to AWS IAM.


### PR DESCRIPTION
Other than the fact that "The the" doesn't really make any sense anywhere
that it's used in Terraform, they're a post-punk band from the UK.

Fixes "The The" so that they can get back to playing songs.