### PR TITLE
Allowing at-rest encryption when using S3

### DIFF
--- a/state/remote/s3_test.go
+++ b/state/remote/s3_test.go
@@ -28,6 +28,7 @@ func TestS3Factory(t *testing.T) {
 	config["region"] = "us-west-1"
 	config["bucket"] = "foo"
 	config["key"] = "bar"
+	config["encrypt"] = "1"
 	// For this test we'll provide the credentials as config. The
 	// acceptance tests implicitly test passing credentials as
 	// environment variables.
@@ -80,11 +81,13 @@ func TestS3Client(t *testing.T) {
 
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "testState"
+	testData := []byte(`testing data`)
 
 	config := make(map[string]string)
 	config["region"] = regionName
 	config["bucket"] = bucketName
 	config["key"] = keyName
+	config["encrypt"] = "1"
 
 	client, err := s3Factory(config)
 	if err != nil {
@@ -105,6 +108,13 @@ func TestS3Client(t *testing.T) {
 	if err != nil {
 		t.Skipf("Failed to create test S3 bucket, so skipping")
 	}
+
+	// Ensure we can perform a PUT request with the encryption header
+	err = s3Client.Put(testData)
+	if err != nil {
+		t.Logf("WARNING: Failed to send test data to S3 bucket. (error was %s)", err)
+	}
+
 	defer func() {
 		deleteBucketReq := &s3.DeleteBucketInput{
 			Bucket: &bucketName,


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/issues/1421

This change allows the user to specify `-backend-config="encrypt=1"`
to tell S3 to encrypt the data that's in the bucket when using S3
for remote config storage.

The encryption uses "Amazon S3-managed encryption keys" so it should
not require any further user intervention.

A line was added to the unit test just for coverage.
The acceptance test was modified to:
  a) Use encryption
  b) Push some test data up to the bucket created to ensure
     that Amazon accepts the header.