### PR TITLE
Update log.go

### DIFF
--- a/log.go
+++ b/log.go
@@ -13,7 +13,7 @@ const EnvLogFile = "TF_LOG_PATH" //Set to a file
 // logOutput determines where we should send logs (if anywhere).
 func logOutput() (logOutput io.Writer, err error) {
 	logOutput = nil
-	if os.Getenv(EnvLog) != "" {
+	if os.Getenv(EnvLog) == 1 {
 		logOutput = os.Stderr
 
 		if logPath := os.Getenv(EnvLogFile); logPath != "" {


### PR DESCRIPTION
Currently TF_LOG must be empty to turn it off as opposed to a falsey value. All the GH issues I've seen say to set TF_LOG to 1, so why not check for that instead?