### PR TITLE
provider/aws: Allow ElastiCache Subnet Group updates

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -32,6 +32,7 @@ func TestAccAWSElasticacheCluster_basic(t *testing.T) {
 }
 
 func TestAccAWSElasticacheCluster_vpc(t *testing.T) {
+	var csg elasticache.CacheSubnetGroup
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -40,7 +41,7 @@ func TestAccAWSElasticacheCluster_vpc(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSElasticacheClusterInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSubnetGroupExists("aws_elasticache_subnet_group.bar"),
+					testAccCheckAWSElasticacheSubnetGroupExists("aws_elasticache_subnet_group.bar", &csg),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar"),
 				),
 			},

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -17,13 +17,13 @@ func resourceAwsElasticacheSubnetGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsElasticacheSubnetGroupCreate,
 		Read:   resourceAwsElasticacheSubnetGroupRead,
+		Update: resourceAwsElasticacheSubnetGroupUpdate,
 		Delete: resourceAwsElasticacheSubnetGroupDelete,
 
 		Schema: map[string]*schema.Schema{
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -34,7 +34,6 @@ func resourceAwsElasticacheSubnetGroup() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set: func(v interface{}) int {
 					return hashcode.String(v.(string))
@@ -110,6 +109,29 @@ func resourceAwsElasticacheSubnetGroupRead(d *schema.ResourceData, meta interfac
 	return nil
 }
 
+func resourceAwsElasticacheSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	if d.HasChange("subnet_ids") || d.HasChange("description") {
+		var subnets []*string
+		if v := d.Get("subnet_ids"); v != nil {
+			for _, v := range v.(*schema.Set).List() {
+				subnets = append(subnets, aws.String(v.(string)))
+			}
+		}
+		log.Printf("[DEBUG] Updating ElastiCache Subnet Group")
+
+		_, err := conn.ModifyCacheSubnetGroup(&elasticache.ModifyCacheSubnetGroupInput{
+			CacheSubnetGroupName:        aws.String(d.Get("name").(string)),
+			CacheSubnetGroupDescription: aws.String(d.Get("description").(string)),
+			SubnetIDs:                   subnets,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceAwsElasticacheSubnetGroupRead(d, meta)
+}
 func resourceAwsElasticacheSubnetGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
@@ -10,16 +10,50 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSElasticacheSubnetGroup(t *testing.T) {
+func TestAccAWSElasticacheSubnetGroup_basic(t *testing.T) {
+	var csg elasticache.CacheSubnetGroup
+	config := fmt.Sprintf(testAccAWSElasticacheSubnetGroupConfig, genRandInt())
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSElasticacheSubnetGroupConfig,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSubnetGroupExists("aws_elasticache_subnet_group.bar"),
+					testAccCheckAWSElasticacheSubnetGroupExists("aws_elasticache_subnet_group.bar", &csg),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheSubnetGroup_update(t *testing.T) {
+	var csg elasticache.CacheSubnetGroup
+	rn := "aws_elasticache_subnet_group.bar"
+	ri := genRandInt()
+	preConfig := fmt.Sprintf(testAccAWSElasticacheSubnetGroupUpdateConfigPre, ri)
+	postConfig := fmt.Sprintf(testAccAWSElasticacheSubnetGroupUpdateConfigPost, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheSubnetGroupExists(rn, &csg),
+					testAccCheckAWSElastiCacheSubnetGroupAttrs(&csg, rn, 1),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheSubnetGroupExists(rn, &csg),
+					testAccCheckAWSElastiCacheSubnetGroupAttrs(&csg, rn, 2),
 				),
 			},
 		},
@@ -46,7 +80,7 @@ func testAccCheckAWSElasticacheSubnetGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSElasticacheSubnetGroupExists(n string) resource.TestCheckFunc {
+func testAccCheckAWSElasticacheSubnetGroupExists(n string, csg *elasticache.CacheSubnetGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -58,17 +92,47 @@ func testAccCheckAWSElasticacheSubnetGroupExists(n string) resource.TestCheckFun
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
-		_, err := conn.DescribeCacheSubnetGroups(&elasticache.DescribeCacheSubnetGroupsInput{
+		resp, err := conn.DescribeCacheSubnetGroups(&elasticache.DescribeCacheSubnetGroupsInput{
 			CacheSubnetGroupName: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
 			return fmt.Errorf("CacheSubnetGroup error: %v", err)
 		}
+
+		for _, c := range resp.CacheSubnetGroups {
+			if rs.Primary.ID == *c.CacheSubnetGroupName {
+				*csg = *c
+			}
+		}
+
+		if csg == nil {
+			return fmt.Errorf("cache subnet group not found")
+		}
 		return nil
 	}
 }
 
-var testAccAWSElasticacheSubnetGroupConfig = fmt.Sprintf(`
+func testAccCheckAWSElastiCacheSubnetGroupAttrs(csg *elasticache.CacheSubnetGroup, n string, count int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if len(csg.Subnets) != count {
+			return fmt.Errorf("Bad cache subnet count, expected: %d, got: %d", count, len(csg.Subnets))
+		}
+
+		if rs.Primary.Attributes["description"] != *csg.CacheSubnetGroupDescription {
+			return fmt.Errorf("Bad cache subnet description, expected: %s, got: %s", rs.Primary.Attributes["description"], *csg.CacheSubnetGroupDescription)
+		}
+
+		return nil
+	}
+}
+
+var testAccAWSElasticacheSubnetGroupConfig = `
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
@@ -90,4 +154,63 @@ resource "aws_elasticache_subnet_group" "bar" {
     description = "tf-test-cache-subnet-group-descr"
     subnet_ids = ["${aws_subnet.foo.id}"]
 }
-`, genRandInt())
+`
+var testAccAWSElasticacheSubnetGroupUpdateConfigPre = `
+resource "aws_vpc" "foo" {
+    cidr_block = "10.0.0.0/16"
+    tags {
+            Name = "tf-elc-sub-test"
+    }
+}
+
+resource "aws_subnet" "foo" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "10.0.1.0/24"
+    availability_zone = "us-west-2a"
+    tags {
+            Name = "tf-test"
+    }
+}
+
+resource "aws_elasticache_subnet_group" "bar" {
+    name = "tf-test-cache-subnet-%03d"
+    description = "tf-test-cache-subnet-group-descr"
+    subnet_ids = ["${aws_subnet.foo.id}"]
+}
+`
+
+var testAccAWSElasticacheSubnetGroupUpdateConfigPost = `
+resource "aws_vpc" "foo" {
+    cidr_block = "10.0.0.0/16"
+    tags {
+            Name = "tf-elc-sub-test"
+    }
+}
+
+resource "aws_subnet" "foo" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "10.0.1.0/24"
+    availability_zone = "us-west-2a"
+    tags {
+            Name = "tf-test"
+    }
+}
+
+resource "aws_subnet" "bar" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "10.0.2.0/24"
+    availability_zone = "us-west-2a"
+    tags {
+            Name = "tf-test-foo-update"
+    }
+}
+
+resource "aws_elasticache_subnet_group" "bar" {
+    name = "tf-test-cache-subnet-%03d"
+    description = "tf-test-cache-subnet-group-descr-edited"
+    subnet_ids = [
+			"${aws_subnet.foo.id}",
+			"${aws_subnet.bar.id}",
+		]
+}
+`


### PR DESCRIPTION
Adds update method for ElastiCache Subnet Groups, things are no longer all `ForceNew`.

- can update `description`
- can update `subnet_ids`

This should also fix #2178