### PR TITLE
Add SoftLayer provider

### DIFF
--- a/builtin/bins/provider-softlayer/main.go
+++ b/builtin/bins/provider-softlayer/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/softlayer"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: softlayer.Provider,
+	})
+}

--- a/builtin/bins/provider-softlayer/main_test.go
+++ b/builtin/bins/provider-softlayer/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/builtin/providers/softlayer/config.go
+++ b/builtin/providers/softlayer/config.go
@@ -1,0 +1,38 @@
+package softlayer
+
+import (
+	"log"
+
+	slclient "github.com/maximilien/softlayer-go/client"
+	softlayer "github.com/maximilien/softlayer-go/softlayer"
+)
+
+type Config struct {
+	Username string
+	ApiKey string
+}
+
+type Client struct {
+	virtualGuestService softlayer.SoftLayer_Virtual_Guest_Service
+	sshKeyService softlayer.SoftLayer_Security_Ssh_Key_Service
+}
+
+func (c *Config) Client() (*Client, error) {
+	slc := slclient.NewSoftLayerClient(c.Username, c.ApiKey)
+	virtualGuestService, err := slc.GetSoftLayer_Virtual_Guest_Service()
+
+	if err != nil {
+		return nil, err
+	}
+
+	sshKeyService, err := slc.GetSoftLayer_Security_Ssh_Key_Service()
+
+	client := &Client {
+		virtualGuestService: virtualGuestService,
+		sshKeyService: sshKeyService,
+	}
+
+	log.Println("[INFO] Created SoftLayer client")
+
+	return client, nil
+}

--- a/builtin/providers/softlayer/provider.go
+++ b/builtin/providers/softlayer/provider.go
@@ -1,0 +1,42 @@
+package softlayer
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"username": &schema.Schema{
+				Type: schema.TypeString,
+				Required: true,
+				DefaultFunc: schema.EnvDefaultFunc("SOFTLAYER_USERNAME", nil),
+				Description: "The user name for SoftLayer API operations.",
+			},
+			"api_key": &schema.Schema{
+				Type: schema.TypeString,
+				Required: true,
+				DefaultFunc: schema.EnvDefaultFunc("SOFTLAYER_API_KEY", nil),
+				Description: "The API key for SoftLayer API operations.",
+			},
+		},
+
+		ResourcesMap: map[string]*schema.Resource{
+			"softlayer_virtualserver": resourceSoftLayerVirtualserver(),
+			"softlayer_ssh_key": resourceSoftLayerSSHKey(),
+		},
+
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := Config{
+		Username: d.Get("username").(string),
+		ApiKey: d.Get("api_key").(string),
+
+	}
+
+	return config.Client()
+}

--- a/builtin/providers/softlayer/provider_test.go
+++ b/builtin/providers/softlayer/provider_test.go
@@ -1,0 +1,38 @@
+package softlayer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"softlayer": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("SOFTLAYER_USERNAME"); v == "" {
+		t.Fatal("SOFTLAYER_USERNAME must be set for acceptance tests")
+	}
+	if v := os.Getenv("SOFTLAYER_API_KEY"); v == "" {
+		t.Fatal("SOFTLAYER_API_KEY must be set for acceptance tests")
+	}
+}

