### PR TITLE
provider/openstack: scheduler_hints and servergroups

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -68,6 +68,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_compute_instance_v2":            resourceComputeInstanceV2(),
 			"openstack_compute_keypair_v2":             resourceComputeKeypairV2(),
 			"openstack_compute_secgroup_v2":            resourceComputeSecGroupV2(),
+			"openstack_compute_servergroup_v2":         resourceComputeServerGroupV2(),
 			"openstack_compute_floatingip_v2":          resourceComputeFloatingIPV2(),
 			"openstack_fw_firewall_v1":                 resourceFWFirewallV1(),
 			"openstack_fw_policy_v1":                   resourceFWPolicyV1(),

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/tenantnetworks"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
@@ -225,6 +226,48 @@ func resourceComputeInstanceV2() *schema.Resource {
 				},
 				Set: resourceComputeVolumeAttachmentHash,
 			},
+			"scheduler_hints": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"different_host": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"same_host": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"query": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"target_cell": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"build_near_host_ip": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: resourceComputeSchedulerHintsHash,
+			},
 		},
 	}
 }
@@ -287,6 +330,16 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 		createOpts = &bootfromvolume.CreateOptsExt{
 			createOpts,
 			blockDevice,
+		}
+	}
+
+	schedulerHintsRaw := d.Get("scheduler_hints").(*schema.Set).List()
+	if len(schedulerHintsRaw) > 0 {
+		log.Printf("[DEBUG] schedulerhints: %+v", schedulerHintsRaw)
+		schedulerHints := resourceInstanceSchedulerHintsV2(d, schedulerHintsRaw[0].(map[string]interface{}))
+		createOpts = &schedulerhints.CreateOptsExt{
+			createOpts,
+			schedulerHints,
 		}
 	}
 
@@ -873,6 +926,40 @@ func resourceInstanceBlockDeviceV2(d *schema.ResourceData, bd map[string]interfa
 	return bfvOpts
 }
 
+func resourceInstanceSchedulerHintsV2(d *schema.ResourceData, schedulerHintsRaw map[string]interface{}) schedulerhints.SchedulerHints {
+	differentHost := []string{}
+	if len(schedulerHintsRaw["different_host"].([]interface{})) > 0 {
+		for _, dh := range schedulerHintsRaw["different_host"].([]interface{}) {
+			differentHost = append(differentHost, dh.(string))
+		}
+	}
+
+	sameHost := []string{}
+	if len(schedulerHintsRaw["same_host"].([]interface{})) > 0 {
+		for _, sh := range schedulerHintsRaw["same_host"].([]interface{}) {
+			sameHost = append(sameHost, sh.(string))
+		}
+	}
+
+	query := make([]interface{}, len(schedulerHintsRaw["query"].([]interface{})))
+	if len(schedulerHintsRaw["query"].([]interface{})) > 0 {
+		for _, q := range schedulerHintsRaw["query"].([]interface{}) {
+			query = append(query, q.(string))
+		}
+	}
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		Group:           schedulerHintsRaw["group"].(string),
+		DifferentHost:   differentHost,
+		SameHost:        sameHost,
+		Query:           query,
+		TargetCell:      schedulerHintsRaw["target_cell"].(string),
+		BuildNearHostIP: schedulerHintsRaw["build_near_host_ip"].(string),
+	}
+
+	return schedulerHints
+}
+
 func getImageID(client *gophercloud.ServiceClient, d *schema.ResourceData) (string, error) {
 	imageId := d.Get("image_id").(string)
 
@@ -956,6 +1043,29 @@ func resourceComputeVolumeAttachmentHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["volume_id"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["device"].(string)))
+	return hashcode.String(buf.String())
+}
+
+func resourceComputeSchedulerHintsHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if m["group"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
+	}
+
+	if m["target_cell"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["target_cell"].(string)))
+	}
+
+	if m["build_host_near_ip"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["build_host_near_ip"].(string)))
+	}
+
+	buf.WriteString(fmt.Sprintf("%s-", m["different_host"].([]interface{})))
+	buf.WriteString(fmt.Sprintf("%s-", m["same_host"].([]interface{})))
+	buf.WriteString(fmt.Sprintf("%s-", m["query"].([]interface{})))
+
 	return hashcode.String(buf.String())
 }
 

