### PR TITLE
Fixing bugs with `aws_network_interface` and added docs.

### DIFF
--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -78,9 +78,17 @@ func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).ec2conn
 
 	request := &ec2.CreateNetworkInterfaceInput{
-		Groups:             expandStringList(d.Get("security_groups").(*schema.Set).List()),
-		SubnetID:           aws.String(d.Get("subnet_id").(string)),
-		PrivateIPAddresses: expandPrivateIPAddesses(d.Get("private_ips").(*schema.Set).List()),
+		SubnetID: aws.String(d.Get("subnet_id").(string)),
+	}
+
+	security_groups := d.Get("security_groups").(*schema.Set).List()
+	if len(security_groups) != 0 {
+		request.Groups = expandStringList(security_groups)
+	}
+
+	private_ips := d.Get("private_ips").(*schema.Set).List()
+	if len(private_ips) != 0 {
+		request.PrivateIPAddresses = expandPrivateIPAddesses(private_ips)
 	}
 
 	log.Printf("[DEBUG] Creating network interface")

--- a/website/source/docs/providers/aws/r/network_interface.markdown
+++ b/website/source/docs/providers/aws/r/network_interface.markdown
@@ -1,0 +1,51 @@
+---
+layout: "aws"
+page_title: "AWS: aws_network_interface"
+sidebar_current: "docs-aws-resource-network-interface"
+description: |-
+  Provides an Elastic network interface (ENI) resource.
+---
+
+# aws\_network\_interface
+
+Provides an Elastic network interface (ENI) resource.
+
+## Example Usage
+
+```
+resource "aws_network_interface" "test" {
+    subnet_id = "${aws_subnet.public_a.id}"
+	private_ips = ["10.0.0.50"]
+	security_groups = ["${aws_security_group.web.name}"]
+	attachment {
+		instance = "${aws_instance.test.id}"
+		device_index = 1
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `subnet_id` - (Required) Subnet ID to create the ENI in.
+* `private_ips` - (Optional) List of private IPs to assign to the ENI.
+* `security_groups` - (Optional) List of security group IDs to assign to the ENI.
+* `attachment` - (Required) Block to define the attachment of the ENI. Documented below.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `attachment` block supports:
+
+* `instance` - (Required) ID of the instance to attach to.
+* `device_index` - (Required) Integer to define the devices index.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `subnet_id` - Subnet ID the ENI is in.
+* `private_ips` - List of private IPs assigned to the ENI.
+* `security_groups` - List of security groups attached to the ENI.
+* `attachment` - Block defining the attachment of the ENI.
+* `tags` - Tags assigned to the ENI.
+

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -133,6 +133,10 @@
 							<a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
 						</li>
 
+						<li<%= sidebar_current("docs-aws-resource-network-interface") %>>
+							<a href="/docs/providers/aws/r/network_interface.html">aws_network_acl</a>
+						</li>
+
 						<li<%= sidebar_current("docs-aws-resource-proxy-protocol-policy") %>>
 							<a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
 						</li>


### PR DESCRIPTION
When a user tried to create an `aws_network_interface` resource without specifying the `private_ips` or `security_groups` attributes the API call to AWS would fail with a 500 HTTP error. Length checks have been put in place for both of these attributes before they are added to the `ec2.CreateNetworkInterfaceInput` struct.

Documentation was also added for the `aws_network_interface` resource.

I believe there is already a duplicate PR #1987 - but it fails to also check the assignment of the `security_groups` attribute.