### PR TITLE
terraform: splatting with computed values is computed [GH-2744]

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -433,6 +433,11 @@ func (i *Interpolater) computeResourceMultiVariable(
 			continue
 		}
 
+		// If any value is unknown, the whole thing is unknown
+		if attr == config.UnknownVariableValue {
+			return config.UnknownVariableValue, nil
+		}
+
 		values = append(values, attr)
 	}
 

--- a/terraform/test-fixtures/interpolate-resource-variable/main.tf
+++ b/terraform/test-fixtures/interpolate-resource-variable/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "web" {}


### PR DESCRIPTION
Fixes #2744 

If any value in a splat (multi-resource variable access) is computed, then the whole value should be computed. 