### PR TITLE
core: close provider/provisioner connections when not used anymore

### DIFF
--- a/rpc/mux_broker.go
+++ b/rpc/mux_broker.go
@@ -3,9 +3,9 @@ package rpc
 import (
 	"encoding/binary"
 	"fmt"
+	"math/rand"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/yamux"
@@ -17,7 +17,6 @@ import (
 // or accept a connection from, and the broker handles the details of
 // holding these channels open while they're being negotiated.
 type muxBroker struct {
-	nextId  uint32
 	session *yamux.Session
 	streams map[uint32]*muxBrokerPending
 
@@ -95,9 +94,12 @@ func (m *muxBroker) Dial(id uint32) (net.Conn, error) {
 	return stream, nil
 }
 
-// NextId returns a unique ID to use next.
+// NextId returns a unique ID to use next. There is no need for seeding the
+// rand package as the returned ID's aren't stored or used anywhere outside
+// the current runtime. So it's perfectly fine to get the same pseudo-random
+// numbers each time terraform is running.
 func (m *muxBroker) NextId() uint32 {
-	return atomic.AddUint32(&m.nextId, 1)
+	return rand.Uint32()
 }
 
 // Run starts the brokering and should be executed in a goroutine, since it

--- a/rpc/resource_provider.go
+++ b/rpc/resource_provider.go
@@ -174,6 +174,10 @@ func (p *ResourceProvider) Resources() []terraform.ResourceType {
 	return result
 }
 
+func (p *ResourceProvider) Close() error {
+	return p.Client.Close()
+}
+
 // ResourceProviderServer is a net/rpc compatible structure for serving
 // a ResourceProvider. This should not be used directly.
 type ResourceProviderServer struct {

--- a/rpc/resource_provider_test.go
+++ b/rpc/resource_provider_test.go
@@ -488,3 +488,31 @@ func TestResourceProvider_validateResource_warns(t *testing.T) {
 		t.Fatalf("bad: %#v", w)
 	}
 }
+
+func TestResourceProvider_close(t *testing.T) {
+	client, _ := testNewClientServer(t)
+	defer client.Close()
+
+	provider, err := client.ResourceProvider()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var p interface{}
+	p = provider
+	pCloser, ok := p.(terraform.ResourceProviderCloser)
+	if !ok {
+		t.Fatal("should be a ResourceProviderCloser")
+	}
+
+	if err := pCloser.Close(); err != nil {
+		t.Fatalf("failed to close provider: %s", err)
+	}
+
+	// The connection should be closed now, so if we to make a
+	// new call we should get an error.
+	err = provider.Configure(&terraform.ResourceConfig{})
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}

--- a/rpc/resource_provisioner.go
+++ b/rpc/resource_provisioner.go
@@ -63,6 +63,10 @@ func (p *ResourceProvisioner) Apply(
 	return err
 }
 
+func (p *ResourceProvisioner) Close() error {
+	return p.Client.Close()
+}
+
 type ResourceProvisionerValidateArgs struct {
 	Config *terraform.ResourceConfig
 }

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -28,6 +28,9 @@ type EvalContext interface {
 	// initialized) or returns nil if the provider isn't initialized.
 	Provider(string) ResourceProvider
 
+	// CloseProvider closes provider connections that aren't needed anymore.
+	CloseProvider(string) error
+
 	// ConfigureProvider configures the provider with the given
 	// configuration. This is a separate context call because this call
 	// is used to store the provider configuration for inheritance lookups
@@ -50,6 +53,10 @@ type EvalContext interface {
 	// Provisioner gets the provisioner instance with the given name (already
 	// initialized) or returns nil if the provisioner isn't initialized.
 	Provisioner(string) ResourceProvisioner
+
+	// CloseProvisioner closes provisioner connections that aren't needed
+	// anymore.
+	CloseProvisioner(string) error
 
 	// Interpolate takes the given raw configuration and completes
 	// the interpolations, returning the processed ResourceConfig.

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -25,6 +25,10 @@ type MockEvalContext struct {
 	ProviderName     string
 	ProviderProvider ResourceProvider
 
+	CloseProviderCalled   bool
+	CloseProviderName     string
+	CloseProviderProvider ResourceProvider
+
 	ProviderInputCalled bool
 	ProviderInputName   string
 	ProviderInputConfig map[string]interface{}
@@ -54,6 +58,10 @@ type MockEvalContext struct {
 	ProvisionerCalled      bool
 	ProvisionerName        string
 	ProvisionerProvisioner ResourceProvisioner
+
+	CloseProvisionerCalled      bool
+	CloseProvisionerName        string
+	CloseProvisionerProvisioner ResourceProvisioner
 
 	InterpolateCalled       bool
 	InterpolateConfig       *config.RawConfig
@@ -105,6 +113,12 @@ func (c *MockEvalContext) Provider(n string) ResourceProvider {
 	return c.ProviderProvider
 }
 
+func (c *MockEvalContext) CloseProvider(n string) error {
+	c.CloseProviderCalled = true
+	c.CloseProviderName = n
+	return nil
+}
+
 func (c *MockEvalContext) ConfigureProvider(n string, cfg *ResourceConfig) error {
 	c.ConfigureProviderCalled = true
 	c.ConfigureProviderName = n
@@ -148,6 +162,12 @@ func (c *MockEvalContext) Provisioner(n string) ResourceProvisioner {
 	c.ProvisionerCalled = true
 	c.ProvisionerName = n
 	return c.ProvisionerProvisioner
+}
+
+func (c *MockEvalContext) CloseProvisioner(n string) error {
+	c.CloseProvisionerCalled = true
+	c.CloseProvisionerName = n
+	return nil
 }
 
 func (c *MockEvalContext) Interpolate(

--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -71,6 +71,17 @@ func (n *EvalInitProvider) Eval(ctx EvalContext) (interface{}, error) {
 	return ctx.InitProvider(n.Name)
 }
 
+// EvalCloseProvider is an EvalNode implementation that closes provider
+// connections that aren't needed anymore.
+type EvalCloseProvider struct {
+	Name string
+}
+
+func (n *EvalCloseProvider) Eval(ctx EvalContext) (interface{}, error) {
+	ctx.CloseProvider(n.Name)
+	return nil, nil
+}
+
 // EvalGetProvider is an EvalNode implementation that retrieves an already
 // initialized provider instance for the given name.
 type EvalGetProvider struct {

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -112,6 +112,22 @@ func TestEvalInitProvider(t *testing.T) {
 	}
 }
 
+func TestEvalCloseProvider(t *testing.T) {
+	n := &EvalCloseProvider{Name: "foo"}
+	provider := &MockResourceProvider{}
+	ctx := &MockEvalContext{CloseProviderProvider: provider}
+	if _, err := n.Eval(ctx); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !ctx.CloseProviderCalled {
+		t.Fatal("should be called")
+	}
+	if ctx.CloseProviderName != "foo" {
+		t.Fatalf("bad: %#v", ctx.CloseProviderName)
+	}
+}
+
 func TestEvalGetProvider_impl(t *testing.T) {
 	var _ EvalNode = new(EvalGetProvider)
 }

--- a/terraform/eval_provisioner.go
+++ b/terraform/eval_provisioner.go
@@ -15,6 +15,17 @@ func (n *EvalInitProvisioner) Eval(ctx EvalContext) (interface{}, error) {
 	return ctx.InitProvisioner(n.Name)
 }
 
+// EvalCloseProvisioner is an EvalNode implementation that closes provisioner
+// connections that aren't needed anymore.
+type EvalCloseProvisioner struct {
+	Name string
+}
+
+func (n *EvalCloseProvisioner) Eval(ctx EvalContext) (interface{}, error) {
+	ctx.CloseProvisioner(n.Name)
+	return nil, nil
+}
+
 // EvalGetProvisioner is an EvalNode implementation that retrieves an already
 // initialized provisioner instance for the given name.
 type EvalGetProvisioner struct {

--- a/terraform/eval_provisioner_test.go
+++ b/terraform/eval_provisioner_test.go
@@ -24,6 +24,22 @@ func TestEvalInitProvisioner(t *testing.T) {
 	}
 }
 
+func TestEvalCloseProvisioner(t *testing.T) {
+	n := &EvalCloseProvisioner{Name: "foo"}
+	provisioner := &MockResourceProvisioner{}
+	ctx := &MockEvalContext{CloseProvisionerProvisioner: provisioner}
+	if _, err := n.Eval(ctx); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !ctx.CloseProvisionerCalled {
+		t.Fatal("should be called")
+	}
+	if ctx.CloseProvisionerName != "foo" {
+		t.Fatalf("bad: %#v", ctx.CloseProvisionerName)
+	}
+}
+
 func TestEvalGetProvisioner_impl(t *testing.T) {
 	var _ EvalNode = new(EvalGetProvisioner)
 }

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -72,3 +72,9 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 
 	return &EvalSequence{Nodes: seq}
 }
+
+// CloseProviderEvalTree returns the evaluation tree for closing
+// provider connections that aren't needed anymore.
+func CloseProviderEvalTree(n string) EvalNode {
+	return &EvalCloseProvider{Name: n}
+}

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -116,12 +116,14 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 		// Provider-related transformations
 		&MissingProviderTransformer{Providers: b.Providers},
 		&ProviderTransformer{},
+		&CloseProviderTransformer{},
 		&PruneProviderTransformer{},
 		&DisableProviderTransformer{},
 
 		// Provisioner-related transformations
 		&MissingProvisionerTransformer{Provisioners: b.Provisioners},
 		&ProvisionerTransformer{},
+		&CloseProvisionerTransformer{},
 		&PruneProvisionerTransformer{},
 
 		// Run our vertex-level transforms

--- a/terraform/graph_builder_test.go
+++ b/terraform/graph_builder_test.go
@@ -196,6 +196,8 @@ aws_instance.db
 aws_instance.web
   aws_instance.db
 provider.aws
+provider.aws (close)
+  aws_instance.web
 `
 
 const testBuiltinGraphBuilderVerboseStr = `
@@ -213,8 +215,28 @@ aws_instance.web (destroy tainted)
 aws_instance.web (destroy)
   provider.aws
 provider.aws
+provider.aws (close)
+  aws_instance.web
 `
 
+const testBuiltinGraphBuilderMultiLevelStr = `
+module.foo.module.bar.output.value
+  module.foo.module.bar.var.bar
+module.foo.module.bar.plan-destroy
+module.foo.module.bar.var.bar
+  module.foo.var.foo
+module.foo.plan-destroy
+module.foo.var.foo
+root
+  module.foo.module.bar.output.value
+  module.foo.module.bar.plan-destroy
+  module.foo.plan-destroy
+`
+
+/*
+TODO: Commented out this const as it's likely this needs to
+be updated when the TestBuiltinGraphBuilder_modules test is
+enabled again.
 const testBuiltinGraphBuilderModuleStr = `
 aws_instance.web
   aws_instance.web (destroy)
@@ -231,17 +253,4 @@ module.consul (expanded)
   provider.aws
 provider.aws
 `
-
-const testBuiltinGraphBuilderMultiLevelStr = `
-module.foo.module.bar.output.value
-  module.foo.module.bar.var.bar
-module.foo.module.bar.plan-destroy
-module.foo.module.bar.var.bar
-  module.foo.var.foo
-module.foo.plan-destroy
-module.foo.var.foo
-root
-  module.foo.module.bar.output.value
-  module.foo.module.bar.plan-destroy
-  module.foo.plan-destroy
-`
+*/

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -71,6 +71,12 @@ type ResourceProvider interface {
 	Refresh(*InstanceInfo, *InstanceState) (*InstanceState, error)
 }
 
+// ResourceProviderCloser is an interface that providers that can close
+// connections that aren't needed anymore must implement.
+type ResourceProviderCloser interface {
+	Close() error
+}
+
 // ResourceType is a type of resource that a resource provider can manage.
 type ResourceType struct {
 	Name string

--- a/terraform/resource_provisioner.go
+++ b/terraform/resource_provisioner.go
@@ -23,6 +23,12 @@ type ResourceProvisioner interface {
 	Apply(UIOutput, *InstanceState, *ResourceConfig) error
 }
 
+// ResourceProvisionerCloser is an interface that provisioners that can close
+// connections that aren't needed anymore must implement.
+type ResourceProvisionerCloser interface {
+	Close() error
+}
+
 // ResourceProvisionerFactory is a function type that creates a new instance
 // of a resource provisioner.
 type ResourceProvisionerFactory func() (ResourceProvisioner, error)

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -348,11 +348,6 @@ func (n *graphNodeCloseProvider) DotNode(name string, opts *GraphDotOpts) *dot.N
 	})
 }
 
-// GraphNodeDotterOrigin impl.
-func (n *graphNodeCloseProvider) DotOrigin() bool {
-	return true
-}
-
 // GraphNodeFlattenable impl.
 func (n *graphNodeCloseProvider) Flatten(p []string) (dag.Vertex, error) {
 	return &graphNodeCloseProviderFlat{

--- a/terraform/transform_provisioner_test.go
+++ b/terraform/transform_provisioner_test.go
@@ -18,9 +18,18 @@ func TestMissingProvisionerTransformer(t *testing.T) {
 		}
 	}
 
-	transform := &MissingProvisionerTransformer{Provisioners: []string{"foo"}}
-	if err := transform.Transform(&g); err != nil {
-		t.Fatalf("err: %s", err)
+	{
+		transform := &MissingProvisionerTransformer{Provisioners: []string{"foo"}}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &CloseProvisionerTransformer{}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
 	}
 
 	actual := strings.TrimSpace(g.String())
@@ -57,6 +66,13 @@ func TestPruneProvisionerTransformer(t *testing.T) {
 	}
 
 	{
+		transform := &CloseProvisionerTransformer{}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
 		transform := &PruneProvisionerTransformer{}
 		if err := transform.Transform(&g); err != nil {
 			t.Fatalf("err: %s", err)
@@ -86,10 +102,14 @@ func TestGraphNodeMissingProvisioner_ProvisionerName(t *testing.T) {
 const testTransformMissingProvisionerBasicStr = `
 aws_instance.web
 provisioner.foo
+provisioner.shell (close)
+  aws_instance.web
 `
 
 const testTransformPruneProvisionerBasicStr = `
 aws_instance.web
   provisioner.foo
 provisioner.foo
+provisioner.foo (close)
+  aws_instance.web
 `


### PR DESCRIPTION
Currently Terraform is leaking goroutines and with that memory. I know strictly speaking this maybe isn’t a real concern for Terraform as it’s mostly used as a short running command line executable.

But there are a few of us out there that are using Terraform in some long running processes and then this starts to become a problem.

Next to that it’s of course good programming practise to clean up resources when they're not needed anymore. So even for the standard command line use case, this seems an improvement in resource management.

Personally I see no downsides as the primary connection to the plugin is kept alive (the plugin is not killed) and only unused connections that will never be used again are closed to free up any related
goroutines and memory.