### PR TITLE
Update docs for Cloudstack with SSH keypair and timeout

### DIFF
--- a/website/source/docs/providers/cloudstack/index.html.markdown
+++ b/website/source/docs/providers/cloudstack/index.html.markdown
@@ -43,3 +43,8 @@ The following arguments are supported:
 
 * `secret_key` - (Required) This is the CloudStack secret key. It must be provided,
   but it can also be sourced from the `CLOUDSTACK_SECRET_KEY` environment variable.
+
+* `timeout` - (Optional) A value in seconds. This is the time allowed for Cloudstack 
+  to complete each asynchronous job triggered. If unset, this can be sourced from the
+  `CLOUDSTACK_TIMEOUT` environment variable. Otherwise, this will default to 300 
+  seconds.

--- a/website/source/docs/providers/cloudstack/r/instance.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/instance.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `user_data` - (Optional) The user data to provide when launching the instance.
 
+* `keypair` - (Optional) The name of the SSH keypair that will be used to access this instance.
+
 * `expunge` - (Optional) This determines if the instance is expunged when it is
     destroyed (defaults false)
 

--- a/website/source/docs/providers/cloudstack/r/ssh_keypair.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/ssh_keypair.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "cloudstack"
+page_title: "CloudStack: cloudstack_ssh_keypair"
+sidebar_current: "docs-cloudstack-resource-ssh-keypair"
+description: |-
+  Creates or registers an SSH keypair.
+---
+
+# cloudstack\_ssh\_keypair
+
+Creates or registers an SSH keypair.
+
+## Example Usage
+
+```
+resource "cloudstack_ssh_keypair" "myKey" {
+  name = "myKey"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name to give the SSH keypair. This is a unique value within a Cloudstack account.
+
+* `public_key` - (Optional) The full public key text of this keypair. If this is omitted, Cloudstack 
+  will generate a new keypair.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The keypair ID. This is set to the keypair `name` argument.
+* `fingerprint` - The fingerprint of the public key specified or calculated.
+* `private_key` - This is returned only if Cloudstack generated the keypair.

--- a/website/source/layouts/cloudstack.erb
+++ b/website/source/layouts/cloudstack.erb
@@ -53,6 +53,10 @@
                             <a href="/docs/providers/cloudstack/r/port_forward.html">cloudstack_port_forward</a>
                         </li>
 
+			<li<%= sidebar_current("docs-cloudstack-resource-ssh-keypair") %>>
+                            <a href="/docs/providers/cloudstack/r/ssh_keypair.html">cloudstack_ssh_keypair</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-cloudstack-resource-template") %>>
                             <a href="/docs/providers/cloudstack/r/template.html">cloudstack_template</a>
                         </li>


### PR DESCRIPTION
Updating docs following PR #2004 

I also noticed the timeout field on the provider is missing so I added that in too

@svanharmelen happy with this?