### PR TITLE
provider/aws: Converge on TestAccAWS for acceptance tests names

### DIFF
--- a/builtin/providers/aws/resource_aws_customer_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccCustomerGateway_basic(t *testing.T) {
+func TestAccAWSCustomerGateway_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_flow_log_test.go
+++ b/builtin/providers/aws/resource_aws_flow_log_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccFlowLog_basic(t *testing.T) {
+func TestAccAWSFlowLog_basic(t *testing.T) {
 	var flowLog ec2.FlowLog
 	lgn := os.Getenv("LOG_GROUP_NAME")
 
@@ -31,7 +31,7 @@ func TestAccFlowLog_basic(t *testing.T) {
 	})
 }
 
-func TestAccFlowLog_subnet(t *testing.T) {
+func TestAccAWSFlowLog_subnet(t *testing.T) {
 	var flowLog ec2.FlowLog
 	lgn := os.Getenv("LOG_GROUP_NAME")
 

--- a/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
+++ b/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccIAMServerCertificate_basic(t *testing.T) {
+func TestAccAWSIAMServerCertificate_basic(t *testing.T) {
 	var cert iam.ServerCertificate
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_kinesis_stream_test.go
+++ b/builtin/providers/aws/resource_aws_kinesis_stream_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccKinesisStream_basic(t *testing.T) {
+func TestAccAWSKinesisStream_basic(t *testing.T) {
 	var stream kinesis.StreamDescription
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSLambdaFunction_normal(t *testing.T) {
+func TestAccAWSLambdaFunction_basic(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_route53_delegation_set_test.go
+++ b/builtin/providers/aws/resource_aws_route53_delegation_set_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
-func TestAccRoute53DelegationSet_basic(t *testing.T) {
+func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -29,7 +29,7 @@ func TestAccRoute53DelegationSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccRoute53DelegationSet_withZones(t *testing.T) {
+func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
-func TestAccRoute53HealthCheck_basic(t *testing.T) {
+func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -34,7 +34,7 @@ func TestAccRoute53HealthCheck_basic(t *testing.T) {
 	})
 }
 
-func TestAccRoute53HealthCheck_IpConfig(t *testing.T) {
+func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -50,7 +50,7 @@ func TestExpandRecordName(t *testing.T) {
 	}
 }
 
-func TestAccRoute53Record_basic(t *testing.T) {
+func TestAccAWSRoute53Record_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -66,7 +66,7 @@ func TestAccRoute53Record_basic(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_txtSupport(t *testing.T) {
+func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -82,7 +82,7 @@ func TestAccRoute53Record_txtSupport(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_generatesSuffix(t *testing.T) {
+func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -98,7 +98,7 @@ func TestAccRoute53Record_generatesSuffix(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_wildcard(t *testing.T) {
+func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -122,7 +122,7 @@ func TestAccRoute53Record_wildcard(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_weighted(t *testing.T) {
+func TestAccAWSRoute53Record_weighted(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -139,7 +139,7 @@ func TestAccRoute53Record_weighted(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_alias(t *testing.T) {
+func TestAccAWSRoute53Record_alias(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -155,7 +155,7 @@ func TestAccRoute53Record_alias(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_weighted_alias(t *testing.T) {
+func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -182,7 +182,7 @@ func TestAccRoute53Record_weighted_alias(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_TypeChange(t *testing.T) {
+func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
-func TestAccRoute53ZoneAssociation_basic(t *testing.T) {
+func TestAccAWSRoute53ZoneAssociation_basic(t *testing.T) {
 	var zone route53.HostedZone
 
 	resource.Test(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccRoute53ZoneAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccRoute53ZoneAssociation_region(t *testing.T) {
+func TestAccAWSRoute53ZoneAssociation_region(t *testing.T) {
 	var zone route53.HostedZone
 
 	// record the initialized providers so that we can use them to

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -64,7 +64,7 @@ func TestCleanChangeID(t *testing.T) {
 	}
 }
 
-func TestAccRoute53Zone_basic(t *testing.T) {
+func TestAccAWSRoute53Zone_basic(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 	var td route53.ResourceTagSet
 
@@ -85,7 +85,7 @@ func TestAccRoute53Zone_basic(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Zone_private_basic(t *testing.T) {
+func TestAccAWSRoute53Zone_private_basic(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
 	resource.Test(t, resource.TestCase{
@@ -104,7 +104,7 @@ func TestAccRoute53Zone_private_basic(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Zone_private_region(t *testing.T) {
+func TestAccAWSRoute53Zone_private_region(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
 	// record the initialized providers so that we can use them to

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDHCPOptions_basic(t *testing.T) {
+func TestAccAWSDHCPOptions_basic(t *testing.T) {
 	var d ec2.DHCPOptions
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccVpcEndpoint_basic(t *testing.T) {
+func TestAccAWSVpcEndpoint_basic(t *testing.T) {
 	var endpoint ec2.VPCEndpoint
 
 	resource.Test(t, resource.TestCase{
@@ -29,7 +29,7 @@ func TestAccVpcEndpoint_basic(t *testing.T) {
 	})
 }
 
-func TestAccVpcEndpoint_withRouteTableAndPolicy(t *testing.T) {
+func TestAccAWSVpcEndpoint_withRouteTableAndPolicy(t *testing.T) {
 	var endpoint ec2.VPCEndpoint
 	var routeTable ec2.RouteTable
 

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccVpc_basic(t *testing.T) {
+func TestAccAWSVpc_basic(t *testing.T) {
 	var vpc ec2.VPC
 
 	resource.Test(t, resource.TestCase{
@@ -32,7 +32,7 @@ func TestAccVpc_basic(t *testing.T) {
 	})
 }
 
-func TestAccVpc_dedicatedTenancy(t *testing.T) {
+func TestAccAWSVpc_dedicatedTenancy(t *testing.T) {
 	var vpc ec2.VPC
 
 	resource.Test(t, resource.TestCase{
@@ -52,7 +52,7 @@ func TestAccVpc_dedicatedTenancy(t *testing.T) {
 	})
 }
 
-func TestAccVpc_tags(t *testing.T) {
+func TestAccAWSVpc_tags(t *testing.T) {
 	var vpc ec2.VPC
 
 	resource.Test(t, resource.TestCase{
@@ -83,7 +83,7 @@ func TestAccVpc_tags(t *testing.T) {
 	})
 }
 
-func TestAccVpcUpdate(t *testing.T) {
+func TestAccAWSVpc_update(t *testing.T) {
 	var vpc ec2.VPC
 
 	resource.Test(t, resource.TestCase{
@@ -187,7 +187,7 @@ func testAccCheckVpcExists(n string, vpc *ec2.VPC) resource.TestCheckFunc {
 }
 
 // https://github.com/hashicorp/terraform/issues/1301
-func TestAccVpc_bothDnsOptionsSet(t *testing.T) {
+func TestAccAWSVpc_bothDnsOptionsSet(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/aws/resource_aws_vpn_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway_test.go
@@ -87,7 +87,7 @@ func TestAccAWSVpnGateway_delete(t *testing.T) {
 	})
 }
 
-func TestAccVpnGateway_tags(t *testing.T) {
+func TestAccAWSVpnGateway_tags(t *testing.T) {
 	var v ec2.VPNGateway
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
An attempt to converge the tests into a standard naming scheme

- TestAccAWS for aws tests
- a `_basic` test for each suite, save a few that are quick (Network ACLs, for
  example)