### PR TITLE
Strip 'sdk' suffix from methods; it's a remnant

### DIFF
--- a/builtin/providers/aws/resource_aws_customer_gateway.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway.go
@@ -82,7 +82,7 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	// Create tags.
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	}
 
@@ -147,7 +147,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("bgp_asn", customerGateway.BGPASN)
 	d.Set("ip_address", customerGateway.IPAddress)
 	d.Set("type", customerGateway.Type)
-	d.Set("tags", tagsToMapSDK(customerGateway.Tags))
+	d.Set("tags", tagsToMap(customerGateway.Tags))
 
 	return nil
 }
@@ -156,7 +156,7 @@ func resourceAwsCustomerGatewayUpdate(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).ec2conn
 
 	// Update tags if required.
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	}
 

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -610,7 +610,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("subnet_id", instance.SubnetID)
 	}
 	d.Set("ebs_optimized", instance.EBSOptimized)
-	d.Set("tags", tagsToMapSDK(instance.Tags))
+	d.Set("tags", tagsToMap(instance.Tags))
 
 	// Determine whether we're referring to security groups with
 	// IDs or names. We use a heuristic to figure this out. By default,
@@ -700,7 +700,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	// TODO(mitchellh): wait for the attributes we modified to
 	// persist the change...
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -334,9 +334,9 @@ func TestAccAWSInstance_tags(t *testing.T) {
 				Config: testAccCheckInstanceConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
-					testAccCheckTagsSDK(&v.Tags, "foo", "bar"),
+					testAccCheckTags(&v.Tags, "foo", "bar"),
 					// Guard against regression of https://github.com/hashicorp/terraform/issues/914
-					testAccCheckTagsSDK(&v.Tags, "#", ""),
+					testAccCheckTags(&v.Tags, "#", ""),
 				),
 			},
 
@@ -344,8 +344,8 @@ func TestAccAWSInstance_tags(t *testing.T) {
 				Config: testAccCheckInstanceConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
-					testAccCheckTagsSDK(&v.Tags, "foo", ""),
-					testAccCheckTagsSDK(&v.Tags, "bar", "baz"),
+					testAccCheckTags(&v.Tags, "foo", ""),
+					testAccCheckTags(&v.Tags, "bar", "baz"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -43,7 +43,7 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	d.SetId(*ig.InternetGatewayID)
 	log.Printf("[INFO] InternetGateway ID: %s", d.Id())
 
-	err = setTagsSDK(conn, d)
+	err = setTags(conn, d)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func resourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("vpc_id", ig.Attachments[0].VPCID)
 	}
 
-	d.Set("tags", tagsToMapSDK(ig.Tags))
+	d.Set("tags", tagsToMap(ig.Tags))
 
 	return nil
 }
@@ -93,7 +93,7 @@ func resourceAwsInternetGatewayUpdate(d *schema.ResourceData, meta interface{}) 
 
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	}
 

--- a/builtin/providers/aws/resource_aws_internet_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway_test.go
@@ -98,7 +98,7 @@ func TestAccAWSInternetGateway_tags(t *testing.T) {
 				Config: testAccCheckInternetGatewayConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
-					testAccCheckTagsSDK(&v.Tags, "foo", "bar"),
+					testAccCheckTags(&v.Tags, "foo", "bar"),
 				),
 			},
 
