### PR TITLE
WIP Spot bids as separate resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -105,6 +105,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_role":                     resourceAwsIamRole(),
 			"aws_iam_user_policy":              resourceAwsIamUserPolicy(),
 			"aws_iam_user":                     resourceAwsIamUser(),
+			"aws_spot_bid":                     resourceAwsSpotBid(),
 			"aws_instance":                     resourceAwsInstance(),
 			"aws_internet_gateway":             resourceAwsInternetGateway(),
 			"aws_key_pair":                     resourceAwsKeyPair(),

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -68,18 +68,7 @@ func resourceAwsInstance() *schema.Resource {
 				Computed: true,
 			},
 
-			// Fallback to on demand if spot bid fails
-			"spot_fallback": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
-			"spot_persist": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
-			"spot_price": &schema.Schema{
+			"spot_request": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -135,11 +124,6 @@ func resourceAwsInstance() *schema.Resource {
 				Set: func(v interface{}) int {
 					return hashcode.String(v.(string))
 				},
-			},
-
-			"spot_request_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 
 			"public_dns": &schema.Schema{
@@ -333,297 +317,210 @@ func resourceAwsInstance() *schema.Resource {
 func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	// Figure out user data
-	userData := ""
-	if v := d.Get("user_data"); v != nil {
-		userData = base64.StdEncoding.EncodeToString([]byte(v.(string)))
-	}
+	if d.Get("spot_request").(string) != "" {
 
-	// check for non-default Subnet, and cast it to a String
-	var hasSubnet bool
-	subnet, hasSubnet := d.GetOk("subnet_id")
-	subnetID := subnet.(string)
-
-	placement := &ec2.Placement{
-		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
-		GroupName:        aws.String(d.Get("placement_group").(string)),
-	}
-
-	if hasSubnet {
-		// Tenancy is only valid inside a VPC
-		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Placement.html
-		if v := d.Get("tenancy").(string); v != "" {
-			placement.Tenancy = aws.String(v)
-		}
-	}
-
-	iam := &ec2.IAMInstanceProfileSpecification{
-		Name: aws.String(d.Get("iam_instance_profile").(string)),
-	}
-
-	// Build the creation struct
-	runOpts := &ec2.RunInstancesInput{
-		ImageID:               aws.String(d.Get("ami").(string)),
-		Placement:             placement,
-		InstanceType:          aws.String(d.Get("instance_type").(string)),
-		MaxCount:              aws.Long(int64(1)),
-		MinCount:              aws.Long(int64(1)),
-		UserData:              aws.String(userData),
-		EBSOptimized:          aws.Boolean(d.Get("ebs_optimized").(bool)),
-		DisableAPITermination: aws.Boolean(d.Get("disable_api_termination").(bool)),
-		IAMInstanceProfile:    iam,
-	}
-
-	associatePublicIPAddress := false
-	if v := d.Get("associate_public_ip_address"); v != nil {
-		associatePublicIPAddress = v.(bool)
-	}
-
-	var groups []*string
-	if v := d.Get("security_groups"); v != nil {
-		// Security group names.
-		// For a nondefault VPC, you must use security group IDs instead.
-		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
-		sgs := v.(*schema.Set).List()
-		if len(sgs) > 0 && hasSubnet {
-			log.Printf("[WARN] Deprecated. Attempting to use 'security_groups' within a VPC instance. Use 'vpc_security_group_ids' instead.")
-		}
-		for _, v := range sgs {
-			str := v.(string)
-			groups = append(groups, aws.String(str))
-		}
-	}
-
-	if hasSubnet && associatePublicIPAddress {
-		// If we have a non-default VPC / Subnet specified, we can flag
-		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
-		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise
-		// you get: Network interfaces and an instance-level subnet ID may not be specified on the same request
-		// You also need to attach Security Groups to the NetworkInterface instead of the instance,
-		// to avoid: Network interfaces and an instance-level security groups may not be specified on
-		// the same request
-		ni := &ec2.InstanceNetworkInterfaceSpecification{
-			AssociatePublicIPAddress: aws.Boolean(associatePublicIPAddress),
-			DeviceIndex:              aws.Long(int64(0)),
-			SubnetID:                 aws.String(subnetID),
-			Groups:                   groups,
+		// Figure out user data
+		userData := ""
+		if v := d.Get("user_data"); v != nil {
+			userData = base64.StdEncoding.EncodeToString([]byte(v.(string)))
 		}
 
-		if v, ok := d.GetOk("private_ip"); ok {
-			ni.PrivateIPAddress = aws.String(v.(string))
-		}
+		// check for non-default Subnet, and cast it to a String
+		var hasSubnet bool
+		subnet, hasSubnet := d.GetOk("subnet_id")
+		subnetID := subnet.(string)
 
-		if v := d.Get("vpc_security_group_ids"); v != nil {
-			for _, v := range v.(*schema.Set).List() {
-				ni.Groups = append(ni.Groups, aws.String(v.(string)))
-			}
-		}
-
-		runOpts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
-	} else {
-		if subnetID != "" {
-			runOpts.SubnetID = aws.String(subnetID)
-		}
-
-		if v, ok := d.GetOk("private_ip"); ok {
-			runOpts.PrivateIPAddress = aws.String(v.(string))
-		}
-		if runOpts.SubnetID != nil &&
-			*runOpts.SubnetID != "" {
-			runOpts.SecurityGroupIDs = groups
-		} else {
-			runOpts.SecurityGroups = groups
-		}
-
-		if v := d.Get("vpc_security_group_ids"); v != nil {
-			for _, v := range v.(*schema.Set).List() {
-				runOpts.SecurityGroupIDs = append(runOpts.SecurityGroupIDs, aws.String(v.(string)))
-			}
-		}
-	}
-
-	if v, ok := d.GetOk("key_name"); ok {
-		runOpts.KeyName = aws.String(v.(string))
-	}
-
-	blockDevices := make([]*ec2.BlockDeviceMapping, 0)
-
-	if v, ok := d.GetOk("ebs_block_device"); ok {
-		vL := v.(*schema.Set).List()
-		for _, v := range vL {
-			bd := v.(map[string]interface{})
-			ebs := &ec2.EBSBlockDevice{
-				DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
-				Encrypted:           aws.Boolean(bd["encrypted"].(bool)),
-			}
-
-			if v, ok := bd["snapshot_id"].(string); ok && v != "" {
-				ebs.SnapshotID = aws.String(v)
-			}
-
-			if v, ok := bd["volume_size"].(int); ok && v != 0 {
-				ebs.VolumeSize = aws.Long(int64(v))
-			}
-
-			if v, ok := bd["volume_type"].(string); ok && v != "" {
-				ebs.VolumeType = aws.String(v)
-			}
-
-			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Long(int64(v))
-			}
-
-			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
-				DeviceName: aws.String(bd["device_name"].(string)),
-				EBS:        ebs,
-			})
-		}
-	}
-
-	if v, ok := d.GetOk("ephemeral_block_device"); ok {
-		vL := v.(*schema.Set).List()
-		for _, v := range vL {
-			bd := v.(map[string]interface{})
-			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
-				DeviceName:  aws.String(bd["device_name"].(string)),
-				VirtualName: aws.String(bd["virtual_name"].(string)),
-			})
-		}
-	}
-
-	if v, ok := d.GetOk("root_block_device"); ok {
-		vL := v.(*schema.Set).List()
-		if len(vL) > 1 {
-			return fmt.Errorf("Cannot specify more than one root_block_device.")
-		}
-		for _, v := range vL {
-			bd := v.(map[string]interface{})
-			ebs := &ec2.EBSBlockDevice{
-				DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
-			}
-
-			if v, ok := bd["volume_size"].(int); ok && v != 0 {
-				ebs.VolumeSize = aws.Long(int64(v))
-			}
-
-			if v, ok := bd["volume_type"].(string); ok && v != "" {
-				ebs.VolumeType = aws.String(v)
-			}
-
-			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Long(int64(v))
-			}
-
-			if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {
-				if dn == nil {
-					return fmt.Errorf(
-						"Expected 1 AMI for ID: %s, got none",
-						d.Get("ami").(string))
-				}
-
-				blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
-					DeviceName: dn,
-					EBS:        ebs,
-				})
-			} else {
-				return err
-			}
-		}
-	}
-
-	if len(blockDevices) > 0 {
-		runOpts.BlockDeviceMappings = blockDevices
-	}
-
-	instanceID := ""
-	onDemand := true
-
-	if sp := d.Get("spot_price").(string); sp != "" {
-		// FIXME: check that instance type is not t2.micro, t2.small, or t2.medium
-
-		onDemand = false
-		// FIXME: validate spot price casts to a sensible decimal
-
-		spotPlacement := &ec2.SpotPlacement{
+		placement := &ec2.Placement{
 			AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
 			GroupName:        aws.String(d.Get("placement_group").(string)),
 		}
 
-		launchSpec := &ec2.RequestSpotLaunchSpecification{
-			Placement:           spotPlacement,
-			BlockDeviceMappings: runOpts.BlockDeviceMappings,
-			ImageID:             runOpts.ImageID,
-			InstanceType:        runOpts.InstanceType,
-			UserData:            runOpts.UserData,
-			EBSOptimized:        runOpts.EBSOptimized,
-			IAMInstanceProfile:  runOpts.IAMInstanceProfile,
-			NetworkInterfaces:   runOpts.NetworkInterfaces,
+		if hasSubnet {
+			// Tenancy is only valid inside a VPC
+			// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Placement.html
+			if v := d.Get("tenancy").(string); v != "" {
+				placement.Tenancy = aws.String(v)
+			}
 		}
 
-		if runOpts.SubnetID != nil {
-			launchSpec.SubnetID = runOpts.SubnetID
+		iam := &ec2.IAMInstanceProfileSpecification{
+			Name: aws.String(d.Get("iam_instance_profile").(string)),
 		}
 
-		if runOpts.SecurityGroupIDs != nil {
-			launchSpec.SecurityGroupIDs = runOpts.SecurityGroupIDs
+		// Build the creation struct
+		runOpts := &ec2.RunInstancesInput{
+			ImageID:               aws.String(d.Get("ami").(string)),
+			Placement:             placement,
+			InstanceType:          aws.String(d.Get("instance_type").(string)),
+			MaxCount:              aws.Long(int64(1)),
+			MinCount:              aws.Long(int64(1)),
+			UserData:              aws.String(userData),
+			EBSOptimized:          aws.Boolean(d.Get("ebs_optimized").(bool)),
+			DisableAPITermination: aws.Boolean(d.Get("disable_api_termination").(bool)),
+			IAMInstanceProfile:    iam,
 		}
 
-		if runOpts.SecurityGroups != nil {
-			launchSpec.SecurityGroups = runOpts.SecurityGroups
+		associatePublicIPAddress := false
+		if v := d.Get("associate_public_ip_address"); v != nil {
+			associatePublicIPAddress = v.(bool)
 		}
 
-		if runOpts.KeyName != nil {
-			launchSpec.KeyName = runOpts.KeyName
+		var groups []*string
+		if v := d.Get("security_groups"); v != nil {
+			// Security group names.
+			// For a nondefault VPC, you must use security group IDs instead.
+			// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
+			sgs := v.(*schema.Set).List()
+			if len(sgs) > 0 && hasSubnet {
+				log.Printf("[WARN] Deprecated. Attempting to use 'security_groups' within a VPC instance. Use 'vpc_security_group_ids' instead.")
+			}
+			for _, v := range sgs {
+				str := v.(string)
+				groups = append(groups, aws.String(str))
+			}
 		}
 
-		spotType := "one-time"
+		if hasSubnet && associatePublicIPAddress {
+			// If we have a non-default VPC / Subnet specified, we can flag
+			// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
+			// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise
+			// you get: Network interfaces and an instance-level subnet ID may not be specified on the same request
+			// You also need to attach Security Groups to the NetworkInterface instead of the instance,
+			// to avoid: Network interfaces and an instance-level security groups may not be specified on
+			// the same request
+			ni := &ec2.InstanceNetworkInterfaceSpecification{
+				AssociatePublicIPAddress: aws.Boolean(associatePublicIPAddress),
+				DeviceIndex:              aws.Long(int64(0)),
+				SubnetID:                 aws.String(subnetID),
+				Groups:                   groups,
+			}
 
-		if d.Get("spot_persist").(bool) {
-			spotType = "persistent"
-		}
-		// Build the spot instance struct
-		spotOpts := &ec2.RequestSpotInstancesInput{
-			SpotPrice:           aws.String(sp),
-			Type:                aws.String(spotType),
-			InstanceCount:       aws.Long(1),
-			LaunchSpecification: launchSpec,
-		}
+			if v, ok := d.GetOk("private_ip"); ok {
+				ni.PrivateIPAddress = aws.String(v.(string))
+			}
 
-		// Make the spot instance request
-		var spotResp *ec2.RequestSpotInstancesOutput
-		spotResp, err := conn.RequestSpotInstances(spotOpts)
+			if v := d.Get("vpc_security_group_ids"); v != nil {
+				for _, v := range v.(*schema.Set).List() {
+					ni.Groups = append(ni.Groups, aws.String(v.(string)))
+				}
+			}
 
-		request_id := *spotResp.SpotInstanceRequests[0].SpotInstanceRequestID
-		d.Set("spot_request_id", request_id)
-
-		spotStateConf := &resource.StateChangeConf{
-			// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html
-			Pending:    []string{"start", "pending-evaluation", "pending-fulfillment"},
-			Target:     "fulfilled",
-			Refresh:    SpotInstanceStateRefreshFunc(conn, request_id),
-			Timeout:    10 * time.Minute,
-			Delay:      10 * time.Second,
-			MinTimeout: 3 * time.Second,
-		}
-
-		log.Printf("[DEBUG] waiting for spot bid to resolve... this may take several minutes.")
-		spotRequestRaw, err := spotStateConf.WaitForState()
-		spotRequest := spotRequestRaw.(*ec2.SpotInstanceRequest)
-
-		fallback := d.Get("spot_fallback").(bool)
-
-		if err != nil && !fallback {
-			return fmt.Errorf("Error while waiting for spot request (%s) to resolve: %s", request_id, err)
-		} else if fallback {
-			log.Printf("[DEBUG] unable to fulfill spot request (%s) because %s", request_id, err)
-			// FIXME cancel the spot request before falling back to on demand
-			onDemand = true
+			runOpts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
 		} else {
-			instanceID = *spotRequest.InstanceID
-		}
-	}
+			if subnetID != "" {
+				runOpts.SubnetID = aws.String(subnetID)
+			}
 
-	if onDemand {
+			if v, ok := d.GetOk("private_ip"); ok {
+				runOpts.PrivateIPAddress = aws.String(v.(string))
+			}
+			if runOpts.SubnetID != nil &&
+				*runOpts.SubnetID != "" {
+				runOpts.SecurityGroupIDs = groups
+			} else {
+				runOpts.SecurityGroups = groups
+			}
+
+			if v := d.Get("vpc_security_group_ids"); v != nil {
+				for _, v := range v.(*schema.Set).List() {
+					runOpts.SecurityGroupIDs = append(runOpts.SecurityGroupIDs, aws.String(v.(string)))
+				}
+			}
+		}
+
+		if v, ok := d.GetOk("key_name"); ok {
+			runOpts.KeyName = aws.String(v.(string))
+		}
+
+		blockDevices := make([]*ec2.BlockDeviceMapping, 0)
+
+		if v, ok := d.GetOk("ebs_block_device"); ok {
+			vL := v.(*schema.Set).List()
+			for _, v := range vL {
+				bd := v.(map[string]interface{})
+				ebs := &ec2.EBSBlockDevice{
+					DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
+					Encrypted:           aws.Boolean(bd["encrypted"].(bool)),
+				}
+
+				if v, ok := bd["snapshot_id"].(string); ok && v != "" {
+					ebs.SnapshotID = aws.String(v)
+				}
+
+				if v, ok := bd["volume_size"].(int); ok && v != 0 {
+					ebs.VolumeSize = aws.Long(int64(v))
+				}
+
+				if v, ok := bd["volume_type"].(string); ok && v != "" {
+					ebs.VolumeType = aws.String(v)
+				}
+
+				if v, ok := bd["iops"].(int); ok && v > 0 {
+					ebs.IOPS = aws.Long(int64(v))
+				}
+
+				blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+					DeviceName: aws.String(bd["device_name"].(string)),
+					EBS:        ebs,
+				})
+			}
+		}
+
+		if v, ok := d.GetOk("ephemeral_block_device"); ok {
+			vL := v.(*schema.Set).List()
+			for _, v := range vL {
+				bd := v.(map[string]interface{})
+				blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+					DeviceName:  aws.String(bd["device_name"].(string)),
+					VirtualName: aws.String(bd["virtual_name"].(string)),
+				})
+			}
+		}
+
+		if v, ok := d.GetOk("root_block_device"); ok {
+			vL := v.(*schema.Set).List()
+			if len(vL) > 1 {
+				return fmt.Errorf("Cannot specify more than one root_block_device.")
+			}
+			for _, v := range vL {
+				bd := v.(map[string]interface{})
+				ebs := &ec2.EBSBlockDevice{
+					DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
+				}
+
+				if v, ok := bd["volume_size"].(int); ok && v != 0 {
+					ebs.VolumeSize = aws.Long(int64(v))
+				}
+
+				if v, ok := bd["volume_type"].(string); ok && v != "" {
+					ebs.VolumeType = aws.String(v)
+				}
+
+				if v, ok := bd["iops"].(int); ok && v > 0 {
+					ebs.IOPS = aws.Long(int64(v))
+				}
+
+				if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {
+					if dn == nil {
+						return fmt.Errorf(
+							"Expected 1 AMI for ID: %s, got none",
+							d.Get("ami").(string))
+					}
+
+					blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+						DeviceName: dn,
+						EBS:        ebs,
+					})
+				} else {
+					return err
+				}
+			}
+		}
+
+		if len(blockDevices) > 0 {
+			runOpts.BlockDeviceMappings = blockDevices
+		}
+
 		// Create the instance
 		log.Printf("[DEBUG] Run configuration: %#v", runOpts)
 		var err error
@@ -649,47 +546,13 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		instance := runResp.Instances[0]
 		log.Printf("[INFO] Instance ID: %s", *instance.InstanceID)
 
-		// Wait for the instance to become running so we can get some attributes
-		// that aren't available until later.
-		log.Printf(
-			"[DEBUG] Waiting for instance (%s) to become running",
-			*instance.InstanceID)
+		// Store the resulting ID so we can look this up later
+		d.SetId(*instance.InstanceID)
 
-		instanceID = *instance.InstanceID
-	}
-
-	// Store the resulting ID so we can look this up later
-	d.SetId(instanceID)
-
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"pending"},
-		Target:     "running",
-		Refresh:    InstanceStateRefreshFunc(conn, instanceID),
-		Timeout:    10 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	instanceRaw, err := stateConf.WaitForState()
-	if err != nil {
-		return fmt.Errorf(
-			"Error waiting for instance (%s) to become ready: %s",
-			instanceID, err)
-	}
-
-	instance := instanceRaw.(*ec2.Instance)
-
-	// Initialize the connection info
-	if instance.PublicIPAddress != nil {
-		d.SetConnInfo(map[string]string{
-			"type": "ssh",
-			"host": *instance.PublicIPAddress,
-		})
-	} else if instance.PrivateIPAddress != nil {
-		d.SetConnInfo(map[string]string{
-			"type": "ssh",
-			"host": *instance.PrivateIPAddress,
-		})
+		err = waitForInstance(conn, *instance.InstanceID)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Set our attributes
@@ -701,8 +564,53 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsInstanceUpdate(d, meta)
 }
 
