### PR TITLE
Recognize non-hashed changes to set items

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -771,14 +771,6 @@ func (m schemaMap) diffSet(
 	os := o.(*Set)
 	ns := n.(*Set)
 
-	// If the new value was set, compare the listCode's to determine if
-	// the two are equal. Comparing listCode's instead of the actuall values
-	// is needed because there could be computed values in the set which
-	// would result in false positives while comparing.
-	if !all && nSet && reflect.DeepEqual(os.listCode(), ns.listCode()) {
-		return nil
-	}
-
 	// Get the counts
 	oldLen := os.Len()
 	newLen := ns.Len()
@@ -823,20 +815,26 @@ func (m schemaMap) diffSet(
 		})
 	}
 
-	for _, code := range ns.listCode() {
-		// If the code is negative (first character is -) then
-		// replace it with "~" for our computed set stuff.
-		codeStr := strconv.Itoa(code)
-		if codeStr[0] == '-' {
-			codeStr = string('~') + codeStr[1:]
+	// Diff must consider the union of the keys in both sets,
+	// so we can detect both items removed and items added.
+	codeStrs := make(map[string]int)
+	for _, set := range []*Set{ns, os} {
+		for _, code := range set.listCode() {
+			codeStr := strconv.Itoa(code)
+			if codeStr[0] == '-' {
+				codeStr = string('~') + codeStr[1:]
+			}
+			codeStrs[codeStr] = code
 		}
+	}
 
+	for codeStr, _ := range codeStrs {
 		switch t := schema.Elem.(type) {
 		case *Resource:
 			// This is a complex resource
 			for k2, schema := range t.Schema {
 				subK := fmt.Sprintf("%s.%s.%s", k, codeStr, k2)
-				err := m.diff(subK, schema, diff, d, true)
+				err := m.diff(subK, schema, diff, d, false)
 				if err != nil {
 					return err
 				}
@@ -850,7 +848,7 @@ func (m schemaMap) diffSet(
 			// This is just a primitive element, so go through each and
 			// just diff each.
 			subK := fmt.Sprintf("%s.%s", k, codeStr)
-			err := m.diff(subK, &t2, diff, d, true)
+			err := m.diff(subK, &t2, diff, d, false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
(This PR is currently more a conversation-starter than necessarily a correct change.)

While working on #2162 it became apparent that, when using sets of sub-resources, correct diffing is only ensured if all of the element type properties are considered by the hash returned by the ``Set`` function.

It felt to me like this was a bug, for two reasons:
* if the intent was to consider the entire element content in the hash, it wouldn't make sense to have a separate ``Set`` implementation for each set since a single central implementation that iterates (recursively) over all of the element schema properties would be sufficient
* when a set item has a unique identifier element, it seems intuitive that changes to attributes *other* than the unique identifier should appear as single-attribute diffs rather than deleting and re-adding the entire element.

In the OpsWorks Layer resource from #2162, this manifests in the implementation of the ``ebs_volume`` attribute, which looks like this:

```js
resource "aws_opsworks_custom_layer" "foo" {
    // ...various stuff irrelevant to this PR...

    ebs_volume {
        mount_point = "/mnt"
        size = 4
        number_of_disks = 1
    }
}
```

For this resource my change considers each ``ebs_volume`` to be identified by its mount point, so the ``Set`` function returns a hash of the mount point path. I expected that changes to ``mount_point`` would show as deleting one item and adding another, while changes to either ``size`` or ``number_of_disks`` would show as a diff like this:

```
~ aws_opsworks_custom_layer.bar
    ebs_volume.890030859.number_of_disks: "1" => "2"
```

Instead what happens today is that changes to anything other than the mount point are not seen as a diff at all.

Looking at other resource implementations I see that the usual technique is to try to include the whole sub-element in the hash function, but several older bugs in the issue tracker seem to boil down to missing things in such implementations, so it seems like the current situation is error-prone.

The patch associated with this PR takes the position that there should be a separation between an element's identifier (the result of ``Set``) and its entire content, and there should be a visible difference in the diff between changing the value of an element vs. creating a new element depending on which attributes have changed. An advantage of this approach is that adding entirely new attributes to an existing object needn't change the hash.

Another reasonable position would be that the entire content of the element should always be considered in the hash function, in which case I'd expect not to need to provide a ``Set`` implementation at all since it should be possible to provide a fully-general single implementation that would then apply across all sets. In this case, any change to the element schema would cause all items to show as updated in the diff.

The *current* situation doesn't feel right to me, but it's very possible that I'm just missing the motivation behind it.
