### PR TITLE
provider/aws/aws_instance: add `instance_initiated_shutdown_behavior`

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
      EBS-optimized.
 * `disable_api_termination` - (Optional) If true, enables [EC2 Instance
      Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination)
+* `instance_initiated_shutdown_behavior` - (Optional) [Shutdown Behavior](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) Can be `"stop"`
+or `"terminate"`. (Default: `"stop"`)
 * `instance_type` - (Required) The type of instance to start
 * `key_name` - (Optional) The key name to use for the instance.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)


### PR DESCRIPTION
accepts string values of 'stop' or 'terminate'.

Fixes #2130.

I'm not a golang expert, so please review for completeness.
Locally tested the resulting binary; works as I expect.

Signed-off-by: Marc Tamsky <tamsky@users.noreply.github.com>