### PR TITLE
aws: Add validation for aws_db_subnet_group.name

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -155,16 +155,16 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					fsi := v.(string)
-					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(fsi) {
+					value := v.(string)
+					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
 						es = append(es, fmt.Errorf(
-							"only alphanumeric characters and hyphens allowed in %s", k))
+							"only alphanumeric characters and hyphens allowed in %q", k))
 					}
-					if regexp.MustCompile(`--`).MatchString(fsi) {
-						es = append(es, fmt.Errorf("%s cannot contain two consecutive hyphens", k))
+					if regexp.MustCompile(`--`).MatchString(value) {
+						es = append(es, fmt.Errorf("%q cannot contain two consecutive hyphens", k))
 					}
-					if regexp.MustCompile(`-$`).MatchString(fsi) {
-						es = append(es, fmt.Errorf("%s cannot end in a hyphen", k))
+					if regexp.MustCompile(`-$`).MatchString(value) {
+						es = append(es, fmt.Errorf("%q cannot end in a hyphen", k))
 					}
 					return
 				},

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -24,6 +25,22 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+					}
+					if len(value) > 255 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 255 characters", k))
+					}
+					if regexp.MustCompile(`(?i)^default$`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"%q is not allowed as %q", "Default", k))
+					}
+					return
+				},
 			},
 
 			"description": &schema.Schema{


### PR DESCRIPTION
Closes #2320

http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-subnet-group.html
![screen shot 2015-06-26 at 12 42 16](https://cloud.githubusercontent.com/assets/287584/8376605/d24374b8-1c00-11e5-9a0f-23ce6a83fd7c.png)
