### PR TITLE
provider/aws elasticache parameter group

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -97,6 +97,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ecs_task_definition":          resourceAwsEcsTaskDefinition(),
 			"aws_eip":                          resourceAwsEip(),
 			"aws_elasticache_cluster":          resourceAwsElasticacheCluster(),
+			"aws_elasticache_parameter_group":  resourceAwsElasticacheParameterGroup(),
 			"aws_elasticache_security_group":   resourceAwsElasticacheSecurityGroup(),
 			"aws_elasticache_subnet_group":     resourceAwsElasticacheSubnetGroup(),
 			"aws_elb":                          resourceAwsElb(),

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
@@ -191,15 +191,12 @@ func resourceAwsElasticacheParameterGroupDeleteRefreshFunc(
 
 		if _, err := conn.DeleteCacheParameterGroup(&deleteOpts); err != nil {
 			elasticahceerr, ok := err.(awserr.Error)
-			if !ok {
+			if ok && elasticahceerr.Code() == "CacheParameterGroupNotFoundFault" {
+				d.SetId("")
 				return d, "error", err
 			}
-
-			if elasticahceerr.Code() != "CacheParameterGroupNotFoundFault" {
-				return d, "error", err
-			}
+			return d, "error", err
 		}
-
 		return d, "destroyed", nil
 	}
 }

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -51,19 +50,6 @@ func resourceAwsElasticacheParameterGroup() *schema.Resource {
 						"value": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
-						},
-						"apply_method": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "immediate",
-							// this parameter is not actually state, but a
-							// meta-parameter describing how the RDS API call
-							// to modify the parameter group should be made.
-							// Future reads of the resource from AWS don't tell
-							// us what we used for apply_method previously, so
-							// by squashing state to an empty string we avoid
-							// needing to do an update for every future run.
-							StateFunc: func(interface{}) string { return "" },
 						},
 					},
 				},
