### PR TITLE
terraform: missing provider should add missing aliases [GH-2023]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -683,6 +683,10 @@ func (o *Output) mergerMerge(m merger) merger {
 	return &result
 }
 
+func (c *ProviderConfig) GoString() string {
+	return fmt.Sprintf("*%#v", *c)
+}
+
 func (c *ProviderConfig) FullName() string {
 	if c.Alias == "" {
 		return c.Name

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -379,6 +379,14 @@ do_instance.foo:
   type = do_instance
 `
 
+const testTerraformApplyModuleProviderAliasStr = `
+<no state>
+module.child:
+  aws_instance.foo:
+    ID = foo
+    provider = aws.eu
+`
+
 const testTerraformApplyOutputOrphanStr = `
 <no state>
 Outputs:

--- a/terraform/test-fixtures/apply-module-provider-alias/child/main.tf
+++ b/terraform/test-fixtures/apply-module-provider-alias/child/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+    alias = "eu"
+}
+
+resource "aws_instance" "foo" {
+    provider = "aws.eu"
+}

--- a/terraform/test-fixtures/apply-module-provider-alias/main.tf
+++ b/terraform/test-fixtures/apply-module-provider-alias/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+    source = "./child"
+}

--- a/terraform/test-fixtures/apply-provider-alias-missing/main.tf
+++ b/terraform/test-fixtures/apply-provider-alias-missing/main.tf
@@ -1,8 +1,0 @@
-provider "aws" {
-	alias = "bar"
-}
-
-resource "aws_instance" "bar" {
-    foo = "bar"
-    provider = "aws.bar"
-}

--- a/terraform/test-fixtures/transform-provider-missing/main.tf
+++ b/terraform/test-fixtures/transform-provider-missing/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {}
+resource "aws_instance" "web" {}
+resource "foo_instance" "web" {}

--- a/terraform/transform_provider_test.go
+++ b/terraform/transform_provider_test.go
@@ -63,7 +63,7 @@ func TestCloseProviderTransformer(t *testing.T) {
 }
 
 func TestMissingProviderTransformer(t *testing.T) {
-	mod := testModule(t, "transform-provider-basic")
+	mod := testModule(t, "transform-provider-missing")
 
 	g := Graph{Path: RootModulePath}
 	{
@@ -74,7 +74,7 @@ func TestMissingProviderTransformer(t *testing.T) {
 	}
 
 	{
-		transform := &MissingProviderTransformer{Providers: []string{"foo"}}
+		transform := &MissingProviderTransformer{Providers: []string{"foo", "bar"}}
 		if err := transform.Transform(&g); err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -275,10 +275,13 @@ provider.aws (close)
 
 const testTransformMissingProviderBasicStr = `
 aws_instance.web
+foo_instance.web
 provider.aws
 provider.aws (close)
   aws_instance.web
 provider.foo
+provider.foo (close)
+  foo_instance.web
 `
 
 const testTransformPruneProviderBasicStr = `


### PR DESCRIPTION
Fixes #2023 

The missing provider transform should add provider aliases as well. This makes provider aliases work more easily in modules.