### PR TITLE
output command supports printing all outputs

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -27,7 +27,7 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	var allOutputs bool = false
+	allOutputs := false
 	var name string
 	if len(args) > 1 {
 		c.Ui.Error(
@@ -35,11 +35,14 @@ func (c *OutputCommand) Run(args []string) int {
 				"of an output variable or no arguments to show all outputs.\n")
 		cmdFlags.Usage()
 		return 1
-	} else if len(args) == 0 {
+	}
+
+	if len(args) == 0 {
 		allOutputs = true
 	} else {
 		name = args[0]
 	}
+
 	stateStore, err := c.Meta.State()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error reading state: %s", err))

--- a/command/output.go
+++ b/command/output.go
@@ -3,6 +3,7 @@ package command
 import (
 	"flag"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -26,15 +27,19 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) != 1 || args[0] == "" {
+	var allOutputs bool = false
+	var name string
+	if len(args) > 1 {
 		c.Ui.Error(
 			"The output command expects exactly one argument with the name\n" +
-				"of an output variable.\n")
+				"of an output variable or no arguments to show all outputs.\n")
 		cmdFlags.Usage()
 		return 1
+	} else if len(args) == 0 {
+		allOutputs = true
+	} else {
+		name = args[0]
 	}
-	name := args[0]
-
 	stateStore, err := c.Meta.State()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error reading state: %s", err))
@@ -68,6 +73,20 @@ func (c *OutputCommand) Run(args []string) int {
 		return 1
 	}
 
+        if allOutputs {
+                ks := make([]string, 0, len(mod.Outputs))
+                for k, _ := range mod.Outputs {
+                        ks = append(ks, k)
+                }
+                sort.Strings(ks)
+
+                for _, k := range ks {
+                        v := mod.Outputs[k]
+                        c.Ui.Output(fmt.Sprintf("%s = %s", k, v))
+                }
+		return 0
+        }
+
 	v, ok := mod.Outputs[name]
 	if !ok {
 		c.Ui.Error(fmt.Sprintf(
@@ -84,17 +103,20 @@ func (c *OutputCommand) Run(args []string) int {
 
 func (c *OutputCommand) Help() string {
 	helpText := `
-Usage: terraform output [options] NAME
+Usage: terraform output [options] [NAME]
 
   Reads an output variable from a Terraform state file and prints
-  the value.
+  the value.  If NAME is not specified, all outputs are printed.
 
 Options:
 
   -state=path      Path to the state file to read. Defaults to
                    "terraform.tfstate".
 
-  -no-color           If specified, output won't contain any color.
+  -no-color        If specified, output won't contain any color.
+
+  -module=name     If specified, returns the outputs for a
+                   specific module
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
if no output name is specified all outputs are displayed
fixed formating and added missing help for -module parameter
closes #2390 