### PR TITLE
Fix link in the docs

### DIFF
--- a/website/source/layouts/cloudstack.erb
+++ b/website/source/layouts/cloudstack.erb
@@ -54,7 +54,7 @@
                         </li>
 
                         <li<%= sidebar_current("docs-cloudstack-resource-secondary-ipaddress") %>>
-                            <a href="/docs/providers/cloudstack/r/secondary_ipaddres.html">cloudstack_secondary_ipaddress</a>
+                            <a href="/docs/providers/cloudstack/r/secondary_ipaddress.html">cloudstack_secondary_ipaddress</a>
                         </li>
 
                         <li<%= sidebar_current("docs-cloudstack-resource-ssh-keypair") %>>


### PR DESCRIPTION
@phinze @catsby I know normally the website is only updated when a new release is cut, but would be great to have this fix released a little before that (as 0.6.1 is just cut a few days ago) to fix this one:

![image](https://cloud.githubusercontent.com/assets/4171547/8834462/9f053d3e-30b4-11e5-837c-1599844ff801.png)
