### PR TITLE
acc tests: ensure each resource has a _basic test

### DIFF
--- a/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy_test.go
+++ b/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSAppCookieStickinessPolicy(t *testing.T) {
+func TestAccAWSAppCookieStickinessPolicy_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_customer_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccCustomerGateway(t *testing.T) {
+func TestAccCustomerGateway_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
-func TestAccAWSDBInstance(t *testing.T) {
+func TestAccAWSDBInstance_basic(t *testing.T) {
 	var v rds.DBInstance
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSDBParameterGroup(t *testing.T) {
+func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 	var v rds.DBParameterGroup
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSDBSecurityGroup(t *testing.T) {
+func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 	var v rds.DBSecurityGroup
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
-func TestAccAWSDBSubnetGroup(t *testing.T) {
+func TestAccAWSDBSubnetGroup_basic(t *testing.T) {
 	var v rds.DBSubnetGroup
 
 	testCheck := func(*terraform.State) error {

--- a/builtin/providers/aws/resource_aws_ebs_volume_test.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSEBSVolume(t *testing.T) {
+func TestAccAWSEBSVolume_basic(t *testing.T) {
 	var v ec2.Volume
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/builtin/providers/aws/resource_aws_ecs_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSEcsCluster(t *testing.T) {
+func TestAccAWSEcsCluster_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSEcsTaskDefinition(t *testing.T) {
+func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_elasticache_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_security_group_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSElasticacheSecurityGroup(t *testing.T) {
+func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_iam_group_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_policy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIAMGroupPolicy(t *testing.T) {
+func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_iam_instance_profile_test.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAWSIAMInstanceProfile(t *testing.T) {
+func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/builtin/providers/aws/resource_aws_iam_role_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_policy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIAMRolePolicy(t *testing.T) {
+func TestAccAWSIAMRolePolicy_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_iam_user_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_policy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIAMUserPolicy(t *testing.T) {
+func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -14,6 +14,26 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAWSLaunchConfiguration_basic(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSLaunchConfigurationNoNameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
+					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(
+						"aws_launch_configuration.bar", "terraform-"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchConfiguration_withBlockDevices(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
 
@@ -55,26 +75,6 @@ func TestAccAWSLaunchConfiguration_withSpotPrice(t *testing.T) {
 					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
 					resource.TestCheckResourceAttr(
 						"aws_launch_configuration.bar", "spot_price", "0.01"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLaunchConfiguration_withGeneratedName(t *testing.T) {
-	var conf autoscaling.LaunchConfiguration
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSLaunchConfigurationNoNameConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(
-						"aws_launch_configuration.bar", "terraform-"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsLBCookieStickinessPolicy(t *testing.T) {
+func TestAccAwsLBCookieStickinessPolicy_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_main_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_main_route_table_association_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSMainRouteTableAssociation(t *testing.T) {
+func TestAccAWSMainRouteTableAssociation_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_proxy_protocol_policy_test.go
+++ b/builtin/providers/aws/resource_aws_proxy_protocol_policy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSProxyProtocolPolicy(t *testing.T) {
+func TestAccAWSProxyProtocolPolicy_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_association_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSRouteTableAssociation(t *testing.T) {
+func TestAccAWSRouteTableAssociation_basic(t *testing.T) {
 	var v, v2 ec2.RouteTable
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-func TestAccAWSSNSTopicSubscription(t *testing.T) {
+func TestAccAWSSNSTopicSubscription_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_sns_topic_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-func TestAccAWSSNSTopic(t *testing.T) {
+func TestAccAWSSNSTopic_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSSQSQueue(t *testing.T) {
+func TestAccAWSSQSQueue_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_subnet_test.go
+++ b/builtin/providers/aws/resource_aws_subnet_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSSubnet(t *testing.T) {
+func TestAccAWSSubnet_basic(t *testing.T) {
 	var v ec2.Subnet
 
 	testCheck := func(*terraform.State) error {

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options_association_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options_association_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSDHCPOptionsAssociation(t *testing.T) {
+func TestAccAWSDHCPOptionsAssociation_basic(t *testing.T) {
 	var v ec2.VPC
 	var d ec2.DHCPOptions
 

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDHCPOptions(t *testing.T) {
+func TestAccDHCPOptions_basic(t *testing.T) {
 	var d ec2.DHCPOptions
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsVpnConnection(t *testing.T) {
+func TestAccAwsVpnConnection_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_vpn_connection_route_test.go
+++ b/builtin/providers/aws/resource_vpn_connection_route_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsVpnConnectionRoute(t *testing.T) {
+func TestAccAwsVpnConnectionRoute_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/cloudstack/resource_cloudstack_ssh_keypair_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ssh_keypair_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/xanzy/go-cloudstack/cloudstack"
 )
 
-func TestAccCloudStackSSHKeyPair_create(t *testing.T) {
+func TestAccCloudStackSSHKeyPair_basic(t *testing.T) {
 	var sshkey cloudstack.SSHKeyPair
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/consul/resource_consul_keys_test.go
+++ b/builtin/providers/consul/resource_consul_keys_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccConsulKeys(t *testing.T) {
+func TestAccConsulKeys_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() {},
 		Providers:    testAccProviders,

--- a/builtin/providers/dme/resource_dme_record_test.go
+++ b/builtin/providers/dme/resource_dme_record_test.go
@@ -13,7 +13,7 @@ import (
 var _ = fmt.Sprintf("dummy") // dummy
 var _ = os.DevNull           // dummy
 
-func TestAccDMERecordA(t *testing.T) {
+func TestAccDMERecord_basic(t *testing.T) {
 	var record dnsmadeeasy.Record
 	domainid := os.Getenv("DME_DOMAINID")
 

--- a/builtin/providers/google/resource_storage_bucket_test.go
+++ b/builtin/providers/google/resource_storage_bucket_test.go
@@ -1,9 +1,9 @@
 package google
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
-	"bytes"
 	"testing"
 	"time"
 
@@ -14,7 +14,7 @@ import (
 	storage "google.golang.org/api/storage/v1"
 )
 
-func TestAccStorageDefaults(t *testing.T) {
+func TestAccStorage_basic(t *testing.T) {
 	var bucketName string
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/resource_openstack_fw_firewall_v1_test.go
+++ b/builtin/providers/openstack/resource_openstack_fw_firewall_v1_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
 )
 
-func TestAccFWFirewallV1(t *testing.T) {
+func TestAccFWFirewallV1_basic(t *testing.T) {
 
 	var policyID *string
 

--- a/builtin/providers/openstack/resource_openstack_fw_rule_v1_test.go
+++ b/builtin/providers/openstack/resource_openstack_fw_rule_v1_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
 )
 
-func TestAccFWRuleV1(t *testing.T) {
+func TestAccFWRuleV1_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,


### PR DESCRIPTION
Helpful for breadth first acc test sweeps `-run '_basic$'`