### PR TITLE
Add a function to find the index of an element in a list.

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -24,6 +24,7 @@ func init() {
 		"file":       interpolationFuncFile(),
 		"format":     interpolationFuncFormat(),
 		"formatlist": interpolationFuncFormatList(),
+		"index":      interpolationFuncIndex(),
 		"join":       interpolationFuncJoin(),
 		"length":     interpolationFuncLength(),
 		"replace":    interpolationFuncReplace(),
@@ -174,6 +175,25 @@ func interpolationFuncFormatList() ast.Function {
 				list[i] = fmt.Sprintf(format, fmtargs...)
 			}
 			return NewStringList(list).String(), nil
+		},
+	}
+}
+
+// interpolationFuncIndex implements the "index" function that allows one to
+// find the index of a specific element in a list
+func interpolationFuncIndex() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString, ast.TypeString},
+		ReturnType: ast.TypeInt,
+		Callback: func(args []interface{}) (interface{}, error) {
+			haystack := StringList(args[0].(string)).Slice()
+			needle := args[1].(string)
+			for index, element := range haystack {
+				if needle == element {
+					return index, nil
+				}
+			}
+			return nil, fmt.Errorf("Could not find '%s' in '%s'", needle, haystack)
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -206,6 +206,39 @@ func TestInterpolateFuncFormatList(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncIndex(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${index("test", "")}`,
+				nil,
+				true,
+			},
+
+			{
+				fmt.Sprintf(`${index("%s", "foo")}`,
+					NewStringList([]string{"notfoo", "stillnotfoo", "bar"}).String()),
+				nil,
+				true,
+			},
+
+			{
+				fmt.Sprintf(`${index("%s", "foo")}`,
+					NewStringList([]string{"foo"}).String()),
+				"0",
+				false,
+			},
+
+			{
+				fmt.Sprintf(`${index("%s", "bar")}`,
+					NewStringList([]string{"foo", "spam", "bar", "eggs"}).String()),
+				"2",
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncJoin(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -102,6 +102,9 @@ The supported built-in functions are:
       `formatlist("instance %v has private ip %v", aws_instance.foo.*.id, aws_instance.foo.*.private_ip)`.
       Passing lists with different lengths to formatlist results in an error.
 
+  * `index(list, elem)` - Finds the index of a given element in a list. Example:
+      `index(aws_instance.foo.*.tags.Name, "foo-test")`
+
   * `join(delim, list)` - Joins the list with the delimiter. A list is
       only possible with splat variables from resources with a count
       greater than one. Example: `join(",", aws_instance.foo.*.id)`


### PR DESCRIPTION
We've hacked around not being able to pass maps as inputs to modules with interpolations akin to the following (newlines and comments added for easier reading):
```
foo = "${
  element(
    split(",", var.values),
    length(split(  // length of the list by chomping everything from the key onwards
      ",",
      replace(var.keys, "/${var.key}.*/", "")
    )) - 1
  )
}"
```
In essence, we chomp everything in a comma-separated key list starting from the key we're searching for, split the result, find the length of that list minus one, and use that as the index into the comma-separated values list. With an index function we can at least get rid of the replace madness and make our intent clearer, with the above now looking something like this:
```
foo = "${
  element(
    split(",", var.values),
    index(split(",", var.keys), var.key)
  )
}"
```