### PR TITLE
provider/aws: Adds force_destroy option  to route53 zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
   * **New resource: `google_container_cluster`** [GH-2357]
+  * **New resource: `aws_vpc_endpoint`** [GH-2695]
 
 BUG FIXES:
 
@@ -19,6 +20,7 @@ BUG FIXES:
       Security Groups [GH-2644]
   * provider/aws: Bump internet gateway detach timeout [GH-2669]
   * provider/aws: `ecs_cluster` rename (recreation) and deletion is handled correctly [GH-2698]
+  * provider/aws: `aws_route_table` ignores routes generated for VPC endpoints [GH-2695]
   * provider/openstack: allow empty api_key and endpoint_type [GH-2626]
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ IMPROVEMENTS:
   * provider/aws: Create RDS databases from snapshots [GH-2062]
   * provider/aws: Add support for restoring from Redis backup stored in S3 [GH-2634]
   * provider/aws: Add `maintenance_window` to ElastiCache cluster [GH-2642]
+  * provider/aws: Availability Zones are optional when specifying VPC Zone Identifiers in
+      Auto Scaling Groups updates [GH-2724]
   * provider/google: Add metadata_startup_script to google_compute_instance [GH-2375]
 
 ## 0.6.0 (June 30, 2015)

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -376,7 +376,6 @@ func readRecordSets(d *schema.ResourceData, meta interface{}) ([]*route53.Resour
 
 	lopts := &route53.ListResourceRecordSetsInput{
 		HostedZoneID: aws.String(zone),
-		// StartRecordName: aws.String(en),
 	}
 
 	resp, err := conn.ListResourceRecordSets(lopts)

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -65,6 +65,12 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				Computed: true,
 			},
 
+			"force_destroy": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -211,8 +217,20 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",
 		d.Get("name").(string), d.Id())
