### PR TITLE
providers/aws: detect credentials more robustly

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -62,16 +62,9 @@ func (c *Config) Client() (interface{}, error) {
 		client.region = c.Region
 
 		log.Println("[INFO] Building AWS auth structure")
-		creds := credentials.NewChainCredentials([]credentials.Provider{
-			&credentials.StaticProvider{Value: credentials.Value{
-				AccessKeyID:     c.AccessKey,
-				SecretAccessKey: c.SecretKey,
-				SessionToken:    c.Token,
-			}},
-			&credentials.EnvProvider{},
-			&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
-			&credentials.EC2RoleProvider{},
-		})
+		// We fetched all credential sources in Provider.
+		// If it is available, it is stored in c.
+		creds := credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, c.Token)
 		awsConfig := &aws.Config{
 			Credentials: creds,
 			Region:      c.Region,


### PR DESCRIPTION
aws hides its credentials in many places:
multiple env vars, config files,
ec2 metadata.

Terraform currently recognizes only the env vars;
to use the other options, you had to put in a
dummy empty value for access_key and secret_key.

Rather than duplicate all aws checks, ask the
aws sdk to fetch credentials earlier.

---

Please review skeptically. For example, this could cause network access inside Provider, which could block.
