### PR TITLE
Initial cut at some docs for aws_network_interface and a fix for auto-assigned IPs

### DIFF
--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -75,11 +75,21 @@ func resourceAwsNetworkInterface() *schema.Resource {
 func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	conn := meta.(*AWSClient).ec2conn
+	var request *ec2.CreateNetworkInterfaceInput
 
-	request := &ec2.CreateNetworkInterfaceInput{
-		Groups:             expandStringList(d.Get("security_groups").(*schema.Set).List()),
-		SubnetID:           aws.String(d.Get("subnet_id").(string)),
-		PrivateIPAddresses: expandPrivateIPAddesses(d.Get("private_ips").(*schema.Set).List()),
+	if (len(d.Get("private_ips").(*schema.Set).List()) > 0) {
+		log.Printf("[DEBUG] Using provided Private IP Address(es)")
+		request = &ec2.CreateNetworkInterfaceInput{
+			Groups:             expandStringList(d.Get("security_groups").(*schema.Set).List()),
+			SubnetID:           aws.String(d.Get("subnet_id").(string)),
+			PrivateIPAddresses: expandPrivateIPAddesses(d.Get("private_ips").(*schema.Set).List()),
+		}
+	} else {
+		log.Printf("[DEBUG] Auto-assigning IP Address")
+		request = &ec2.CreateNetworkInterfaceInput{
+			Groups:             expandStringList(d.Get("security_groups").(*schema.Set).List()),
+			SubnetID:           aws.String(d.Get("subnet_id").(string)),
+		}
 	}
 
 	log.Printf("[DEBUG] Creating network interface")

--- a/website/source/docs/providers/aws/r/network_interface.html.markdown
+++ b/website/source/docs/providers/aws/r/network_interface.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "aws"
+page_title: "AWS: aws_network_interface"
+sidebar_current: "docs-aws-resource-network-interface"
+description: |-
+  Provides a resource to create an Elastic Network Interface
+---
+
+# aws\_network\_interface
+
+Provides a resource to create an Elastic Network Interface.
+
+## Example Usage
+
+```
+resource "aws_network_interface" "bar" {
+    subnet_id = "${aws_subnet.foo.id}"
+    private_ips = ["172.16.10.100"]
+    security_groups = ["${aws_security_group.foo.id}"]
+
+    tags {
+        Name = "bar_interface"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `subnet_id` - (Required) The subnet ID to create in.
+* `security_groups` - (Optional) A list of security group names to associate with.
+* `private_ips` - (Optional) The private IP of the interface.
+* `attachment` - (Optional) A mapping to attach the interface to an instance. 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `attachment` mapping supports the following:
+
+* `instance` - (Required) The instance ID to attach to.
+* `device_index` - (Required) The integer index number of the device for the network interface attachment.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Elastic Network Interface.
+
+You can find more technical documentation about Elastic Network Interfaces in the
+official [AWS User Guide](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html).

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -120,6 +120,11 @@
 						<li<%= sidebar_current("docs-aws-resource-network-acl") %>>
 							<a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
 						</li>
+
+						<li<%= sidebar_current("docs-aws-resource-network-interface") %>>
+							<a href="/docs/providers/aws/r/network_interface.html">aws_network_interface</a>
+						</li>
+
 						<li<%= sidebar_current("docs-aws-resource-key-pair") %>>
 							<a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
 						</li>


### PR DESCRIPTION
The docs still needs some love. I suspect there should be a bit more about how to reference the id of the attachment, but I was a little hazy on that, and I'm hoping someone who's actually using that feature could have a peek at that. I also wasn't sure if the secondary private ip stuff was supported, so I've left that out as well.

As for the fix to the Go code.. I now have a total of about 4 hours of Go experience, so this might be the sub-optimal way to handle the problem.

To clarify, when I say "the problem", I mean private_ips field is marked as optional. But, when trying to actually create an ENI without that set in terraform, I was getting back an "InternalError" which appeared to be raised on the Amazon side.