--- a/builtin/providers/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_servergroup_v2.go
@@ -1,0 +1,123 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/servergroups"
+)
+
+func resourceComputeServerGroupV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeServerGroupV2Create,
+		Read:   resourceComputeServerGroupV2Read,
+		Update: nil,
+		Delete: resourceComputeServerGroupV2Delete,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"policies": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"members": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceComputeServerGroupV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	createOpts := &servergroups.CreateOpts{
+		Name:     d.Get("name").(string),
+		Policies: resourceServerGroupPoliciesV2(d),
+	}
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	newSG, err := servergroups.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating ServerGroup", err)
+	}
+
+	d.SetId(newSG.ID)
+
+	return resourceComputeServerGroupV2Read(d, meta)
+}
+
+func resourceComputeServerGroupV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	sg, err := servergroups.Get(computeClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "server group")
+	}
+
+	log.Printf("[DEBUG] Retrieved ServerGroup %s: %+v", d.Id(), sg)
+
+	// Set the name
+	d.Set("name", sg.Name)
+
+	// Set the policies
+	policies := []string{}
+	for _, p := range sg.Policies {
+		policies = append(policies, p)
+	}
+	d.Set("policies", policies)
+
+	// Set the members
+	members := []string{}
+	for _, m := range sg.Members {
+		members = append(members, m)
+	}
+	d.Set("members", members)
+
+	return nil
+}
+
+func resourceComputeServerGroupV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	log.Printf("[DEBUG] Deleting ServerGroup %s", d.Id())
+	if err := servergroups.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
+		return fmt.Errorf("Error deleting ServerGroup: %s", err)
+	}
+
+	return nil
+}
+
+func resourceServerGroupPoliciesV2(d *schema.ResourceData) []string {
+	rawPolicies := d.Get("policies").([]interface{})
+	policies := make([]string, len(rawPolicies))
+	for i, raw := range rawPolicies {
+		policies[i] = raw.(string)
+	}
+	return policies
+}

--- a/builtin/providers/openstack/resource_openstack_compute_servergroup_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_servergroup_v2_test.go
@@ -1,0 +1,88 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/servergroups"
+)
+
+func TestAccComputeV2ServerGroup_basic(t *testing.T) {
+	var serverGroup servergroups.ServerGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2ServerGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2ServerGroup_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2ServerGroupExists(t, "openstack_compute_servergroup_v2.mysg", &serverGroup),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeV2ServerGroupDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	computeClient, err := config.computeV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("(testAccCheckComputeV2ServerGroupDestroy) Error creating OpenStack compute client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_compute_servergroup_v2" {
+			continue
+		}
+
+		_, err := servergroups.Get(computeClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("ServerGroup still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckComputeV2ServerGroupExists(t *testing.T, n string, kp *servergroups.ServerGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		computeClient, err := config.computeV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("(testAccCheckComputeV2ServerGroupExists) Error creating OpenStack compute client: %s", err)
+		}
+
+		found, err := servergroups.Get(computeClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("ServerGroup not found")
+		}
+
+		*kp = *found
+
+		return nil
+	}
+}
+
+var testAccComputeV2ServerGroup_basic = `
+  resource "openstack_compute_servergroup_v2" "mysg" {
+		name = "my server group"
+		policies = ["affinity"]
+  }`

--- a/builtin/providers/openstack/resource_openstack_compute_servergroup_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_servergroup_v2_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/servergroups"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 )
 
 func TestAccComputeV2ServerGroup_basic(t *testing.T) {
@@ -22,6 +23,27 @@ func TestAccComputeV2ServerGroup_basic(t *testing.T) {
 				Config: testAccComputeV2ServerGroup_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2ServerGroupExists(t, "openstack_compute_servergroup_v2.mysg", &serverGroup),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeV2ServerGroup_affinity(t *testing.T) {
+	var instance servers.Server
+	var sg servergroups.ServerGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2ServerGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2ServerGroup_affinity,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2ServerGroupExists(t, "openstack_compute_servergroup_v2.mysg", &sg),
+					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.myinstance", &instance),
+					testAccCheckComputeV2InstanceInServerGroup(&instance, &sg),
 				),
 			},
 		},
@@ -81,8 +103,36 @@ func testAccCheckComputeV2ServerGroupExists(t *testing.T, n string, kp *servergr
 	}
 }
 