--- a/builtin/providers/softlayer/resource_softlayer_ssh_key.go
+++ b/builtin/providers/softlayer/resource_softlayer_ssh_key.go
@@ -1,0 +1,125 @@
+package softlayer
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	datatypes "github.com/maximilien/softlayer-go/data_types"
+)
+
+func resourceSoftLayerSSHKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSoftLayerSSHKeyCreate,
+		Read:   resourceSoftLayerSSHKeyRead,
+		Update: resourceSoftLayerSSHKeyUpdate,
+		Delete: resourceSoftLayerSSHKeyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"public_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"fingerprint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSoftLayerSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).sshKeyService
+
+	// Build up our creation options
+	opts := datatypes.SoftLayer_Security_Ssh_Key{
+		Label: d.Get("name").(string),
+		Key: d.Get("public_key").(string),
+	}
+
+	res, err := client.CreateObject(opts)
+	if err != nil {
+		return fmt.Errorf("Error creating SSH Key: %s", err)
+	}
+
+	d.SetId(strconv.Itoa(res.Id))
+	log.Printf("[INFO] SSH Key: %d", res.Id)
+
+	return resourceSoftLayerSSHKeyRead(d, meta)
+}
+
+func resourceSoftLayerSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).sshKeyService
+
+	keyId, _ := strconv.Atoi(d.Id())
+
+	key, err := client.GetObject(keyId)
+	if err != nil {
+		// If the key is somehow already destroyed, mark as
+		// succesfully gone
+		if strings.Contains(err.Error(), "404 Not Found") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving SSH key: %s", err)
+	}
+
+	d.Set("id", key.Id)
+	d.Set("name", key.Label)
+	d.Set("public_key", strings.TrimSpace(key.Key))
+	d.Set("fingerprint", key.Fingerprint)
+
+	return nil
+}
+
+func resourceSoftLayerSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).sshKeyService
+
+	keyId, _ := strconv.Atoi(d.Id())
+
+	key, err := client.GetObject(keyId)
+	if err != nil {
+		return fmt.Errorf("Error retrieving SSH key: %s", err)
+	}
+
+	key.Label = d.Get("name").(string)
+
+	_, err = client.EditObject(keyId, key)
+	if err != nil {
+		return fmt.Errorf("Error editing SSH key: %s", err)
+	}
+	return nil
+}
+
+func resourceSoftLayerSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).sshKeyService
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting SSH Key: %s", err)
+	}
+
+	log.Printf("[INFO] Deleting SSH key: %d", id)
+	_, err = client.DeleteObject(id)
+	if err != nil {
+		return fmt.Errorf("Error deleting SSH key: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/softlayer/resource_softlayer_ssh_key_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_ssh_key_test.go
@@ -1,0 +1,108 @@
+package softlayer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	datatypes "github.com/maximilien/softlayer-go/data_types"
+)
+
+func TestAccSoftLayerSSHKey_Basic(t *testing.T) {
+	var key datatypes.SoftLayer_Security_Ssh_Key
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSoftLayerSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSoftLayerSSHKeyConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerSSHKeyExists("softlayer_ssh_key.testacc_foobar", &key),
+					testAccCheckSoftLayerSSHKeyAttributes(&key),
+					resource.TestCheckResourceAttr(
+						"softlayer_ssh_key.testacc_foobar", "name", "testacc_foobar"),
+					resource.TestCheckResourceAttr(
+						"softlayer_ssh_key.testacc_foobar", "public_key", testAccValidPublicKey),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSoftLayerSSHKeyDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client).sshKeyService
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "softlayer_ssh_key" {
+			continue
+		}
+
+		keyId, _ := strconv.Atoi(rs.Primary.ID)
+
+		// Try to find the key
+		_, err := client.GetObject(keyId)
+
+		if err == nil {
+			fmt.Errorf("SSH key still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSoftLayerSSHKeyAttributes(key *datatypes.SoftLayer_Security_Ssh_Key) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if key.Label != "testacc_foobar" {
+			return fmt.Errorf("Bad name: %s", key.Label)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSoftLayerSSHKeyExists(n string, key *datatypes.SoftLayer_Security_Ssh_Key) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		keyId, _ := strconv.Atoi(rs.Primary.ID)
+
+		client := testAccProvider.Meta().(*Client).sshKeyService
+		foundKey, err := client.GetObject(keyId)
+
+		if err != nil {
+			return err
+		}
+
+		if strconv.Itoa(int(foundKey.Id)) != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		*key = foundKey
+
+		return nil
+	}
+}
+
+var testAccCheckSoftLayerSSHKeyConfig_basic = fmt.Sprintf(`
+resource "softlayer_ssh_key" "testacc_foobar" {
+    name = "testacc_foobar"
+    public_key = "%s"
+}`, testAccValidPublicKey)
+
+var testAccValidPublicKey = strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -1,0 +1,265 @@
+package softlayer
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	datatypes "github.com/maximilien/softlayer-go/data_types"
+)
+
+func resourceSoftLayerVirtualserver() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSoftLayerVirtualserverCreate,
+		Read: resourceSoftLayerVirtualserverRead,
+		Update: resourceSoftLayerVirtualserverUpdate,
+		Delete: resourceSoftLayerVirtualserverDelete,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"domain": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"image": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"cpu": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"ram": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"ipv4_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ipv4_address_private": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ssh_keys": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+		},
+	}
+}
+
+func resourceSoftLayerVirtualserverCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).virtualGuestService
+	if client == nil {
+		return fmt.Errorf("The client was nil.")
+	}
+
+	dc := datatypes.Datacenter {
+		Name: d.Get("region").(string),
+	}
+
+	opts := datatypes.SoftLayer_Virtual_Guest_Template {
+		Hostname: d.Get("name").(string),
+		Domain: d.Get("domain").(string),
+		OperatingSystemReferenceCode: d.Get("image").(string),
+		HourlyBillingFlag: true,
+		Datacenter: dc,
+		StartCpus: d.Get("cpu").(int),
+		MaxMemory: d.Get("ram").(int),
+	}
+
+	// Get configured ssh_keys
+	ssh_keys := d.Get("ssh_keys.#").(int)
+	if ssh_keys > 0 {
+		opts.SshKeys = make([]datatypes.SshKey, 0, ssh_keys)
+		for i := 0; i < ssh_keys; i++ {
+			key := fmt.Sprintf("ssh_keys.%d", i)
+			id := d.Get(key).(int)
+			sshKey := datatypes.SshKey {
+			  Id: id,
+			}
+			opts.SshKeys = append(opts.SshKeys, sshKey)
+		}
+	}
+
+	log.Printf("[INFO] Creating virtual machine")
+
+	guest, err := client.CreateObject(opts)
+
+	if err != nil {
+		return fmt.Errorf("Error creating virtual server: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%d", guest.Id))
+
+	log.Printf("[INFO] Virtual Machine ID: %s", d.Id())
+
+	// wait for machine availability
+	_, err = WaitForNoActiveTransactions(d, meta)
+
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for virtual machine (%s) to become ready: %s", d.Id(), err)
+	}
+
+	_, err = WaitForPublicIpAvailable(d, meta)
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for virtual machine (%s) to become ready: %s", d.Id(), err)
+	}
+
+	return resourceSoftLayerVirtualserverRead(d, meta)
+}
+
+func resourceSoftLayerVirtualserverRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).virtualGuestService
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Not a valid ID, must be an integer: %s", err)
+	}
+	result, err := client.GetObject(id)
+	if err != nil {
+		return fmt.Errorf("Error retrieving virtual server: %s", err)
+	}
+
+	d.Set("name", result.Hostname)
+	d.Set("domain", result.Domain)
+	if result.Datacenter != nil {
+		d.Set("region", result.Datacenter.Name)
+	}
+	d.Set("cpu", result.StartCpus)
+	d.Set("ram", result.MaxMemory)
+	d.Set("has_public_ip", result.PrimaryIpAddress != "")
+	d.Set("ipv4_address", result.PrimaryIpAddress)
+	d.Set("ipv4_address_private", result.PrimaryBackendIpAddress)
+	return nil
+}
+
+func resourceSoftLayerVirtualserverUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).virtualGuestService
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Not a valid ID, must be an integer: %s", err)
+	}
+	result, err := client.GetObject(id)
+	if err != nil {
+		return fmt.Errorf("Error retrieving virtual server: %s", err)
+	}
+
+	result.Hostname = d.Get("name").(string)
+	result.Domain = d.Get("domain").(string)
+	result.StartCpus = d.Get("cpu").(int)
+	result.MaxMemory = d.Get("ram").(int)
+
+	_, err = client.EditObject(id, result)
+
+	if err != nil {
+		return fmt.Errorf("Couldn't update virtual server: %s", err)
+	}
+
+	return nil
+}
+
+func resourceSoftLayerVirtualserverDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).virtualGuestService
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Not a valid ID, must be an integer: %s", err)
+	}
+
+	_, err = WaitForNoActiveTransactions(d, meta)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting virtual server, couldn't wait for zero active transactions: %s", err)
+	}
+
+	_, err = client.DeleteObject(id)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting virtual server: %s", err)
+	}
+
+	return nil
+}
+
+func WaitForPublicIpAvailable(d *schema.ResourceData, meta interface{}) (interface{}, error) {
+	log.Printf("Waiting for server (%s) to get a public IP", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"", "unavailable"},
+		Target: "available",
+		Refresh: func() (interface{}, string, error) {
+			fmt.Println("Refreshing server state...")
+			client := meta.(*Client).virtualGuestService
+			id, err := strconv.Atoi(d.Id())
+			if err != nil {
+				return nil, "", fmt.Errorf("Not a valid ID, must be an integer: %s", err)
+			}
+			result, err := client.GetObject(id)
+			if err != nil {
+				return nil, "", fmt.Errorf("Error retrieving virtual server: %s", err)
+			}
+			if result.PrimaryIpAddress == "" {
+				return result, "unavailable", nil
+			} else {
+				return result, "available", nil
+			}
+		},
+		Timeout: 30 * time.Minute,
+		Delay: 10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	return stateConf.WaitForState()
+}
+
+func WaitForNoActiveTransactions(d *schema.ResourceData, meta interface{}) (interface{}, error) {
+	log.Printf("Waiting for server (%s) to have zero active transactions", d.Id())
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return nil, fmt.Errorf("The instance ID %s must be numeric", d.Id())
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"", "active"},
+		Target: "idle",
+		Refresh: func() (interface{}, string, error) {
+			client := meta.(*Client).virtualGuestService
+			transactions, err := client.GetActiveTransactions(id)
+			if err != nil {
+				return nil, "", fmt.Errorf("Couldn't get active transactions: %s", err)
+			}
+			if len(transactions) == 0 {
+				return transactions, "idle", nil
+			} else {
+				return transactions, "active", nil
+			}
+		},
+		Timeout: 10 * time.Minute,
+		Delay: 10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	return stateConf.WaitForState()
+}

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -71,6 +71,11 @@ func resourceSoftLayerVirtualserver() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
+
+			"user_data": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -98,6 +103,15 @@ func resourceSoftLayerVirtualserverCreate(d *schema.ResourceData, meta interface
 		StartCpus: d.Get("cpu").(int),
 		MaxMemory: d.Get("ram").(int),
 		NetworkComponents: []datatypes.NetworkComponents{networkComponent},
+	}
+
+	userData := d.Get("user_data").(string)
+	if userData != "" {
+		opts.UserData = []datatypes.UserData {
+			datatypes.UserData {
+				Value: userData,
+			},
+		}
 	}
 
 	// Get configured ssh_keys
