### PR TITLE
terraform: flattening multi-level modules works

### DIFF
--- a/terraform/graph_builder_test.go
+++ b/terraform/graph_builder_test.go
@@ -136,6 +136,24 @@ func TestBuiltinGraphBuilder_cbdDepNonCbd_errorsWhenVerbose(t *testing.T) {
 	}
 }
 
+func TestBuiltinGraphBuilder_multiLevelModule(t *testing.T) {
+	b := &BuiltinGraphBuilder{
+		Root:     testModule(t, "graph-builder-multi-level-module"),
+		Validate: true,
+	}
+
+	g, err := b.Build(RootModulePath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testBuiltinGraphBuilderMultiLevelStr)
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
 /*
 TODO: This exposes a really bad bug we need to fix after we merge
 the f-ast-branch. This bug still exists in master.
@@ -212,4 +230,18 @@ module.consul (expanded)
   aws_security_group.firewall
   provider.aws
 provider.aws
+`
+
+const testBuiltinGraphBuilderMultiLevelStr = `
+module.foo.module.bar.output.value
+  module.foo.module.bar.var.bar
+module.foo.module.bar.plan-destroy
+module.foo.module.bar.var.bar
+  module.foo.var.foo
+module.foo.plan-destroy
+module.foo.var.foo
+root
+  module.foo.module.bar.output.value
+  module.foo.module.bar.plan-destroy
+  module.foo.plan-destroy
 `

--- a/terraform/test-fixtures/graph-builder-multi-level-module/foo/bar/main.tf
+++ b/terraform/test-fixtures/graph-builder-multi-level-module/foo/bar/main.tf
@@ -1,0 +1,2 @@
+variable "bar" {}
+output "value" { value = "${var.bar}" }

--- a/terraform/test-fixtures/graph-builder-multi-level-module/foo/main.tf
+++ b/terraform/test-fixtures/graph-builder-multi-level-module/foo/main.tf
@@ -1,0 +1,6 @@
+module "bar" {
+    source = "./bar"
+    bar = "${var.foo}"
+}
+
+variable "foo" {}

--- a/terraform/test-fixtures/graph-builder-multi-level-module/main.tf
+++ b/terraform/test-fixtures/graph-builder-multi-level-module/main.tf
@@ -1,0 +1,4 @@
+module "foo" {
+    source = "./foo"
+    foo = "bar"
+}

--- a/terraform/transform_flatten.go
+++ b/terraform/transform_flatten.go
@@ -53,6 +53,10 @@ func (t *FlattenTransformer) Transform(g *Graph) error {
 
 		// Go through the subgraph and flatten all the nodes
 		for _, sv := range subgraph.Vertices() {
+			if _, ok := sv.(GraphNodeSubPath); ok {
+				continue
+			}
+
 			fn, ok := sv.(GraphNodeFlattenable)
 			if !ok {
 				return fmt.Errorf(

--- a/terraform/transform_flatten.go
+++ b/terraform/transform_flatten.go
@@ -53,6 +53,8 @@ func (t *FlattenTransformer) Transform(g *Graph) error {
 
 		// Go through the subgraph and flatten all the nodes
 		for _, sv := range subgraph.Vertices() {
+			// If the vertex already has a subpath then we assume it has
+			// already been flattened. Ignore it.
 			if _, ok := sv.(GraphNodeSubPath); ok {
 				continue
 			}


### PR DESCRIPTION
Fixes #1854 

Multiple nesting levels of modules were not being flattened properly. This adds a test for that and fixes it.