### PR TITLE
providers/google: Change account_file to expect a JSON string

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -23,9 +23,10 @@ import (
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
-	AccountFile string
-	Project     string
-	Region      string
+	AccountFile         string
+	AccountFileContents string
+	Project             string
+	Region              string
 
 	clientCompute *compute.Service
 	clientContainer *container.Service
@@ -39,6 +40,9 @@ func (c *Config) loadAndValidate() error {
 	// TODO: validation that it isn't blank
 	if c.AccountFile == "" {
 		c.AccountFile = os.Getenv("GOOGLE_ACCOUNT_FILE")
+	}
+	if c.AccountFileContents == "" {
+		c.AccountFileContents = os.Getenv("GOOGLE_ACCOUNT_FILE_CONTENTS")
 	}
 	if c.Project == "" {
 		c.Project = os.Getenv("GOOGLE_PROJECT")

--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -71,13 +71,13 @@ func (c *Config) loadAndValidate() error {
 			}
 
 			contents = string(b)
-		}
 
-		if err := parseJSON(&account, contents); err != nil {
-			return fmt.Errorf(
-				"Error parsing account file '%s': %s",
-				contents,
-				err)
+			if err := parseJSON(&account, contents); err != nil {
+				return fmt.Errorf(
+					"Error parsing account file '%s': %s",
+					contents,
+					err)
+			}
 		}
 
 		clientScopes := []string{

--- a/builtin/providers/google/config_test.go
+++ b/builtin/providers/google/config_test.go
@@ -1,24 +1,63 @@
 package google
 
 import (
-	"reflect"
+	"io/ioutil"
 	"testing"
 )
 
-func TestConfigLoadJSON_account(t *testing.T) {
-	var actual accountFile
-	if err := loadJSON(&actual, "./test-fixtures/fake_account.json"); err != nil {
-		t.Fatalf("err: %s", err)
+const testFakeAccountFilePath = "./test-fixtures/fake_account.json"
+
+func TestConfigLoadAndValidate_accountFile(t *testing.T) {
+	config := Config{
+		AccountFile: testFakeAccountFilePath,
+		Project:     "my-gce-project",
+		Region:      "us-central1",
 	}
 
-	expected := accountFile{
-		PrivateKeyId: "foo",
-		PrivateKey:   "bar",
-		ClientEmail:  "foo@bar.com",
-		ClientId:     "id@foo.com",
+	err := config.loadAndValidate()
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}
+
+func TestConfigLoadAndValidate_accountFileContents(t *testing.T) {
+	contents, err := ioutil.ReadFile(testFakeAccountFilePath)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	config := Config{
+		AccountFileContents: string(contents),
+		Project:             "my-gce-project",
+		Region:              "us-central1",
 	}
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+	err = config.loadAndValidate()
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}
+
+func TestConfigLoadAndValidate_none(t *testing.T) {
+	config := Config{
+		Project: "my-gce-project",
+		Region:  "us-central1",
+	}
+
+	err := config.loadAndValidate()
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}
+
+func TestConfigLoadAndValidate_both(t *testing.T) {
+	config := Config{
+		AccountFile:         testFakeAccountFilePath,
+		AccountFileContents: "{}",
+		Project:             "my-gce-project",
+		Region:              "us-central1",
+	}
+
+	if config.loadAndValidate() == nil {
+		t.Fatalf("expected error, but got nil")
 	}
 }

--- a/builtin/providers/google/config_test.go
+++ b/builtin/providers/google/config_test.go
@@ -7,7 +7,7 @@ import (
 
 const testFakeAccountFilePath = "./test-fixtures/fake_account.json"
 
-func TestConfigLoadAndValidate_accountFile(t *testing.T) {
+func TestConfigLoadAndValidate_accountFilePath(t *testing.T) {
 	config := Config{
 		AccountFile: testFakeAccountFilePath,
 		Project:     "my-gce-project",
@@ -20,15 +20,15 @@ func TestConfigLoadAndValidate_accountFile(t *testing.T) {
 	}
 }
 
-func TestConfigLoadAndValidate_accountFileContents(t *testing.T) {
+func TestConfigLoadAndValidate_accountFileJSON(t *testing.T) {
 	contents, err := ioutil.ReadFile(testFakeAccountFilePath)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
 	config := Config{
-		AccountFileContents: string(contents),
-		Project:             "my-gce-project",
-		Region:              "us-central1",
+		AccountFile: string(contents),
+		Project:     "my-gce-project",
+		Region:      "us-central1",
 	}
 
 	err = config.loadAndValidate()
@@ -37,24 +37,11 @@ func TestConfigLoadAndValidate_accountFileContents(t *testing.T) {
 	}
 }
 
-func TestConfigLoadAndValidate_none(t *testing.T) {
+func TestConfigLoadAndValidate_accountFileJSONInvalid(t *testing.T) {
 	config := Config{
-		Project: "my-gce-project",
-		Region:  "us-central1",
-	}
-
-	err := config.loadAndValidate()
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-}
-
-func TestConfigLoadAndValidate_both(t *testing.T) {
-	config := Config{
-		AccountFile:         testFakeAccountFilePath,
-		AccountFileContents: "{}",
-		Project:             "my-gce-project",
-		Region:              "us-central1",
+		AccountFile: "{this is not json}",
+		Project:     "my-gce-project",
+		Region:      "us-central1",
 	}
 
 	if config.loadAndValidate() == nil {

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -10,15 +10,17 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"account_file": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"account_file_contents"},
+				DefaultFunc:   schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
 			},
 
 			"account_file_contents": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE_CONTENTS", nil),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"account_file"},
+				DefaultFunc:   schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE_CONTENTS", nil),
 			},
 
 			"project": &schema.Schema{

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -87,9 +87,12 @@ ${file("filename.json")} instead.`)
 		return
 	}
 
-	if _, err := os.Stat(value); os.IsNotExist(err) {
-		errors = append(errors, err)
-		fmt.Errorf("account_file path does not exist: %s", value)
+	if _, err := os.Stat(value); err != nil {
+		errors = append(errors,
+			fmt.Errorf(
+				"account_file path could not be read from '%s': %s",
+				value,
+				err))
 	}
 
 	return

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -15,6 +15,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
 			},
 
+			"account_file_contents": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE_CONTENTS", nil),
+			},
+
 			"project": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -83,7 +83,7 @@ func validateAccountFile(v interface{}, k string) (warnings []string, errors []e
 account_file is not valid JSON, so we are assuming it is a file path. This
 support will be removed in the future. Please update your configuration to use
 ${file("filename.json")} instead.`)
-
+	} else {
 		return
 	}
 

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -10,17 +10,15 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"account_file": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"account_file_contents"},
-				DefaultFunc:   schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", ""),
 			},
 
 			"account_file_contents": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"account_file"},
-				DefaultFunc:   schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE_CONTENTS", nil),
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE_CONTENTS", ""),
 			},
 
 			"project": &schema.Schema{

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -59,9 +59,10 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AccountFile: d.Get("account_file").(string),
-		Project:     d.Get("project").(string),
-		Region:      d.Get("region").(string),
+		AccountFile:         d.Get("account_file").(string),
+		AccountFileContents: d.Get("account_file_contents").(string),
+		Project:             d.Get("project").(string),
+		Region:              d.Get("region").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -34,13 +34,19 @@ resource "google_compute_instance" "default" {
 
 The following keys can be used to configure the provider.
 
-* `account_file` - (Required) Path to the JSON file used to describe your
-  account credentials, downloaded from Google Cloud Console. More details on
-  retrieving this file are below.  The _account file_ can be "" if you
-  are running terraform from a GCE instance with a properly-configured [Compute
-  Engine Service Account](https://cloud.google.com/compute/docs/authentication).
-  This can also be specified with the `GOOGLE_ACCOUNT_FILE` shell environment
-  variable.
+* `account_file` - (Required, unless `account_file_contents` is present) Path
+  to the JSON file used to describe your account credentials, downloaded from
+  Google Cloud Console. More details on retrieving this file are below. The
+  _account file_ can be "" if you are running terraform from a GCE instance with
+  a properly-configured [Compute Engine Service
+  Account](https://cloud.google.com/compute/docs/authentication). This can also
+  be specified with the `GOOGLE_ACCOUNT_FILE` shell environment variable.
+
+* `account_file_contents` - (Required, unless `account_file` is present) The
+  contents of `account_file`. This can be used to pass the account credentials
+  with a Terraform var or environment variable if the account file is not
+  accessible. This can also be specified with the `GOOGLE_ACCOUNT_FILE_CONTENTS`
+  shell environment variable.
 
 * `project` - (Required) The ID of the project to apply any resources to.  This
   can also be specified with the `GOOGLE_PROJECT` shell environment variable.

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available resources.
 ```
 # Configure the Google Cloud provider
 provider "google" {
-    account_file = "account.json"
+    account_file = "${file("account.json")}"
     project = "my-gce-project"
     region = "us-central1"
 }
@@ -34,19 +34,13 @@ resource "google_compute_instance" "default" {
 
 The following keys can be used to configure the provider.
 
-* `account_file` - (Required, unless `account_file_contents` is present) Path
-  to the JSON file used to describe your account credentials, downloaded from
-  Google Cloud Console. More details on retrieving this file are below. The
-  _account file_ can be "" if you are running terraform from a GCE instance with
-  a properly-configured [Compute Engine Service
-  Account](https://cloud.google.com/compute/docs/authentication). This can also
-  be specified with the `GOOGLE_ACCOUNT_FILE` shell environment variable.
-
-* `account_file_contents` - (Required, unless `account_file` is present) The
-  contents of `account_file`. This can be used to pass the account credentials
-  with a Terraform var or environment variable if the account file is not
-  accessible. This can also be specified with the `GOOGLE_ACCOUNT_FILE_CONTENTS`
-  shell environment variable.
+* `account_file` - (Required) Contents of the JSON file used to describe your
+  account credentials, downloaded from Google Cloud Console. More details on
+  retrieving this file are below. The `account file` can be "" if you are running
+  terraform from a GCE instance with a properly-configured [Compute Engine
+  Service Account](https://cloud.google.com/compute/docs/authentication). This
+  can also be specified with the `GOOGLE_ACCOUNT_FILE` shell environment
+  variable.
 
 * `project` - (Required) The ID of the project to apply any resources to.  This
   can also be specified with the `GOOGLE_PROJECT` shell environment variable.


### PR DESCRIPTION
Using the Google provider from [Atlas](https://atlas.hashicorp.com) if currently not possible without committing the `account_file` to version control, or only using `terraform push`. This adds `account_file_contents` to allow specifying the contents of the `account_file` in an environment variable (encrypted on Atlas).