### PR TITLE
communicator/ssh: sort agent after static keyfile

### DIFF
--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -180,10 +180,6 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 		User: opts.user,
 	}
 
-	if opts.sshAgent != nil {
-		conf.Auth = append(conf.Auth, opts.sshAgent.Auth())
-	}
-
 	if opts.keyFile != "" {
 		pubKeyAuth, err := readPublicKeyFromPath(opts.keyFile)
 		if err != nil {
@@ -196,6 +192,10 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 		conf.Auth = append(conf.Auth, ssh.Password(opts.password))
 		conf.Auth = append(conf.Auth, ssh.KeyboardInteractive(
 			PasswordKeyboardInteractive(opts.password)))
+	}
+
+	if opts.sshAgent != nil {
+		conf.Auth = append(conf.Auth, opts.sshAgent.Auth())
 	}
 
 	return conf, nil


### PR DESCRIPTION
In the SSH client configuration, we had SSH Agent authentication listed
before the static PrivateKey loaded from the `key_file` setting.
Switching the default of the `agent` setting exposed the fact that the
SSH agent overrides the `key_file` during the handshake. By listing the
`key_file` first, we catch the provided key before any query goes out to
the agent.

Adds a key-based authentication SSH test to cover this new behavior. It
fails without the reordering on any machine with an SSH agent running.

Fixes #2614