### PR TITLE
aws_app_cookie_stickiness_policy doc fix

### DIFF
--- a/website/source/docs/providers/aws/r/app_cookie_stickiness_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/app_cookie_stickiness_policy.html.markdown
@@ -26,7 +26,7 @@ resource "aws_elb" "lb" {
 
 resource "aws_app_cookie_stickiness_policy" "foo" {
 	  name = "foo_policy"
-	  load_balancer = "${aws_elb.lb}"
+	  load_balancer = "${aws_elb.lb.id}"
 	  lb_port = 80
 	  cookie_name = "MyAppCookie"
 }


### PR DESCRIPTION
The docs missed the .id to link back to the elb. It resulted in 

```
Error loading config: Error loading /Users/mzupan/aws/ec2-rabbit.tf: Error reading config for aws_lb_cookie_stickiness_policy[rabbitadmin]: aws_elb.rabbit: resource variables must be three parts: type.name.attr in:

${aws_elb.rabbit}
```
