### PR TITLE
core: make orphans flattenable

### DIFF
--- a/terraform/transform_orphan.go
+++ b/terraform/transform_orphan.go
@@ -176,6 +176,13 @@ func (n *graphNodeOrphanResource) DependentOn() []string {
 	return n.dependentOn
 }
 
+func (n *graphNodeOrphanResource) Flatten(p []string) (dag.Vertex, error) {
+	return &graphNodeOrphanResourceFlat{
+		graphNodeOrphanResource: n,
+		PathValue:               p,
+	}, nil
+}
+
 func (n *graphNodeOrphanResource) Name() string {
 	return fmt.Sprintf("%s (orphan)", n.ResourceName)
 }
@@ -289,4 +296,20 @@ func (n *graphNodeOrphanResource) EvalTree() EvalNode {
 
 func (n *graphNodeOrphanResource) dependableName() string {
 	return n.ResourceName
+}
+
+// Same as graphNodeOrphanResource, but for flattening
+type graphNodeOrphanResourceFlat struct {
+	*graphNodeOrphanResource
+
+	PathValue []string
+}
+
+func (n *graphNodeOrphanResourceFlat) Name() string {
+	return fmt.Sprintf(
+		"%s.%s", modulePrefixStr(n.PathValue), n.graphNodeOrphanResource.Name())
+}
+
+func (n *graphNodeOrphanResourceFlat) Path() []string {
+	return n.PathValue
 }


### PR DESCRIPTION
Got this while playing around in a module:

> * unflattenable node: aws_security_group.internal (orphan)
> *terraform.graphNodeOrphanResource

Basically just copied implementation from
d503cc2d824f6c5cd3fbc18e9887faecf6f14bb9