### PR TITLE
use /usr/bin/env bash

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script builds the application from source for multiple platforms.
 

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Get the version from the command line

--- a/scripts/website_push.sh
+++ b/scripts/website_push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"


### PR DESCRIPTION
[Not everybody](https://nixos.org/) has a `/bin/bash`. It's my understanding that `/usr/bin/env bash` is be a safe replacement.