### PR TITLE
Fix a number of issues in AWS network ACLs

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -66,3 +66,19 @@ func protocolIntegers() map[string]int {
 	}
 	return protocolIntegers
 }
+
+// expectedPortPair stores a pair of ports we expect to see together.
+type expectedPortPair struct {
+	to_port   int64
+	from_port int64
+}
+
+// validatePorts ensures the ports and protocol match expected
+// values.
+func validatePorts(to int64, from int64, expected expectedPortPair) bool {
+	if to != expected.to_port || from != expected.from_port {
+		return false
+	}
+
+	return true
+}

--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 
 	"github.com/awslabs/aws-sdk-go/aws"
@@ -81,4 +82,18 @@ func validatePorts(to int64, from int64, expected expectedPortPair) bool {
 	}
 
 	return true
+}
+
+// validateCIDRBlock ensures the passed CIDR block represents an implied
+// network, and not an overly-specified IP address.
+func validateCIDRBlock(cidr string) error {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
+	if ipnet.String() != cidr {
+		return fmt.Errorf("%s is not a valid mask; did you mean %s?", cidr, ipnet)
+	}
+
+	return nil
 }

--- a/builtin/providers/aws/network_acl_entry_test.go
+++ b/builtin/providers/aws/network_acl_entry_test.go
@@ -152,3 +152,23 @@ func Test_validatePorts(t *testing.T) {
 		}
 	}
 }
+
+func Test_validateCIDRBlock(t *testing.T) {
+	for _, ts := range []struct {
+		cidr      string
+		shouldErr bool
+	}{
+		{"10.2.2.0/24", false},
+		{"10.2.2.0/1234", true},
+		{"10/24", true},
+		{"10.2.2.2/24", true},
+	} {
+		err := validateCIDRBlock(ts.cidr)
+		if ts.shouldErr && err == nil {
+			t.Fatalf("Input '%s' should error but didn't!", ts.cidr)
+		}
+		if !ts.shouldErr && err != nil {
+			t.Fatalf("Got unexpected error for '%s' input: %s", ts.cidr, err)
+		}
+	}
+}

--- a/builtin/providers/aws/network_acl_entry_test.go
+++ b/builtin/providers/aws/network_acl_entry_test.go
@@ -135,3 +135,20 @@ func Test_flattenNetworkACLEntry(t *testing.T) {
 	}
 
 }
+
+func Test_validatePorts(t *testing.T) {
+	for _, ts := range []struct {
+		to       int64
+		from     int64
+		expected *expectedPortPair
+		wanted   bool
+	}{
+		{0, 0, &expectedPortPair{0, 0}, true},
+		{0, 1, &expectedPortPair{0, 0}, false},
+	} {
+		got := validatePorts(ts.to, ts.from, *ts.expected)
+		if got != ts.wanted {
+			t.Fatalf("Got: %t; Expected: %t\n", got, ts.wanted)
+		}
+	}
+}

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -23,29 +23,29 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.3409203205.protocol", "tcp"),
+						"aws_network_acl.bar", "ingress.1216169466.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.3409203205.rule_no", "1"),
+						"aws_network_acl.bar", "ingress.1216169466.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.3409203205.from_port", "80"),
+						"aws_network_acl.bar", "ingress.1216169466.from_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.3409203205.to_port", "80"),
+						"aws_network_acl.bar", "ingress.1216169466.to_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.3409203205.action", "allow"),
+						"aws_network_acl.bar", "ingress.1216169466.action", "allow"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.3409203205.cidr_block", "10.3.10.3/18"),
+						"aws_network_acl.bar", "ingress.1216169466.cidr_block", "10.3.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.2579689292.protocol", "tcp"),
+						"aws_network_acl.bar", "egress.2634340476.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.2579689292.rule_no", "2"),
+						"aws_network_acl.bar", "egress.2634340476.rule_no", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.2579689292.from_port", "443"),
+						"aws_network_acl.bar", "egress.2634340476.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.2579689292.to_port", "443"),
+						"aws_network_acl.bar", "egress.2634340476.to_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.2579689292.cidr_block", "10.3.2.3/18"),
+						"aws_network_acl.bar", "egress.2634340476.cidr_block", "10.3.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.2579689292.action", "allow"),
+						"aws_network_acl.bar", "egress.2634340476.action", "allow"),
 				),
 			},
 		},
@@ -66,17 +66,17 @@ func TestAccAWSNetworkAcl_OnlyIngressRules(t *testing.T) {
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					// testAccCheckSubnetAssociation("aws_network_acl.foos", "aws_subnet.blob"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.protocol", "tcp"),
+						"aws_network_acl.foos", "ingress.3264550475.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.rule_no", "2"),
+						"aws_network_acl.foos", "ingress.3264550475.rule_no", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.from_port", "443"),
+						"aws_network_acl.foos", "ingress.3264550475.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.to_port", "443"),
+						"aws_network_acl.foos", "ingress.3264550475.to_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.action", "deny"),
+						"aws_network_acl.foos", "ingress.3264550475.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.cidr_block", "10.2.2.3/18"),
+						"aws_network_acl.foos", "ingress.3264550475.cidr_block", "10.2.0.0/18"),
 				),
 			},
 		},
