### PR TITLE
interpolate: Interpolate computed list attributes

### DIFF
--- a/config/string_list_test.go
+++ b/config/string_list_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStringList_slice(t *testing.T) {
+	expected := []string{"apple", "banana", "pear"}
+	l := NewStringList(expected)
+	actual := l.Slice()
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestStringList_element(t *testing.T) {
+	list := []string{"apple", "banana", "pear"}
+	l := NewStringList(list)
+	actual := l.Element(1)
+
+	expected := "banana"
+
+	if actual != expected {
+		t.Fatalf("Expected 2nd element from %q to be %q, got %q",
+			list, expected, actual)
+	}
+}

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -2,7 +2,10 @@ package terraform
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -327,6 +330,11 @@ func (i *Interpolater) computeResourceVariable(
 		return attr, nil
 	}
 
+	// computed list attribute
+	if _, ok := r.Primary.Attributes[v.Field+".#"]; ok {
+		return i.interpolateListAttribute(v.Field, r.Primary.Attributes)
+	}
+
 	// At apply time, we can't do the "maybe has it" check below
 	// that we need for plans since parent elements might be computed.
 	// Therefore, it is an error and we're missing the key.
@@ -410,8 +418,8 @@ func (i *Interpolater) computeResourceMultiVariable(
 	}
 
 	var values []string
-	for i := 0; i < count; i++ {
-		id := fmt.Sprintf("%s.%d", v.ResourceId(), i)
+	for j := 0; j < count; j++ {
+		id := fmt.Sprintf("%s.%d", v.ResourceId(), j)
 
 		// If we're dealing with only a single resource, then the
 		// ID doesn't have a trailing index.
@@ -430,6 +438,21 @@ func (i *Interpolater) computeResourceMultiVariable(
 
 		attr, ok := r.Primary.Attributes[v.Field]
 		if !ok {
+			// computed list attribute
+			_, ok := r.Primary.Attributes[v.Field+".#"]
+			if !ok {
+				continue
+			}
+			attr, err = i.interpolateListAttribute(v.Field, r.Primary.Attributes)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		if config.IsStringList(attr) {
+			for _, s := range config.StringList(attr).Slice() {
+				values = append(values, s)
+			}
 			continue
 		}
 
@@ -459,6 +482,26 @@ func (i *Interpolater) computeResourceMultiVariable(
 	}
 
 	return config.NewStringList(values).String(), nil
+}
+
+func (i *Interpolater) interpolateListAttribute(
+	resourceID string,
+	attributes map[string]string) (string, error) {
+
+	attr := attributes[resourceID+".#"]
+	log.Printf("[DEBUG] Interpolating computed list attribute %s (%s)",
+		resourceID, attr)
+
+	var members []string
+	numberedListMember := regexp.MustCompile("^" + resourceID + "\\.[0-9]+$")
+	for id, value := range attributes {
+		if numberedListMember.MatchString(id) {
+			members = append(members, value)
+		}
+	}
+
+	sort.Strings(members)
+	return config.NewStringList(members).String(), nil
 }
 
 func (i *Interpolater) resourceVariableInfo(

--- a/terraform/test-fixtures/interpolate-multi-vars/main.tf
+++ b/terraform/test-fixtures/interpolate-multi-vars/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_zone" "yada" {
+
+}
+
+resource "aws_route53_zone" "terra" {
+	count = 2
+}


### PR DESCRIPTION
This will solve issues with all list attributes that are computed and currently can't be actually used as lists (i.e. we can't use built-in functions like `join()`).

The current output coming from `valueResourceVar` is `config.UnknownVariableValue` since it's looking for `resource.attribute` whereas it's present as `resource.attribute.#` + `resource.attribute.0` + `resource.attribute.1` etc. in the given `map`.

### Status:

 - [x] Implementation for resources w/out `count`
 - [x] Implementation for resources w/ `count`
 - [x] Tests for resources w/out `count`
 - [x] Tests for resources w/ `count`

Related: https://github.com/hashicorp/terraform/pull/1999

### Test plan
#### `TypeList`
```ruby
resource "aws_route53_zone" "main" {
  name = "mainexample.com"
}

output "new" {
  value = "${join(" ", aws_route53_zone.main.name_servers)}"
}
output "old" {
  value = "${aws_route53_zone.main.name_servers.0} ${aws_route53_zone.main.name_servers.1} ${aws_route53_zone.main.name_servers.2} ${aws_route53_zone.main.name_servers.3}"
}
```
#### `TypeMap`
```ruby
resource "aws_instance" "sample" {
  ami = "ami-2cd3dc44"
  instance_type = "t2.micro"

  tags {
    Name = "TerraformTest"
    CustomTag = "Yada Yada"
  }
}

output "tags" {
  value = "${aws_instance.sample.tags.Name}"
}
```
```ruby
resource "aws_instance" "sample" {
  ami = "ami-2cd3dc44"
  instance_type = "t2.micro"

  # not sure if anyone would want to do this, but it's possible
  tags {
    "0" = "TerraformTest"
    "1" = "Yada Yada"
  }
}

output "tags" {
  value = "${join(",", aws_instance.sample.tags)}"
}
```
#### `TypeSet`
```ruby
resource "aws_elb" "bar" {
  name = "foobar-terraform-elb"
  availability_zones = ["us-east-1b", "us-east-1c", "us-east-1d"]

  listener {
    instance_port = 8080
    instance_protocol = "http"
    lb_port = 80
    lb_protocol = "http"
  }
}

output "azs" {
  value = "${join(",", aws_elb.bar.availability_zones)}"
}
```

### Impact

```
$ grep -l -R -E '(TypeSet|TypeList)' ./builtin/providers/* | sort | uniq
```
```
./builtin/providers/atlas/resource_artifact.go
./builtin/providers/aws/autoscaling_tags.go
./builtin/providers/aws/provider.go
./builtin/providers/aws/resource_aws_autoscaling_group.go
./builtin/providers/aws/resource_aws_autoscaling_notification.go
./builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go
./builtin/providers/aws/resource_aws_db_instance.go
./builtin/providers/aws/resource_aws_db_parameter_group.go
./builtin/providers/aws/resource_aws_db_security_group.go
./builtin/providers/aws/resource_aws_db_subnet_group.go
./builtin/providers/aws/resource_aws_dynamodb_table.go
./builtin/providers/aws/resource_aws_ecs_service.go
./builtin/providers/aws/resource_aws_ecs_task_definition.go
./builtin/providers/aws/resource_aws_elasticache_cluster.go
./builtin/providers/aws/resource_aws_elasticache_parameter_group.go
./builtin/providers/aws/resource_aws_elasticache_security_group.go
./builtin/providers/aws/resource_aws_elasticache_subnet_group.go
./builtin/providers/aws/resource_aws_elb.go
./builtin/providers/aws/resource_aws_iam_group_membership.go
./builtin/providers/aws/resource_aws_iam_instance_profile.go
./builtin/providers/aws/resource_aws_iam_policy_attachment.go
./builtin/providers/aws/resource_aws_instance.go
./builtin/providers/aws/resource_aws_launch_configuration.go
./builtin/providers/aws/resource_aws_network_acl.go
./builtin/providers/aws/resource_aws_network_interface.go
./builtin/providers/aws/resource_aws_proxy_protocol_policy.go
./builtin/providers/aws/resource_aws_route53_delegation_set.go
./builtin/providers/aws/resource_aws_route53_record.go
./builtin/providers/aws/resource_aws_route53_zone.go
./builtin/providers/aws/resource_aws_route_table.go
./builtin/providers/aws/resource_aws_s3_bucket.go
./builtin/providers/aws/resource_aws_security_group.go
./builtin/providers/aws/resource_aws_security_group_rule.go
./builtin/providers/aws/resource_aws_vpc_dhcp_options.go
./builtin/providers/aws/resource_aws_vpn_connection.go
./builtin/providers/azure/resource_azure_instance.go
./builtin/providers/azure/resource_azure_local_network.go
./builtin/providers/azure/resource_azure_security_group_rule.go
./builtin/providers/azure/resource_azure_sql_database_server_firewall_rule.go
./builtin/providers/azure/resource_azure_virtual_network.go
./builtin/providers/cloudstack/resource_cloudstack_egress_firewall.go
./builtin/providers/cloudstack/resource_cloudstack_firewall.go
./builtin/providers/cloudstack/resource_cloudstack_network_acl_rule.go
./builtin/providers/cloudstack/resource_cloudstack_port_forward.go
./builtin/providers/consul/resource_consul_keys.go
./builtin/providers/digitalocean/resource_digitalocean_droplet.go
./builtin/providers/docker/resource_docker_container.go
./builtin/providers/google/resource_compute_firewall.go
./builtin/providers/google/resource_compute_instance.go
./builtin/providers/google/resource_compute_instance_template.go
./builtin/providers/google/resource_compute_route.go
./builtin/providers/google/resource_compute_target_pool.go
./builtin/providers/google/resource_dns_managed_zone.go
./builtin/providers/google/resource_dns_record_set.go
./builtin/providers/heroku/resource_heroku_addon.go
./builtin/providers/heroku/resource_heroku_app.go
./builtin/providers/mailgun/resource_mailgun_domain.go
./builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
./builtin/providers/openstack/resource_openstack_compute_instance_v2.go
./builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
./builtin/providers/openstack/resource_openstack_compute_servergroup_v2.go
./builtin/providers/openstack/resource_openstack_fw_policy_v1.go
./builtin/providers/openstack/resource_openstack_lb_pool_v1.go
./builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
```
