### PR TITLE
provider/aws: Code cleanups for Spot Requests

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -95,6 +95,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	}
 
 	// Make the spot instance request
+	log.Printf("[DEBUG] Requesting spot bid opts: %s", awsutil.StringValue(spotOpts))
 	resp, err := conn.RequestSpotInstances(spotOpts)
 	if err != nil {
 		return fmt.Errorf("Error requesting spot instances: %s", err)
@@ -184,7 +185,7 @@ func resourceAwsSpotInstanceRequestUpdate(d *schema.ResourceData, meta interface
 
 	d.Partial(false)
 
-	return resourceAwsInstanceRead(d, meta)
+	return resourceAwsSpotInstanceRequestRead(d, meta)
 }
 
 func resourceAwsSpotInstanceRequestDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -38,7 +39,7 @@ func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 			}
 		}
 		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %#v for %s", create, d.Id())
+			log.Printf("[DEBUG] Creating tags: %s for %s", awsutil.StringValue(create), d.Id())
 			_, err := conn.CreateTags(&ec2.CreateTagsInput{
 				Resources: []*string{aws.String(d.Id())},
 				Tags:      create,


### PR DESCRIPTION
Fixes `TestAccAWSSpotInstanceRequest_basic`