### PR TITLE
provider/google: fixing the build...

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
-	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/dns/v1"
@@ -27,11 +26,10 @@ type Config struct {
 	Project     string
 	Region      string
 
-	clientCompute     *compute.Service
-	clientComputeBeta *computeBeta.Service
-	clientContainer   *container.Service
-	clientDns         *dns.Service
-	clientStorage     *storage.Service
+	clientCompute   *compute.Service
+	clientContainer *container.Service
+	clientDns       *dns.Service
+	clientStorage   *storage.Service
 }
 
 func (c *Config) loadAndValidate() error {
@@ -114,13 +112,6 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientCompute.UserAgent = userAgent
-
-	log.Printf("[INFO] Instantiating Beta GCE client...")
-	c.clientComputeBeta, err = computeBeta.New(client)
-	if err != nil {
-		return err
-	}
-	c.clientComputeBeta.UserAgent = userAgent
 
 	log.Printf("[INFO] Instantiating GKE client...")
 	c.clientContainer, err = container.New(client)


### PR DESCRIPTION
The v0.beta is removed ( https://github.com/google/google-api-go-client/commit/18450f4e95c7e76ce3a5dc3a8cb7178ab6d56121), so I also removed it from here. Strangely enough I cannot find any code that actually used it other then in being instantiated in the provider config func.