### PR TITLE
aws: Fix validation for aws_elb.name

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -28,7 +28,7 @@ func resourceAwsElb() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if !regexp.MustCompile(`^[0-9a-z-]$`).MatchString(value) {
+					if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 						errors = append(errors, fmt.Errorf(
 							"only lowercase alphanumeric characters and hyphens allowed in %q", k))
 					}


### PR DESCRIPTION
Same case as https://github.com/hashicorp/terraform/pull/2522

I double checked all other validations for the same bug, they're OK.