### PR TITLE
docs: tweaks to RELEASING

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,28 +21,38 @@ As a pre-1.0 project, we use the MINOR and PATCH versions as follows:
 For maintainer documentation purposes, here is the current release process:
 
 ```sh
-# Verify tests pass
+# Spin up a fresh build VM
+vagrant destroy -f
+vagrant up
+vagrant ssh
+cd /opt/gopath/src/github.com/hashicorp/terraform/
+
+# Fetch dependencies
+make updatedeps
+
+# Verify unit tests pass
 make test
 
 # Prep release commit
 export VERSION="vX.Y.Z"
-# Edit CHANGELOG, adding current date to unreleased version header
+# Edit CHANGELOG.md, adding current date to unreleased version header
 # Edit version.go, setting VersionPrelease to empty string
 
 # Snapshot dependency information
 godep save ./...
-mv Godeps/Godeps.json deps/$(echo $VERSION | sed 's/\./-/g').json
-rm -rf Godeps
+cp Godeps/Godeps.json deps/$(echo $VERSION | sed 's/\./-/g').json
 
-# Make and tag release commit
+# Make and tag release commit (skipping Godeps dir)
+git add CHANGELOG.md terraform/version.go deps/
 git commit -a -m "${VERSION}"
 git tag -m "${VERSION}" "${VERSION}"
 
-# Build release in Vagrant machine
-vagrant destroy -f; vagrant up # Build a fresh VM for a clean build
-vagrant ssh
-cd /opt/gopath/src/github.com/hashicorp/terraform/
+# Build the release
 make release
+
+# Make an archive with vendored dependencies
+stashName=$(git stash)
+git archive -o terraform-$VERSION-src.tar.gz $stashName
 
 # Zip and push release to bintray
 export BINTRAY_API_KEY="..."
@@ -56,9 +66,18 @@ git push origin master
 git push origin vX.Y.Z
 
 # Click "publish" on the release from the Bintray Web UI
+# Upload terraform-$VERSION-src.tar.gz as a file to the GitHub release.
 
 # -- Release is complete! --
 
-# Make a follow-on commit to master restoring VersionPrerelease to "dev" and
-setting up a new CHANGELOG section.
+# Start release branch (to be used for reproducible builds and docs updates)
+git checkout -b release/$VERSION
+git push origin release/$VERSION
+
+# Clean up master
+git checkout master
+# Set VersionPrerelease to "dev"
+# Add new CHANGELOG section for next release
+git add -A
+git commit -m "release: clean up after ${VERSION}"
 ```


### PR DESCRIPTION
 - jump into the VM first
 - include full Godeps snapshot in release archive that's uploaded with
   the github tag
 - start a release branch as part of the process, setting us up for
   docs deploys