### PR TITLE
terraform: error if resource not found in module [GH-1997]

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -6559,6 +6559,23 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_unknownAttributeInterpolate(t *testing.T) {
+	m := testModule(t, "apply-unknown-interpolate")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	if _, err := ctx.Plan(); err == nil {
+		t.Fatal("should error")
+	}
+}
+
 func TestContext2Apply_vars(t *testing.T) {
 	m := testModule(t, "apply-vars")
 	p := testProvider("aws")

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -362,7 +362,7 @@ MISSING:
 	// Validation for missing interpolations should happen at a higher
 	// semantic level. If we reached this point and don't have variables,
 	// just return the computed value.
-	if scope == nil || scope.Resource == nil {
+	if scope == nil && scope.Resource == nil {
 		return config.UnknownVariableValue, nil
 	}
 

--- a/terraform/test-fixtures/apply-unknown-interpolate/child/main.tf
+++ b/terraform/test-fixtures/apply-unknown-interpolate/child/main.tf
@@ -1,0 +1,1 @@
+variable "value" {}

--- a/terraform/test-fixtures/apply-unknown-interpolate/main.tf
+++ b/terraform/test-fixtures/apply-unknown-interpolate/main.tf
@@ -1,0 +1,6 @@
+resource "aws_instance" "foo" {}
+
+module "child" {
+    source = "./child"
+    value = "${aws_instance.foo.nope}"
+}


### PR DESCRIPTION
This fixes a part of #1997.

I honestly don't know what this check I changed does. I removed the thing and the tests all still passed. Instead of removing it, I decided to just make it more strict. I added a test that failed before the change, so now we can check that behavior. 

Basically: unknown resource attributes as parameters to modules were slipping by validation. No longer the case!