### PR TITLE
Fix a nil access error when security group can't be found.

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -156,16 +156,19 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 		d.SetId("")
 	}
 
-	var rule *ec2.IPPermission
 	ruleType := d.Get("type").(string)
-	var rl []*ec2.IPPermission
-	switch ruleType {
-	case "ingress":
-		rl = sg.IPPermissions
-	default:
-		rl = sg.IPPermissionsEgress
+
+	rl := []*ec2.IPPermission{}
+	if sg != nil {
+		switch ruleType {
+		case "ingress":
+			rl = sg.IPPermissions
+		default:
+			rl = sg.IPPermissionsEgress
+		}
 	}
 
+	var rule *ec2.IPPermission
 	for _, r := range rl {
 		if d.Id() == ipPermissionIDHash(ruleType, r) {
 			rule = r


### PR DESCRIPTION
Not sure of the specifics on how I hit this codepath, but this fixed a panic I was seeing where `sg` was nil. 