### PR TITLE
maint: Codify a Vagrant-based release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ dev: generate
 quickdev: generate
 	@TF_QUICKDEV=1 TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
+release: updatedeps
+	gox -build-toolchain
+	@$(MAKE) bin
+
 # test runs the unit tests and vets the code
 test: generate
 	TF_ACC= go test $(TEST) $(TESTARGS) -timeout=30s -parallel=4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing Terraform
+
+This document contains details about the Terraform release process.
+
+## Schedule
+
+Terraform currently has no fixed release schedule, the HashiCorp maintainers
+can usually give a feel for roughly when the next release is planned.
+
+## Versioning
+
+As a pre-1.0 project, we use the MINOR and PATCH versions as follows:
+
+ * a `MINOR` version increment indicates a release that may contain backwards
+   incompatible changes
+ * a `PATCH` version increment indicates a release that may contain bugfixes as
+   well as additive (backwards compatible) features and enhancements
+
+## Process
+
+For maintainer documentation purposes, here is the current release process:
+
+```sh
+# Verify tests pass
+make test
+
+# Prep release commit
+export VERSION="vX.Y.Z"
+# Edit CHANGELOG, adding current date to unreleased version header
+# Edit version.go, setting VersionPrelease to empty string
+
+# Snapshot dependency information
+godep save
+mv Godeps/Godeps.json deps/$(echo $VERSION | sed 's/\./-/g').json
+rm -rf Godeps
+
+# Make and tag release commit
+git commit -a -m "${VERSION}"
+git tag -m "${VERSION}" "${VERSION}"
+
+# Build release in Vagrant machine
+vagrant destroy -f; vagrant up # Build a fresh VM for a clean build
+vagrant ssh
+cd /opt/gopath/src/github.com/hashicorp/terraform/
+make release
+
+# Zip and push release to bintray
+export BINTRAY_API_KEY="..."
+./scripts/dist "X.Y.Z" # no `v` prefix here
+
+# -- "Point of no return" --
+# -- Process can be aborted safely at any point before this --
+
+# Push the release commit and tag
+git push origin master
+git push origin vX.Y.Z
+
+# Click "publish" on the release from the Bintray Web UI
+
+# -- Release is complete! --
+
+# Make a follow-on commit to master restoring VersionPrerelease to "dev" and
+setting up a new CHANGELOG section.
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,34 +5,52 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $script = <<SCRIPT
-# Install Go and prerequisites
-apt-get -qq update
-apt-get -qq install build-essential curl git-core libpcre3-dev mercurial pkg-config zip
-hg clone -u release https://code.google.com/p/go /opt/go
-cd /opt/go/src && ./all.bash
+SRCROOT="/opt/go"
+SRCPATH="/opt/gopath"
 
-# Setup the GOPATH
-mkdir -p /opt/gopath
-cat <<EOF >/etc/profile.d/gopath.sh
-export GOPATH="/opt/gopath"
-export PATH="/opt/go/bin:\$GOPATH/bin:\$PATH"
+# Get the ARCH
+ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
+
+# Install Prereq Packages
+sudo apt-get update
+sudo apt-get install -y build-essential curl git-core libpcre3-dev mercurial pkg-config zip
+
+# Install Go
+cd /tmp
+wget -q https://storage.googleapis.com/golang/go1.4.2.linux-${ARCH}.tar.gz
+tar -xf go1.4.2.linux-${ARCH}.tar.gz
+sudo mv go $SRCROOT
+sudo chmod 775 $SRCROOT
+sudo chown vagrant:vagrant $SRCROOT
+
+# Setup the GOPATH; even though the shared folder spec gives the working
+# directory the right user/group, we need to set it properly on the
+# parent path to allow subsequent "go get" commands to work.
+sudo mkdir -p $SRCPATH
+sudo chown -R vagrant:vagrant $SRCPATH 2>/dev/null || true
+# ^^ silencing errors here because we expect this to fail for the shared folder
+
+cat <<EOF >/tmp/gopath.sh
+export GOPATH="$SRCPATH"
+export GOROOT="$SRCROOT"
+export PATH="$SRCROOT/bin:$SRCPATH/bin:\$PATH"
 EOF
-
-# Make sure the GOPATH is usable by vagrant
-chown -R vagrant:vagrant /opt/go
-chown -R vagrant:vagrant /opt/gopath
+sudo mv /tmp/gopath.sh /etc/profile.d/gopath.sh
+sudo chmod 0755 /etc/profile.d/gopath.sh
+source /etc/profile.d/gopath.sh
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "chef/ubuntu-12.04"
 
-  config.vm.provision "shell", inline: $script
+  config.vm.provision "shell", inline: $script, privileged: false
+  config.vm.synced_folder '.', '/opt/gopath/src/github.com/hashicorp/terraform'
 
   ["vmware_fusion", "vmware_workstation"].each do |p|
-    config.vm.provider "p" do |v|
-      v.vmx["memsize"] = "2048"
-      v.vmx["numvcpus"] = "2"
-      v.vmx["cpuid.coresPerSocket"] = "1"
+    config.vm.provider p do |v|
+      v.vmx["memsize"] = "4096"
+      v.vmx["numvcpus"] = "4"
+      v.vmx['cpuid.coresPerSocket'] = '2'
     end
   end
 end


### PR DESCRIPTION
 * update Vagrantfile to modern Consul-style version
 * add `make release` for a one-shot command to get from fresh vagrant
   machine to a built release
 * add RELEASING.md to document details about the release process