### PR TITLE
provisioner/chef: Fix Chef provisioner http proxy

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -22,6 +22,9 @@ func (p *Provisioner) linuxInstallChefClient(
 	if p.HTTPProxy != "" {
 		prefix += fmt.Sprintf("http_proxy='%s' ", p.HTTPProxy)
 	}
+	if p.HTTPSProxy != "" {
+		prefix += fmt.Sprintf("https_proxy='%s' ", p.HTTPSProxy)
+	}
 	if p.NOProxy != nil {
 		prefix += fmt.Sprintf("no_proxy='%s' ", strings.Join(p.NOProxy, ","))
 	}

--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -20,7 +20,7 @@ func (p *Provisioner) linuxInstallChefClient(
 	// Build up the command prefix
 	prefix := ""
 	if p.HTTPProxy != "" {
-		prefix += fmt.Sprintf("proxy_http='%s' ", p.HTTPProxy)
+		prefix += fmt.Sprintf("http_proxy='%s' ", p.HTTPProxy)
 	}
 	if p.NOProxy != nil {
 		prefix += fmt.Sprintf("no_proxy='%s' ", strings.Join(p.NOProxy, ","))

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -58,9 +58,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			}),
 
 			Commands: map[string]bool{
-				"proxy_http='http://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
-				"proxy_http='http://proxy.local' bash ./install.sh -v \"\"":                    true,
-				"proxy_http='http://proxy.local' rm -f install.sh":                             true,
+				"http_proxy='http://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
+				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                    true,
+				"http_proxy='http://proxy.local' rm -f install.sh":                             true,
 			},
 		},
 
@@ -77,11 +77,11 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			}),
 
 			Commands: map[string]bool{
-				"proxy_http='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
+				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"curl -LO https://www.chef.io/chef/install.sh": true,
-				"proxy_http='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
+				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"bash ./install.sh -v \"\"": true,
-				"proxy_http='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
+				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"rm -f install.sh": true,
 			},
 		},

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -64,6 +64,24 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 		},
 
+		"HTTPSProxy": {
+			Config: testConfig(t, map[string]interface{}{
+				"https_proxy":            "https://proxy.local",
+				"node_name":              "nodename1",
+				"prevent_sudo":           true,
+				"run_list":               []interface{}{"cookbook::recipe"},
+				"server_url":             "https://chef.local",
+				"validation_client_name": "validator",
+				"validation_key_path":    "validator.pem",
+			}),
+
+			Commands: map[string]bool{
+				"https_proxy='https://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
+				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                    true,
+				"https_proxy='https://proxy.local' rm -f install.sh":                             true,
+			},
+		},
+
 		"NOProxy": {
 			Config: testConfig(t, map[string]interface{}{
 				"http_proxy":             "http://proxy.local",


### PR DESCRIPTION
Added support for HTTPS proxy in Chef provisioner and fixed the HTTP proxy prefix.