### PR TITLE
provider/docker: Fix Repository in PullOptions

### DIFF
--- a/builtin/providers/docker/resource_docker_image_funcs.go
+++ b/builtin/providers/docker/resource_docker_image_funcs.go
@@ -83,7 +83,7 @@ func pullImage(data *Data, client *dc.Client, image string) error {
 		splitPortRepo := strings.Split(splitImageName[1], "/")
 		pullOpts.Registry = splitImageName[0] + ":" + splitPortRepo[0]
 		pullOpts.Tag = splitImageName[2]
-		pullOpts.Repository = strings.Join(splitPortRepo[1:], "/")
+		pullOpts.Repository = pullOpts.Registry + "/" + strings.Join(splitPortRepo[1:], "/")
 
 	// It's either registry:port/username/repo, registry:port/repo,
 	// or repo:tag with default registry
@@ -98,7 +98,7 @@ func pullImage(data *Data, client *dc.Client, image string) error {
 		// registry:port/username/repo or registry:port/repo
 		default:
 			pullOpts.Registry = splitImageName[0] + ":" + splitPortRepo[0]
-			pullOpts.Repository = strings.Join(splitPortRepo[1:], "/")
+			pullOpts.Repository = pullOpts.Registry + "/" + strings.Join(splitPortRepo[1:], "/")
 			pullOpts.Tag = "latest"
 		}
 

--- a/builtin/providers/docker/resource_docker_image_test.go
+++ b/builtin/providers/docker/resource_docker_image_test.go
@@ -1,9 +1,8 @@
 package docker
 
 import (
-	"testing"
-
 	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
 )
 
 func TestAccDockerImage_basic(t *testing.T) {
@@ -24,9 +23,34 @@ func TestAccDockerImage_basic(t *testing.T) {
 	})
 }
 
+func TestAddDockerImage_private(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAddDockerPrivateImageConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"docker_image.foobar",
+						"latest",
+						"2c40b0526b6358710fd09e7b8c022429268cc61703b4777e528ac9d469a07ca1"),
+				),
+			},
+		},
+	})
+}
+
 const testAccDockerImageConfig = `
 resource "docker_image" "foo" {
 	name = "ubuntu:trusty-20150320"
+	keep_updated = true
+}
+`
+
+const testAddDockerPrivateImageConfig = `
+resource "docker_image" "foobar" {
+	name = "gcr.io:443/google_containers/pause:0.8.0"
 	keep_updated = true
 }
 `


### PR DESCRIPTION
https://github.com/hashicorp/terraform/commit/0558763f875d285f547d5e0609734e92cc6976b5 breaks pulling images from private registries. The docker api client/daemon expects the whole image name including the registry as Repository attribute in pull options (as in "private.registry.com:port/image" as the image name not just "image"). Currently if you do a docker_image resource with name = "private.registry.com:port/image:tag" it will create the following pulloptions:

```golang
&PullOptions{
  Registry: "private.registry.com:port",
  Tag: "tag",
  Repository: "image"
}
```
This tries to pull image called library/image:tag from default docker registry and the pull will fail with error message:
Unable to read Docker image into resource: Unable to pull image private.registry.com:port/image:tag: Error pulling image private.registry.com:port/image:tag: Error: image library/image:tag not found. 

The correct pull options would be (and what the previous version of pullImage did):
```golang
&PullOptions{
  Registry: "private.registry.com:port",
  Tag: "tag",
  Repository: "private.registry.com:port/image"
}
```

I created an acceptance test that does not pass without this change against google docker registry. Tested against docker 1.7.