@@ -184,6 +198,15 @@ func resourceSoftLayerVirtualserverUpdate(d *schema.ResourceData, meta interface
 	result.StartCpus = d.Get("cpu").(int)
 	result.MaxMemory = d.Get("ram").(int)
 	result.NetworkComponents[0].MaxSpeed = d.Get("public_network_speed").(int)
+
+	userData := d.Get("user_data").(string)
+	if userData != "" {
+		result.UserData = []datatypes.UserData {
+			datatypes.UserData {
+				Value: userData,
+			},
+		}
+	}
 
 	_, err = client.EditObject(id, result)
 

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -50,6 +50,12 @@ func resourceSoftLayerVirtualserver() *schema.Resource {
 				Required: true,
 			},
 
+			"public_network_speed": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default: 1000,
+			},
+
 			"ipv4_address": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -79,6 +85,10 @@ func resourceSoftLayerVirtualserverCreate(d *schema.ResourceData, meta interface
 		Name: d.Get("region").(string),
 	}
 
+	networkComponent := datatypes.NetworkComponents {
+		MaxSpeed: d.Get("public_network_speed").(int),
+	}
+
 	opts := datatypes.SoftLayer_Virtual_Guest_Template {
 		Hostname: d.Get("name").(string),
 		Domain: d.Get("domain").(string),
@@ -87,6 +97,7 @@ func resourceSoftLayerVirtualserverCreate(d *schema.ResourceData, meta interface
 		Datacenter: dc,
 		StartCpus: d.Get("cpu").(int),
 		MaxMemory: d.Get("ram").(int),
+		NetworkComponents: []datatypes.NetworkComponents{networkComponent},
 	}
 
 	// Get configured ssh_keys
@@ -148,6 +159,7 @@ func resourceSoftLayerVirtualserverRead(d *schema.ResourceData, meta interface{}
 	if result.Datacenter != nil {
 		d.Set("region", result.Datacenter.Name)
 	}
+	d.Set("public_network_speed", result.NetworkComponents[0].MaxSpeed)
 	d.Set("cpu", result.StartCpus)
 	d.Set("ram", result.MaxMemory)
 	d.Set("has_public_ip", result.PrimaryIpAddress != "")
@@ -171,6 +183,7 @@ func resourceSoftLayerVirtualserverUpdate(d *schema.ResourceData, meta interface
 	result.Domain = d.Get("domain").(string)
 	result.StartCpus = d.Get("cpu").(int)
 	result.MaxMemory = d.Get("ram").(int)
+	result.NetworkComponents[0].MaxSpeed = d.Get("public_network_speed").(int)
 
 	_, err = client.EditObject(id, result)
 

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -30,6 +30,8 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "region", "ams01"),
 					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "public_network_speed", "10"),
+					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "cpu", "1"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "ram", "1024"),
@@ -106,6 +108,7 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     domain = "bar.example.com"
     image = "DEBIAN_7_64"
     region = "ams01"
