### PR TITLE
terraform: return unknown if resource not found

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -321,10 +321,7 @@ func (i *Interpolater) computeResourceVariable(
 		r = nil
 	}
 	if r == nil {
-		return "", fmt.Errorf(
-			"Resource '%s' not found for variable '%s'",
-			id,
-			v.FullKey())
+		goto MISSING
 	}
 
 	if r.Primary == nil {
@@ -367,6 +364,13 @@ func (i *Interpolater) computeResourceVariable(
 	}
 
 MISSING:
+	// Validation for missing interpolations should happen at a higher
+	// semantic level. If we reached this point and don't have variables,
+	// just return the computed value.
+	if scope == nil || scope.Resource == nil {
+		return config.UnknownVariableValue, nil
+	}
+
 	// If the operation is refresh, it isn't an error for a value to
 	// be unknown. Instead, we return that the value is computed so
 	// that the graph can continue to refresh other nodes. It doesn't


### PR DESCRIPTION
I actually couldn't get a test for this to repro for the life of me, but this made a local config pass that was previously failing. We used to return errors as an extra check but really we should be catching errors like this in the graph and config validation. The issue is with the module flattening variables for resources are rendered/evaluated sometimes without there being any state, which was resulting in an error.

If I can get a test case I will, but otherwise this doesn't case any other tests to fail.