### PR TITLE
provisioner/chef: fixes issue #2568

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -33,7 +33,7 @@ func (p *Provisioner) linuxInstallChefClient(
 	}
 
 	// Then execute the install.sh scrip to download and install Chef Client
-	err = p.runCommand(o, comm, fmt.Sprintf("%sbash ./install.sh -v %s", prefix, p.Version))
+	err = p.runCommand(o, comm, fmt.Sprintf("%sbash ./install.sh -v %q", prefix, p.Version))
 	if err != nil {
 		return err
 	}

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -24,7 +24,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"sudo curl -LO https://www.chef.io/chef/install.sh": true,
-				"sudo bash ./install.sh -v ":                        true,
+				"sudo bash ./install.sh -v \"\"":                    true,
 				"sudo rm -f install.sh":                             true,
 			},
 		},
@@ -41,7 +41,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"curl -LO https://www.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v ":                        true,
+				"bash ./install.sh -v \"\"":                    true,
 				"rm -f install.sh":                             true,
 			},
 		},
@@ -59,7 +59,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"proxy_http='http://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
-				"proxy_http='http://proxy.local' bash ./install.sh -v ":                        true,
+				"proxy_http='http://proxy.local' bash ./install.sh -v \"\"":                    true,
 				"proxy_http='http://proxy.local' rm -f install.sh":                             true,
 			},
 		},
@@ -80,7 +80,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 				"proxy_http='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"curl -LO https://www.chef.io/chef/install.sh": true,
 				"proxy_http='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
-					"bash ./install.sh -v ": true,
+					"bash ./install.sh -v \"\"": true,
 				"proxy_http='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"rm -f install.sh": true,
 			},
@@ -99,7 +99,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"curl -LO https://www.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v 11.18.6":                 true,
+				"bash ./install.sh -v \"11.18.6\"":             true,
 				"rm -f install.sh":                             true,
 			},
 		},


### PR DESCRIPTION
When surrounding the version with quotes, even no version (an empty string) will be accepted as parameter. The install.sh script treats an empty version string the same as when no version is set. So it will then just use the latest available version.