### PR TITLE
provider/aws: Add AWS RDS Read Replica

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -91,7 +91,6 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
-				Default:  1,
 			},
 
 			"backup_window": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -445,11 +445,6 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[DEBUG] Error setting replicas attribute: %#v, error: %#v", replicas, err)
 	}
 
-	if v.ReadReplicaSourceDBInstanceIdentifier != nil {
-		log.Printf("\n\n------\nread replica instance identifier: %#v", *v.ReadReplicaSourceDBInstanceIdentifier)
-	} else {
-		log.Printf("\n\n------\nno replica identifier")
-	}
 	d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)
 
 	return nil
@@ -493,7 +488,6 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("\n\n-------- ENTER UPDATE -------\n\n")
 	conn := meta.(*AWSClient).rdsconn
 
 	d.Partial(true)
@@ -622,7 +616,6 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 	d.Partial(false)
-	log.Printf("\n\n-------- EXIT UPDATE -------\n\n")
 	return resourceAwsDbInstanceRead(d, meta)
 }
 

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -26,6 +26,7 @@ func resourceAwsDbInstance() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -89,6 +90,7 @@ func resourceAwsDbInstance() *schema.Resource {
 			"backup_retention_period": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 				Default:  1,
 			},
 
@@ -191,6 +193,17 @@ func resourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"replicate_source_db": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"replicas": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -199,87 +212,113 @@ func resourceAwsDbInstance() *schema.Resource {
 func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
-	opts := rds.CreateDBInstanceInput{
-		AllocatedStorage:     aws.Long(int64(d.Get("allocated_storage").(int))),
-		DBInstanceClass:      aws.String(d.Get("instance_class").(string)),
-		DBInstanceIdentifier: aws.String(d.Get("identifier").(string)),
-		DBName:               aws.String(d.Get("name").(string)),
-		MasterUsername:       aws.String(d.Get("username").(string)),
-		MasterUserPassword:   aws.String(d.Get("password").(string)),
-		Engine:               aws.String(d.Get("engine").(string)),
-		EngineVersion:        aws.String(d.Get("engine_version").(string)),
-		StorageEncrypted:     aws.Boolean(d.Get("storage_encrypted").(bool)),
-		Tags:                 tags,
-	}
 
-	if attr, ok := d.GetOk("storage_type"); ok {
-		opts.StorageType = aws.String(attr.(string))
-	}
-
-	attr := d.Get("backup_retention_period")
-	opts.BackupRetentionPeriod = aws.Long(int64(attr.(int)))
-
-	if attr, ok := d.GetOk("iops"); ok {
-		opts.IOPS = aws.Long(int64(attr.(int)))
-	}
-
-	if attr, ok := d.GetOk("port"); ok {
-		opts.Port = aws.Long(int64(attr.(int)))
-	}
-
-	if attr, ok := d.GetOk("multi_az"); ok {
-		opts.MultiAZ = aws.Boolean(attr.(bool))
-	}
-
-	if attr, ok := d.GetOk("availability_zone"); ok {
-		opts.AvailabilityZone = aws.String(attr.(string))
-	}
-
-	if attr, ok := d.GetOk("license_model"); ok {
-		opts.LicenseModel = aws.String(attr.(string))
-	}
-
-	if attr, ok := d.GetOk("maintenance_window"); ok {
-		opts.PreferredMaintenanceWindow = aws.String(attr.(string))
-	}
-
-	if attr, ok := d.GetOk("backup_window"); ok {
-		opts.PreferredBackupWindow = aws.String(attr.(string))
-	}
-
-	if attr, ok := d.GetOk("publicly_accessible"); ok {
-		opts.PubliclyAccessible = aws.Boolean(attr.(bool))
-	}
-
-	if attr, ok := d.GetOk("db_subnet_group_name"); ok {
-		opts.DBSubnetGroupName = aws.String(attr.(string))
-	}
-
-	if attr, ok := d.GetOk("parameter_group_name"); ok {
-		opts.DBParameterGroupName = aws.String(attr.(string))
-	}
-
-	if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-		var s []*string
-		for _, v := range attr.List() {
-			s = append(s, aws.String(v.(string)))
+	if v, ok := d.GetOk("replicate_source_db"); ok {
+		opts := rds.CreateDBInstanceReadReplicaInput{
+			SourceDBInstanceIdentifier: aws.String(v.(string)),
+			DBInstanceClass:            aws.String(d.Get("instance_class").(string)),
+			DBInstanceIdentifier:       aws.String(d.Get("identifier").(string)),
+			Tags:                       tags,
 		}
-		opts.VPCSecurityGroupIDs = s
-	}
-
-	if attr := d.Get("security_group_names").(*schema.Set); attr.Len() > 0 {
-		var s []*string
-		for _, v := range attr.List() {
-			s = append(s, aws.String(v.(string)))
+		if attr, ok := d.GetOk("iops"); ok {
+			opts.IOPS = aws.Long(int64(attr.(int)))
 		}
-		opts.DBSecurityGroups = s
-	}
 
-	log.Printf("[DEBUG] DB Instance create configuration: %#v", opts)
-	var err error
-	_, err = conn.CreateDBInstance(&opts)
-	if err != nil {
-		return fmt.Errorf("Error creating DB Instance: %s", err)
+		if attr, ok := d.GetOk("port"); ok {
+			opts.Port = aws.Long(int64(attr.(int)))
+		}
+
+		if attr, ok := d.GetOk("availability_zone"); ok {
+			opts.AvailabilityZone = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("publicly_accessible"); ok {
+			opts.PubliclyAccessible = aws.Boolean(attr.(bool))
+		}
+		_, err := conn.CreateDBInstanceReadReplica(&opts)
+		if err != nil {
+			return fmt.Errorf("Error creating DB Instance: %s", err)
+		}
+	} else {
+		opts := rds.CreateDBInstanceInput{
+			AllocatedStorage:     aws.Long(int64(d.Get("allocated_storage").(int))),
+			DBName:               aws.String(d.Get("name").(string)),
+			DBInstanceClass:      aws.String(d.Get("instance_class").(string)),
+			DBInstanceIdentifier: aws.String(d.Get("identifier").(string)),
+			MasterUsername:       aws.String(d.Get("username").(string)),
+			MasterUserPassword:   aws.String(d.Get("password").(string)),
+			Engine:               aws.String(d.Get("engine").(string)),
+			EngineVersion:        aws.String(d.Get("engine_version").(string)),
+			StorageEncrypted:     aws.Boolean(d.Get("storage_encrypted").(bool)),
+			Tags:                 tags,
+		}
+
+		attr := d.Get("backup_retention_period")
+		opts.BackupRetentionPeriod = aws.Long(int64(attr.(int)))
+		if attr, ok := d.GetOk("multi_az"); ok {
+			opts.MultiAZ = aws.Boolean(attr.(bool))
+		}
+
+		if attr, ok := d.GetOk("maintenance_window"); ok {
+			opts.PreferredMaintenanceWindow = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("backup_window"); ok {
+			opts.PreferredBackupWindow = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("license_model"); ok {
+			opts.LicenseModel = aws.String(attr.(string))
+		}
+		if attr, ok := d.GetOk("parameter_group_name"); ok {
+			opts.DBParameterGroupName = aws.String(attr.(string))
+		}
+
+		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			var s []*string
+			for _, v := range attr.List() {
+				s = append(s, aws.String(v.(string)))
+			}
+			opts.VPCSecurityGroupIDs = s
+		}
+
+		if attr := d.Get("security_group_names").(*schema.Set); attr.Len() > 0 {
+			var s []*string
+			for _, v := range attr.List() {
+				s = append(s, aws.String(v.(string)))
+			}
+			opts.DBSecurityGroups = s
+		}
+		if attr, ok := d.GetOk("storage_type"); ok {
+			opts.StorageType = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+			opts.DBSubnetGroupName = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("iops"); ok {
+			opts.IOPS = aws.Long(int64(attr.(int)))
+		}
+
+		if attr, ok := d.GetOk("port"); ok {
+			opts.Port = aws.Long(int64(attr.(int)))
+		}
+
+		if attr, ok := d.GetOk("availability_zone"); ok {
+			opts.AvailabilityZone = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("publicly_accessible"); ok {
+			opts.PubliclyAccessible = aws.Boolean(attr.(bool))
+		}
+
+		log.Printf("[DEBUG] DB Instance create configuration: %#v", opts)
+		var err error
+		_, err = conn.CreateDBInstance(&opts)
+		if err != nil {
+			return fmt.Errorf("Error creating DB Instance: %s", err)
+		}
 	}
 
 	d.SetId(d.Get("identifier").(string))
@@ -299,7 +338,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Wait, catching any errors
-	_, err = stateConf.WaitForState()
+	_, err := stateConf.WaitForState()
 	if err != nil {
 		return err
 	}
@@ -397,6 +436,23 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("security_group_names", sgn)
 
+	// replica things
+
+	var replicas []string
+	for _, v := range v.ReadReplicaDBInstanceIdentifiers {
+		replicas = append(replicas, *v)
+	}
+	if err := d.Set("replicas", replicas); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting replicas attribute: %#v, error: %#v", replicas, err)
+	}
+
+	if v.ReadReplicaSourceDBInstanceIdentifier != nil {
+		log.Printf("\n\n------\nread replica instance identifier: %#v", *v.ReadReplicaSourceDBInstanceIdentifier)
+	} else {
+		log.Printf("\n\n------\nno replica identifier")
+	}
+	d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)
+
 	return nil
 }
 
@@ -438,6 +494,7 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("\n\n-------- ENTER UPDATE -------\n\n")
 	conn := meta.(*AWSClient).rdsconn
 
 	d.Partial(true)
@@ -536,6 +593,28 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	// seperate request to promote a database
+	if d.HasChange("replicate_source_db") {
+		if d.Get("replicate_source_db").(string) == "" {
+			// promote
+			opts := rds.PromoteReadReplicaInput{
+				DBInstanceIdentifier: aws.String(d.Id()),
+			}
+			attr := d.Get("backup_retention_period")
+			opts.BackupRetentionPeriod = aws.Long(int64(attr.(int)))
+			if attr, ok := d.GetOk("backup_window"); ok {
+				opts.PreferredBackupWindow = aws.String(attr.(string))
+			}
+			_, err := conn.PromoteReadReplica(&opts)
+			if err != nil {
+				return fmt.Errorf("Error promoting database: %#v", err)
+			}
+			d.Set("replicate_source_db", "")
+		} else {
+			return fmt.Errorf("cannot elect new source database for replication")
+		}
+	}
+
 	if arn, err := buildRDSARN(d, meta); err == nil {
 		if err := setTagsRDS(conn, d, arn); err != nil {
 			return err
@@ -544,6 +623,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 	d.Partial(false)
+	log.Printf("\n\n-------- EXIT UPDATE -------\n\n")
 	return resourceAwsDbInstanceRead(d, meta)
 }
 

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -670,6 +670,10 @@ func resourceAwsDbInstanceStateRefreshFunc(
 			return nil, "", nil
 		}
 
+		if v.DBInstanceStatus != nil {
+			log.Printf("[DEBUG] DB Instance status for instance %s: %s", d.Id(), *v.DBInstanceStatus)
+		}
+
 		return v, *v.DBInstanceStatus, nil
 	}
 }

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -209,7 +209,7 @@ func testAccReplicaInstanceConfig(val int) string {
 	resource "aws_db_instance" "replica" {
 	  identifier = "tf-replica-db-%d"
 		backup_retention_period = 0
-	  replicate_source_db = "${aws_db_instance.bar.identifier}"
+		replicate_source_db = "${aws_db_instance.bar.identifier}"
 		allocated_storage = "${aws_db_instance.bar.allocated_storage}"
 		engine = "${aws_db_instance.bar.engine}"
 		engine_version = "${aws_db_instance.bar.engine_version}"

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 * `username` - (Required) Username for the master DB user.
 * `availability_zone` - (Optional) The AZ for the RDS instance.
 * `backup_retention_period` - (Optional) The days to retain backups for. Must be
-`1` or greater to be a source for a [Read Replicate][1].
+`1` or greater to be a source for a [Read Replica][1].
 * `backup_window` - (Optional) The backup window.
 * `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
     storage_type of "io1".
@@ -74,7 +74,7 @@ database, and to use this value as the source database. This correlates to the
  more information on using Replication.
 
 
-~> **NOTE:** Removing the `relicate_source` attribute from an existing RDS
+~> **NOTE:** Removing the `replicate_source` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully
 standalone database.
 

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 * `apply_immediately` - (Optional) Specifies whether any database modifications
      are applied immediately, or during the next maintenance window. Default is
      `false`. See [Amazon RDS Documentation for more for more information.](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
-* `replicate_source` - (Optional) Specifies that this resource is a Replicate
+* `replicate_source_db` - (Optional) Specifies that this resource is a Replicate
 database, and to use this value as the source database. This correlates to the
 `identifier` of another Amazon RDS Database to replicate. See
 [DB Instance Replication][1] and
@@ -74,7 +74,7 @@ database, and to use this value as the source database. This correlates to the
  more information on using Replication.
 
 
-~> **NOTE:** Removing the `replicate_source` attribute from an existing RDS
+~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully
 standalone database.
 

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -48,7 +48,8 @@ The following arguments are supported:
     show up in logs, and it will be stored in the state file.
 * `username` - (Required) Username for the master DB user.
 * `availability_zone` - (Optional) The AZ for the RDS instance.
-* `backup_retention_period` - (Optional) The days to retain backups for.
+* `backup_retention_period` - (Optional) The days to retain backups for. Must be
+`1` or greater to be a source for a [Read Replicate][1].
 * `backup_window` - (Optional) The backup window.
 * `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
     storage_type of "io1".
@@ -65,6 +66,17 @@ The following arguments are supported:
 * `apply_immediately` - (Optional) Specifies whether any database modifications
      are applied immediately, or during the next maintenance window. Default is
      `false`. See [Amazon RDS Documentation for more for more information.](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
+* `replicate_source` - (Optional) Specifies that this resource is a Replicate
+database, and to use this value as the source database. This correlates to the
+`identifier` of another Amazon RDS Database to replicate. See
+[DB Instance Replication][1] and
+[Working with PostgreSQL and MySQL Read Replicas](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html) for
+ more information on using Replication.
+
+
+~> **NOTE:** Removing the `relicate_source` attribute from an existing RDS
+Replicate database managed by Terraform will promote the database to a fully
+standalone database.
 
 ## Attributes Reference
 
@@ -88,3 +100,5 @@ The following attributes are exported:
 * `username` - The master username for the database
 * `storage_encrypted` - Specifies whether the DB instance is encrypted
 
+
+[1]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html


### PR DESCRIPTION
My proposal for adding support to for read replicas to `resource_aws_db`, by way of adding a `replicate_source_db` attribute, referencing the `identifier` of the source database.

**Caveats**:

- Replicas inherit many of their attributes from the primary database (`username`, `password`, `engine`). Many of these are required when creating a database instance, but not when creating a replica. The trouble there is if being a replica is just a flag on a resource, that resource still needs those required attributes, even if they're ignored (inherited) from the source. Until Terraform has a `ValidateFunc` or `RequiredIf` concept(s), we're stuck repeating ourselves. 

- Replicas can be promoted to full, standalone databases. Terraform can support this by sending a `PromoteReadReplica` API call when the `replicate_source_db` attribute is removed in the configuration. This may be a surprise to some users, since we can't notify them that "removing this attribute makes a full read/write database" during `plan`. 

- If you use the example config below and let TF do the inheritance of attributes, you may get in a weird state when you promote. Manual managing of the config file will be required if you need to separate the two database more. 

**Example config:**

```javascript
resource "aws_db_instance" "primary" {
  identifier = "tf-primary-db"
  allocated_storage = 5
  engine = "mysql"
  engine_version = "5.6.19b"
  instance_class = "db.t1.micro"
  name = "baz"
  password = "fofofofxx"
  username = "foo"
  multi_az = false
  apply_immediately = true
  backup_retention_period = 1
  tags {
    Name = "tf-primary-db"
  }
  parameter_group_name = "default.mysql5.6"
}

resource "aws_db_instance" "replica" {
  identifier = "tf-replica-db"
  replicate_source_db = "${aws_db_instance.primary.identifier}"
  allocated_storage = "${aws_db_instance.primary.allocated_storage}"
  engine = "${aws_db_instance.primary.engine}"
  engine_version = "${aws_db_instance.primary.engine_version}"
  instance_class = "${aws_db_instance.primary.instance_class}"
  password = "${aws_db_instance.primary.password}"
  username = "${aws_db_instance.primary.username}"
  tags {
    Name = "tf-replica-db"
  }
}
```

In practice, users may want to manually duplicate all those fields. In the implementation, we'll have to ignore most of them that don't apply. 

The fields that are applicable to replica creation:

```go
AutoMinorVersionUpgrade *bool 
AvailabilityZone *string
DBInstanceClass *string
DBInstanceIdentifier *string
DBSubnetGroupName *string
IOPS *int64
OptionGroupName *string
Port *int64
PubliclyAccessible *bool
SourceDBInstanceIdentifier *string
StorageType *string
Tags []*Tag
```

**Relevant docs:**

- [DB Instance Replication](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html)
- [Working with PostgreSQL and MySQL Read Replicas](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.Promote)
- [API Docs for `create`](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference//API_CreateDBInstanceReadReplica.html)

**Things:**

- [x] Docs (mostly)
- [x] Example config
- [x] Implementation 
- [x] Acceptance tests


I welcome thoughts on this approach