### PR TITLE
add note to aws_iam_policy_attachment explaining its use/limitations

### DIFF
--- a/website/source/docs/providers/aws/r/iam_policy_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy_attachment.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Attaches a Managed IAM Policy to user(s), role(s), and/or group(s)
 
+~> **NOTE:** The aws_iam_policy_attachment resource is only meant to be used once for each managed policy. All of the users/roles/groups that a single policy is being attached to should be declared by a single aws_iam_policy_attachment resource.
+
 ```
 resource "aws_iam_user" "user" {
     name = "test-user"


### PR DESCRIPTION
This addition to the documentation should elucidate the implementation of `aws_iam_policy_attachment` to users a bit more.