### PR TITLE
Split AWS provider topics by service.

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1,296 +1,406 @@
 <% wrap_layout :inner do %>
-	<% content_for :sidebar do %>
-		<div class="docs-sidebar hidden-print affix-top" role="complementary">
-			<ul class="nav docs-sidenav">
-				<li<%= sidebar_current("docs-home") %>>
-					<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
-				</li>
-
-				<li<%= sidebar_current("docs-aws-index") %>>
-					<a href="/docs/providers/aws/index.html">AWS Provider</a>
-				</li>
-
-				<li<%= sidebar_current(/^docs-aws-resource/) %>>
-					<a href="#">Resources</a>
-					<ul class="nav nav-visible">
-						<li<%= sidebar_current("docs-aws-app-cookie-stickiness-policy") %>>
-							<a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
-						</li>
-						<li<%= sidebar_current("docs-aws-resource-autoscaling-group") %>>
-							<a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-autoscaling-notification") %>>
-							<a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-autoscaling-policy") %>>
-							<a href="/docs/providers/aws/r/autoscaling_policy.html">aws_autoscaling_policy</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-cloudwatch-metric-alarm") %>>
-							<a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-customer-gateway") %>>
-							<a href="/docs/providers/aws/r/customer_gateway.html">aws_customer_gateway</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-db-instance") %>>
-							<a href="/docs/providers/aws/r/db_instance.html">aws_db_instance</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-db-parameter-group") %>>
-							<a href="/docs/providers/aws/r/db_parameter_group.html">aws_db_parameter_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-db-security-group") %>>
-							<a href="/docs/providers/aws/r/db_security_group.html">aws_db_security_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-db-subnet-group") %>>
-							<a href="/docs/providers/aws/r/db_subnet_group.html">aws_db_subnet_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-dynamodb-table") %>>
-							<a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-ebs-volume") %>>
-							<a href="/docs/providers/aws/r/ebs_volume.html">aws_ebs_volume</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-ecs-cluster") %>>
-							<a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-ecs-service") %>>
-							<a href="/docs/providers/aws/r/ecs_service.html">aws_ecs_service</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-ecs-task-definition") %>>
-							<a href="/docs/providers/aws/r/ecs_task_definition.html">aws_ecs_task_definition</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-eip") %>>
-							<a href="/docs/providers/aws/r/eip.html">aws_eip</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-elasticache-cluster") %>>
-							<a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-elasticache-parameter-group") %>>
-							<a href="/docs/providers/aws/r/elasticache_parameter_group.html">aws_elasticache_parameter_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-elasticache-security-group") %>>
-							<a href="/docs/providers/aws/r/elasticache_security_group.html">aws_elasticache_security_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-elasticache-subnet-group") %>>
-							<a href="/docs/providers/aws/r/elasticache_subnet_group.html">aws_elasticache_subnet_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-elb") %>>
-							<a href="/docs/providers/aws/r/elb.html">aws_elb</a>
-						</li>
-
-                                                <li<%= sidebar_current("docs-aws-resource-flow-log") %>>
-                                                        <a href="/docs/providers/aws/r/flow_log.html">aws_flow_log</a>
-                                                </li>
-
-						<li<%= sidebar_current("docs-aws-resource-iam-access-key") %>>
-							<a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
-						</li>
+    <% content_for :sidebar do %>
+        <div class="docs-sidebar hidden-print affix-top" role="complementary">
+            <ul class="nav docs-sidenav">
+                <li<%= sidebar_current("docs-home") %>>
+                    <a href="/docs/providers/index.html">&laquo; Documentation Home</a>
+                </li>
 
-						<li<%= sidebar_current("docs-aws-resource-iam-group") %>>
-							<a href="/docs/providers/aws/r/iam_group.html">aws_iam_group</a>
-						</li>
+                <li<%= sidebar_current("docs-aws-index") %>>
+                    <a href="/docs/providers/aws/index.html">AWS Provider</a>
+                </li>
 
-						<li<%= sidebar_current("docs-aws-resource-iam-group-policy") %>>
-							<a href="/docs/providers/aws/r/iam_group_policy.html">aws_iam_group_policy</a>
-						</li>
 
