### PR TITLE
Make elasticache_subnet_group subnet_ids as required argument

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -32,8 +32,7 @@ func resourceAwsElasticacheSubnetGroup() *schema.Resource {
 			},
 			"subnet_ids": &schema.Schema{
 				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set: func(v interface{}) int {
 					return hashcode.String(v.(string))

--- a/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `description` – (Required) Description for the cache subnet group
 * `name` – (Required) Name for the cache subnet group. This value is stored as 
 a lowercase string
-* `subnet_ids` – (Optional) List of VPC Subnet IDs for the cache subnet group
+* `subnet_ids` – (Required) List of VPC Subnet IDs for the cache subnet group
 
 ## Attributes Reference
 


### PR DESCRIPTION
## WHAT

Make elasticache_subnet_group `subnet_ids` as _required_ argument.

## WHY

Terraform v0.5.3 describes that elasticache_subnet_group `subnet_ids` is _optional_ argument.
However, AWS API document ([CreateCacheSubnetGroup - Amazon ElastiCache](http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSubnetGroup.html)) describes that `subnet_ids` is _required_ argument.

I tried to create ElastiCache Subnet Group without `subnet_ids` with the below code:

```
resource "aws_elasticache_subnet_group" "hoge" {
    name        = "hoge"
    description = "Group for hoge"
}
```

and then I got the the below error by `terraform apply`:

```
aws_elasticache_subnet_group.hoge: Creating...
  description:  "" => "Group for hoge"
  name:         "" => "hoge"
  subnet_ids.#: "" => "<computed>"
aws_elasticache_subnet_group.hoge: Error: 1 error(s) occurred:

* Error creating CacheSubnetGroup: InvalidParameterValue: The parameter SubnetIds must be provided.
	status code: 400, request id: [6107dfa2-1b1f-11e5-a9d3-d5506ffa70a9]
Error applying plan:

1 error(s) occurred:

* 1 error(s) occurred:

* 1 error(s) occurred:

* Error creating CacheSubnetGroup: InvalidParameterValue: The parameter SubnetIds must be provided.
	status code: 400, request id: [6107dfa2-1b1f-11e5-a9d3-d5506ffa70a9]
```