### PR TITLE
terraform: module orphans providers should inherit config

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -4375,6 +4375,54 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
+	m := testModule(t, "apply-module-orphan-provider-inherit")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	p.ConfigureFn = func(c *ResourceConfig) error {
+		if _, ok := c.Get("value"); !ok {
+			return fmt.Errorf("value is not found")
+		}
+
+		return nil
+	}
+
+	// Create a state with an orphan module
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: []string{"root", "child"},
+				Resources: map[string]*ResourceState{
+					"aws_instance.bar": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		State:  state,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := ctx.Apply(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 	m := testModule(t, "apply-module-var-resource-count")
 	p := testProvider("aws")

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -117,14 +117,12 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 		&MissingProviderTransformer{Providers: b.Providers},
 		&ProviderTransformer{},
 		&CloseProviderTransformer{},
-		&PruneProviderTransformer{},
 		&DisableProviderTransformer{},
 
 		// Provisioner-related transformations
 		&MissingProvisionerTransformer{Provisioners: b.Provisioners},
 		&ProvisionerTransformer{},
 		&CloseProvisionerTransformer{},
-		&PruneProvisionerTransformer{},
 
 		// Run our vertex-level transforms
 		&VertexTransformer{
@@ -154,6 +152,12 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 	// We don't do the following for modules.
 	if len(path) <= 1 {
 		steps = append(steps,
+			// Prune the providers and provisioners. This must happen
+			// only once because flattened modules might depend on empty
+			// providers.
+			&PruneProviderTransformer{},
+			&PruneProvisionerTransformer{},
+
 			// Create the destruction nodes
 			&DestroyTransformer{FullDestroy: b.Destroy},
 			&CreateBeforeDestroyTransformer{},

--- a/terraform/test-fixtures/apply-module-orphan-provider-inherit/main.tf
+++ b/terraform/test-fixtures/apply-module-orphan-provider-inherit/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+    value = "foo"
+}


### PR DESCRIPTION
Fixes #2096 

The issue here was that we were pruning the parent provider before we could make the dependency connection to get the inheritence to work. The solution is to move the pruning down as the final step. All other tests pass. 