### PR TITLE
providers/aws: aws_elb: Allow alnum plus hyphen in name attribute

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -28,9 +28,9 @@ func resourceAwsElb() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
 						errors = append(errors, fmt.Errorf(
-							"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+							"only alphanumeric characters and hyphens allowed in %q", k))
 					}
 					if len(value) > 32 {
 						errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
@radeksimko : https://github.com/hashicorp/terraform/pull/2517#issuecomment-117362827