### PR TITLE
providers/cloudflare: if resource no longer exists, set ID to ""

### DIFF
--- a/builtin/providers/cloudflare/resource_cloudflare_record.go
+++ b/builtin/providers/cloudflare/resource_cloudflare_record.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pearkes/cloudflare"
@@ -91,7 +92,14 @@ func resourceCloudFlareRecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	rec, err := client.RetrieveRecord(d.Get("domain").(string), d.Id())
 	if err != nil {
-		return fmt.Errorf("Couldn't find CloudFlare Record ID (%s) for domain (%s): %s", d.Id(), d.Get("domain").(string), err)
+		if strings.Contains(err.Error(), "not found") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf(
+			"Couldn't find CloudFlare Record ID (%s) for domain (%s): %s",
+			d.Id(), d.Get("domain").(string), err)
 	}
 
 	d.Set("name", rec.Name)


### PR DESCRIPTION
Fixes #301 

Unfortunately there isn't a better error we get from the upstream lib (that we also control!), so we'll just do a string match for now.