### PR TITLE
core: fix "provider ... couldn't be found" bug

### DIFF
--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -335,6 +335,13 @@ func (n *graphNodeResourceDestroyFlat) CreateNode() dag.Vertex {
 	return n.FlatCreateNode
 }
 
+func (n *graphNodeResourceDestroyFlat) ProvidedBy() []string {
+	prefix := modulePrefixStr(n.PathValue)
+	return modulePrefixList(
+		n.GraphNodeConfigResource.ProvidedBy(),
+		prefix)
+}
+
 // graphNodeResourceDestroy represents the logical destruction of a
 // resource. This node doesn't mean it will be destroyed for sure, but
 // instead that if a destroy were to happen, it must happen at this point.

--- a/terraform/test-fixtures/apply-module-provider-close-nested/child/main.tf
+++ b/terraform/test-fixtures/apply-module-provider-close-nested/child/main.tf
@@ -1,0 +1,3 @@
+module "subchild" {
+    source = "./subchild"
+}

--- a/terraform/test-fixtures/apply-module-provider-close-nested/child/subchild/main.tf
+++ b/terraform/test-fixtures/apply-module-provider-close-nested/child/subchild/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "foo" {}

--- a/terraform/test-fixtures/apply-module-provider-close-nested/main.tf
+++ b/terraform/test-fixtures/apply-module-provider-close-nested/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+    source = "./child"
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -130,7 +130,7 @@ func (t *CloseProviderTransformer) Transform(g *Graph) error {
 					provider, ok := pm[p]
 					if !ok {
 						err = multierror.Append(err, fmt.Errorf(
-							"%s: provider %s couldn't be found",
+							"%s: provider %s couldn't be found for closing",
 							dag.VertexName(v), p))
 						continue
 					}


### PR DESCRIPTION
The `CloseProviderTransformer` relies on the `ProvidedBy()` interface to
look up the proper dependency for the the graph nodes it adds. This
interface needs to yield the name of a provider, _AND_ for flattened
nodes it needs to yield the full path to a provider.

Destroy nodes did not implement this second part, which resulted in
"provider X couldn't be found" when both of these were true:

 * A module included a resource that dependend on a provider
 * The root did _NOT_ include a provider config

Implementing a proper ProvidedBy() on the flattened version of
destroy nodes solves the issue.

fixes #2581