### PR TITLE
provider/aws: bump internet gateway detach timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -207,7 +207,7 @@ func resourceAwsInternetGatewayDetach(d *schema.ResourceData, meta interface{}) 
 		Pending: []string{"detaching"},
 		Target:  "detached",
 		Refresh: detachIGStateRefreshFunc(conn, d.Id(), vpcID.(string)),
-		Timeout: 2 * time.Minute,
+		Timeout: 5 * time.Minute,
 		Delay:   10 * time.Second,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {


### PR DESCRIPTION
I've been seeing lots of this error lately on `terraform destroy`:

`* Error waiting for internet gateway (igw-[foo]) to detach: timeout while waiting for state to become 'detached'`

A second destroy works fine in these cases, so this should be sufficient.