### PR TITLE
Fix printf verb %s of wrong type

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -392,7 +392,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(lcName)
 
 	log.Printf(
-		"[DEBUG] autoscaling create launch configuration: %s", aws.StringValue(createLaunchConfigurationOpts))
+		"[DEBUG] autoscaling create launch configuration: %s", aws.StringValue(&createLaunchConfigurationOpts))
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
@@ -433,7 +433,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		LaunchConfigurationNames: []*string{aws.String(d.Id())},
 	}
 
-	log.Printf("[DEBUG] launch configuration describe configuration: %s", aws.StringValue(describeOpts))
+	log.Printf("[DEBUG] launch configuration describe configuration: %s", aws.StringValue(&describeOpts))
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -392,7 +392,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(lcName)
 
 	log.Printf(
-		"[DEBUG] autoscaling create launch configuration: %s", createLaunchConfigurationOpts)
+		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
@@ -433,7 +433,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		LaunchConfigurationNames: []*string{aws.String(d.Id())},
 	}
 
-	log.Printf("[DEBUG] launch configuration describe configuration: %s", describeOpts)
+	log.Printf("[DEBUG] launch configuration describe configuration: %#v", describeOpts)
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -392,7 +393,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(lcName)
 
 	log.Printf(
-		"[DEBUG] autoscaling create launch configuration: %s", aws.StringValue(&createLaunchConfigurationOpts))
+		"[DEBUG] autoscaling create launch configuration: %s", awsutil.Prettify(createLaunchConfigurationOpts))
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
@@ -433,7 +434,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		LaunchConfigurationNames: []*string{aws.String(d.Id())},
 	}
 
-	log.Printf("[DEBUG] launch configuration describe configuration: %s", aws.StringValue(&describeOpts))
+	log.Printf("[DEBUG] launch configuration describe configuration: %s", awsutil.Prettify(describeOpts))
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -392,7 +393,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(lcName)
 
 	log.Printf(
-		"[DEBUG] autoscaling create launch configuration: %#v", createLaunchConfigurationOpts)
+		"[DEBUG] autoscaling create launch configuration: %s", awsutil.StringValue(createLaunchConfigurationOpts))
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
@@ -433,7 +434,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		LaunchConfigurationNames: []*string{aws.String(d.Id())},
 	}
 
-	log.Printf("[DEBUG] launch configuration describe configuration: %#v", describeOpts)
+	log.Printf("[DEBUG] launch configuration describe configuration: %s", awsutil.StringValue(describeOpts))
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -393,7 +392,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	createLaunchConfigurationOpts.LaunchConfigurationName = aws.String(lcName)
 
 	log.Printf(
-		"[DEBUG] autoscaling create launch configuration: %s", awsutil.StringValue(createLaunchConfigurationOpts))
+		"[DEBUG] autoscaling create launch configuration: %s", aws.StringValue(createLaunchConfigurationOpts))
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
@@ -434,7 +433,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		LaunchConfigurationNames: []*string{aws.String(d.Id())},
 	}
 
-	log.Printf("[DEBUG] launch configuration describe configuration: %s", awsutil.StringValue(describeOpts))
+	log.Printf("[DEBUG] launch configuration describe configuration: %s", aws.StringValue(describeOpts))
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)


### PR DESCRIPTION
Fixes:

```
make test TEST=./builtin/providers/aws
go generate ./...                                                               TF_ACC= go test ./builtin/providers/aws  -timeout=30s -parallel=4               ok      github.com/hashicorp/terraform.dev/builtin/providers/aws    0.014s      go tool vet -asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr .
builtin/providers/aws/resource_aws_launch_configuration.go:436: arg describeOpts for printf verb %s of wrong type: github.com/aws/aws-sdk-go/service/autoscaling.DescribeLaunchConfigurationsInput

Vet found suspicious constructs. Please check the reported constructs
and fix them if necessary before submitting the code for review.
make[1]: *** [vet] Error 1
make: *** [test] Error 2
```