### PR TITLE
helper/schema: record schema version when destroy fails

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -119,7 +119,7 @@ func (r *Resource) Apply(
 		if s.ID != "" {
 			// Destroy the resource since it is created
 			if err := r.Delete(data, meta); err != nil {
-				return data.State(), err
+				return r.recordCurrentSchemaVersion(data.State()), err
 			}
 
 			// Make sure the ID is gone.

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -180,6 +180,7 @@ func TestResourceApply_destroyPartial(t *testing.T) {
 				Optional: true,
 			},
 		},
+		SchemaVersion: 3,
 	}
 
 	r.Delete = func(d *ResourceData, m interface{}) error {
@@ -209,10 +210,13 @@ func TestResourceApply_destroyPartial(t *testing.T) {
 			"id":  "bar",
 			"foo": "42",
 		},
+		Meta: map[string]string{
+			"schema_version": "3",
+		},
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("expected:\n%#v\n\ngot:\n%#v", expected, actual)
 	}
 }
 


### PR DESCRIPTION
This was just a missed exit from the resource.Apply function -
subsequent refreshes would add the SchemaVersion back into the state,
but having the state recorded once without the meta information can
cause problems with Atlas's remote state checksumming.