### PR TITLE
provider/digitalocean: check if the droplet no longer exists.

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -165,6 +165,12 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	// Retrieve the droplet properties for updating the state
 	droplet, err := client.RetrieveDroplet(d.Id())
 	if err != nil {
+		// check if the droplet no longer exists.
+		if err.Error() == "Error retrieving droplet: API Error: 404 Not Found" {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("Error retrieving droplet: %s", err)
 	}
 


### PR DESCRIPTION
if you manually delete a droplet from the Digital Ocean control panel, you no longer can use terraform without fiddling with the tfstate file due to:

```
terraform plan -no-color
Refreshing Terraform state prior to plan...

digitalocean_droplet.web: Refreshing state... (ID: 5874338)
Error refreshing state: 1 error(s) occurred:

* 1 error(s) occurred:

* Error retrieving droplet: Error retrieving droplet: API Error: 404 Not Found
```

The resource reader was missing a check for the droplet existence. this PR fixes that.