### PR TITLE
providers/aws: Move up where we assign tags on Instance

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -679,6 +679,11 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	d.Partial(true)
+	if err := setTags(conn, d); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
 
 	// SourceDestCheck can only be set on VPC instances
 	if d.Get("subnet_id").(string) != "" {
@@ -725,11 +730,6 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	// TODO(mitchellh): wait for the attributes we modified to
 	// persist the change...
 
-	if err := setTags(conn, d); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
-	}
 	d.Partial(false)
 
 	return resourceAwsInstanceRead(d, meta)


### PR DESCRIPTION
Takes care of #2025 
Acceptance tests pass, shouldn't be any issue here.