### PR TITLE
Only depend on variables for counts for destroy nodes

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -80,7 +80,18 @@ func (d *Diff) Empty() bool {
 
 func (d *Diff) String() string {
 	var buf bytes.Buffer
+
+	keys := make([]string, 0, len(d.Modules))
+	lookup := make(map[string]*ModuleDiff)
 	for _, m := range d.Modules {
+		key := fmt.Sprintf("module.%s", strings.Join(m.Path[1:], "."))
+		keys = append(keys, key)
+		lookup[key] = m
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		m := lookup[key]
 		mStr := m.String()
 
 		// If we're the root module, we just write the output directly.
@@ -89,7 +100,7 @@ func (d *Diff) String() string {
 			continue
 		}
 
-		buf.WriteString(fmt.Sprintf("module.%s:\n", strings.Join(m.Path[1:], ".")))
+		buf.WriteString(fmt.Sprintf("%s:\n", key))
 
 		s := bufio.NewScanner(strings.NewReader(mStr))
 		for s.Scan() {

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -153,7 +153,7 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 	if len(path) <= 1 {
 		steps = append(steps,
 			// Create the destruction nodes
-			&DestroyTransformer{},
+			&DestroyTransformer{FullDestroy: b.Destroy},
 			&CreateBeforeDestroyTransformer{},
 			b.conditional(&conditionalOpts{
 				If:   func() bool { return !b.Verbose },

--- a/terraform/graph_config_node_output.go
+++ b/terraform/graph_config_node_output.go
@@ -62,7 +62,7 @@ func (n *GraphNodeConfigOutput) Proxy() bool {
 }
 
 // GraphNodeDestroyEdgeInclude impl.
-func (n *GraphNodeConfigOutput) DestroyEdgeInclude(bool) bool {
+func (n *GraphNodeConfigOutput) DestroyEdgeInclude(dag.Vertex) bool {
 	return false
 }
 

--- a/terraform/graph_config_node_output.go
+++ b/terraform/graph_config_node_output.go
@@ -62,7 +62,7 @@ func (n *GraphNodeConfigOutput) Proxy() bool {
 }
 
 // GraphNodeDestroyEdgeInclude impl.
-func (n *GraphNodeConfigOutput) DestroyEdgeInclude() bool {
+func (n *GraphNodeConfigOutput) DestroyEdgeInclude(bool) bool {
 	return false
 }
 

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -9,6 +9,12 @@ import (
 	"github.com/hashicorp/terraform/dot"
 )
 
+// GraphNodeCountDependent is implemented by resources for giving only
+// the dependencies they have from the "count" field.
+type GraphNodeCountDependent interface {
+	CountDependentOn() []string
+}
+
 // GraphNodeConfigResource represents a resource within the config graph.
 type GraphNodeConfigResource struct {
 	Resource *config.Resource
@@ -29,6 +35,18 @@ func (n *GraphNodeConfigResource) ConfigType() GraphNodeConfigType {
 
 func (n *GraphNodeConfigResource) DependableName() []string {
 	return []string{n.Resource.Id()}
+}
+
+// GraphNodeCountDependent impl.
+func (n *GraphNodeConfigResource) CountDependentOn() []string {
+	result := make([]string, 0, len(n.Resource.RawCount.Variables))
+	for _, v := range n.Resource.RawCount.Variables {
+		if vn := varNameForVar(v); vn != "" {
+			result = append(result, vn)
+		}
+	}
+
+	return result
 }
 
 // GraphNodeDependent impl.

--- a/terraform/graph_config_node_variable.go
+++ b/terraform/graph_config_node_variable.go
@@ -56,11 +56,14 @@ func (n *GraphNodeConfigVariable) VariableName() string {
 }
 
 // GraphNodeDestroyEdgeInclude impl.
-func (n *GraphNodeConfigVariable) DestroyEdgeInclude() bool {
+func (n *GraphNodeConfigVariable) DestroyEdgeInclude(full bool) bool {
 	// Don't include variables as dependencies in destroy nodes.
 	// Destroy nodes don't interpolate anyways and this has a possibility
 	// to create cycles. See GH-1835
-	return false
+	//
+	// We include the variable on non-full destroys because it might
+	// be used for count interpolation.
+	return !full
 }
 
 // GraphNodeProxy impl.

--- a/terraform/graph_config_node_variable.go
+++ b/terraform/graph_config_node_variable.go
@@ -55,6 +55,14 @@ func (n *GraphNodeConfigVariable) VariableName() string {
 	return n.Variable.Name
 }
 
+// GraphNodeDestroyEdgeInclude impl.
+func (n *GraphNodeConfigVariable) DestroyEdgeInclude() bool {
+	// Don't include variables as dependencies in destroy nodes.
+	// Destroy nodes don't interpolate anyways and this has a possibility
+	// to create cycles. See GH-1835
+	return false
+}
+
 // GraphNodeProxy impl.
 func (n *GraphNodeConfigVariable) Proxy() bool {
 	return true

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -996,6 +996,26 @@ module.child:
     ID = bar
 `
 
+const testTerraformPlanModuleDestroyCycleStr = `
+DIFF:
+
+module.a_module:
+  DESTROY MODULE
+  DESTROY: aws_instance.a
+module.b_module:
+  DESTROY MODULE
+  DESTROY: aws_instance.b
+
+STATE:
+
+module.a_module:
+  aws_instance.a:
+    ID = a
+module.b_module:
+  aws_instance.b:
+    ID = b
+`
+
 const testTerraformPlanModuleDestroyMultivarStr = `
 DIFF:
 

--- a/terraform/test-fixtures/plan-module-destroy-gh-1835/a/main.tf
+++ b/terraform/test-fixtures/plan-module-destroy-gh-1835/a/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "a" {}
+
+output "a_output" {
+  value = "${aws_instance.a.id}"
+}

--- a/terraform/test-fixtures/plan-module-destroy-gh-1835/b/main.tf
+++ b/terraform/test-fixtures/plan-module-destroy-gh-1835/b/main.tf
@@ -1,0 +1,5 @@
+variable "a_id" {}
+
+resource "aws_instance" "b" {
+  command = "echo ${var.a_id}"
+}

--- a/terraform/test-fixtures/plan-module-destroy-gh-1835/main.tf
+++ b/terraform/test-fixtures/plan-module-destroy-gh-1835/main.tf
@@ -1,0 +1,8 @@
+module "a_module" {
+  source = "./a"
+}
+
+module "b_module" {
+  source = "./b"
+  a_id = "${module.a_module.a_output}"
+}

--- a/terraform/transform_destroy.go
+++ b/terraform/transform_destroy.go
@@ -49,7 +49,7 @@ type GraphNodeDestroyPrunable interface {
 // as an edge within the destroy graph. This is usually done because it
 // might cause unnecessary cycles.
 type GraphNodeDestroyEdgeInclude interface {
-	DestroyEdgeInclude(bool) bool
+	DestroyEdgeInclude(dag.Vertex) bool
 }
 
 // DestroyTransformer is a GraphTransformer that creates the destruction
@@ -114,7 +114,7 @@ func (t *DestroyTransformer) transform(
 			// If this thing specifically requests to not be depended on
 			// by destroy nodes, then don't.
 			if i, ok := edgeRaw.(GraphNodeDestroyEdgeInclude); ok &&
-				!i.DestroyEdgeInclude(t.FullDestroy) {
+				!i.DestroyEdgeInclude(v) {
 				continue
 			}
 

--- a/terraform/transform_destroy.go
+++ b/terraform/transform_destroy.go
@@ -49,12 +49,14 @@ type GraphNodeDestroyPrunable interface {
 // as an edge within the destroy graph. This is usually done because it
 // might cause unnecessary cycles.
 type GraphNodeDestroyEdgeInclude interface {
-	DestroyEdgeInclude() bool
+	DestroyEdgeInclude(bool) bool
 }
 
 // DestroyTransformer is a GraphTransformer that creates the destruction
 // nodes for things that _might_ be destroyed.
-type DestroyTransformer struct{}
+type DestroyTransformer struct {
+	FullDestroy bool
+}
 
 func (t *DestroyTransformer) Transform(g *Graph) error {
 	var connect, remove []dag.Edge
@@ -111,7 +113,8 @@ func (t *DestroyTransformer) transform(
 		for _, edgeRaw := range downEdges {
 			// If this thing specifically requests to not be depended on
 			// by destroy nodes, then don't.
-			if i, ok := edgeRaw.(GraphNodeDestroyEdgeInclude); ok && !i.DestroyEdgeInclude() {
+			if i, ok := edgeRaw.(GraphNodeDestroyEdgeInclude); ok &&
+				!i.DestroyEdgeInclude(t.FullDestroy) {
 				continue
 			}
 


### PR DESCRIPTION
Fixes #1835

This fixes  #1835. See the other PR I made for this for more information. 

The change here is that destroy nodes should only include dependent variables if the `count` depends on them. There are still real issues (see previous PR), but this fixes #1835 while keeping everything else working and also makes the surface area of real cycles even smaller.