### PR TITLE
providers/aws: Add support for policy on S3 bucket

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -271,7 +271,7 @@ func testAccCheckAWSS3BucketWebsite(n string, indexDoc string, errorDoc string, 
 // within AWS
 var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 var testAccWebsiteEndpoint = fmt.Sprintf("tf-test-bucket-%d.s3-website-us-west-2.amazonaws.com", randInt)
-var testAccAWSS3BucketPolicy = fmt.Sprintf(`{"Version":"2008-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::tf-test-bucket-%d/*"}]}`, randInt)
+var testAccAWSS3BucketPolicy = fmt.Sprintf(`{ "Version": "2008-10-17", "Statement": [ { "Sid": "", "Effect": "Allow", "Principal": { "AWS": "*" }, "Action": "s3:GetObject", "Resource": "arn:aws:s3:::tf-test-bucket-%d/*" } ] }`, randInt)
 
 var testAccAWSS3BucketConfig = fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -29,6 +30,32 @@ func TestAccAWSS3Bucket_basic(t *testing.T) {
 						"aws_s3_bucket.bucket", "region", "us-west-2"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "website_endpoint", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3Bucket_Policy(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithPolicy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketPolicy(
+						"aws_s3_bucket.bucket", testAccAWSS3BucketPolicy),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketPolicy(
+						"aws_s3_bucket.bucket", ""),
 				),
 			},
 		},
@@ -145,6 +172,37 @@ func testAccCheckAWSS3BucketExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckAWSS3BucketPolicy(n string, policy string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[n]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		out, err := conn.GetBucketPolicy(&s3.GetBucketPolicyInput{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			if policy == "" {
+				// expected
+				return nil
+			} else {
+				return fmt.Errorf("GetBucketPolicy error: %v, expected %s", err, policy)
+			}
+		}
+
+		if v := out.Policy; v == nil {
+			if policy != "" {
+				return fmt.Errorf("bad policy, found nil, expected: %s", policy)
+			}
+		} else {
+			if *v != policy {
+				return fmt.Errorf("bad policy, expected: %s, got %#v", policy, *v)
+			}
+		}
+
+		return nil
+	}
+}
 func testAccCheckAWSS3BucketWebsite(n string, indexDoc string, errorDoc string, redirectTo string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
@@ -202,6 +260,8 @@ func testAccCheckAWSS3BucketWebsite(n string, indexDoc string, errorDoc string, 
 // within AWS
 var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 var testAccWebsiteEndpoint = fmt.Sprintf("tf-test-bucket-%d.s3-website-us-west-2.amazonaws.com", randInt)
+var testAccAWSS3BucketPolicy = fmt.Sprintf(`{ "Version": "2008-10-17", "Statement": [ { "Sid": "", "Effect": "Allow", "Principal": { "AWS": "*" }, "Action": "s3:GetObject", "Resource": "arn:aws:s3:::tf-test-bucket-%d/*" } ] }`, randInt)
+
 var testAccAWSS3BucketConfig = fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
 	bucket = "tf-test-bucket-%d"
@@ -242,3 +302,11 @@ resource "aws_s3_bucket" "bucket" {
 	}
 }
 `, randInt)
+
+var testAccAWSS3BucketConfigWithPolicy = fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+	policy = %s
+}
+`, randInt, strconv.Quote(testAccAWSS3BucketPolicy))

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -32,6 +32,7 @@ resource "aws_s3_bucket" "b" {
 resource "aws_s3_bucket" "b" {
     bucket = "s3-website-test.hashicorp.com"
     acl = "public-read"
+    policy = "#{file("policy.json")}"
 
     website {
         index_document = "index.html"
@@ -46,6 +47,7 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket.
 * `acl` - (Optional) The [canned ACL](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Defaults to "private".
+* `policy` - (Optional) A valid [bucket policy](http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document.
 * `tags` - (Optional) A mapping of tags to assign to the bucket.
 * `website` - (Optional) A website object (documented below).
 


### PR DESCRIPTION
Adds support for policies on S3 buckets: http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html

```c
resource "aws_s3_bucket" "default" {
  bucket = "hc-jc-tf-test"
  policy = "${file("policy.json")}"
}
```