### PR TITLE
Expose Terraform version

### DIFF
--- a/terraform/version.go
+++ b/terraform/version.go
@@ -1,0 +1,9 @@
+package terraform
+
+// The main version number that is being run at the moment.
+const Version = "0.6.0"
+
+// A pre-release marker for the version. If this is "" (empty string)
+// then it means that it is a final release. Otherwise, this is a pre-release
+// such as "dev" (in development), "beta", "rc1", etc.
+const VersionPrerelease = "dev"

--- a/version.go
+++ b/version.go
@@ -1,12 +1,9 @@
 package main
 
+import "github.com/hashicorp/terraform/terraform"
+
 // The git commit that was compiled. This will be filled in by the compiler.
 var GitCommit string
 
-// The main version number that is being run at the moment.
-const Version = "0.6.0"
-
-// A pre-release marker for the version. If this is "" (empty string)
-// then it means that it is a final release. Otherwise, this is a pre-release
-// such as "dev" (in development), "beta", "rc1", etc.
-const VersionPrerelease = "dev"
+const Version = terraform.Version
+const VersionPrerelease = terraform.VersionPrerelease


### PR DESCRIPTION
There's currently no way to reference Terraform version internally in the codebase - e.g. [here](https://github.com/hashicorp/terraform/blob/master/builtin/providers/google/config.go#L98-102) nor externally when someone decides to use Terraform as a Go library in another project.

I think this is the least painful way of exposing it, but I'm open for suggestions.

FYI @sparkprime 