### PR TITLE
Support arbitrary per-field schema validation

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_policy.go
@@ -59,7 +59,7 @@ func resourceAwsIamPolicyCreate(d *schema.ResourceData, meta interface{}) error 
 
 	response, err := iamconn.CreatePolicy(request)
 	if err != nil {
-		return fmt.Errorf("Error creating IAM policy %s: %#v", name, err)
+		return fmt.Errorf("Error creating IAM policy %s: %s", name, err)
 	}
 
 	return readIamPolicy(d, response.Policy)
@@ -78,7 +78,7 @@ func resourceAwsIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading IAM policy %s: %#v", d.Id(), err)
+		return fmt.Errorf("Error reading IAM policy %s: %s", d.Id(), err)
 	}
 
 	return readIamPolicy(d, response.Policy)
@@ -101,7 +101,7 @@ func resourceAwsIamPolicyUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if _, err := iamconn.CreatePolicyVersion(request); err != nil {
-		return fmt.Errorf("Error updating IAM policy %s: %#v", d.Id(), err)
+		return fmt.Errorf("Error updating IAM policy %s: %s", d.Id(), err)
 	}
 	return nil
 }
@@ -187,7 +187,7 @@ func iamPolicyDeleteVersion(arn, versionID string, iamconn *iam.IAM) error {
 
 	_, err := iamconn.DeletePolicyVersion(request)
 	if err != nil {
-		return fmt.Errorf("Error deleting version %s from IAM policy %s: %#v", versionID, arn, err)
+		return fmt.Errorf("Error deleting version %s from IAM policy %s: %s", versionID, arn, err)
 	}
 	return nil
 }
@@ -199,7 +199,7 @@ func iamPolicyListVersions(arn string, iamconn *iam.IAM) ([]*iam.PolicyVersion, 
 
 	response, err := iamconn.ListPolicyVersions(request)
 	if err != nil {
-		return nil, fmt.Errorf("Error listing versions for IAM policy %s: %#v", arn, err)
+		return nil, fmt.Errorf("Error listing versions for IAM policy %s: %s", arn, err)
 	}
 	return response.Versions, nil
 }


### PR DESCRIPTION
...and use it to protect against delayed sadness on `final_snapshot_identifier`.