@@ -106,8 +106,8 @@ func TestAccAWSInternetGateway_tags(t *testing.T) {
 				Config: testAccCheckInternetGatewayConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
-					testAccCheckTagsSDK(&v.Tags, "foo", ""),
-					testAccCheckTagsSDK(&v.Tags, "bar", "baz"),
+					testAccCheckTags(&v.Tags, "foo", ""),
+					testAccCheckTags(&v.Tags, "bar", "baz"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -166,7 +166,7 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("vpc_id", networkAcl.VPCID)
-	d.Set("tags", tagsToMapSDK(networkAcl.Tags))
+	d.Set("tags", tagsToMap(networkAcl.Tags))
 
 	if err := d.Set("ingress", networkAclEntriesToMapList(ingressEntries)); err != nil {
 		return err
@@ -213,7 +213,7 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -149,7 +149,7 @@ func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 				Config: testAccAWSNetworkAclEgressConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.bond", &networkAcl),
-					testAccCheckTagsSDK(&networkAcl.Tags, "foo", "bar"),
+					testAccCheckTags(&networkAcl.Tags, "foo", "bar"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -120,7 +120,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("security_groups", flattenGroupIdentifiers(eni.Groups))
 
 	// Tags
-	d.Set("tags", tagsToMapSDK(eni.TagSet))
+	d.Set("tags", tagsToMap(eni.TagSet))
 
 	if eni.Attachment != nil {
 		attachment := []map[string]interface{}{flattenAttachment(eni.Attachment)}
@@ -226,7 +226,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		d.SetPartial("security_groups")
 	}
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -170,7 +170,7 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("route", route)
 
 	// Tags
-	d.Set("tags", tagsToMapSDK(rt.Tags))
+	d.Set("tags", tagsToMap(rt.Tags))
 
 	return nil
 }
@@ -289,7 +289,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -134,7 +134,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				Config: testAccRouteTableConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-					testAccCheckTagsSDK(&route_table.Tags, "foo", "bar"),
+					testAccCheckTags(&route_table.Tags, "foo", "bar"),
 				),
 			},
 
@@ -142,8 +142,8 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				Config: testAccRouteTableConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
-					testAccCheckTagsSDK(&route_table.Tags, "foo", ""),
-					testAccCheckTagsSDK(&route_table.Tags, "bar", "baz"),
+					testAccCheckTags(&route_table.Tags, "foo", ""),
+					testAccCheckTags(&route_table.Tags, "bar", "baz"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -251,7 +251,7 @@ func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("owner_id", sg.OwnerID)
 	d.Set("ingress", ingressRules)
 	d.Set("egress", egressRules)
-	d.Set("tags", tagsToMapSDK(sg.Tags))
+	d.Set("tags", tagsToMap(sg.Tags))
 	return nil
 }
 
@@ -281,7 +281,7 @@ func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	}
 

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -428,7 +428,7 @@ func TestAccAWSSecurityGroup_tags(t *testing.T) {
 				Config: testAccAWSSecurityGroupConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists("aws_security_group.foo", &group),
-					testAccCheckTagsSDK(&group.Tags, "foo", "bar"),
+					testAccCheckTags(&group.Tags, "foo", "bar"),
 				),
 			},
 
@@ -436,8 +436,8 @@ func TestAccAWSSecurityGroup_tags(t *testing.T) {
 				Config: testAccAWSSecurityGroupConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists("aws_security_group.foo", &group),
-					testAccCheckTagsSDK(&group.Tags, "foo", ""),
-					testAccCheckTagsSDK(&group.Tags, "bar", "baz"),
+					testAccCheckTags(&group.Tags, "foo", ""),
+					testAccCheckTags(&group.Tags, "bar", "baz"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -115,7 +115,7 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("cidr_block", subnet.CIDRBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIPOnLaunch)
-	d.Set("tags", tagsToMapSDK(subnet.Tags))
+	d.Set("tags", tagsToMap(subnet.Tags))
 
 	return nil
 }
@@ -125,7 +125,7 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	d.Partial(true)
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -134,7 +134,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("dhcp_options_id", vpc.DHCPOptionsID)
 
 	// Tags
-	d.Set("tags", tagsToMapSDK(vpc.Tags))
+	d.Set("tags", tagsToMap(vpc.Tags))
 
 	// Attributes
 	attribute := "enableDnsSupport"
@@ -229,7 +229,7 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.SetPartial("enable_dns_support")
 	}
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
@@ -151,7 +151,7 @@ func resourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	opts := resp.DHCPOptions[0]
-	d.Set("tags", tagsToMapSDK(opts.Tags))
+	d.Set("tags", tagsToMap(opts.Tags))
 
 	for _, cfg := range opts.DHCPConfigurations {
 		tfKey := strings.Replace(*cfg.Key, "-", "_", -1)
@@ -173,7 +173,7 @@ func resourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceAwsVpcDhcpOptionsUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	return setTagsSDK(conn, d)
+	return setTags(conn, d)
 }
 
 func resourceAwsVpcDhcpOptionsDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -104,7 +104,7 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("peer_owner_id", pc.AccepterVPCInfo.OwnerID)
 	d.Set("peer_vpc_id", pc.AccepterVPCInfo.VPCID)
 	d.Set("vpc_id", pc.RequesterVPCInfo.VPCID)
