### PR TITLE
Remove notes about nameservers only being available for public zones.

### DIFF
--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -49,10 +49,6 @@ resource "aws_route53_record" "dev-ns" {
 }
 ```
 
-~> **NOTE:** The `name_servers` set is populated only for public Hosted Zones.
-Private Zones will contain any empty set since AWS does not return a `DelegationSet`
-for private Hosted Zones.
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -67,5 +63,5 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `zone_id` - The Hosted Zone ID. This can be referenced by zone records.
-* `name_servers` - A list of name servers in a default delegation set. Supported only for Public Hosted Zones.
+* `name_servers` - A list of name servers in a default delegation set.
   Find more about delegation sets in [AWS docs](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-reusable-delegation-sets.html).


### PR DESCRIPTION
Support for nameservers in private zones was added in bd6ff34.