### PR TITLE
provider/aws: Improved Auto Scaling Groups updates

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -321,11 +321,12 @@ func testAccCheckAWSAutoScalingGroupAttributesVPCZoneIdentifer(group *autoscalin
 			subnets = append(subnets, rs.Primary.Attributes["id"])
 		}
 
-		if group.VPCZoneIdentifier == nil || *group.VPCZoneIdentifier != "" {
+		if group.VPCZoneIdentifier == nil {
 			return fmt.Errorf("Bad VPC Zone Identifier\nexpected: %s\ngot nil", subnets)
 		}
 
 		zones := strings.Split(*group.VPCZoneIdentifier, ",")
+
 		remaining := len(zones)
 		for _, z := range zones {
 			for _, s := range subnets {
@@ -516,7 +517,7 @@ resource "aws_launch_configuration" "foobar" {
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["us-west-2a"]
   name = "vpc-asg-test"
-  max_size = 1
+  max_size = 2
   min_size = 1
   health_check_grace_period = 300
   health_check_type = "ELB"
@@ -565,7 +566,7 @@ resource "aws_autoscaling_group" "bar" {
     "${aws_subnet.alt.id}",
   ]
   name = "vpc-asg-test"
-  max_size = 1
+  max_size = 2
   min_size = 1
   health_check_grace_period = 300
   health_check_type = "ELB"

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -45,7 +45,8 @@ The following arguments are supported:
 * `max_size` - (Required) The maximum size of the auto scale group.
 * `min_size` - (Required) The minimum size of the auto scale group.
     (See also [Waiting for Capacity](#waiting-for-capacity) below.)
-* `availability_zones` - (Required) A list of AZs to launch resources in.
+* `availability_zones` - (Optional) A list of AZs to launch resources in.
+   Required only if you do not specify any `vpc_zone_identifier`
 * `launch_configuration` - (Required) The ID of the launch configuration to use.
 * `health_check_grace_period` - (Optional) Time after instance comes into service before checking health.
 * `health_check_type` - (Optional) "EC2" or "ELB". Controls how health checking is done.


### PR DESCRIPTION
- availability zones are optional if you specify a VPC Zone Identifier (subnet)
- availability zones can be updated in place

Fixes https://github.com/hashicorp/terraform/issues/2338

Remaining:

- [x] doc update