### PR TITLE
Fix two serious problems when using links in Docker containers

### DIFF
--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -211,15 +211,17 @@ func fetchDockerContainer(name string, client *dc.Client) (*dc.APIContainers, er
 		// Sometimes the Docker API prefixes container names with /
 		// like it does in these commands. But if there's no
 		// set name, it just uses the ID without a /...ugh.
-		var dockerContainerName string
-		if len(apiContainer.Names) > 0 {
-			dockerContainerName = strings.TrimLeft(apiContainer.Names[0], "/")
-		} else {
-			dockerContainerName = apiContainer.ID
-		}
-
-		if dockerContainerName == name {
-			return &apiContainer, nil
+		switch len(apiContainer.Names) {
+		case 0:
+			if apiContainer.ID == name {
+				return &apiContainer, nil
+			}
+		default:
+			for _, containerName := range apiContainer.Names {
+				if strings.TrimLeft(containerName, "/") == name {
+					return &apiContainer, nil
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
1) When linking to other containers, introduce a slight delay; this lets the Docker API get those containers running. Otherwise when you try to start a container linking to them, the start command will fail, leading to an error.

2) Links cause there to be more than one name for a container to be returned. As a result, only looking at the first element of the container names could cause a container to not be found, leading Terraform to remove it from state and attempt to recreate it.