+func waitForInstance(conn *ec2.EC2, instanceID string) error {
+
+	// Wait for the instance to become running so we can get some attributes
+	// that aren't available until later.
+	log.Printf(
+		"[DEBUG] Waiting for instance (%s) to become running",
+		instanceID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"pending"},
+		Target:     "running",
+		Refresh:    InstanceStateRefreshFunc(conn, instanceID),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for instance (%s) to become ready: %s",
+			instanceID, err)
+	}
+
+	return nil
+}
+
 func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
+
+	spot_request := d.Get("spot_request").(string)
+
+	if spot_request == "" && d.Id() == "" {
+		resp, _ := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+			SpotInstanceRequestIDs: []*string{aws.String(spot_request)},
+		})
+
+		req := resp.SpotInstanceRequests[0]
+		instanceID := req.InstanceID
+
+		if instanceID == nil || *instanceID == "" {
+			return nil
+		}
+
+		waitForInstance(conn, *instanceID)
+		d.SetId(*instanceID)
+	}
 
 	resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
 		InstanceIDs: []*string{aws.String(d.Id())},
@@ -726,6 +634,19 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	instance := resp.Reservations[0].Instances[0]
+
+	// Initialize the connection info
+	if instance.PublicIPAddress != nil {
+		d.SetConnInfo(map[string]string{
+			"type": "ssh",
+			"host": *instance.PublicIPAddress,
+		})
+	} else if instance.PrivateIPAddress != nil {
+		d.SetConnInfo(map[string]string{
+			"type": "ssh",
+			"host": *instance.PrivateIPAddress,
+		})
+	}
 
 	// If the instance is terminated, then it is gone
 	if *instance.State.Name == "terminated" {
@@ -869,8 +790,6 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	req := &ec2.TerminateInstancesInput{
 		InstanceIDs: []*string{aws.String(d.Id())},
 	}
-
-	// FIXME cancel spot instance request on termination
 	if _, err := conn.TerminateInstances(req); err != nil {
 		return fmt.Errorf("Error terminating instance: %s", err)
 	}
@@ -897,41 +816,6 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId("")
 	return nil
-}
-
-// SpotInstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
-// an EC2 spot instance request
-func SpotInstanceStateRefreshFunc(conn *ec2.EC2, reqID string) resource.StateRefreshFunc {
-
-	//SpotInstanceRequests
-
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
-			SpotInstanceRequestIDs: []*string{aws.String(reqID)},
-		})
-
-		// FIXME: actually do error handling instead of happy path
-		if err != nil {
-			/*
-			   if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
-			     // Set this to nil as if we didn't find anything.
-			     resp = nil
-			   } else {
-			     log.Printf("Error on InstanceStateRefresh: %s", err)
-			     return nil, "", err
-			   }
-			*/
-		}
-
-		if resp == nil || len(resp.SpotInstanceRequests) == 0 {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
-		}
-
-		req := resp.SpotInstanceRequests[0]
-		return req, *req.Status.Code, nil
-	}
 }
 
 // InstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -68,6 +68,17 @@ func resourceAwsInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			// Fallback to on demand if spot bid fails
