### PR TITLE
core: fix crash on provider warning

### DIFF
--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -40,9 +40,8 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 		},
 	})
 
-	// Apply stuff
 	seq = append(seq, &EvalOpFilter{
-		Ops: []walkOperation{walkValidate, walkRefresh, walkPlan, walkApply},
+		Ops: []walkOperation{walkValidate},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalGetProvider{
@@ -61,6 +60,32 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 				&EvalValidateProvider{
 					Provider: &provider,
 					Config:   &resourceConfig,
+				},
+				&EvalSetProviderConfig{
+					Provider: n,
+					Config:   &resourceConfig,
+				},
+			},
+		},
+	})
+
+	// Apply stuff
+	seq = append(seq, &EvalOpFilter{
+		Ops: []walkOperation{walkRefresh, walkPlan, walkApply},
+		Node: &EvalSequence{
+			Nodes: []EvalNode{
+				&EvalGetProvider{
+					Name:   n,
+					Output: &provider,
+				},
+				&EvalInterpolate{
+					Config: config,
+					Output: &resourceConfig,
+				},
+				&EvalBuildProviderConfig{
+					Provider: n,
+					Config:   &resourceConfig,
+					Output:   &resourceConfig,
 				},
 				&EvalSetProviderConfig{
 					Provider: n,

--- a/terraform/test-fixtures/apply-provider-warning/main.tf
+++ b/terraform/test-fixtures/apply-provider-warning/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "foo" {}


### PR DESCRIPTION
When a provider validation only returns a warning, we were cutting the
evaltree short by returning an error. This is fine during a
`walkValidate` but was causing trouble during `walkPlan` and
`walkApply`.

fixes #2870