### PR TITLE
terraform: orphan module should flatten

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -2628,6 +2628,52 @@ func TestContext2Validate_moduleProviderInherit(t *testing.T) {
 	}
 }
 
+func TestContext2Validate_moduleProviderInheritOrphan(t *testing.T) {
+	m := testModule(t, "validate-module-pc-inherit-orphan")
+	p := testProvider("aws")
+	c := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: &State{
+			Modules: []*ModuleState{
+				&ModuleState{
+					Path: []string{"root", "child"},
+					Resources: map[string]*ResourceState{
+						"aws_instance.bar": &ResourceState{
+							Type: "aws_instance",
+							Primary: &InstanceState{
+								ID: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	p.ValidateFn = func(c *ResourceConfig) ([]string, []error) {
+		v, ok := c.Get("set")
+		if !ok {
+			return nil, []error{fmt.Errorf("not set")}
+		}
+		if v != "bar" {
+			return nil, []error{fmt.Errorf("bad: %#v", v)}
+		}
+
+		return nil, nil
+	}
+
+	w, e := c.Validate()
+	if len(w) > 0 {
+		t.Fatalf("bad: %#v", w)
+	}
+	if len(e) > 0 {
+		t.Fatalf("bad: %s", e)
+	}
+}
+
 func TestContext2Validate_moduleProviderVar(t *testing.T) {
 	m := testModule(t, "validate-module-pc-vars")
 	p := testProvider("aws")

--- a/terraform/test-fixtures/validate-module-pc-inherit-orphan/main.tf
+++ b/terraform/test-fixtures/validate-module-pc-inherit-orphan/main.tf
@@ -1,0 +1,9 @@
+variable "foo" {
+    default = "bar"
+}
+
+provider "aws" {
+    set = "${var.foo}"
+}
+
+resource "aws_instance" "foo" {}

--- a/terraform/transform_expand.go
+++ b/terraform/transform_expand.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/dag"
@@ -61,25 +60,6 @@ func (n *GraphNodeBasicSubgraph) Subgraph() *Graph {
 	return n.Graph
 }
 
-func (n *GraphNodeBasicSubgraph) Flatten(p []string) (dag.Vertex, error) {
-	return &graphNodeBasicSubgraphFlat{
-		GraphNodeBasicSubgraph: n,
-		PathValue:              p,
-	}, nil
-}
-
-// Same as GraphNodeBasicSubgraph, but for flattening
-type graphNodeBasicSubgraphFlat struct {
-	*GraphNodeBasicSubgraph
-
-	PathValue []string
-}
-
-func (n *graphNodeBasicSubgraphFlat) Name() string {
-	return fmt.Sprintf(
-		"%s.%s", modulePrefixStr(n.PathValue), n.GraphNodeBasicSubgraph.Name())
-}
-
-func (n *graphNodeBasicSubgraphFlat) Path() []string {
-	return n.PathValue
+func (n *GraphNodeBasicSubgraph) FlattenGraph() *Graph {
+	return n.Graph
 }


### PR DESCRIPTION
This builds on top of what @phinze did, but instead of flattening the orphan module vertex, we actually allow the graph it represents to be flattened. This fixes the test case in question where the subgraph wasn't actually being done in the right order.