### PR TITLE
Correct syntax error in group membership test.

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group_membership_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_membership_test.go
@@ -59,7 +59,7 @@ func testAccCheckAWSGroupMembershipDestroy(s *terraform.State) error {
 		for _, u := range resp.Users {
 			for _, i := range users {
 				if i == *u.UserName {
-					return fmt.Errorf("Error: User (s) still a member of Group (%s)", i, *resp.Group.GroupName)
+					return fmt.Errorf("Error: User (%s) still a member of Group (%s)", i, *resp.Group.GroupName)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2300. Regression in 4d59019288f2c2a3bd519728ba841eec7f4e6e59