### PR TITLE
terraform: provider input should be scoped by path

### DIFF
--- a/terraform/eval_context_builtin_test.go
+++ b/terraform/eval_context_builtin_test.go
@@ -1,0 +1,42 @@
+package terraform
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestBuiltinEvalContextProviderInput(t *testing.T) {
+	var lock sync.Mutex
+	cache := make(map[string]map[string]interface{})
+
+	ctx1 := testBuiltinEvalContext(t)
+	ctx1.PathValue = []string{"root"}
+	ctx1.ProviderInputConfig = cache
+	ctx1.ProviderLock = &lock
+
+	ctx2 := testBuiltinEvalContext(t)
+	ctx2.PathValue = []string{"root", "child"}
+	ctx2.ProviderInputConfig = cache
+	ctx2.ProviderLock = &lock
+
+	expected1 := map[string]interface{}{"value": "foo"}
+	ctx1.SetProviderInput("foo", expected1)
+
+	expected2 := map[string]interface{}{"value": "bar"}
+	ctx2.SetProviderInput("foo", expected2)
+
+	actual1 := ctx1.ProviderInput("foo")
+	actual2 := ctx2.ProviderInput("foo")
+
+	if !reflect.DeepEqual(actual1, expected1) {
+		t.Fatalf("bad: %#v %#v", actual1, expected1)
+	}
+	if !reflect.DeepEqual(actual2, expected2) {
+		t.Fatalf("bad: %#v %#v", actual2, expected2)
+	}
+}
+
+func testBuiltinEvalContext(t *testing.T) *BuiltinEvalContext {
+	return &BuiltinEvalContext{}
+}


### PR DESCRIPTION
Fixes #2024 

The provider input before wasn't scoped by path, which caused
non-descendant parts of the graph to grab the configuration of another
sub-tree. The result is that you'd often get copied provider
configurations across the module barriers.

This isn't very straightforward, but it was easy to reproduce with the example config in #2024 (changed to AWS for ease of config). I couldn't get a context test for this because of the weird parallelism, but added a test on the EvalContext which is important for this behavior.