### PR TITLE
provider/aws: Add validation for aws_security_group (name+description)

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -28,6 +28,14 @@ func resourceAwsSecurityGroup() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 255 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 255 characters", k))
+					}
+					return
+				},
 			},
 
 			"description": &schema.Schema{
@@ -35,6 +43,14 @@ func resourceAwsSecurityGroup() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  "Managed by Terraform",
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 255 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 255 characters", k))
+					}
+					return
+				},
 			},
 
 			"vpc_id": &schema.Schema{


### PR DESCRIPTION
http://docs.aws.amazon.com/cli/latest/reference/ec2/create-security-group.html

![screen shot 2015-06-26 at 15 11 10](https://cloud.githubusercontent.com/assets/287584/8379109/a475e524-1c15-11e5-82c8-faef69e2d176.png)

I did not bother with the regexp constraints since that's account-specific.