@@ -97,21 +97,21 @@ func TestAccAWSNetworkAcl_OnlyIngressRulesChange(t *testing.T) {
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					testIngressRuleLength(&networkAcl, 2),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.protocol", "tcp"),
+						"aws_network_acl.foos", "ingress.2824900805.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.rule_no", "1"),
+						"aws_network_acl.foos", "ingress.2824900805.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.from_port", "0"),
+						"aws_network_acl.foos", "ingress.2824900805.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.to_port", "22"),
+						"aws_network_acl.foos", "ingress.2824900805.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.action", "deny"),
+						"aws_network_acl.foos", "ingress.2824900805.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.cidr_block", "10.2.2.3/18"),
+						"aws_network_acl.foos", "ingress.2824900805.cidr_block", "10.2.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.from_port", "443"),
+						"aws_network_acl.foos", "ingress.3264550475.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2750166237.rule_no", "2"),
+						"aws_network_acl.foos", "ingress.3264550475.rule_no", "2"),
 				),
 			},
 			resource.TestStep{
@@ -120,17 +120,17 @@ func TestAccAWSNetworkAcl_OnlyIngressRulesChange(t *testing.T) {
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					testIngressRuleLength(&networkAcl, 1),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.protocol", "tcp"),
+						"aws_network_acl.foos", "ingress.2824900805.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.rule_no", "1"),
+						"aws_network_acl.foos", "ingress.2824900805.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.from_port", "0"),
+						"aws_network_acl.foos", "ingress.2824900805.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.to_port", "22"),
+						"aws_network_acl.foos", "ingress.2824900805.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.action", "deny"),
+						"aws_network_acl.foos", "ingress.2824900805.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.37211640.cidr_block", "10.2.2.3/18"),
+						"aws_network_acl.foos", "ingress.2824900805.cidr_block", "10.2.0.0/18"),
 				),
 			},
 		},
@@ -330,7 +330,7 @@ resource "aws_network_acl" "foos" {
 		protocol = "tcp"
 		rule_no = 1
 		action = "deny"
-		cidr_block =  "10.2.2.3/18"
+		cidr_block =  "10.2.0.0/18"
 		from_port = 0
 		to_port = 22
 	}
@@ -338,7 +338,7 @@ resource "aws_network_acl" "foos" {
 		protocol = "tcp"
 		rule_no = 2
 		action = "deny"
-		cidr_block =  "10.2.2.3/18"
+		cidr_block =  "10.2.0.0/18"
 		from_port = 443
 		to_port = 443
 	}
@@ -360,7 +360,7 @@ resource "aws_network_acl" "foos" {
 		protocol = "tcp"
 		rule_no = 1
 		action = "deny"
-		cidr_block =  "10.2.2.3/18"
+		cidr_block =  "10.2.0.0/18"
 		from_port = 0
 		to_port = 22
 	}
@@ -383,16 +383,25 @@ resource "aws_network_acl" "bond" {
 		protocol = "tcp"
 		rule_no = 2
 		action = "allow"
-		cidr_block =  "10.2.2.3/18"
+		cidr_block =  "10.2.0.0/18"
 		from_port = 443
 		to_port = 443
+	}
+
+	egress = {
+		protocol = "-1"
+		rule_no = 4
+		action = "allow"
+		cidr_block = "0.0.0.0/0"
+		from_port = 0
+		to_port = 0
 	}
 
 	egress = {
 		protocol = "tcp"
 		rule_no = 1
 		action = "allow"
-		cidr_block =  "10.2.10.3/18"
+		cidr_block =  "10.2.0.0/18"
 		from_port = 80
 		to_port = 80
 	}
@@ -401,7 +410,7 @@ resource "aws_network_acl" "bond" {
 		protocol = "tcp"
 		rule_no = 3
 		action = "allow"
-		cidr_block =  "10.2.10.3/18"
+		cidr_block =  "10.2.0.0/18"
 		from_port = 22
 		to_port = 22
 	}
@@ -427,7 +436,7 @@ resource "aws_network_acl" "bar" {
 		protocol = "tcp"
 		rule_no = 2
 		action = "allow"
-		cidr_block =  "10.3.2.3/18"
+		cidr_block =  "10.3.0.0/18"
 		from_port = 443
 		to_port = 443
 	}
@@ -436,7 +445,7 @@ resource "aws_network_acl" "bar" {
 		protocol = "tcp"
 		rule_no = 1
 		action = "allow"
-		cidr_block =  "10.3.10.3/18"
+		cidr_block =  "10.3.0.0/18"
 		from_port = 80
 		to_port = 80
 	}

--- a/website/source/docs/providers/aws/r/network_acl.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl.html.markdown
@@ -20,7 +20,7 @@ resource "aws_network_acl" "main" {
 		protocol = "tcp"
 		rule_no = 2
 		action = "allow"
-		cidr_block =  "10.3.2.3/18"
+		cidr_block =  "10.3.0.0/18"
 		from_port = 443
 		to_port = 443
 	}
@@ -29,7 +29,7 @@ resource "aws_network_acl" "main" {
 		protocol = "tcp"
 		rule_no = 1
 		action = "allow"
-		cidr_block =  "10.3.10.3/18"
+		cidr_block =  "10.3.0.0/18"
 		from_port = 80
 		to_port = 80
 	}
@@ -56,8 +56,10 @@ Both `egress` and `ingress` support the following keys:
 * `to_port` - (Required) The to port to match.
 * `rule_no` - (Required) The rule number. Used for ordering.
 * `action` - (Required) The action to take.
-* `protocol` - (Required) The protocol to match.
-* `cidr_block` - (Optional) The CIDR block to match.
+* `protocol` - (Required) The protocol to match. If using the -1 'all'
+protocol, you must specify a from and to port of 0.
+* `cidr_block` - (Optional) The CIDR block to match. This must be a
+valid network mask.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Turns out network ACLs weren't working quite right. They had four distinct hashing problems all of which were masked by #1808.

Not anymore. This PR should fix all of them. I recommend reviewing it by commit, rather than by the total file changed diff, as they're logically separated.