### PR TITLE
provider/aws: Add support for ICMP Protocol in Network ACLs

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -34,6 +34,18 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2
 			RuleNumber: aws.Long(int64(data["rule_no"].(int))),
 			CIDRBlock:  aws.String(data["cidr_block"].(string)),
 		}
+
+		// Specify additional required fields for ICMP
+		if p == 1 {
+			e.ICMPTypeCode = &ec2.ICMPTypeCode{}
+			if v, ok := data["icmp_code"]; ok {
+				e.ICMPTypeCode.Code = aws.Long(int64(v.(int)))
+			}
+			if v, ok := data["icmp_type"]; ok {
+				e.ICMPTypeCode.Type = aws.Long(int64(v.(int)))
+			}
+		}
+
 		entries = append(entries, e)
 	}
 	return entries, nil

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -76,6 +76,14 @@ func resourceAwsNetworkAcl() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"icmp_type": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"icmp_code": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 					},
 				},
 				Set: resourceAwsNetworkAclEntryHash,
@@ -108,6 +116,14 @@ func resourceAwsNetworkAcl() *schema.Resource {
 						},
 						"cidr_block": &schema.Schema{
 							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"icmp_type": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"icmp_code": &schema.Schema{
+							Type:     schema.TypeInt,
 							Optional: true,
 						},
 					},
@@ -377,9 +393,10 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, conn *ec2
 			Protocol:     add.Protocol,
 			RuleAction:   add.RuleAction,
 			RuleNumber:   add.RuleNumber,
+			ICMPTypeCode: add.ICMPTypeCode,
 		})
 		if connErr != nil {
-			return fmt.Errorf("Error creating %s entry: %s", entryType, err)
+			return fmt.Errorf("Error creating %s entry: %s", entryType, connErr)
 		}
 	}
 	return nil
@@ -466,6 +483,13 @@ func resourceAwsNetworkAclEntryHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
+	if v, ok := m["icmp_type"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+	if v, ok := m["icmp_code"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
 	return hashcode.String(buf.String())
 }
 
@@ -536,6 +560,11 @@ func networkAclEntriesToMapList(networkAcls []*ec2.NetworkACLEntry) []map[string
 		if entry.PortRange != nil {
 			acl["from_port"] = *entry.PortRange.From
 			acl["to_port"] = *entry.PortRange.To
+		}
+
+		if entry.ICMPTypeCode != nil {
+			acl["icmp_type"] = *entry.ICMPTypeCode.Type
+			acl["icmp_code"] = *entry.ICMPTypeCode.Code
 		}
 
 		result = append(result, acl)

--- a/website/source/docs/providers/aws/r/network_acl.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl.html.markdown
@@ -62,6 +62,10 @@ Both `egress` and `ingress` support the following keys:
 protocol, you must specify a from and to port of 0.
 * `cidr_block` - (Optional) The CIDR block to match. This must be a
 valid network mask.
+* `icmp_type` - (Optional) The ICMP type to be used. Default 0.
+* `icmp_code` - (Optional) The ICMP type code to be used. Default 0.
+
+~> Note: For more information on ICMP types and codes, see here: http://www.nthelp.com/icmp.html
 
 ## Attributes Reference
 


### PR DESCRIPTION
- added `icmp_type` attribute
- added `icmp_code` attribute
- fixed an issue hiding the error

I _believe_ they way I've added them should be backwards compatible, e.g. people who aren't using this won't all of the sudden show changes to be made in `plan`. 

AWS docs for this are here: 

- [CreateNetworkAclEntry ][1]


Should fix #2085


[1]: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkAclEntry.html