### PR TITLE
docs/aws: Fix example of aws_iam_role_policy

### DIFF
--- a/website/source/docs/providers/aws/r/iam_role_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_role_policy.html.markdown
@@ -18,15 +18,16 @@ resource "aws_iam_role_policy" "test_policy" {
     role = "${aws_iam_role.test_role.id}"
     policy = <<EOF
 {
-    "Version": "2008-10-17",
-    "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {"AWS": "*"},
-            "Effect": "Allow",
-            "Sid": ""
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }


### PR DESCRIPTION
`policy` expects policy, not `assume_role_policy`. Those are two different policies.