### PR TITLE
Support go get in go 1.5 (fixes #2893)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ updatedeps:
 	go list ./... \
 		| xargs go list -f '{{join .Deps "\n"}}' \
 		| grep -v github.com/hashicorp/terraform \
+		| grep -v '/internal/' \
 		| sort -u \
 		| xargs go get -f -u -v
 


### PR DESCRIPTION
I've figured out what was causing the problem with go get in Go 1.5.
When the list of packages was generated, among those there were also packages like ```github.com/aws/aws-sdk-go/internal/endpoints``` which is an internal one and shouldn't be fetched.
This PR attempts to fix that (I really hope that there won't be people putting their dependencies in a folder called ```internal``` and then at least don't rewrite the import path for it```).