### PR TITLE
Add resource sums to terraform plan

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -53,6 +53,9 @@ func (c *PlanCommand) Run(args []string) int {
 		}
 	}
 
+	countHook := new(CountHook)
+	c.Meta.extraHooks = []terraform.Hook{countHook}
+
 	ctx, _, err := c.Context(contextOpts{
 		Destroy:   destroy,
 		Path:      path,
@@ -129,6 +132,13 @@ func (c *PlanCommand) Run(args []string) int {
 		Color:       c.Colorize(),
 		ModuleDepth: moduleDepth,
 	}))
+
+	c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
+		"[reset][bold]Plan:[reset] "+
+			"%d to add, %d to change, %d to destroy.",
+		countHook.ToAdd,
+		(countHook.ToChange + countHook.ToRemoveAndAdd),
+		countHook.ToRemove)))
 
 	if detailed {
 		return 2


### PR DESCRIPTION
Closes #2355

### Test plan

`sample.tf`
```ruby
provider "aws" {
  access_key = ""
  secret_key = ""
  region = "${var.aws_region}"
}

resource "aws_vpc" "main" {
  cidr_block = "10.0.1.0/16"
}

resource "aws_instance" "web" {
    ami = "ami-1234"
    instance_type = "m1.small"
}
```

```sh
$ terraform plan # 2 to add, 0 to change, 0 to destroy
```
```sh
$ terraform plan -target=aws_vpc.main # 1 to add, 0 to change, 0 to destroy
```
```sh
$ terraform plan -destroy # 0 to add, 0 to change, 0 to destroy
```
```sh
$ terraform apply
$ # change aws_vpc.main.cidr_block
$ terraform plan # 0 to add, 1 to change, 0 to destroy
```
```sh
$ terraform plan -destroy # 0 to add, 0 to change, 2 to destroy
```
```sh
$ terraform plan -destroy -target=aws_instance.web # 0 to add, 0 to change, 1 to destroy
```