### PR TITLE
provider/openstack: Minor volume fixes

### DIFF
--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -53,6 +53,7 @@ func resourceBlockStorageVolumeV1() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 			"snapshot_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -209,7 +209,6 @@ func resourceComputeInstanceV2() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"id": &schema.Schema{
 							Type:     schema.TypeString,
-							Optional: true,
 							Computed: true,
 						},
 						"volume_id": &schema.Schema{
@@ -955,7 +954,6 @@ func resourceComputeVolumeAttachmentHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["volume_id"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["device"].(string)))
 	return hashcode.String(buf.String())
 }
 

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -46,7 +46,7 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 	})
 }
 
-func _TestAccComputeV2Instance_volumeAttach(t *testing.T) {
+func TestAccComputeV2Instance_volumeAttach(t *testing.T) {
 	var instance servers.Server
 	var volume volumes.Volume
 
@@ -229,6 +229,7 @@ var testAccComputeV2Instance_volumeAttach = fmt.Sprintf(`
   resource "openstack_compute_instance_v2" "foo" {
     region = "%s"
     name = "terraform-test"
+    security_groups = ["default"]
     volume {
       volume_id = "${openstack_blockstorage_volume_v1.myvol.id}"
     }


### PR DESCRIPTION
This commit follows suit of #1897 by fixing volume-related
parameters which allow the volume attach acceptance test
to work. It also re-enables the volume attach test.

Fixes #1830 