### PR TITLE
provider/gce: Fix updates for http_health_check (set defaults)

### DIFF
--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -21,7 +21,7 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 			"check_interval_sec": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  5,
 			},
 
 			"description": &schema.Schema{
@@ -32,7 +32,7 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 			"healthy_threshold": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  2,
 			},
 
 			"host": &schema.Schema{
@@ -49,13 +49,13 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 			"port": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  80,
 			},
 
 			"request_path": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  "/",
 			},
 
 			"self_link": &schema.Schema{
@@ -66,13 +66,13 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 			"timeout_sec": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  5,
 			},
 
 			"unhealthy_threshold": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  2,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_http_health_check_test.go
+++ b/builtin/providers/google/resource_compute_http_health_check_test.go
@@ -25,6 +25,32 @@ func TestAccComputeHttpHealthCheck_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeHttpHealthCheck_update(t *testing.T) {
+	var healthCheck compute.HttpHealthCheck
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHttpHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHttpHealthCheck_update1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeHttpHealthCheckExists(
+						"google_compute_http_health_check.foobar", &healthCheck),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeHttpHealthCheck_update2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeHttpHealthCheckExists(
+						"google_compute_http_health_check.foobar", &healthCheck),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeHttpHealthCheckDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -81,5 +107,24 @@ resource "google_compute_http_health_check" "foobar" {
 	request_path = "/health_check"
 	timeout_sec = 2
 	unhealthy_threshold = 3
+}
+`
+
+const testAccComputeHttpHealthCheck_update1 = `
+resource "google_compute_http_health_check" "foobar" {
+	name = "terraform-test"
+	description = "Resource created for Terraform acceptance testing"
+	request_path = "/not_default"
+}
+`
+
+/* Change description, restore request_path to default, and change
+* thresholds from defaults */
+const testAccComputeHttpHealthCheck_update2 = `
+resource "google_compute_http_health_check" "foobar" {
+	name = "terraform-test"
+	description = "Resource updated for Terraform acceptance testing"
+	healthy_threshold = 10
+	unhealthy_threshold = 10
 }
 `

--- a/builtin/providers/google/resource_compute_http_health_check_test.go
+++ b/builtin/providers/google/resource_compute_http_health_check_test.go
@@ -72,14 +72,14 @@ func testAccCheckComputeHttpHealthCheckExists(n string) resource.TestCheckFunc {
 
 const testAccComputeHttpHealthCheck_basic = `
 resource "google_compute_http_health_check" "foobar" {
-    check_interval_sec = 3
+	check_interval_sec = 3
 	description = "Resource created for Terraform acceptance testing"
 	healthy_threshold = 3
 	host = "foobar"
-    name = "terraform-test"
+	name = "terraform-test"
 	port = "80"
-    request_path = "/health_check"
-    timeout_sec = 2
+	request_path = "/health_check"
+	timeout_sec = 2
 	unhealthy_threshold = 3
 }
 `


### PR DESCRIPTION
#### provider/gce: Test updates to http_health_check

By first creating a very simple resource that mostly uses the default
values and then changing the two thresholds from their computed defaults.

This currently fails with the following error and will be fixed in a
subsequent commit:

    --- FAIL: TestAccComputeHttpHealthCheck_update (5.58s)
            testing.go:131: Step 1 error: Error applying: 1 error(s) occurred:

                    * 1 error(s) occurred:

                    * 1 error(s) occurred:

                    * Error patching HttpHealthCheck: googleapi: Error 400: Invalid value for field 'resource.port': '0'.  Must be greater than or equal to 1
                    More details:
                    Reason: invalid, Message: Invalid value for field 'resource.port': '0'.  Must be greater than or equal to 1
                    Reason: invalid, Message: Invalid value for field 'resource.checkIntervalSec': '0'.  Must be greater than or equal to 1
                    Reason: invalid, Message: Invalid value for field 'resource.timeoutSec': '0'.  Must be greater than or equal to 1

#### provider/gce: Set defaults for http_health_check

In order to fix the failing test in the preceding commit when optional
params are changed from their default "computed" values.

These weren't working well with `HttpHealthCheck.Patch()` because it was
attempting to set all unspecified params to Go's type defaults (eg. 0 for
int64) which the API rejected.

Changing the call to `HttpHealthCheck.Update()` seemed to fix this but it
still didn't allow you to reset a param back to it's default by no longer
specifying it.

Settings defaults like this, which match the Terraform docs, seems like the
best all round solution. Includes two additional tests for the acceptance
tests which verify the params are really getting set correctly.