### PR TITLE
Increase subnet & security group deletion timeout (2 -> 5 mins)

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -295,7 +295,7 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[DEBUG] Security Group destroy: %v", d.Id())
 
-	return resource.Retry(2*time.Minute, func() error {
+	return resource.Retry(5*time.Minute, func() error {
 		_, err := conn.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
 			GroupID: aws.String(d.Id()),
 		})

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -166,7 +166,7 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 	wait := resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     "destroyed",
-		Timeout:    2 * time.Minute,
+		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			_, err := conn.DeleteSubnet(req)


### PR DESCRIPTION
This should prevent DependencyViolation errors while waiting for larger ASGs to shut down.

Feel free to replicate the `DependencyViolation` with the following setup of 5-nodes in ASG:
https://gist.github.com/radeksimko/28a5bd3cd6d2ed30599b

Before running `terraform destroy`, make sure to wait until the ASG fully comes up and both checks are green (usually takes a few minutes).
![screen shot 2015-05-09 at 21 33 53](https://cloud.githubusercontent.com/assets/287584/7552052/9a003e70-f698-11e4-9dc1-48bf10e78110.png)
The shutdown process then takes more time as it apparently needs to shut all running services.
Running `apply` & `destroy` immediately works well, but that's not the use-case we care about. :smiley: 