### PR TITLE
core: show outputs after `terraform refresh`

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -230,38 +230,10 @@ func (c *ApplyCommand) Run(args []string) int {
 			c.Meta.StateOutPath())))
 	}
 
-	// If we have outputs, then output those at the end.
-	var outputs map[string]string
-	if !c.Destroy && state != nil {
-		outputs = state.RootModule().Outputs
-	}
-	if len(outputs) > 0 {
-		outputBuf := new(bytes.Buffer)
-		outputBuf.WriteString("[reset][bold][green]\nOutputs:\n\n")
-
-		// Output the outputs in alphabetical order
-		keyLen := 0
-		keys := make([]string, 0, len(outputs))
-		for key, _ := range outputs {
-			keys = append(keys, key)
-			if len(key) > keyLen {
-				keyLen = len(key)
-			}
+	if !c.Destroy {
+		if outputs := outputsAsString(state); outputs != "" {
+			c.Ui.Output(c.Colorize().Color(outputs))
 		}
-		sort.Strings(keys)
-
-		for _, k := range keys {
-			v := outputs[k]
-
-			outputBuf.WriteString(fmt.Sprintf(
-				"  %s%s = %s\n",
-				k,
-				strings.Repeat(" ", keyLen-len(k)),
-				v))
-		}
-
-		c.Ui.Output(c.Colorize().Color(
-			strings.TrimSpace(outputBuf.String())))
 	}
 
 	return 0
@@ -372,4 +344,39 @@ Options:
 
 `
 	return strings.TrimSpace(helpText)
+}
+
+func outputsAsString(state *terraform.State) string {
+	if state == nil {
+		return ""
+	}
+
+	outputs := state.RootModule().Outputs
+	outputBuf := new(bytes.Buffer)
+	if len(outputs) > 0 {
+		outputBuf.WriteString("[reset][bold][green]\nOutputs:\n\n")
+
+		// Output the outputs in alphabetical order
+		keyLen := 0
+		keys := make([]string, 0, len(outputs))
+		for key, _ := range outputs {
+			keys = append(keys, key)
+			if len(key) > keyLen {
+				keyLen = len(key)
+			}
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := outputs[k]
+
+			outputBuf.WriteString(fmt.Sprintf(
+				"  %s%s = %s\n",
+				k,
+				strings.Repeat(" ", keyLen-len(k)),
+				v))
+		}
+	}
+
+	return strings.TrimSpace(outputBuf.String())
 }

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -105,6 +105,10 @@ func (c *RefreshCommand) Run(args []string) int {
 		return 1
 	}
 
+	if outputs := outputsAsString(newState); outputs != "" {
+		c.Ui.Output(c.Colorize().Color(outputs))
+	}
+
 	return 0
 }
 

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -581,6 +581,35 @@ func TestRefresh_disableBackup(t *testing.T) {
 	}
 }
 
+func TestRefresh_displaysOutputs(t *testing.T) {
+	state := testState()
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &RefreshCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		testFixturePath("refresh-output"),
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	outputValue := "foo.example.com"
+	actual := ui.OutputWriter.String()
+	if !strings.Contains(actual, outputValue) {
+		t.Fatalf("Expected:\n%s\n\nTo include: %q", actual, outputValue)
+	}
+}
+
 const refreshVarFile = `
 foo = "bar"
 `

--- a/command/test-fixtures/refresh-output/main.tf
+++ b/command/test-fixtures/refresh-output/main.tf
@@ -1,0 +1,7 @@
+resource "test_instance" "foo" {
+    ami = "bar"
+}
+
+output "endpoint" {
+  value = "foo.example.com"
+}


### PR DESCRIPTION
closes #25