### PR TITLE
increase allowed size of userdata for cloudstack provider

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_instance.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance.go
@@ -168,10 +168,10 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	if userData, ok := d.GetOk("user_data"); ok {
                 //deployVirtualMachine uses POST, so max userdata is 32K
                 //https://github.com/xanzy/go-cloudstack/commit/c767de689df1faedfec69233763a7c5334bee1f6
-		if len(ud) > 32768 {
+		if len(userData.(string)) > 32768 {
 			return fmt.Errorf(
 				"The supplied user_data contains %d bytes before encoding, "+
-					"this exeeds the limit of 32768 bytes", len(ud))
+					"this exeeds the limit of 32768 bytes", len(userData.(string)))
 		}
 		ud := base64.StdEncoding.EncodeToString([]byte(userData.(string)))
 		p.SetUserdata(ud)

--- a/builtin/providers/cloudstack/resource_cloudstack_instance.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance.go
@@ -166,12 +166,14 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	// If the user data contains any info, it needs to be base64 encoded and
 	// added to the parameter struct
 	if userData, ok := d.GetOk("user_data"); ok {
-		ud := base64.StdEncoding.EncodeToString([]byte(userData.(string)))
-		if len(ud) > 2048 {
+                //deployVirtualMachine uses POST, so max userdata is 32K
+                //https://github.com/xanzy/go-cloudstack/commit/c767de689df1faedfec69233763a7c5334bee1f6
+		if len(ud) > 32768 {
 			return fmt.Errorf(
-				"The supplied user_data contains %d bytes after encoding, "+
-					"this exeeds the limit of 2048 bytes", len(ud))
+				"The supplied user_data contains %d bytes before encoding, "+
+					"this exeeds the limit of 32768 bytes", len(ud))
 		}
+		ud := base64.StdEncoding.EncodeToString([]byte(userData.(string)))
 		p.SetUserdata(ud)
 	}
 


### PR DESCRIPTION
go-cloudstack changes the API request method to POST when calling deployVirtualMachine. This allows the max size of userdata to go up to 32KB