### PR TITLE
terraform: all providers for ProvidedBy() should be added

### DIFF
--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -379,6 +379,15 @@ do_instance.foo:
   type = do_instance
 `
 
+const testTerraformApplyModuleOnlyProviderStr = `
+<no state>
+module.child:
+  aws_instance.foo:
+    ID = foo
+  test_instance.foo:
+    ID = foo
+`
+
 const testTerraformApplyModuleProviderAliasStr = `
 <no state>
 module.child:

--- a/terraform/test-fixtures/apply-module-only-provider/child/main.tf
+++ b/terraform/test-fixtures/apply-module-only-provider/child/main.tf
@@ -1,0 +1,2 @@
+resource "aws_instance" "foo" {}
+resource "test_instance" "foo" {}

--- a/terraform/test-fixtures/apply-module-only-provider/main.tf
+++ b/terraform/test-fixtures/apply-module-only-provider/main.tf
@@ -1,0 +1,5 @@
+provider "aws" {}
+
+module "child" {
+    source = "./child"
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -167,7 +167,7 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 		for _, p := range pv.ProvidedBy() {
 			if _, ok := m[p]; ok {
 				// This provider already exists as a configure node
-				break
+				continue
 			}
 
 			// If the provider has an alias in it, we just want the type


### PR DESCRIPTION
We were quitting early if any of the `ProvidedBy` providers were added, but we actually need to add all. I thought it was an array of precedence... but in fact it is just that multiple providers are needed. Modules, for example, depend on multiple providers.