### PR TITLE
provider/openstack: Remove duplicate doc link of load balancer pool

### DIFF
--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -37,9 +37,6 @@
             <li<%= sidebar_current("docs-openstack-resource-fw-rule-v1") %>>
               <a href="/docs/providers/openstack/r/fw_rule_v1.html">openstack_fw_rule_v1</a>
             </li>
-            <li<%= sidebar_current("docs-openstack-resource-lb-pool-v1") %>>
-              <a href="/docs/providers/openstack/r/lb_pool_v1.html">openstack_lb_pool_v1</a>
-            </li>
             <li<%= sidebar_current("docs-openstack-resource-lb-monitor-v1") %>>
               <a href="/docs/providers/openstack/r/lb_monitor_v1.html">openstack_lb_monitor_v1</a>
             </li>


### PR DESCRIPTION
This commit removes the duplicate sidebar link of the load balancer pool resource.