### PR TITLE
Fixed bug where docker_container resource was not working properly with swarm

### DIFF
--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	dc "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -117,7 +116,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*dc.Client)
 
-	apiContainer, err := fetchDockerContainer(d.Get("name").(string), client)
+	apiContainer, err := fetchDockerContainer(d.Id(), client)
 	if err != nil {
 		return err
 	}
@@ -189,7 +188,7 @@ func stringSetToStringSlice(stringSet *schema.Set) []string {
 	return ret
 }
 
-func fetchDockerContainer(name string, client *dc.Client) (*dc.APIContainers, error) {
+func fetchDockerContainer(ID string , client *dc.Client) (*dc.APIContainers, error) {
 	apiContainers, err := client.ListContainers(dc.ListContainersOptions{All: true})
 
 	if err != nil {
@@ -197,17 +196,7 @@ func fetchDockerContainer(name string, client *dc.Client) (*dc.APIContainers, er
 	}
 
 	for _, apiContainer := range apiContainers {
-		// Sometimes the Docker API prefixes container names with /
-		// like it does in these commands. But if there's no
-		// set name, it just uses the ID without a /...ugh.
-		var dockerContainerName string
-		if len(apiContainer.Names) > 0 {
-			dockerContainerName = strings.TrimLeft(apiContainer.Names[0], "/")
-		} else {
-			dockerContainerName = apiContainer.ID
-		}
-
-		if dockerContainerName == name {
+		if apiContainer.ID == ID {
 			return &apiContainer, nil
 		}
 	}


### PR DESCRIPTION
The docker_container resource was failing to work with Swarm as it was using the container name to test if it had started on a Swarm cluster. As Swarm prepends the hostname to a container name, this was failing. I have modified fetchDockerContainer to use the container's sha rather than it's name to test that it is still running.