### PR TITLE
helper/schema: validate ConflictsWith against top-level

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -61,12 +61,13 @@ func (p *Provider) InternalValidate() error {
 		return errors.New("provider is nil")
 	}
 
-	if err := schemaMap(p.Schema).InternalValidate(); err != nil {
+	sm := schemaMap(p.Schema)
+	if err := sm.InternalValidate(sm); err != nil {
 		return err
 	}
 
 	for k, r := range p.ResourcesMap {
-		if err := r.InternalValidate(); err != nil {
+		if err := r.InternalValidate(nil); err != nil {
 			return fmt.Errorf("%s: %s", k, err)
 		}
 	}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -220,10 +220,11 @@ func (r *Resource) Refresh(
 // Provider.InternalValidate() will automatically call this for all of
 // the resources it manages, so you don't need to call this manually if it
 // is part of a Provider.
-func (r *Resource) InternalValidate() error {
+func (r *Resource) InternalValidate(topSchemaMap schemaMap) error {
 	if r == nil {
 		return errors.New("resource is nil")
 	}
+	tsm := topSchemaMap
 
 	if r.isTopLevel() {
 		// All non-Computed attributes must be ForceNew if Update is not defined
@@ -239,9 +240,10 @@ func (r *Resource) InternalValidate() error {
 					"No Update defined, must set ForceNew on: %#v", nonForceNewAttrs)
 			}
 		}
+		tsm = schemaMap(r.Schema)
 	}
 
-	return schemaMap(r.Schema).InternalValidate()
+	return schemaMap(r.Schema).InternalValidate(tsm)
 }
 
 // Returns true if the resource is "top level" i.e. not a sub-resource.

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -334,7 +334,7 @@ func TestResourceInternalValidate(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		err := tc.In.InternalValidate()
+		err := tc.In.InternalValidate(schemaMap{})
 		if (err != nil) != tc.Err {
 			t.Fatalf("%d: bad: %s", i, err)
 		}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2799,7 +2799,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		err := schemaMap(tc.In).InternalValidate()
+		err := schemaMap(tc.In).InternalValidate(schemaMap{})
 		if (err != nil) != tc.Err {
 			if tc.Err {
 				t.Fatalf("%d: Expected error did not occur:\n\n%#v", i, tc.In)


### PR DESCRIPTION
The runtime impl of ConfictsWith uses Resource.Get(), which makes it
work with any other attribute of the resource - the InternalValidate was
only checking against the local schemaMap though, preventing subResource
from using ConflictsWith properly.

It's a lot of wiring and it's a bit ugly, but it's not runtime code, so
I'm a bit less concerned about that aspect.

This should take care of the problem mentioned in #1909