@@ -222,8 +208,7 @@ func resourceAwsElasticacheParameterHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-	// Store the value as a lower case string, to match how we store them in flattenParameters
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["value"].(string))))
+	buf.WriteString(fmt.Sprintf("%s-", m["value"].(string)))
 
 	return hashcode.String(buf.String())
 }

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
@@ -1,0 +1,229 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+)
+
+func resourceAwsElasticacheParameterGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsElasticacheParameterGroupCreate,
+		Read:   resourceAwsElasticacheParameterGroupRead,
+		Update: resourceAwsElasticacheParameterGroupUpdate,
+		Delete: resourceAwsElasticacheParameterGroupDelete,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"family": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"parameter": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"apply_method": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "immediate",
+							// this parameter is not actually state, but a
+							// meta-parameter describing how the RDS API call
+							// to modify the parameter group should be made.
+							// Future reads of the resource from AWS don't tell
+							// us what we used for apply_method previously, so
+							// by squashing state to an empty string we avoid
+							// needing to do an update for every future run.
+							StateFunc: func(interface{}) string { return "" },
+						},
+					},
+				},
+				Set: resourceAwsElasticacheParameterHash,
+			},
+		},
+	}
+}
+
+func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	createOpts := elasticache.CreateCacheParameterGroupInput{
+		CacheParameterGroupName:   aws.String(d.Get("name").(string)),
+		CacheParameterGroupFamily: aws.String(d.Get("family").(string)),
+		Description:            aws.String(d.Get("description").(string)),
+	}
+
+	log.Printf("[DEBUG] Create Cache Parameter Group: %#v", createOpts)
+	_, err := conn.CreateCacheParameterGroup(&createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating DB Parameter Group: %s", err)
+	}
+
+	d.Partial(true)
+	d.SetPartial("name")
+	d.SetPartial("family")
+	d.SetPartial("description")
+	d.Partial(false)
+
+	d.SetId(*createOpts.CacheParameterGroupName)
+	log.Printf("[INFO] Cache Parameter Group ID: %s", d.Id())
+
+	return resourceAwsElasticacheParameterGroupUpdate(d, meta)
+}
+
+func resourceAwsElasticacheParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	describeOpts := elasticache.DescribeCacheParameterGroupsInput{
+		CacheParameterGroupName: aws.String(d.Id()),
+	}
+
+	describeResp, err := conn.DescribeCacheParameterGroups(&describeOpts)
+	if err != nil {
+		return err
+	}
+
+	if len(describeResp.CacheParameterGroups) != 1 ||
+		*describeResp.CacheParameterGroups[0].CacheParameterGroupName != d.Id() {
+		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.CacheParameterGroups)
+	}
+
+	d.Set("name", describeResp.CacheParameterGroups[0].CacheParameterGroupName)
+	d.Set("family", describeResp.CacheParameterGroups[0].CacheParameterGroupFamily)
+	d.Set("description", describeResp.CacheParameterGroups[0].Description)
+
+	// Only include user customized parameters as there's hundreds of system/default ones
+	describeParametersOpts := elasticache.DescribeCacheParametersInput{
+		CacheParameterGroupName: aws.String(d.Id()),
+		Source:               aws.String("user"),
+	}
+
+	describeParametersResp, err := conn.DescribeCacheParameters(&describeParametersOpts)
+	if err != nil {
+		return err
+	}
+
+	d.Set("parameter", flattenElastiCacheParameters(describeParametersResp.Parameters))
+
+	return nil
+}
+
+func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	d.Partial(true)
+
+	if d.HasChange("parameter") {
+		o, n := d.GetChange("parameter")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		// Expand the "parameter" set to aws-sdk-go compat []elasticacheconn.Parameter
+		parameters, err := expandElastiCacheParameters(ns.Difference(os).List())
+		if err != nil {
+			return err
+		}
+
+		if len(parameters) > 0 {
+			modifyOpts := elasticache.ModifyCacheParameterGroupInput{
+				CacheParameterGroupName: aws.String(d.Get("name").(string)),
+				ParameterNameValues:     parameters,
+			}
+
+			log.Printf("[DEBUG] Modify Cache Parameter Group: %#v", modifyOpts)
+			_, err = conn.ModifyCacheParameterGroup(&modifyOpts)
+			if err != nil {
+				return fmt.Errorf("Error modifying Cache Parameter Group: %s", err)
+			}
+		}
+		d.SetPartial("parameter")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsElasticacheParameterGroupRead(d, meta)
+}
+
+func resourceAwsElasticacheParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"pending"},
+		Target:     "destroyed",
+		Refresh:    resourceAwsElasticacheParameterGroupDeleteRefreshFunc(d, meta),
+		Timeout:    3 * time.Minute,
+		MinTimeout: 1 * time.Second,
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func resourceAwsElasticacheParameterGroupDeleteRefreshFunc(
+	d *schema.ResourceData,
+	meta interface{}) resource.StateRefreshFunc {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	return func() (interface{}, string, error) {
+
+		deleteOpts := elasticache.DeleteCacheParameterGroupInput{
+			CacheParameterGroupName: aws.String(d.Id()),
+		}
+
+		if _, err := conn.DeleteCacheParameterGroup(&deleteOpts); err != nil {
+			elasticahceerr, ok := err.(awserr.Error)
+			if !ok {
+				return d, "error", err
+			}
+
+			if elasticahceerr.Code() != "CacheParameterGroupNotFoundFault" {
+				return d, "error", err
+			}
+		}
+
+		return d, "destroyed", nil
+	}
+}
+
+func resourceAwsElasticacheParameterHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	// Store the value as a lower case string, to match how we store them in flattenParameters
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["value"].(string))))
+
+	return hashcode.String(buf.String())
+}

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group_test.go
@@ -1,0 +1,210 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSElasticacheParameterGroup_basic(t *testing.T) {
+	var v elasticache.CacheParameterGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheParameterGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
+					testAccCheckAWSElasticacheParameterGroupAttributes(&v),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "name", "parameter-group-test-terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "family", "redis2.8"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "description", "Test parameter group for terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "parameter.283487565.name", "appendonly"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "parameter.283487565.value", "yes"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSElasticacheParameterGroupAddParametersConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
+					testAccCheckAWSElasticacheParameterGroupAttributes(&v),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "name", "parameter-group-test-terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "family", "redis2.8"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "description", "Test parameter group for terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "parameter.283487565.name", "appendonly"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "parameter.283487565.value", "yes"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "parameter.2196914567.name", "appendfsync"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "parameter.2196914567.value", "always"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheParameterGroupOnly(t *testing.T) {
+	var v elasticache.CacheParameterGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheParameterGroupOnlyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
+					testAccCheckAWSElasticacheParameterGroupAttributes(&v),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "name", "parameter-group-test-terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "family", "redis2.8"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "description", "Test parameter group for terraform"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSElasticacheParameterGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elasticache_parameter_group" {
+			continue
+		}
+
+		// Try to find the Group
+		resp, err := conn.DescribeCacheParameterGroups(
+			&elasticache.DescribeCacheParameterGroupsInput{
+				CacheParameterGroupName: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if len(resp.CacheParameterGroups) != 0 &&
+				*resp.CacheParameterGroups[0].CacheParameterGroupName == rs.Primary.ID {
+				return fmt.Errorf("Cache Parameter Group still exists")
+			}
+		}
+
+		// Verify the error
+		newerr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if newerr.Code() != "InvalidCacheParameterGroup.NotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSElasticacheParameterGroupAttributes(v *elasticache.CacheParameterGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if *v.CacheParameterGroupName != "parameter-group-test-terraform" {
+			return fmt.Errorf("bad name: %#v", v.CacheParameterGroupName)
+		}
+
+		if *v.CacheParameterGroupFamily != "redis2.8" {
+			return fmt.Errorf("bad family: %#v", v.CacheParameterGroupFamily)
+		}
+
+		if *v.Description != "Test parameter group for terraform" {
+			return fmt.Errorf("bad description: %#v", v.Description)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSElasticacheParameterGroupExists(n string, v *elasticache.CacheParameterGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cache Parameter Group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+
+		opts := elasticache.DescribeCacheParameterGroupsInput{
+			CacheParameterGroupName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeCacheParameterGroups(&opts)
+
+		if err != nil {
+			return err
+		}
+
+		if len(resp.CacheParameterGroups) != 1 ||
+			*resp.CacheParameterGroups[0].CacheParameterGroupName != rs.Primary.ID {
+			return fmt.Errorf("Cache Parameter Group not found")
+		}
+
+		*v = *resp.CacheParameterGroups[0]
+
+		return nil
+	}
+}
+
+const testAccAWSElasticacheParameterGroupConfig = `
+resource "aws_elasticache_parameter_group" "bar" {
+	name = "parameter-group-test-terraform"
+	family = "redis2.8"
+	description = "Test parameter group for terraform"
+	parameter {
+	  name = "appendonly"
+	  value = "yes"
+	}
+}
+`
+
+const testAccAWSElasticacheParameterGroupAddParametersConfig = `
+resource "aws_elasticache_parameter_group" "bar" {
+	name = "parameter-group-test-terraform"
+	family = "redis2.8"
+	description = "Test parameter group for terraform"
+	parameter {
+	  name = "appendonly"
+	  value = "yes"
+	}
+	parameter {
+	  name = "appendfsync"
+	  value = "always"
+	}
+}
+`
+
+const testAccAWSElasticacheParameterGroupOnlyConfig = `
+resource "aws_elasticache_parameter_group" "bar" {
+	name = "parameter-group-test-terraform"
+	family = "redis2.8"
+	description = "Test parameter group for terraform"
+}
+`

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -393,6 +394,32 @@ func TestexpandParameters(t *testing.T) {
 	}
 }
 
+func TestexpandElasticacheParameters(t *testing.T) {
+	expanded := []interface{}{
+		map[string]interface{}{
+			"name":         "character_set_client",
+			"value":        "utf8",
+			"apply_method": "immediate",
+		},
+	}
+	parameters, err := expandElastiCacheParameters(expanded)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	expected := &elasticache.Parameter{
+		ParameterName:  aws.String("activerehashing"),
+		ParameterValue: aws.String("yes"),
+	}
+
+	if !reflect.DeepEqual(parameters[0], expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			parameters[0],
+			expected)
+	}
+}
+
 func TestflattenParameters(t *testing.T) {
 	cases := []struct {
 		Input  []*rds.Parameter
@@ -416,6 +443,35 @@ func TestflattenParameters(t *testing.T) {
 
 	for _, tc := range cases {
 		output := flattenParameters(tc.Input)
+		if !reflect.DeepEqual(output, tc.Output) {
+			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
+		}
+	}
+}
+
+func TestflattenElasticacheParameters(t *testing.T) {
+	cases := []struct {
+		Input  []*elasticache.Parameter
+		Output []map[string]interface{}
+	}{
+		{
+			Input: []*elasticache.Parameter{
+				&elasticache.Parameter{
+					ParameterName:  aws.String("activerehashing"),
+					ParameterValue: aws.String("yes"),
+				},
+			},
+			Output: []map[string]interface{}{
+				map[string]interface{}{
+					"name":  "activerehashing",
+					"value": "yes",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenElastiCacheParameters(tc.Input)
 		if !reflect.DeepEqual(output, tc.Output) {
 			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
 		}

--- a/website/source/docs/providers/aws/r/elasticache_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_parameter_group.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elasticache_parameter_group"
+sidebar_current: "docs-aws-resource-elasticache-parameter-group"
+---
+
+# aws\_elasticache\_parameter\_group
+
+Provides an ElastiCache parameter group resource.
+
+## Example Usage
+
+```
+resource "aws_elasticache_parameter_group" "default" {
+    name = "cache-params"
+    family = "redis2.8"
+    description = "Cache cluster default param group"
+
+  	parameter {
+   	  name = "activerehashing"
+   	  value = "yes"
+   	}
+
+   	parameter {
+      name = "min-slaves-to-write"
+      value = "2"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the ElastiCache parameter group.
+* `family` - (Required) The family of the ElastiCache parameter group.
+* `description` - (Required) The description of the ElastiCache parameter group.
+* `parameter` - (Optional) A list of ElastiCache parameters to apply.
+
+Parameter blocks support the following:
+
+* `name` - (Required) The name of the ElastiCache parameter.
+* `value` - (Required) The value of the ElastiCache parameter.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ElastiCache parameter group name.

--- a/website/source/docs/providers/aws/r/elasticache_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_parameter_group.html.markdown
@@ -16,14 +16,14 @@ resource "aws_elasticache_parameter_group" "default" {
     family = "redis2.8"
     description = "Cache cluster default param group"
 
-  	parameter {
-   	  name = "activerehashing"
-   	  value = "yes"
-   	}
+    parameter {
+        name = "activerehashing"
+        value = "yes"
+    }
 
-   	parameter {
-      name = "min-slaves-to-write"
-      value = "2"
+    parameter {
+        name = "min-slaves-to-write"
+        value = "2"
     }
 }
 ```

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -65,6 +65,10 @@
 							<a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
 						</li>
 
+						<li<%= sidebar_current("docs-aws-resource-elasticache-parameter-group") %>>
+							<a href="/docs/providers/aws/r/elasticache_parameter_group.html">aws_elasticache_parameter_group</a>
+						</li>
+
 						<li<%= sidebar_current("docs-aws-resource-elasticache-security-group") %>>
 							<a href="/docs/providers/aws/r/elasticache_security_group.html">aws_elasticache_security_group</a>
 						</li>


### PR DESCRIPTION
Implements `aws_elasticache_parameter_group`

This almost a 1/1 copy of `aws_db_parameter_group`

    vagrant@vagrant:/opt/gopath/src/github.com/hashicorp/terraform$ make test TEST=./builtin/providers/aws
    go generate ./...
    TF_ACC= go test ./builtin/providers/aws  -timeout=30s -parallel=4
    ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.032s
    make[1]: Entering directory `/opt/gopath/src/github.com/hashicorp/terraform'
    go tool vet -asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr .
    make[1]: Leaving directory `/opt/gopath/src/github.com/hashicorp/terraform'


    vagrant@vagrant:/opt/gopath/src/github.com/hashicorp/terraform$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=ElasticacheParameterGroup' 2>/dev/null
    go generate ./...
    TF_ACC=1 go test ./builtin/providers/aws -v -run=ElasticacheParameterGroup -timeout 90m
    === RUN TestAccAWSElasticacheParameterGroup_basic
    --- PASS: TestAccAWSElasticacheParameterGroup_basic (9.21s)
    === RUN TestAccAWSElasticacheParameterGroupOnly
    --- PASS: TestAccAWSElasticacheParameterGroupOnly (4.61s)
    PASS
    ok  	github.com/hashicorp/terraform/builtin/providers/aws	13.846s
