### PR TITLE
helper/schema: internal validate as part of provider validation

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -97,6 +97,13 @@ func (p *Provider) Input(
 
 // Validate implementation of terraform.ResourceProvider interface.
 func (p *Provider) Validate(c *terraform.ResourceConfig) ([]string, []error) {
+	if err := p.InternalValidate(); err != nil {
+		return nil, []error{fmt.Errorf(
+			"Internal validation of the provider failed! This is always a bug\n"+
+				"with the provider itself, and not a user issue. Please report\n"+
+				"this bug:\n\n%s", err)}
+	}
+
 	return schemaMap(p.Schema).Validate(c)
 }
 

--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -117,6 +117,36 @@ func TestProviderResources(t *testing.T) {
 	}
 }
 
+func TestProviderValidate(t *testing.T) {
+	cases := []struct {
+		P      *Provider
+		Config map[string]interface{}
+		Err    bool
+	}{
+		{
+			P: &Provider{
+				Schema: map[string]*Schema{
+					"foo": &Schema{},
+				},
+			},
+			Config: nil,
+			Err:    true,
+		},
+	}
+
+	for i, tc := range cases {
+		c, err := config.NewRawConfig(tc.Config)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		_, es := tc.P.Validate(terraform.NewResourceConfig(c))
+		if (len(es) > 0) != tc.Err {
+			t.Fatalf("%d: %#v", i, es)
+		}
+	}
+}
+
 func TestProviderValidateResource(t *testing.T) {
 	cases := []struct {
 		P      *Provider


### PR DESCRIPTION
Fixes #1291 

This makes it so that provider validation also calls `InternalValidate`. The error message clearly states this is a bug with the provider. This should help catch some custom provider bugs.