### PR TITLE
provider/aws: Fix ECS cluster+service bugs

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_cluster.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -57,7 +58,7 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Received ECS clusters: %#v", out.Clusters)
+	log.Printf("[DEBUG] Received ECS clusters: %s", awsutil.StringValue(out.Clusters))
 
 	d.SetId(*out.Clusters[0].ClusterARN)
 	d.Set("name", *out.Clusters[0].ClusterName)
@@ -76,7 +77,7 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 		})
 
 		if err == nil {
-			log.Printf("[DEBUG] ECS cluster %s deleted: %#v", d.Id(), out)
+			log.Printf("[DEBUG] ECS cluster %s deleted: %s", d.Id(), awsutil.StringValue(out))
 			return nil
 		}
 

--- a/builtin/providers/aws/resource_aws_ecs_cluster.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster.go
@@ -2,9 +2,12 @@ package aws
 
 import (
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -67,14 +70,31 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Deleting ECS cluster %s", d.Id())
 
-	// TODO: Handle ClientException: The Cluster cannot be deleted while Container Instances are active.
-	// TODO: Handle ClientException: The Cluster cannot be deleted while Services are active.
+	return resource.Retry(10*time.Minute, func() error {
+		out, err := conn.DeleteCluster(&ecs.DeleteClusterInput{
+			Cluster: aws.String(d.Id()),
+		})
 
-	out, err := conn.DeleteCluster(&ecs.DeleteClusterInput{
-		Cluster: aws.String(d.Id()),
+		if err == nil {
+			log.Printf("[DEBUG] ECS cluster %s deleted: %#v", d.Id(), out)
+			return nil
+		}
+
+		awsErr, ok := err.(awserr.Error)
+		if !ok {
+			return resource.RetryError{Err: err}
+		}
+
+		if awsErr.Code() == "ClusterContainsContainerInstancesException" {
+			log.Printf("[TRACE] Retrying ECS cluster %q deletion after %q", d.Id(), awsErr.Code())
+			return err
+		}
+
+		if awsErr.Code() == "ClusterContainsServicesException" {
+			log.Printf("[TRACE] Retrying ECS cluster %q deletion after %q", d.Id(), awsErr.Code())
+			return err
+		}
+
+		return resource.RetryError{Err: err}
 	})
-
-	log.Printf("[DEBUG] ECS cluster %s deleted: %#v", d.Id(), out)
-
-	return err
 }

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -88,6 +88,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 		ServiceName:    aws.String(d.Get("name").(string)),
 		TaskDefinition: aws.String(d.Get("task_definition").(string)),
 		DesiredCount:   aws.Long(int64(d.Get("desired_count").(int))),
+		ClientToken:    aws.String(resource.UniqueId()),
 	}
 
 	if v, ok := d.GetOk("cluster"); ok {

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -36,6 +36,7 @@ func resourceAwsEcsService() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"task_definition": &schema.Schema{
@@ -129,6 +130,10 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	out, err := conn.DescribeServices(&input)
 	if err != nil {
 		return err
+	}
+
+	if len(out.Services) < 1 {
+		return nil
 	}
 
 	service := out.Services[0]

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -97,14 +98,14 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	loadBalancers := expandEcsLoadBalancers(d.Get("load_balancer").(*schema.Set).List())
 	if len(loadBalancers) > 0 {
-		log.Printf("[DEBUG] Adding ECS load balancers: %#v", loadBalancers)
+		log.Printf("[DEBUG] Adding ECS load balancers: %s", awsutil.StringValue(loadBalancers))
 		input.LoadBalancers = loadBalancers
 	}
 	if v, ok := d.GetOk("iam_role"); ok {
 		input.Role = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating ECS service: %#v", input)
+	log.Printf("[DEBUG] Creating ECS service: %s", awsutil.StringValue(input))
 	out, err := conn.CreateService(&input)
 	if err != nil {
 		return err
@@ -138,7 +139,7 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	service := out.Services[0]
-	log.Printf("[DEBUG] Received ECS service %#v", service)
+	log.Printf("[DEBUG] Received ECS service %s", awsutil.StringValue(service))
 
 	d.SetId(*service.ServiceARN)
 	d.Set("name", *service.ServiceName)
@@ -188,7 +189,7 @@ func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 	service := out.Service
-	log.Printf("[DEBUG] Updated ECS service %#v", service)
+	log.Printf("[DEBUG] Updated ECS service %s", awsutil.StringValue(service))
 
 	return resourceAwsEcsServiceRead(d, meta)
 }
@@ -228,7 +229,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 		Cluster: aws.String(d.Get("cluster").(string)),
 	}
 
-	log.Printf("[DEBUG] Deleting ECS service %#v", input)
+	log.Printf("[DEBUG] Deleting ECS service %s", awsutil.StringValue(input))
 	out, err := conn.DeleteService(&input)
 	if err != nil {
 		return err

--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -90,7 +91,7 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 		input.Volumes = volumes
 	}
 
-	log.Printf("[DEBUG] Registering ECS task definition: %#v", input)
+	log.Printf("[DEBUG] Registering ECS task definition: %s", awsutil.StringValue(input))
 	out, err := conn.RegisterTaskDefinition(&input)
 	if err != nil {
 		return err
@@ -98,7 +99,7 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 
 	taskDefinition := *out.TaskDefinition
 
-	log.Printf("[DEBUG] ECS task definition registered: %#v (rev. %d)",
+	log.Printf("[DEBUG] ECS task definition registered: %q (rev. %d)",
 		*taskDefinition.TaskDefinitionARN, *taskDefinition.Revision)
 
 	d.SetId(*taskDefinition.Family)
@@ -117,7 +118,7 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Received task definition %#v", out)
+	log.Printf("[DEBUG] Received task definition %s", awsutil.StringValue(out))
 
 	taskDefinition := out.TaskDefinition
 

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -317,6 +318,32 @@ func TestCheckResourceAttr(name, key, value string) TestCheckFunc {
 				name,
 				key,
 				value,
+				is.Attributes[key])
+		}
+
+		return nil
+	}
+}
+
+func TestMatchResourceAttr(name, key string, r *regexp.Regexp) TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		is := rs.Primary
+		if is == nil {
+			return fmt.Errorf("No primary instance: %s", name)
+		}
+
+		if !r.MatchString(is.Attributes[key]) {
+			return fmt.Errorf(
+				"%s: Attribute '%s' didn't match %q, got %#v",
+				name,
+				key,
+				r.String(),
 				is.Attributes[key])
 		}
 


### PR DESCRIPTION
Since these bugs were more or less related to each other and the SDK has changed a little bit too, it would be more difficult to send these as separate PRs.
At least I tried to separate modifications per commits, so it should be easy to review.

Closes:

 - https://github.com/hashicorp/terraform/issues/2691
 - https://github.com/hashicorp/terraform/issues/2427

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=Ecs'
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=Ecs -timeout 90m
=== RUN TestAccAWSEcsCluster_basic
--- PASS: TestAccAWSEcsCluster_basic (2.40s)
=== RUN TestAccAWSEcsServiceWithARN
--- PASS: TestAccAWSEcsServiceWithARN (14.66s)
=== RUN TestAccAWSEcsServiceWithFamilyAndRevision
--- PASS: TestAccAWSEcsServiceWithFamilyAndRevision (20.99s)
=== RUN TestAccAWSEcsServiceWithRenamedCluster
--- PASS: TestAccAWSEcsServiceWithRenamedCluster (38.28s)
=== RUN TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (3.08s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	79.429s
```