### PR TITLE
providers/consul: add scheme argument

### DIFF
--- a/builtin/providers/consul/config.go
+++ b/builtin/providers/consul/config.go
@@ -9,6 +9,7 @@ import (
 type Config struct {
 	Datacenter string `mapstructure:"datacenter"`
 	Address    string `mapstructure:"address"`
+	Scheme     string `mapstructure:"scheme"`
 }
 
 // Client() returns a new client for accessing consul.
@@ -21,10 +22,13 @@ func (c *Config) Client() (*consulapi.Client, error) {
 	if c.Address != "" {
 		config.Address = c.Address
 	}
+	if c.Scheme != "" {
+		config.Scheme = c.Scheme
+	}
 	client, err := consulapi.NewClient(config)
 
-	log.Printf("[INFO] Consul Client configured with address: '%s', datacenter: '%s'",
-		config.Address, config.Datacenter)
+	log.Printf("[INFO] Consul Client configured with address: '%s', scheme: '%s', datacenter: '%s'",
+		config.Address, config.Scheme, config.Datacenter)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/providers/consul/resource_provider.go
+++ b/builtin/providers/consul/resource_provider.go
@@ -21,6 +21,11 @@ func Provider() terraform.ResourceProvider {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"scheme": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/builtin/providers/consul/resource_provider_test.go
+++ b/builtin/providers/consul/resource_provider_test.go
@@ -42,6 +42,7 @@ func TestResourceProvider_Configure(t *testing.T) {
 	raw := map[string]interface{}{
 		"address":    "demo.consul.io:80",
 		"datacenter": "nyc3",
+		"scheme":     "https",
 	}
 
 	rawConfig, err := config.NewRawConfig(raw)

--- a/website/source/docs/providers/consul/index.html.markdown
+++ b/website/source/docs/providers/consul/index.html.markdown
@@ -43,6 +43,7 @@ resource "aws_instance" "app" {
 
 The following arguments are supported:
 
-* `address` - (Optional) The HTTP API address of the agent to use. Defaults to "127.0.0.1:8500".
+* `address` - (Optional) The HTTP(S) API address of the agent to use. Defaults to "127.0.0.1:8500".
+* `scheme` - (Optional) The URL scheme of the agent to use ("http" or "https"). Defaults to "http".
 * `datacenter` - (Optional) The datacenter to use. Defaults to that of the agent.
 


### PR DESCRIPTION
This enables connecting to consul over https
without having to set the envvar CONSUL_HTTP_SSL.