### PR TITLE
Add retry to aws_launch_configuration Create to wait for IAM instance profile propagation

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -373,7 +373,14 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	log.Printf(
 		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
-	_, err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
+
+	// IAM profiles can take ~10 seconds to propagate in AWS:
+	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
+	err := resource.Retry(30*time.Second, func() error {
+		_, err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
+		return err
+	})
+
 	if err != nil {
 		return fmt.Errorf("Error creating launch configuration: %s", err)
 	}


### PR DESCRIPTION
Wrapped aws_launch_configuration Create in a resource.Retry to wait for IAM instance profile propagation.

This should fix Issue: #2349 