-						<li<%= sidebar_current("docs-aws-resource-iam-group-membership") %>>
-							<a href="/docs/providers/aws/r/iam_group_membership.html">aws_iam_group_membership</a>
-						</li>
+                <li<%= sidebar_current(/^docs-aws-resource-cloudwatch/) %>>
+                    <a href="#">CloudWatch Resources</a>
+                    <ul class="nav nav-visible">
 
-						<li<%= sidebar_current("docs-aws-resource-iam-instance-profile") %>>
-							<a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
-						</li>
+                        <li<%= sidebar_current("docs-aws-resource-cloudwatch-metric-alarm") %>>
+                            <a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
+                        </li>
 
-						<li<%= sidebar_current("docs-aws-resource-iam-policy") %>>
-							<a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
-						</li>
-						<li<%= sidebar_current("docs-aws-resource-iam-policy-attachment") %>>
-							<a href="/docs/providers/aws/r/iam_policy_attachment.html">aws_iam_policy_attachment</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-iam-role") %>>
-							<a href="/docs/providers/aws/r/iam_role.html">aws_iam_role</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-iam-role-policy") %>>
-							<a href="/docs/providers/aws/r/iam_role_policy.html">aws_iam_role_policy</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-iam-server-certificate") %>>
-							<a href="/docs/providers/aws/r/iam_server_certificate.html">aws_iam_server_certificate</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-iam-user") %>>
-							<a href="/docs/providers/aws/r/iam_user.html">aws_iam_user</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-iam-user-policy") %>>
-							<a href="/docs/providers/aws/r/iam_user_policy.html">aws_iam_user_policy</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-instance") %>>
-							<a href="/docs/providers/aws/r/instance.html">aws_instance</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-internet-gateway") %>>
-							<a href="/docs/providers/aws/r/internet_gateway.html">aws_internet_gateway</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-key-pair") %>>
-							<a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-kinesis-stream") %>>
-							<a href="/docs/providers/aws/r/kinesis_stream.html">aws_kinesis_stream</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-lambda-function") %>>
-							<a href="/docs/providers/aws/r/lambda_function.html">aws_lambda_function</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-launch-configuration") %>>
-							<a href="/docs/providers/aws/r/launch_configuration.html">aws_launch_configuration</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-lb-cookie-stickiness-policy") %>>
-							<a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-main-route-table-assoc") %>>
-							<a href="/docs/providers/aws/r/main_route_table_assoc.html">aws_main_route_table_association</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-network-acl") %>>
-							<a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-network-interface") %>>
-							<a href="/docs/providers/aws/r/network_interface.html">aws_network_interface</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-proxy-protocol-policy") %>>
-							<a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-route53-delegation-set") %>>
-							<a href="/docs/providers/aws/r/route53_delegation_set.html">aws_route53_delegation_set</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-route53-health-check") %>>
-							<a href="/docs/providers/aws/r/route53_health_check.html">aws_route53_health_check</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-route53-record") %>>
-							<a href="/docs/providers/aws/r/route53_record.html">aws_route53_record</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-route53-zone") %>>
-							<a href="/docs/providers/aws/r/route53_zone.html">aws_route53_zone</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-route53-zone-association") %>>
-							<a href="/docs/providers/aws/r/route53_zone_association.html">aws_route53_zone_association</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-route-table|") %>>
-							<a href="/docs/providers/aws/r/route_table.html">aws_route_table</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-route-table-association") %>>
-							<a href="/docs/providers/aws/r/route_table_association.html">aws_route_table_association</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-s3-bucket") %>>
-							<a href="/docs/providers/aws/r/s3_bucket.html">aws_s3_bucket</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-security-group") %>>
-							<a href="/docs/providers/aws/r/security_group.html">aws_security_group</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-security-group-rule") %>>
-							<a href="/docs/providers/aws/r/security_group_rule.html">aws_security_group_rule</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-sns-topic") %>>
-							<a href="/docs/providers/aws/r/sns_topic.html">aws_sns_topic</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-sns-topic-subscription") %>>
-							<a href="/docs/providers/aws/r/sns_topic_subscription.html">aws_sns_topic_subscription</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-spot-instance-request") %>>
-							<a href="/docs/providers/aws/r/spot_instance_request.html">aws_spot_instance_request</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-sqs-queue") %>>
-							<a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-subnet") %>>
-							<a href="/docs/providers/aws/r/subnet.html">aws_subnet</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-volume-attachment") %>>
-							<a href="/docs/providers/aws/r/volume_attachment.html">aws_volume_attachment</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpc") %>>
-							<a href="/docs/providers/aws/r/vpc.html">aws_vpc</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpc-dhcp-options") %>>
-							<a href="/docs/providers/aws/r/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpc-dhcp-options-association") %>>
-							<a href="/docs/providers/aws/r/vpc_dhcp_options_association.html">aws_vpc_dhcp_options_association</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpc-endpoint") %>>
-							<a href="/docs/providers/aws/r/vpc_endpoint.html">aws_vpc_endpoint</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpc-peering") %>>
-							<a href="/docs/providers/aws/r/vpc_peering.html">aws_vpc_peering</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpn-connection") %>>
-							<a href="/docs/providers/aws/r/vpn_connection.html">aws_vpn_connection</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpn-connection-route") %>>
-							<a href="/docs/providers/aws/r/vpn_connection_route.html">aws_vpn_connection_route</a>
-						</li>
-
-						<li<%= sidebar_current("docs-aws-resource-vpn-gateway") %>>
-							<a href="/docs/providers/aws/r/vpn_gateway.html">aws_vpn_gateway</a>
-						</li>
-					</ul>
-				</li>
-			</ul>
-		</div>
-	<% end %>
-
-	<%= yield %>
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-dynamodb/) %>>
+                    <a href="#">DynamoDB Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-dynamodb-table") %>>
+                            <a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-(app|autoscaling|ebs|elb|eip|instance|launch|lb|proxy|spot|volume)/) %>>
+                    <a href="#">EC2 Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-app-cookie-stickiness-policy") %>>
+                            <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-autoscaling-group") %>>
+                            <a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-autoscaling-notification") %>>
+                            <a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-autoscaling-policy") %>>
+                            <a href="/docs/providers/aws/r/autoscaling_policy.html">aws_autoscaling_policy</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-ebs-volume") %>>
+                            <a href="/docs/providers/aws/r/ebs_volume.html">aws_ebs_volume</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-eip") %>>
+                            <a href="/docs/providers/aws/r/eip.html">aws_eip</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-elb") %>>
+                            <a href="/docs/providers/aws/r/elb.html">aws_elb</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-instance") %>>
+                            <a href="/docs/providers/aws/r/instance.html">aws_instance</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-launch-configuration") %>>
+                            <a href="/docs/providers/aws/r/launch_configuration.html">aws_launch_configuration</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-lb-cookie-stickiness-policy") %>>
+                            <a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-proxy-protocol-policy") %>>
+                            <a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
+                        </li>
+
+
+                        <li<%= sidebar_current("docs-aws-resource-spot-instance-request") %>>
+                            <a href="/docs/providers/aws/r/spot_instance_request.html">aws_spot_instance_request</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-volume-attachment") %>>
+                            <a href="/docs/providers/aws/r/volume_attachment.html">aws_volume_attachment</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-ecs/) %>>
+                    <a href="#">ECS Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-ecs-cluster") %>>
+                            <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-ecs-service") %>>
+                            <a href="/docs/providers/aws/r/ecs_service.html">aws_ecs_service</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-ecs-task-definition") %>>
+                            <a href="/docs/providers/aws/r/ecs_task_definition.html">aws_ecs_task_definition</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-elasticache/) %>>
+                    <a href="#">ElastiCache Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-elasticache-cluster") %>>
+                            <a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-elasticache-parameter-group") %>>
+                            <a href="/docs/providers/aws/r/elasticache_parameter_group.html">aws_elasticache_parameter_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-elasticache-security-group") %>>
+                            <a href="/docs/providers/aws/r/elasticache_security_group.html">aws_elasticache_security_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-elasticache-subnet-group") %>>
+                            <a href="/docs/providers/aws/r/elasticache_subnet_group.html">aws_elasticache_subnet_group</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-iam/) %>>
+                    <a href="#">IAM Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-access-key") %>>
+                            <a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-group") %>>
+                            <a href="/docs/providers/aws/r/iam_group.html">aws_iam_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-group-policy") %>>
+                            <a href="/docs/providers/aws/r/iam_group_policy.html">aws_iam_group_policy</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-group-membership") %>>
+                            <a href="/docs/providers/aws/r/iam_group_membership.html">aws_iam_group_membership</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-instance-profile") %>>
+                            <a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-policy") %>>
+                            <a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-resource-iam-policy-attachment") %>>
+                            <a href="/docs/providers/aws/r/iam_policy_attachment.html">aws_iam_policy_attachment</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-role") %>>
+                            <a href="/docs/providers/aws/r/iam_role.html">aws_iam_role</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-role-policy") %>>
+                            <a href="/docs/providers/aws/r/iam_role_policy.html">aws_iam_role_policy</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-server-certificate") %>>
+                            <a href="/docs/providers/aws/r/iam_server_certificate.html">aws_iam_server_certificate</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-user") %>>
+                            <a href="/docs/providers/aws/r/iam_user.html">aws_iam_user</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-user-policy") %>>
+                            <a href="/docs/providers/aws/r/iam_user_policy.html">aws_iam_user_policy</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-kinesis/) %>>
+                    <a href="#">Kinesis Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-kinesis-stream") %>>
+                            <a href="/docs/providers/aws/r/kinesis_stream.html">aws_kinesis_stream</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-lambda/) %>>
+                    <a href="#">Lambda Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-lambda-function") %>>
+                            <a href="/docs/providers/aws/r/lambda_function.html">aws_lambda_function</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-db/) %>>
+                    <a href="#">RDS Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-db-instance") %>>
+                            <a href="/docs/providers/aws/r/db_instance.html">aws_db_instance</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-db-parameter-group") %>>
+                            <a href="/docs/providers/aws/r/db_parameter_group.html">aws_db_parameter_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-db-security-group") %>>
+                            <a href="/docs/providers/aws/r/db_security_group.html">aws_db_security_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-db-subnet-group") %>>
+                            <a href="/docs/providers/aws/r/db_subnet_group.html">aws_db_subnet_group</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-route53/) %>>
+                    <a href="#">Route53 Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-delegation-set") %>>
+                            <a href="/docs/providers/aws/r/route53_delegation_set.html">aws_route53_delegation_set</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-health-check") %>>
+                            <a href="/docs/providers/aws/r/route53_health_check.html">aws_route53_health_check</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-record") %>>
+                            <a href="/docs/providers/aws/r/route53_record.html">aws_route53_record</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-zone") %>>
+                            <a href="/docs/providers/aws/r/route53_zone.html">aws_route53_zone</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-zone-association") %>>
+                            <a href="/docs/providers/aws/r/route53_zone_association.html">aws_route53_zone_association</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-s3/) %>>
+                    <a href="#">S3 Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-s3-bucket") %>>
+                            <a href="/docs/providers/aws/r/s3_bucket.html">aws_s3_bucket</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-sns/) %>>
+                    <a href="#">SNS Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-sns-topic") %>>
+                            <a href="/docs/providers/aws/r/sns_topic.html">aws_sns_topic</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-sns-topic-subscription") %>>
+                            <a href="/docs/providers/aws/r/sns_topic_subscription.html">aws_sns_topic_subscription</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-sqs/) %>>
+                    <a href="#">SQS Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-sqs-queue") %>>
+                            <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li<%= sidebar_current(/^docs-aws-resource-(customer|flow|internet-gateway|key-pair|main-route|network|route-|security-group|subnet|vpc|vpn)/) %>>
+                    <a href="#">VPC Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-customer-gateway") %>>
+                            <a href="/docs/providers/aws/r/customer_gateway.html">aws_customer_gateway</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-flow-log") %>>
+                            <a href="/docs/providers/aws/r/flow_log.html">aws_flow_log</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-internet-gateway") %>>
+                            <a href="/docs/providers/aws/r/internet_gateway.html">aws_internet_gateway</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-key-pair") %>>
+                            <a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-main-route-table-assoc") %>>
+                            <a href="/docs/providers/aws/r/main_route_table_assoc.html">aws_main_route_table_association</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-network-acl") %>>
+                            <a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-network-interface") %>>
+                            <a href="/docs/providers/aws/r/network_interface.html">aws_network_interface</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route-table|") %>>
+                            <a href="/docs/providers/aws/r/route_table.html">aws_route_table</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route-table-association") %>>
+                            <a href="/docs/providers/aws/r/route_table_association.html">aws_route_table_association</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-security-group") %>>
+                            <a href="/docs/providers/aws/r/security_group.html">aws_security_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-security-group-rule") %>>
+                            <a href="/docs/providers/aws/r/security_group_rule.html">aws_security_group_rule</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-subnet") %>>
+                            <a href="/docs/providers/aws/r/subnet.html">aws_subnet</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpc") %>>
+                            <a href="/docs/providers/aws/r/vpc.html">aws_vpc</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpc-dhcp-options") %>>
+                            <a href="/docs/providers/aws/r/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpc-dhcp-options-association") %>>
+                            <a href="/docs/providers/aws/r/vpc_dhcp_options_association.html">aws_vpc_dhcp_options_association</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpc-endpoint") %>>
+                            <a href="/docs/providers/aws/r/vpc_endpoint.html">aws_vpc_endpoint</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpc-peering") %>>
+                            <a href="/docs/providers/aws/r/vpc_peering.html">aws_vpc_peering</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpn-connection") %>>
+                            <a href="/docs/providers/aws/r/vpn_connection.html">aws_vpn_connection</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpn-connection-route") %>>
+                            <a href="/docs/providers/aws/r/vpn_connection_route.html">aws_vpn_connection_route</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-vpn-gateway") %>>
+                            <a href="/docs/providers/aws/r/vpn_gateway.html">aws_vpn_gateway</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+            </ul>
+        </div>
+    <% end %>
+
+    <%= yield %>
 <% end %>


