### PR TITLE
provider/openstack: Allow empty api_key and endpoint_type

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -44,7 +44,7 @@ func Provider() terraform.ResourceProvider {
 			"api_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFunc("OS_AUTH_TOKEN"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_AUTH_TOKEN"),
 			},
 			"domain_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -64,7 +64,7 @@ func Provider() terraform.ResourceProvider {
 			"endpoint_type": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFunc("OS_ENDPOINT_TYPE"),
+				DefaultFunc: envDefaultFuncAllowMissing("OS_ENDPOINT_TYPE"),
 			},
 		},
 


### PR DESCRIPTION
These two provider options are optional though if they are not set,
the user will be prompted to enter values.

By changing them to use the envDefaultFuncAllowMissing, the values
are still passed in the environment if they are set and safely
discarded if they are not.