### PR TITLE
provider/dnsimple: domain and type should force new records

### DIFF
--- a/builtin/providers/dnsimple/resource_dnsimple_record.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record.go
@@ -19,6 +19,7 @@ func resourceDNSimpleRecord() *schema.Resource {
 			"domain": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"domain_id": &schema.Schema{
@@ -39,6 +40,7 @@ func resourceDNSimpleRecord() *schema.Resource {
 			"type": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"value": &schema.Schema{

--- a/builtin/providers/dnsimple/resource_dnsimple_record.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record.go
@@ -76,12 +76,12 @@ func resourceDNSimpleRecordCreate(d *schema.ResourceData, meta interface{}) erro
 		newRecord.Ttl = ttl.(string)
 	}
 
-	log.Printf("[DEBUG] DNS Simple Record create configuration: %#v", newRecord)
+	log.Printf("[DEBUG] DNSimple Record create configuration: %#v", newRecord)
 
 	recId, err := client.CreateRecord(d.Get("domain").(string), newRecord)
 
 	if err != nil {
-		return fmt.Errorf("Failed to create DNS Simple Record: %s", err)
+		return fmt.Errorf("Failed to create DNSimple Record: %s", err)
 	}
 
 	d.SetId(recId)
@@ -95,7 +95,7 @@ func resourceDNSimpleRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 	rec, err := client.RetrieveRecord(d.Get("domain").(string), d.Id())
 	if err != nil {
-		return fmt.Errorf("Couldn't find DNS Simple Record: %s", err)
+		return fmt.Errorf("Couldn't find DNSimple Record: %s", err)
 	}
 
 	d.Set("domain_id", rec.StringDomainId())
@@ -135,11 +135,11 @@ func resourceDNSimpleRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 		updateRecord.Ttl = attr.(string)
 	}
 
-	log.Printf("[DEBUG] DNS Simple Record update configuration: %#v", updateRecord)
+	log.Printf("[DEBUG] DNSimple Record update configuration: %#v", updateRecord)
 
 	_, err := client.UpdateRecord(d.Get("domain").(string), d.Id(), updateRecord)
 	if err != nil {
-		return fmt.Errorf("Failed to update DNS Simple Record: %s", err)
+		return fmt.Errorf("Failed to update DNSimple Record: %s", err)
 	}
 
 	return resourceDNSimpleRecordRead(d, meta)
@@ -148,12 +148,12 @@ func resourceDNSimpleRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 func resourceDNSimpleRecordDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*dnsimple.Client)
 
-	log.Printf("[INFO] Deleting DNS Simple Record: %s, %s", d.Get("domain").(string), d.Id())
+	log.Printf("[INFO] Deleting DNSimple Record: %s, %s", d.Get("domain").(string), d.Id())
 
 	err := client.DestroyRecord(d.Get("domain").(string), d.Id())
 
 	if err != nil {
-		return fmt.Errorf("Error deleting DNS Simple Record: %s", err)
+		return fmt.Errorf("Error deleting DNSimple Record: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
DNSimple does not support changing the domain or type of a DNS record after it has been created. (https://developer.dnsimple.com/v1/domains/records/#update) Currently, at best an error occurs and at worst records are changed and your state file is corrupted. This change should fix the problem by forcing new resources for these two attributes.

I also fixed the wording to use their proper company name, `DNSimple`.