### PR TITLE
Add ForceNew metadata_startup_script field

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -191,6 +191,12 @@ func resourceComputeInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"metadata_startup_script": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"metadata": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -469,13 +475,18 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		serviceAccounts = append(serviceAccounts, serviceAccount)
 	}
 
+	metadata, err := resourceInstanceMetadata(d)
+	if err != nil {
+		return fmt.Errorf("Error creating metadata: %s", err)
+	}
+
 	// Create the instance information
 	instance := compute.Instance{
 		CanIpForward:      d.Get("can_ip_forward").(bool),
 		Description:       d.Get("description").(string),
 		Disks:             disks,
 		MachineType:       machineType.SelfLink,
-		Metadata:          resourceInstanceMetadata(d),
+		Metadata:          metadata,
 		Name:              d.Get("name").(string),
 		NetworkInterfaces: networkInterfaces,
 		Tags:              resourceInstanceTags(d),
@@ -662,7 +673,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 	// If the Metadata has changed, then update that.
 	if d.HasChange("metadata") {
-		metadata := resourceInstanceMetadata(d)
+		metadata, err := resourceInstanceMetadata(d)
+		if err != nil {
+			return fmt.Errorf("Error updating metadata: %s", err)
+		}
 		op, err := config.clientCompute.Instances.SetMetadata(
 			config.Project, zone, d.Id(), metadata).Do()
 		if err != nil {
@@ -781,9 +795,18 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceInstanceMetadata(d *schema.ResourceData) *compute.Metadata {
+func resourceInstanceMetadata(d *schema.ResourceData) (*compute.Metadata, error) {
 	m := &compute.Metadata{}
-	if mdMap := d.Get("metadata").(map[string]interface{}); len(mdMap) > 0 {
+	mdMap := d.Get("metadata").(map[string]interface{})
+	_, mapScriptExists := mdMap["startup-script"]
+	dScript, dScriptExists := d.GetOk("metadata_startup_script")
+	if mapScriptExists && dScriptExists {
+		return nil, fmt.Errorf("Not allowed to have both metadata_startup_script and metadata.startup-script")
+	}
+	if dScriptExists {
+		mdMap["startup-script"] = dScript
+	}
+	if len(mdMap) > 0 {
 		m.Items = make([]*compute.MetadataItems, 0, len(mdMap))
 		for key, val := range mdMap {
 			m.Items = append(m.Items, &compute.MetadataItems{
@@ -797,7 +820,7 @@ func resourceInstanceMetadata(d *schema.ResourceData) *compute.Metadata {
 		m.Fingerprint = d.Get("metadata_fingerprint").(string)
 	}
 
-	return m
+	return m, nil
 }
 
 func resourceInstanceTags(d *schema.ResourceData) *compute.Tags {

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -331,7 +331,11 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	instanceProperties.Description = d.Get("instance_description").(string)
 	instanceProperties.MachineType = d.Get("machine_type").(string)
 	instanceProperties.Disks = buildDisks(d, meta)
-	instanceProperties.Metadata = resourceInstanceMetadata(d)
+	metadata, err := resourceInstanceMetadata(d)
+	if err != nil {
+		return err
+	}
+	instanceProperties.Metadata = metadata
 	err, networks := buildNetworks(d, meta)
 	if err != nil {
 		return err

--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -476,10 +476,10 @@ resource "google_compute_instance" "foobar" {
 
 	metadata {
 		foo = "bar"
-	}
-	metadata {
 		baz = "qux"
 	}
+
+	metadata_startup_script = "echo Hello"
 }`
 
 const testAccComputeInstance_basic2 = `

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -44,6 +44,8 @@ resource "google_compute_instance" "default" {
 		foo = "bar"
 	}
 
+    metadata_startup_script = "echo hi > /test.txt"
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -72,6 +74,12 @@ The following arguments are supported:
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within the instance.
+
+* `metadata_startup_script` - (Optional) An alternative to using the
+  startup-script metadata key, except this one forces the instance to be
+  recreated (thus re-running the script) if it is changed.  This replaces the
+  startup-script metadata key on the created instance and thus the two mechanisms
+  are not allowed to be used simultaneously.
 
 * `network_interface` - (Required) Networks to attach to the instance. This can be
     specified multiple times for multiple networks. Structure is documented


### PR DESCRIPTION
This lacks tests & docs, but I wanted to discuss it before working further:

The idea is that if you use the metadata field startup-script to define the internal state of the instance, then you want changing that script to recreate the instance.  The same is true for aws_instance and the userdata field, but this PR is just for GCE right now.

This solution adds another attribute called metadata_startup_script that is ForceNew and cannot be specified at the same time as metadata.startup_script.

What do you think?