### PR TITLE
Remove status argument from `aws_iam_access_key` example usage

### DIFF
--- a/website/source/docs/providers/aws/r/iam_access_key.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_access_key.html.markdown
@@ -15,7 +15,6 @@ Provides an IAM access key. This is a set of credentials that allow API requests
 ```
 resource "aws_iam_access_key" "lb" {
     user = "${aws_iam_user.lb.name}"
-    status = "Active"
 }
 
 resource "aws_iam_user" "lb" {

--- a/website/source/docs/providers/aws/r/iam_user.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user.html.markdown
@@ -20,7 +20,6 @@ resource "aws_iam_user" "lb" {
 
 resource "aws_iam_access_key" "lb" {
     user = "${aws_iam_user.lb.name}"
-    status = "Active"
 }
 
 resource "aws_iam_user_policy" "lb_ro" {

--- a/website/source/docs/providers/aws/r/iam_user_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user_policy.html.markdown
@@ -39,7 +39,6 @@ resource "aws_iam_user" "lb" {
 
 resource "aws_iam_access_key" "lb" {
     user = "${aws_iam_user.lb.name}"
-    status = "Active"
 }
 ```
 


### PR DESCRIPTION
`aws_iam_access_key` resource is not supported `status` field.

Example from https://www.terraform.io/docs/providers/aws/r/iam_access_key.html:

    resource "aws_iam_access_key" "lb" {
        user = "${aws_iam_user.lb.name}"
        status = "Active"
    }

    resource "aws_iam_user" "lb" {
        name = "loadbalancer"
        path = "/system/"
    }

Result:

    $ terraform plan
    There are warnings and/or errors related to your configuration. Please
    fix these before continuing.

    Errors:

      * aws_iam_access_key.lb: "status": this field cannot be set