### PR TITLE
provider/aws: fix missing format arg

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -90,7 +90,7 @@ func resourceAwsDbInstance() *schema.Resource {
 					}
 					if regexp.MustCompile(`-$`).MatchString(value) {
 						errors = append(errors, fmt.Errorf(
-							"%q cannot end with a hyphen"))
+							"%q cannot end with a hyphen", k))
 					}
 					return
 				},


### PR DESCRIPTION
Just adds a missing format string arg.