### PR TITLE
provider/aws: adding support for SQS queues

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/awslabs/aws-sdk-go/service/rds"
 	"github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/awslabs/aws-sdk-go/service/s3"
+	"github.com/awslabs/aws-sdk-go/service/sqs"
 )
 
 type Config struct {
@@ -40,6 +41,7 @@ type AWSClient struct {
 	rdsconn         *rds.RDS
 	iamconn         *iam.IAM
 	elasticacheconn *elasticache.ElastiCache
+	sqsconn         *sqs.SQS
 }
 
 // Client configures and returns a fully initailized AWSClient
@@ -113,6 +115,9 @@ func (c *Config) Client() (interface{}, error) {
 
 		log.Println("[INFO] Initializing Elasticache Connection")
 		client.elasticacheconn = elasticache.New(awsConfig)
+
+		log.Println("[INFO] Initializing SQS Connection")
+		client.sqsconn = sqs.New(awsConfig)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -121,6 +121,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_s3_bucket":                    resourceAwsS3Bucket(),
 			"aws_security_group":               resourceAwsSecurityGroup(),
 			"aws_security_group_rule":          resourceAwsSecurityGroupRule(),
+			"aws_sqs":                          resourceAwsSQS(),
 			"aws_subnet":                       resourceAwsSubnet(),
 			"aws_vpc_dhcp_options_association": resourceAwsVpcDhcpOptionsAssociation(),
 			"aws_vpc_dhcp_options":             resourceAwsVpcDhcpOptions(),

--- a/builtin/providers/aws/resource_aws_sqs.go
+++ b/builtin/providers/aws/resource_aws_sqs.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/sqs"
+)
+
+func resourceAwsSQS() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSQSCreate,
+		Read:   resourceAwsSQSRead,
+		Update: resourceAwsSQSUpdate,
+		Delete: resourceAwsSQSDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"visibility_timeout": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"retention_period": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  345600,
+			},
+			"max_message_size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  262144,
+			},
+			"delivery_delay": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"receive_wait_time": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+		},
+	}
+}
+
+func resourceAwsSQSCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+
+	params := &sqs.CreateQueueInput{
+		QueueName: aws.String(d.Get("name").(string)),
+		Attributes: &map[string]*string{
+			"VisibilityTimeout":             aws.String(strconv.Itoa(d.Get("visibility_timeout").(int))),
+			"MessageRetentionPeriod":        aws.String(strconv.Itoa(d.Get("retention_period").(int))),
+			"MaximumMessageSize":            aws.String(strconv.Itoa(d.Get("max_message_size").(int))),
+			"DelaySeconds":                  aws.String(strconv.Itoa(d.Get("delivery_delay").(int))),
+			"ReceiveMessageWaitTimeSeconds": aws.String(strconv.Itoa(d.Get("receive_wait_time").(int))),
+		},
+	}
+
+	resp, err := conn.CreateQueue(params)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.QueueURL)
+
+	return nil
+}
+
+
+func resourceAwsSQSRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+
+	params := &sqs.GetQueueAttributesInput{
+	    QueueURL: aws.String(d.Id()), 
+	}
+	_, err := conn.GetQueueAttributes(params)
+
+	if err != nil {
+		return err
+	}
+
+
+	return nil
+}
+
+
+func resourceAwsSQSUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+
+	params := &sqs.SetQueueAttributesInput{
+	    Attributes: &map[string]*string{ 
+	        "VisibilityTimeout":             aws.String(strconv.Itoa(d.Get("visibility_timeout").(int))),
+			"MessageRetentionPeriod":        aws.String(strconv.Itoa(d.Get("retention_period").(int))),
+			"MaximumMessageSize":            aws.String(strconv.Itoa(d.Get("max_message_size").(int))),
+			"DelaySeconds":                  aws.String(strconv.Itoa(d.Get("delivery_delay").(int))),
+			"ReceiveMessageWaitTimeSeconds": aws.String(strconv.Itoa(d.Get("receive_wait_time").(int))),
+	    },
+	    QueueURL: aws.String(d.Id()),
+	}
+	_, err := conn.SetQueueAttributes(params)
+	
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsSQSRead(d, meta)
+}
+
+
+func resourceAwsSQSDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+
+	params := &sqs.DeleteQueueInput{
+	    QueueURL: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteQueue(params)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_sqs.go
+++ b/builtin/providers/aws/resource_aws_sqs.go
@@ -88,6 +88,7 @@ func resourceAwsSQSRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	d.Set("queue_url", d.Id())
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_sqs_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_test.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSSQS_normal(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSQSConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExists("aws_sqs.sqs-name"),
+				),
+			},
+		},
+	})
+}
+
+
+func testAccCheckAWSSQSDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sqsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sqs" {
+			continue
+		}
+
+		// Try to find key pair
+		params := &sqs.GetQueueAttributesInput{
+		    QueueURL: aws.String(rs.Primary.ID), 
+		}
+		_, err := conn.GetQueueAttributes(params)
+		if err == nil {
+			return fmt.Errorf("still exist.")
+		}
+
+		// Verify the error is what we want
+		_, ok := err.(aws.APIError)
+		if !ok {
+			return err
+		}
+	}
+
+	return nil
+}
+
+
+func testAccCheckAWSSQSExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SQS Queue with that name is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sqsconn
+
+		params := &sqs.GetQueueAttributesInput{
+		    QueueURL: aws.String(rs.Primary.ID), 
+		}
+		resp, err := conn.GetQueueAttributes(params)
+
+		if err != nil {
+			return err
+		}
+
+		// checking if attributes are defaults
+		for k, v := range *resp.Attributes {
+			if k == "VisibilityTimeout" && *v != "0" {
+				return fmt.Errorf("VisibilityTimeout was not set to 0")
+			}
+
+			if k == "MessageRetentionPeriod" && *v != "345600" {
+				return fmt.Errorf("MessageRetentionPeriod was not set to 345600")
+			}
+
+			if k == "MaximumMessageSize" && *v != "262144" {
+				return fmt.Errorf("MaximumMessageSize was not set to 262144")
+			}
+
+			if k == "DelaySeconds" && *v != "0" {
+				return fmt.Errorf("DelaySeconds was not set to 0")
+			}
+
+			if k == "ReceiveMessageWaitTimeSeconds" && *v != "0" {
+				return fmt.Errorf("ReceiveMessageWaitTimeSeconds was not set to 0")
+			}
+		}
+
+		return nil
+	}
+}
+
+const testAccAWSSQSConfig = `
+resource "aws_sqs" "test" {
+    name = "sqs-name"
+}
+
+`
+

