### PR TITLE
Add $PATH change to dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Developing Terraform
 
 If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.4+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
 
-For local dev first make sure Go is properly installed, including setting up a [GOPATH](http://golang.org/doc/code.html#GOPATH). Next, install the following software packages, which are needed for some dependencies:
+For local dev first make sure Go is properly installed, including setting up a [GOPATH](http://golang.org/doc/code.html#GOPATH). You will also need to add `$GOPATH/bin` to your `$PATH`. Next, install the following software packages, which are needed for some dependencies:
 
 -	[Git](http://git-scm.com/)
 -	[Mercurial](http://mercurial.selenic.com/)


### PR DESCRIPTION
`make` failed because it uses `stringer`, which is in `$GOPATH/bin`. Updating `$PATH` enables a successful build.