### PR TITLE
provider/template: don't error when rendering fails in Exists

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -60,6 +60,10 @@ type TestCase struct {
 // potentially complex update logic. In general, simply create/destroy
 // tests will only need one step.
 type TestStep struct {
+	// PreConfig is called before the Config is applied to perform any per-step
+	// setup that needs to happen
+	PreConfig func()
+
 	// Config a string of the configuration to give to Terraform.
 	Config string
 
@@ -160,6 +164,10 @@ func testStep(
 	opts terraform.ContextOpts,
 	state *terraform.State,
 	step TestStep) (*terraform.State, error) {
+	if step.PreConfig != nil {
+		step.PreConfig()
+	}
+
 	cfgPath, err := ioutil.TempDir("", "tf-test")
 	if err != nil {
 		return state, fmt.Errorf(


### PR DESCRIPTION
The Exists function can run in a context where the contents of the
template have changed, but it uses the old set of variables from the
state. This means that when the set of variables changes, rendering will
fail in Exists. This was returning an error, but really it just needs to
be treated as a scenario where the template needs re-rendering.

fixes #2344 and possibly a few other template issues floating around