### PR TITLE
Add -no-color option for subcommands

### DIFF
--- a/command/get.go
+++ b/command/get.go
@@ -77,6 +77,8 @@ Options:
   -update=false       If true, modules already downloaded will be checked
                       for updates and updated if necessary.
 
+  -no-color           If specified, output won't contain any color.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/graph.go
+++ b/command/graph.go
@@ -103,6 +103,9 @@ Options:
 
   -verbose             Generate a verbose, "worst-case" graph, with all nodes
                        for potential operations in place.
+
+  -no-color           If specified, output won't contain any color.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/init.go
+++ b/command/init.go
@@ -149,6 +149,8 @@ Options:
   -backend-config="k=v"  Specifies configuration for the remote storage
                          backend. This can be specified multiple times.
 
+  -no-color           If specified, output won't contain any color.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -351,6 +351,7 @@ func (m *Meta) process(args []string, vars bool) []string {
 	for i, v := range args {
 		if v == "-no-color" {
 			m.color = false
+			m.Color = false
 			args = append(args[:i], args[i+1:]...)
 			break
 		}

--- a/command/output.go
+++ b/command/output.go
@@ -94,6 +94,8 @@ Options:
   -state=path      Path to the state file to read. Defaults to
                    "terraform.tfstate".
 
+  -no-color           If specified, output won't contain any color.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/plan.go
+++ b/command/plan.go
@@ -189,7 +189,6 @@ Options:
   -var-file=foo       Set variables in the Terraform configuration from
                       a file. If "terraform.tfvars" is present, it will be
                       automatically loaded if this flag is not specified.
-
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/push.go
+++ b/command/push.go
@@ -221,6 +221,8 @@ Options:
   -vcs=true            If true (default), push will upload only files
                        comitted to your VCS, if detected.
 
+  -no-color           If specified, output won't contain any color.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/remote.go
+++ b/command/remote.go
@@ -42,6 +42,10 @@ Usage: terraform remote <subcommand> [options]
 
   Configure remote state storage with Terraform.
 
+Options:
+
+  -no-color   If specified, output won't contain any color.
+
 Available subcommands:
 
   config      Configure the remote storage settings.

--- a/command/remote_config.go
+++ b/command/remote_config.go
@@ -368,6 +368,8 @@ Options:
   -state=path            Path to read state. Defaults to "terraform.tfstate"
                          unless remote state is enabled.
 
+  -no-color              If specified, output won't contain any color.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/remote_pull.go
+++ b/command/remote_pull.go
@@ -74,6 +74,9 @@ Usage: terraform pull [options]
 
   Refreshes the cached state file from the remote server.
 
+Options:
+
+  -no-color           If specified, output won't contain any color.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/remote_push.go
+++ b/command/remote_push.go
@@ -81,6 +81,8 @@ Usage: terraform push [options]
 
 Options:
 
+  -no-color              If specified, output won't contain any color.
+
   -force                 Forces the upload of the local state, ignoring any
                          conflicts. This should be used carefully, as force pushing
 						 can cause remote state information to be lost.


### PR DESCRIPTION
This piece of code is apparently responsible for deciding whether to colorize the output:
https://github.com/hashicorp/terraform/blob/master/command/meta.go#L349-357

but that function is effectively removing the `-no-color` from arguments list, but only setting the internal `color` property, therefore when the `Meta` struct (already having `color=false` and no argument to be processed) is passed down to the subcommand, it will take the default `Color` which is `true` and turn color always back on.

Closes #2333 

Was there any specific intention with `color/Color`?