### PR TITLE
provider/aws: fix issue with reading VPC id in AWS Security Group

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -149,7 +149,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	securityGroupOpts := &ec2.CreateSecurityGroupInput{}
 
-	if v := d.Get("vpc_id"); v != nil {
+	if v, ok := d.GetOk("vpc_id"); ok {
 		securityGroupOpts.VPCID = aws.String(v.(string))
 	}
 


### PR DESCRIPTION
Currently, if no `vpc_id` is specified, we still read `vpc_id` from the config and set a `""` value along in the request. 

Changing this to `d.GetOk` discerns not present vs. zero value, in either case we won't set `VPCID` in the request. 