### PR TITLE
communicator/ssh: agent forward failure is not fatal

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -136,11 +136,13 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 		}
 		defer session.Close()
 
-		if err = agent.RequestAgentForwarding(session); err != nil {
-			return err
-		}
+		err = agent.RequestAgentForwarding(session)
 
-		log.Printf("[INFO] agent forwarding enabled")
+		if err == nil {
+			log.Printf("[INFO] agent forwarding enabled")
+		} else {
+			log.Printf("[WARN] error forwarding agent: %s", err)
+		}
 	}
 
 	if o != nil {


### PR DESCRIPTION
On connections where no second hop is made, there's no problem if the
agent forwarding connection is denied, so we shouldn't treat that as a
fatal error.