### PR TITLE
command: ask for input even if tfvars is set [GH-2161]

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -190,7 +190,7 @@ func (m *Meta) InputMode() terraform.InputMode {
 
 	var mode terraform.InputMode
 	mode |= terraform.InputModeProvider
-	if len(m.variables) == 0 && m.autoKey == "" {
+	if len(m.variables) == 0 {
 		mode |= terraform.InputModeVar
 		mode |= terraform.InputModeVarUnset
 	}

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -158,7 +158,7 @@ func TestMetaInputMode_defaultVars(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if m.InputMode()&terraform.InputModeVar != 0 {
+	if m.InputMode()&terraform.InputModeVar == 0 {
 		t.Fatalf("bad: %#v", m.InputMode())
 	}
 }

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -119,7 +119,7 @@ func TestPush_input(t *testing.T) {
 		"foo": "foo",
 	}
 	if !reflect.DeepEqual(client.UpsertOptions.Variables, variables) {
-		t.Fatalf("bad: %#v", client.UpsertOptions)
+		t.Fatalf("bad: %#v", client.UpsertOptions.Variables)
 	}
 }
 


### PR DESCRIPTION
Fixes #2161 

We used to not ask for input if we have a `tfvars`. I think we did this because we _used_ to not have the `InputModeVarUnset`. Now that we have that more fine-grained control which only asks for input for vars that are not set, I don't think this is necessary anymore.

One test failed which explicitly checked that flag, I changed it for the new beavior. The rest are good.