### PR TITLE
changed combine() to concat() in docs

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -73,7 +73,7 @@ are documented below.
 The supported built-in functions are:
 
   * `concat(list1, list2)` - Combines two or more lists into a single list.
-     Example: `combine(aws_instance.db.*.tags.Name, aws_instance.web.*.tags.Name)`
+     Example: `concat(aws_instance.db.*.tags.Name, aws_instance.web.*.tags.Name)`
 
   * `element(list, index)` - Returns a single element from a list
       at the given index. If the index is greater than the number of


### PR DESCRIPTION
The example of the concat() function uses combine() instead of concat().