### PR TITLE
provider/aws: wait for ASG capacity on creation

### DIFF
--- a/website/source/docs/providers/aws/r/autoscale.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscale.html.markdown
@@ -43,12 +43,19 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the auto scale group.
 * `max_size` - (Required) The maximum size of the auto scale group.
-* `min_size` - (Required) The minimum size of the auto scale group.
+* `min_size` - (Required) The minimum size of the auto scale group. Terraform
+  waits after ASG creation for this number of healthy instances to show up in
+  the ASG before continuing. Currently, it will wait for a maxiumum of 10m, if
+  ASG creation is taking more than a few minutes, it's worth investigating for
+  scaling actvity errors caused by problems with the selected Launch
+  Configuration.
 * `availability_zones` - (Required) A list of AZs to launch resources in.
 * `launch_configuration` - (Required) The ID of the launch configuration to use.
 * `health_check_grace_period` - (Optional) Time after instance comes into service before checking health.
 * `health_check_type` - (Optional) "EC2" or "ELB". Controls how health checking is done.
-* `desired_capacity` - (Optional) The number of Amazon EC2 instances that should be running in the group.
+* `desired_capacity` - (Optional) The number of Amazon EC2 instances that
+  should be running in the group. (If this is specified, Terraform will wait for
+  this number of healthy instances after ASG creation instead of `min_size`.)
 * `force_delete` - (Optional) Allows deleting the autoscaling group without waiting
    for all instances in the pool to terminate.
 * `load_balancers` (Optional) A list of load balancer names to add to the autoscaling


### PR DESCRIPTION
On ASG creation, waits for up to 10m for desired_capacity or min_size
healthy nodes to show up in the group before continuing.

With CBD and proper HealthCheck tuning, this allows us guarantee safe
ASG replacement.