### PR TITLE
helper/schema: validate objects are objects [GH-2166]

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1096,6 +1096,13 @@ func (m schemaMap) validateObject(
 	k string,
 	schema map[string]*Schema,
 	c *terraform.ResourceConfig) ([]string, []error) {
+	raw, _ := c.GetRaw(k)
+	if _, ok := raw.(map[string]interface{}); !ok {
+		return nil, []error{fmt.Errorf(
+			"%s: expected object, got %s",
+			k, reflect.ValueOf(raw).Kind())}
+	}
+
 	var ws []string
 	var es []error
 	for subK, s := range schema {
@@ -1114,7 +1121,6 @@ func (m schemaMap) validateObject(
 	}
 
 	// Detect any extra/unknown keys and report those as errors.
-	raw, _ := c.GetRaw(k)
 	if m, ok := raw.(map[string]interface{}); ok {
 		for subk, _ := range m {
 			if _, ok := schema[subk]; !ok {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2981,6 +2981,29 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Err: false,
 		},
 
+		"Sub-resource is the wrong type": {
+			Schema: map[string]*Schema{
+				"ingress": &Schema{
+					Type:     TypeList,
+					Required: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"from": &Schema{
+								Type:     TypeInt,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"ingress": []interface{}{"foo"},
+			},
+
+			Err: true,
+		},
+
 		"Not a list": {
 			Schema: map[string]*Schema{
 				"ingress": &Schema{


### PR DESCRIPTION
Fixes #2166 

This adds validation that objects are actually objects. This avoids panics. I'm actually sure there are more issues that have hit this, but I haven't found them yet.

Test added.