### PR TITLE
provider/aws: Add aws_launch_configuration.enable_monitoring

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -106,6 +106,13 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"enable_monitoring": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"ebs_block_device": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -254,6 +261,12 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("user_data"); ok {
 		userData := base64.StdEncoding.EncodeToString([]byte(v.(string)))
 		createLaunchConfigurationOpts.UserData = aws.String(userData)
+	}
+
+	if v, ok := d.GetOk("enable_monitoring"); ok {
+		createLaunchConfigurationOpts.InstanceMonitoring = &autoscaling.InstanceMonitoring{
+			Enabled: aws.Boolean(v.(bool)),
+		}
 	}
 
 	if v, ok := d.GetOk("iam_instance_profile"); ok {
@@ -423,6 +436,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	d.Set("iam_instance_profile", lc.IAMInstanceProfile)
 	d.Set("ebs_optimized", lc.EBSOptimized)
 	d.Set("spot_price", lc.SpotPrice)
+	d.Set("enable_monitoring", lc.InstanceMonitoring.Enabled)
 	d.Set("security_groups", lc.SecurityGroups)
 
 	if err := readLCBlockDevices(d, lc, ec2conn); err != nil {

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `security_groups` - (Optional) A list of associated security group IDS.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.
 * `user_data` - (Optional) The user data to provide when launching the instance.
+* `enable_monitoring` - (Optional) Enables/disables detailed monitoring. This is enabled by default.
 * `block_device_mapping` - (Optional) A list of block devices to add. Their keys are documented below.
 
 <a id="block-devices"></a>


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/479

I'm not convinced we should make this disabled by default. We had a similar situation in the past - when changing behaviour of `egress` rules in security groups where the default egress rule allowing all traffic was suddenly removed by default (and kept in the previous TF versions). This was BC, but it reality worst case scenario was that instances couldn't talk to the outside world -> de facto no direct data loss.

I don't think that disabling detailed monitoring suddenly is a good idea for people who rely on those data.

Nonetheless if anyone comes up with a meaningful reason why we *should do* the BC, I'm open.

### Test plan
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSLaunchConfiguration' 2>/dev/null
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSLaunchConfiguration -timeout 90m
=== RUN TestAccAWSLaunchConfiguration_basic
--- PASS: TestAccAWSLaunchConfiguration_basic (2.60s)
=== RUN TestAccAWSLaunchConfiguration_withBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (3.98s)
=== RUN TestAccAWSLaunchConfiguration_withSpotPrice
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (1.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	8.516s
```

cc @bantonj @frntn