### PR TITLE
helper/schema: blank ID refresh doesn't exist [GH-1905]

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -171,6 +171,11 @@ func (r *Resource) Validate(c *terraform.ResourceConfig) ([]string, []error) {
 func (r *Resource) Refresh(
 	s *terraform.InstanceState,
 	meta interface{}) (*terraform.InstanceState, error) {
+	// If the ID is already somehow blank, it doesn't exist
+	if s.ID == "" {
+		return nil, nil
+	}
+
 	if r.Exists != nil {
 		// Make a copy of data so that if it is modified it doesn't
 		// affect our Read later.

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -388,6 +388,35 @@ func TestResourceRefresh(t *testing.T) {
 	}
 }
 
+func TestResourceRefresh_blankId(t *testing.T) {
+	r := &Resource{
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+	}
+
+	r.Read = func(d *ResourceData, m interface{}) error {
+		d.SetId("foo")
+		return nil
+	}
+
+	s := &terraform.InstanceState{
+		ID:         "",
+		Attributes: map[string]string{},
+	}
+
+	actual, err := r.Refresh(s, 42)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if actual != nil {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestResourceRefresh_delete(t *testing.T) {
 	r := &Resource{
 		Schema: map[string]*Schema{


### PR DESCRIPTION
Fixes #1905 

I'm still not sure how this possibly happens but this allows refresh to just be a no-op.