### PR TITLE
provider/aws: Network Interface private ips can be computed

### DIFF
--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -34,6 +34,7 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},


### PR DESCRIPTION
Fixes #2729