### PR DESCRIPTION
With so many AWS provider resources, the docs are getting pretty hard to navigate. This is particularly true due to the mismatch of some resources encoding the service name (like aws_route53_record) but some others ignoring it (like aws_subnet) or using a generic prefix (like aws_db_instance), which causes an alphabetical ordering to muddle up all of the services.

Since the AWS UI and docs are themselves oriented around services, most users should be familiar with the service brands and understand which resources belong to which service. Thus this categorization follows the primary categorization used within the AWS Console, preferring EC2-VPC over EC2-Classic-style bucketing.

Here's the navigation structure this patch creates (since it's probably quite hard to see from the HTML diff):

* CLOUDWATCH RESOURCES
  * aws_cloudwatch_metric_alarm
* DYNAMODB RESOURCES
  * aws_dynamodb_table
* EC2 RESOURCES
  * aws_app_cookie_stickiness_policy
  * aws_autoscaling_group
  * aws_autoscaling_notification
  * aws_autoscaling_policy
  * aws_ebs_volume
  * aws_eip
  * aws_elb
  * aws_instance
  * aws_launch_configuration
  * aws_lb_cookie_stickiness_policy
  * aws_proxy_protocol_policy
  * aws_spot_instance_request
  * aws_volume_attachment
* ECS RESOURCES
  * aws_ecs_cluster
  * aws_ecs_service
  * aws_ecs_task_definition
