### PR TITLE
provider/aws: Update SQS/SNS to work with upstream changes

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -12,11 +12,10 @@ import (
 
 // Mutable attributes
 var SNSAttributeMap = map[string]string{
-	"display_name" : "DisplayName",
-	"policy" : "Policy",
+	"display_name":    "DisplayName",
+	"policy":          "Policy",
 	"delivery_policy": "DeliveryPolicy",
 }
-
 
 func resourceAwsSnsTopic() *schema.Resource {
 	return &schema.Resource{
@@ -32,20 +31,20 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ForceNew: true,
 			},
 			"display_name": &schema.Schema{
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  false,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
 			},
 			"policy": &schema.Schema{
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  false,
-				Computed:  true,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
 			},
 			"delivery_policy": &schema.Schema{
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  false,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
 			},
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,
@@ -93,8 +92,8 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 				if !(k == "policy" && n == "") {
 					// Make API call to update attributes
 					req := &sns.SetTopicAttributesInput{
-						TopicARN: aws.String(d.Id()),
-						AttributeName: aws.String(attrKey),
+						TopicARN:       aws.String(d.Id()),
+						AttributeName:  aws.String(attrKey),
 						AttributeValue: aws.String(n.(string)),
 					}
 					snsconn.SetTopicAttributes(req)
@@ -117,8 +116,8 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if attributeOutput.Attributes != nil && len(*attributeOutput.Attributes) > 0 {
-		attrmap := *attributeOutput.Attributes
+	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
+		attrmap := attributeOutput.Attributes
 		resource := *resourceAwsSnsTopic()
 		// iKey = internal struct key, oKey = AWS Attribute Map key
 		for iKey, oKey := range SNSAttributeMap {

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -10,7 +10,6 @@ import (
 	"github.com/awslabs/aws-sdk-go/service/sns"
 )
 
-
 func resourceAwsSnsTopicSubscription() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsSnsTopicSubscriptionCreate,
@@ -25,29 +24,29 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 				ForceNew: false,
 			},
 			"endpoint": &schema.Schema{
-				Type: 	   schema.TypeString,
-				Required:  true,
-				ForceNew:  false,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
 			},
 			"topic_arn": &schema.Schema{
-				Type:      schema.TypeString,
-				Required:  true,
-				ForceNew:  false,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
 			},
 			"delivery_policy": &schema.Schema{
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  false,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
 			},
 			"raw_message_delivery": &schema.Schema{
-				Type:      schema.TypeBool,
-				Optional:  true,
-				ForceNew:  false,
-				Default:   false,
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Default:  false,
 			},
 			"arn": &schema.Schema{
-				Type:      schema.TypeString,
-				Computed:  true,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -56,7 +55,7 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 func resourceAwsSnsTopicSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
 	snsconn := meta.(*AWSClient).snsconn
 
-	if(d.Get("protocol") == "email") {
+	if d.Get("protocol") == "email" {
 		return fmt.Errorf("Email endpoints are not supported!")
 	}
 
@@ -107,8 +106,8 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 
 		req := &sns.SetSubscriptionAttributesInput{
 			SubscriptionARN: aws.String(d.Id()),
-			AttributeName: aws.String("RawMessageDelivery"),
-			AttributeValue: aws.String(attrValue),
+			AttributeName:   aws.String("RawMessageDelivery"),
+			AttributeValue:  aws.String(attrValue),
 		}
 		_, err := snsconn.SetSubscriptionAttributes(req)
 
@@ -132,8 +131,8 @@ func resourceAwsSnsTopicSubscriptionRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	if attributeOutput.Attributes != nil && len(*attributeOutput.Attributes) > 0 {
-		attrHash := *attributeOutput.Attributes
+	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
+		attrHash := attributeOutput.Attributes
 		log.Printf("[DEBUG] raw message delivery: %s", *attrHash["RawMessageDelivery"])
 		if *attrHash["RawMessageDelivery"] == "true" {
 			d.Set("raw_message_delivery", true)
@@ -158,7 +157,7 @@ func resourceAwsSnsTopicSubscriptionDelete(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.SubscribeOutput, err error)  {
+func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.SubscribeOutput, err error) {
 	protocol := d.Get("protocol").(string)
 	endpoint := d.Get("endpoint").(string)
 	topic_arn := d.Get("topic_arn").(string)

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -108,7 +108,7 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if len(attributes) > 0 {
-		req.Attributes = &attributes
+		req.Attributes = attributes
 	}
 
 	output, err := sqsconn.CreateQueue(req)
@@ -144,7 +144,7 @@ func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 	if len(attributes) > 0 {
 		req := &sqs.SetQueueAttributesInput{
 			QueueURL:   aws.String(d.Id()),
-			Attributes: &attributes,
+			Attributes: attributes,
 		}
 		sqsconn.SetQueueAttributes(req)
 	}
@@ -164,8 +164,8 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if attributeOutput.Attributes != nil && len(*attributeOutput.Attributes) > 0 {
-		attrmap := *attributeOutput.Attributes
+	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
+		attrmap := attributeOutput.Attributes
 		resource := *resourceAwsSqsQueue()
 		// iKey = internal struct key, oKey = AWS Attribute Map key
 		for iKey, oKey := range AttributeMap {

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -84,7 +84,7 @@ func testAccCheckAWSSQSExistsWithDefaults(n string) resource.TestCheckFunc {
 		}
 
 		// checking if attributes are defaults
-		for k, v := range *resp.Attributes {
+		for k, v := range resp.Attributes {
 			if k == "VisibilityTimeout" && *v != "30" {
 				return fmt.Errorf("VisibilityTimeout (%s) was not set to 30", *v)
 			}
@@ -134,7 +134,7 @@ func testAccCheckAWSSQSExistsWithOverrides(n string) resource.TestCheckFunc {
 		}
 
 		// checking if attributes match our overrides
-		for k, v := range *resp.Attributes {
+		for k, v := range resp.Attributes {
 			if k == "VisibilityTimeout" && *v != "60" {
 				return fmt.Errorf("VisibilityTimeout (%s) was not set to 60", *v)
 			}

--- a/helper/schema/valuetype_string.go
+++ b/helper/schema/valuetype_string.go
@@ -9,7 +9,7 @@ const _ValueType_name = "TypeInvalidTypeBoolTypeIntTypeFloatTypeStringTypeListTy
 var _ValueType_index = [...]uint8{0, 11, 19, 26, 35, 45, 53, 60, 67, 77}
 
 func (i ValueType) String() string {
-	if i < 0 || i+1 >= ValueType(len(_ValueType_index)) {
+	if i < 0 || i >= ValueType(len(_ValueType_index)-1) {
 		return fmt.Sprintf("ValueType(%d)", i)
 	}
 	return _ValueType_name[_ValueType_index[i]:_ValueType_index[i+1]]

--- a/terraform/graphnodeconfigtype_string.go
+++ b/terraform/graphnodeconfigtype_string.go
@@ -9,7 +9,7 @@ const _GraphNodeConfigType_name = "GraphNodeConfigTypeInvalidGraphNodeConfigType
 var _GraphNodeConfigType_index = [...]uint8{0, 26, 53, 80, 105, 130, 157}
 
 func (i GraphNodeConfigType) String() string {
-	if i < 0 || i+1 >= GraphNodeConfigType(len(_GraphNodeConfigType_index)) {
+	if i < 0 || i >= GraphNodeConfigType(len(_GraphNodeConfigType_index)-1) {
 		return fmt.Sprintf("GraphNodeConfigType(%d)", i)
 	}
 	return _GraphNodeConfigType_name[_GraphNodeConfigType_index[i]:_GraphNodeConfigType_index[i+1]]

--- a/terraform/instancetype_string.go
+++ b/terraform/instancetype_string.go
@@ -9,7 +9,7 @@ const _InstanceType_name = "TypeInvalidTypePrimaryTypeTaintedTypeDeposed"
 var _InstanceType_index = [...]uint8{0, 11, 22, 33, 44}
 
 func (i InstanceType) String() string {
-	if i < 0 || i+1 >= InstanceType(len(_InstanceType_index)) {
+	if i < 0 || i >= InstanceType(len(_InstanceType_index)-1) {
 		return fmt.Sprintf("InstanceType(%d)", i)
 	}
 	return _InstanceType_name[_InstanceType_index[i]:_InstanceType_index[i+1]]

--- a/terraform/walkoperation_string.go
+++ b/terraform/walkoperation_string.go
@@ -9,7 +9,7 @@ const _walkOperation_name = "walkInvalidwalkInputwalkApplywalkPlanwalkPlanDestro
 var _walkOperation_index = [...]uint8{0, 11, 20, 29, 37, 52, 63, 75}
 
 func (i walkOperation) String() string {
-	if i+1 >= walkOperation(len(_walkOperation_index)) {
+	if i >= walkOperation(len(_walkOperation_index)-1) {
 		return fmt.Sprintf("walkOperation(%d)", i)
 	}
 	return _walkOperation_name[_walkOperation_index[i]:_walkOperation_index[i+1]]


### PR DESCRIPTION
`aws-sdk-go` introduced a breaking change with [commit d993b41140][1]. TL;DR it now uses/returns `map` instead of `*map`. 

The breaks were pretty isolated to just the recent SQS and SNS things. 

There's also commit 78e7519 that came from running `go generate`  (part of `make test`)


[1]: https://github.com/awslabs/aws-sdk-go/commit/d993b4114018e8fee2cc91f81c7cbb873a794d73