### PR TITLE
core: fix deadlock w/ CBD + modules

### DIFF
--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -311,6 +311,7 @@ func (n *GraphNodeConfigResourceFlat) DestroyNode(mode GraphNodeDestroyMode) Gra
 	return &graphNodeResourceDestroyFlat{
 		graphNodeResourceDestroy: node,
 		PathValue:                n.PathValue,
+		FlatCreateNode:           n,
 	}
 }
 
@@ -318,6 +319,9 @@ type graphNodeResourceDestroyFlat struct {
 	*graphNodeResourceDestroy
 
 	PathValue []string
+
+	// Needs to be able to properly yield back a flattened create node to prevent
+	FlatCreateNode *GraphNodeConfigResourceFlat
 }
 
 func (n *graphNodeResourceDestroyFlat) Name() string {
@@ -327,6 +331,10 @@ func (n *graphNodeResourceDestroyFlat) Name() string {
 
 func (n *graphNodeResourceDestroyFlat) Path() []string {
 	return n.PathValue
+}
+
+func (n *graphNodeResourceDestroyFlat) CreateNode() dag.Vertex {
+	return n.FlatCreateNode
 }
 
 // graphNodeResourceDestroy represents the logical destruction of a

--- a/terraform/test-fixtures/plan-module-deadlock/child/main.tf
+++ b/terraform/test-fixtures/plan-module-deadlock/child/main.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "foo" {
+  count = "${length("abc")}"
+  lifecycle { create_before_destroy = true }
+}

--- a/terraform/test-fixtures/plan-module-deadlock/main.tf
+++ b/terraform/test-fixtures/plan-module-deadlock/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}


### PR DESCRIPTION
fixes #1947

Root cause was a bad edge being made by the CBD transform going from the
flattened destroy node to the unflattened create node, which was no
longer in the graph. The destroy node therefore had a dependency that
could never be satisfied, which locked up the walk.