### PR TITLE
config: parse lifecycle block with mapstructure for weak decode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,8 +84,8 @@ type Resource struct {
 // ResourceLifecycle is used to store the lifecycle tuning parameters
 // to allow customized behavior
 type ResourceLifecycle struct {
-	CreateBeforeDestroy bool `hcl:"create_before_destroy"`
-	PreventDestroy      bool `hcl:"prevent_destroy"`
+	CreateBeforeDestroy bool `mapstructure:"create_before_destroy"`
+	PreventDestroy      bool `mapstructure:"prevent_destroy"`
 }
 
 // Provisioner is a configured provisioner step on a resource.

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -394,6 +394,43 @@ func TestLoad_createBeforeDestroy(t *testing.T) {
 	}
 }
 
+func TestLoad_preventDestroyString(t *testing.T) {
+	c, err := Load(filepath.Join(fixtureDir, "prevent-destroy-string.tf"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	actual := resourcesStr(c.Resources)
+	if actual != strings.TrimSpace(createBeforeDestroyResourcesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
+	// Check for the flag value
+	r := c.Resources[0]
+	if r.Name != "web" && r.Type != "aws_instance" {
+		t.Fatalf("Bad: %#v", r)
+	}
+
+	// Should enable create before destroy
+	if !r.Lifecycle.PreventDestroy {
+		t.Fatalf("Bad: %#v", r)
+	}
+
+	r = c.Resources[1]
+	if r.Name != "bar" && r.Type != "aws_instance" {
+		t.Fatalf("Bad: %#v", r)
+	}
+
+	// Should not enable create before destroy
+	if r.Lifecycle.PreventDestroy {
+		t.Fatalf("Bad: %#v", r)
+	}
+}
+
 func TestLoad_temporary_files(t *testing.T) {
 	_, err := LoadDir(filepath.Join(fixtureDir, "dir-temporary-files"))
 	if err == nil {

--- a/config/test-fixtures/prevent-destroy-string.tf
+++ b/config/test-fixtures/prevent-destroy-string.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "web" {
+    ami = "foo"
+    lifecycle {
+        prevent_destroy = "true"
+    }
+}
+
+resource "aws_instance" "bar" {
+    ami = "foo"
+}


### PR DESCRIPTION
Fixes #1975 

This uses mapstructure weak decode to parse values so that we can get types to not matter as much for the lifecycle flags.

This doesn't fix the aspect of #1975 where we don't validate that interpolations aren't in these flags, but the end result is still the same for that, and the type error is clearer from mapstructure.