### PR TITLE
state/remote/s3: Allows KMS Key Encryption setting when using S3 backend with encrypt

### DIFF
--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -50,7 +50,7 @@ func s3Factory(conf map[string]string) (Client, error) {
 	if raw, ok := conf["acl"]; ok {
 		acl = raw
 	}
-	kmsKeyID := conf["kmsKeyID"]
+	kmsKeyID := conf["kms_key_id"]
 
 	accessKeyId := conf["access_key"]
 	secretAccessKey := conf["secret_key"]

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -149,7 +149,7 @@ func (c *S3Client) Put(data []byte) error {
 
 	if c.serverSideEncryption {
 		if c.kmsKeyID != "" {
-			i.SSEKMSKeyID = &c.kmsKeyID
+			i.SSEKMSKeyId = &c.kmsKeyID
 			i.ServerSideEncryption = aws.String("aws:kms")
 		} else {
 			i.ServerSideEncryption = aws.String("AES256")


### PR DESCRIPTION
This change allows encrypt with AWS KMS key.

Example
```
terraform remote config \
  -backend=s3
  -backend-config="bucket=bucket-tfstate"
  -backend-config="key=terraform.tfstate"
  -backend-config="region=ap-northeast-1"
  -backend-config="encrypt=1"
  -backend-config="kms_key_id=arn:aws:kms:ap-northeast-1:123456789:key/ac54dbd2-f301-42c1-bab9-88e6a84292a9"
```