### PR TITLE
Increase default timeout for acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ testacc: generate
 		echo "  make testacc TEST=./builtin/providers/aws"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 45m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 90m
 
 # testrace runs the race checker
 testrace: generate

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To run the acceptance tests, invoke `make testacc`:
 ```sh
 $ make testacc TEST=./builtin/providers/aws TESTARGS='-run=Vpc'
 go generate ./...
-TF_ACC=1 go test ./builtin/providers/aws -v -run=Vpc -timeout 45m
+TF_ACC=1 go test ./builtin/providers/aws -v -run=Vpc -timeout 90m
 === RUN TestAccVpc_basic
 2015/02/10 14:11:17 [INFO] Test: Using us-west-2 as test region
 [...]


### PR DESCRIPTION
The current default timeout is not enough for all Route53-related tests, especially after adding more in https://github.com/hashicorp/terraform/pull/1999
