### PR TITLE
Computed provider variables properly validate

### DIFF
--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3469,6 +3469,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 			},
 			Err: true,
 		},
+
 		"ValidateFunc gets decoded type": {
 			Schema: map[string]*Schema{
 				"maybe": &Schema{
@@ -3485,6 +3486,27 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Config: map[string]interface{}{
 				"maybe": "true",
 			},
+		},
+
+		"ValidateFunc is not called with a computed value": {
+			Schema: map[string]*Schema{
+				"validate_me": &Schema{
+					Type:     TypeString,
+					Required: true,
+					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+						es = append(es, fmt.Errorf("something is not right here"))
+						return
+					},
+				},
+			},
+			Config: map[string]interface{}{
+				"validate_me": "${var.foo}",
+			},
+			Vars: map[string]string{
+				"var.foo": config.UnknownVariableValue,
+			},
+
+			Err: false,
 		},
 	}
 

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -2466,6 +2466,10 @@ func TestContext2Validate_computedVar(t *testing.T) {
 		return nil, c.CheckSet([]string{"value"})
 	}
 
+	p.ConfigureFn = func(c *ResourceConfig) error {
+		return fmt.Errorf("Configure should not be called for provider")
+	}
+
 	w, e := c.Validate()
 	if len(w) > 0 {
 		t.Fatalf("bad: %#v", w)

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -62,6 +62,16 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 					Provider: &provider,
 					Config:   &resourceConfig,
 				},
+			},
+		},
+	})
+
+	// We configure on everything but validate, since validate may
+	// not have access to all the variables.
+	seq = append(seq, &EvalOpFilter{
+		Ops: []walkOperation{walkRefresh, walkPlan, walkApply},
+		Node: &EvalSequence{
+			Nodes: []EvalNode{
 				&EvalConfigProvider{
 					Provider: n,
 					Config:   &resourceConfig,

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -62,6 +62,10 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 					Provider: &provider,
 					Config:   &resourceConfig,
 				},
+				&EvalSetProviderConfig{
+					Provider: n,
+					Config:   &resourceConfig,
+				},
 			},
 		},
 	})

--- a/terraform/test-fixtures/apply-provider-computed/main.tf
+++ b/terraform/test-fixtures/apply-provider-computed/main.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+    value = "${test_instance.foo.value}"
+}
+
+resource "aws_instance" "bar" {}
+
+resource "test_instance" "foo" {
+    value = "yes"
+}

--- a/terraform/test-fixtures/validate-computed-var/main.tf
+++ b/terraform/test-fixtures/validate-computed-var/main.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+    value = "${test_instance.foo.value}"
+}
+
+resource "aws_instance" "bar" {}
+
+resource "test_instance" "foo" {
+    value = "yes"
+}


### PR DESCRIPTION
Fixes #2362 

This adds a lot of tests (most already passing before this PR, but had to be verified) and fixes some issues where computed provider variables weren't working as expected since they'd fail validation. If you look at #2362 it explains quite well.

This fixes that, and added one failing test that is now passing to verify behavior.