### PR TITLE
provider/azure: Provide a simpler error when using a Platform Image without a Storage Service

### DIFF
--- a/builtin/providers/azure/errors.go
+++ b/builtin/providers/azure/errors.go
@@ -1,0 +1,5 @@
+package azure
+
+import "errors"
+
+var PlatformStorageError = errors.New("When using a platform image, the 'storage' parameter is required")

--- a/builtin/providers/azure/resource_azure_instance.go
+++ b/builtin/providers/azure/resource_azure_instance.go
@@ -591,6 +591,10 @@ func retrieveImageDetails(
 		return configureForImage, osType, nil
 	}
 
+	if err == PlatformStorageError {
+		return nil, "", err
+	}
+
 	return nil, "", fmt.Errorf("Could not find image with label '%s'. Available images are: %s",
 		label, strings.Join(append(VMLabels, OSLabels...), ", "))
 }
@@ -647,7 +651,7 @@ func retrieveOSImageDetails(
 			if img.MediaLink == "" {
 				if storage == "" {
 					return nil, "", nil,
-						fmt.Errorf("When using a platform image, the 'storage' parameter is required")
+						PlatformStorageError
 				}
 				img.MediaLink = fmt.Sprintf(osDiskBlobStorageURL, storage, name)
 			}

--- a/builtin/providers/azure/resource_azure_instance.go
+++ b/builtin/providers/azure/resource_azure_instance.go
@@ -650,8 +650,7 @@ func retrieveOSImageDetails(
 			}
 			if img.MediaLink == "" {
 				if storage == "" {
-					return nil, "", nil,
-						PlatformStorageError
+					return nil, "", nil, PlatformStorageError
 				}
 				img.MediaLink = fmt.Sprintf(osDiskBlobStorageURL, storage, name)
 			}

--- a/website/source/docs/providers/azure/r/instance.html.markdown
+++ b/website/source/docs/providers/azure/r/instance.html.markdown
@@ -72,7 +72,8 @@ The following arguments are supported:
 
 * `storage_service_name` - (Optional) The name of an existing storage account
     within the subscription which will be used to store the VHDs of this
-    instance. Changing this forces a new resource to be created.
+    instance. Changing this forces a new resource to be created. **A Storage
+    Service is required if you are using a Platform Image**
 
 * `reverse_dns` - (Optional) The DNS address to which the IP address of the
     hosted service resolves when queried using a reverse DNS query. Changing

--- a/website/source/docs/providers/azure/r/storage_service.html.markdown
+++ b/website/source/docs/providers/azure/r/storage_service.html.markdown
@@ -26,7 +26,7 @@ resource "azure_storage_service" "tfstor" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the storage service. Must be between 4 and 24
-    lowercase-only characters or digits Must be unique on Azure.
+    lowercase-only characters or digits. Must be unique on Azure.
 
 * `location` - (Required) The location where the storage service should be created.
     For a list of all Azure locations, please consult [this link](http://azure.microsoft.com/en-us/regions/).


### PR DESCRIPTION
Currently, when attempting to use a Platform Image without a Storage Service, you get a cryptic and misleading error: 


```
Error applying plan:

1 error(s) occurred:

* azure_instance.web: Could not find image with label 'OpenLogic 6.5'. Available images are: CDH 5.1 Evaluation, Microsoft Azure Site Recovery Configuration Server, Microsoft Azure Site Recovery Configuration Server, Microsoft Azure Site Recovery Master Target Server, Microsoft Azure Site Recovery Master Target Server, Microsoft Azure Site Recovery Process Server, Microsoft Azure Site Recovery Process Server, HDP 2.1.5 with 16 data disks, HDP 2.1.5 with 8 data disks, Hortonworks Sandbox with HDP 2.2.4-2, Hortonworks Sandbox with HDP 2.2, Hortonworks Sandbox with HDP 2.2.4-2v2, Hortonworks Sandbox with HDP 2.2.4-2v3, Hortonworks Sandbox with HDP 2.2.4-2v4, Hortonworks Sandbox with HDP 2.2.4-2v5, ...... 
```

The error is originating here:

- https://github.com/hashicorp/terraform/blob/master/builtin/providers/azure/resource_azure_instance.go#L642-668

But we're swallowing that specific error and returning a more generic one here:

- https://github.com/hashicorp/terraform/blob/master/builtin/providers/azure/resource_azure_instance.go#L589-L595

This obfuscates what the underlying problem is and the user can't self-diagnose and correct. 

My patch does a few things, and we can pick what we like:

- Adds a note to the documentation that Platform Images require a Storage Service
- Introduces a generic `errors` file to consolidate some common errors, but only has a `PlatformStorageError` for now
- Checks for `PlatformStorageError` after `retrieveOSImageDetails`, and returns that error afterwards 


New output:

```
Error applying plan:

1 error(s) occurred:

* azure_instance.web: When using a platform image, the 'storage' parameter is required

```


I've introduced the specific errors here to help trap any errors thrown but also maintain the current fall-through flow in `retrieveImageDetails` (if `retrieveVMImageDetails` errors, then still try `retrieveOSImageDetails`, and error at the end).