### PR TITLE
Amend AWS spot instace state name cancelled

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -160,7 +160,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 	request := resp.SpotInstanceRequests[0]
 
 	// if the request is cancelled, then it is gone
-	if *request.State == "canceled" {
+	if *request.State == "cancelled" {
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
I think is a simple typo, you can check the AWS doc here: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotInstanceRequest.html

I realise the problem when my spot instance was cancelled and the terraform plan was never reflecting that.