### PR TITLE
provider/aws: fix breakages from awserr refactor

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -36,7 +36,7 @@ type AWSClient struct {
 	elbconn         *elb.ELB
 	autoscalingconn *autoscaling.AutoScaling
 	s3conn          *s3.S3
-	sqsconn		*sqs.SQS
+	sqsconn         *sqs.SQS
 	r53conn         *route53.Route53
 	region          string
 	rdsconn         *rds.RDS

--- a/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/elb"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -90,7 +91,7 @@ func resourceAwsAppCookieStickinessPolicyRead(d *schema.ResourceData, meta inter
 
 	getResp, err := elbconn.DescribeLoadBalancerPolicies(request)
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "PolicyNotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "PolicyNotFound" {
 			// The policy is gone.
 			d.SetId("")
 			return nil

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -141,11 +142,11 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidGroup.NotFound" {
+		if ec2err.Code() != "InvalidGroup.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_customer_gateway.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -100,7 +101,7 @@ func customerGatewayRefreshFunc(conn *ec2.EC2, gatewayId string) resource.StateR
 			Filters: []*ec2.Filter{gatewayFilter},
 		})
 		if err != nil {
-			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidCustomerGatewayID.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidCustomerGatewayID.NotFound" {
 				resp = nil
 			} else {
 				log.Printf("Error on CustomerGatewayRefresh: %s", err)
@@ -130,7 +131,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 		Filters: []*ec2.Filter{gatewayFilter},
 	})
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidCustomerGatewayID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidCustomerGatewayID.NotFound" {
 			d.SetId("")
 			return nil
 		} else {
@@ -172,7 +173,7 @@ func resourceAwsCustomerGatewayDelete(d *schema.ResourceData, meta interface{}) 
 		CustomerGatewayID: aws.String(d.Id()),
 	})
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidCustomerGatewayID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidCustomerGatewayID.NotFound" {
 			d.SetId("")
 			return nil
 		} else {

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/awslabs/aws-sdk-go/service/rds"
 
@@ -275,7 +276,8 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] DB Instance create configuration: %#v", opts)
-	_, err := conn.CreateDBInstance(&opts)
+	var err error
+	_, err = conn.CreateDBInstance(&opts)
 	if err != nil {
 		return fmt.Errorf("Error creating DB Instance: %s", err)
 	}
