### PR TITLE
provider/aws: Add expanded name as output to route53_record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
   * provider/aws: `aws_s3_bucket` exports `hosted_zone_id` and `region` [GH-1865]
+  * provider/aws: `aws_route53_record` exports `fqdn` [GH-1847]
 
 BUG FIXES:
 

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -29,6 +29,11 @@ func resourceAwsRoute53Record() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"fqdn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"type": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -216,6 +221,8 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	en := expandRecordName(d.Get("name").(string), *zoneRecord.HostedZone.Name)
+	log.Printf("[DEBUG] Expanded record name: %s", en)
+	d.Set("fqdn", en)
 
 	lopts := &route53.ListResourceRecordSetsInput{
 		HostedZoneID:    aws.String(cleanZoneID(zone)),

--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -106,5 +106,5 @@ Alias records support the following:
 
 ## Attributes Reference
 
-No attributes are exported.
+* `fqdn` - [FQDN](http://en.wikipedia.org/wiki/Fully_qualified_domain_name) built using the zone domain and `name`
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/hashicorp/terraform/issues/1126 

With this change, the following:

```
${aws_route53_record.log.name}.${aws_route53_zone.primary.name}
```
can be shortened to this:

```
${aws_route53_record.log.fqdn}
```
and more importantly if the zone is part of another module, I don't have to pass in the domain as a string into the module where I'm creating a record.

I'm still not entirely sure about the name - `fqdn`, it could also be `expanded_name`, what do you think @catsby ?