+    public_network_speed = 10
     cpu = 1
     ram = 1024
 }

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -1,0 +1,112 @@
+package softlayer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	datatypes "github.com/maximilien/softlayer-go/data_types"
+)
+
+func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
+	var server datatypes.SoftLayer_Virtual_Guest
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: testAccCheckSoftLayerVirtualserverDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSoftLayerVirtualserverConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "name", "terraform-test"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "domain", "bar.example.com"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "region", "ams01"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "cpu", "1"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "ram", "1024"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSoftLayerVirtualserverDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client).virtualGuestService
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "softlayer_virtualserver" {
+			continue
+		}
+
+		serverId, _ := strconv.Atoi(rs.Primary.ID)
+
+		// Try to find the server
+		_, err := client.GetObject(serverId)
+
+		// Wait
+
+		if err != nil && !strings.Contains(err.Error(), "404") {
+			return fmt.Errorf(
+				"Error waiting for server (%s) to be destroyed: %s",
+				rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSoftLayerVirtualserverExists(n string, server *datatypes.SoftLayer_Virtual_Guest) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No virtual server ID is set")
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		client := testAccProvider.Meta().(*Client).virtualGuestService
+		retrieveServer, err := client.GetObject(id)
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("The ID is %d", id)
+
+		if retrieveServer.Id != id {
+			return fmt.Errorf("Virtual server not found")
+		}
+
+		*server = retrieveServer
+
+		return nil
+	}
+}
+
+const testAccCheckSoftLayerVirtualserverConfig_basic = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
+    name = "terraform-test"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    cpu = 1
+    ram = 1024
+}
+`

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -36,6 +36,12 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "ram", "1024"),
 					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "disks.0", "25"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "disks.1", "10"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "disks.2", "20"),
+					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "{\"fox\":[45]}"),
 				),
 			},
@@ -113,6 +119,7 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     public_network_speed = 10
     cpu = 1
     ram = 1024
+    disks = [25, 10, 20]
     user_data = "{\"fox\":[45]}"
 }
 `

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -35,6 +35,8 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 						"softlayer_virtualserver.terraform-acceptance-test-1", "cpu", "1"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "ram", "1024"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "{\"fox\":[45]}"),
 				),
 			},
 		},
@@ -111,5 +113,6 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     public_network_speed = 10
     cpu = 1
     ram = 1024
+    user_data = "{\"fox\":[45]}"
 }
 `


### PR DESCRIPTION
This adds rudimentary support for SoftLayer provisioning;
at first, only two resources are supported:

- softlayer_virtualserver
- softlayer_ssh_key

The provider uses github.com/maximilien/softlayer-go to
make calls to the SoftLayer API.

There are also standard integration tests that verify
behavior.

Example configuration:

```
provider "softlayer" {
  username="johnsmith"
  api_key="XXXXXX"
}

resource "softlayer_virtualserver" "foo" {
  name="terraform-test"
  domain="example.com"
  image="DEBIAN_7_64"
  region="ams01"
  cpu=1
  ram=1024
  ssh_keys=["${softlayer_ssh_key.main-key.id}"]
}

resource "softlayer_ssh_key" "main-key" {
  name="terraform-test-key"
  public_key="${file(\"~/.ssh/id_rsa.pub\")}"
}
```

Instead of the username and api_key variables, one
can use environment variables SOFTLAYER_USERNAME
and SOFTLAYER_API_KEY.