### PR TITLE
Clarify syntax for RDS maintenance window param

### DIFF
--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 * `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
     storage_type of "io1".
 * `maintenance_window` - (Optional) The window to perform maintenance in.
+  Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00".
 * `multi_az` - (Optional) Specifies if the RDS instance is multi-AZ
 * `port` - (Optional) The port on which the DB accepts connections.
 * `publicly_accessible` - (Optional) Bool to control if instance is publicly accessible.


### PR DESCRIPTION
The docs don't suggest a maintenance window for RDS maintenance windows,
even though they can be set. Commit provides syntax as well as example to
make this feature more obvious in future.

Uses syntax as mentioned in awslabs/aws-sdk-go at
https://github.com/awslabs/aws-sdk-go/blob/master/service/rds/api.go#L5285

Thanks to Rahul on terraform-tool mailing list for pointing me at that.