### PR TITLE
provider/aws: ignore association not exist on EIP destroy [GH-2295]

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -222,6 +222,17 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 				PublicIP: aws.String(d.Get("public_ip").(string)),
 			})
 		}
+
+		if err != nil {
+			// First check if the association ID is not found. If this
+			// is the case, then it was already disassociated somehow,
+			// and that is okay. The most commmon reason for this is that
+			// the instance or ENI it was attached it was destroyed.
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAssociationID.NotFound" {
+				err = nil
+			}
+		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #2295 

This ignores if the association is gone for an EIP during the destruction phase. This can happen because  an instance destroy automatically removes the association, and we have clear refresh-then-destroy phases in TF>