### PR TITLE
aws_db_instance: Downcase "engine" for RDS

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -46,6 +46,10 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					value := v.(string)
+					return strings.ToLower(value)
+				},
 			},
 
 			"engine_version": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -176,7 +176,7 @@ resource "aws_db_instance" "bar" {
 	identifier = "foobarbaz-test-terraform-%d"
 
 	allocated_storage = 10
-	engine = "mysql"
+	engine = "MySQL"
 	engine_version = "5.6.21"
 	instance_class = "db.t1.micro"
 	name = "baz"


### PR DESCRIPTION
If we don't, then mixed case engines (e.g. "MySQL") will force a rebuild
of the db_instance on every apply.

Unfortunately, we can't simply write lowercase to the state file. The
engine property forces a new instance when a diff is detected. This
solution, while not perfect, protects the user from themselves.