### PR TITLE
provider/cloudstack: Added loadbalancer support to the provider

### DIFF
--- a/builtin/providers/cloudstack/provider.go
+++ b/builtin/providers/cloudstack/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudstack_firewall":             resourceCloudStackFirewall(),
 			"cloudstack_instance":             resourceCloudStackInstance(),
 			"cloudstack_ipaddress":            resourceCloudStackIPAddress(),
+			"cloudstack_loadbalancer_rule":    resourceCloudStackLoadBalancerRule(),
 			"cloudstack_network":              resourceCloudStackNetwork(),
 			"cloudstack_network_acl":          resourceCloudStackNetworkACL(),
 			"cloudstack_network_acl_rule":     resourceCloudStackNetworkACLRule(),

--- a/builtin/providers/cloudstack/resource_cloudstack_loadbalancer.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_loadbalancer.go
@@ -1,0 +1,236 @@
+package cloudstack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+)
+
+func resourceCloudStackLoadBalancerRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudStackLoadBalancerRuleCreate,
+		Read:   resourceCloudStackLoadBalancerRuleRead,
+		Update: resourceCloudStackLoadBalancerRuleUpdate,
+		Delete: resourceCloudStackLoadBalancerRuleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"ipaddress": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"network": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"algorithm": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"private_port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"public_port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"members": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceCloudStackLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+	d.Partial(true)
+
+	// Create a new parameter struct
+	p := cs.LoadBalancer.NewCreateLoadBalancerRuleParams(
+		d.Get("algorithm").(string),
+		d.Get("name").(string),
+		d.Get("private_port").(int),
+		d.Get("public_port").(int),
+	)
+
+	// Set the description
+	if description, ok := d.GetOk("description"); ok {
+		p.SetDescription(description.(string))
+	} else {
+		p.SetDescription(d.Get("name").(string))
+	}
+
+	// Retrieve the network and the UUID
+	if network, ok := d.GetOk("network"); ok {
+		networkid, e := retrieveUUID(cs, "network", network.(string))
+		if e != nil {
+			return e.Error()
+		}
+
+		// Set the default network ID
+		p.SetNetworkid(networkid)
+	}
+
+	// Retrieve the ipaddress UUID
+	ipaddressid, e := retrieveUUID(cs, "ipaddress", d.Get("ipaddress").(string))
+	if e != nil {
+		return e.Error()
+	}
+	p.SetPublicipid(ipaddressid)
+
+	// Create the load balancer rule
+	r, err := cs.LoadBalancer.CreateLoadBalancerRule(p)
+	if err != nil {
+		return err
+	}
+
+	// Set the load balancer rule UUID and set partials
+	d.SetId(r.Id)
+	d.SetPartial("name")
+	d.SetPartial("description")
+	d.SetPartial("ipaddress")
+	d.SetPartial("network")
+	d.SetPartial("algorithm")
+	d.SetPartial("private_port")
+	d.SetPartial("public_port")
+
+	// Create a new parameter struct
+	ap := cs.LoadBalancer.NewAssignToLoadBalancerRuleParams(r.Id)
+
+	var mbs []string
+	for _, id := range d.Get("members").([]interface{}) {
+		mbs = append(mbs, id.(string))
+	}
+
+	ap.SetVirtualmachineids(mbs)
+
+	_, err = cs.LoadBalancer.AssignToLoadBalancerRule(ap)
+	if err != nil {
+		return err
+	}
+
+	d.SetPartial("members")
+
+	d.Partial(false)
+	return resourceCloudStackLoadBalancerRuleRead(d, meta)
+}
+
+func resourceCloudStackLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	// Get the load balancer details
+	lb, count, err := cs.LoadBalancer.GetLoadBalancerRuleByID(d.Id())
+	if err != nil {
+		if count == 0 {
+			log.Printf("[DEBUG] Load balancer rule %s does no longer exist", d.Get("name").(string))
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("algorithm", lb.Algorithm)
+	d.Set("public_port", lb.Publicport)
+	d.Set("private_port", lb.Privateport)
+
+	// Get the network details
+	network, _, err := cs.Network.GetNetworkByID(lb.Networkid)
+	if err != nil {
+		return err
+	}
+
+	setValueOrUUID(d, "ipaddress", lb.Publicip, lb.Publicipid)
+	setValueOrUUID(d, "network", network.Name, lb.Networkid)
+
+	return nil
+}
+
+func resourceCloudStackLoadBalancerRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	if d.HasChange("name") || d.HasChange("description") || d.HasChange("algorithm") {
+		name := d.Get("name").(string)
+
+		// Create new parameter struct
+		p := cs.LoadBalancer.NewUpdateLoadBalancerRuleParams(d.Id())
+
+		if d.HasChange("name") {
+			log.Printf("[DEBUG] Name has changed for load balancer rule %s, starting update", name)
+
+			p.SetName(name)
+		}
+
+		if d.HasChange("description") {
+			log.Printf(
+				"[DEBUG] Description has changed for load balancer rule %s, starting update", name)
+
+			p.SetDescription(d.Get("description").(string))
+		}
+
+		if d.HasChange("algorithm") {
+			algorithm := d.Get("algorithm").(string)
+
+			log.Printf(
+				"[DEBUG] Algorithm has changed to %s for load balancer rule %s, starting update",
+				algorithm,
+				name,
+			)
+
+			// Set the new Algorithm
+			p.SetAlgorithm(algorithm)
+		}
+
+		_, err := cs.LoadBalancer.UpdateLoadBalancerRule(p)
+		if err != nil {
+			return fmt.Errorf(
+				"Error updating load balancer rule %s", name)
+		}
+	}
+	return resourceCloudStackLoadBalancerRuleRead(d, meta)
+}
+
+func resourceCloudStackLoadBalancerRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	// Create a new parameter struct
+	p := cs.LoadBalancer.NewDeleteLoadBalancerRuleParams(d.Id())
+
+	log.Printf("[INFO] Deleting load balancer rule: %s", d.Get("name").(string))
+	if _, err := cs.LoadBalancer.DeleteLoadBalancerRule(p); err != nil {
+		// This is a very poor way to be told the UUID does no longer exist :(
+		if !strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", d.Id())) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/builtin/providers/cloudstack/resource_cloudstack_loadbalancer_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_loadbalancer_test.go
@@ -1,0 +1,242 @@
+package cloudstack
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+)
+
+func TestAccCloudStackLoadBalancerRule_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackLoadBalancerRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCloudStackLoadBalancerRule_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackLoadBalancerRuleExist("cloudstack_loadbalancer_rule.foo"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "name", "terraform-lb"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "algorithm", "roundrobin"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "public_port", "80"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "private_port", "80"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudStackLoadBalancerRule_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackLoadBalancerRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCloudStackLoadBalancerRule_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackLoadBalancerRuleExist("cloudstack_loadbalancer_rule.foo"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "name", "terraform-lb"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "algorithm", "roundrobin"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "public_port", "80"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "private_port", "80"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccCloudStackLoadBalancerRule_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackLoadBalancerRuleExist("cloudstack_loadbalancer_rule.foo"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "name", "terraform-lb-update"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "algorithm", "leastconn"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "public_port", "443"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "private_port", "443"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudStackLoadBalancerRuleExist(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No loadbalancer rule ID is set")
+		}
+
+		for k, uuid := range rs.Primary.Attributes {
+			if !strings.Contains(k, "uuid") {
+				continue
+			}
+
+			cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+			_, count, err := cs.LoadBalancer.GetLoadBalancerRuleByID(uuid)
+
+			if err != nil {
+				return err
+			}
+
+			if count == 0 {
+				return fmt.Errorf("Loadbalancer rule for %s not found", k)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackLoadBalancerRuleDestroy(s *terraform.State) error {
+	cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudstack_loadbalancer_rule" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Loadbalancer rule ID is set")
+		}
+
+		for k, uuid := range rs.Primary.Attributes {
+			if !strings.Contains(k, "uuid") {
+				continue
+			}
+
+			_, _, err := cs.LoadBalancer.GetLoadBalancerRuleByID(uuid)
+			if err == nil {
+				return fmt.Errorf("Loadbalancer rule %s still exists", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+var testAccCloudStackLoadBalancerRule_basic = fmt.Sprintf(`
+resource "cloudstack_vpc" "foobar" {
+	name = "terraform-vpc"
+	cidr = "%s"
+	vpc_offering = "%s"
+	zone = "%s"
+}
+
+resource "cloudstack_network" "foo" {
+  name = "terraform-network"
+  cidr = "%s"
+  network_offering = "%s"
+  vpc = "${cloudstack_vpc.foobar.name}"
+  zone = "${cloudstack_vpc.foobar.zone}"
+}
+
+resource "cloudstack_ipaddress" "foo" {
+  vpc = "${cloudstack_vpc.foobar.name}"
+}
+
+resource "cloudstack_instance" "foobar1" {
+  name = "terraform-server1"
+  display_name = "terraform"
+  service_offering= "%s"
+  network = "${cloudstack_network.foo.name}"
+  template = "%s"
+  zone = "${cloudstack_network.foo.zone}"
+  user_data = "foobar\nfoo\nbar"
+  expunge = true
+}
+
+resource "cloudstack_loadbalancer_rule" "foo" {
+  name = "terraform-lb"
+  ipaddress = "${cloudstack_ipaddress.foo.ipaddress}"
+  algorithm = "roundrobin"
+  network = "${cloudstack_network.foo.id}"
+  public_port = 80
+  private_port = 80
+  members = ["${cloudstack_instance.foobar1.id}"]
+}`,
+	CLOUDSTACK_VPC_CIDR_1,
+	CLOUDSTACK_VPC_OFFERING,
+	CLOUDSTACK_ZONE,
+	CLOUDSTACK_VPC_NETWORK_CIDR,
+	CLOUDSTACK_VPC_NETWORK_OFFERING,
+	CLOUDSTACK_SERVICE_OFFERING_1,
+	CLOUDSTACK_TEMPLATE)
+
+var testAccCloudStackLoadBalancerRule_update = fmt.Sprintf(`
+resource "cloudstack_vpc" "foobar" {
+    name = "terraform-vpc"
+    cidr = "%s"
+    vpc_offering = "%s"
+    zone = "%s"
+}
+
+resource "cloudstack_network" "foo" {
+  name = "terraform-network"
+  cidr = "%s"
+  network_offering = "%s"
+  vpc = "${cloudstack_vpc.foobar.name}"
+  zone = "${cloudstack_vpc.foobar.zone}"
+}
+
+resource "cloudstack_ipaddress" "foo" {
+  vpc = "${cloudstack_vpc.foobar.name}"
+}
+
+resource "cloudstack_instance" "foobar1" {
+  name = "terraform-server1"
+  display_name = "terraform"
+  service_offering= "%s"
+  network = "${cloudstack_network.foo.name}"
+  template = "%s"
+  zone = "${cloudstack_network.foo.zone}"
+  user_data = "foobar\nfoo\nbar"
+  expunge = true
+}
+
+resource "cloudstack_instance" "foobar2" {
+  name = "terraform-server2"
+  display_name = "terraform"
+  service_offering= "%s"
+  network = "${cloudstack_network.foo.name}"
+  template = "%s"
+  zone = "${cloudstack_network.foo.zone}"
+  user_data = "foobar\nfoo\nbar"
+  expunge = true
+}
+
+resource "cloudstack_loadbalancer_rule" "foo" {
+  name = "terraform-lb-update"
+  ipaddress = "${cloudstack_ipaddress.foo.ipaddress}"
+  algorithm = "leastconn"
+  network = "${cloudstack_network.foo.id}"
+  public_port = 443
+  private_port = 443
+  members = ["${cloudstack_instance.foobar2.id}", "${cloudstack_instance.foobar1.id}"]
+}`,
+	CLOUDSTACK_VPC_CIDR_1,
+	CLOUDSTACK_VPC_OFFERING,
+	CLOUDSTACK_ZONE,
+	CLOUDSTACK_VPC_NETWORK_CIDR,
+	CLOUDSTACK_VPC_NETWORK_OFFERING,
+	CLOUDSTACK_SERVICE_OFFERING_1,
+	CLOUDSTACK_TEMPLATE,
+	CLOUDSTACK_SERVICE_OFFERING_1,
+	CLOUDSTACK_TEMPLATE)

--- a/website/source/docs/providers/cloudstack/r/loadbalancer_rule.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/loadbalancer_rule.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "cloudstack"
+page_title: "CloudStack: cloudstack_loadbalancer_rule"
+sidebar_current: "docs-cloudstack-resource-loadbalancer-rule"
+description: |-
+  Creates a load balancer rule.
+---
+
+# cloudstack\_loadbalancer\_rule
+
+Creates a loadbalancer rule.
+
+## Example Usage
+
+```
+resource "cloudstack_loadbalancer_rule" "default" {
+  name = "loadbalancer-rule-1"
+  description = "Loadbalancer rule 1"
+  ipaddress = "192.168.0.1"
+  algorithm = "roundrobin"
+  private_port = 80
+  public_port = 80
+  members = ["server-1", "server-2"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the loadbalancer rule.
+    Changing this forces a new resource to be created.
+
+* `description` - (Optional) The description of the load balancer rule.
+
+* `ipaddress` - (Required) Public ip address from where the network traffic will be load balanced from.
+    Changing this forces a new resource to be created.
+
+* `network` - (Optional) The guest network this rule will be created for. Required when public Ip address is
+    not associated with any Guest network yet (VPC case).
+
+* `algorithm` - (Required) Load balancer rule algorithm (source, roundrobin, leastconn).Changing this forces
+    a new resource to be created.
+
+* `private_port` - (Required) The private port of the private ip address/virtual machine where the network
+    traffic will be load balanced to. Changing this forces a new resource to be created.
+
+* `public_port` - (Required) The public port from where the network traffic will be load balanced from.
+    Changing this forces a new resource to be created.
+
+* `members` - (Required) List of instances to assign to the load balancer rule. Changing this forces a new
+    resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The load balancer rule ID.
+* `description` - The description of the load balancer rule.

--- a/website/source/layouts/cloudstack.erb
+++ b/website/source/layouts/cloudstack.erb
@@ -33,6 +33,10 @@
                             <a href="/docs/providers/cloudstack/r/ipaddress.html">cloudstack_ipaddress</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-cloudstack-resource-loadbalancer-rule") %>>
+                            <a href="/docs/providers/cloudstack/r/loadbalancer_rule.html">cloudstack_loadbalancer_rule</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-cloudstack-resource-network") %>>
                             <a href="/docs/providers/cloudstack/r/network.html">cloudstack_network</a>
                         </li>


### PR DESCRIPTION
Added load balancer feature to the Cloudstack provider to be able to add a loadbalancer resource to your configuration and load balance your instances from a public IP.