### PR TITLE
Grandchild module orphans should be destroyed

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2145,6 +2145,57 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
+	m := testModule(t, "apply-destroy-deeply-nested-module")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	s := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: []string{"root", "child", "subchild", "subsubchild"},
+				Resources: map[string]*ResourceState{
+					"aws_instance.bar": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: s,
+	})
+
+	// First plan and apply a create operation
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Test that things were destroyed
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(`
+module.child.subchild.subsubchild:
+  <no state>
+	`)
+	if actual != expected {
+		t.Fatalf("bad: \n%s", actual)
+	}
+}
+
 func TestContext2Apply_destroyOutputs(t *testing.T) {
 	m := testModule(t, "apply-destroy-outputs")
 	h := new(HookRecordApplyOrder)

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -145,7 +145,7 @@ func (s *State) ModuleOrphans(path []string, c *config.Config) [][]string {
 		}
 
 		// If we have the direct child, then just skip it.
-		key := m.Path[len(m.Path)-2]
+		key := m.Path[len(path)]
 		if _, ok := direct[key]; ok {
 			continue
 		}

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -85,6 +85,28 @@ func TestStateModuleOrphans(t *testing.T) {
 	}
 }
 
+func TestStateModuleOrphans_nested(t *testing.T) {
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: RootModulePath,
+			},
+			&ModuleState{
+				Path: []string{RootModuleName, "foo", "bar"},
+			},
+		},
+	}
+
+	actual := state.ModuleOrphans(RootModulePath, nil)
+	expected := [][]string{
+		[]string{RootModuleName, "foo"},
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestStateModuleOrphans_nilConfig(t *testing.T) {
 	state := &State{
 		Modules: []*ModuleState{

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -483,6 +483,11 @@ const testTerraformApplyDestroyStr = `
 <no state>
 `
 
+const testTerraformApplyDestroyNestedModuleStr = `
+module.child.subchild:
+  <no state>
+`
+
 const testTerraformApplyErrorStr = `
 aws_instance.bar:
   ID = bar

--- a/terraform/test-fixtures/apply-destroy-deeply-nested-module/child/main.tf
+++ b/terraform/test-fixtures/apply-destroy-deeply-nested-module/child/main.tf
@@ -1,0 +1,3 @@
+module "subchild" {
+  source = "./subchild"
+}

--- a/terraform/test-fixtures/apply-destroy-deeply-nested-module/child/subchild/main.tf
+++ b/terraform/test-fixtures/apply-destroy-deeply-nested-module/child/subchild/main.tf
@@ -1,0 +1,5 @@
+/*
+module "subsubchild" {
+  source = "./subsubchild"
+}
+*/

--- a/terraform/test-fixtures/apply-destroy-deeply-nested-module/child/subchild/subsubchild/main.tf
+++ b/terraform/test-fixtures/apply-destroy-deeply-nested-module/child/subchild/subsubchild/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "bar" {}

--- a/terraform/test-fixtures/apply-destroy-deeply-nested-module/main.tf
+++ b/terraform/test-fixtures/apply-destroy-deeply-nested-module/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}

--- a/terraform/test-fixtures/apply-destroy-nested-module/child/main.tf
+++ b/terraform/test-fixtures/apply-destroy-nested-module/child/main.tf
@@ -1,0 +1,3 @@
+module "subchild" {
+    source = "./subchild"
+}

--- a/terraform/test-fixtures/apply-destroy-nested-module/child/subchild/main.tf
+++ b/terraform/test-fixtures/apply-destroy-nested-module/child/subchild/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "bar" {}

--- a/terraform/test-fixtures/apply-destroy-nested-module/main.tf
+++ b/terraform/test-fixtures/apply-destroy-nested-module/main.tf
@@ -1,0 +1,5 @@
+/*
+module "child" {
+    source = "./child"
+}
+*/

--- a/terraform/transform_orphan.go
+++ b/terraform/transform_orphan.go
@@ -100,9 +100,14 @@ func (t *OrphanTransformer) Transform(g *Graph) error {
 	moduleOrphans := t.State.ModuleOrphans(g.Path, config)
 	moduleVertexes := make([]dag.Vertex, len(moduleOrphans))
 	for i, path := range moduleOrphans {
+		var deps []string
+		if s := t.State.ModuleByPath(path); s != nil {
+			deps = s.Dependencies
+		}
+
 		moduleVertexes[i] = g.Add(&graphNodeOrphanModule{
 			Path:        path,
-			dependentOn: t.State.ModuleByPath(path).Dependencies,
+			dependentOn: deps,
 		})
 	}
 
@@ -355,4 +360,10 @@ func (n *graphNodeOrphanResourceFlat) CreateBeforeDestroy() bool {
 
 func (n *graphNodeOrphanResourceFlat) CreateNode() dag.Vertex {
 	return n
+}
+
+func (n *graphNodeOrphanResourceFlat) ProvidedBy() []string {
+	return modulePrefixList(
+		n.graphNodeOrphanResource.ProvidedBy(),
+		modulePrefixStr(n.PathValue))
 }


### PR DESCRIPTION
Fixes #2770 

This was an interesting bug found by @ryanking. Basically: when adding orphan modules to the graph, only direct descendants were added by inspecting the state. If the direct descendant has no state (no resources in the original config), then grandchildren will never get discovered and never added to the graph.

This PR mainly modifies `State.ModuleOrphans` to return orphans that have grandchildren even if they're not in the state. 

This PR also contains a few bug fixes necessary to make this work otherwise, but the above is the meat of the change.

(Aside: we should really switch to a tree structure internally to make functions like ModuleOrphans more efficient than `O(N)`, but... one day). 