### PR TITLE
A base64 interpolation function would be nice

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"encoding/base64"
 
 	"github.com/hashicorp/terraform/config/lang/ast"
 	"github.com/mitchellh/go-homedir"
@@ -91,6 +92,19 @@ func interpolationFuncFile() ast.Function {
 			}
 
 			return string(data), nil
+		},
+	}
+}
+
+// interpolationFuncBase64 implements the "base64" function to
+// encode a string in base64
+func interpolationFuncBase64() ast.Function {
+	return ast.Function{
+		ArgTypes:     []ast.Type{ast.TypeString},
+		ReturnType:   ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			toEncode := []byte(args[0])
+			return base64.StdEncoding.EncodeToString(toEncode), nil
 		},
 	}
 }


### PR DESCRIPTION
Would be nice to have an interpolation function to encode a string in base64 for when the templating provider is used with cloud-config for user_data containing a write_files section. (Disclaimer: I've never written Go before, nor have I added additional change proposals for the test suite. This is maybe more of a proof of concept?)