### PR TITLE
provider/aws: Report available sooner for RDS

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -589,6 +589,16 @@ func resourceAwsDbInstanceStateRefreshFunc(
 			return nil, "", nil
 		}
 
+		if v.DBInstanceStatus != nil {
+			log.Printf("[DEBUG] DB Instance status for instance %s: %s", d.Id(), *v.DBInstanceStatus)
+		}
+
+		if a, ok := d.GetOk("backup_retention_period"); ok {
+			if a.(int) > 0 && v.DBInstanceStatus != nil && *v.DBInstanceStatus == "backing-up" {
+				return v, "available", nil
+			}
+		}
+
 		return v, *v.DBInstanceStatus, nil
 	}
 }


### PR DESCRIPTION
Implements option number 2 from #1097. 

In order to speed up our creation time, but still not progress until we can safely do so, we report an `available` status for the database if we're waiting on a backup, and our status is `backing-up`. This state is reached once the database is up and running, but AWS won't report `available` until the backup is done. 

The output for a database with no backups:

```
2015/05/19 15:05:26 [DEBUG] DB Instance status: creating
2015/05/19 15:05:26 [TRACE] Waiting 10s before next try
2015/05/19 15:05:36 [DEBUG] DB Instance describe configuration: <truncated>
2015/05/19 15:05:36 [DEBUG] DB Instance status: available
2015/05/19 15:05:36 [DEBUG] DB Instance describe configuration: <truncated>
<moving on>
```

And with a `backup_retention_period` > 1:

```
2015/05/19 15:14:15 [DEBUG] DB Instance status: creating
2015/05/19 15:14:15 [TRACE] Waiting 10s before next try
2015/05/19 15:14:25 [DEBUG] DB Instance describe configuration: <truncated>
2015/05/19 15:14:25 [DEBUG] DB Instance status: backing-up
2015/05/19 15:14:25 [DEBUG] DB Instance describe configuration: <truncated>
2015/05/19 15:14:26 [DEBUG] root: eval: *terraform.EvalWriteState
<moving on>
```
... and then we go about our business. 

The decimation on instance backups ([here](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.BackingUpAndRestoringAmazonRDSInstances.html)) mentions some I/O caveats:

> During the backup window, storage I/O may be suspended while your data is being backed up and you may experience elevated latency. This I/O suspension typically lasts for the duration of the snapshot.

It's _probably_ acceptable in our case. 

cc @radeksimko and @phinze for thoughts

We also add extra `[DEBUG]` here so people can see the status of the operation, e.g. `creating`, `backing-up` etc