### PR TITLE
Allow multiple providers of the same kind in a JSON tf

### DIFF
--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -331,7 +331,13 @@ func loadProvidersHcl(os *hclobj.Object) ([]*ProviderConfig, error) {
 	// their raw configuration objects. We'll parse those later.
 	for _, o1 := range os.Elem(false) {
 		for _, o2 := range o1.Elem(true) {
-			objects = append(objects, o2)
+			if o1.Type == hclobj.ValueTypeList {
+				for _, o3 := range o2.Elem(true) {
+					objects = append(objects, o3)
+				}
+			} else {
+				objects = append(objects, o2)
+			}
 		}
 	}
 


### PR DESCRIPTION
This is probably not the correct way to do this, but it allows accepting JSON of the form:

    "provider": [
        {
            "google": {
                "alias": "us-central1",
                "account_file": "../service_account_key.json",
                "project": "abiding-truth-649",
                "region": "us-central1"
            }
        },
        {
            "google": {
                "alias": "europe-west1",
                "account_file": "../service_account_key.json",
                "project": "abiding-truth-649",
                "region": "europe-west1"
            }
        }
    ],
