### PR TITLE
provisioner/chef: improve the decoding logic to prevent parameter not found errors

### DIFF
--- a/builtin/providers/azure/provider.go
+++ b/builtin/providers/azure/provider.go
@@ -45,7 +45,7 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	settingsFile, err := homedir.Expand(d.Get("settings_file").(string))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error expanding the settings file path: %s", err)
 	}
 
 	config := Config{


### PR DESCRIPTION
We need to decode both the Raw config and the parsed Config to make sure all set keys are visible. Otherwise keys that will need to be interpolated later, will be missing causing the validation to fail.

Also piggy bagged a small update to the Azure error output in case a `homedir.Expand()` fails.