### PR TITLE
command/push: local vars override remote ones

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -132,6 +132,10 @@ func (c *PushCommand) Run(args []string) int {
 		return 1
 	}
 	for k, v := range vars {
+		// Local variables override remote ones
+		if _, exists := ctx.Variables()[k]; exists {
+			continue
+		}
 		ctx.SetVariable(k, v)
 	}
 

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -205,6 +205,10 @@ func TestPush_inputTfvars(t *testing.T) {
 	defer os.Remove(archivePath)
 
 	client := &mockPushClient{File: archivePath}
+	// Provided vars should override existing ones
+	client.GetResult = map[string]string{
+		"foo": "old",
+	}
 	ui := new(cli.MockUi)
 	c := &PushCommand{
 		Meta: Meta{


### PR DESCRIPTION
Otherwise once you push a variable it becomes very difficult to change.