### PR TITLE
Switching the healthcheck shouldn't cause a refresh of the resource

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -79,7 +79,6 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			"availability_zones": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -240,6 +240,11 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 		opts.HealthCheckGracePeriod = aws.Long(int64(d.Get("health_check_grace_period").(int)))
 	}
 
+	if d.HasChange("health_check_type") {
+		opts.HealthCheckGracePeriod = aws.Long(int64(d.Get("health_check_grace_period").(int)))
+		opts.HealthCheckType = aws.String(d.Get("health_check_type").(string))
+	}
+
 	if err := setAutoscalingTags(conn, d); err != nil {
 		return err
 	} else {


### PR DESCRIPTION
Switching the healthcheck from elb->ec2 or ec2->elb shouldn't cause the ASG to re-create itself

You can do this operation in the AWS console 