### PR TITLE
provider/docker: Add privileged option

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -136,6 +136,12 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"privileged": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -85,6 +85,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(retContainer.ID)
 
 	hostConfig := &dc.HostConfig{
+		Privileged: d.Get("privileged").(bool),
 		PublishAllPorts: d.Get("publish_all_ports").(bool),
 	}
 

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
   kept running. If false, then as long as the container exists, Terraform
   assumes it is successful.
 * `ports` - (Optional) See [Ports](#ports) below for details.
+* `privileged` - (Optional, bool) Run container in privileged mode.
 * `publish_all_ports` - (Optional, bool) Publish all ports of the container.
 * `volumes` - (Optional) See [Volumes](#volumes) below for details.
 


### PR DESCRIPTION
Add _privileged_ option to docker_container resource. With this option set to _true_, Docker runs the container in [privileged](https://docs.docker.com/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration) mode.