+			"spot_fallback": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"spot_price": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"subnet_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -119,6 +130,11 @@ func resourceAwsInstance() *schema.Resource {
 				Set: func(v interface{}) int {
 					return hashcode.String(v.(string))
 				},
+			},
+
+			"spot_request_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"public_dns": &schema.Schema{
@@ -514,44 +530,130 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		runOpts.BlockDeviceMappings = blockDevices
 	}
 
-	// Create the instance
-	log.Printf("[DEBUG] Run configuration: %#v", runOpts)
-	var err error
+	instanceID := ""
+	onDemand := true
 
-	var runResp *ec2.Reservation
-	for i := 0; i < 5; i++ {
-		runResp, err = conn.RunInstances(runOpts)
-		if awsErr, ok := err.(awserr.Error); ok {
-			// IAM profiles can take ~10 seconds to propagate in AWS:
-			//  http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-			if awsErr.Code() == "InvalidParameterValue" && strings.Contains(awsErr.Message(), "Invalid IAM Instance Profile") {
-				log.Printf("[DEBUG] Invalid IAM Instance Profile referenced, retrying...")
-				time.Sleep(2 * time.Second)
-				continue
-			}
+	if sp := d.Get("spot_price").(string); sp != "" {
+		// FIXME: check that instance type is not t2.micro, t2.small, or t2.medium
+
+		onDemand = false
+		// FIXME: validate spot price casts to a sensible decimal
+
+		spotPlacement := &ec2.SpotPlacement{
+			AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
+			GroupName:        aws.String(d.Get("placement_group").(string)),
 		}
-		break
-	}
-	if err != nil {
-		return fmt.Errorf("Error launching source instance: %s", err)
+
+		launchSpec := &ec2.RequestSpotLaunchSpecification{
+			Placement:           spotPlacement,
+			BlockDeviceMappings: runOpts.BlockDeviceMappings,
+			ImageID:             runOpts.ImageID,
+			InstanceType:        runOpts.InstanceType,
+			UserData:            runOpts.UserData,
+			EBSOptimized:        runOpts.EBSOptimized,
+			IAMInstanceProfile:  runOpts.IAMInstanceProfile,
+			NetworkInterfaces:   runOpts.NetworkInterfaces,
+		}
+
+		if runOpts.SubnetID != nil {
+			launchSpec.SubnetID = runOpts.SubnetID
+		}
+
+		if runOpts.SecurityGroupIDs != nil {
+			launchSpec.SecurityGroupIDs = runOpts.SecurityGroupIDs
+		}
+
+		if runOpts.SecurityGroups != nil {
+			launchSpec.SecurityGroups = runOpts.SecurityGroups
+		}
+
+		if runOpts.KeyName != nil {
+			launchSpec.KeyName = runOpts.KeyName
+		}
+
+		// Build the spot instance struct
+		spotOpts := &ec2.RequestSpotInstancesInput{
+			SpotPrice:           aws.String(sp), // Required
+			InstanceCount:       aws.Long(1),
+			LaunchSpecification: launchSpec,
+		}
+
+		// Make the spot instance request
+		var spotResp *ec2.RequestSpotInstancesOutput
+		spotResp, err := conn.RequestSpotInstances(spotOpts)
+
+		request_id := *spotResp.SpotInstanceRequests[0].SpotInstanceRequestID
+		d.Set("spot_request_id", request_id)
+
+		spotStateConf := &resource.StateChangeConf{
+			// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html
+			Pending:    []string{"start", "pending-evaluation", "pending-fulfillment"},
+			Target:     "fulfilled",
+			Refresh:    SpotInstanceStateRefreshFunc(conn, request_id),
+			Timeout:    10 * time.Minute,
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		log.Printf("[DEBUG] waiting for spot bid to resolve... this may take several minutes.")
+		spotRequestRaw, err := spotStateConf.WaitForState()
+		spotRequest := spotRequestRaw.(*ec2.SpotInstanceRequest)
+
+		fallback := d.Get("spot_fallback").(bool)
+
+		if err != nil && !fallback {
+			return fmt.Errorf("Error while waiting for spot request (%s) to resolve: %s", request_id, err)
+		} else if fallback {
+			log.Printf("[DEBUG] unable to fulfill spot request (%s) because %s", request_id, err)
+			// FIXME cancel the spot request before falling back to on demand
+			onDemand = true
+		} else {
+			instanceID = *spotRequest.InstanceID
+		}
 	}
 
-	instance := runResp.Instances[0]
-	log.Printf("[INFO] Instance ID: %s", *instance.InstanceID)
+	if onDemand {
+		// Create the instance
+		log.Printf("[DEBUG] Run configuration: %#v", runOpts)
+		var err error
+
+		var runResp *ec2.Reservation
+		for i := 0; i < 5; i++ {
+			runResp, err = conn.RunInstances(runOpts)
+			if awsErr, ok := err.(awserr.Error); ok {
+				// IAM profiles can take ~10 seconds to propagate in AWS:
+				//  http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
+				if awsErr.Code() == "InvalidParameterValue" && strings.Contains(awsErr.Message(), "Invalid IAM Instance Profile") {
+					log.Printf("[DEBUG] Invalid IAM Instance Profile referenced, retrying...")
+					time.Sleep(2 * time.Second)
+					continue
+				}
+			}
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("Error launching source instance: %s", err)
+		}
+
+		instance := runResp.Instances[0]
+		log.Printf("[INFO] Instance ID: %s", *instance.InstanceID)
+
+		// Wait for the instance to become running so we can get some attributes
+		// that aren't available until later.
+		log.Printf(
+			"[DEBUG] Waiting for instance (%s) to become running",
+			*instance.InstanceID)
+
+		instanceID = *instance.InstanceID
+	}
 
 	// Store the resulting ID so we can look this up later
-	d.SetId(*instance.InstanceID)
-
-	// Wait for the instance to become running so we can get some attributes
-	// that aren't available until later.
-	log.Printf(
-		"[DEBUG] Waiting for instance (%s) to become running",
-		*instance.InstanceID)
+	d.SetId(instanceID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     "running",
-		Refresh:    InstanceStateRefreshFunc(conn, *instance.InstanceID),
+		Refresh:    InstanceStateRefreshFunc(conn, instanceID),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -561,10 +663,10 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for instance (%s) to become ready: %s",
-			*instance.InstanceID, err)
+			instanceID, err)
 	}
 
