### PR TITLE
Remove computeBeta references; it no longer exists upstream

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
-	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/dns/v1"
@@ -28,7 +27,6 @@ type Config struct {
 	Region      string
 
 	clientCompute     *compute.Service
-	clientComputeBeta *computeBeta.Service
 	clientContainer   *container.Service
 	clientDns         *dns.Service
 	clientStorage     *storage.Service
@@ -114,13 +112,6 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientCompute.UserAgent = userAgent
-
-	log.Printf("[INFO] Instantiating Beta GCE client...")
-	c.clientComputeBeta, err = computeBeta.New(client)
-	if err != nil {
-		return err
-	}
-	c.clientComputeBeta.UserAgent = userAgent
 
 	log.Printf("[INFO] Instantiating GKE client...")
 	c.clientContainer, err = container.New(client)

--- a/deps/v0-6-0.json
+++ b/deps/v0-6-0.json
@@ -354,10 +354,6 @@
 			"Rev": "b5adcc2dcdf009d0391547edc6ecbaff889f5bb9"
 		},
 		{
-			"ImportPath": "google.golang.org/api/compute/v0.beta",
-			"Rev": "a09229c13c2f13bbdedf7b31b506cad4c83ef3bf"
-		},
-		{
 			"ImportPath": "google.golang.org/api/compute/v1",
 			"Rev": "a09229c13c2f13bbdedf7b31b506cad4c83ef3bf"
 		},


### PR DESCRIPTION
I'm just getting my feet wet with terraform for the first time today and had issues with running updatedeps during the build process since `google.golang.org/api/compute/v0.beta` no longer exists upstream. I removed references to it (doesn't look like it's used anywhere?) and was able to successfully compile it.