### PR TITLE
config/lang: don't see * as part of var name [GH-2046]

### DIFF
--- a/config/lang/ast/call.go
+++ b/config/lang/ast/call.go
@@ -41,3 +41,7 @@ func (n *Call) Type(s Scope) (Type, error) {
 
 	return f.ReturnType, nil
 }
+
+func (n *Call) GoString() string {
+	return fmt.Sprintf("*%#v", *n)
+}

--- a/config/lang/lex.go
+++ b/config/lang/lex.go
@@ -192,9 +192,17 @@ func (x *parserLex) lexModeInterpolation(yylval *parserSymType) int {
 
 func (x *parserLex) lexId(yylval *parserSymType) int {
 	var b bytes.Buffer
+	var last rune
 	for {
 		c := x.next()
 		if c == lexEOF {
+			break
+		}
+
+		// We only allow * after a '.' for resource splast: type.name.*.id
+		// Otherwise, its probably multiplication.
+		if c == '*' && last != '.' {
+			x.backup()
 			break
 		}
 
@@ -214,6 +222,8 @@ func (x *parserLex) lexId(yylval *parserSymType) int {
 			x.Error(err.Error())
 			return lexEOF
 		}
+
+		last = c
 	}
 
 	yylval.token = &parserToken{Value: b.String()}

--- a/config/lang/parse_test.go
+++ b/config/lang/parse_test.go
@@ -184,6 +184,41 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"foo ${var.bar*1} baz",
+			false,
+			&ast.Concat{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.LiteralNode{
+						Value: "foo ",
+						Typex: ast.TypeString,
+						Posx:  ast.Pos{Column: 1, Line: 1},
+					},
+					&ast.Arithmetic{
+						Op: ast.ArithmeticOpMul,
+						Exprs: []ast.Node{
+							&ast.VariableAccess{
+								Name: "var.bar",
+								Posx: ast.Pos{Column: 7, Line: 1},
+							},
+							&ast.LiteralNode{
+								Value: 1,
+								Typex: ast.TypeInt,
+								Posx:  ast.Pos{Column: 15, Line: 1},
+							},
+						},
+						Posx: ast.Pos{Column: 7, Line: 1},
+					},
+					&ast.LiteralNode{
+						Value: " baz",
+						Typex: ast.TypeString,
+						Posx:  ast.Pos{Column: 17, Line: 1},
+					},
+				},
+			},
+		},
+
+		{
 			"${foo()}",
 			false,
 			&ast.Concat{


### PR DESCRIPTION
Fixes #2046 

This wasn't as straightforward as I expected (though still simple), since actually '*' _should_ be part of identifier names in certain cases. So we check if the prior char was '.' and let it through. Otherwise, we bail. 

There are tests covering both cases. One is new, the other already existed.