### PR TITLE
providers/aws: vpc peering failed == deleted [GH-2322]

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -101,6 +101,14 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 
 	pc := pcRaw.(*ec2.VPCPeeringConnection)
 
+	// The failed status is a status that we can assume just means the
+	// connection is gone. Destruction isn't allowed, and it eventually
+	// just "falls off" the console. See GH-2322
+	if *pc.Status.Code == "failed" {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("accept_status", *pc.Status.Code)
 	d.Set("peer_owner_id", pc.AccepterVPCInfo.OwnerID)
 	d.Set("peer_vpc_id", pc.AccepterVPCInfo.VPCID)


### PR DESCRIPTION
Fixes #2322

If a VPC peering connection is "failed" it can no longer be deleted. AWS eventually cleans these up automatically, so we should just treat it like it doesn't exist.

Note the state diagram here: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-peering.html It leads me to believe there are other states like this, but this is the only one verified by a user.