### PR TITLE
terraform: validation should succeed if env var set [GH-1930]

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -103,9 +103,6 @@ func NewContext(opts *ContextOpts) *Context {
 	// Setup the variables. We first take the variables given to us.
 	// We then merge in the variables set in the environment.
 	variables := make(map[string]string)
-	for k, v := range opts.Variables {
-		variables[k] = v
-	}
 	for _, v := range os.Environ() {
 		if !strings.HasPrefix(v, VarEnvPrefix) {
 			continue
@@ -117,6 +114,9 @@ func NewContext(opts *ContextOpts) *Context {
 		v = v[idx+1:]
 
 		// Override the command-line set variable
+		variables[k] = v
+	}
+	for k, v := range opts.Variables {
 		variables[k] = v
 	}
 

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -6417,6 +6417,10 @@ func TestContext2Apply_vars(t *testing.T) {
 }
 
 func TestContext2Apply_varsEnv(t *testing.T) {
+	// Set the env var
+	old := tempEnv(t, "TF_VAR_ami", "baz")
+	defer os.Setenv("TF_VAR_ami", old)
+
 	m := testModule(t, "apply-vars-env")
 	p := testProvider("aws")
 	p.ApplyFn = testApplyFn
@@ -6427,10 +6431,6 @@ func TestContext2Apply_varsEnv(t *testing.T) {
 			"aws": testProviderFuncFixed(p),
 		},
 	})
-
-	// Set the env var
-	old := tempEnv(t, "TF_VAR_ami", "baz")
-	defer os.Setenv("TF_VAR_ami", old)
 
 	w, e := ctx.Validate()
 	if len(w) > 0 {

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -49,11 +49,6 @@ func (i *Interpolater) Values(
 		}
 		for _, v := range mod.Config().Variables {
 			for k, val := range v.DefaultsMap() {
-				envKey := VarEnvPrefix + strings.TrimPrefix(k, "var.")
-				if v := os.Getenv(envKey); v != "" {
-					val = v
-				}
-
 				result[k] = ast.Variable{
 					Value: val,
 					Type:  ast.TypeString,


### PR DESCRIPTION
Fixes #1930 

We need to set the variables earlier so validation passes. Tests still pass.