### PR TITLE
aws_lb_cookie_stickiness_policy can't be created when cookie_expiration_period omitted

### DIFF
--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -41,7 +41,7 @@ func resourceAwsLBCookieStickinessPolicy() *schema.Resource {
 
 			"cookie_expiration_period": &schema.Schema{
 				Type:     schema.TypeInt,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 		},
@@ -53,9 +53,12 @@ func resourceAwsLBCookieStickinessPolicyCreate(d *schema.ResourceData, meta inte
 
 	// Provision the LBStickinessPolicy
 	lbspOpts := &elb.CreateLBCookieStickinessPolicyInput{
-		CookieExpirationPeriod: aws.Int64(int64(d.Get("cookie_expiration_period").(int))),
 		LoadBalancerName:       aws.String(d.Get("load_balancer").(string)),
 		PolicyName:             aws.String(d.Get("name").(string)),
+	}
+
+	if v := d.Get("cookie_expiration_period").(int); v > 0 {
+		lbspOpts.CookieExpirationPeriod = aws.Int64(int64(v))
 	}
 
 	if _, err := elbconn.CreateLBCookieStickinessPolicy(lbspOpts); err != nil {


### PR DESCRIPTION
Cookie expiration periods are optional in AWS, but when the cookie_expiration_period argument is omitted in Terraform it ends up making the AWS request with CookieExpirationPeriod=0, which is rejected.

I don't know enough Go or how Terraform does its internal resolution of what is a destroy / create vs update to know the best way to fix this, but this way works for my (manual) tests, although it makes cookie_expiration_period required, setting it to <= 0 makes the cookie expiry the duration of the browser session. I didn't update the docs as I'm guessing there's a better way of doing this that retains cookie_expiration_period as optional.

I tried to leave cookie_expiration_period as optional, but when an existing policy is updated from having a cookie_expiration_period > 0 to having the argument omitted, Terraform interpreted this as an update and failed:
```
$ terraform apply
aws_elb.lb: Refreshing state... (ID: test-lb)
aws_lb_cookie_stickiness_policy.foo: Refreshing state... (ID: test-lb:80:foo-policy)
aws_lb_cookie_stickiness_policy.foo: Modifying...
  cookie_expiration_period: "300" => "0"
Error applying plan:

1 error(s) occurred:

* aws_lb_cookie_stickiness_policy.foo: Error creating LBCookieStickinessPolicy: DuplicatePolicyName: Policy Name [foo-policy] already exists.
	status code: 400, request id: [b6d5d33a-37ab-11e5-92e9-130cf42989bf]
```

Here's a simple configuration that shows the original bug when cookie_expiration_period is omitted:
```
resource "aws_elb" "lb" {
        name = "test-lb"
        availability_zones = ["us-west-2a"]

        listener {
                instance_port = 8000
                instance_protocol = "http"
                lb_port = 80
                lb_protocol = "http"
        }
}
resource "aws_lb_cookie_stickiness_policy" "foo" {
        name = "foo-policy"
        load_balancer = "${aws_elb.lb.id}"
        lb_port = 80
}
```