### PR TITLE
provider/aws: Clean up externally removed Launch Configurations

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -480,7 +480,8 @@ func resourceAwsLaunchConfigurationDelete(d *schema.ResourceData, meta interface
 		})
 	if err != nil {
 		autoscalingerr, ok := err.(awserr.Error)
-		if ok && autoscalingerr.Code() == "InvalidConfiguration.NotFound" {
+		if ok && (autoscalingerr.Code() == "InvalidConfiguration.NotFound" || autoscalingerr.Code() == "ValidationError") {
+			log.Printf("[DEBUG] Launch configuration (%s) not found", d.Id())
 			return nil
 		}
 


### PR DESCRIPTION
Handle Launch Configurations that are not found more gracefully, by tolerating
an additional API error indicating the LC no longer exists.