### PR TITLE
Fix argument mistake in IAM group policy document

### DIFF
--- a/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `policy` - (Required) The policy document. This is a JSON formatted string.
   The heredoc syntax or `file` funciton is helpful here.
 * `name` - (Required) Name of the policy.
-* `user` - (Required) The IAM group to attach to the policy.
+* `group` - (Required) The IAM group to attach to the policy.
 
 ## Attributes Reference
 


### PR DESCRIPTION
IAM group policy takes `group` argument, not `user` argument.