### PR TITLE
provider/openstack: Add missing doc link for Server Groups

### DIFF
--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -28,6 +28,9 @@
             <li<%= sidebar_current("docs-openstack-resource-compute-secgroup-v2") %>>
               <a href="/docs/providers/openstack/r/compute_secgroup_v2.html">openstack_compute_secgroup_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-compute-servergroup-v2") %>>
+              <a href="/docs/providers/openstack/r/compute_servergroup_v2.html">openstack_compute_servergroup_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-fw-firewall-v1") %>>
               <a href="/docs/providers/openstack/r/fw_firewall_v1.html">openstack_fw_firewall_v1</a>
             </li>


### PR DESCRIPTION
This commit adds the missing sidebar link for the Server Groups resource.