+
+	if ok := d.Get("force_destroy").(bool); ok {
+		err := deleteZoneRecordSets(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
 	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{ID: aws.String(d.Id())})
+
 	if err != nil {
+		if awserr, ok := err.(awserr.Error); ok {
+			log.Printf("[DEBUG] AWS Error deleting hosted zone %s", awserr)
+		}
 		return err
 	}
 
@@ -264,4 +282,74 @@ func getNameServers(zoneId string, zoneName string, r53 *route53.Route53) ([]str
 	}
 	sort.Strings(ns)
 	return ns, nil
+}
+
+// Similar to that found in resource_aws_route53_record
+// We only have info on the zone here though, as opposed to record set variables
+func deleteZoneRecordSets(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	zone := cleanZoneID(d.Get("zone_id").(string))
+	log.Printf("[DEBUG] Deleting resource records for zone: %s, name: %s",
+		zone, d.Get("name").(string))
+	var err error
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
+	if err != nil {
+		return err
+	}
+	// Get the records
+	rec, err := resourceAwsRoute53RecordBuildSet(d, *zoneRecord.HostedZone.Name)
+	if err != nil {
+		return err
+	}
+
+	// Create the new records
+	changeBatch := &route53.ChangeBatch{
+		Comment: aws.String("Deleted by Terraform"),
+		Changes: []*route53.Change{
+			&route53.Change{
+				Action:            aws.String("DELETE"),
+				ResourceRecordSet: rec,
+			},
+		},
+	}
+
+	req := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneID: aws.String(cleanZoneID(zone)),
+		ChangeBatch:  changeBatch,
+	}
+
+	wait := resource.StateChangeConf{
+		Pending:    []string{"rejected"},
+		Target:     "accepted",
+		Timeout:    5 * time.Minute,
+		MinTimeout: 1 * time.Second,
+		Refresh: func() (interface{}, string, error) {
+			_, err := conn.ChangeResourceRecordSets(req)
+			if err != nil {
+				if r53err, ok := err.(awserr.Error); ok {
+					if r53err.Code() == "PriorRequestNotComplete" {
+						// There is some pending operation, so just retry
+						// in a bit.
+						return 42, "rejected", nil
+					}
+
+					if r53err.Code() == "InvalidChangeBatch" {
+						// This means that the record is already gone.
+						return 42, "accepted", nil
+					}
+				}
+
+				return 42, "failure", err
+			}
+
+			return 42, "accepted", nil
+		},
+	}
+
+	if _, err := wait.WaitForState(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -366,4 +366,12 @@ resource "aws_route53_record" "rr_test" {
   records = ["This is a test record set"]
 }
 
+resource "aws_route53_record" "rr_test2" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "test2"
+  type = "TXT"
+  ttl = "60"
+  records = ["This is a test record set #2"]
+}
+
 `

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -156,10 +156,6 @@ func testAccCheckRoute53ZoneDestroy(s *terraform.State) error {
 	return testAccCheckRoute53ZoneDestroyWithProvider(s, testAccProvider)
 }
 
-// func testAccCheckRoute53ZoneForceDestroy(s *terraform.State) error {
-// 	return testAccCheckRoute53ZoneForceDestroyWithProvider(s, testAccProvider)
-// }
-
 func testAccCheckRoute53ZoneDestroyWithProviders(providers *[]*schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, provider := range *providers {
@@ -188,21 +184,6 @@ func testAccCheckRoute53ZoneDestroyWithProvider(s *terraform.State, provider *sc
 	}
 	return nil
 }
-
-// func testAccCheckRoute53ZoneForceDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
-// 	conn := provider.Meta().(*AWSClient).r53conn
-// 	for _, rs := range s.RootModule().Resources {
-// 		if rs.Type != "aws_route53_zone" {
-// 			continue
-// 		}
-
-// 		_, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
-// 		if err == nil {
-// 			return fmt.Errorf("Hosted zone still exists")
-// 		}
-// 	}
-// 	return nil
-// }
 
 func testAccCheckRoute53ZoneExists(n string, zone *route53.GetHostedZoneOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -134,9 +134,31 @@ func TestAccRoute53Zone_private_region(t *testing.T) {
 	})
 }
 
+func TestAccRoute53Zone_force_destroy(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53ZoneWithRecordsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRoute53ZoneDestroy(s *terraform.State) error {
 	return testAccCheckRoute53ZoneDestroyWithProvider(s, testAccProvider)
 }
+
+// func testAccCheckRoute53ZoneForceDestroy(s *terraform.State) error {
+// 	return testAccCheckRoute53ZoneForceDestroyWithProvider(s, testAccProvider)
+// }
 
 func testAccCheckRoute53ZoneDestroyWithProviders(providers *[]*schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -166,6 +188,21 @@ func testAccCheckRoute53ZoneDestroyWithProvider(s *terraform.State, provider *sc
 	}
 	return nil
 }
+
+// func testAccCheckRoute53ZoneForceDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+// 	conn := provider.Meta().(*AWSClient).r53conn
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "aws_route53_zone" {
+// 			continue
+// 		}
+
+// 		_, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
+// 		if err == nil {
+// 			return fmt.Errorf("Hosted zone still exists")
+// 		}
+// 	}
+// 	return nil
+// }
 
 func testAccCheckRoute53ZoneExists(n string, zone *route53.GetHostedZoneOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -326,4 +363,26 @@ resource "aws_route53_zone" "main" {
 	vpc_id = "${aws_vpc.main.id}"
 	vpc_region = "us-east-1"
 }
+`
+
+const testAccRoute53ZoneWithRecordsConfig = `
+resource "aws_route53_zone" "main" {
+	name = "hashicorp.com"
+	comment = "Custom comment"
+	force_destroy = true
+
+	tags {
+		foo = "bar"
+		Name = "tf-route53-tag-test"
+	}
+}
+
+resource "aws_route53_record" "rr_test" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "test"
+  type = "TXT"
+  ttl = "60"
+  records = ["This is a test record set"]
+}
+
 `


### PR DESCRIPTION
This is a boolean option to force destroy record sets in a route53 zone. 

I use route53 for master node service discovery from an ASG where record sets are dynamically added/removed. 

This allows tearing down a zone with existing records. 