### PR TITLE
provider/aws: Error when unable to find a Root Block Device name

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -778,6 +778,10 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 		rootDeviceName = image.BlockDeviceMappings[0].DeviceName
 	}
 
+        if rootDeviceName == nil {
+                return nil, fmt.Errorf("[WARN] Error finding Root Device Name for AMI (%s)", ami)
+        }
+
 	return rootDeviceName, nil
 }
 


### PR DESCRIPTION
Fixes #2633 by returning an error if we can't find a Root Block Device 


With a config like this (using an ami that is Instance backed):

```javascript
provider "aws" {
    region = "us-west-2"
}
resource "aws_launch_configuration" "foobar" {
    name = "root_ami_thing"
    image_id = "ami-3fd3e90f"
    instance_type = "t2.micro"
    key_name = "packerkeything"

    root_block_device {
        volume_type = "gp2"
        volume_size = "64"
    }
}

resource "aws_autoscaling_group" "bar" {
  availability_zones = ["us-west-2a"]
  name = "foobar3-terraform-test"
  max_size = 2
  min_size = 0
  health_check_grace_period = 300
  health_check_type = "ELB"
  desired_capacity = 2
  force_delete = true
  termination_policies = ["OldestInstance"]
  launch_configuration = "${aws_launch_configuration.foobar.name}"
}
```

Now produces error: 

```
Error applying plan:

1 error(s) occurred:

* [WARN] Error finding Root Device Name for AMI (ami-3fd3e90f)
```

Instead of the error shown in #2633