### PR TITLE
provider/aws: Add cloudwatch_log_group

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -41,22 +42,23 @@ type Config struct {
 }
 
 type AWSClient struct {
-	cloudwatchconn  *cloudwatch.CloudWatch
-	dynamodbconn    *dynamodb.DynamoDB
-	ec2conn         *ec2.EC2
-	ecsconn         *ecs.ECS
-	elbconn         *elb.ELB
-	autoscalingconn *autoscaling.AutoScaling
-	s3conn          *s3.S3
-	sqsconn         *sqs.SQS
-	snsconn         *sns.SNS
-	r53conn         *route53.Route53
-	region          string
-	rdsconn         *rds.RDS
-	iamconn         *iam.IAM
-	kinesisconn     *kinesis.Kinesis
-	elasticacheconn *elasticache.ElastiCache
-	lambdaconn      *lambda.Lambda
+	cloudwatchconn     *cloudwatch.CloudWatch
+	cloudwatchlogsconn *cloudwatchlogs.CloudWatchLogs
+	dynamodbconn       *dynamodb.DynamoDB
+	ec2conn            *ec2.EC2
+	ecsconn            *ecs.ECS
+	elbconn            *elb.ELB
+	autoscalingconn    *autoscaling.AutoScaling
+	s3conn             *s3.S3
+	sqsconn            *sqs.SQS
+	snsconn            *sns.SNS
+	r53conn            *route53.Route53
+	region             string
+	rdsconn            *rds.RDS
+	iamconn            *iam.IAM
+	kinesisconn        *kinesis.Kinesis
+	elasticacheconn    *elasticache.ElastiCache
+	lambdaconn         *lambda.Lambda
 }
 
 // Client configures and returns a fully initialized AWSClient
