### PR TITLE
providers/dme: unable to find record, set ID to "" [GH-2440]

### DIFF
--- a/builtin/providers/dme/resource_dme_record.go
+++ b/builtin/providers/dme/resource_dme_record.go
@@ -110,6 +110,11 @@ func resourceDMERecordRead(d *schema.ResourceData, meta interface{}) error {
 
 	rec, err := client.ReadRecord(domainid, recordid)
 	if err != nil {
+		if strings.Contains(err.Error(), "Unable to find") {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("Couldn't find record: %s", err)
 	}
 


### PR DESCRIPTION
Fixes #2440 

Upstream there is no way to detect this other than string comparison...