### PR TITLE
Upd vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,9 +13,9 @@ cd /opt/go/src && ./all.bash
 
 # Setup the GOPATH
 mkdir -p /opt/gopath
-cat <<EOF >/etc/profile.d/gopath.sh
+cat << 'EOF' >/etc/profile.d/gopath.sh
 export GOPATH="/opt/gopath"
-export PATH="/opt/go/bin:\$GOPATH/bin:\$PATH"
+export PATH="/opt/go/bin:$GOPATH/bin:$PATH"
 EOF
 
 # Make sure the GOPATH is usable by vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ chown -R vagrant:vagrant /opt/gopath
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/ubuntu-12.04"
+  config.vm.box = "chef/ubuntu-14.04"
 
   config.vm.provision "shell", inline: $script
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,9 @@ $script = <<SCRIPT
 # Install Go and prerequisites
 apt-get -qq update
 apt-get -qq install build-essential curl git-core libpcre3-dev mercurial pkg-config zip
-hg clone -u release https://code.google.com/p/go /opt/go
+git clone https://go.googlesource.com/go /opt/go
+cd /opt/go
+git checkout release-branch.go1.4
 cd /opt/go/src && ./all.bash
 
 # Setup the GOPATH


### PR DESCRIPTION
Updated Vagrantfile to:
use modern Ubuntu (14.04) chef box
properly create /etc/init.d/gopath.sh preventing shell interpretation of variables during creation
install Go from source using latest Google instructions (git repo) from https://golang.org/doc/install/source