@@ -156,6 +158,9 @@ func (c *Config) Client() (interface{}, error) {
 
 		log.Println("[INFO] Initializing CloudWatch SDK connection")
 		client.cloudwatchconn = cloudwatch.New(awsConfig)
+
+		log.Println("[INFO] Initializing CloudWatch Logs connection")
+		client.cloudwatchlogsconn = cloudwatchlogs.New(awsConfig)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -163,6 +163,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_autoscaling_group":            resourceAwsAutoscalingGroup(),
 			"aws_autoscaling_notification":     resourceAwsAutoscalingNotification(),
 			"aws_autoscaling_policy":           resourceAwsAutoscalingPolicy(),
+			"aws_cloudwatch_log_group":         resourceAwsCloudWatchLogGroup(),
 			"aws_cloudwatch_metric_alarm":      resourceAwsCloudWatchMetricAlarm(),
 			"aws_customer_gateway":             resourceAwsCustomerGateway(),
 			"aws_db_instance":                  resourceAwsDbInstance(),

--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -1,0 +1,146 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+)
+
+func resourceAwsCloudWatchLogGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudWatchLogGroupCreate,
+		Read:   resourceAwsCloudWatchLogGroupRead,
+		Update: resourceAwsCloudWatchLogGroupUpdate,
+		Delete: resourceAwsCloudWatchLogGroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"retention_in_days": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsCloudWatchLogGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+
+	log.Printf("[DEBUG] Creating CloudWatch Log Group: %s", d.Get("name").(string))
+	_, err := conn.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+		LogGroupName: aws.String(d.Get("name").(string)),
+	})
+	if err != nil {
+		return fmt.Errorf("Creating CloudWatch Log Group failed: %s", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	log.Println("[INFO] CloudWatch Log Group created")
+
+	return resourceAwsCloudWatchLogGroupUpdate(d, meta)
+}
+
+func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+	log.Printf("[DEBUG] Reading CloudWatch Log Group: %q", d.Get("name").(string))
+	lg, err := lookupCloudWatchLogGroup(conn, d.Get("name").(string), nil)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Found Log Group: %#v", *lg)
+
+	d.Set("arn", *lg.Arn)
+	d.Set("name", *lg.LogGroupName)
+
+	if lg.RetentionInDays != nil {
+		d.Set("retention_in_days", *lg.RetentionInDays)
+	}
+
+	return nil
+}
+
+func lookupCloudWatchLogGroup(conn *cloudwatchlogs.CloudWatchLogs,
+	name string, nextToken *string) (*cloudwatchlogs.LogGroup, error) {
+	input := &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(name),
+		NextToken:          nextToken,
+	}
+	resp, err := conn.DescribeLogGroups(input)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, lg := range resp.LogGroups {
+		if *lg.LogGroupName == name {
+			return lg, nil
+		}
+	}
+
+	if resp.NextToken != nil {
+		return lookupCloudWatchLogGroup(conn, name, resp.NextToken)
+	}
+
+	return nil, fmt.Errorf("CloudWatch Log Group %q not found", name)
+}
+
+func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+
+	name := d.Get("name").(string)
+	log.Printf("[DEBUG] Updating CloudWatch Log Group: %q", name)
+
+	if d.HasChange("retention_in_days") {
+		var err error
+
+		if v, ok := d.GetOk("retention_in_days"); ok {
+			input := cloudwatchlogs.PutRetentionPolicyInput{
+				LogGroupName:    aws.String(name),
+				RetentionInDays: aws.Int64(int64(v.(int))),
+			}
+			log.Printf("[DEBUG] Setting retention for CloudWatch Log Group: %q: %s", name, input)
+			_, err = conn.PutRetentionPolicy(&input)
+		} else {
+			log.Printf("[DEBUG] Deleting retention for CloudWatch Log Group: %q", name)
+			_, err = conn.DeleteRetentionPolicy(&cloudwatchlogs.DeleteRetentionPolicyInput{
+				LogGroupName: aws.String(name),
+			})
+		}
+
+		return err
+	}
+
+	return resourceAwsCloudWatchLogGroupRead(d, meta)
+}
+
+func resourceAwsCloudWatchLogGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+	log.Printf("[INFO] Deleting CloudWatch Log Group: %s", d.Id())
+	_, err := conn.DeleteLogGroup(&cloudwatchlogs.DeleteLogGroupInput{
+		LogGroupName: aws.String(d.Get("name").(string)),
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting CloudWatch Log Group: %s", err)
+	}
+	log.Println("[INFO] CloudWatch Log Group deleted")
+
+	d.SetId("")
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group_test.go
@@ -1,0 +1,147 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCloudWatchLogGroup_basic(t *testing.T) {
+	var lg cloudwatchlogs.LogGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchLogGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudWatchLogGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "retention_in_days", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchLogGroup_retentionPolicy(t *testing.T) {
+	var lg cloudwatchlogs.LogGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchLogGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudWatchLogGroupConfig_withRetention,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "retention_in_days", "365"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCloudWatchLogGroupConfigModified_withRetention,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "retention_in_days", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchLogGroup_multiple(t *testing.T) {
+	var lg cloudwatchlogs.LogGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchLogGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudWatchLogGroupConfig_multiple,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.alpha", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.alpha", "retention_in_days", "14"),
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.beta", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.beta", "retention_in_days", "0"),
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.charlie", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.charlie", "retention_in_days", "3653"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudWatchLogGroupExists(n string, lg *cloudwatchlogs.LogGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
+		logGroup, err := lookupCloudWatchLogGroup(conn, rs.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		*lg = *logGroup
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCloudWatchLogGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudwatch_log_group" {
+			continue
+		}
+
+		_, err := lookupCloudWatchLogGroup(conn, rs.Primary.ID, nil)
+		if err == nil {
+			return fmt.Errorf("LogGroup Still Exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+var testAccAWSCloudWatchLogGroupConfig = `
+resource "aws_cloudwatch_log_group" "foobar" {
+    name = "foo-bar"
+}
+`
+
+var testAccAWSCloudWatchLogGroupConfig_withRetention = `
+resource "aws_cloudwatch_log_group" "foobar" {
+    name = "foo-bang"
+    retention_in_days = 365
+}
+`
+
+var testAccAWSCloudWatchLogGroupConfigModified_withRetention = `
+resource "aws_cloudwatch_log_group" "foobar" {
+    name = "foo-bang"
+}
+`
+
+var testAccAWSCloudWatchLogGroupConfig_multiple = `
+resource "aws_cloudwatch_log_group" "alpha" {
+    name = "foo-bar"
+    retention_in_days = 14
+}
+resource "aws_cloudwatch_log_group" "beta" {
+    name = "foo-bara"
+}
+resource "aws_cloudwatch_log_group" "charlie" {
+    name = "foo-baraa"
+    retention_in_days = 3653
+}
+`

--- a/website/source/docs/providers/aws/r/cloudwatch_log_group.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_log_group.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_log_group"
+sidebar_current: "docs-aws-resource-cloudwatch-log-group"
+description: |-
+  Provides a CloudWatch Log Group resource.
+---
+
+# aws\_cloudwatch\_log\_group
+
+Provides a CloudWatch Log Group resource.
+
+## Example Usage
+
+```
+resource "aws_cloudwatch_log_group" "yada" {
+  name = "Yada"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the log group
+* `retention_in_days` - (Optional) Specifies the number of days
+  you want to retain log events in the specified log group.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) specifying the log group.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -15,6 +15,10 @@
                     <a href="#">CloudWatch Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-cloudwatch-log-group") %>>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-cloudwatch-metric-alarm") %>>
                             <a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
                         </li>


### PR DESCRIPTION
### Status

 - [x] Reading existing group precisely (probably will have to look up in returned list)
 - [x] Deleting group
 - [x] Creating group
 - [x] Docs
 - [x] Acceptance tests

This should make https://github.com/hashicorp/terraform/pull/2384 much more useful.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=CloudWatchLogGroup' 2>~/tf.log
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=CloudWatchLogGroup -timeout 90m
=== RUN TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (20.78s)
=== RUN TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (35.24s)
=== RUN TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (16.42s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	72.460s
```

cc @catsby 