### PR TITLE
provider/aws: Deregister ECS task definition correctly

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
@@ -22,6 +22,12 @@ func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins"),
 				),
 			},
+			resource.TestStep{
+				Config: testAccAWSEcsTaskDefinitionModifier,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins"),
+				),
+			},
 		},
 	})
 }
@@ -63,7 +69,7 @@ func testAccCheckAWSEcsTaskDefinitionExists(name string) resource.TestCheckFunc 
 
 var testAccAWSEcsTaskDefinition = `
 resource "aws_ecs_task_definition" "jenkins" {
-  family = "jenkins"
+  family = "terraform-acc-test"
   container_definitions = <<TASK_DEFINITION
 [
 	{
@@ -87,6 +93,55 @@ resource "aws_ecs_task_definition" "jenkins" {
 	},
 	{
 		"cpu": 10,
+		"command": ["sleep", "10"],
+		"entryPoint": ["/"],
+		"essential": true,
+		"image": "mongodb",
+		"memory": 128,
+		"name": "mongodb",
+		"portMappings": [
+			{
+				"containerPort": 28017,
+				"hostPort": 28017
+			}
+		]
+	}
+]
+TASK_DEFINITION
+
+  volume {
+    name = "jenkins-home"
+    host_path = "/ecs/jenkins-home"
+  }
+}
+`
+
+var testAccAWSEcsTaskDefinitionModifier = `
+resource "aws_ecs_task_definition" "jenkins" {
+  family = "terraform-acc-test"
+  container_definitions = <<TASK_DEFINITION
+[
+	{
+		"cpu": 10,
+		"command": ["sleep", "10"],
+		"entryPoint": ["/"],
+		"environment": [
+			{"name": "VARNAME", "value": "VARVAL"}
+		],
+		"essential": true,
+		"image": "jenkins",
+		"links": ["mongodb"],
+		"memory": 128,
+		"name": "jenkins",
+		"portMappings": [
+			{
+				"containerPort": 80,
+				"hostPort": 8080
+			}
+		]
+	},
+	{
+		"cpu": 20,
 		"command": ["sleep", "10"],
 		"entryPoint": ["/"],
 		"essential": true,

--- a/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
@@ -10,10 +10,6 @@ description: |-
 
 Provides an ECS task definition to be used in `aws_ecs_service`.
 
-~> **NOTE:** There is currently no way to unregister
-any previously registered task definition.
-See related [thread in AWS forum](https://forums.aws.amazon.com/thread.jspa?threadID=170378&tstart=0).
-
 ## Example Usage
 
 ```


### PR DESCRIPTION
Deregistration [has been finally implemented](https://aws.amazon.com/about-aws/whats-new/2015/06/amazon-ec2-container-service-supports-task-definition-deregistration-and-environment-variable-overrides/) and it expects revision as an argument, which means that if user modifies the task definition, new revision is generated = `revision` + `arn` bumped.

<del>
1. The old revision is not referenced after that change anywhere anymore, which raises a question whether we should just deregister the old revision after the change has been successfully applied?
2. We now treat `ecs_task_definition` as a resource holding all revisions to make updates in definitions easy. Should we iterate over all revisions and deregister all of them on `destroy`?
How do we know if these revisions have been created by Terraform?
</del>

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=Ecs' 2>/dev/null
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=Ecs -timeout 90m
=== RUN TestAccAWSEcsCluster_basic
--- PASS: TestAccAWSEcsCluster_basic (1.48s)
=== RUN TestAccAWSEcsServiceWithARN
--- PASS: TestAccAWSEcsServiceWithARN (20.41s)
=== RUN TestAccAWSEcsServiceWithFamilyAndRevision
--- PASS: TestAccAWSEcsServiceWithFamilyAndRevision (29.80s)
=== RUN TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (2.01s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	53.714s
```