### PR TITLE
schema: Add field name to ValidateFunc

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -154,17 +154,17 @@ func resourceAwsDbInstance() *schema.Resource {
 			"final_snapshot_identifier": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: func(v interface{}) (ws []string, es []error) {
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 					fsi := v.(string)
 					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(fsi) {
 						es = append(es, fmt.Errorf(
-							"only alphanumeric characters and hyphens allowed"))
+							"only alphanumeric characters and hyphens allowed in %s", k))
 					}
 					if regexp.MustCompile(`--`).MatchString(fsi) {
-						es = append(es, fmt.Errorf("cannot contain two consecutive hyphens"))
+						es = append(es, fmt.Errorf("%s cannot contain two consecutive hyphens", k))
 					}
 					if regexp.MustCompile(`-$`).MatchString(fsi) {
-						es = append(es, fmt.Errorf("cannot end in a hyphen"))
+						es = append(es, fmt.Errorf("%s cannot end in a hyphen", k))
 					}
 					return
 				},

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -183,7 +183,7 @@ type SchemaStateFunc func(interface{}) string
 
 // SchemaValidateFunc is a function used to validate a single field in the
 // schema.
-type SchemaValidateFunc func(interface{}) ([]string, []error)
+type SchemaValidateFunc func(interface{}, string) ([]string, []error)
 
 func (s *Schema) GoString() string {
 	return fmt.Sprintf("*%#v", *s)
@@ -1172,7 +1172,7 @@ func (m schemaMap) validatePrimitive(
 	}
 
 	if schema.ValidateFunc != nil {
-		return schema.ValidateFunc(decoded)
+		return schema.ValidateFunc(decoded, k)
 	}
 
 	return nil, nil

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2803,7 +2803,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 				"foo": &Schema{
 					Type:     TypeMap,
 					Required: true,
-					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 						return
 					},
 				},
@@ -3422,7 +3422,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 				"validate_me": &Schema{
 					Type:     TypeString,
 					Required: true,
-					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 						return
 					},
 				},
@@ -3438,7 +3438,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 				"validate_me": &Schema{
 					Type:     TypeString,
 					Required: true,
-					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 						es = append(es, fmt.Errorf("something is not right here"))
 						return
 					},
@@ -3458,7 +3458,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 				"number": &Schema{
 					Type:     TypeInt,
 					Required: true,
-					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 						t.Fatalf("Should not have gotten validate call")
 						return
 					},
@@ -3475,7 +3475,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 				"maybe": &Schema{
 					Type:     TypeBool,
 					Required: true,
-					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 						if _, ok := v.(bool); !ok {
 							t.Fatalf("Expected bool, got: %#v", v)
 						}
@@ -3493,7 +3493,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 				"validate_me": &Schema{
 					Type:     TypeString,
 					Required: true,
-					ValidateFunc: func(v interface{}) (ws []string, es []error) {
+					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 						es = append(es, fmt.Errorf("something is not right here"))
 						return
 					},


### PR DESCRIPTION
This effectively changes this:

>   * aws_db_instance.default: only alphanumeric characters and hyphens allowed

to this:

>  * aws_db_instance.default: only alphanumeric characters and hyphens allowed in final_snapshot_identifier

and generally allows us to provide user more useful error messages.

cc @phinze 