### PR TITLE
core: keys() and values() funcs for map variables

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -384,6 +384,104 @@ func TestInterpolateFuncLookup(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncKeys(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.foo.bar": ast.Variable{
+				Value: "baz",
+				Type:  ast.TypeString,
+			},
+			"var.foo.qux": ast.Variable{
+				Value: "quack",
+				Type:  ast.TypeString,
+			},
+			"var.str": ast.Variable{
+				Value: "astring",
+				Type:  ast.TypeString,
+			},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${keys("foo")}`,
+				fmt.Sprintf(
+					"bar%squx",
+					InterpSplitDelim),
+				false,
+			},
+
+			// Invalid key
+			{
+				`${keys("not")}`,
+				nil,
+				true,
+			},
+
+			// Too many args
+			{
+				`${keys("foo", "bar")}`,
+				nil,
+				true,
+			},
+
+			// Not a map
+			{
+				`${keys("str")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncValues(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.foo.bar": ast.Variable{
+				Value: "quack",
+				Type:  ast.TypeString,
+			},
+			"var.foo.qux": ast.Variable{
+				Value: "baz",
+				Type:  ast.TypeString,
+			},
+			"var.str": ast.Variable{
+				Value: "astring",
+				Type:  ast.TypeString,
+			},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${values("foo")}`,
+				fmt.Sprintf(
+					"quack%sbaz",
+					InterpSplitDelim),
+				false,
+			},
+
+			// Invalid key
+			{
+				`${values("not")}`,
+				nil,
+				true,
+			},
+
+			// Too many args
+			{
+				`${values("foo", "bar")}`,
+				nil,
+				true,
+			},
+
+			// Not a map
+			{
+				`${values("str")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncElement(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -304,6 +304,8 @@ func langEvalConfig(vs map[string]ast.Variable) *lang.EvalConfig {
 		funcMap[k] = v
 	}
 	funcMap["lookup"] = interpolationFuncLookup(vs)
+	funcMap["keys"] = interpolationFuncKeys(vs)
+	funcMap["values"] = interpolationFuncValues(vs)
 
 	return &lang.EvalConfig{
 		GlobalScope: &ast.BasicScope{


### PR DESCRIPTION
they work on maps with both keys and values that are string types, which
AFAICT are the only types of maps we have right now.

closes #1915