### PR TITLE
Update variables.tf in aws-two-tier

### DIFF
--- a/examples/aws-two-tier/variables.tf
+++ b/examples/aws-two-tier/variables.tf
@@ -1,9 +1,13 @@
+
+# variables have two properties.  description & default.  If the default property is not set, then terraform plan will error.
 variable "key_name" {
-    description = "Name of the SSH keypair to use in AWS."
+    description = "Name of the SSH keypair to use in AWS.",
+    default = "REPLACE_WITH_AWS_KEYPAIR_NAME"
 }
 
 variable "key_path" {
-    description = "Path to the private portion of the SSH key specified."
+    description = "Path to the private portion of the SSH key specified.",
+    default = "REPLACE_WITH_AWS_KEYPAIR_PATH"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
I updated the tf file to include a descriptor under TF.  This was added to help newcomers.  The error message " * Required variable not set: ami" is not helpful in hinting a user at what they should fix.  Alternatively, the error message could be updated to say  * Variable object ami missing required object property "default"