### PR TITLE
Update AWS ASG termination policy code and tests

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -112,12 +112,9 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			},
 
 			"termination_policies": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 
 			"tag": autoscalingTagsSchema(),
@@ -169,9 +166,8 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 		autoScalingGroupOpts.VPCZoneIdentifier = expandVpcZoneIdentifiers(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("termination_policies"); ok && v.(*schema.Set).Len() > 0 {
-		autoScalingGroupOpts.TerminationPolicies = expandStringList(
-			v.(*schema.Set).List())
+	if v, ok := d.GetOk("termination_policies"); ok && len(v.([]interface{})) > 0 {
+		autoScalingGroupOpts.TerminationPolicies = expandStringList(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group create configuration: %#v", autoScalingGroupOpts)
@@ -259,6 +255,24 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("availability_zones") {
 		if v, ok := d.GetOk("availability_zones"); ok && v.(*schema.Set).Len() > 0 {
 			opts.AvailabilityZones = expandStringList(d.Get("availability_zones").(*schema.Set).List())
+		}
+	}
+
+	if d.HasChange("termination_policies") {
+		// If the termination policy is set to null, we need to explicitly set
+		// it back to "Default", or the API won't reset it for us.
+		// This means GetOk() will fail us on the zero check.
+		v := d.Get("termination_policies")
+		if len(v.([]interface{})) > 0 {
+			opts.TerminationPolicies = expandStringList(v.([]interface{}))
+		} else {
+			// Policies is a slice of string pointers, so build one.
+			// Maybe there's a better idiom for this?
+			log.Printf("[DEBUG] Explictly setting null termination policy to 'Default'")
+			pol := "Default"
+			s := make([]*string, 1, 1)
+			s[0] = &pol
+			opts.TerminationPolicies = s
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -45,7 +45,9 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "force_delete", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "termination_policies.912102603", "OldestInstance"),
+						"aws_autoscaling_group.bar", "termination_policies.0", "OldestInstance"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "termination_policies.1", "ClosestToNextInstanceHour"),
 				),
 			},
 
@@ -56,6 +58,8 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.new", &lc),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "desired_capacity", "5"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "termination_policies.0", "ClosestToNextInstanceHour"),
 					testLaunchConfigurationName("aws_autoscaling_group.bar", &lc),
 					testAccCheckAutoscalingTags(&group.Tags, "Bar", map[string]interface{}{
 						"value":               "bar-foo",
@@ -359,7 +363,7 @@ resource "aws_autoscaling_group" "bar" {
   health_check_type = "ELB"
   desired_capacity = 4
   force_delete = true
-  termination_policies = ["OldestInstance"]
+  termination_policies = ["OldestInstance","ClosestToNextInstanceHour"]
 
   launch_configuration = "${aws_launch_configuration.foobar.name}"
 
@@ -391,6 +395,7 @@ resource "aws_autoscaling_group" "bar" {
   health_check_type = "ELB"
   desired_capacity = 5
   force_delete = true
+  termination_policies = ["ClosestToNextInstanceHour"]
 
   launch_configuration = "${aws_launch_configuration.new.name}"
 


### PR DESCRIPTION
The initial PR to handle AWS autoscaling group termination policy was
unfinished (#506).  It only worked on "create", and so had a needless 
ForceNew that would rebuild autoscaling groups on any policy change.

It also used a HashString set, so it didn't preserve ordering of multiple 
policies correctly.  AWS applies termination policies in order, so that matters.

I added the "update" operation, and converted to a TypeList to preserve
ordering.  In addition, removing the policy or setting it to a null list
will reset the policy to "Default", the standard AWS policy.

I updated the acceptance tests to verify the update code, but the null case is
difficult to test automatically.  I manually verified correct behavior of everything
on a sample ASG as well.

The "Default" setting code might benefit from some polishing, Go is not one
of my best languages.  That code's necessity may not be obvious, so I 
commented it and added a debug-level log line for least surprise.