### PR TITLE
terraform: module computed vars with splat vars don't error

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -1935,6 +1935,23 @@ func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 	}
 }
 
+func TestContext2Refresh_moduleComputedVar(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "refresh-module-computed-var")
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	// This was failing (see GH-2188) at some point, so this test just
+	// verifies that the failure goes away.
+	if _, err := ctx.Refresh(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestContext2Refresh_delete(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "refresh-basic")

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -437,6 +437,14 @@ func (i *Interpolater) computeResourceMultiVariable(
 	}
 
 	if len(values) == 0 {
+		// If the operation is refresh, it isn't an error for a value to
+		// be unknown. Instead, we return that the value is computed so
+		// that the graph can continue to refresh other nodes. It doesn't
+		// matter because the config isn't interpolated anyways.
+		if i.Operation == walkRefresh {
+			return config.UnknownVariableValue, nil
+		}
+
 		return "", fmt.Errorf(
 			"Resource '%s' does not have attribute '%s' "+
 				"for variable '%s'",

--- a/terraform/test-fixtures/refresh-module-computed-var/child/main.tf
+++ b/terraform/test-fixtures/refresh-module-computed-var/child/main.tf
@@ -1,0 +1,5 @@
+variable "value" {}
+
+output "value" {
+    value = "${var.value}"
+}

--- a/terraform/test-fixtures/refresh-module-computed-var/main.tf
+++ b/terraform/test-fixtures/refresh-module-computed-var/main.tf
@@ -1,0 +1,8 @@
+module "child" {
+    source = "./child"
+    value = "${join(" ", aws_instance.test.*.id)}"
+}
+
+resource "aws_instance" "test" {
+    value = "yes"
+}


### PR DESCRIPTION
Fixes #2188 

Splat vars weren't properly returning unknown var on refresh if they were computed. This needs to happen so the graph can continue. It isn't an issue because on refresh the configuration isn't actually used anyways so the unknown value never gets passed into anything...