### PR TITLE
link new openstack resource docs into sidebar

### DIFF
--- a/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_compute_floatingip_v2"
-sidebar_current: "docs-openstack-resource-compute-floatingip-2"
+sidebar_current: "docs-openstack-resource-compute-floatingip-v2"
 description: |-
   Manages a V2 floating IP resource within OpenStack Nova (compute).
 ---

--- a/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_compute_secgroup_v2"
-sidebar_current: "docs-openstack-resource-compute-secgroup-2"
+sidebar_current: "docs-openstack-resource-compute-secgroup-v2"
 description: |-
   Manages a V2 security group resource within OpenStack.
 ---

--- a/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_fw_firewall_v1"
-sidebar_current: "docs-openstack-resource-fw-firewall-1"
+sidebar_current: "docs-openstack-resource-fw-firewall-v1"
 description: |-
   Manages a v1 firewall resource within OpenStack.
 ---

--- a/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_fw_policy_v1"
-sidebar_current: "docs-openstack-resource-fw-policy-1"
+sidebar_current: "docs-openstack-resource-fw-policy-v1"
 description: |-
   Manages a v1 firewall policy resource within OpenStack.
 ---

--- a/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_fw_rule_v1"
-sidebar_current: "docs-openstack-resource-fw-rule-1"
+sidebar_current: "docs-openstack-resource-fw-rule-v1"
 description: |-
   Manages a v1 firewall rule resource within OpenStack.
 ---

--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_networking_floatingip_v2"
-sidebar_current: "docs-openstack-resource-networking-floatingip-2"
+sidebar_current: "docs-openstack-resource-networking-floatingip-v2"
 description: |-
   Manages a V2 floating IP resource within OpenStack Neutron (networking).
 ---

--- a/website/source/docs/providers/openstack/r/networking_router_interface_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_router_interface_v2.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_networking_router_interface_v2"
-sidebar_current: "docs-openstack-resource-networking-router-interface-2"
+sidebar_current: "docs-openstack-resource-networking-router-interface-v2"
 description: |-
   Manages a V2 router interface resource within OpenStack.
 ---

--- a/website/source/docs/providers/openstack/r/networking_router_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_router_v2.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_networking_router_v2"
-sidebar_current: "docs-openstack-resource-networking-router-2"
+sidebar_current: "docs-openstack-resource-networking-router-v2"
 description: |-
   Manages a V2 router resource within OpenStack.
 ---

--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -16,6 +16,9 @@
             <li<%= sidebar_current("docs-openstack-resource-blockstorage-volume-v1") %>>
               <a href="/docs/providers/openstack/r/blockstorage_volume_v1.html">openstack_blockstorage_volume_v1</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-compute-floatingip-v2") %>>
+              <a href="/docs/providers/openstack/r/compute_floatingip_v2.html">openstack_compute_floatingip_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-compute-instance-v2") %>>
               <a href="/docs/providers/openstack/r/compute_instance_v2.html">openstack_compute_instance_v2</a>
             </li>
@@ -24,6 +27,21 @@
             </li>
             <li<%= sidebar_current("docs-openstack-resource-compute-secgroup-v2") %>>
               <a href="/docs/providers/openstack/r/compute_secgroup_v2.html">openstack_compute_secgroup_v2</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-fw-firewall-v1") %>>
+              <a href="/docs/providers/openstack/r/fw_firewall_v1.html">openstack_fw_firewall_v1</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-fw-firewall-v1") %>>
+              <a href="/docs/providers/openstack/r/fw_firewall_v1.html">openstack_fw_firewall_v1</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-fw-policy-v1") %>>
+              <a href="/docs/providers/openstack/r/fw_policy_v1.html">openstack_fw_policy_v1</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-fw-rule-v1") %>>
+              <a href="/docs/providers/openstack/r/fw_rule_v1.html">openstack_fw_rule_v1</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-lb-pool-v1") %>>
+              <a href="/docs/providers/openstack/r/lb_pool_v1.html">openstack_lb_pool_v1</a>
             </li>
             <li<%= sidebar_current("docs-openstack-resource-lb-monitor-v1") %>>
               <a href="/docs/providers/openstack/r/lb_monitor_v1.html">openstack_lb_monitor_v1</a>
@@ -34,8 +52,17 @@
             <li<%= sidebar_current("docs-openstack-resource-lb-vip-v1") %>>
               <a href="/docs/providers/openstack/r/lb_vip_v1.html">openstack_lb_vip_v1</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-networking-floatingip-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_floatingip_v2.html">openstack_networking_floatingip_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-networking-network-v2") %>>
               <a href="/docs/providers/openstack/r/networking_network_v2.html">openstack_networking_network_v2</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-networking-router-interface-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_router_interface_v2.html">openstack_networking_router_interface_v2</a>
+            </li>
+            <li<%= sidebar_current("docs-openstack-resource-networking-router-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_router_v2.html">openstack_networking_router_v2</a>
             </li>
             <li<%= sidebar_current("docs-openstack-resource-networking-subnet-v2") %>>
               <a href="/docs/providers/openstack/r/networking_subnet_v2.html">openstack_networking_subnet_v2</a>


### PR DESCRIPTION
In [PR#1805](https://github.com/hashicorp/terraform/pull/1805) I wrote:
> it's possible I missed a sidebar reference in one of the new files

well, actually I missed the `website/source/layouts/openstack.erb` file where the sidebar is actually defined, and furthermore I had the misfortune to copy-paste from the one existing resource doc (compute_secgroup_v2.html.markdown) where the sidebar reference ended in `-2` rather than `-v2` as it should have.

This pull request fixes that problem - at the moment you can only view the new docs if you know they are already there, e.g. https://terraform.io/docs/providers/openstack/r/networking_router_v2.html but with luck this will make them visible to everyone.