### PR TITLE
provider/aws: Add docs for elasticache_cluster - cache_nodes

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -67,13 +67,5 @@ names to associate with this cache cluster
 
 The following attributes are exported:
 
-* `cluster_id`
-* `engine`
-* `engine_version`
-* `node_type`
-* `num_cache_nodes`
-* `parameter_group_name`
-* `port`
-* `subnet_group_name`
-* `security_group_names`
-* `security_group_ids`
+* `cache_nodes` - List of node objects including `id`, `address` and `port`.
+   Referenceable e.g. as `${aws_elasticache_cluster.bar.cache_nodes.0.address}`


### PR DESCRIPTION
Fixes #2272 

I also removed all existing "exported" variables since these are actually input variables, exported _"by design"_. I don't think there's value in duplicating these.

If anyone thinks otherwise, then we should do it in docs of other resources as well, but I feel this would cause docs cluttering.