### PR TITLE
provider/openstack: add state 'downloading' to resource 'blockstorage_volume_v1'

### DIFF
--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -47,8 +47,8 @@ func testAccPreCheck(t *testing.T) {
 	v1 := os.Getenv("OS_IMAGE_ID")
 	v2 := os.Getenv("OS_IMAGE_NAME")
 
-	if v1 == "" && v2 == "" {
-		t.Fatal("OS_IMAGE_ID or OS_IMAGE_NAME must be set for acceptance tests")
+	if v1 == "" || v2 == "" {
+		t.Fatal("OS_IMAGE_ID and OS_IMAGE_NAME must be set for acceptance tests")
 	}
 
 	v = os.Getenv("OS_POOL_NAME")

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -136,6 +136,7 @@ func resourceBlockStorageVolumeV1Create(d *schema.ResourceData, meta interface{}
 		v.ID)
 
 	stateConf := &resource.StateChangeConf{
+                Pending:    []string{"downloading"},
 		Target:     "available",
 		Refresh:    VolumeV1StateRefreshFunc(blockStorageClient, v.ID),
 		Timeout:    10 * time.Minute,
@@ -267,7 +268,7 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Waiting for volume (%s) to delete", d.Id())
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"deleting", "available"},
+		Pending:    []string{"deleting", "downloading", "available"},
 		Target:     "deleted",
 		Refresh:    VolumeV1StateRefreshFunc(blockStorageClient, d.Id()),
 		Timeout:    10 * time.Minute,

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1_test.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1_test.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -12,6 +13,15 @@ import (
 
 func TestAccBlockStorageV1Volume_basic(t *testing.T) {
 	var volume volumes.Volume
+
+	var testAccBlockStorageV1Volume_bootable = fmt.Sprintf(`
+		resource "openstack_blockstorage_volume_v1" "volume_1" {
+			region = "%s"
+			name = "tf-test-volume-bootable"
+			size = 5
+			image_id = "%s"
+		}`,
+		os.Getenv("OS_REGION_NAME"), os.Getenv("OS_IMAGE_ID"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -31,6 +41,12 @@ func TestAccBlockStorageV1Volume_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("openstack_blockstorage_volume_v1.volume_1", "name", "tf-test-volume-updated"),
 					testAccCheckBlockStorageV1VolumeMetadata(&volume, "foo", "bar"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccBlockStorageV1Volume_bootable,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("openstack_blockstorage_volume_v1.volume_1", "name", "tf-test-volume-bootable"),
 				),
 			},
 		},


### PR DESCRIPTION
When using an image as the source of new volume the state 'downloading'
prior to the state 'available' is fine.

It is also fine to destroy a volume in the state 'downloading'.

Closes-bug: #2865