-	instance = instanceRaw.(*ec2.Instance)
+	instance := instanceRaw.(*ec2.Instance)
 
 	// Initialize the connection info
 	if instance.PublicIPAddress != nil {
@@ -756,6 +858,8 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	req := &ec2.TerminateInstancesInput{
 		InstanceIDs: []*string{aws.String(d.Id())},
 	}
+
+	// FIXME cancel spot instance request on termination
 	if _, err := conn.TerminateInstances(req); err != nil {
 		return fmt.Errorf("Error terminating instance: %s", err)
 	}
@@ -782,6 +886,41 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId("")
 	return nil
+}
+
+// SpotInstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// an EC2 spot instance request
+func SpotInstanceStateRefreshFunc(conn *ec2.EC2, reqID string) resource.StateRefreshFunc {
+
+	//SpotInstanceRequests
+
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+			SpotInstanceRequestIDs: []*string{aws.String(reqID)},
+		})
+
+		// FIXME: actually do error handling instead of happy path
+		if err != nil {
+			/*
+			   if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
+			     // Set this to nil as if we didn't find anything.
+			     resp = nil
+			   } else {
+			     log.Printf("Error on InstanceStateRefresh: %s", err)
+			     return nil, "", err
+			   }
+			*/
+		}
+
+		if resp == nil || len(resp.SpotInstanceRequests) == 0 {
+			// Sometimes AWS just has consistency issues and doesn't see
+			// our instance yet. Return an empty state.
+			return nil, "", nil
+		}
+
+		req := resp.SpotInstanceRequests[0]
+		return req, *req.Status.Code, nil
+	}
 }
 
 // InstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -74,6 +74,11 @@ func resourceAwsInstance() *schema.Resource {
 				Optional: true,
 			},
 