-	d.Set("tags", tagsToMapSDK(pc.Tags))
+	d.Set("tags", tagsToMap(pc.Tags))
 
 	return nil
 }
@@ -125,7 +125,7 @@ func resourceVPCPeeringConnectionAccept(conn *ec2.EC2, id string) (string, error
 func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -46,7 +46,7 @@ func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 				Config: testAccVpcPeeringConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSVpcPeeringConnectionExists("aws_vpc_peering_connection.foo", &connection),
-					testAccCheckTagsSDK(&connection.Tags, "foo", "bar"),
+					testAccCheckTags(&connection.Tags, "foo", "bar"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -66,7 +66,7 @@ func TestAccVpc_tags(t *testing.T) {
 					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
-					testAccCheckTagsSDK(&vpc.Tags, "foo", "bar"),
+					testAccCheckTags(&vpc.Tags, "foo", "bar"),
 				),
 			},
 
@@ -74,8 +74,8 @@ func TestAccVpc_tags(t *testing.T) {
 				Config: testAccVpcConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckTagsSDK(&vpc.Tags, "foo", ""),
-					testAccCheckTagsSDK(&vpc.Tags, "bar", "baz"),
+					testAccCheckTags(&vpc.Tags, "foo", ""),
+					testAccCheckTags(&vpc.Tags, "bar", "baz"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -185,7 +185,7 @@ func resourceAwsVpnConnectionCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// Create tags.
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	}
 
@@ -243,7 +243,7 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("vpn_gateway_id", vpnConnection.VPNGatewayID)
 	d.Set("customer_gateway_id", vpnConnection.CustomerGatewayID)
 	d.Set("type", vpnConnection.Type)
-	d.Set("tags", tagsToMapSDK(vpnConnection.Tags))
+	d.Set("tags", tagsToMap(vpnConnection.Tags))
 
 	if vpnConnection.Options != nil {
 		if err := d.Set("static_routes_only", vpnConnection.Options.StaticRoutesOnly); err != nil {
@@ -269,7 +269,7 @@ func resourceAwsVpnConnectionUpdate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).ec2conn
 
 	// Update tags if required.
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	}
 

--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -89,7 +89,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("vpc_id", vpnGateway.VPCAttachments[0].VPCID)
 	}
 	d.Set("availability_zone", vpnGateway.AvailabilityZone)
-	d.Set("tags", tagsToMapSDK(vpnGateway.Tags))
+	d.Set("tags", tagsToMap(vpnGateway.Tags))
 
 	return nil
 }
@@ -109,7 +109,7 @@ func resourceAwsVpnGatewayUpdate(d *schema.ResourceData, meta interface{}) error
 
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := setTagsSDK(conn, d); err != nil {
+	if err := setTags(conn, d); err != nil {
 		return err
 	}
 

--- a/builtin/providers/aws/resource_aws_vpn_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway_test.go
@@ -98,7 +98,7 @@ func TestAccVpnGateway_tags(t *testing.T) {
 				Config: testAccCheckVpnGatewayConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpnGatewayExists("aws_vpn_gateway.foo", &v),
-					testAccCheckTagsSDK(&v.Tags, "foo", "bar"),
+					testAccCheckTags(&v.Tags, "foo", "bar"),
 				),
 			},
 
@@ -106,8 +106,8 @@ func TestAccVpnGateway_tags(t *testing.T) {
 				Config: testAccCheckVpnGatewayConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpnGatewayExists("aws_vpn_gateway.foo", &v),
-					testAccCheckTagsSDK(&v.Tags, "foo", ""),
-					testAccCheckTagsSDK(&v.Tags, "bar", "baz"),
+					testAccCheckTags(&v.Tags, "foo", ""),
+					testAccCheckTags(&v.Tags, "bar", "baz"),
 				),
 			},
 		},

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -19,12 +19,12 @@ func tagsSchema() *schema.Schema {
 
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags"
-func setTagsSDK(conn *ec2.EC2, d *schema.ResourceData) error {
+func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})
 		n := nraw.(map[string]interface{})
