### PR TITLE
Add missing docs to aws provider sidebar

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -13,6 +13,9 @@
 				<li<%= sidebar_current(/^docs-aws-resource/) %>>
 					<a href="#">Resources</a>
 					<ul class="nav nav-visible">
+						<li<%= sidebar_current("docs-aws-app-cookie-stickiness-policy") %>>
+							<a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
+						</li>
 						<li<%= sidebar_current("docs-aws-resource-autoscaling-group") %>>
 							<a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
 						</li>


### PR DESCRIPTION
Already exists, just adding it to the sidebar: https://terraform.io/docs/providers/aws/r/app_cookie_stickiness_policy.html