+			"spot_persist": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"spot_price": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -571,9 +576,15 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			launchSpec.KeyName = runOpts.KeyName
 		}
 
+		spotType := "one-time"
+
+		if d.Get("spot_persist").(bool) {
+			spotType = "persistent"
+		}
 		// Build the spot instance struct
 		spotOpts := &ec2.RequestSpotInstancesInput{
-			SpotPrice:           aws.String(sp), // Required
+			SpotPrice:           aws.String(sp),
+			Type:                aws.String(spotType),
 			InstanceCount:       aws.Long(1),
 			LaunchSpecification: launchSpec,
 		}

--- a/builtin/providers/aws/resource_aws_spot_bid.go
+++ b/builtin/providers/aws/resource_aws_spot_bid.go
@@ -1,0 +1,605 @@
+package aws
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"log"
+	//	"strings"
+	"time"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	//	"github.com/awslabs/aws-sdk-go/aws/awserr"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSpotBid() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSpotBidCreate,
+		Read:   resourceAwsSpotBidRead,
+		Update: resourceAwsSpotBidUpdate,
+		Delete: resourceAwsSpotBidDelete,
+
+		SchemaVersion: 1,
+		//		MigrateState:  resourceAwsSpotBidMigrateState, // FIXME: not implemented
+
+		Schema: map[string]*schema.Schema{
+			"ami": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"associate_public_ip_address": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"availability_zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"placement_group": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"instance_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"key_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"spot_persist": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"spot_price": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"subnet_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"source_dest_check": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"user_data": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					switch v.(type) {
+					case string:
+						hash := sha1.Sum([]byte(v.(string)))
+						return hex.EncodeToString(hash[:])
+					default:
+						return ""
+					}
+				},
+			},
+
+			"security_groups": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"vpc_security_group_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set: func(v interface{}) int {
+					return hashcode.String(v.(string))
+				},
+			},
+
+			"public_dns": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"public_ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"private_dns": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ebs_optimized": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"iam_instance_profile": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			"tenancy": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"tags": tagsSchema(),
+
+			"block_device": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Removed:  "Split out into three sub-types; see Changelog and Docs",
+			},
+
+			"ebs_block_device": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"delete_on_termination": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+							ForceNew: true,
+						},
+
+						"device_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"encrypted": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"iops": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"snapshot_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"volume_size": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"volume_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", m["snapshot_id"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+
+			"ephemeral_block_device": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"virtual_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", m["virtual_name"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+
+			"root_block_device": &schema.Schema{
+				// TODO: This is a set because we don't support singleton
+				//       sub-resources today. We'll enforce that the set only ever has
+				//       length zero or one below. When TF gains support for
+				//       sub-resources this can be converted.
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					// "You can only modify the volume size, volume type, and Delete on
+					// Termination flag on the block device mapping entry for the root
+					// device volume." - bit.ly/ec2bdmap
+					Schema: map[string]*schema.Schema{
+						"delete_on_termination": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+							ForceNew: true,
+						},
+
+						"iops": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"volume_size": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"volume_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					// there can be only one root device; no need to hash anything
+					return 0
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsSpotBidCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	// Figure out user data
+	userData := ""
+	if v := d.Get("user_data"); v != nil {
+		userData = base64.StdEncoding.EncodeToString([]byte(v.(string)))
+	}
+
+	// check for non-default Subnet, and cast it to a String
+	var hasSubnet bool
+	subnet, hasSubnet := d.GetOk("subnet_id")
+	subnetID := subnet.(string)
+
+	placement := &ec2.SpotPlacement{
+		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
+		GroupName:        aws.String(d.Get("placement_group").(string)),
+	}
+
+	iam := &ec2.IAMInstanceProfileSpecification{
+		Name: aws.String(d.Get("iam_instance_profile").(string)),
+	}
+
+	// Build the creation struct
+	launchSpec := &ec2.RequestSpotLaunchSpecification{
+		ImageID:            aws.String(d.Get("ami").(string)),
+		Placement:          placement,
+		InstanceType:       aws.String(d.Get("instance_type").(string)),
+		UserData:           aws.String(userData),
+		EBSOptimized:       aws.Boolean(d.Get("ebs_optimized").(bool)),
+		IAMInstanceProfile: iam,
+	}
+
+	associatePublicIPAddress := false
+	if v := d.Get("associate_public_ip_address"); v != nil {
+		associatePublicIPAddress = v.(bool)
+	}
+
+	var groups []*string
+	if v := d.Get("security_groups"); v != nil {
+		// Security group names.
+		// For a nondefault VPC, you must use security group IDs instead.
+		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
+		sgs := v.(*schema.Set).List()
+		if len(sgs) > 0 && hasSubnet {
+			log.Printf("[WARN] Deprecated. Attempting to use 'security_groups' within a VPC instance. Use 'vpc_security_group_ids' instead.")
+		}
+		for _, v := range sgs {
+			str := v.(string)
+			groups = append(groups, aws.String(str))
+		}
+	}
+
+	if hasSubnet && associatePublicIPAddress {
+		// If we have a non-default VPC / Subnet specified, we can flag
+		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
+		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise
+		// you get: Network interfaces and an instance-level subnet ID may not be specified on the same request
+		// You also need to attach Security Groups to the NetworkInterface instead of the instance,
+		// to avoid: Network interfaces and an instance-level security groups may not be specified on
+		// the same request
+		ni := &ec2.InstanceNetworkInterfaceSpecification{
+			AssociatePublicIPAddress: aws.Boolean(associatePublicIPAddress),
+			DeviceIndex:              aws.Long(int64(0)),
+			SubnetID:                 aws.String(subnetID),
+			Groups:                   groups,
+		}
+
+		if v, ok := d.GetOk("private_ip"); ok {
+			ni.PrivateIPAddress = aws.String(v.(string))
+		}
+
+		if v := d.Get("vpc_security_group_ids"); v != nil {
+			for _, v := range v.(*schema.Set).List() {
+				ni.Groups = append(ni.Groups, aws.String(v.(string)))
+			}
+		}
+
+		launchSpec.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
+	} else {
+		if subnetID != "" {
+			launchSpec.SubnetID = aws.String(subnetID)
+		}
+
+		if launchSpec.SubnetID != nil &&
+			*launchSpec.SubnetID != "" {
+			launchSpec.SecurityGroupIDs = groups
+		} else {
+			launchSpec.SecurityGroups = groups
+		}
+
+		if v := d.Get("vpc_security_group_ids"); v != nil {
+			for _, v := range v.(*schema.Set).List() {
+				launchSpec.SecurityGroupIDs = append(launchSpec.SecurityGroupIDs, aws.String(v.(string)))
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("key_name"); ok {
+		launchSpec.KeyName = aws.String(v.(string))
+	}
+
+	blockDevices := make([]*ec2.BlockDeviceMapping, 0)
+
+	if v, ok := d.GetOk("ebs_block_device"); ok {
+		vL := v.(*schema.Set).List()
+		for _, v := range vL {
+			bd := v.(map[string]interface{})
+			ebs := &ec2.EBSBlockDevice{
+				DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
+				Encrypted:           aws.Boolean(bd["encrypted"].(bool)),
+			}
+
+			if v, ok := bd["snapshot_id"].(string); ok && v != "" {
+				ebs.SnapshotID = aws.String(v)
+			}
+
+			if v, ok := bd["volume_size"].(int); ok && v != 0 {
+				ebs.VolumeSize = aws.Long(int64(v))
+			}
+
+			if v, ok := bd["volume_type"].(string); ok && v != "" {
+				ebs.VolumeType = aws.String(v)
+			}
+
+			if v, ok := bd["iops"].(int); ok && v > 0 {
+				ebs.IOPS = aws.Long(int64(v))
+			}
+
+			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+				DeviceName: aws.String(bd["device_name"].(string)),
+				EBS:        ebs,
+			})
+		}
+	}
+
+	if v, ok := d.GetOk("ephemeral_block_device"); ok {
+		vL := v.(*schema.Set).List()
+		for _, v := range vL {
+			bd := v.(map[string]interface{})
+			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+				DeviceName:  aws.String(bd["device_name"].(string)),
+				VirtualName: aws.String(bd["virtual_name"].(string)),
+			})
+		}
+	}
+
+	if v, ok := d.GetOk("root_block_device"); ok {
+		vL := v.(*schema.Set).List()
+		if len(vL) > 1 {
+			return fmt.Errorf("Cannot specify more than one root_block_device.")
+		}
+		for _, v := range vL {
+			bd := v.(map[string]interface{})
+			ebs := &ec2.EBSBlockDevice{
+				DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
+			}
+
+			if v, ok := bd["volume_size"].(int); ok && v != 0 {
+				ebs.VolumeSize = aws.Long(int64(v))
+			}
+
+			if v, ok := bd["volume_type"].(string); ok && v != "" {
+				ebs.VolumeType = aws.String(v)
+			}
+
+			if v, ok := bd["iops"].(int); ok && v > 0 {
+				ebs.IOPS = aws.Long(int64(v))
+			}
+
+			if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {
+				if dn == nil {
+					return fmt.Errorf(
+						"Expected 1 AMI for ID: %s, got none",
+						d.Get("ami").(string))
+				}
+
+				blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+					DeviceName: dn,
+					EBS:        ebs,
+				})
+			} else {
+				return err
+			}
+		}
+	}
+
+	if len(blockDevices) > 0 {
+		launchSpec.BlockDeviceMappings = blockDevices
+	}
+
+	spotType := "one-time"
+
+	if d.Get("spot_persist").(bool) {
+		spotType = "persistent"
+	}
+
+	spotOpts := &ec2.RequestSpotInstancesInput{
+		SpotPrice:           aws.String(d.Get("spot_price").(string)),
+		Type:                aws.String(spotType),
+		InstanceCount:       aws.Long(1),
+		LaunchSpecification: launchSpec,
+	}
+
+	// Make the spot instance request
+	var spotResp *ec2.RequestSpotInstancesOutput
+	spotResp, err := conn.RequestSpotInstances(spotOpts)
+
+	request_id := *spotResp.SpotInstanceRequests[0].SpotInstanceRequestID
+	d.SetId(request_id)
+
+	spotStateConf := &resource.StateChangeConf{
+		// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html
+		Pending:    []string{"start", "pending-evaluation", "pending-fulfillment"},
+		Target:     "fulfilled",
+		Refresh:    SpotInstanceStateRefreshFunc(conn, request_id),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	log.Printf("[DEBUG] waiting for spot bid to resolve... this may take several minutes.")
+	_, err = spotStateConf.WaitForState()
+
+	if err != nil {
+		return fmt.Errorf("Error while waiting for spot request (%s) to resolve: %s", request_id, err)
+	}
+
+	return nil
+}
+
+// Update spot state, etc
+func resourceAwsSpotBidRead(d *schema.ResourceData, meta interface{}) error {
+	//conn := meta.(*AWSClient).ec2conn
+
+	// FIXME implement to actually update state
+
+	return nil
+}
+
+// Bids are not mutable, except maybe tags?
+func resourceAwsSpotBidUpdate(d *schema.ResourceData, meta interface{}) error {
+	//conn := meta.(*AWSClient).ec2conn
+
+	d.Partial(true)
+
+	// FIXME either do something here or decide explicitly to do nothing
+
+	d.Partial(false)
+
+	return resourceAwsInstanceRead(d, meta)
+}
+
+func resourceAwsSpotBidDelete(d *schema.ResourceData, meta interface{}) error {
+	//conn := meta.(*AWSClient).ec2conn
+
+	// FIXME actually delete this
+
+	d.SetId("")
+	return nil
+}
+
+// SpotInstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// an EC2 spot instance request
+func SpotInstanceStateRefreshFunc(conn *ec2.EC2, reqID string) resource.StateRefreshFunc {
+
+	//SpotInstanceRequests
+
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+			SpotInstanceRequestIDs: []*string{aws.String(reqID)},
+		})
+
+		// FIXME: actually do error handling instead of happy path
+		if err != nil {
+			/*
+			   if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
+			     // Set this to nil as if we didn't find anything.
+			     resp = nil
+			   } else {
+			     log.Printf("Error on InstanceStateRefresh: %s", err)
+			     return nil, "", err
+			   }
+			*/
+		}
+
+		if resp == nil || len(resp.SpotInstanceRequests) == 0 {
+			// Sometimes AWS just has consistency issues and doesn't see
+			// our instance yet. Return an empty state.
+			return nil, "", nil
+		}
+
+		req := resp.SpotInstanceRequests[0]
+		return req, *req.Status.Code, nil
+	}
+}


