### PR TITLE
[WIP] Adds support for heroku formation management

### DIFF
--- a/builtin/providers/heroku/provider.go
+++ b/builtin/providers/heroku/provider.go
@@ -30,6 +30,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_domain": resourceHerokuDomain(),
 			"heroku_drain":  resourceHerokuDrain(),
 			"heroku_cert":   resourceHerokuCert(),
+			"heroku_formation": resourceHerokuFormation(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/heroku/resource_heroku_formation.go
+++ b/builtin/providers/heroku/resource_heroku_formation.go
@@ -1,0 +1,116 @@
+package heroku
+
+import (
+	"fmt"
+
+	"github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceHerokuFormation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuFormationCreate,
+		Read:   resourceHerokuFormationRead,
+		Update: resourceHerokuFormationUpdate,
+		Delete: resourceHerokuFormationDelete,
+		Exists: resourceHerokuFormationExists,
+
+		Schema: map[string]*schema.Schema{
+			"app": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"quantity": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"size": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+func resourceHerokuFormationCreate(d *schema.ResourceData, meta interface{}) error {
+
+	d.SetId("")
+	return resourceHerokuFormationUpdate(d, meta)
+}
+
+func resourceHerokuFormationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	formations, err := client.FormationList(d.Get("app").(string), (&heroku.ListRange{Max: 10000}))
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving formation list: %s", err)
+	}
+
+	for _, formation := range formations {
+		if formation.Type == d.Get("type").(string) {
+			d.Set("size", formation.Size)
+			d.Set("quantity", formation.Quantity)
+			d.SetId(formation.ID)
+		}
+	}
+
+	return nil
+}
+
+func resourceHerokuFormationUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	app := d.Get("app").(string)
+
+	quantity := d.Get("quantity").(int)
+	size := d.Get("size").(string)
+
+	if d.Id() == d.Get("type") && (d.HasChange("quantity") || d.HasChange("size")) {
+		opts := heroku.FormationUpdateOpts{
+			Quantity: &quantity,
+		}
+
+		if size != "" {
+			opts.Size = &size
+		}
+		_, err := client.FormationUpdate(app, d.Get("type").(string), opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceHerokuFormationRead(d, meta)
+}
+
+func resourceHerokuFormationDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func resourceHerokuFormationExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*heroku.Service)
+
+	formations, err := client.FormationList(d.Get("app").(string), (&heroku.ListRange{Max: 10000}))
+
+	if err != nil {
+		return false, fmt.Errorf("Error retrieving formation list: %s", err)
+	}
+
+  exists := false
+	for _, formation := range formations {
+		if formation.Type == d.Get("type").(string) {
+      exists = true
+		}
+	}
+
+	return exists, nil
+}


### PR DESCRIPTION
This adds support for managing heroku formations (dynos and sizes). It might make more sense to call this 'heroku dynos', but formations the more correct term.

Notably, this somewhat violates the CRUD promise, as there is actually no way to actually create dynos for apps that have not yet been deployed. Once an app is deployed however, this will allow for its dyno formations to be managed in terraform. This need to deploy an app makes this tricky to test, however, the code is really quite simple - just a few calls and comparisons.

The workflow I hope to support here is to manage heroku dynos via git. This would allow us to code review dyno changes, and have a history of who changed them and why. The use case here is that rather than giving every developer access to every heroku account, and trying to somehow track who changed what, we just have a single account that can manage all dynos - elegantly tracked in Git.

Since dynos are a pretty key part of heroku, and I cannot see any other way to manage them with terraform, I feel there is a fundamental need for this support - that's why I've made this patch.

In my tests, I can confirm:

* The app is successfully created without the any formations specified
* Future plans / applies will continue to show that the formations are outstanding
* Once the app is deployed, and dynos exist for the given formation, the formation is successfully created.
* The formation can successfully manage the size and quantity of dynos for a given type of the app



