### PR TITLE
Allow underscores in aws_db_subnet_group name

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -27,9 +27,9 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+					if !regexp.MustCompile(`^[0-9A-Za-z-_]+$`).MatchString(value) {
 						errors = append(errors, fmt.Errorf(
-							"only alphanumeric characters and hyphens allowed in %q", k))
+							"only alphanumeric characters, hyphens and underscores allowed in %q", k))
 					}
 					if len(value) > 255 {
 						errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
Docs don't claim they are allowed but they are.

They don't explicitly say they are not allowed... but yea.

http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-ModifyDBSubnetGroup.html

```
Constraints: Must contain from 1 to 255 alphanumeric characters or hyphens. First character must be a letter. Cannot end with a hyphen or contain two consecutive hyphens.
```

For https://github.com/hashicorp/terraform/issues/2603