### PR TITLE
Missing "aws_" in website docs for aws_iam_group_policy

### DIFF
--- a/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
@@ -13,7 +13,7 @@ Provides an IAM policy attached to a group.
 ## Example Usage
 
 ```
-resource "iam_group_policy" "my_developer_policy" {
+resource "aws_iam_group_policy" "my_developer_policy" {
     name = "my_developer_policy"
     group = "${aws_iam_group.my_developers.id}"
     policy = <<EOF


### PR DESCRIPTION
Just a simple missing fix.