--- a/website/source/docs/providers/aws/r/sqs.html.markdown
+++ b/website/source/docs/providers/aws/r/sqs.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "aws"
+page_title: "AWS: aws_sqs"
+sidebar_current: "docs-aws-resource-sqs"
+description: |-
+  Provides a SQS resource.
+---
+
+# aws\_sqs
+
+Provides a SQS resource.
+
+## Example Usage
+
+```
+resource "aws_sqs" "queue" {
+    name = "queue-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `visibility_timeout` - (Optional) The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). The default for this attribute is 0 (zero)
+* `retention_period` - (Optional) The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days). The default for this attribute is 345600 (4 days).
+* `max_message_size` - (Optional) The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB). The default for this attribute is 262144 (256 KiB).
+* `delivery_delay` - (Optional) The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout.
+* `receive_wait_time` - (Optional) The time for which a ReceiveMessage call will wait for a message to arrive. An integer from 0 to 20 (seconds). The default for this attribute is 0.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `queue_url` - The URL for the created Amazon SQS queue.


### PR DESCRIPTION
Disclaimer, I'm pretty new to Go but this seems to be working in my tests for adding/editing/delete a queue. It also passed `make test` but I might be doing things wrong

This adds basic SQS functionality to create/edit/delete a SQS queue. Right now it doesn't support anything like dead letter or permissions.

Let me know if anything really bad or something I missed sticks out