### PR TITLE
provider/aws: Fix issue in Security Group Rules where the Security Group is not found

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -152,7 +152,9 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 	sg_id := d.Get("security_group_id").(string)
 	sg, err := findResourceSecurityGroup(conn, sg_id)
 	if err != nil {
+		log.Printf("[DEBUG] Error finding Secuirty Group (%s) for Rule (%s): %s", sg_id, d.Id(), err)
 		d.SetId("")
+		return nil
 	}
 
 	var rule *ec2.IPPermission
@@ -256,6 +258,7 @@ func findResourceSecurityGroup(conn *ec2.EC2, id string) (*ec2.SecurityGroup, er
 	if err != nil {
 		return nil, err
 	}
+
 	if resp == nil || len(resp.SecurityGroups) != 1 || resp.SecurityGroups[0] == nil {
 		return nil, fmt.Errorf(
 			"Expected to find one security group with ID %q, got: %#v",

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -105,7 +105,7 @@ func TestIpPermissionIDHash(t *testing.T) {
 	}
 }
 
-func TestAccAWSSecurityGroupRule_Ingress(t *testing.T) {
+func TestAccAWSSecurityGroupRule_Ingress_VPC(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testRuleCount := func(*terraform.State) error {
@@ -142,7 +142,7 @@ func TestAccAWSSecurityGroupRule_Ingress(t *testing.T) {
 	})
 }
 
-func TestAccAWSSecurityGroupRule_IngressClassic(t *testing.T) {
+func TestAccAWSSecurityGroupRule_Ingress_Classic(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testRuleCount := func(*terraform.State) error {


### PR DESCRIPTION
After creation, if a security group is destroyed, a Security Group Rule set the id to `""` but did not return, causing a panic down the road. 

This is an alternative to #2797 

Fixes #2845 
Fixes #2593 