### PR TITLE
provider/aws: export elasticache nodes

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -161,13 +161,14 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 
 	d.SetId(clusterId)
 
-	return nil
+        return resourceAwsElasticacheClusterRead(d, meta)
 }
 
 func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 	req := &elasticache.DescribeCacheClustersInput{
-		CacheClusterID: aws.String(d.Id()),
+                CacheClusterID:    aws.String(d.Id()),
+                ShowCacheNodeInfo: aws.Boolean(true),
 	}
 
 	res, err := conn.DescribeCacheClusters(req)
@@ -210,9 +211,9 @@ func setCacheNodeData(d *schema.ResourceData, c *elasticache.CacheCluster) error
 			return fmt.Errorf("Unexpected nil pointer in: %#v", node)
 		}
 		cacheNodeData = append(cacheNodeData, map[string]interface{}{
-			"id":      node.CacheNodeID,
-			"address": node.Endpoint.Address,
-			"port":    node.Endpoint.Port,
+                        "id":      *node.CacheNodeID,
+                        "address": *node.Endpoint.Address,
+                        "port":    int(*node.Endpoint.Port),
 		})
 	}
 

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -234,7 +234,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).elasticacheconn
 	arn, err := buildECARN(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] Error building ARN for ElastiCache Cluster, not updating Tags for cluster %s", *c.CacheClusterID)
+		log.Printf("[DEBUG] Error building ARN for ElastiCache Cluster, not updating Tags for cluster %s", d.Id())
 	} else {
 		if err := setTagsEC(conn, d, arn); err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -23,6 +23,8 @@ func TestAccAWSElasticacheCluster(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_cluster.bar", "cache_nodes.0.id", "001"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSElasticacheCluster(t *testing.T) {
+func TestAccAWSElasticacheCluster_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -24,7 +24,7 @@ func TestAccAWSElasticacheCluster(t *testing.T) {
 					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_cluster.bar", "cache_nodes.0.id", "001"),
+						"aws_elasticache_cluster.bar", "cache_nodes.0.id", "0001"),
 				),
 			},
 		},
@@ -95,6 +95,9 @@ func genRandInt() int {
 }
 
 var testAccAWSElasticacheClusterConfig = fmt.Sprintf(`
+provider "aws" { 
+	region = "us-east-1"
+}
 resource "aws_security_group" "bar" {
     name = "tf-test-security-group-%03d"
     description = "tf-test-security-group-descr"

--- a/builtin/providers/aws/tagsEC.go
+++ b/builtin/providers/aws/tagsEC.go
@@ -1,0 +1,95 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsEC(conn *elasticache.ElastiCache, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsEC(tagsFromMapEC(o), tagsFromMapEC(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove), len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.RemoveTagsFromResource(&elasticache.RemoveTagsFromResourceInput{
+				ResourceName: aws.String(arn),
+				TagKeys:      k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.AddTagsToResource(&elasticache.AddTagsToResourceInput{
+				ResourceName: aws.String(arn),
+				Tags:         create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsEC(oldTags, newTags []*elasticache.Tag) ([]*elasticache.Tag, []*elasticache.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*elasticache.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapEC(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapEC(m map[string]interface{}) []*elasticache.Tag {
+	result := make([]*elasticache.Tag, 0, len(m))
+	for k, v := range m {
+		result = append(result, &elasticache.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapEC(ts []*elasticache.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		result[*t.Key] = *t.Value
+	}
+
+	return result
+}

--- a/builtin/providers/aws/tagsEC_test.go
+++ b/builtin/providers/aws/tagsEC_test.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/awslabs/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDiffelasticacheTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsEC(tagsFromMapEC(tc.Old), tagsFromMapEC(tc.New))
+		cm := tagsToMapEC(c)
+		rm := tagsToMapEC(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// testAccCheckTags can be used to check the tags on a resource.
+func testAccCheckelasticacheTags(
+	ts []*elasticache.Tag, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m := tagsToMapEC(ts)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("Missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("Extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Here's a start to a fix for https://github.com/hashicorp/terraform/issues/1918

Needs to wait for `len(cluster.CacheNodes) == cluster.NumCacheNodes`, since
apparently that takes a bit of time and the initial response always has
an empty collection of nodes.

I _think_ that doing a complex `Computed` attribute is okay, and you can reference it like `aws_elasticache_cluster.foo.cache_nodes.0.address`.

pushing up the WIP in case @catsby has bandwidth to finish this first

------
**@catsby is doing:**
- [x] export cache node info (#1918)
- [x] touch ups (don't require `parameter_group`, others)
- [x] add tag support (#1919) (d8f3783)