### PR TITLE
provider/aws: Add validation for aws_db_instance.identifier

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -74,6 +74,26 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^[0-9a-z-]$`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+					}
+					if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"first character of %q must be a letter", k))
+					}
+					if regexp.MustCompile(`--`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot contain two consecutive hyphens", k))
+					}
+					if regexp.MustCompile(`-$`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot end with a hyphen"))
+					}
+					return
+				},
 			},
 
 			"instance_class": &schema.Schema{


### PR DESCRIPTION
http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html

![screen shot 2015-06-26 at 14 59 57](https://cloud.githubusercontent.com/assets/287584/8378843/0adce102-1c14-11e5-9a92-12886a7c8091.png)

I did not bother with the character limit since it's engine-specific and it's not quite easy yet to do validation based on other fields.