### PR DESCRIPTION
An alternative solution to https://github.com/hashicorp/terraform/issues/1339 based on comments from https://github.com/hashicorp/terraform/pull/2095

This notably moves spot bids to be their **own** resource, and personally I think it's much cleaner.

The major drawback that would need to be covered in refactoring though is that they share lots of attributes, and those would need to be refactored to DRY things up, but as mentioned in comments on the other PR, I think this probably the most favorable solution.

One thing I'm not very happy with is that attributes provided by aws_spot_bid and required by aws_instance have to be specified twice. 

A sample terraform file is provided below, which illustrates this problem:

```
resource "aws_spot_bid" "test" {
    ami = "ami-50948838"
    instance_type = "m1.small"
    spot_price = "0.05"
    spot_persist = true
    key_name = "dale.hamel"
    tags {
        Name = "HelloWorld"
    }
}

resource "aws_instance" "web" {
    ami = "${aws_spot_bid.test.ami}"
    instance_type = "${aws_spot_bid.test.instance_type}"
    spot_request = "${aws_spot_bid.test.id}"
}

```

This "works" but there are lots of FIXMEs and no tests, so this should be considered another rough-cut for review of the concept.

Between this and the other PR, the two major options of either having spot instances be special types of instances, verses having spot bids be their own resource are covered. I can't think of a third option, but perhaps there is one?

I'm closing the other PR in favor of this one, if we decide we don't like this approach we can reopen it.

summary of changes:

* Spot bid logic moved almost entirely out to it's own resource
* aws instances can take a spot_request as a parameter. If they do, then they don't launch an on demand instance, and instead expect that a spot instance is ready for them.


@cbednarski @mitchellh @catsby for review