@@ -558,8 +560,8 @@ func resourceAwsDbInstanceRetrieve(
 	resp, err := conn.DescribeDBInstances(&opts)
 
 	if err != nil {
-		dbinstanceerr, ok := err.(aws.APIError)
-		if ok && dbinstanceerr.Code == "DBInstanceNotFound" {
+		dbinstanceerr, ok := err.(awserr.Error)
+		if ok && dbinstanceerr.Code() == "DBInstanceNotFound" {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("Error retrieving DB Instances: %s", err)

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/rds"
 )
 
@@ -57,6 +58,7 @@ func testAccCheckAWSDBInstanceDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the Group
+		var err error
 		resp, err := conn.DescribeDBInstances(
 			&rds.DescribeDBInstancesInput{
 				DBInstanceIdentifier: aws.String(rs.Primary.ID),
@@ -70,11 +72,11 @@ func testAccCheckAWSDBInstanceDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		newerr, ok := err.(*aws.APIError)
+		newerr, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if newerr.Code != "InvalidDBInstance.NotFound" {
+		if newerr.Code() != "InvalidDBInstance.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/rds"
 )
 
@@ -203,12 +204,12 @@ func resourceAwsDbParameterGroupDeleteRefreshFunc(
 		}
 
 		if _, err := rdsconn.DeleteDBParameterGroup(&deleteOpts); err != nil {
-			rdserr, ok := err.(aws.APIError)
+			rdserr, ok := err.(awserr.Error)
 			if !ok {
 				return d, "error", err
 			}
 
-			if rdserr.Code != "DBParameterGroupNotFoundFault" {
+			if rdserr.Code() != "DBParameterGroupNotFoundFault" {
 				return d, "error", err
 			}
 		}

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -127,11 +128,11 @@ func testAccCheckAWSDBParameterGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		newerr, ok := err.(aws.APIError)
+		newerr, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if newerr.Code != "InvalidDBParameterGroup.NotFound" {
+		if newerr.Code() != "InvalidDBParameterGroup.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/multierror"
@@ -170,8 +171,8 @@ func resourceAwsDbSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 	_, err := conn.DeleteDBSecurityGroup(&opts)
 
 	if err != nil {
-		newerr, ok := err.(aws.APIError)
-		if ok && newerr.Code == "InvalidDBSecurityGroup.NotFound" {
+		newerr, ok := err.(awserr.Error)
+		if ok && newerr.Code() == "InvalidDBSecurityGroup.NotFound" {
 			return nil
 		}
 		return err

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -59,11 +60,11 @@ func testAccCheckAWSDBSecurityGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		newerr, ok := err.(aws.APIError)
+		newerr, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if newerr.Code != "InvalidDBSecurityGroup.NotFound" {
+		if newerr.Code() != "InvalidDBSecurityGroup.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/rds"
 )
 
@@ -55,11 +56,11 @@ func testAccCheckDBSubnetGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		rdserr, ok := err.(aws.APIError)
+		rdserr, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if rdserr.Code != "DBSubnetGroupNotFoundFault" {
+		if rdserr.Code() != "DBSubnetGroupNotFoundFault" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_ebs_volume.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -102,7 +103,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 
 	response, err := conn.DescribeVolumes(request)
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVolume.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVolume.NotFound" {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -123,7 +124,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	describeAddresses, err := ec2conn.DescribeAddresses(req)
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidAllocationID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAllocationID.NotFound" {
 			d.SetId("")
 			return nil
 		}
@@ -247,7 +248,7 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 		if err == nil {
 			return nil
 		}
-		if _, ok := err.(aws.APIError); !ok {
+		if _, ok := err.(awserr.Error); !ok {
 			return resource.RetryError{Err: err}
 		}
 

--- a/builtin/providers/aws/resource_aws_eip_test.go
+++ b/builtin/providers/aws/resource_aws_eip_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -98,12 +99,12 @@ func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		providerErr, ok := err.(aws.APIError)
+		providerErr, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
 
-		if providerErr.Code != "InvalidAllocationID.NotFound" {
+		if providerErr.Code() != "InvalidAllocationID.NotFound" {
 			return fmt.Errorf("Unexpected error: %s", err)
 		}
 	}

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/elasticache"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -310,9 +311,9 @@ func CacheClusterStateRefreshFunc(conn *elasticache.ElastiCache, clusterID, give
 			CacheClusterID: aws.String(clusterID),
 		})
 		if err != nil {
-			apierr := err.(aws.APIError)
-			log.Printf("[DEBUG] message: %v, code: %v", apierr.Message, apierr.Code)
-			if apierr.Message == fmt.Sprintf("CacheCluster not found: %v", clusterID) {
+			apierr := err.(awserr.Error)
+			log.Printf("[DEBUG] message: %v, code: %v", apierr.Message(), apierr.Code())
+			if apierr.Message() == fmt.Sprintf("CacheCluster not found: %v", clusterID) {
 				log.Printf("[DEBUG] Detect deletion")
 				return nil, "", nil
 			}

--- a/builtin/providers/aws/resource_aws_elasticache_security_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_security_group.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -125,12 +126,12 @@ func resourceAwsElasticacheSecurityGroupDelete(d *schema.ResourceData, meta inte
 			CacheSecurityGroupName: aws.String(d.Id()),
 		})
 		if err != nil {
-			apierr, ok := err.(aws.APIError)
+			apierr, ok := err.(awserr.Error)
 			if !ok {
 				return err
 			}
 			log.Printf("[DEBUG] APIError.Code: %v", apierr.Code)
-			switch apierr.Code {
+			switch apierr.Code() {
 			case "InvalidCacheSecurityGroupState":
 				return err
 			case "DependencyViolation":

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -119,12 +120,12 @@ func resourceAwsElasticacheSubnetGroupDelete(d *schema.ResourceData, meta interf
 			CacheSubnetGroupName: aws.String(d.Id()),
 		})
 		if err != nil {
-			apierr, ok := err.(aws.APIError)
+			apierr, ok := err.(awserr.Error)
 			if !ok {
 				return err
 			}
 			log.Printf("[DEBUG] APIError.Code: %v", apierr.Code)
-			switch apierr.Code {
+			switch apierr.Code() {
 			case "DependencyViolation":
 				// If it is a dependency violation, we want to retry
 				return err

--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/elb"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -552,6 +553,6 @@ func resourceAwsElbListenerHash(v interface{}) int {
 }
 
 func isLoadBalancerNotFound(err error) bool {
-	elberr, ok := err.(aws.APIError)
-	return ok && elberr.Code == "LoadBalancerNotFound"
+	elberr, ok := err.(awserr.Error)
+	return ok && elberr.Code() == "LoadBalancerNotFound"
 }

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/elb"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -381,12 +382,12 @@ func testAccCheckAWSELBDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		providerErr, ok := err.(aws.APIError)
+		providerErr, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
 
-		if providerErr.Code != "InvalidLoadBalancerName.NotFound" {
+		if providerErr.Code() != "InvalidLoadBalancerName.NotFound" {
 			return fmt.Errorf("Unexpected error: %s", err)
 		}
 	}

--- a/builtin/providers/aws/resource_aws_iam_access_key.go
+++ b/builtin/providers/aws/resource_aws_iam_access_key.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -71,7 +72,7 @@ func resourceAwsIamAccessKeyRead(d *schema.ResourceData, meta interface{}) error
 
 	getResp, err := iamconn.ListAccessKeys(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" { // XXX TEST ME
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX TEST ME
 			// the user does not exist, so the key can't exist.
 			d.SetId("")
 			return nil

--- a/builtin/providers/aws/resource_aws_iam_access_key_test.go
+++ b/builtin/providers/aws/resource_aws_iam_access_key_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -49,11 +50,11 @@ func testAccCheckAWSAccessKeyDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "NoSuchEntity" {
+		if ec2err.Code() != "NoSuchEntity" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -66,7 +67,7 @@ func resourceAwsIamGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	getResp, err := iamconn.GetGroup(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" {
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_iam_group_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_group_policy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -66,9 +67,10 @@ func resourceAwsIamGroupPolicyRead(d *schema.ResourceData, meta interface{}) err
 		GroupName:  aws.String(group),
 	}
 
+	var err error
 	getResp, err := iamconn.GetGroupPolicy(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" { // XXX test me
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_iam_group_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -46,11 +47,11 @@ func testAccCheckAWSGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "NoSuchEntity" {
+		if ec2err.Code() != "NoSuchEntity" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_iam_instance_profile.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -59,6 +60,7 @@ func resourceAwsIamInstanceProfileCreate(d *schema.ResourceData, meta interface{
 		Path:                aws.String(d.Get("path").(string)),
 	}
 
+	var err error
 	response, err := iamconn.CreateInstanceProfile(request)
 	if err == nil {
 		err = instanceProfileReadResult(d, response.InstanceProfile)
@@ -87,7 +89,7 @@ func instanceProfileRemoveRole(iamconn *iam.IAM, profileName, roleName string) e
 	}
 
 	_, err := iamconn.RemoveRoleFromInstanceProfile(request)
-	if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" {
+	if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
 		return nil
 	}
 	return err
@@ -156,7 +158,7 @@ func resourceAwsIamInstanceProfileRead(d *schema.ResourceData, meta interface{})
 
 	result, err := iamconn.GetInstanceProfile(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" {
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_iam_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_policy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -73,7 +74,7 @@ func resourceAwsIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
 	response, err := iamconn.GetPolicy(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" {
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
 			d.SetId("")
 			return nil
 		}
@@ -118,7 +119,7 @@ func resourceAwsIamPolicyDelete(d *schema.ResourceData, meta interface{}) error 
 
 	_, err := iamconn.DeletePolicy(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" {
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
 			return nil
 		}
 		return fmt.Errorf("Error reading IAM policy %s: %#v", d.Id(), err)

--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -72,7 +73,7 @@ func resourceAwsIamRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	getResp, err := iamconn.GetRole(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" { // XXX test me
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_iam_role_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_role_policy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -66,9 +67,10 @@ func resourceAwsIamRolePolicyRead(d *schema.ResourceData, meta interface{}) erro
 		RoleName:   aws.String(role),
 	}
 
+	var err error
 	getResp, err := iamconn.GetRolePolicy(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" { // XXX test me
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_iam_role_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -46,11 +47,11 @@ func testAccCheckAWSRoleDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "NoSuchEntity" {
+		if ec2err.Code() != "NoSuchEntity" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -75,7 +76,7 @@ func resourceAwsIamUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	getResp, err := iamconn.GetUser(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" { // XXX test me
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_iam_user_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_user_policy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -66,9 +67,10 @@ func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) erro
 		UserName:   aws.String(user),
 	}
 
+	var err error
 	getResp, err := iamconn.GetUserPolicy(request)
 	if err != nil {
-		if iamerr, ok := err.(aws.APIError); ok && iamerr.Code == "NoSuchEntity" { // XXX test me
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_iam_user_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -46,11 +47,11 @@ func testAccCheckAWSUserDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "NoSuchEntity" {
+		if ec2err.Code() != "NoSuchEntity" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -482,6 +483,7 @@ func testAccCheckInstanceDestroyWithProvider(s *terraform.State, provider *schem
 		}
 
 		// Try to find the resource
+		var err error
 		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIDs: []*string{aws.String(rs.Primary.ID)},
 		})
@@ -494,11 +496,11 @@ func testAccCheckInstanceDestroyWithProvider(s *terraform.State, provider *schem
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidInstanceID.NotFound" {
+		if ec2err.Code() != "InvalidInstanceID.NotFound" {
 			return err
 		}
 	}
@@ -526,7 +528,7 @@ func testAccCheckInstanceExistsWithProviders(n string, i *ec2.Instance, provider
 			resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
 				InstanceIDs: []*string{aws.String(rs.Primary.ID)},
 			})
-			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidInstanceID.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
 				continue
 			}
 			if err != nil {

--- a/builtin/providers/aws/resource_aws_internet_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -135,11 +136,11 @@ func testAccCheckInternetGatewayDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidInternetGatewayID.NotFound" {
+		if ec2err.Code() != "InvalidInternetGatewayID.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -78,11 +79,11 @@ func testAccCheckAWSKeyPairDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidKeyPair.NotFound" {
+		if ec2err.Code() != "InvalidKeyPair.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -440,8 +441,8 @@ func resourceAwsLaunchConfigurationDelete(d *schema.ResourceData, meta interface
 			LaunchConfigurationName: aws.String(d.Id()),
 		})
 	if err != nil {
-		autoscalingerr, ok := err.(aws.APIError)
-		if ok && autoscalingerr.Code == "InvalidConfiguration.NotFound" {
+		autoscalingerr, ok := err.(awserr.Error)
+		if ok && autoscalingerr.Code() == "InvalidConfiguration.NotFound" {
 			return nil
 		}
 

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -119,11 +120,11 @@ func testAccCheckAWSLaunchConfigurationDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		providerErr, ok := err.(aws.APIError)
+		providerErr, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if providerErr.Code != "InvalidLaunchConfiguration.NotFound" {
+		if providerErr.Code() != "InvalidLaunchConfiguration.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/elb"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -90,7 +91,7 @@ func resourceAwsLBCookieStickinessPolicyRead(d *schema.ResourceData, meta interf
 
 	getResp, err := elbconn.DescribeLoadBalancerPolicies(request)
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "PolicyNotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "PolicyNotFound" {
 			// The policy is gone.
 			d.SetId("")
 			return nil

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -393,8 +394,8 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 			NetworkACLID: aws.String(d.Id()),
 		})
 		if err != nil {
-			ec2err := err.(aws.APIError)
-			switch ec2err.Code {
+			ec2err := err.(awserr.Error)
+			switch ec2err.Code() {
 			case "InvalidNetworkAclID.NotFound":
 				return nil
 			case "DependencyViolation":

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -244,12 +245,12 @@ func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
 		// Confirm error code is what we want
-		if ec2err.Code != "InvalidNetworkAclID.NotFound" {
+		if ec2err.Code() != "InvalidNetworkAclID.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -102,7 +103,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	describeResp, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
 
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidNetworkInterfaceID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidNetworkInterfaceID.NotFound" {
 			// The ENI is gone now, so just remove it from the state
 			d.SetId("")
 			return nil

--- a/builtin/providers/aws/resource_aws_network_interface_test.go
+++ b/builtin/providers/aws/resource_aws_network_interface_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -155,7 +156,7 @@ func testAccCheckAWSENIDestroy(s *terraform.State) error {
 		_, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
 
 		if err != nil {
-			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidNetworkInterfaceID.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidNetworkInterfaceID.NotFound" {
 				return nil
 			}
 

--- a/builtin/providers/aws/resource_aws_proxy_protocol_policy.go
+++ b/builtin/providers/aws/resource_aws_proxy_protocol_policy.go
@@ -165,6 +165,7 @@ func resourceAwsProxyProtocolPolicyDelete(d *schema.ResourceData, meta interface
 	req := &elb.DescribeLoadBalancersInput{
 		LoadBalancerNames: []*string{elbname},
 	}
+	var err error
 	resp, err := elbconn.DescribeLoadBalancers(req)
 	if err != nil {
 		if isLoadBalancerNotFound(err) {

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/route53"
 )
 
@@ -78,6 +79,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", *req.Name)
+	var err error
 	resp, err := r53.CreateHostedZone(req)
 	if err != nil {
 		return err
@@ -114,7 +116,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 	zone, err := r53.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(d.Id())})
 	if err != nil {
 		// Handle a deleted zone
-		if r53err, ok := err.(aws.APIError); ok && r53err.Code == "NoSuchHostedZone" {
+		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/route53"
 )
 
@@ -56,6 +57,7 @@ func resourceAwsRoute53ZoneAssociationCreate(d *schema.ResourceData, meta interf
 	}
 
 	log.Printf("[DEBUG] Associating Route53 Private Zone %s with VPC %s with region %s", *req.HostedZoneID, *req.VPC.VPCID, *req.VPC.VPCRegion)
+	var err error
 	resp, err := r53.AssociateVPCWithHostedZone(req)
 	if err != nil {
 		return err
@@ -93,7 +95,7 @@ func resourceAwsRoute53ZoneAssociationRead(d *schema.ResourceData, meta interfac
 	zone, err := r53.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone_id)})
 	if err != nil {
 		// Handle a deleted zone
-		if r53err, ok := err.(aws.APIError); ok && r53err.Code == "NoSuchHostedZone" {
+		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/aws/resource_aws_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_route_table_association.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -102,8 +103,8 @@ func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interfa
 	resp, err := conn.ReplaceRouteTableAssociation(req)
 
 	if err != nil {
-		ec2err, ok := err.(aws.APIError)
-		if ok && ec2err.Code == "InvalidAssociationID.NotFound" {
+		ec2err, ok := err.(awserr.Error)
+		if ok && ec2err.Code() == "InvalidAssociationID.NotFound" {
 			// Not found, so just create a new one
 			return resourceAwsRouteTableAssociationCreate(d, meta)
 		}
@@ -126,8 +127,8 @@ func resourceAwsRouteTableAssociationDelete(d *schema.ResourceData, meta interfa
 		AssociationID: aws.String(d.Id()),
 	})
 	if err != nil {
-		ec2err, ok := err.(aws.APIError)
-		if ok && ec2err.Code == "InvalidAssociationID.NotFound" {
+		ec2err, ok := err.(awserr.Error)
+		if ok && ec2err.Code() == "InvalidAssociationID.NotFound" {
 			return nil
 		}
 

--- a/builtin/providers/aws/resource_aws_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_association_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -51,11 +52,11 @@ func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
 		})
 		if err != nil {
 			// Verify the error is what we want
-			ec2err, ok := err.(aws.APIError)
+			ec2err, ok := err.(awserr.Error)
 			if !ok {
 				return err
 			}
-			if ec2err.Code != "InvalidRouteTableID.NotFound" {
+			if ec2err.Code() != "InvalidRouteTableID.NotFound" {
 				return err
 			}
 			return nil

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -171,11 +172,11 @@ func testAccCheckRouteTableDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidRouteTableID.NotFound" {
+		if ec2err.Code() != "InvalidRouteTableID.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/s3"
 )
 
@@ -146,11 +147,12 @@ func resourceAwsS3BucketUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
-	_, err := s3conn.HeadBucket(&s3.HeadBucketInput{
+	var err error
+	_, err = s3conn.HeadBucket(&s3.HeadBucketInput{
 		Bucket: aws.String(d.Id()),
 	})
 	if err != nil {
-		if awsError, ok := err.(aws.APIError); ok && awsError.StatusCode == 404 {
+		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() == 404 {
 			d.SetId("")
 		} else {
 			// some of the AWS SDK's errors can be empty strings, so let's add

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -244,9 +245,9 @@ func findResourceSecurityGroup(conn *ec2.EC2, id string) (*ec2.SecurityGroup, er
 	}
 	resp, err := conn.DescribeSecurityGroups(req)
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok {
-			if ec2err.Code == "InvalidSecurityGroupID.NotFound" ||
-				ec2err.Code == "InvalidGroup.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok {
+			if ec2err.Code() == "InvalidSecurityGroupID.NotFound" ||
+				ec2err.Code() == "InvalidGroup.NotFound" {
 				resp = nil
 				err = nil
 			}

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -216,12 +217,12 @@ func testAccCheckAWSSecurityGroupRuleDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
 		// Confirm error code is what we want
-		if ec2err.Code != "InvalidGroup.NotFound" {
+		if ec2err.Code() != "InvalidGroup.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -310,12 +311,12 @@ func testAccCheckAWSSecurityGroupDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
 		// Confirm error code is what we want
-		if ec2err.Code != "InvalidGroup.NotFound" {
+		if ec2err.Code() != "InvalidGroup.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -12,15 +12,14 @@ import (
 )
 
 var AttributeMap = map[string]string{
-	"delay_seconds" : "DelaySeconds",
-	"max_message_size" : "MaximumMessageSize",
-	"message_retention_seconds" : "MessageRetentionPeriod",
-	"receive_wait_time_seconds" : "ReceiveMessageWaitTimeSeconds",
-	"visibility_timeout_seconds" : "VisibilityTimeout",
-	"policy" : "Policy",
-	"redrive_policy": "RedrivePolicy",
+	"delay_seconds":              "DelaySeconds",
+	"max_message_size":           "MaximumMessageSize",
+	"message_retention_seconds":  "MessageRetentionPeriod",
+	"receive_wait_time_seconds":  "ReceiveMessageWaitTimeSeconds",
+	"visibility_timeout_seconds": "VisibilityTimeout",
+	"policy":                     "Policy",
+	"redrive_policy":             "RedrivePolicy",
 }
-
 
 // A number of these are marked as computed because if you don't
 // provide a value, SQS will provide you with defaults (which are the
@@ -39,12 +38,12 @@ func resourceAwsSqsQueue() *schema.Resource {
 				ForceNew: true,
 			},
 			"delay_seconds": &schema.Schema{
-				Type: 	  schema.TypeInt,
+				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
 			"max_message_size": &schema.Schema{
-				Type:	  schema.TypeInt,
+				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
@@ -79,14 +78,14 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	sqsconn := meta.(*AWSClient).sqsconn
 
 	name := d.Get("name").(string)
- 
+
 	log.Printf("[DEBUG] SQS queue create: %s", name)
 
 	req := &sqs.CreateQueueInput{
 		QueueName: aws.String(name),
 	}
 
-	attributes := make(map[string]*string) 
+	attributes := make(map[string]*string)
 
 	resource := *resourceAwsSqsQueue()
 
@@ -139,11 +138,11 @@ func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if len(attributes) > 0 {
 		req := &sqs.SetQueueAttributesInput{
-			QueueURL: aws.String(d.Id()), 
+			QueueURL:   aws.String(d.Id()),
 			Attributes: &attributes,
 		}
 		sqsconn.SetQueueAttributes(req)
-	} 
+	}
 
 	return resourceAwsSqsQueueRead(d, meta)
 }
@@ -152,7 +151,7 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	sqsconn := meta.(*AWSClient).sqsconn
 
 	attributeOutput, err := sqsconn.GetQueueAttributes(&sqs.GetQueueAttributesInput{
-		QueueURL: aws.String(d.Id()),
+		QueueURL:       aws.String(d.Id()),
 		AttributeNames: []*string{aws.String("All")},
 	})
 	if err != nil {
@@ -167,7 +166,7 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 			if attrmap[oKey] != nil {
 				if resource.Schema[iKey].Type == schema.TypeInt {
 					value, err := strconv.Atoi(*attrmap[oKey])
-					if  err != nil {
+					if err != nil {
 						return err
 					}
 					d.Set(iKey, value)
@@ -193,5 +192,3 @@ func resourceAwsSqsQueueDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	return nil
 }
-
-

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/sqs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -32,7 +33,6 @@ func TestAccAWSSQSQueue(t *testing.T) {
 	})
 }
 
-
 func testAccCheckAWSSQSQueueDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sqsconn
 
@@ -51,7 +51,7 @@ func testAccCheckAWSSQSQueueDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		_, ok := err.(aws.APIError)
+		_, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
@@ -59,7 +59,6 @@ func testAccCheckAWSSQSQueueDestroy(s *terraform.State) error {
 
 	return nil
 }
-
 
 func testAccCheckAWSSQSExistsWithDefaults(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -75,7 +74,7 @@ func testAccCheckAWSSQSExistsWithDefaults(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).sqsconn
 
 		params := &sqs.GetQueueAttributesInput{
-			QueueURL: aws.String(rs.Primary.ID),
+			QueueURL:       aws.String(rs.Primary.ID),
 			AttributeNames: []*string{aws.String("All")},
 		}
 		resp, err := conn.GetQueueAttributes(params)
@@ -125,7 +124,7 @@ func testAccCheckAWSSQSExistsWithOverrides(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).sqsconn
 
 		params := &sqs.GetQueueAttributesInput{
-			QueueURL: aws.String(rs.Primary.ID),
+			QueueURL:       aws.String(rs.Primary.ID),
 			AttributeNames: []*string{aws.String("All")},
 		}
 		resp, err := conn.GetQueueAttributes(params)

--- a/builtin/providers/aws/resource_aws_subnet_test.go
+++ b/builtin/providers/aws/resource_aws_subnet_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -63,11 +64,11 @@ func testAccCheckSubnetDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidSubnetID.NotFound" {
+		if ec2err.Code() != "InvalidSubnetID.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -247,8 +248,8 @@ func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[INFO] Deleting VPC: %s", d.Id())
 	if _, err := conn.DeleteVPC(DeleteVpcOpts); err != nil {
-		ec2err, ok := err.(aws.APIError)
-		if ok && ec2err.Code == "InvalidVpcID.NotFound" {
+		ec2err, ok := err.(awserr.Error)
+		if ok && ec2err.Code() == "InvalidVpcID.NotFound" {
 			return nil
 		}
 
@@ -267,7 +268,7 @@ func VPCStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 		}
 		resp, err := conn.DescribeVPCs(DescribeVpcOpts)
 		if err != nil {
-			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpcID.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpcID.NotFound" {
 				resp = nil
 			} else {
 				log.Printf("Error on VPCStateRefresh: %s", err)

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -58,11 +59,11 @@ func testAccCheckDHCPOptionsDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidDhcpOptionsID.NotFound" {
+		if ec2err.Code() != "InvalidDhcpOptionsID.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -179,7 +180,7 @@ func resourceAwsVPCPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) r
 			VPCPeeringConnectionIDs: []*string{aws.String(id)},
 		})
 		if err != nil {
-			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpcPeeringConnectionID.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpcPeeringConnectionID.NotFound" {
 				resp = nil
 			} else {
 				log.Printf("Error on VPCPeeringConnectionStateRefresh: %s", err)

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -133,11 +134,11 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidVpcID.NotFound" {
+		if ec2err.Code() != "InvalidVpcID.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -200,7 +201,7 @@ func vpnConnectionRefreshFunc(conn *ec2.EC2, connectionId string) resource.State
 		})
 
 		if err != nil {
-			if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpnConnectionID.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
 				resp = nil
 			} else {
 				log.Printf("Error on VPNConnectionRefresh: %s", err)
@@ -224,7 +225,7 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 		VPNConnectionIDs: []*string{aws.String(d.Id())},
 	})
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpnConnectionID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
 			d.SetId("")
 			return nil
 		} else {
@@ -285,7 +286,7 @@ func resourceAwsVpnConnectionDelete(d *schema.ResourceData, meta interface{}) er
 		VPNConnectionID: aws.String(d.Id()),
 	})
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpnConnectionID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
 			d.SetId("")
 			return nil
 		} else {

--- a/builtin/providers/aws/resource_aws_vpn_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -135,11 +136,11 @@ func testAccCheckVpnGatewayDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(aws.APIError)
+		ec2err, ok := err.(awserr.Error)
 		if !ok {
 			return err
 		}
-		if ec2err.Code != "InvalidVpnGatewayID.NotFound" {
+		if ec2err.Code() != "InvalidVpnGatewayID.NotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_vpn_connection_route.go
+++ b/builtin/providers/aws/resource_vpn_connection_route.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -82,7 +83,7 @@ func resourceAwsVpnConnectionRouteRead(d *schema.ResourceData, meta interface{})
 		Filters: routeFilters,
 	})
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpnConnectionID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
 			d.SetId("")
 			return nil
 		} else {
@@ -117,7 +118,7 @@ func resourceAwsVpnConnectionRouteDelete(d *schema.ResourceData, meta interface{
 		VPNConnectionID:      aws.String(d.Get("vpn_connection_id").(string)),
 	})
 	if err != nil {
-		if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "InvalidVpnConnectionID.NotFound" {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
 			d.SetId("")
 			return nil
 		} else {

--- a/builtin/providers/aws/s3_tags.go
+++ b/builtin/providers/aws/s3_tags.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -101,7 +102,7 @@ func getTagSetS3(s3conn *s3.S3, bucket string) ([]*s3.Tag, error) {
 	}
 
 	response, err := s3conn.GetBucketTagging(request)
-	if ec2err, ok := err.(aws.APIError); ok && ec2err.Code == "NoSuchTagSet" {
+	if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "NoSuchTagSet" {
 		// There is no tag set associated with the bucket.
 		return []*s3.Tag{}, nil
 	} else if err != nil {

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
 	"github.com/awslabs/aws-sdk-go/aws/credentials"
 	"github.com/awslabs/aws-sdk-go/service/s3"
 )
@@ -78,8 +79,8 @@ func (c *S3Client) Get() (*Payload, error) {
 	})
 
 	if err != nil {
-		if awserr := aws.Error(err); awserr != nil {
-			if awserr.Code == "NoSuchKey" {
+		if awserr := awserr.Error(err); awserr != nil {
+			if awserr.Code() == "NoSuchKey" {
 				return nil, nil
 			} else {
 				return nil, err


### PR DESCRIPTION
This landed in aws-sdk-go yesterday, breaking the AWS provider in many places:

https://github.com/awslabs/aws-sdk-go/commit/3c259c9586a4a82d6f00e7c01a69263f798e8ffe

Here, with much sedding, grepping, and manual massaging, we attempt to
catch Terraform up to the new `awserr.Error` interface world.