### PR TITLE
providers/aws: Clarifies db_security_group usage docs.

### DIFF
--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -101,4 +101,7 @@ The following attributes are exported:
 * `storage_encrypted` - Specifies whether the DB instance is encrypted
 
 
+~> For a more detailed documentation about the different parameters please refer to
+the [AWS official documentation](http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-ModifyDBInstance.html)
+
 [1]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html

--- a/website/source/docs/providers/aws/r/db_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_security_group.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # aws\_db\_security\_group
 
-Provides an RDS security group resource.
+Provides an RDS security group resource. This is only for DB instances in the
+EC2-Classic Platform. For instances inside a VPC, use the
+[`aws_db_instance.vpc_security_group_ids`](/docs/providers/aws/r/db_instance.html#vpc_security_group_ids)
+attribute instead.
 
 ## Example Usage
 


### PR DESCRIPTION
* `db_security_group` is only intended to be used in EC2-Classic Platform.
For DB instances in a VPC, we associate VPC security groups instead,
when declaring the `db_instance` resource.

* `db_instance` passwords are limited to 41 characters by AWS.