### PR TITLE
provider/aws: Fix issue with Launch Configurations and enable_monitoring

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -118,8 +118,8 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 			"enable_monitoring": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
+				Default:  true,
 			},
 
 			"ebs_block_device": &schema.Schema{
@@ -272,10 +272,8 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		createLaunchConfigurationOpts.UserData = aws.String(userData)
 	}
 
-	if v, ok := d.GetOk("enable_monitoring"); ok {
-		createLaunchConfigurationOpts.InstanceMonitoring = &autoscaling.InstanceMonitoring{
-			Enabled: aws.Boolean(v.(bool)),
-		}
+	createLaunchConfigurationOpts.InstanceMonitoring = &autoscaling.InstanceMonitoring{
+		Enabled: aws.Boolean(d.Get("enable_monitoring").(bool)),
 	}
 
 	if v, ok := d.GetOk("iam_instance_profile"); ok {
@@ -394,7 +392,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(lcName)
 
 	log.Printf(
-		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
+		"[DEBUG] autoscaling create launch configuration: %s", createLaunchConfigurationOpts)
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
@@ -435,7 +433,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		LaunchConfigurationNames: []*string{aws.String(d.Id())},
 	}
 
-	log.Printf("[DEBUG] launch configuration describe configuration: %#v", describeOpts)
+	log.Printf("[DEBUG] launch configuration describe configuration: %s", describeOpts)
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)


### PR DESCRIPTION
Previously, because of how `d.GetOk` works, this block was never being executed and you could not set this value to `false`. By adding a default of `true` to match [AWS][1], we can determine if the value is false and set it correctly. 

Fixes #2734


[1]: http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_CreateLaunchConfiguration.html