### PR TITLE
provider/aws: Correctly default Instance source_dest_check to true

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -85,6 +85,7 @@ func resourceAwsInstance() *schema.Resource {
 			"source_dest_check": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 
 			"user_data": &schema.Schema{
@@ -641,6 +642,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("subnet_id", instance.SubnetID)
 	}
 	d.Set("ebs_optimized", instance.EBSOptimized)
+	d.Set("source_dest_check", instance.SourceDestCheck)
 	d.Set("tags", tagsToMap(instance.Tags))
 
 	// Determine whether we're referring to security groups with

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -642,7 +642,6 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("subnet_id", instance.SubnetID)
 	}
 	d.Set("ebs_optimized", instance.EBSOptimized)
-	d.Set("source_dest_check", instance.SourceDestCheck)
 	d.Set("tags", tagsToMap(instance.Tags))
 
 	// Determine whether we're referring to security groups with

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -653,7 +653,6 @@ resource "aws_instance" "foo" {
 	ami = "ami-4fccb37f"
 	instance_type = "m1.small"
 	subnet_id = "${aws_subnet.foo.id}"
-	source_dest_check = true
 }
 `
 


### PR DESCRIPTION
Addresses issue raised in #2187, where `source_dest_check` was incorrectly defaulting to `false`. This adds a default of `true` to the attribute, matching both our docs and AWS docs.

We also now export this attribute 