### PR TITLE
Add preemptible and automatic_restart options on GCE instance

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -246,6 +246,20 @@ func resourceComputeInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"automatic_restart": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
+			"preemptible": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -469,6 +483,11 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		serviceAccounts = append(serviceAccounts, serviceAccount)
 	}
 
+	scheduling := &compute.Scheduling{
+		AutomaticRestart: d.Get("automatic_restart").(bool),
+		Preemptible:      d.Get("preemptible").(bool),
+	}
+
 	// Create the instance information
 	instance := compute.Instance{
 		CanIpForward:      d.Get("can_ip_forward").(bool),
@@ -480,6 +499,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		NetworkInterfaces: networkInterfaces,
 		Tags:              resourceInstanceTags(d),
 		ServiceAccounts:   serviceAccounts,
+		Scheduling:        scheduling,
 	}
 
 	log.Printf("[INFO] Requesting instance creation")

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -85,6 +85,11 @@ The following arguments are supported:
 
 * `tags` - (Optional) Tags to attach to the instance.
 
+* `preemptible` - (Optional) Whether the instance is preemptible. This defaults to false.
+
+* `automatic_restart` - (Optional) Whether the instance should be automatically restarted
+    if it is terminated by Compute Engine. This default to false.
+
 The `disk` block supports: (Note that either disk or image is required, unless
 the type is "local-ssd", in which case scratch must be true).
 


### PR DESCRIPTION
Add preemptible (https://cloud.google.com/compute/docs/instances/preemptible) and automatic_restart (https://cloud.google.com/compute/docs/instances/#autorestart) options on GCE instance