### PR TITLE
provider/aws: Add aws_codedeploy_app

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -70,6 +71,7 @@ type AWSClient struct {
 	lambdaconn         *lambda.Lambda
 	opsworksconn       *opsworks.OpsWorks
 	glacierconn        *glacier.Glacier
+	codedeployconn     *codedeploy.CodeDeploy
 }
 
 // Client configures and returns a fully initialized AWSClient
@@ -192,6 +194,9 @@ func (c *Config) Client() (interface{}, error) {
 
 		log.Println("[INFO] Initializing Glacier connection")
 		client.glacierconn = glacier.New(awsConfig)
+
+		log.Println("[INFO] Initializing CodeDeploy Connection")
+		client.codedeployconn = codedeploy.New(awsConfig)
 	}
 
 	if len(errs) > 0 {

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -166,6 +166,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudwatch_log_group":         resourceAwsCloudWatchLogGroup(),
 			"aws_autoscaling_lifecycle_hook":   resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":      resourceAwsCloudWatchMetricAlarm(),
+			"aws_codedeploy_app":               resourceAwsCodeDeployApp(),
 			"aws_customer_gateway":             resourceAwsCustomerGateway(),
 			"aws_db_instance":                  resourceAwsDbInstance(),
 			"aws_db_parameter_group":           resourceAwsDbParameterGroup(),

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -167,6 +167,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_autoscaling_lifecycle_hook":   resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":      resourceAwsCloudWatchMetricAlarm(),
 			"aws_codedeploy_app":               resourceAwsCodeDeployApp(),
+			"aws_codedeploy_deployment_group":  resourceAwsCodeDeployDeploymentGroup(),
 			"aws_customer_gateway":             resourceAwsCustomerGateway(),
 			"aws_db_instance":                  resourceAwsDbInstance(),
 			"aws_db_parameter_group":           resourceAwsDbParameterGroup(),

--- a/builtin/providers/aws/resource_aws_codedeploy_app.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_app.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+)
+
+func resourceAwsCodeDeployApp() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCodeDeployAppCreate,
+		Read:   resourceAwsCodeDeployAppRead,
+		Update: resourceAwsCodeDeployUpdate,
+		Delete: resourceAwsCodeDeployAppDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			// The unique ID is set by AWS on create.
+			"unique_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsCodeDeployAppCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	application := d.Get("name").(string)
+	log.Printf("[DEBUG] Creating CodeDeploy application %s", application)
+
+	resp, err := conn.CreateApplication(&codedeploy.CreateApplicationInput{
+		ApplicationName: aws.String(application),
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] CodeDeploy application %s created", *resp.ApplicationId)
+
+	// Despite giving the application a unique ID, AWS doesn't actually use
+	// it in API calls. Use it and the app name to identify the resource in
+	// the state file. This allows us to reliably detect both when the TF
+	// config file changes and when the user deletes the app without removing
+	// it first from the TF config.
+	d.SetId(fmt.Sprintf("%s:%s", *resp.ApplicationId, application))
+
+	return resourceAwsCodeDeployAppRead(d, meta)
+}
+
+func resourceAwsCodeDeployAppRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	_, application := resourceAwsCodeDeployAppParseId(d.Id())
+	log.Printf("[DEBUG] Reading CodeDeploy application %s", application)
+	resp, err := conn.GetApplication(&codedeploy.GetApplicationInput{
+		ApplicationName: aws.String(application),
+	})
+	if err != nil {
+		if codedeployerr, ok := err.(awserr.Error); ok && codedeployerr.Code() == "ApplicationDoesNotExistException" {
+			d.SetId("")
+			return nil
+		} else {
+			log.Printf("[ERROR] Error finding CodeDeploy application: %s", err)
+			return err
+		}
+	}
+
+	d.Set("name", *resp.Application.ApplicationName)
+
+	return nil
+}
+
+func resourceAwsCodeDeployUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	o, n := d.GetChange("name")
+
+	_, err := conn.UpdateApplication(&codedeploy.UpdateApplicationInput{
+		ApplicationName:    aws.String(o.(string)),
+		NewApplicationName: aws.String(n.(string)),
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] CodeDeploy application %s updated", n)
+
+	d.Set("name", n)
+
+	return nil
+}
+
+func resourceAwsCodeDeployAppDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	_, err := conn.DeleteApplication(&codedeploy.DeleteApplicationInput{
+		ApplicationName: aws.String(d.Get("name").(string)),
+	})
+	if err != nil {
+		if cderr, ok := err.(awserr.Error); ok && cderr.Code() == "InvalidApplicationNameException" {
+			d.SetId("")
+			return nil
+		} else {
+			log.Printf("[ERROR] Error deleting CodeDeploy application: %s", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsCodeDeployAppParseId(id string) (string, string) {
+	parts := strings.SplitN(id, ":", 2)
+	return parts[0], parts[1]
+}

--- a/builtin/providers/aws/resource_aws_codedeploy_app_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_app_test.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCodeDeployApp_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployAppDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployApp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployAppModifier,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeDeployAppDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).codedeployconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_codedeploy_app" {
+			continue
+		}
+
+		resp, err := conn.GetApplication(&codedeploy.GetApplicationInput{
+			ApplicationName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if resp.Application != nil {
+				return fmt.Errorf("CodeDeploy app still exists:\n%#v", *resp.Application.ApplicationId)
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAWSCodeDeployAppExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+var testAccAWSCodeDeployApp = `
+resource "aws_codedeploy_app" "foo" {
+	name = "foo"
+}`
+
+var testAccAWSCodeDeployAppModifier = `
+resource "aws_codedeploy_app" "foo" {
+	name = "bar"
+}`

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -1,0 +1,375 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+)
+
+func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCodeDeployDeploymentGroupCreate,
+		Read:   resourceAwsCodeDeployDeploymentGroupRead,
+		Update: resourceAwsCodeDeployDeploymentGroupUpdate,
+		Delete: resourceAwsCodeDeployDeploymentGroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"application_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 100 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot exceed 100 characters", k))
+					}
+					return
+				},
+			},
+
+			"deployment_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 100 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot exceed 100 characters", k))
+					}
+					return
+				},
+			},
+
+			"service_role_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"autoscaling_groups": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"deployment_config_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "CodeDeployDefault.OneAtATime",
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 100 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot exceed 100 characters", k))
+					}
+					return
+				},
+			},
+
+			"ec2_tag_filter": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"type": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateTagFilters,
+						},
+
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Set: resourceAwsCodeDeployTagFilterHash,
+			},
+
+			"on_premises_instance_tag_filter": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"type": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateTagFilters,
+						},
+
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Set: resourceAwsCodeDeployTagFilterHash,
+			},
+		},
+	}
+}
+
+func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	application := d.Get("application_name").(string)
+	deploymentGroup := d.Get("deployment_group_name").(string)
+
+	input := codedeploy.CreateDeploymentGroupInput{
+		ApplicationName:     aws.String(application),
+		DeploymentGroupName: aws.String(deploymentGroup),
+		ServiceRoleArn:      aws.String(d.Get("service_role_arn").(string)),
+	}
+	if attr, ok := d.GetOk("deployment_config_name"); ok {
+		input.DeploymentConfigName = aws.String(attr.(string))
+	}
+	if attr, ok := d.GetOk("autoscaling_groups"); ok {
+		input.AutoScalingGroups = expandStringList(attr.(*schema.Set).List())
+	}
+	if attr, ok := d.GetOk("on_premises_instance_tag_filters"); ok {
+		onPremFilters := buildOnPremTagFilters(attr.(*schema.Set).List())
+		input.OnPremisesInstanceTagFilters = onPremFilters
+	}
+	if attr, ok := d.GetOk("ec2_tag_filter"); ok {
+		ec2TagFilters := buildEC2TagFilters(attr.(*schema.Set).List())
+		input.Ec2TagFilters = ec2TagFilters
+	}
+
+	// Retry to handle IAM role eventual consistency.
+	var resp *codedeploy.CreateDeploymentGroupOutput
+	var err error
+	err = resource.Retry(2*time.Minute, func() error {
+		resp, err = conn.CreateDeploymentGroup(&input)
+		if err != nil {
+			codedeployErr, ok := err.(awserr.Error)
+			if !ok {
+				return &resource.RetryError{Err: err}
+			}
+			if codedeployErr.Code() == "InvalidRoleException" {
+				log.Printf("[DEBUG] Trying to create deployment group again: %q",
+					codedeployErr.Message())
+				return err
+			}
+
+			return &resource.RetryError{Err: err}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.DeploymentGroupId)
+
+	return resourceAwsCodeDeployDeploymentGroupRead(d, meta)
+}
+
+func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	log.Printf("[DEBUG] Reading CodeDeploy DeploymentGroup %s", d.Id())
+	resp, err := conn.GetDeploymentGroup(&codedeploy.GetDeploymentGroupInput{
+		ApplicationName:     aws.String(d.Get("application_name").(string)),
+		DeploymentGroupName: aws.String(d.Get("deployment_group_name").(string)),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.Set("application_name", *resp.DeploymentGroupInfo.ApplicationName)
+	d.Set("autoscaling_groups", resp.DeploymentGroupInfo.AutoScalingGroups)
+	d.Set("deployment_config_name", *resp.DeploymentGroupInfo.DeploymentConfigName)
+	d.Set("deployment_group_name", *resp.DeploymentGroupInfo.DeploymentGroupName)
+	d.Set("service_role_arn", *resp.DeploymentGroupInfo.ServiceRoleArn)
+	if err := d.Set("ec2_tag_filter", ec2TagFiltersToMap(resp.DeploymentGroupInfo.Ec2TagFilters)); err != nil {
+		return err
+	}
+	if err := d.Set("on_premises_instance_tag_filter", onPremisesTagFiltersToMap(resp.DeploymentGroupInfo.OnPremisesInstanceTagFilters)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	input := codedeploy.UpdateDeploymentGroupInput{
+		ApplicationName:            aws.String(d.Get("application_name").(string)),
+		CurrentDeploymentGroupName: aws.String(d.Get("deployment_group_name").(string)),
+	}
+
+	if d.HasChange("autoscaling_groups") {
+		_, n := d.GetChange("autoscaling_groups")
+		input.AutoScalingGroups = expandStringList(n.(*schema.Set).List())
+	}
+	if d.HasChange("deployment_config_name") {
+		_, n := d.GetChange("deployment_config_name")
+		input.DeploymentConfigName = aws.String(n.(string))
+	}
+	if d.HasChange("deployment_group_name") {
+		_, n := d.GetChange("deployment_group_name")
+		input.NewDeploymentGroupName = aws.String(n.(string))
+	}
+
+	// TagFilters aren't like tags. They don't append. They simply replace.
+	if d.HasChange("on_premises_instance_tag_filter") {
+		_, n := d.GetChange("on_premises_instance_tag_filter")
+		onPremFilters := buildOnPremTagFilters(n.(*schema.Set).List())
+		input.OnPremisesInstanceTagFilters = onPremFilters
+	}
+	if d.HasChange("ec2_tag_filter") {
+		_, n := d.GetChange("ec2_tag_filter")
+		ec2Filters := buildEC2TagFilters(n.(*schema.Set).List())
+		input.Ec2TagFilters = ec2Filters
+	}
+
+	log.Printf("[DEBUG] Updating CodeDeploy DeploymentGroup %s", d.Id())
+	_, err := conn.UpdateDeploymentGroup(&input)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsCodeDeployDeploymentGroupRead(d, meta)
+}
+
+func resourceAwsCodeDeployDeploymentGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	log.Printf("[DEBUG] Deleting CodeDeploy DeploymentGroup %s", d.Id())
+	_, err := conn.DeleteDeploymentGroup(&codedeploy.DeleteDeploymentGroupInput{
+		ApplicationName:     aws.String(d.Get("application_name").(string)),
+		DeploymentGroupName: aws.String(d.Get("deployment_group_name").(string)),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+// buildOnPremTagFilters converts raw schema lists into a list of
+// codedeploy.TagFilters.
+func buildOnPremTagFilters(configured []interface{}) []*codedeploy.TagFilter {
+	filters := make([]*codedeploy.TagFilter, 0)
+	for _, raw := range configured {
+		var filter codedeploy.TagFilter
+		m := raw.(map[string]interface{})
+
+		filter.Key = aws.String(m["key"].(string))
+		filter.Type = aws.String(m["type"].(string))
+		filter.Value = aws.String(m["value"].(string))
+
+		filters = append(filters, &filter)
+	}
+
+	return filters
+}
+
+// buildEC2TagFilters converts raw schema lists into a list of
+// codedeploy.EC2TagFilters.
+func buildEC2TagFilters(configured []interface{}) []*codedeploy.EC2TagFilter {
+	filters := make([]*codedeploy.EC2TagFilter, 0)
+	for _, raw := range configured {
+		var filter codedeploy.EC2TagFilter
+		m := raw.(map[string]interface{})
+
+		filter.Key = aws.String(m["key"].(string))
+		filter.Type = aws.String(m["type"].(string))
+		filter.Value = aws.String(m["value"].(string))
+
+		filters = append(filters, &filter)
+	}
+
+	return filters
+}
+
+// ec2TagFiltersToMap converts lists of tag filters into a []map[string]string.
+func ec2TagFiltersToMap(list []*codedeploy.EC2TagFilter) []map[string]string {
+	result := make([]map[string]string, 0, len(list))
+	for _, tf := range list {
+		l := make(map[string]string)
+		if *tf.Key != "" {
+			l["key"] = *tf.Key
+		}
+		if *tf.Value != "" {
+			l["value"] = *tf.Value
+		}
+		if *tf.Type != "" {
+			l["type"] = *tf.Type
+		}
+		result = append(result, l)
+	}
+	return result
+}
+
+// onPremisesTagFiltersToMap converts lists of on-prem tag filters into a []map[string]string.
+func onPremisesTagFiltersToMap(list []*codedeploy.TagFilter) []map[string]string {
+	result := make([]map[string]string, 0, len(list))
+	for _, tf := range list {
+		l := make(map[string]string)
+		if *tf.Key != "" {
+			l["key"] = *tf.Key
+		}
+		if *tf.Value != "" {
+			l["value"] = *tf.Value
+		}
+		if *tf.Type != "" {
+			l["type"] = *tf.Type
+		}
+		result = append(result, l)
+	}
+	return result
+}
+
+// validateTagFilters confirms the "value" component of a tag filter is one of
+// AWS's three allowed types.
+func validateTagFilters(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value != "KEY_ONLY" && value != "VALUE_ONLY" && value != "KEY_AND_VALUE" {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of \"KEY_ONLY\", \"VALUE_ONLY\", or \"KEY_AND_VALUE\"", k))
+	}
+	return
+}
+
+func resourceAwsCodeDeployTagFilterHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	// Nothing's actually required in tag filters, so we must check the
+	// presence of all values before attempting a hash.
+	if v, ok := m["key"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["type"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["value"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	return hashcode.String(buf.String())
+}

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1,0 +1,199 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroupModifier,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeDeployDeploymentGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).codedeployconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_codedeploy_deployment_group" {
+			continue
+		}
+
+		resp, err := conn.GetDeploymentGroup(&codedeploy.GetDeploymentGroupInput{
+			ApplicationName:     aws.String(rs.Primary.Attributes["application_name"]),
+			DeploymentGroupName: aws.String(rs.Primary.Attributes["deployment_group_name"]),
+		})
+
+		if err == nil {
+			if resp.DeploymentGroupInfo.DeploymentGroupName != nil {
+				return fmt.Errorf("CodeDeploy deployment group still exists:\n%#v", *resp.DeploymentGroupInfo.DeploymentGroupName)
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAWSCodeDeployDeploymentGroupExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+var testAccAWSCodeDeployDeploymentGroup = `
+resource "aws_codedeploy_app" "foo_app" {
+	name = "foo_app"
+}
+
+resource "aws_iam_role_policy" "foo_policy" {
+	name = "foo_policy"
+	role = "${aws_iam_role.foo_role.id}"
+	policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DeleteLifecycleHook",
+	        "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeLifecycleHooks",
+                "autoscaling:PutLifecycleHook",
+                "autoscaling:RecordLifecycleActionHeartbeat",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
+                "tag:GetTags",
+	        "tag:GetResources"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "foo_role" {
+	name = "foo_role"
+	assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "codedeploy.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codedeploy_deployment_group" "foo" {
+	application_name = "${aws_codedeploy_app.foo_app.name}"
+	deployment_group_name = "foo"
+	service_role_arn = "${aws_iam_role.foo_role.arn}"
+	ec2_tag_filter {
+		key = "filterkey"
+		type = "KEY_AND_VALUE"
+		value = "filtervalue"
+	}
+}`
+
+var testAccAWSCodeDeployDeploymentGroupModifier = `
+resource "aws_codedeploy_app" "foo_app" {
+	name = "foo_app"
+}
+
+resource "aws_iam_role_policy" "foo_policy" {
+	name = "foo_policy"
+	role = "${aws_iam_role.foo_role.id}"
+	policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DeleteLifecycleHook",
+	        "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeLifecycleHooks",
+                "autoscaling:PutLifecycleHook",
+                "autoscaling:RecordLifecycleActionHeartbeat",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
+                "tag:GetTags",
+	        "tag:GetResources"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "foo_role" {
+	name = "foo_role"
+	assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "codedeploy.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codedeploy_deployment_group" "foo" {
+	application_name = "${aws_codedeploy_app.foo_app.name}"
+	deployment_group_name = "bar"
+	service_role_arn = "${aws_iam_role.foo_role.arn}"
+	ec2_tag_filter {
+		key = "filterkey"
+		type = "KEY_AND_VALUE"
+		value = "filtervalue"
+	}
+}`

--- a/website/source/docs/providers/aws/r/codedeploy_app.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_app.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "aws"
+page_title: "AWS: aws_codedeploy_app"
+sidebar_current: "docs-aws-resource-codedeploy-app"
+description: |\
+  Provides a CodeDeploy application.
+---
+
+# aws\_codedeploy\_app
+
+Provides a CodeDeploy application to be used as a basis for deployments
+
+## Example Usage
+
+```
+resource "aws_codedeploy_app" "foo" {
+  name = "foo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the application.
+
+## Attribute Reference
+
+The following arguments are exported:
+
+* `id` - Amazon's assigned ID for the application.
+* `name` - The application's name.

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -1,0 +1,108 @@
+---
+layout: "aws"
+page_title: "AWS: aws_codedeploy_deployment_group"
+sidebar_current: "docs-aws-resource-codedeploy-deployment-group"
+description: |\
+  Provides a CodeDeploy deployment group.
+---
+
+# aws\_codedeploy\_deployment\_group
+
+Provides a CodeDeploy deployment group for an application
+
+## Example Usage
+
+```
+resource "aws_codedeploy_app" "foo_app" {
+    name = "foo_app"
+}
+
+resource "aws_iam_role_policy" "foo_policy" {
+    name = "foo_policy"
+    role = "${aws_iam_role.foo_role.id}"
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DeleteLifecycleHook",
+            "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeLifecycleHooks",
+                "autoscaling:PutLifecycleHook",
+                "autoscaling:RecordLifecycleActionHeartbeat",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
+                "tag:GetTags",
+            "tag:GetResources"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "foo_role" {
+    name = "foo_role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "codedeploy.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codedeploy_deployment_group" "foo" {
+    application_name = "${aws_codedeploy_app.foo_app.name}"
+    deployment_group_name = "bar"
+    service_role_arn = "${aws_iam_role.foo_role.arn}"
+    ec2_tag_filter {
+        key = "filterkey"
+        type = "KEY_AND_VALUE"
+        value = "filtervalue"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_name` - (Required) The name of the application.
+* `deployment_group_name` - (Required) The name of the deployment group.
+* `service_role_arn` - (Required) The service role ARN that allows deployments.
+* `autoscaling_groups` - (Optional) Autoscaling groups associated with the deployment group.
+* `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
+* `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
+* `on_premises_instance_tag_filter" - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
+
+Both ec2_tag_filter and on_premises_tag_filter blocks support the following:
+
+* `key` - (Optional) The key of the tag filter.
+* `type` - (Optional) The type of the tag filter, either KEY_ONLY, VALUE_ONLY, or KEY_AND_VALUE.
+* `value` - (Optional) The value of the tag filter.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The deployment group's ID.
+* `application_name` - The group's assigned application.
+* `deployment_group_name` - The group's name.
+* `service_role_arn` - The group's service role ARN.
+* `autoscaling_groups` - The autoscaling groups associated with the deployment group.
+* `deployment_config_name` - The name of the group's deployment config.


### PR DESCRIPTION
This is (preliminary) support for CodeDeploy. It's sort of useless by itself but is a complete resource in its own right. I'd rather submit these for review and merge one at a time than dropping a giant patch that represents 3-4 distinct resources, even if they're most useful when used together.

I also haven't written the rest yet.

- [x] Docs
- [x] Create / Update / Delete an application all supported
- [x] Acceptance tests

I saw @radeksimko post a test plan over in #2636, so in the interest of submitting a complete PR:

## Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSCodeDeployApp' 2>/dev/null
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSCodeDeployApp -timeout 90m
=== RUN TestAccAWSCodeDeployApp_basic
--- PASS: TestAccAWSCodeDeployApp_basic (1.56s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    1.563s
```