### PR TITLE
provider/aws: clarify scaling timeout error

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -462,7 +462,7 @@ func waitForASGCapacity(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
-		return fmt.Errorf("Still need to wait for more healthy instances.")
+		return fmt.Errorf("Still need to wait for more healthy instances. This could mean instances failed to launch. See Scaling History for more information.")
 	})
 }
 


### PR DESCRIPTION
This just gives the user a better hint to why their scaling may have timed out.