### PR TITLE
provider/aws: Fix issue in Classic env with external Security Groups

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -157,12 +157,15 @@ func expandIPPerms(
 
 				perm.UserIDGroupPairs[i] = &ec2.UserIDGroupPair{
 					GroupID: aws.String(id),
-					UserID:  aws.String(ownerId),
 				}
+
+				if ownerId != "" {
+					perm.UserIDGroupPairs[i].UserID = aws.String(ownerId)
+				}
+
 				if !vpc {
 					perm.UserIDGroupPairs[i].GroupID = nil
 					perm.UserIDGroupPairs[i].GroupName = aws.String(id)
-					perm.UserIDGroupPairs[i].UserID = nil
 				}
 			}
 		}


### PR DESCRIPTION
Linking a security group from another account requires setting the UserID, which
we were stripping out

Example usage:

```javascript
provider "aws" {
  region = "us-east-1"
}

resource "aws_security_group" "tf_test_self" {
  name = "tf_test_self"
  description = "tf_test_self"

  ingress {
    from_port = 80
    to_port = 80
    protocol = "tcp"
    security_groups = ["1111111111111/hi-clint", "default"]
  }

  tags {
    Name = "tf_test_self"
  }
}
```