### PR TITLE
Add tags to EBS volumes

### DIFF
--- a/builtin/providers/aws/resource_aws_ebs_volume_test.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume_test.go
@@ -26,6 +26,22 @@ func TestAccAWSEBSVolume(t *testing.T) {
 	})
 }
 
+func TestAccAWSEBSVolume_withTags(t *testing.T) {
+	var v ec2.Volume
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsEbsVolumeConfigWithTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.tags_test", &v),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVolumeExists(n string, v *ec2.Volume) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -58,5 +74,15 @@ const testAccAwsEbsVolumeConfig = `
 resource "aws_ebs_volume" "test" {
 	availability_zone = "us-west-2a"
 	size = 1
+}
+`
+
+const testAccAwsEbsVolumeConfigWithTags = `
+resource "aws_ebs_volume" "tags_test" {
+	availability_zone = "us-west-2a"
+	size = 1
+	tags {
+		Name = "TerraformTest"
+	}
 }
 `

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -28,7 +28,7 @@ func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 
 		// Set tags
 		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			log.Printf("[DEBUG] Removing tags: %#v from %s", remove, d.Id())
 			_, err := conn.DeleteTags(&ec2.DeleteTagsInput{
 				Resources: []*string{aws.String(d.Id())},
 				Tags:      remove,
@@ -38,7 +38,7 @@ func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 			}
 		}
 		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %#v", create)
+			log.Printf("[DEBUG] Creating tags: %#v for %s", create, d.Id())
 			_, err := conn.CreateTags(&ec2.CreateTagsInput{
 				Resources: []*string{aws.String(d.Id())},
 				Tags:      create,

--- a/website/source/docs/providers/aws/r/ebs_volume.html.md
+++ b/website/source/docs/providers/aws/r/ebs_volume.html.md
@@ -16,6 +16,9 @@ Manages a single EBS volume.
 resource "aws_ebs_volume" "example" {
     availability_zone = "us-west-1a"
     size = 40
+    tags {
+        Name = "HelloWorld"
+    }
 }
 ```
 
@@ -30,7 +33,7 @@ The following arguments are supported:
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `type` - (Optional) The type of EBS volume.
 * `kms_key_id` - (Optional) The KMS key ID for the volume.
-
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
https://github.com/hashicorp/terraform/issues/1296#issuecomment-106573913

### Test plan
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=EBS' 2>/dev/null
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=EBS -timeout 45m
=== RUN TestAccAWSEBSVolume
--- PASS: TestAccAWSEBSVolume (14.95s)
=== RUN TestAccAWSEBSVolume_withTags
--- PASS: TestAccAWSEBSVolume_withTags (14.70s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	29.665s
```