### PR TITLE
provider/gce: Fix updates for http_health_check

### DIFF
--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -180,11 +180,11 @@ func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface
 		hchk.UnhealthyThreshold = int64(v.(int))
 	}
 
-	log.Printf("[DEBUG] HttpHealthCheck patch request: %#v", hchk)
-	op, err := config.clientCompute.HttpHealthChecks.Patch(
+	log.Printf("[DEBUG] HttpHealthCheck update request: %#v", hchk)
+	op, err := config.clientCompute.HttpHealthChecks.Update(
 		config.Project, hchk.Name, hchk).Do()
 	if err != nil {
-		return fmt.Errorf("Error patching HttpHealthCheck: %s", err)
+		return fmt.Errorf("Error updating HttpHealthCheck: %s", err)
 	}
 
 	// It probably maybe worked, so store the ID now
@@ -202,7 +202,7 @@ func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface
 	state.MinTimeout = 1 * time.Second
 	opRaw, err := state.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for HttpHealthCheck to patch: %s", err)
+		return fmt.Errorf("Error waiting for HttpHealthCheck to update: %s", err)
 	}
 	op = opRaw.(*compute.Operation)
 	if op.Error != nil {

--- a/builtin/providers/google/resource_compute_http_health_check_test.go
+++ b/builtin/providers/google/resource_compute_http_health_check_test.go
@@ -30,6 +30,36 @@ func TestAccComputeHttpHealthCheck_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeHttpHealthCheck_update(t *testing.T) {
+	var healthCheck compute.HttpHealthCheck
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHttpHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHttpHealthCheck_update1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeHttpHealthCheckExists(
+						"google_compute_http_health_check.foobar", &healthCheck),
+					testAccCheckComputeHttpHealthCheckThresholds(
+						0, 0, &healthCheck),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeHttpHealthCheck_update2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeHttpHealthCheckExists(
+						"google_compute_http_health_check.foobar", &healthCheck),
+					testAccCheckComputeHttpHealthCheckThresholds(
+						10, 10, &healthCheck),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeHttpHealthCheckDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -102,5 +132,22 @@ resource "google_compute_http_health_check" "foobar" {
 	request_path = "/health_check"
 	timeout_sec = 2
 	unhealthy_threshold = 3
+}
+`
+
+const testAccComputeHttpHealthCheck_update1 = `
+resource "google_compute_http_health_check" "foobar" {
+	name = "terraform-test"
+	description = "Resource created for Terraform acceptance testing"
+}
+`
+
+/* Change one existing param and set two new params */
+const testAccComputeHttpHealthCheck_update2 = `
+resource "google_compute_http_health_check" "foobar" {
+	name = "terraform-test"
+	description = "Resource updated for Terraform acceptance testing"
+	healthy_threshold = 10
+	unhealthy_threshold = 10
 }
 `

--- a/builtin/providers/google/resource_compute_http_health_check_test.go
+++ b/builtin/providers/google/resource_compute_http_health_check_test.go
@@ -72,14 +72,14 @@ func testAccCheckComputeHttpHealthCheckExists(n string) resource.TestCheckFunc {
 
 const testAccComputeHttpHealthCheck_basic = `
 resource "google_compute_http_health_check" "foobar" {
-    check_interval_sec = 3
+	check_interval_sec = 3
 	description = "Resource created for Terraform acceptance testing"
 	healthy_threshold = 3
 	host = "foobar"
-    name = "terraform-test"
+	name = "terraform-test"
 	port = "80"
-    request_path = "/health_check"
-    timeout_sec = 2
+	request_path = "/health_check"
+	timeout_sec = 2
 	unhealthy_threshold = 3
 }
 `


### PR DESCRIPTION
Use `Update()` instead of `Patch()` when modifying `http_health_check`
resources. This fixes the new acceptance test in the previous commit, which
appeared to be trying to reset default values.

In doing this I've realised that this also doesn't handle resetting a param
back to it's default value by omitting it from the config. I'm not sure
whether that should be handled and whether it makes sense to change these
from `Computed` to `Default`.