### PR TITLE
Handle AWS keypairs which no longer exist

### DIFF
--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -65,6 +65,11 @@ func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	resp, err := conn.DescribeKeyPairs(req)
 	if err != nil {
+		awsErr, ok := err.(aws.APIError)
+		if ok && awsErr.Code == "InvalidKeyPair.NotFound" {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error retrieving KeyPair: %s", err)
 	}
 


### PR DESCRIPTION
When refreshing a keypair, update state appropriately rather than crash
if the keypair no longer exists on AWS.

Likely fixes #1851.