### PR TITLE
provider/aws: Fix issue with restoring from snapshot ID

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -433,11 +433,14 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			bd := v.(map[string]interface{})
 			ebs := &ec2.EBSBlockDevice{
 				DeleteOnTermination: aws.Boolean(bd["delete_on_termination"].(bool)),
-				Encrypted:           aws.Boolean(bd["encrypted"].(bool)),
 			}
 
 			if v, ok := bd["snapshot_id"].(string); ok && v != "" {
 				ebs.SnapshotID = aws.String(v)
+			}
+
+			if v, ok := bd["encrypted"].(bool); ok && v {
+				ebs.Encrypted = aws.Boolean(v)
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -95,7 +95,7 @@ Each `ebs_block_device` supports the following:
   on instance termination (Default: `true`).
 * `encrypted` - (Optional) Enables [EBS
   encryption](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
-  on the volume (Default: `false`).
+  on the volume (Default: `false`). Cannot be used with `snapshot_id`.
 
 Modifying any `ebs_block_device` currently requires resource replacement.
 


### PR DESCRIPTION
You can't specify `encrypted` and `snapshot_id`... even sending `false` for `encrypted` isn't accepted. 

Fixes #1862 