### PR TITLE
communicator/ssh: switch agent default to true

### DIFF
--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -62,6 +62,15 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		return nil, err
 	}
 
+	// To default Agent to true, we need to check the raw string, since the
+	// decoded boolean can't represent "absence of config".
+	//
+	// And if SSH_AUTH_SOCK is not set, there's no agent to connect to, so we
+	// shouldn't try.
+	if s.Ephemeral.ConnInfo["agent"] == "" && os.Getenv("SSH_AUTH_SOCK") != "" {
+		connInfo.Agent = true
+	}
+
 	if connInfo.User == "" {
 		connInfo.User = DefaultUser
 	}

--- a/website/source/docs/provisioners/connection.html.markdown
+++ b/website/source/docs/provisioners/connection.html.markdown
@@ -71,7 +71,7 @@ provisioner "file" {
 * `key_file` - The SSH key to use for the connection. This takes preference over the
   password if provided.
 
-* `agent` - Set to true to enable using ssh-agent to authenticate.
+* `agent` - Set to false to disable using ssh-agent to authenticate.
 
 **Additional arguments only supported by the "winrm" connection type:**
 


### PR DESCRIPTION
This changes SSH Agent utilization from opt-in to opt-out, bringing
Terraform in line with the behavior of Packer and `ssh` itself.