### PR TITLE
dynamodb - only require nonkey attributes on INCLUDE

### DIFF
--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -208,7 +208,7 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 				ProjectionType: aws.String(lsi["projection_type"].(string)),
 			}
 
-			if lsi["projection_type"] != "ALL" {
+			if lsi["projection_type"] == "INCLUDE" {
 				non_key_attributes := []*string{}
 				for _, attr := range lsi["non_key_attributes"].([]interface{}) {
 					non_key_attributes = append(non_key_attributes, aws.String(attr.(string)))
@@ -570,7 +570,7 @@ func createGSIFromData(data *map[string]interface{}) dynamodb.GlobalSecondaryInd
 		ProjectionType: aws.String((*data)["projection_type"].(string)),
 	}
 
-	if (*data)["projection_type"] != "ALL" {
+	if (*data)["projection_type"] == "INCLUDE" {
 		non_key_attributes := []*string{}
 		for _, attr := range (*data)["non_key_attributes"].([]interface{}) {
 			non_key_attributes = append(non_key_attributes, aws.String(attr.(string)))

--- a/builtin/providers/aws/resource_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table_test.go
@@ -251,7 +251,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 			range_key = "TestGSIRangeKey"
 			write_capacity = 10
 			read_capacity = 10
-			projection_type = "ALL"
+			projection_type = "KEYS_ONLY"
 		}
 }
 `

--- a/builtin/providers/aws/resource_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table_test.go
@@ -279,6 +279,10 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 			name = "ReplacementGSIRangeKey"
 			type = "N"
 		}
+		attribute {
+			name = "TestNonKeyAttribute"
+			type = "S"
+		}
 		local_secondary_index {
 			name = "TestTableLSI"
 			range_key = "TestLSIRangeKey"
@@ -290,7 +294,8 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 			range_key = "ReplacementGSIRangeKey"
 			write_capacity = 5
 			read_capacity = 5
-			projection_type = "ALL"
+			projection_type = "INCLUDE"
+			non_key_attributes = ["TestNonKeyAttribute"]
 		}
 }
 `


### PR DESCRIPTION
@johnewart: Thank you for adding support for DynamoDB.  I'm pinging you because I'd like your feedback on a tiny issue I ran into while I was trying it out.

I was creating indexes with a projection_type of KEYS_ONLY and getting an error about invalid value for "globalSecondaryIndexes.1.member.projection.nonKeyAttributes."  I am suggesting this change based on it allowing my updates to work and the documentation here:
http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Projection.html

I am not 100% sure this is the right course.  It is possible that the correct fix is at the AWS SDK level, but since it unblocked me, I thought I would offer it up.