### PR TITLE
Correct to_port in egress example

### DIFF
--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -35,7 +35,7 @@ resource "aws_security_group" "allow_all" {
 
   egress {
       from_port = 0
-      to_port = 65535
+      to_port = 0
       protocol = "-1"
       cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
When using `-1` for the protocol, both `from_port` and `to_port` must be `0`, or so says AWS thru Terraform:

```
* from_port (0) and to_port (65535) must both be 0 to use the the 'ALL' "-1" protocol!
```