### PR TITLE
Allow setting the notification topic ARN for ElastiCache clusters.

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -73,6 +73,10 @@ names to associate with this cache cluster
 Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. 
 Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
 
+* `notification_topic_arn` – (Optional) An Amazon Resource Name (ARN) of an 
+SNS topic to send ElastiCache notifications to. Example: 
+`arn:aws:sns:us-east-1:012345678999:my_sns_topic`
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 


### PR DESCRIPTION
I learned that setting an empty string for the ARN on modify is a no-op, so you have to set the status to "inactive". This was the one oddity in this change.

I manually tested various creation / update scenarios, but let me know if there's somewhere I can add some tests. 