### PR TITLE
Set AWS Elasticache Port Number to be required

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -52,8 +52,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 			},
 			"port": &schema.Schema{
 				Type:     schema.TypeInt,
-				Default:  11211,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 			"engine_version": &schema.Schema{
@@ -123,7 +122,7 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 	numNodes := int64(d.Get("num_cache_nodes").(int)) // 2
 	engine := d.Get("engine").(string)                // memcached
 	engineVersion := d.Get("engine_version").(string) // 1.4.14
-	port := int64(d.Get("port").(int))                // 11211
+	port := int64(d.Get("port").(int))                // e.g) 11211
 	subnetGroupName := d.Get("subnet_group_name").(string)
 	securityNameSet := d.Get("security_group_names").(*schema.Set)
 	securityIdSet := d.Get("security_group_ids").(*schema.Set)

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -95,7 +95,7 @@ func genRandInt() int {
 }
 
 var testAccAWSElasticacheClusterConfig = fmt.Sprintf(`
-provider "aws" { 
+provider "aws" {
 	region = "us-east-1"
 }
 resource "aws_security_group" "bar" {
@@ -120,6 +120,7 @@ resource "aws_elasticache_cluster" "bar" {
     engine = "memcached"
     node_type = "cache.m1.small"
     num_cache_nodes = 1
+    port = 11211
     parameter_group_name = "default.memcached1.4"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
 }

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -17,6 +17,7 @@ resource "aws_elasticache_cluster" "bar" {
     cluster_id = "cluster-example"
     engine = "memcached"
     node_type = "cache.m1.small"
+    port = 11211
     num_cache_nodes = 1
     parameter_group_name = "default.memcached1.4"
 }
@@ -47,8 +48,8 @@ value must be between 1 and 20
 * `parameter_group_name` – (Required) Name of the parameter group to associate
 with this cache cluster
 
-* `port` – (Optional) The port number on which each of the cache nodes will
-accept connections. Default 11211.
+* `port` – (Required) The port number on which each of the cache nodes will
+accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.
 
 * `subnet_group_name` – (Optional, VPC only) Name of the subnet group to be used
 for the cache cluster.


### PR DESCRIPTION
Set Elasticache Port number to not be set by default, and require
Elasticache Port number to be specified.

Also updated acceptance tests to supply port number upon resource
declaration

Fixes #2084