### PR TITLE
terraform: orphan dependencies should be inverted

### DIFF
--- a/terraform/test-fixtures/graph-builder-orphan-deps/main.tf
+++ b/terraform/test-fixtures/graph-builder-orphan-deps/main.tf
@@ -1,0 +1,1 @@
+provider "aws" {}

--- a/terraform/transform_destroy.go
+++ b/terraform/transform_destroy.go
@@ -1,6 +1,8 @@
 package terraform
 
-import "github.com/hashicorp/terraform/dag"
+import (
+	"github.com/hashicorp/terraform/dag"
+)
 
 type GraphNodeDestroyMode byte
 
@@ -102,6 +104,12 @@ func (t *DestroyTransformer) transform(
 		// Store it
 		nodeToCn[n] = cn
 		nodeToDn[cn] = n
+
+		// If the creation node is equal to the destroy node, then
+		// don't do any of the edge jump rope below.
+		if n.(interface{}) == cn.(interface{}) {
+			continue
+		}
 
 		// Add it to the graph
 		g.Add(n)

--- a/terraform/transform_orphan.go
+++ b/terraform/transform_orphan.go
@@ -298,6 +298,24 @@ func (n *graphNodeOrphanResource) dependableName() string {
 	return n.ResourceName
 }
 
+// GraphNodeDestroyable impl.
+func (n *graphNodeOrphanResource) DestroyNode(mode GraphNodeDestroyMode) GraphNodeDestroy {
+	if mode != DestroyPrimary {
+		return nil
+	}
+
+	return n
+}
+
+// GraphNodeDestroy impl.
+func (n *graphNodeOrphanResource) CreateBeforeDestroy() bool {
+	return false
+}
+
+func (n *graphNodeOrphanResource) CreateNode() dag.Vertex {
+	return n
+}
+
 // Same as graphNodeOrphanResource, but for flattening
 type graphNodeOrphanResourceFlat struct {
 	*graphNodeOrphanResource
@@ -312,4 +330,22 @@ func (n *graphNodeOrphanResourceFlat) Name() string {
 
 func (n *graphNodeOrphanResourceFlat) Path() []string {
 	return n.PathValue
+}
+
+// GraphNodeDestroyable impl.
+func (n *graphNodeOrphanResourceFlat) DestroyNode(mode GraphNodeDestroyMode) GraphNodeDestroy {
+	if mode != DestroyPrimary {
+		return nil
+	}
+
+	return n
+}
+
+// GraphNodeDestroy impl.
+func (n *graphNodeOrphanResourceFlat) CreateBeforeDestroy() bool {
+	return false
+}
+
+func (n *graphNodeOrphanResourceFlat) CreateNode() dag.Vertex {
+	return n
 }


### PR DESCRIPTION
Fixes #2363 

This is a weird-ish one. I'm not sure when this regression happened actually but it feels... old. Like, I think this might be back from the original graph refactor...

Anyways, when an orphan depends on another orphan, the dependencies should be inverted. We do this all within the framework of the existing `DestroyTransformer` but having the nodes implement `GraphNodeDestroyable`. 

The only weird thing is we had to add an edge case handler for if the destroy node equals the creation node (in `transform_destroy.go`). I've commented this to note what is going on.