### PR TITLE
provisioner/chef: add an option to specifically specify the target OS

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -12,7 +12,7 @@ const (
 	installURL = "https://www.chef.io/chef/install.sh"
 )
 
-func (p *Provisioner) sshInstallChefClient(
+func (p *Provisioner) linuxInstallChefClient(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 
@@ -41,7 +41,7 @@ func (p *Provisioner) sshInstallChefClient(
 	return p.runCommand(o, comm, fmt.Sprintf("%srm -f install.sh", prefix))
 }
 
-func (p *Provisioner) sshCreateConfigFiles(
+func (p *Provisioner) linuxCreateConfigFiles(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 	// Make sure the config directory exists

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceProvider_sshInstallChefClient(t *testing.T) {
+func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 	cases := map[string]struct {
 		Config   *terraform.ResourceConfig
 		Commands map[string]bool
@@ -118,14 +118,14 @@ func TestResourceProvider_sshInstallChefClient(t *testing.T) {
 
 		p.useSudo = !p.PreventSudo
 
-		err = p.sshInstallChefClient(o, c)
+		err = p.linuxInstallChefClient(o, c)
 		if err != nil {
 			t.Fatalf("Test %q failed: %v", k, err)
 		}
 	}
 }
 
-func TestResourceProvider_sshCreateConfigFiles(t *testing.T) {
+func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 	cases := map[string]struct {
 		Config   *terraform.ResourceConfig
 		Commands map[string]bool
@@ -149,7 +149,7 @@ func TestResourceProvider_sshCreateConfigFiles(t *testing.T) {
 
 			Uploads: map[string]string{
 				"/etc/chef/validation.pem":  "VALIDATOR-PEM-FILE",
-				"/etc/chef/client.rb":       defaultSSHClientConf,
+				"/etc/chef/client.rb":       defaultLinuxClientConf,
 				"/etc/chef/first-boot.json": `{"run_list":["cookbook::recipe"]}`,
 			},
 		},
@@ -170,7 +170,7 @@ func TestResourceProvider_sshCreateConfigFiles(t *testing.T) {
 
 			Uploads: map[string]string{
 				"/etc/chef/validation.pem":  "VALIDATOR-PEM-FILE",
-				"/etc/chef/client.rb":       defaultSSHClientConf,
+				"/etc/chef/client.rb":       defaultLinuxClientConf,
 				"/etc/chef/first-boot.json": `{"run_list":["cookbook::recipe"]}`,
 			},
 		},
@@ -194,7 +194,7 @@ func TestResourceProvider_sshCreateConfigFiles(t *testing.T) {
 
 			Uploads: map[string]string{
 				"/etc/chef/validation.pem":  "VALIDATOR-PEM-FILE",
-				"/etc/chef/client.rb":       proxySSHClientConf,
+				"/etc/chef/client.rb":       proxyLinuxClientConf,
 				"/etc/chef/first-boot.json": `{"run_list":["cookbook::recipe"]}`,
 			},
 		},
@@ -236,7 +236,7 @@ func TestResourceProvider_sshCreateConfigFiles(t *testing.T) {
 
 			Uploads: map[string]string{
 				"/etc/chef/validation.pem": "VALIDATOR-PEM-FILE",
-				"/etc/chef/client.rb":      defaultSSHClientConf,
+				"/etc/chef/client.rb":      defaultLinuxClientConf,
 				"/etc/chef/first-boot.json": `{"key1":{"subkey1":{"subkey2a":["val1","val2","val3"],` +
 					`"subkey2b":{"subkey3":"value3"}}},"key2":"value2","run_list":["cookbook::recipe"]}`,
 			},
@@ -258,19 +258,19 @@ func TestResourceProvider_sshCreateConfigFiles(t *testing.T) {
 
 		p.useSudo = !p.PreventSudo
 
-		err = p.sshCreateConfigFiles(o, c)
+		err = p.linuxCreateConfigFiles(o, c)
 		if err != nil {
 			t.Fatalf("Test %q failed: %v", k, err)
 		}
 	}
 }
 
-const defaultSSHClientConf = `log_location            STDOUT
+const defaultLinuxClientConf = `log_location            STDOUT
 chef_server_url         "https://chef.local"
 validation_client_name  "validator"
 node_name               "nodename1"`
 
-const proxySSHClientConf = `log_location            STDOUT
+const proxyLinuxClientConf = `log_location            STDOUT
 chef_server_url         "https://chef.local"
 validation_client_name  "validator"
 node_name               "nodename1"

--- a/builtin/provisioners/chef/windows_provisioner.go
+++ b/builtin/provisioners/chef/windows_provisioner.go
@@ -46,7 +46,7 @@ Write-Host 'Installing Chef Client...'
 Start-Process -FilePath msiexec -ArgumentList /qn, /i, $dest -Wait
 `
 
-func (p *Provisioner) winrmInstallChefClient(
+func (p *Provisioner) windowsInstallChefClient(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 	script := path.Join(path.Dir(comm.ScriptPath()), "ChefClient.ps1")
@@ -62,7 +62,7 @@ func (p *Provisioner) winrmInstallChefClient(
 	return p.runCommand(o, comm, installCmd)
 }
 
-func (p *Provisioner) winrmCreateConfigFiles(
+func (p *Provisioner) windowsCreateConfigFiles(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 	// Make sure the config directory exists

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceProvider_winrmInstallChefClient(t *testing.T) {
+func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 	cases := map[string]struct {
 		Config        *terraform.ResourceConfig
 		Commands      map[string]bool
@@ -28,7 +28,7 @@ func TestResourceProvider_winrmInstallChefClient(t *testing.T) {
 			},
 
 			UploadScripts: map[string]string{
-				"ChefClient.ps1": defaultWinRMInstallScript,
+				"ChefClient.ps1": defaultWindowsInstallScript,
 			},
 		},
 
@@ -48,7 +48,7 @@ func TestResourceProvider_winrmInstallChefClient(t *testing.T) {
 			},
 
 			UploadScripts: map[string]string{
-				"ChefClient.ps1": proxyWinRMInstallScript,
+				"ChefClient.ps1": proxyWindowsInstallScript,
 			},
 		},
 
@@ -67,7 +67,7 @@ func TestResourceProvider_winrmInstallChefClient(t *testing.T) {
 			},
 
 			UploadScripts: map[string]string{
-				"ChefClient.ps1": versionWinRMInstallScript,
+				"ChefClient.ps1": versionWindowsInstallScript,
 			},
 		},
 	}
@@ -87,14 +87,14 @@ func TestResourceProvider_winrmInstallChefClient(t *testing.T) {
 
 		p.useSudo = false
 
-		err = p.winrmInstallChefClient(o, c)
+		err = p.windowsInstallChefClient(o, c)
 		if err != nil {
 			t.Fatalf("Test %q failed: %v", k, err)
 		}
 	}
 }
 
-func TestResourceProvider_winrmCreateConfigFiles(t *testing.T) {
+func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 	cases := map[string]struct {
 		Config   *terraform.ResourceConfig
 		Commands map[string]bool
@@ -115,7 +115,7 @@ func TestResourceProvider_winrmCreateConfigFiles(t *testing.T) {
 
 			Uploads: map[string]string{
 				"C:/chef/validation.pem":  "VALIDATOR-PEM-FILE",
-				"C:/chef/client.rb":       defaultWinRMClientConf,
+				"C:/chef/client.rb":       defaultWindowsClientConf,
 				"C:/chef/first-boot.json": `{"run_list":["cookbook::recipe"]}`,
 			},
 		},
@@ -138,7 +138,7 @@ func TestResourceProvider_winrmCreateConfigFiles(t *testing.T) {
 
 			Uploads: map[string]string{
 				"C:/chef/validation.pem":  "VALIDATOR-PEM-FILE",
-				"C:/chef/client.rb":       proxyWinRMClientConf,
+				"C:/chef/client.rb":       proxyWindowsClientConf,
 				"C:/chef/first-boot.json": `{"run_list":["cookbook::recipe"]}`,
 			},
 		},
@@ -179,7 +179,7 @@ func TestResourceProvider_winrmCreateConfigFiles(t *testing.T) {
 
 			Uploads: map[string]string{
 				"C:/chef/validation.pem": "VALIDATOR-PEM-FILE",
-				"C:/chef/client.rb":      defaultWinRMClientConf,
+				"C:/chef/client.rb":      defaultWindowsClientConf,
 				"C:/chef/first-boot.json": `{"key1":{"subkey1":{"subkey2a":["val1","val2","val3"],` +
 					`"subkey2b":{"subkey3":"value3"}}},"key2":"value2","run_list":["cookbook::recipe"]}`,
 			},
@@ -201,14 +201,14 @@ func TestResourceProvider_winrmCreateConfigFiles(t *testing.T) {
 
 		p.useSudo = false
 
-		err = p.winrmCreateConfigFiles(o, c)
+		err = p.windowsCreateConfigFiles(o, c)
 		if err != nil {
 			t.Fatalf("Test %q failed: %v", k, err)
 		}
 	}
 }
 
-const defaultWinRMInstallScript = `
+const defaultWindowsInstallScript = `
 $winver = [System.Environment]::OSVersion.Version | % {"{0}.{1}" -f $_.Major,$_.Minor}
 
 switch ($winver)
@@ -245,7 +245,7 @@ Write-Host 'Installing Chef Client...'
 Start-Process -FilePath msiexec -ArgumentList /qn, /i, $dest -Wait
 `
 
-const proxyWinRMInstallScript = `
+const proxyWindowsInstallScript = `
 $winver = [System.Environment]::OSVersion.Version | % {"{0}.{1}" -f $_.Major,$_.Minor}
 
 switch ($winver)
@@ -282,7 +282,7 @@ Write-Host 'Installing Chef Client...'
 Start-Process -FilePath msiexec -ArgumentList /qn, /i, $dest -Wait
 `
 
-const versionWinRMInstallScript = `
+const versionWindowsInstallScript = `
 $winver = [System.Environment]::OSVersion.Version | % {"{0}.{1}" -f $_.Major,$_.Minor}
 
 switch ($winver)
@@ -319,12 +319,12 @@ Write-Host 'Installing Chef Client...'
 Start-Process -FilePath msiexec -ArgumentList /qn, /i, $dest -Wait
 `
 
-const defaultWinRMClientConf = `log_location            STDOUT
+const defaultWindowsClientConf = `log_location            STDOUT
 chef_server_url         "https://chef.local"
 validation_client_name  "validator"
 node_name               "nodename1"`
 
-const proxyWinRMClientConf = `log_location            STDOUT
+const proxyWindowsClientConf = `log_location            STDOUT
 chef_server_url         "https://chef.local"
 validation_client_name  "validator"
 node_name               "nodename1"

--- a/website/source/docs/provisioners/chef.html.markdown
+++ b/website/source/docs/provisioners/chef.html.markdown
@@ -67,6 +67,10 @@ The following arguments are supported:
 
 * `node_name (string)` - (Required) The name of the node to register with the Chef Server.
 
+* `os_type (string)` - (Optional) The OS type of the node. Valid options are: `linux` and
+  `windows`. If not supplied the connection type will be used to determine the OS type (`ssh`
+  will asume `linux` and `winrm` will assume `windows`). 
+
 * `prevent_sudo (boolean)` - (Optional) Prevent the use of sudo while installing, configuring
   and running the initial Chef Client run. This option is only used with `ssh` type
   [connections](/docs/provisioners/connection.html).


### PR DESCRIPTION
Before this option (`os_type`) the provisioner would use the connection type to determine the targeted OS. When not supplying a value for `os_type`, it will fall back to the old behaviour, so this is fully BC.