### PR TITLE
provider/openstack: change security groups to set

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -92,10 +92,13 @@ func resourceComputeInstanceV2() *schema.Resource {
 				},
 			},
 			"security_groups": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set: 	  func(v interface{}) int {
+					return hashcode.String(v.(string))
+				},
 			},
 			"availability_zone": &schema.Schema{
 				Type:     schema.TypeString,
@@ -547,7 +550,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 
 	if d.HasChange("security_groups") {
 		oldSGRaw, newSGRaw := d.GetChange("security_groups")
-		oldSGSlice, newSGSlice := oldSGRaw.([]interface{}), newSGRaw.([]interface{})
+		oldSGSlice, newSGSlice := oldSGRaw.(*schema.Set).List(), newSGRaw.(*schema.Set).List()
 		oldSGSet := schema.NewSet(func(v interface{}) int { return hashcode.String(v.(string)) }, oldSGSlice)
 		newSGSet := schema.NewSet(func(v interface{}) int { return hashcode.String(v.(string)) }, newSGSlice)
 		secgroupsToAdd := newSGSet.Difference(oldSGSet)
@@ -754,7 +757,7 @@ func ServerV2StateRefreshFunc(client *gophercloud.ServiceClient, instanceID stri
 }
 
 func resourceInstanceSecGroupsV2(d *schema.ResourceData) []string {
-	rawSecGroups := d.Get("security_groups").([]interface{})
+	rawSecGroups := d.Get("security_groups").(*schema.Set).List()
 	secgroups := make([]string, len(rawSecGroups))
 	for i, raw := range rawSecGroups {
 		secgroups[i] = raw.(string)


### PR DESCRIPTION
This commit converts the openstack compute instances security groups to
a set from a list.

This fixes ordering problems which forces or indicates change to security
groups where none exist, and mimics the functionality in the aws
provider's compute resource.

Includes fixes from dupuy addressing crashes due to an empty state.

Third attempt.