### PR TITLE
Document work-arounds necessary to parameterize list types.

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -112,5 +112,8 @@ The supported built-in functions are:
 
   * `split(delim, string)` - Splits the string previously created by `join`
       back into a list. This is useful for pushing lists through module
-      outputs since they currently only support string values.
+      outputs since they currently only support string values. Depending on the
+      use, the string this is being performed within may need to be wrapped 
+      in brackets to indicate that the output is actually a list, e.g.
+      `a_resource_param = ["${split(",", var.CSV_STRING)}"]`.
       Example: `split(",", module.amod.server_ids)`

--- a/website/source/docs/modules/usage.html.markdown
+++ b/website/source/docs/modules/usage.html.markdown
@@ -59,6 +59,22 @@ for a module by inspecting the source of it very easily.
 Additionally, because these map directly to variables, they're always simple
 key/value pairs. Modules can't have complex variable inputs.
 
+## Dealing with parameters of the list type
+
+Variables are currently unable to hold the list type. Sometimes, though, it's
+desirable to parameterize a module's resource with an attribute that is of the
+list type, for example `aws_instance.security_groups`. 
+
+Until a future release broadens the functionality of variables to include list
+types, the way to work around this limitation is to use the [`split` and
+`join`](/docs/configuration/interpolation.html) string interpolation functions
+to pass a delimited string as a module parameter, and then "unpack" that
+parameter using `split` within the module definition. 
+
+Depending on the resource parameter in question, you may have to 
+indicate that the unpacked string is actually a list but using the 
+`resource_param = ["${split(",", var.CSV_STRING)}"]` notation.
+
 ## Outputs
 
 Modules can also specify their own [outputs](/docs/configuration/outputs.html).

--- a/website/source/docs/modules/usage.html.markdown
+++ b/website/source/docs/modules/usage.html.markdown
@@ -66,14 +66,18 @@ desirable to parameterize a module's resource with an attribute that is of the
 list type, for example `aws_instance.security_groups`. 
 
 Until a future release broadens the functionality of variables to include list
-types, the way to work around this limitation is to use the [`split` and
-`join`](/docs/configuration/interpolation.html) string interpolation functions
-to pass a delimited string as a module parameter, and then "unpack" that
-parameter using `split` within the module definition. 
+types, the way to work around this limitation is to pass a delimited string as
+a module parameter, and then "unpack" that parameter using
+[`split`](/docs/configuration/interpolation.html) interpolation function within
+the module definition. 
 
 Depending on the resource parameter in question, you may have to 
-indicate that the unpacked string is actually a list but using the 
-`resource_param = ["${split(",", var.CSV_STRING)}"]` notation.
+indicate that the unpacked string is actually a list by using list notation.
+For example:
+
+```
+resource_param = ["${split(",", var.CSV_STRING)}"]
+```
 
 ## Outputs
 


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/issues/57.

AFAICT, nowhere is the `[string_interpolated_to_a_list]` notation documented. This PR fixes that, as well as adds documentation related to parameterizing list-typed resource attributes in modules.