### PR TITLE
provider/aws: fix panic when route has no cidr_block

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -361,7 +361,10 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 func resourceAwsRouteTableHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["cidr_block"].(string)))
+
+	if v, ok := m["cidr_block"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
 
 	if v, ok := m["gateway_id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))


### PR DESCRIPTION
While cidr_block is required for static route creation, there are
apparently cases (involving some combination of VPNs, Customer Gateways,
and automatic route propogation) where the cidr_block can come back nil.
This means we cannot assume it's there in the set hash calculation.