### PR TITLE
Openstack / Add endpoint type provider configuration

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -61,6 +61,11 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Default:  false,
 			},
+			"endpoint_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: envDefaultFunc("OS_ENDPOINT_TYPE"),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -99,6 +104,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		DomainID:         d.Get("domain_id").(string),
 		DomainName:       d.Get("domain_name").(string),
 		Insecure:         d.Get("insecure").(bool),
+		EndpointType:     d.Get("endpoint_type").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -42,8 +42,8 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: envDefaultFunc("OS_PASSWORD"),
 			},
 			"api_key": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
 				DefaultFunc: envDefaultFunc("OS_AUTH_TOKEN"),
 			},
 			"domain_id": &schema.Schema{

--- a/website/source/docs/providers/openstack/index.html.markdown
+++ b/website/source/docs/providers/openstack/index.html.markdown
@@ -60,6 +60,10 @@ The following arguments are supported:
 * `insecure` - (Optional) Explicitly allow the provider to perform
     "insecure" SSL requests. If omitted, default value is `false`
 
+* `endpoint_type` - (Optional) Specify which type of endpoint to use from the
+    service catalog. It can be set using the OS_ENDPOINT_TYPE environment
+    variable. If not set, public endpoints is used.
+
 ## Testing
 
 In order to run the Acceptance Tests for development, the following environment


### PR DESCRIPTION
Add the possibility to specify the endpoint type (public, admin, internal). The default remains the same (public).