-		create, remove := diffTagsSDK(tagsFromMapSDK(o), tagsFromMapSDK(n))
+		create, remove := diffTags(tagsFromMap(o), tagsFromMap(n))
 
 		// Set tags
 		if len(remove) > 0 {
@@ -55,7 +55,7 @@ func setTagsSDK(conn *ec2.EC2, d *schema.ResourceData) error {
 // diffTags takes our tags locally and the ones remotely and returns
 // the set of tags that must be created, and the set of tags that must
 // be destroyed.
-func diffTagsSDK(oldTags, newTags []*ec2.Tag) ([]*ec2.Tag, []*ec2.Tag) {
+func diffTags(oldTags, newTags []*ec2.Tag) ([]*ec2.Tag, []*ec2.Tag) {
 	// First, we're creating everything we have
 	create := make(map[string]interface{})
 	for _, t := range newTags {
@@ -72,11 +72,11 @@ func diffTagsSDK(oldTags, newTags []*ec2.Tag) ([]*ec2.Tag, []*ec2.Tag) {
 		}
 	}
 
-	return tagsFromMapSDK(create), remove
+	return tagsFromMap(create), remove
 }
 
 // tagsFromMap returns the tags for the given map of data.
-func tagsFromMapSDK(m map[string]interface{}) []*ec2.Tag {
+func tagsFromMap(m map[string]interface{}) []*ec2.Tag {
 	result := make([]*ec2.Tag, 0, len(m))
 	for k, v := range m {
 		result = append(result, &ec2.Tag{
@@ -89,7 +89,7 @@ func tagsFromMapSDK(m map[string]interface{}) []*ec2.Tag {
 }
 
 // tagsToMap turns the list of tags into a map.
-func tagsToMapSDK(ts []*ec2.Tag) map[string]string {
+func tagsToMap(ts []*ec2.Tag) map[string]string {
 	result := make(map[string]string)
 	for _, t := range ts {
 		result[*t.Key] = *t.Value

--- a/builtin/providers/aws/tags_test.go
+++ b/builtin/providers/aws/tags_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestDiffTagsSDK(t *testing.T) {
+func TestDiffTags(t *testing.T) {
 	cases := []struct {
 		Old, New       map[string]interface{}
 		Create, Remove map[string]string
@@ -49,9 +49,9 @@ func TestDiffTagsSDK(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		c, r := diffTagsSDK(tagsFromMapSDK(tc.Old), tagsFromMapSDK(tc.New))
-		cm := tagsToMapSDK(c)
-		rm := tagsToMapSDK(r)
+		c, r := diffTags(tagsFromMap(tc.Old), tagsFromMap(tc.New))
+		cm := tagsToMap(c)
+		rm := tagsToMap(r)
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}
@@ -62,10 +62,10 @@ func TestDiffTagsSDK(t *testing.T) {
 }
 
 // testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckTagsSDK(
+func testAccCheckTags(
 	ts *[]*ec2.Tag, key string, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		m := tagsToMapSDK(*ts)
+		m := tagsToMap(*ts)
 		v, ok := m[key]
 		if value != "" && !ok {
 			return fmt.Errorf("Missing tag: %s", key)

--- a/builtin/providers/google/resource_compute_http_health_check_test.go
+++ b/builtin/providers/google/resource_compute_http_health_check_test.go
@@ -116,7 +116,7 @@ func testAccCheckComputeHttpHealthCheckExists(n string, healthCheck *compute.Htt
 func testAccCheckComputeHttpHealthCheckRequestPath(path string, healthCheck *compute.HttpHealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if healthCheck.RequestPath != path {
-			return fmt.Errorf("RequestPath doesn't match: expected %d, got %d", path, healthCheck.RequestPath)
+			return fmt.Errorf("RequestPath doesn't match: expected %s, got %s", path, healthCheck.RequestPath)
 		}
 
 		return nil


### PR DESCRIPTION
- removes the `*SDK` suffix I had added during one of the great `aws-sdk-go` migrations. 
- fixes an issue reported by `go vet`