### PR TITLE
AWS: launch config remove the image_id lookup

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -446,7 +446,6 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	lc := describConfs.LaunchConfigurations[0]
 
 	d.Set("key_name", lc.KeyName)
-	d.Set("image_id", lc.ImageID)
 	d.Set("instance_type", lc.InstanceType)
 	d.Set("name", lc.LaunchConfigurationName)
 


### PR DESCRIPTION
So this is a strange use case fix. 

Every now and then we update the AMI and don't want to tear down instances/ASG that are build on older AMIs done by terraform

If we spin up an instance using aws_instance we can just edit the json state file and terraform honors that since it doesn't query AWS for the currently running AMI. 

Launch config queries AWS for the image_id so terraform wants to tear it down and re-build. 

I'm trying to make this standard since on #terraform on IRC I was told to just edit the state json if I had to make a AMI change.

If this is needed then close the PR. 