### PR TITLE
Updated the names for autoscaling to match breaking changes in upstream

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -323,7 +323,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 
 func getAwsAutoscalingGroup(
 	d *schema.ResourceData,
-	meta interface{}) (*autoscaling.AutoScalingGroup, error) {
+	meta interface{}) (*autoscaling.Group, error) {
 	conn := meta.(*AWSClient).autoscalingconn
 
 	describeOpts := autoscaling.DescribeAutoScalingGroupsInput{
@@ -466,7 +466,7 @@ func waitForASGCapacity(d *schema.ResourceData, meta interface{}) error {
 // provided ASG.
 //
 // Nested like: lbName -> instanceId -> instanceState
-func getLBInstanceStates(g *autoscaling.AutoScalingGroup, meta interface{}) (map[string]map[string]string, error) {
+func getLBInstanceStates(g *autoscaling.Group, meta interface{}) (map[string]map[string]string, error) {
 	lbInstanceStates := make(map[string]map[string]string)
 	elbconn := meta.(*AWSClient).elbconn
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
-	var group autoscaling.AutoScalingGroup
+	var group autoscaling.Group
 	var lc autoscaling.LaunchConfiguration
 
 	resource.Test(t, resource.TestCase{
@@ -68,7 +68,7 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSAutoScalingGroup_tags(t *testing.T) {
-	var group autoscaling.AutoScalingGroup
+	var group autoscaling.Group
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -102,7 +102,7 @@ func TestAccAWSAutoScalingGroup_tags(t *testing.T) {
 }
 
 func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
-	var group autoscaling.AutoScalingGroup
+	var group autoscaling.Group
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -154,7 +154,7 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
+func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.Group) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *group.AvailabilityZones[0] != "us-west-2a" {
 			return fmt.Errorf("Bad availability_zones: %#v", group.AvailabilityZones[0])
@@ -207,7 +207,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.AutoScalingGro
 	}
 }
 
-func testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
+func testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(group *autoscaling.Group) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *group.LoadBalancerNames[0] != "foobar-terraform-test" {
 			return fmt.Errorf("Bad load_balancers: %#v", group.LoadBalancerNames[0])
@@ -217,7 +217,7 @@ func testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(group *autoscaling.Au
 	}
 }
 
-func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.AutoScalingGroup) resource.TestCheckFunc {
+func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.Group) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -266,7 +266,7 @@ func testLaunchConfigurationName(n string, lc *autoscaling.LaunchConfiguration) 
 }
 
 func testAccCheckAWSAutoScalingGroupHealthyCapacity(
-	g *autoscaling.AutoScalingGroup, exp int) resource.TestCheckFunc {
+	g *autoscaling.Group, exp int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		healthy := 0
 		for _, i := range g.Instances {


### PR DESCRIPTION
AutoScalingGroup -> Group

https://github.com/awslabs/aws-sdk-go/commit/04d12702456024d4bf686dc6ae6abcc04037f6bf