### PR TITLE
Fixup aws_security_group doc example.

### DIFF
--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -28,7 +28,7 @@ resource "aws_security_group" "allow_all" {
 
   ingress {
       from_port = 0
-      to_port = 65535
+      to_port = 0
       protocol = "-1"
       cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
Both to_ and from_ port must be zero to use protocol -1.