### PR TITLE
provider/template: don't diff when there's no diff

### DIFF
--- a/builtin/providers/template/resource_test.go
+++ b/builtin/providers/template/resource_test.go
@@ -50,7 +50,6 @@ output "rendered" {
 						}
 						return nil
 					},
-					TransientResource: true,
 				},
 			},
 		})

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -75,12 +75,6 @@ type TestStep struct {
 
 	// Destroy will create a destroy plan if set to true.
 	Destroy bool
-
-	// TransientResource indicates that resources created as part
-	// of this test step are temporary and might be recreated anew
-	// with every planning step. This should only be set for
-	// pseudo-resources, like the null resource or templates.
-	TransientResource bool
 }
 
 // Test performs an acceptance test on a resource.
@@ -269,7 +263,7 @@ func testStep(
 	if p, err := ctx.Plan(); err != nil {
 		return state, fmt.Errorf("Error on second follow-up plan: %s", err)
 	} else {
-		if p.Diff != nil && !p.Diff.Empty() && !step.TransientResource {
+		if p.Diff != nil && !p.Diff.Empty() {
 			return state, fmt.Errorf(
 				"After applying this step and refreshing, the plan was not empty:\n\n%s", p)
 		}


### PR DESCRIPTION
This reworks the template lifecycle a bit such that we get nicer diff
behavior.

First, we tick ForceNew on for both filename and vars, so that the diff
indicates that the template will be "replaced" on change. This is mostly
cosmetic, but it also tracks conceptually with the fact that the
identifier we use is a hash of the contents, so any change essentially
makes a "new resource".

Second, we change the Exists implementation to only return `false` when
there has been a change in the rendered template. This lets descendent
resources see the computed value changing so that they'll properly
trigger in the plan.

Fixes #1898
Refs #1866 (but does not fix, there's another deeper issue there)