### PR TITLE
Fixes incorrect usage of terraform_remote_state in docs

### DIFF
--- a/website/source/docs/state/remote.html.md
+++ b/website/source/docs/state/remote.html.md
@@ -47,7 +47,7 @@ An example is shown below:
 resource "terraform_remote_state" "vpc" {
     backend = "atlas"
     config {
-        path = "hashicorp/vpc-prod"
+        name = "hashicorp/vpc-prod"
     }
 }
 


### PR DESCRIPTION
I was getting an error about a missing 'name' parameter when using the snippet from the docs that referenced a path value.  Looking into the source, I found it was actually supposed to be name for the atlas provider.

It would be awesome if there were documentation for each of the backends and the specific configuration that each requires.