### PR TITLE
core: move targets transform after flatten

### DIFF
--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -140,10 +140,6 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 		// Make sure all the connections that are proxies are connected through
 		&ProxyTransformer{},
 
-		// Optionally reduces the graph to a user-specified list of targets and
-		// their dependencies.
-		&TargetsTransformer{Targets: b.Targets, Destroy: b.Destroy},
-
 		// Make sure we have a single root
 		&RootTransformer{},
 	}
@@ -152,6 +148,10 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 	// We don't do the following for modules.
 	if len(path) <= 1 {
 		steps = append(steps,
+			// Optionally reduces the graph to a user-specified list of targets and
+			// their dependencies.
+			&TargetsTransformer{Targets: b.Targets, Destroy: b.Destroy},
+
 			// Prune the providers and provisioners. This must happen
 			// only once because flattened modules might depend on empty
 			// providers.

--- a/terraform/test-fixtures/apply-targeted-module-dep/child/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-dep/child/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "mod" { }
+
+output "output" {
+  value = "${aws_instance.mod.id}"
+}

--- a/terraform/test-fixtures/apply-targeted-module-dep/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-dep/main.tf
@@ -1,0 +1,7 @@
+module "child" {
+    source = "./child"
+}
+
+resource "aws_instance" "foo" {
+    foo = "${module.child.output}"
+}


### PR DESCRIPTION
Allows target dependencies to be properly calculated across module
boundaries, fixing scenarios where a target depends on something inside
a module, but the contents of the module are not included in the
targeted resources.

fixes #1858