### PR TITLE
Support arbitrary per-field schema validation

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -153,6 +154,20 @@ func resourceAwsDbInstance() *schema.Resource {
 			"final_snapshot_identifier": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: func(v interface{}) (ws []string, es []error) {
+					fsi := v.(string)
+					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(fsi) {
+						es = append(es, fmt.Errorf(
+							"only alphanumeric characters and hyphens allowed"))
+					}
+					if regexp.MustCompile(`--`).MatchString(fsi) {
+						es = append(es, fmt.Errorf("cannot contain two consecutive hyphens"))
+					}
+					if regexp.MustCompile(`-$`).MatchString(fsi) {
+						es = append(es, fmt.Errorf("cannot end in a hyphen"))
+					}
+					return
+				},
 			},
 
 			"db_subnet_group_name": &schema.Schema{

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -132,7 +132,10 @@ type Schema struct {
 	// what do to about the removed attribute.
 	Removed string
 
-	// ValidateFunc allows individual fields to validate
+	// ValidateFunc allows individual fields to define arbitrary validation
+	// logic. It is yielded the provided config value as an interface{} that is
+	// guaranteed to be of the proper Schema type, and it can yield warnings or
+	// errors based on inspection of that value.
 	ValidateFunc SchemaValidateFunc
 }
 
@@ -1183,7 +1186,7 @@ func (m schemaMap) validateType(
 			"%q: [REMOVED] %s", k, schema.Removed))
 	}
 
-	if schema.ValidateFunc != nil {
+	if len(es) == 0 && schema.ValidateFunc != nil {
 		ws2, es2 := schema.ValidateFunc(raw)
 		for _, w := range ws2 {
 			ws = append(ws, fmt.Sprintf("%q: %s", k, w))

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2796,6 +2796,20 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			},
 			false,
 		},
+
+		// ValidateFunc on non-primitive
+		{
+			map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeMap,
+					Required: true,
+					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+						return
+					},
+				},
+			},
+			true,
+		},
 	}
 
 	for i, tc := range cases {
@@ -3435,7 +3449,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 			},
 			Err: true,
 			Errors: []error{
-				fmt.Errorf(`"validate_me": something is not right here`),
+				fmt.Errorf(`something is not right here`),
 			},
 		},
 
@@ -3454,6 +3468,23 @@ func TestSchemaMap_Validate(t *testing.T) {
 				"number": "NaN",
 			},
 			Err: true,
+		},
+		"ValidateFunc gets decoded type": {
+			Schema: map[string]*Schema{
+				"maybe": &Schema{
+					Type:     TypeBool,
+					Required: true,
+					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+						if _, ok := v.(bool); !ok {
+							t.Fatalf("Expected bool, got: %#v", v)
+						}
+						return
+					},
+				},
+			},
+			Config: map[string]interface{}{
+				"maybe": "true",
+			},
 		},
 	}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3399,7 +3399,43 @@ func TestSchemaMap_Validate(t *testing.T) {
 
 			Err: true,
 			Errors: []error{
-				fmt.Errorf("\"optional_att\": conflicts with required_att (\"required-val\")"),
+				fmt.Errorf(`"optional_att": conflicts with required_att ("required-val")`),
+			},
+		},
+
+		"Good with ValidateFunc": {
+			Schema: map[string]*Schema{
+				"validate_me": &Schema{
+					Type:     TypeString,
+					Required: true,
+					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+						return
+					},
+				},
+			},
+			Config: map[string]interface{}{
+				"validate_me": "valid",
+			},
+			Err: false,
+		},
+
+		"Bad with ValidateFunc": {
+			Schema: map[string]*Schema{
+				"validate_me": &Schema{
+					Type:     TypeString,
+					Required: true,
+					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+						es = append(es, fmt.Errorf("something is not right here"))
+						return
+					},
+				},
+			},
+			Config: map[string]interface{}{
+				"validate_me": "invalid",
+			},
+			Err: true,
+			Errors: []error{
+				fmt.Errorf(`"validate_me": something is not right here`),
 			},
 		},
 	}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3438,6 +3438,23 @@ func TestSchemaMap_Validate(t *testing.T) {
 				fmt.Errorf(`"validate_me": something is not right here`),
 			},
 		},
+
+		"ValidateFunc not called when type does not match": {
+			Schema: map[string]*Schema{
+				"number": &Schema{
+					Type:     TypeInt,
+					Required: true,
+					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+						t.Fatalf("Should not have gotten validate call")
+						return
+					},
+				},
+			},
+			Config: map[string]interface{}{
+				"number": "NaN",
+			},
+			Err: true,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
...and use it to protect against delayed sadness on `final_snapshot_identifier`.