### PR TITLE
terraform: fail early if module validation fails

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -434,6 +434,12 @@ func (c *Context) Validate() ([]string, []error) {
 		}
 	}
 
+	// If we have errors at this point, the graphing has no chance,
+	// so just bail early.
+	if errs != nil {
+		return nil, []error{errs}
+	}
+
 	// Build the graph so we can walk it and run Validate on nodes.
 	// We also validate the graph generated here, but this graph doesn't
 	// necessarily match the graph that Plan will generate, so we'll validate the

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -3132,28 +3132,6 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 	}
 }
 
-func TestContext2Validate_varRef(t *testing.T) {
-	m := testModule(t, "validate-variable-ref")
-	p := testProvider("aws")
-	c := testContext2(t, &ContextOpts{
-		Module: m,
-		Providers: map[string]ResourceProviderFactory{
-			"aws": testProviderFuncFixed(p),
-		},
-	})
-
-	computed := false
-	p.ValidateResourceFn = func(t string, c *ResourceConfig) ([]string, []error) {
-		computed = c.IsComputed("foo")
-		return nil, nil
-	}
-
-	c.Validate()
-	if !computed {
-		t.Fatal("should be computed")
-	}
-}
-
 func TestContext2Validate_varRefFilled(t *testing.T) {
 	m := testModule(t, "validate-variable-ref")
 	p := testProvider("aws")


### PR DESCRIPTION
Fixes #1861 

This just bails earlier if we have module validation errors. There isn't a test for this because its mostly a UX change. All errors that are caught at this stage are also caught at the graph stage, but the errors are nicer UX earlier if we bail. 