### PR TITLE
provider/aws: nil protection against VPN connections [GH-2144]

### DIFF
--- a/builtin/providers/aws/resource_vpn_connection_route.go
+++ b/builtin/providers/aws/resource_vpn_connection_route.go
@@ -91,6 +91,12 @@ func resourceAwsVpnConnectionRouteRead(d *schema.ResourceData, meta interface{})
 			return err
 		}
 	}
+	if resp == nil || len(resp.VPNConnections) == 0 {
+		// This is kind of a weird edge case. I'd rather return an error
+		// instead of just blindly setting the ID to ""... since I don't know
+		// what might cause this.
+		return fmt.Errorf("No VPN connections returned")
+	}
 
 	vpnConnection := resp.VPNConnections[0]
 


### PR DESCRIPTION
Fixes #2144 

Just added nil protection. I don't know why this would happen so I'd rather return an error for now.