### PR TITLE
provider/template: store relative path in state

### DIFF
--- a/builtin/providers/template/resource.go
+++ b/builtin/providers/template/resource.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/lang"
@@ -26,6 +28,18 @@ func resource() *schema.Resource {
 				Required:    true,
 				Description: "file to read template from",
 				ForceNew:    true,
+				// Make a "best effort" attempt to relativize the file path.
+				StateFunc: func(v interface{}) string {
+					pwd, err := os.Getwd()
+					if err != nil {
+						return v.(string)
+					}
+					rel, err := filepath.Rel(pwd, v.(string))
+					if err != nil {
+						return v.(string)
+					}
+					return rel
+				},
 			},
 			"vars": &schema.Schema{
 				Type:        schema.TypeMap,


### PR DESCRIPTION
This makes template_file usage in modules portable.