### PR TITLE
core: Add resource IDs to apply-errors + prevent error duplication

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -140,7 +140,8 @@ func (h *UiHook) PostApply(
 	}
 
 	if applyerr != nil {
-		msg = fmt.Sprintf("Error: %s", applyerr)
+		// Errors are collected and printed in ApplyCommand, no need to duplicate
+		return terraform.HookActionContinue, nil
 	}
 
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -94,7 +94,8 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	// if we have one, otherwise we just output it.
 	if err != nil {
 		if n.Error != nil {
-			*n.Error = multierror.Append(*n.Error, err)
+			helpfulErr := fmt.Errorf("%s: %s", n.Info.Id, err.Error())
+			*n.Error = multierror.Append(*n.Error, helpfulErr)
 		} else {
 			return nil, err
 		}

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"fmt"
 	"log"
 )
 
@@ -35,7 +36,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	// Refresh!
 	state, err = provider.Refresh(n.Info, state)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %s", n.Info.Id, err.Error())
 	}
 
 	// Call post-refresh hook


### PR DESCRIPTION
This is a proposal for fixing #2801 and similar with a more systematic approach.

Current state:
```
aws_route53_record.www: Creating...
  fqdn:               "" => "<computed>"
  name:               "" => "www.notexample.com"
  records.#:          "" => "1"
  records.3619153832: "" => "127.0.0.1"
  ttl:                "" => "300"
  type:               "" => "A"
  zone_id:            "" => "WRONGID"
aws_route53_record.www: Error: 1 error(s) occurred:

* NoSuchHostedZone: No hosted zone found with ID: WRONGID
	status code: 404, request id: [d7febede-3063-11e5-9472-2971854b3f91]
Error applying plan:

1 error(s) occurred:

* NoSuchHostedZone: No hosted zone found with ID: WRONGID
	status code: 404, request id: [d7febede-3063-11e5-9472-2971854b3f91]

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

this PR is changing it into the following (no duplicate errors and resource ID mentioned):

```
aws_route53_record.www: Creating...
  fqdn:               "" => "<computed>"
  name:               "" => "www.notexample.com"
  records.#:          "" => "1"
  records.3619153832: "" => "127.0.0.1"
  ttl:                "" => "300"
  type:               "" => "A"
  zone_id:            "" => "WRONGID"
Error applying plan:

1 error(s) occurred:

* aws_route53_record.www: NoSuchHostedZone: No hosted zone found with ID: WRONGID
	status code: 404, request id: [1db1c357-3064-11e5-8c8a-916e2ed8af08]

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure
```

Here's a simple way to trigger an error (and see the difference):
```ruby
provider "aws" {
    region = "us-west-2"
}

resource "aws_route53_record" "www" {
   zone_id = "WRONGID"
   name = "www.notexample.com"
   type = "A"
   ttl = "300"
   records = ["127.0.0.1"]
}
```

`git blame command/hook_ui.go` only brought up @mitchellh , so I think he would be the best candidate for reviewing.

The other option would be to keep the error printing in UiHook which has the advantage of more "real-time" feedback, but in that case we should:

1. Print it in red (it is now bold white)
2. Somehow filter these errors out in `eval_apply.go` so it's not duplicated.

FYI @failshell @catsby 