### PR TITLE
website: Fix page titles and descriptions of ElastiCache websites

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_elasticache_cluster"
 sidebar_current: "docs-aws-resource-elasticache-cluster"
 description: |-
-  Provides an VPC subnet resource.
+  Provides an ElastiCache Cluster resource.
 ---
 
 # aws\_elasticache\_cluster

--- a/website/source/docs/providers/aws/r/elasticache_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_security_group.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_subnet"
+page_title: "AWS: aws_elasticache_security_group"
 sidebar_current: "docs-aws-resource-elasticache-security-group"
 description: |-
   Provides an VPC subnet resource.

--- a/website/source/docs/providers/aws/r/elasticache_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_security_group.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_elasticache_security_group"
 sidebar_current: "docs-aws-resource-elasticache-security-group"
 description: |-
-  Provides an VPC subnet resource.
+  Provides an ElastiCache Security Group to control access to one or more cache clusters.
 ---
 
 # aws\_elasticache\_security\_<wbr>group

--- a/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_subnet"
+page_title: "AWS: aws_elasticache_subnet_group"
 sidebar_current: "docs-aws-resource-elasticache-subnet-group"
 description: |-
   Provides an VPC subnet resource.

--- a/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_elasticache_subnet_group"
 sidebar_current: "docs-aws-resource-elasticache-subnet-group"
 description: |-
-  Provides an VPC subnet resource.
+  Provides an ElastiCache Subnet Group resource.
 ---
 
 # aws\_elasticache\_subnet\_group


### PR DESCRIPTION
Fixed page titles and descriptions of ElastiCache website Front-matters.

- [aws_elasticache_cluster](https://www.terraform.io/docs/providers/aws/r/elasticache_cluster.html)
 - (title was fixed at #2261 :exclamation: )
 - description
- [aws_elasticache_security_group](https://www.terraform.io/docs/providers/aws/r/elasticache_security_group.html)
 - title
 - description
- [aws_elasticache_subnet_group](https://www.terraform.io/docs/providers/aws/r/elasticache_subnet_group.html)
 - title
 - description