### PR TITLE
core: create local state file if it doesn't exist

### DIFF
--- a/state/remote/file.go
+++ b/state/remote/file.go
@@ -30,7 +30,10 @@ func (c *FileClient) Get() (*Payload, error) {
 	f, err := os.Open(c.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			f, err = os.Create(c.Path)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return nil, err


### PR DESCRIPTION
Ran into this issue where the local state file didn't exist. It does now, in the tests, but not for production use. It seems like this is a thing we should create. 

Regardless, as it stands we check if the file does not exist, in which case we return `nil, nil`, when I _think_ we should return the error(?). 

Even so, when I simply create the file with nothing, I get an error about `magic bytes EOF`.

Feel free to close with prejudice 