### PR TITLE
adding concatlist for concatenating lists

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -18,6 +18,7 @@ var Funcs map[string]ast.Function
 
 func init() {
 	Funcs = map[string]ast.Function{
+		"concatlist": interpolationFuncConcatlist(),
 		"file":       interpolationFuncFile(),
 		"format":     interpolationFuncFormat(),
 		"formatlist": interpolationFuncFormatList(),
@@ -50,6 +51,27 @@ func interpolationFuncConcat() ast.Function {
 			}
 
 			return b.String(), nil
+		},
+	}
+}
+
+// interpolationFuncConcatList implements the "concatlist" function that
+// concatenates multiple lists together.
+func interpolationFuncConcatlist() ast.Function {
+	return ast.Function{
+		ArgTypes:     []ast.Type{ast.TypeAny},
+		ReturnType:   ast.TypeString,
+		Variadic:     true,
+		VariadicType: ast.TypeAny,
+		Callback: func(args []interface{}) (interface{}, error) {
+			var list []string
+			for _, arg := range args {
+				parts := strings.Split(arg.(string), InterpSplitDelim)
+				if len(parts) > 0 {
+					list = append(list, parts...)
+				}
+			}
+			return strings.Join(list, InterpSplitDelim), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -35,6 +35,33 @@ func TestInterpolateFuncConcat(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncConcatLists(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${join(",", concatlist(split(",", "A,B"), split(",", "C,D")))}`,
+				"A,B,C,D",
+				false,
+			},
+			{
+				`${join(",", concatlist(split(",", "A,B"), split(",", "C,D"), split(",", "E")))}`,
+				"A,B,C,D,E",
+				false,
+			},
+			{
+				`${join(",", concatlist(split(",", "A,B"), "C"))}`,
+				"A,B,C",
+				false,
+			},
+			{
+				`${join(",", concatlist("A", "B"))}`,
+				"A,B",
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncFile(t *testing.T) {
 	tf, err := ioutil.TempFile("", "tf")
 	if err != nil {


### PR DESCRIPTION
I found myself needing this instead of trying to hack strings together and apart.

The case is this:
```
variable "a_count" {}
variable "b_count" {}

resource "aws_instance" "a" {
         count = "${var.a_count}"
}

resource "aws_instance" "b" {
         count = "${var.b_count}"
}

resource "aws_instance" "combining-a-b" {
         count = "${var.a_count + var.b_count}"

         provisioner "remote-exec" {
           command = "echo ${element(concatlist(aws_instance.a.*.private_ip, aws_instance.b.*.private_ip), count.index)}"
         }
}
```

If I want a resource to be created for multiple, but select an element from the total set, it was really difficult. I can see this concatlist being useful for other things as well.

Thoughts?