+func testAccCheckComputeV2InstanceInServerGroup(instance *servers.Server, sg *servergroups.ServerGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(sg.Members) > 0 {
+			for _, m := range sg.Members {
+				if m == instance.ID {
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("Instance %s is not part of Server Group %s", instance.ID, sg.ID)
+	}
+}
+
 var testAccComputeV2ServerGroup_basic = `
   resource "openstack_compute_servergroup_v2" "mysg" {
-		name = "my server group"
+		name = "mysg"
 		policies = ["affinity"]
   }`
+
+var testAccComputeV2ServerGroup_affinity = `
+	resource "openstack_compute_servergroup_v2" "mysg" {
+		name = "mysg"
+		policies = ["affinity"]
+	}
+
+	resource "openstack_compute_instance_v2" "myinstance" {
+		name = "myinstance"
+		security_groups = ["default"]
+		scheduler_hints {
+			group = "${openstack_compute_servergroup_v2.mysg.id}"
+		}
+	}`

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -83,6 +83,9 @@ The following arguments are supported:
 * `volume` - (Optional) Attach an existing volume to the instance. The volume
     structure is described below.
 
+* `scheduler_hints` - (Optional) Provider the Nova scheduler with hints on how
+    the instance should be launched. The available hints are described below.
+
 The `network` block supports:
 
 * `uuid` - (Required unless `port`  or `name` is provided) The network UUID to
@@ -118,6 +121,25 @@ The `volume` block supports:
 * `device` - (Optional) The device that the volume will be attached as. For
     example:  `/dev/vdc`. Omit this option to allow the volume to be
     auto-assigned a device.
+
+The `scheduler_hints` block supports:
+
+* `group` - (Optional) A UUID of a Server Group. The instance will be placed
+    into that group.
+
+* `different_host` - (Optional) A list of instance UUIDs. The instance will
+    be scheduled on a different host than all other instances.
+
+* `same_host` - (Optional) A list of instance UUIDs. The instance will be
+    scheduled on the same host of those specified.
+
+* `query` - (Optional) A conditional query that a compute node must pass in
+    order to host an instance.
+
+* `target_cell` - (Optional) The name of a cell to host the instance.
+
+* `build_near_host_ip` - (Optional) An IP Address in CIDR form. The instance
+    will be placed on a compute node that is in the same subnet.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/openstack/r/compute_servergroup_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_servergroup_v2.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_servergroup_v2"
+sidebar_current: "docs-openstack-resource-compute-servergroup-v2"
+description: |-
+  Manages a V2 Server Group resource within OpenStack.
+---
+
+# openstack\_compute\_servergroup_v2
+
+Manages a V2 Server Group resource within OpenStack.
+
+## Example Usage
+
+```
+resource "openstack_compute_servergroup_v2" "test-sg" {
+  name = "my-sg"
+  policies = ["anti-affinity"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the V2 Compute client.
+    If omitted, the `OS_REGION_NAME` environment variable is used. Changing
+    this creates a new server group.
+
+* `name` - (Required) A unique name for the server group. Changing this creates
+    a new server group.
+
+* `policies` - (Required) The set of policies for the server group. Only two
+    two policies are available right now, and both are mutually exclusive. See
+    the Policies section for more information. Changing this creates a new
+    server group.
+
+## Policies
+
+* `affinity` - All instances/servers launched in this group will be hosted on
+    the same compute node.
+
+* `anti-affinity` - All instances/servers launched in this group will be
+    hosted on different compute nodes.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `policies` - See Argument Reference above.
+* `members` - The instances that are part of this server group.


### PR DESCRIPTION
This PR introduces two new features:

The first adds the ability to specify scheduling hints to the instance resource. OpenStack scheduling can be read about [here](http://docs.openstack.org/kilo/config-reference/content/section_compute-scheduler.html). There are a lot of methods available to assist the scheduling of instances in the cloud and some of them allow input from the user. This input is known as a "hint". Search the docs page for "hint" to learn more.

The second is a new resource for ServerGroups. [This](http://dev.cloudwatt.com/en/blog/affinity-and-anti-affinity-in-openstack.html) is a great article that describes ServerGroups.

These two new features could/should be in two different PRs, but I included both here because they go hand-in-hand. In order to use ServerGroups, scheduler_hints must be enabled. At the same time, ServerGroups are the only hint-compatible scheduler enabled by default, so in order to test that scheduler_hints works, either OpenStack needs to use a non-default configuration _or_ test with a ServerGroup. :smile: 

I've been wanting to add ServerGroups to Terraform since I started working with it. It's a great complementary feature for scenarios where someone wants to launch several instances and ensure they all land on a different compute node for HA reasons. :smile: 

One other note: These features require a current commit of Gophercloud as the underlying support just landed in it last week.

Please let me know if anyone sees any issues or mistakes with this code.