* ELASTICACHE RESOURCES
  * aws_elasticache_cluster
  * aws_elasticache_parameter_group
  * aws_elasticache_security_group
  * aws_elasticache_subnet_group
* IAM RESOURCES
  * aws_iam_access_key
  * aws_iam_group
  * aws_iam_group_policy
  * aws_iam_group_membership
  * aws_iam_instance_profile
  * aws_iam_policy
  * aws_iam_policy_attachment
  * aws_iam_role
  * aws_iam_role_policy
  * aws_iam_server_certificate
  * aws_iam_user
  * aws_iam_user_policy
* KINESIS RESOURCES
  * aws_kinesis_stream
* LAMBDA RESOURCES
  * aws_lambda_function
* RDS RESOURCES
  * aws_db_instance
  * aws_db_parameter_group
  * aws_db_security_group
  * aws_db_subnet_group
* ROUTE53 RESOURCES
  * aws_route53_delegation_set
  * aws_route53_health_check
  * aws_route53_record
  * aws_route53_zone
  * aws_route53_zone_association
* S3 RESOURCES
  * aws_s3_bucket
* SNS RESOURCES
  * aws_sns_topic
  * aws_sns_topic_subscription
* SQS RESOURCES
  * aws_sqs_queue
* VPC RESOURCES
  * aws_customer_gateway
  * aws_flow_log
  * aws_internet_gateway
  * aws_key_pair
  * aws_main_route_table_association
  * aws_network_acl
  * aws_network_interface
  * aws_route_table
  * aws_route_table_association
  * aws_security_group
  * aws_security_group_rule
  * aws_subnet
  * aws_vpc
  * aws_vpc_dhcp_options
  * aws_vpc_dhcp_options_association
  * aws_vpc_endpoint
  * aws_vpc_peering
  * aws_vpn_connection
  * aws_vpn_connection_route
  * aws_vpn_gateway
