### PR TITLE
provider/aws: WIP Docs for RDS Cluster, Cluster Instance (Aurora)

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -219,6 +219,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_opsworks_ganglia_layer":       resourceAwsOpsworksGangliaLayer(),
 			"aws_opsworks_custom_layer":        resourceAwsOpsworksCustomLayer(),
 			"aws_proxy_protocol_policy":        resourceAwsProxyProtocolPolicy(),
+                        "aws_rds_cluster":                  resourceAwsRDSCluster(),
+                        "aws_rds_cluster_instance":         resourceAwsRDSClusterInstance(),
 			"aws_route53_delegation_set":       resourceAwsRoute53DelegationSet(),
 			"aws_route53_record":               resourceAwsRoute53Record(),
 			"aws_route53_zone_association":     resourceAwsRoute53ZoneAssociation(),

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -75,29 +75,10 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"identifier": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"only lowercase alphanumeric characters and hyphens allowed in %q", k))
-					}
-					if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"first character of %q must be a letter", k))
-					}
-					if regexp.MustCompile(`--`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot contain two consecutive hyphens", k))
-					}
-					if regexp.MustCompile(`-$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot end with a hyphen", k))
-					}
-					return
-				},
+                                Type:         schema.TypeString,
+                                Required:     true,
+                                ForceNew:     true,
+                                ValidateFunc: validateRdsId,
 			},
 
 			"instance_class": &schema.Schema{
@@ -524,7 +505,6 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		if v.DBName != nil && *v.DBName != "" {
 			name = *v.DBName
 		}
-
 		log.Printf("[DEBUG] Error building ARN for DB Instance, not setting Tags for DB %s", name)
 	} else {
 		resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -1,347 +1,347 @@
 package aws
 
 import (
-        "fmt"
-        "log"
-        "regexp"
-        "time"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
 
-        "github.com/aws/aws-sdk-go/aws"
-        "github.com/aws/aws-sdk-go/aws/awserr"
-        "github.com/aws/aws-sdk-go/service/rds"
-        "github.com/hashicorp/terraform/helper/resource"
-        "github.com/hashicorp/terraform/helper/schema"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceAwsRDSCluster() *schema.Resource {
-        return &schema.Resource{
-                Create: resourceAwsRDSClusterCreate,
-                Read:   resourceAwsRDSClusterRead,
-                Update: resourceAwsRDSClusterUpdate,
-                Delete: resourceAwsRDSClusterDelete,
+	return &schema.Resource{
+		Create: resourceAwsRDSClusterCreate,
+		Read:   resourceAwsRDSClusterRead,
+		Update: resourceAwsRDSClusterUpdate,
+		Delete: resourceAwsRDSClusterDelete,
 
-                Schema: map[string]*schema.Schema{
+		Schema: map[string]*schema.Schema{
 
-                        "availability_zones": &schema.Schema{
-                                Type:     schema.TypeSet,
-                                Elem:     &schema.Schema{Type: schema.TypeString},
-                                Optional: true,
-                                ForceNew: true,
-                                Computed: true,
-                                Set:      schema.HashString,
-                        },
+			"availability_zones": &schema.Schema{
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Set:      schema.HashString,
+			},
 
-                        "cluster_identifier": &schema.Schema{
-                                Type:         schema.TypeString,
-                                Required:     true,
-                                ForceNew:     true,
-                                ValidateFunc: validateRdsId,
-                        },
+			"cluster_identifier": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRdsId,
+			},
 
-                        "cluster_members": &schema.Schema{
-                                Type:     schema.TypeSet,
-                                Elem:     &schema.Schema{Type: schema.TypeString},
-                                Optional: true,
-                                Computed: true,
-                                Set:      schema.HashString,
-                        },
+			"cluster_members": &schema.Schema{
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+				Set:      schema.HashString,
+			},
 
-                        "database_name": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                Computed: true,
-                                ForceNew: true,
-                        },
+			"database_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 
-                        "db_subnet_group_name": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                ForceNew: true,
-                                Computed: true,
-                        },
+			"db_subnet_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 
-                        "endpoint": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
+			"endpoint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
-                        "engine": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
+			"engine": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
-                        "final_snapshot_identifier": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-                                        value := v.(string)
-                                        if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
-                                                es = append(es, fmt.Errorf(
-                                                        "only alphanumeric characters and hyphens allowed in %q", k))
-                                        }
-                                        if regexp.MustCompile(`--`).MatchString(value) {
-                                                es = append(es, fmt.Errorf("%q cannot contain two consecutive hyphens", k))
-                                        }
-                                        if regexp.MustCompile(`-$`).MatchString(value) {
-                                                es = append(es, fmt.Errorf("%q cannot end in a hyphen", k))
-                                        }
-                                        return
-                                },
-                        },
+			"final_snapshot_identifier": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"only alphanumeric characters and hyphens allowed in %q", k))
+					}
+					if regexp.MustCompile(`--`).MatchString(value) {
+						es = append(es, fmt.Errorf("%q cannot contain two consecutive hyphens", k))
+					}
+					if regexp.MustCompile(`-$`).MatchString(value) {
+						es = append(es, fmt.Errorf("%q cannot end in a hyphen", k))
+					}
+					return
+				},
+			},
 
-                        "master_username": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Required: true,
-                                ForceNew: true,
-                        },
+			"master_username": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 
-                        "master_password": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Required: true,
-                        },
+			"master_password": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
 
-                        "port": &schema.Schema{
-                                Type:     schema.TypeInt,
-                                Optional: true,
-                                Computed: true,
-                        },
+			"port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 
-                        // apply_immediately is used to determine when the update modifications
-                        // take place.
-                        // See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html
-                        "apply_immediately": &schema.Schema{
-                                Type:     schema.TypeBool,
-                                Optional: true,
-                                Computed: true,
-                        },
+			// apply_immediately is used to determine when the update modifications
+			// take place.
+			// See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html
+			"apply_immediately": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 
-                        "vpc_security_group_ids": &schema.Schema{
-                                Type:     schema.TypeSet,
-                                Optional: true,
-                                Computed: true,
-                                Elem:     &schema.Schema{Type: schema.TypeString},
-                                Set:      schema.HashString,
-                        },
-                },
-        }
+			"vpc_security_group_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
 }
 
 func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error {
-        conn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 
-        createOpts := &rds.CreateDBClusterInput{
-                DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
-                Engine:              aws.String("aurora"),
-                MasterUserPassword:  aws.String(d.Get("master_password").(string)),
-                MasterUsername:      aws.String(d.Get("master_username").(string)),
-        }
+	createOpts := &rds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+		Engine:              aws.String("aurora"),
+		MasterUserPassword:  aws.String(d.Get("master_password").(string)),
+		MasterUsername:      aws.String(d.Get("master_username").(string)),
+	}
 
-        if v := d.Get("database_name"); v.(string) != "" {
-                createOpts.DatabaseName = aws.String(v.(string))
-        }
+	if v := d.Get("database_name"); v.(string) != "" {
+		createOpts.DatabaseName = aws.String(v.(string))
+	}
 
-        if attr, ok := d.GetOk("port"); ok {
-                createOpts.Port = aws.Int64(int64(attr.(int)))
-        }
+	if attr, ok := d.GetOk("port"); ok {
+		createOpts.Port = aws.Int64(int64(attr.(int)))
+	}
 
-        if attr, ok := d.GetOk("db_subnet_group_name"); ok {
-                createOpts.DBSubnetGroupName = aws.String(attr.(string))
-        }
+	if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+		createOpts.DBSubnetGroupName = aws.String(attr.(string))
+	}
 
-        if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-                createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
-        }
+	if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+		createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
+	}
 
-        if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-                createOpts.AvailabilityZones = expandStringList(attr.List())
-        }
+	if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
+		createOpts.AvailabilityZones = expandStringList(attr.List())
+	}
 
-        log.Printf("[DEBUG] RDS Cluster create options: %s", createOpts)
-        resp, err := conn.CreateDBCluster(createOpts)
-        if err != nil {
-                log.Printf("[ERROR] Error creating RDS Cluster: %s", err)
-                return err
-        }
+	log.Printf("[DEBUG] RDS Cluster create options: %s", createOpts)
+	resp, err := conn.CreateDBCluster(createOpts)
+	if err != nil {
+		log.Printf("[ERROR] Error creating RDS Cluster: %s", err)
+		return err
+	}
 
-        log.Printf("[DEBUG]: Cluster create response: %s", resp)
-        d.SetId(*resp.DBCluster.DBClusterIdentifier)
-        stateConf := &resource.StateChangeConf{
-                Pending:    []string{"creating", "backing-up", "modifying"},
-                Target:     "available",
-                Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
-                Timeout:    5 * time.Minute,
-                MinTimeout: 3 * time.Second,
-        }
+	log.Printf("[DEBUG]: Cluster create response: %s", resp)
+	d.SetId(*resp.DBCluster.DBClusterIdentifier)
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating", "backing-up", "modifying"},
+		Target:     "available",
+		Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
+		Timeout:    5 * time.Minute,
+		MinTimeout: 3 * time.Second,
+	}
 
-        // Wait, catching any errors
-        _, err = stateConf.WaitForState()
-        if err != nil {
-                return fmt.Errorf("[WARN] Error waiting for RDS Cluster state to be \"available\": %s", err)
-        }
+	// Wait, catching any errors
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("[WARN] Error waiting for RDS Cluster state to be \"available\": %s", err)
+	}
 
-        return resourceAwsRDSClusterRead(d, meta)
+	return resourceAwsRDSClusterRead(d, meta)
 }
 
 func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
-        conn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 
-        resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
-                DBClusterIdentifier: aws.String(d.Id()),
-        })
+	resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(d.Id()),
+	})
 
-        if err != nil {
-                if awsErr, ok := err.(awserr.Error); ok {
-                        if "DBClusterNotFoundFault" == awsErr.Code() {
-                                d.SetId("")
-                                log.Printf("[DEBUG] RDS Cluster (%s) not found", d.Id())
-                                return nil
-                        }
-                }
-                log.Printf("[DEBUG] Error describing RDS Cluster (%s)", d.Id())
-                return err
-        }
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if "DBClusterNotFoundFault" == awsErr.Code() {
+				d.SetId("")
+				log.Printf("[DEBUG] RDS Cluster (%s) not found", d.Id())
+				return nil
+			}
+		}
+		log.Printf("[DEBUG] Error describing RDS Cluster (%s)", d.Id())
+		return err
+	}
 
-        var dbc *rds.DBCluster
-        for _, c := range resp.DBClusters {
-                if *c.DBClusterIdentifier == d.Id() {
-                        dbc = c
-                }
-        }
+	var dbc *rds.DBCluster
+	for _, c := range resp.DBClusters {
+		if *c.DBClusterIdentifier == d.Id() {
+			dbc = c
+		}
+	}
 
-        if dbc == nil {
-                log.Printf("[WARN] RDS Cluster (%s) not found", d.Id())
-                d.SetId("")
-                return nil
-        }
+	if dbc == nil {
+		log.Printf("[WARN] RDS Cluster (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
 
-        if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
-                return fmt.Errorf("[DEBUG] Error saving AvailabilityZones to state for RDS Cluster (%s): %s", d.Id(), err)
-        }
-        d.Set("database_name", dbc.DatabaseName)
-        d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
-        d.Set("endpoint", dbc.Endpoint)
-        d.Set("engine", dbc.Engine)
-        d.Set("master_username", dbc.MasterUsername)
-        d.Set("port", dbc.Port)
+	if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving AvailabilityZones to state for RDS Cluster (%s): %s", d.Id(), err)
+	}
+	d.Set("database_name", dbc.DatabaseName)
+	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
+	d.Set("endpoint", dbc.Endpoint)
+	d.Set("engine", dbc.Engine)
+	d.Set("master_username", dbc.MasterUsername)
+	d.Set("port", dbc.Port)
 
-        var vpcg []string
-        for _, g := range dbc.VpcSecurityGroups {
-                vpcg = append(vpcg, *g.VpcSecurityGroupId)
-        }
-        if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
-                return fmt.Errorf("[DEBUG] Error saving VPC Security Group IDs to state for RDS Cluster (%s): %s", d.Id(), err)
-        }
+	var vpcg []string
+	for _, g := range dbc.VpcSecurityGroups {
+		vpcg = append(vpcg, *g.VpcSecurityGroupId)
+	}
+	if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving VPC Security Group IDs to state for RDS Cluster (%s): %s", d.Id(), err)
+	}
 
-        var cm []string
-        for _, m := range dbc.DBClusterMembers {
-                cm = append(cm, *m.DBInstanceIdentifier)
-        }
-        if err := d.Set("cluster_members", cm); err != nil {
-                return fmt.Errorf("[DEBUG] Error saving RDS Cluster Members to state for RDS Cluster (%s): %s", d.Id(), err)
-        }
+	var cm []string
+	for _, m := range dbc.DBClusterMembers {
+		cm = append(cm, *m.DBInstanceIdentifier)
+	}
+	if err := d.Set("cluster_members", cm); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving RDS Cluster Members to state for RDS Cluster (%s): %s", d.Id(), err)
+	}
 
-        return nil
+	return nil
 }
 
 func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error {
-        conn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 
-        req := &rds.ModifyDBClusterInput{
-                ApplyImmediately:    aws.Bool(d.Get("apply_immediately").(bool)),
-                DBClusterIdentifier: aws.String(d.Id()),
-        }
+	req := &rds.ModifyDBClusterInput{
+		ApplyImmediately:    aws.Bool(d.Get("apply_immediately").(bool)),
+		DBClusterIdentifier: aws.String(d.Id()),
+	}
 
-        if d.HasChange("master_password") {
-                req.MasterUserPassword = aws.String(d.Get("master_password").(string))
-        }
+	if d.HasChange("master_password") {
+		req.MasterUserPassword = aws.String(d.Get("master_password").(string))
+	}
 
-        if d.HasChange("vpc_security_group_ids") {
-                if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-                        req.VpcSecurityGroupIds = expandStringList(attr.List())
-                } else {
-                        req.VpcSecurityGroupIds = []*string{}
-                }
-        }
+	if d.HasChange("vpc_security_group_ids") {
+		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			req.VpcSecurityGroupIds = expandStringList(attr.List())
+		} else {
+			req.VpcSecurityGroupIds = []*string{}
+		}
+	}
 
-        _, err := conn.ModifyDBCluster(req)
-        if err != nil {
-                return fmt.Errorf("[WARN] Error modifying RDS Cluster (%s): %s", d.Id(), err)
-        }
+	_, err := conn.ModifyDBCluster(req)
+	if err != nil {
+		return fmt.Errorf("[WARN] Error modifying RDS Cluster (%s): %s", d.Id(), err)
+	}
 
-        return resourceAwsRDSClusterRead(d, meta)
+	return resourceAwsRDSClusterRead(d, meta)
 }
 
 func resourceAwsRDSClusterDelete(d *schema.ResourceData, meta interface{}) error {
-        conn := meta.(*AWSClient).rdsconn
-        log.Printf("[DEBUG] Destroying RDS Cluster (%s)", d.Id())
+	conn := meta.(*AWSClient).rdsconn
+	log.Printf("[DEBUG] Destroying RDS Cluster (%s)", d.Id())
 
-        deleteOpts := rds.DeleteDBClusterInput{
-                DBClusterIdentifier: aws.String(d.Id()),
-        }
+	deleteOpts := rds.DeleteDBClusterInput{
+		DBClusterIdentifier: aws.String(d.Id()),
+	}
 
-        finalSnapshot := d.Get("final_snapshot_identifier").(string)
-        if finalSnapshot == "" {
-                deleteOpts.SkipFinalSnapshot = aws.Bool(true)
-        } else {
-                deleteOpts.FinalDBSnapshotIdentifier = aws.String(finalSnapshot)
-                deleteOpts.SkipFinalSnapshot = aws.Bool(false)
-        }
+	finalSnapshot := d.Get("final_snapshot_identifier").(string)
+	if finalSnapshot == "" {
+		deleteOpts.SkipFinalSnapshot = aws.Bool(true)
+	} else {
+		deleteOpts.FinalDBSnapshotIdentifier = aws.String(finalSnapshot)
+		deleteOpts.SkipFinalSnapshot = aws.Bool(false)
+	}
 
-        log.Printf("[DEBUG] RDS Cluster delete options: %s", deleteOpts)
-        _, err := conn.DeleteDBCluster(&deleteOpts)
+	log.Printf("[DEBUG] RDS Cluster delete options: %s", deleteOpts)
+	_, err := conn.DeleteDBCluster(&deleteOpts)
 
-        stateConf := &resource.StateChangeConf{
-                Pending:    []string{"deleting", "backing-up", "modifying"},
-                Target:     "destroyed",
-                Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
-                Timeout:    5 * time.Minute,
-                MinTimeout: 3 * time.Second,
-        }
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deleting", "backing-up", "modifying"},
+		Target:     "destroyed",
+		Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
+		Timeout:    5 * time.Minute,
+		MinTimeout: 3 * time.Second,
+	}
 
-        // Wait, catching any errors
-        _, err = stateConf.WaitForState()
-        if err != nil {
-                return fmt.Errorf("[WARN] Error deleting RDS Cluster (%s): %s", d.Id(), err)
-        }
+	// Wait, catching any errors
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("[WARN] Error deleting RDS Cluster (%s): %s", d.Id(), err)
+	}
 
-        return nil
+	return nil
 }
 
 func resourceAwsRDSClusterStateRefreshFunc(
-        d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
-        return func() (interface{}, string, error) {
-                conn := meta.(*AWSClient).rdsconn
+	d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		conn := meta.(*AWSClient).rdsconn
 
-                resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
-                        DBClusterIdentifier: aws.String(d.Id()),
-                })
+		resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+			DBClusterIdentifier: aws.String(d.Id()),
+		})
 
-                if err != nil {
-                        if awsErr, ok := err.(awserr.Error); ok {
-                                if "DBClusterNotFoundFault" == awsErr.Code() {
-                                        return 42, "destroyed", nil
-                                }
-                        }
-                        log.Printf("[WARN] Error on retrieving DB Cluster (%s) when waiting: %s", d.Id(), err)
-                        return nil, "", err
-                }
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if "DBClusterNotFoundFault" == awsErr.Code() {
+					return 42, "destroyed", nil
+				}
+			}
+			log.Printf("[WARN] Error on retrieving DB Cluster (%s) when waiting: %s", d.Id(), err)
+			return nil, "", err
+		}
 
-                var dbc *rds.DBCluster
+		var dbc *rds.DBCluster
 
-                for _, c := range resp.DBClusters {
-                        if *c.DBClusterIdentifier == d.Id() {
-                                dbc = c
-                        }
-                }
+		for _, c := range resp.DBClusters {
+			if *c.DBClusterIdentifier == d.Id() {
+				dbc = c
+			}
+		}
 
-                if dbc == nil {
-                        return 42, "destroyed", nil
-                }
+		if dbc == nil {
+			return 42, "destroyed", nil
+		}
 
-                if dbc.Status != nil {
-                        log.Printf("[DEBUG] DB Cluster status (%s): %s", d.Id(), *dbc.Status)
-                }
+		if dbc.Status != nil {
+			log.Printf("[DEBUG] DB Cluster status (%s): %s", d.Id(), *dbc.Status)
+		}
 
-                return dbc, *dbc.Status, nil
-        }
+		return dbc, *dbc.Status, nil
+	}
 }

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -1,0 +1,319 @@
+package aws
+
+import (
+        "fmt"
+        "log"
+        "time"
+
+        "github.com/aws/aws-sdk-go/aws"
+        "github.com/aws/aws-sdk-go/aws/awserr"
+        "github.com/aws/aws-sdk-go/service/rds"
+        "github.com/hashicorp/terraform/helper/resource"
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsRDSCluster() *schema.Resource {
+        return &schema.Resource{
+                Create: resourceAwsRDSClusterCreate,
+                Read:   resourceAwsRDSClusterRead,
+                Update: resourceAwsRDSClusterUpdate,
+                Delete: resourceAwsRDSClusterDelete,
+
+                Schema: map[string]*schema.Schema{
+
+                        "availability_zones": &schema.Schema{
+                                Type:     schema.TypeSet,
+                                Elem:     &schema.Schema{Type: schema.TypeString},
+                                Optional: true,
+                                ForceNew: true,
+                                Computed: true,
+                                Set:      schema.HashString,
+                        },
+
+                        "cluster_identifier": &schema.Schema{
+                                Type:         schema.TypeString,
+                                Required:     true,
+                                ForceNew:     true,
+                                ValidateFunc: validateRdsId,
+                        },
+
+                        "cluster_members": &schema.Schema{
+                                Type:     schema.TypeSet,
+                                Elem:     &schema.Schema{Type: schema.TypeString},
+                                Optional: true,
+                                Computed: true,
+                                Set:      schema.HashString,
+                        },
+
+                        "database_name": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Computed: true,
+                                ForceNew: true,
+                        },
+
+                        "db_subnet_group_name": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                ForceNew: true,
+                                Computed: true,
+                        },
+
+                        "endpoint": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Computed: true,
+                        },
+
+                        "engine": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Computed: true,
+                        },
+
+                        "master_username": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                                ForceNew: true,
+                        },
+
+                        "master_password": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+
+                        "port": &schema.Schema{
+                                Type:     schema.TypeInt,
+                                Optional: true,
+                                Computed: true,
+                        },
+
+                        // apply_immediately is used to determine when the update modifications
+                        // take place.
+                        // See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html
+                        "apply_immediately": &schema.Schema{
+                                Type:     schema.TypeBool,
+                                Optional: true,
+                                Computed: true,
+                        },
+
+                        "vpc_security_group_ids": &schema.Schema{
+                                Type:     schema.TypeSet,
+                                Optional: true,
+                                Computed: true,
+                                Elem:     &schema.Schema{Type: schema.TypeString},
+                                Set:      schema.HashString,
+                        },
+                },
+        }
+}
+
+func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error {
+        conn := meta.(*AWSClient).rdsconn
+
+        createOpts := &rds.CreateDBClusterInput{
+                DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+                Engine:              aws.String("aurora"),
+                MasterUserPassword:  aws.String(d.Get("master_password").(string)),
+                MasterUsername:      aws.String(d.Get("master_username").(string)),
+        }
+
+        if v := d.Get("database_name"); v.(string) != "" {
+                createOpts.DatabaseName = aws.String(v.(string))
+        }
+
+        if attr, ok := d.GetOk("port"); ok {
+                createOpts.Port = aws.Int64(int64(attr.(int)))
+        }
+
+        if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+                createOpts.DBSubnetGroupName = aws.String(attr.(string))
+        }
+
+        if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+                createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
+        }
+
+        if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
+                createOpts.AvailabilityZones = expandStringList(attr.List())
+        }
+
+        log.Printf("[DEBUG] RDS Cluster create options: %s", createOpts)
+        resp, err := conn.CreateDBCluster(createOpts)
+        if err != nil {
+                log.Printf("[ERROR] Error creating RDS Cluster: %s", err)
+                return err
+        }
+
+        log.Printf("[DEBUG]: Cluster create response: %s", resp)
+        d.SetId(*resp.DBCluster.DBClusterIdentifier)
+        stateConf := &resource.StateChangeConf{
+                Pending:    []string{"creating", "backing-up", "modifying"},
+                Target:     "available",
+                Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
+                Timeout:    5 * time.Minute,
+                MinTimeout: 3 * time.Second,
+        }
+
+        // Wait, catching any errors
+        _, err = stateConf.WaitForState()
+        if err != nil {
+                return fmt.Errorf("[WARN] Error waiting for RDS Cluster state to be \"available\": %s", err)
+        }
+
+        return resourceAwsRDSClusterRead(d, meta)
+}
+
+func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
+        conn := meta.(*AWSClient).rdsconn
+
+        resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+                DBClusterIdentifier: aws.String(d.Id()),
+                // final snapshot identifier
+        })
+
+        if err != nil {
+                if awsErr, ok := err.(awserr.Error); ok {
+                        if "DBClusterNotFoundFault" == awsErr.Code() {
+                                d.SetId("")
+                                log.Printf("[DEBUG] RDS Cluster (%s) not found", d.Id())
+                                return nil
+                        }
+                }
+                log.Printf("[DEBUG] Error describing RDS Cluster (%s)", d.Id())
+                return err
+        }
+
+        var dbc *rds.DBCluster
+        for _, c := range resp.DBClusters {
+                if *c.DBClusterIdentifier == d.Id() {
+                        dbc = c
+                }
+        }
+
+        if dbc == nil {
+                log.Printf("[WARN] RDS Cluster (%s) not found", d.Id())
+                d.SetId("")
+                return nil
+        }
+
+        if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
+                return fmt.Errorf("[DEBUG] Error saving AvailabilityZones to state for RDS Cluster (%s): %s", d.Id(), err)
+        }
+        d.Set("database_name", dbc.DatabaseName)
+        d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
+        d.Set("endpoint", dbc.Endpoint)
+        d.Set("engine", dbc.Engine)
+        d.Set("master_username", dbc.MasterUsername)
+        d.Set("port", dbc.Port)
+
+        var vpcg []string
+        for _, g := range dbc.VpcSecurityGroups {
+                vpcg = append(vpcg, *g.VpcSecurityGroupId)
+        }
+        if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
+                return fmt.Errorf("[DEBUG] Error saving VPC Security Group IDs to state for RDS Cluster (%s): %s", d.Id(), err)
+        }
+
+        var cm []string
+        for _, m := range dbc.DBClusterMembers {
+                cm = append(cm, *m.DBInstanceIdentifier)
+        }
+        if err := d.Set("cluster_members", cm); err != nil {
+                return fmt.Errorf("[DEBUG] Error saving RDS Cluster Members to state for RDS Cluster (%s): %s", d.Id(), err)
+        }
+
+        return nil
+}
+
+func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+        conn := meta.(*AWSClient).rdsconn
+
+        req := &rds.ModifyDBClusterInput{
+                ApplyImmediately:    aws.Bool(d.Get("apply_immediately").(bool)),
+                DBClusterIdentifier: aws.String(d.Id()),
+        }
+
+        if d.HasChange("master_password") {
+                req.MasterUserPassword = aws.String(d.Get("master_password").(string))
+        }
+
+        if d.HasChange("vpc_security_group_ids") {
+                if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+                        req.VpcSecurityGroupIds = expandStringList(attr.List())
+                } else {
+                        req.VpcSecurityGroupIds = []*string{}
+                }
+        }
+
+        _, err := conn.ModifyDBCluster(req)
+        if err != nil {
+                return fmt.Errorf("[WARN] Error modifying RDS Cluster (%s): %s", d.Id(), err)
+        }
+
+        return resourceAwsRDSClusterRead(d, meta)
+}
+
+func resourceAwsRDSClusterDelete(d *schema.ResourceData, meta interface{}) error {
+        conn := meta.(*AWSClient).rdsconn
+        log.Printf("[DEBUG] Destroying RDS Cluster (%s)", d.Id())
+
+        _, err := conn.DeleteDBCluster(&rds.DeleteDBClusterInput{
+                DBClusterIdentifier: aws.String(d.Id()),
+                SkipFinalSnapshot:   aws.Bool(true),
+                // final snapshot identifier
+        })
+
+        stateConf := &resource.StateChangeConf{
+                Pending:    []string{"deleting", "backing-up", "modifying"},
+                Target:     "destroyed",
+                Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
+                Timeout:    5 * time.Minute,
+                MinTimeout: 3 * time.Second,
+        }
+
+        // Wait, catching any errors
+        _, err = stateConf.WaitForState()
+        if err != nil {
+                return fmt.Errorf("[WARN] Error deleting RDS Cluster (%s): %s", d.Id(), err)
+        }
+
+        return nil
+}
+
+func resourceAwsRDSClusterStateRefreshFunc(
+        d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+        return func() (interface{}, string, error) {
+                conn := meta.(*AWSClient).rdsconn
+
+                resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+                        DBClusterIdentifier: aws.String(d.Id()),
+                })
+
+                if err != nil {
+                        if awsErr, ok := err.(awserr.Error); ok {
+                                if "DBClusterNotFoundFault" == awsErr.Code() {
+                                        return 42, "destroyed", nil
+                                }
+                        }
+                        log.Printf("[WARN] Error on retrieving DB Cluster (%s) when waiting: %s", d.Id(), err)
+                        return nil, "", err
+                }
+
+                var dbc *rds.DBCluster
+
+                for _, c := range resp.DBClusters {
+                        if *c.DBClusterIdentifier == d.Id() {
+                                dbc = c
+                        }
+                }
+
+                if dbc == nil {
+                        return 42, "destroyed", nil
+                }
+
+                if dbc.Status != nil {
+                        log.Printf("[DEBUG] DB Cluster status (%s): %s", d.Id(), *dbc.Status)
+                }
+
+                return dbc, *dbc.Status, nil
+        }
+}

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -1,0 +1,210 @@
+package aws
+
+import (
+        "fmt"
+        "log"
+        "time"
+
+        "github.com/aws/aws-sdk-go/aws"
+        "github.com/aws/aws-sdk-go/service/rds"
+        "github.com/hashicorp/terraform/helper/resource"
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsRDSClusterInstance() *schema.Resource {
+        return &schema.Resource{
+                Create: resourceAwsRDSClusterInstanceCreate,
+                Read:   resourceAwsRDSClusterInstanceRead,
+                Update: resourceAwsRDSClusterInstanceUpdate,
+                Delete: resourceAwsRDSClusterInstanceDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "identifier": &schema.Schema{
+                                Type:         schema.TypeString,
+                                Optional:     true,
+                                ForceNew:     true,
+                                ValidateFunc: validateRdsId,
+                        },
+
+                        "db_subnet_group_name": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                ForceNew: true,
+                                Computed: true,
+                        },
+
+                        "writer": &schema.Schema{
+                                Type:     schema.TypeBool,
+                                Computed: true,
+                        },
+
+                        "cluster_identifier": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                                ForceNew: true,
+                        },
+
+                        "endpoint": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Computed: true,
+                        },
+
+                        "port": &schema.Schema{
+                                Type:     schema.TypeInt,
+                                Computed: true,
+                        },
+
+                        "instance_class": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                                ForceNew: true,
+                        },
+
+                        "tags": tagsSchema(),
+                },
+        }
+}
+
+func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+        conn := meta.(*AWSClient).rdsconn
+        tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
+
+        createOpts := &rds.CreateDBInstanceInput{
+                DBInstanceClass:     aws.String(d.Get("instance_class").(string)),
+                DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+                Engine:              aws.String("aurora"),
+                Tags:                tags,
+        }
+
+        if v := d.Get("identifier").(string); v != "" {
+                createOpts.DBInstanceIdentifier = aws.String(v)
+        } else {
+                createOpts.DBInstanceIdentifier = aws.String(resource.UniqueId())
+        }
+
+        if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+                createOpts.DBSubnetGroupName = aws.String(attr.(string))
+        }
+
+        log.Printf("[DEBUG] Creating RDS DB Instance opts: %s", createOpts)
+        resp, err := conn.CreateDBInstance(createOpts)
+        if err != nil {
+                return err
+        }
+
+        d.SetId(*resp.DBInstance.DBInstanceIdentifier)
+
+        // reuse db_instance refresh func
+        stateConf := &resource.StateChangeConf{
+                Pending:    []string{"creating", "backing-up", "modifying"},
+                Target:     "available",
+                Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
+                Timeout:    40 * time.Minute,
+                MinTimeout: 10 * time.Second,
+                Delay:      10 * time.Second,
+        }
+
+        // Wait, catching any errors
+        _, err = stateConf.WaitForState()
+        if err != nil {
+                return err
+        }
+
+        return resourceAwsRDSClusterInstanceRead(d, meta)
+}
+
+func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{}) error {
+        db, err := resourceAwsDbInstanceRetrieve(d, meta)
+        if err != nil {
+                log.Printf("[WARN] Error on retrieving RDS Cluster Instance (%s): %s", d.Id(), err)
+                d.SetId("")
+                return nil
+        }
+
+        // Retreive DB Cluster information, to determine if this Instance is a writer
+        conn := meta.(*AWSClient).rdsconn
+        resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+                DBClusterIdentifier: db.DBClusterIdentifier,
+        })
+
+        var dbc *rds.DBCluster
+        for _, c := range resp.DBClusters {
+                if *c.DBClusterIdentifier == *db.DBClusterIdentifier {
+                        dbc = c
+                }
+        }
+
+        if dbc == nil {
+                return fmt.Errorf("[WARN] Error finding RDS Cluster (%s) for Cluster Instance (%s): %s",
+                        *db.DBClusterIdentifier, *db.DBInstanceIdentifier, err)
+        }
+
+        for _, m := range dbc.DBClusterMembers {
+                if *db.DBInstanceIdentifier == *m.DBInstanceIdentifier {
+                        if *m.IsClusterWriter == true {
+                                d.Set("writer", true)
+                        } else {
+                                d.Set("writer", false)
+                        }
+                }
+        }
+
+        if db.Endpoint != nil {
+                d.Set("endpoint", db.Endpoint.Address)
+                d.Set("port", db.Endpoint.Port)
+        }
+
+        // Fetch and save tags
+        arn, err := buildRDSARN(d, meta)
+        if err != nil {
+                log.Printf("[DEBUG] Error building ARN for RDS Cluster Instance (%s), not setting Tags", *db.DBInstanceIdentifier)
+        } else {
+                if err := saveTagsRDS(conn, d, arn); err != nil {
+                        log.Printf("[WARN] Failed to save tags for RDS Cluster Instance (%s): %s", *db.DBClusterIdentifier, err)
+                }
+        }
+
+        return nil
+}
+
+func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+        conn := meta.(*AWSClient).rdsconn
+
+        if arn, err := buildRDSARN(d, meta); err == nil {
+                if err := setTagsRDS(conn, d, arn); err != nil {
+                        return err
+                }
+        }
+
+        return resourceAwsRDSClusterInstanceRead(d, meta)
+}
+
+func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+        conn := meta.(*AWSClient).rdsconn
+
+        log.Printf("[DEBUG] RDS Cluster Instance destroy: %v", d.Id())
+
+        opts := rds.DeleteDBInstanceInput{DBInstanceIdentifier: aws.String(d.Id())}
+
+        log.Printf("[DEBUG] RDS Cluster Instance destroy configuration: %s", opts)
+        if _, err := conn.DeleteDBInstance(&opts); err != nil {
+                return err
+        }
+
+        // re-uses db_instance refresh func
+        log.Println("[INFO] Waiting for RDS Cluster Instance to be destroyed")
+        stateConf := &resource.StateChangeConf{
+                Pending:    []string{"modifying", "deleting"},
+                Target:     "",
+                Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
+                Timeout:    40 * time.Minute,
+                MinTimeout: 10 * time.Second,
+        }
+
+        if _, err := stateConf.WaitForState(); err != nil {
+                return err
+        }
+
+        return nil
+
+}

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -54,6 +54,13 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
                                 Computed: true,
                         },
 
+                        "publicly_accessible": &schema.Schema{
+                                Type:     schema.TypeBool,
+                                Optional: true,
+                                Default:  false,
+                                ForceNew: true,
+                        },
+
                         "instance_class": &schema.Schema{
                                 Type:     schema.TypeString,
                                 Required: true,
@@ -73,6 +80,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
                 DBInstanceClass:     aws.String(d.Get("instance_class").(string)),
                 DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
                 Engine:              aws.String("aurora"),
+                PubliclyAccessible:  aws.Bool(d.Get("publicly_accessible").(bool)),
                 Tags:                tags,
         }
 
@@ -153,6 +161,8 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
                 d.Set("endpoint", db.Endpoint.Address)
                 d.Set("port", db.Endpoint.Port)
         }
+
+        d.Set("publicly_accessible", db.PubliclyAccessible)
 
         // Fetch and save tags
         arn, err := buildRDSARN(d, meta)

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -1,220 +1,220 @@
 package aws
 
 import (
-        "fmt"
-        "log"
-        "time"
+	"fmt"
+	"log"
+	"time"
 
-        "github.com/aws/aws-sdk-go/aws"
-        "github.com/aws/aws-sdk-go/service/rds"
-        "github.com/hashicorp/terraform/helper/resource"
-        "github.com/hashicorp/terraform/helper/schema"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceAwsRDSClusterInstance() *schema.Resource {
-        return &schema.Resource{
-                Create: resourceAwsRDSClusterInstanceCreate,
-                Read:   resourceAwsRDSClusterInstanceRead,
-                Update: resourceAwsRDSClusterInstanceUpdate,
-                Delete: resourceAwsRDSClusterInstanceDelete,
+	return &schema.Resource{
+		Create: resourceAwsRDSClusterInstanceCreate,
+		Read:   resourceAwsRDSClusterInstanceRead,
+		Update: resourceAwsRDSClusterInstanceUpdate,
+		Delete: resourceAwsRDSClusterInstanceDelete,
 
-                Schema: map[string]*schema.Schema{
-                        "identifier": &schema.Schema{
-                                Type:         schema.TypeString,
-                                Optional:     true,
-                                ForceNew:     true,
-                                ValidateFunc: validateRdsId,
-                        },
+		Schema: map[string]*schema.Schema{
+			"identifier": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRdsId,
+			},
 
-                        "db_subnet_group_name": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                ForceNew: true,
-                                Computed: true,
-                        },
+			"db_subnet_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 
-                        "writer": &schema.Schema{
-                                Type:     schema.TypeBool,
-                                Computed: true,
-                        },
+			"writer": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 
-                        "cluster_identifier": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Required: true,
-                                ForceNew: true,
-                        },
+			"cluster_identifier": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 
-                        "endpoint": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
+			"endpoint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
-                        "port": &schema.Schema{
-                                Type:     schema.TypeInt,
-                                Computed: true,
-                        },
+			"port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 
-                        "publicly_accessible": &schema.Schema{
-                                Type:     schema.TypeBool,
-                                Optional: true,
-                                Default:  false,
-                                ForceNew: true,
-                        },
+			"publicly_accessible": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 
-                        "instance_class": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Required: true,
-                                ForceNew: true,
-                        },
+			"instance_class": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 
-                        "tags": tagsSchema(),
-                },
-        }
+			"tags": tagsSchema(),
+		},
+	}
 }
 
 func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{}) error {
-        conn := meta.(*AWSClient).rdsconn
-        tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
+	conn := meta.(*AWSClient).rdsconn
+	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
-        createOpts := &rds.CreateDBInstanceInput{
-                DBInstanceClass:     aws.String(d.Get("instance_class").(string)),
-                DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
-                Engine:              aws.String("aurora"),
-                PubliclyAccessible:  aws.Bool(d.Get("publicly_accessible").(bool)),
-                Tags:                tags,
-        }
+	createOpts := &rds.CreateDBInstanceInput{
+		DBInstanceClass:     aws.String(d.Get("instance_class").(string)),
+		DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+		Engine:              aws.String("aurora"),
+		PubliclyAccessible:  aws.Bool(d.Get("publicly_accessible").(bool)),
+		Tags:                tags,
+	}
 
-        if v := d.Get("identifier").(string); v != "" {
-                createOpts.DBInstanceIdentifier = aws.String(v)
-        } else {
-                createOpts.DBInstanceIdentifier = aws.String(resource.UniqueId())
-        }
+	if v := d.Get("identifier").(string); v != "" {
+		createOpts.DBInstanceIdentifier = aws.String(v)
+	} else {
+		createOpts.DBInstanceIdentifier = aws.String(resource.UniqueId())
+	}
 
-        if attr, ok := d.GetOk("db_subnet_group_name"); ok {
-                createOpts.DBSubnetGroupName = aws.String(attr.(string))
-        }
+	if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+		createOpts.DBSubnetGroupName = aws.String(attr.(string))
+	}
 
-        log.Printf("[DEBUG] Creating RDS DB Instance opts: %s", createOpts)
-        resp, err := conn.CreateDBInstance(createOpts)
-        if err != nil {
-                return err
-        }
+	log.Printf("[DEBUG] Creating RDS DB Instance opts: %s", createOpts)
+	resp, err := conn.CreateDBInstance(createOpts)
+	if err != nil {
+		return err
+	}
 
-        d.SetId(*resp.DBInstance.DBInstanceIdentifier)
+	d.SetId(*resp.DBInstance.DBInstanceIdentifier)
 
-        // reuse db_instance refresh func
-        stateConf := &resource.StateChangeConf{
-                Pending:    []string{"creating", "backing-up", "modifying"},
-                Target:     "available",
-                Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-                Timeout:    40 * time.Minute,
-                MinTimeout: 10 * time.Second,
-                Delay:      10 * time.Second,
-        }
+	// reuse db_instance refresh func
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating", "backing-up", "modifying"},
+		Target:     "available",
+		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
+		Timeout:    40 * time.Minute,
+		MinTimeout: 10 * time.Second,
+		Delay:      10 * time.Second,
+	}
 
-        // Wait, catching any errors
-        _, err = stateConf.WaitForState()
-        if err != nil {
-                return err
-        }
+	// Wait, catching any errors
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
 
-        return resourceAwsRDSClusterInstanceRead(d, meta)
+	return resourceAwsRDSClusterInstanceRead(d, meta)
 }
 
 func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{}) error {
-        db, err := resourceAwsDbInstanceRetrieve(d, meta)
-        if err != nil {
-                log.Printf("[WARN] Error on retrieving RDS Cluster Instance (%s): %s", d.Id(), err)
-                d.SetId("")
-                return nil
-        }
+	db, err := resourceAwsDbInstanceRetrieve(d, meta)
+	if err != nil {
+		log.Printf("[WARN] Error on retrieving RDS Cluster Instance (%s): %s", d.Id(), err)
+		d.SetId("")
+		return nil
+	}
 
-        // Retreive DB Cluster information, to determine if this Instance is a writer
-        conn := meta.(*AWSClient).rdsconn
-        resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
-                DBClusterIdentifier: db.DBClusterIdentifier,
-        })
+	// Retreive DB Cluster information, to determine if this Instance is a writer
+	conn := meta.(*AWSClient).rdsconn
+	resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: db.DBClusterIdentifier,
+	})
 
-        var dbc *rds.DBCluster
-        for _, c := range resp.DBClusters {
-                if *c.DBClusterIdentifier == *db.DBClusterIdentifier {
-                        dbc = c
-                }
-        }
+	var dbc *rds.DBCluster
+	for _, c := range resp.DBClusters {
+		if *c.DBClusterIdentifier == *db.DBClusterIdentifier {
+			dbc = c
+		}
+	}
 
-        if dbc == nil {
-                return fmt.Errorf("[WARN] Error finding RDS Cluster (%s) for Cluster Instance (%s): %s",
-                        *db.DBClusterIdentifier, *db.DBInstanceIdentifier, err)
-        }
+	if dbc == nil {
+		return fmt.Errorf("[WARN] Error finding RDS Cluster (%s) for Cluster Instance (%s): %s",
+			*db.DBClusterIdentifier, *db.DBInstanceIdentifier, err)
+	}
 
-        for _, m := range dbc.DBClusterMembers {
-                if *db.DBInstanceIdentifier == *m.DBInstanceIdentifier {
-                        if *m.IsClusterWriter == true {
-                                d.Set("writer", true)
-                        } else {
-                                d.Set("writer", false)
-                        }
-                }
-        }
+	for _, m := range dbc.DBClusterMembers {
+		if *db.DBInstanceIdentifier == *m.DBInstanceIdentifier {
+			if *m.IsClusterWriter == true {
+				d.Set("writer", true)
+			} else {
+				d.Set("writer", false)
+			}
+		}
+	}
 
-        if db.Endpoint != nil {
-                d.Set("endpoint", db.Endpoint.Address)
-                d.Set("port", db.Endpoint.Port)
-        }
+	if db.Endpoint != nil {
+		d.Set("endpoint", db.Endpoint.Address)
+		d.Set("port", db.Endpoint.Port)
+	}
 
-        d.Set("publicly_accessible", db.PubliclyAccessible)
+	d.Set("publicly_accessible", db.PubliclyAccessible)
 
-        // Fetch and save tags
-        arn, err := buildRDSARN(d, meta)
-        if err != nil {
-                log.Printf("[DEBUG] Error building ARN for RDS Cluster Instance (%s), not setting Tags", *db.DBInstanceIdentifier)
-        } else {
-                if err := saveTagsRDS(conn, d, arn); err != nil {
-                        log.Printf("[WARN] Failed to save tags for RDS Cluster Instance (%s): %s", *db.DBClusterIdentifier, err)
-                }
-        }
+	// Fetch and save tags
+	arn, err := buildRDSARN(d, meta)
+	if err != nil {
+		log.Printf("[DEBUG] Error building ARN for RDS Cluster Instance (%s), not setting Tags", *db.DBInstanceIdentifier)
+	} else {
+		if err := saveTagsRDS(conn, d, arn); err != nil {
+			log.Printf("[WARN] Failed to save tags for RDS Cluster Instance (%s): %s", *db.DBClusterIdentifier, err)
+		}
+	}
 
-        return nil
+	return nil
 }
 
 func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-        conn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 
-        if arn, err := buildRDSARN(d, meta); err == nil {
-                if err := setTagsRDS(conn, d, arn); err != nil {
-                        return err
-                }
-        }
+	if arn, err := buildRDSARN(d, meta); err == nil {
+		if err := setTagsRDS(conn, d, arn); err != nil {
+			return err
+		}
+	}
 
-        return resourceAwsRDSClusterInstanceRead(d, meta)
+	return resourceAwsRDSClusterInstanceRead(d, meta)
 }
 
 func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{}) error {
-        conn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 
-        log.Printf("[DEBUG] RDS Cluster Instance destroy: %v", d.Id())
+	log.Printf("[DEBUG] RDS Cluster Instance destroy: %v", d.Id())
 
-        opts := rds.DeleteDBInstanceInput{DBInstanceIdentifier: aws.String(d.Id())}
+	opts := rds.DeleteDBInstanceInput{DBInstanceIdentifier: aws.String(d.Id())}
 
-        log.Printf("[DEBUG] RDS Cluster Instance destroy configuration: %s", opts)
-        if _, err := conn.DeleteDBInstance(&opts); err != nil {
-                return err
-        }
+	log.Printf("[DEBUG] RDS Cluster Instance destroy configuration: %s", opts)
+	if _, err := conn.DeleteDBInstance(&opts); err != nil {
+		return err
+	}
 
-        // re-uses db_instance refresh func
-        log.Println("[INFO] Waiting for RDS Cluster Instance to be destroyed")
-        stateConf := &resource.StateChangeConf{
-                Pending:    []string{"modifying", "deleting"},
-                Target:     "",
-                Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-                Timeout:    40 * time.Minute,
-                MinTimeout: 10 * time.Second,
-        }
+	// re-uses db_instance refresh func
+	log.Println("[INFO] Waiting for RDS Cluster Instance to be destroyed")
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"modifying", "deleting"},
+		Target:     "",
+		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
+		Timeout:    40 * time.Minute,
+		MinTimeout: 10 * time.Second,
+	}
 
-        if _, err := stateConf.WaitForState(); err != nil {
-                return err
-        }
+	if _, err := stateConf.WaitForState(); err != nil {
+		return err
+	}
 
-        return nil
+	return nil
 
 }

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -11,6 +11,7 @@ import (
         "github.com/hashicorp/terraform/terraform"
 
         "github.com/aws/aws-sdk-go/aws"
+        "github.com/aws/aws-sdk-go/aws/awserr"
         "github.com/aws/aws-sdk-go/service/rds"
 )
 
@@ -54,7 +55,13 @@ func testAccCheckAWSClusterInstanceDestroy(s *terraform.State) error {
                         }
                 }
 
-                //check for an expected "Cluster not found" type error
+                // Return nil if the Cluster Instance is already destroyed
+                if awsErr, ok := err.(awserr.Error); ok {
+                        if awsErr.Code() == "DBInstanceNotFound" {
+                                return nil
+                        }
+                }
+
                 return err
 
         }

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+        "fmt"
+        "math/rand"
+        "strings"
+        "testing"
+        "time"
+
+        "github.com/hashicorp/terraform/helper/resource"
+        "github.com/hashicorp/terraform/terraform"
+
+        "github.com/aws/aws-sdk-go/aws"
+        "github.com/aws/aws-sdk-go/service/rds"
+)
+
+func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
+        var v rds.DBInstance
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckAWSClusterDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccAWSClusterInstanceConfig,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+                                        testAccCheckAWSDBClusterInstanceAttributes(&v),
+                                ),
+                        },
+                },
+        })
+}
+
+func testAccCheckAWSClusterInstanceDestroy(s *terraform.State) error {
+        for _, rs := range s.RootModule().Resources {
+                if rs.Type != "aws_rds_cluster" {
+                        continue
+                }
+
+                // Try to find the Group
+                conn := testAccProvider.Meta().(*AWSClient).rdsconn
+                var err error
+                resp, err := conn.DescribeDBInstances(
+                        &rds.DescribeDBInstancesInput{
+                                DBInstanceIdentifier: aws.String(rs.Primary.ID),
+                        })
+
+                if err == nil {
+                        if len(resp.DBInstances) != 0 &&
+                                *resp.DBInstances[0].DBInstanceIdentifier == rs.Primary.ID {
+                                return fmt.Errorf("DB Cluster Instance %s still exists", rs.Primary.ID)
+                        }
+                }
+
+                //check for an expected "Cluster not found" type error
+                return err
+
+        }
+
+        return nil
+}
+
+func testAccCheckAWSDBClusterInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
+        return func(s *terraform.State) error {
+
+                if *v.Engine != "aurora" {
+                        return fmt.Errorf("bad engine, expected \"aurora\": %#v", *v.Engine)
+                }
+
+                if !strings.HasPrefix(*v.DBClusterIdentifier, "tf-aurora-cluster") {
+                        return fmt.Errorf("Bad Cluster Identifier prefix:\nexpected: %s\ngot: %s", "tf-aurora-cluster", *v.DBClusterIdentifier)
+                }
+
+                return nil
+        }
+}
+
+func testAccCheckAWSClusterInstanceExists(n string, v *rds.DBInstance) resource.TestCheckFunc {
+        return func(s *terraform.State) error {
+                rs, ok := s.RootModule().Resources[n]
+                if !ok {
+                        return fmt.Errorf("Not found: %s", n)
+                }
+
+                if rs.Primary.ID == "" {
+                        return fmt.Errorf("No DB Instance ID is set")
+                }
+
+                conn := testAccProvider.Meta().(*AWSClient).rdsconn
+                resp, err := conn.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+                        DBInstanceIdentifier: aws.String(rs.Primary.ID),
+                })
+
+                if err != nil {
+                        return err
+                }
+
+                for _, d := range resp.DBInstances {
+                        if *d.DBInstanceIdentifier == rs.Primary.ID {
+                                *v = *d
+                                return nil
+                        }
+                }
+
+                return fmt.Errorf("DB Cluster (%s) not found", rs.Primary.ID)
+        }
+}
+
+// Add some random to the name, to avoid collision
+var testAccAWSClusterInstanceConfig = fmt.Sprintf(`
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-test-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+}
+
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  identifier = "aurora-cluster-test-instance"
+        cluster_identifier = "${aws_rds_cluster.default.id}"
+  instance_class = "db.r3.large"
+}
+
+`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -1,118 +1,118 @@
 package aws
 
 import (
-        "fmt"
-        "math/rand"
-        "strings"
-        "testing"
-        "time"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
 
-        "github.com/hashicorp/terraform/helper/resource"
-        "github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 
-        "github.com/aws/aws-sdk-go/aws"
-        "github.com/aws/aws-sdk-go/aws/awserr"
-        "github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/rds"
 )
 
 func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
-        var v rds.DBInstance
+	var v rds.DBInstance
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckAWSClusterDestroy,
-                Steps: []resource.TestStep{
-                        resource.TestStep{
-                                Config: testAccAWSClusterInstanceConfig,
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
-                                        testAccCheckAWSDBClusterInstanceAttributes(&v),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSClusterInstanceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSDBClusterInstanceAttributes(&v),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckAWSClusterInstanceDestroy(s *terraform.State) error {
-        for _, rs := range s.RootModule().Resources {
-                if rs.Type != "aws_rds_cluster" {
-                        continue
-                }
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_rds_cluster" {
+			continue
+		}
 
-                // Try to find the Group
-                conn := testAccProvider.Meta().(*AWSClient).rdsconn
-                var err error
-                resp, err := conn.DescribeDBInstances(
-                        &rds.DescribeDBInstancesInput{
-                                DBInstanceIdentifier: aws.String(rs.Primary.ID),
-                        })
+		// Try to find the Group
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
+		var err error
+		resp, err := conn.DescribeDBInstances(
+			&rds.DescribeDBInstancesInput{
+				DBInstanceIdentifier: aws.String(rs.Primary.ID),
+			})
 
-                if err == nil {
-                        if len(resp.DBInstances) != 0 &&
-                                *resp.DBInstances[0].DBInstanceIdentifier == rs.Primary.ID {
-                                return fmt.Errorf("DB Cluster Instance %s still exists", rs.Primary.ID)
-                        }
-                }
+		if err == nil {
+			if len(resp.DBInstances) != 0 &&
+				*resp.DBInstances[0].DBInstanceIdentifier == rs.Primary.ID {
+				return fmt.Errorf("DB Cluster Instance %s still exists", rs.Primary.ID)
+			}
+		}
 
-                // Return nil if the Cluster Instance is already destroyed
-                if awsErr, ok := err.(awserr.Error); ok {
-                        if awsErr.Code() == "DBInstanceNotFound" {
-                                return nil
-                        }
-                }
+		// Return nil if the Cluster Instance is already destroyed
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "DBInstanceNotFound" {
+				return nil
+			}
+		}
 
-                return err
+		return err
 
-        }
+	}
 
-        return nil
+	return nil
 }
 
 func testAccCheckAWSDBClusterInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
-        return func(s *terraform.State) error {
+	return func(s *terraform.State) error {
 
-                if *v.Engine != "aurora" {
-                        return fmt.Errorf("bad engine, expected \"aurora\": %#v", *v.Engine)
-                }
+		if *v.Engine != "aurora" {
+			return fmt.Errorf("bad engine, expected \"aurora\": %#v", *v.Engine)
+		}
 
-                if !strings.HasPrefix(*v.DBClusterIdentifier, "tf-aurora-cluster") {
-                        return fmt.Errorf("Bad Cluster Identifier prefix:\nexpected: %s\ngot: %s", "tf-aurora-cluster", *v.DBClusterIdentifier)
-                }
+		if !strings.HasPrefix(*v.DBClusterIdentifier, "tf-aurora-cluster") {
+			return fmt.Errorf("Bad Cluster Identifier prefix:\nexpected: %s\ngot: %s", "tf-aurora-cluster", *v.DBClusterIdentifier)
+		}
 
-                return nil
-        }
+		return nil
+	}
 }
 
 func testAccCheckAWSClusterInstanceExists(n string, v *rds.DBInstance) resource.TestCheckFunc {
-        return func(s *terraform.State) error {
-                rs, ok := s.RootModule().Resources[n]
-                if !ok {
-                        return fmt.Errorf("Not found: %s", n)
-                }
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
 
-                if rs.Primary.ID == "" {
-                        return fmt.Errorf("No DB Instance ID is set")
-                }
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DB Instance ID is set")
+		}
 
-                conn := testAccProvider.Meta().(*AWSClient).rdsconn
-                resp, err := conn.DescribeDBInstances(&rds.DescribeDBInstancesInput{
-                        DBInstanceIdentifier: aws.String(rs.Primary.ID),
-                })
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
+		resp, err := conn.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+			DBInstanceIdentifier: aws.String(rs.Primary.ID),
+		})
 
-                if err != nil {
-                        return err
-                }
+		if err != nil {
+			return err
+		}
 
-                for _, d := range resp.DBInstances {
-                        if *d.DBInstanceIdentifier == rs.Primary.ID {
-                                *v = *d
-                                return nil
-                        }
-                }
+		for _, d := range resp.DBInstances {
+			if *d.DBInstanceIdentifier == rs.Primary.ID {
+				*v = *d
+				return nil
+			}
+		}
 
-                return fmt.Errorf("DB Cluster (%s) not found", rs.Primary.ID)
-        }
+		return fmt.Errorf("DB Cluster (%s) not found", rs.Primary.ID)
+	}
 }
 
 // Add some random to the name, to avoid collision

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -10,6 +10,7 @@ import (
         "github.com/hashicorp/terraform/terraform"
 
         "github.com/aws/aws-sdk-go/aws"
+        "github.com/aws/aws-sdk-go/aws/awserr"
         "github.com/aws/aws-sdk-go/service/rds"
 )
 
@@ -52,9 +53,14 @@ func testAccCheckAWSClusterDestroy(s *terraform.State) error {
                         }
                 }
 
-                // check for an expected "Cluster not found" type error
-                return err
+                // Return nil if the cluster is already destroyed
+                if awsErr, ok := err.(awserr.Error); ok {
+                        if awsErr.Code() == "DBClusterNotFound" {
+                                return nil
+                        }
+                }
 
+                return err
         }
 
         return nil

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+        "fmt"
+        "math/rand"
+        "testing"
+        "time"
+
+        "github.com/hashicorp/terraform/helper/resource"
+        "github.com/hashicorp/terraform/terraform"
+
+        "github.com/aws/aws-sdk-go/aws"
+        "github.com/aws/aws-sdk-go/service/rds"
+)
+
+func TestAccAWSRDSCluster_basic(t *testing.T) {
+        var v rds.DBCluster
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckAWSClusterDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccAWSClusterConfig,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+                                ),
+                        },
+                },
+        })
+}
+
+func testAccCheckAWSClusterDestroy(s *terraform.State) error {
+        for _, rs := range s.RootModule().Resources {
+                if rs.Type != "aws_rds_cluster" {
+                        continue
+                }
+
+                // Try to find the Group
+                conn := testAccProvider.Meta().(*AWSClient).rdsconn
+                var err error
+                resp, err := conn.DescribeDBClusters(
+                        &rds.DescribeDBClustersInput{
+                                DBClusterIdentifier: aws.String(rs.Primary.ID),
+                        })
+
+                if err == nil {
+                        if len(resp.DBClusters) != 0 &&
+                                *resp.DBClusters[0].DBClusterIdentifier == rs.Primary.ID {
+                                return fmt.Errorf("DB Cluster %s still exists", rs.Primary.ID)
+                        }
+                }
+
+                // check for an expected "Cluster not found" type error
+                return err
+
+        }
+
+        return nil
+}
+
+func testAccCheckAWSClusterExists(n string, v *rds.DBCluster) resource.TestCheckFunc {
+        return func(s *terraform.State) error {
+                rs, ok := s.RootModule().Resources[n]
+                if !ok {
+                        return fmt.Errorf("Not found: %s", n)
+                }
+
+                if rs.Primary.ID == "" {
+                        return fmt.Errorf("No DB Instance ID is set")
+                }
+
+                conn := testAccProvider.Meta().(*AWSClient).rdsconn
+                resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+                        DBClusterIdentifier: aws.String(rs.Primary.ID),
+                })
+
+                if err != nil {
+                        return err
+                }
+
+                for _, c := range resp.DBClusters {
+                        if *c.DBClusterIdentifier == rs.Primary.ID {
+                                *v = *c
+                                return nil
+                        }
+                }
+
+                return fmt.Errorf("DB Cluster (%s) not found", rs.Primary.ID)
+        }
+}
+
+// Add some random to the name, to avoid collision
+var testAccAWSClusterConfig = fmt.Sprintf(`
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+}`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+        "regexp"
 	"sort"
 	"strings"
 
@@ -456,4 +457,25 @@ func expandResourceRecords(recs []interface{}, typeStr string) []*route53.Resour
 		}
 	}
 	return records
+}
+
+func validateRdsId(v interface{}, k string) (ws []string, errors []error) {
+        value := v.(string)
+        if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+                errors = append(errors, fmt.Errorf(
+                        "only lowercase alphanumeric characters and hyphens allowed in %q", k))
+        }
+        if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+                errors = append(errors, fmt.Errorf(
+                        "first character of %q must be a letter", k))
+        }
+        if regexp.MustCompile(`--`).MatchString(value) {
+                errors = append(errors, fmt.Errorf(
+                        "%q cannot contain two consecutive hyphens", k))
+        }
+        if regexp.MustCompile(`-$`).MatchString(value) {
+                errors = append(errors, fmt.Errorf(
+                        "%q cannot end with a hyphen", k))
+        }
+        return
 }

--- a/builtin/providers/aws/tagsRDS.go
+++ b/builtin/providers/aws/tagsRDS.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+        "fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,7 +20,7 @@ func setTagsRDS(conn *rds.RDS, d *schema.ResourceData, arn string) error {
 
 		// Set tags
 		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %#v", remove)
+                        log.Printf("[DEBUG] Removing tags: %s", remove)
 			k := make([]*string, len(remove), len(remove))
 			for i, t := range remove {
 				k[i] = t.Key
@@ -34,7 +35,7 @@ func setTagsRDS(conn *rds.RDS, d *schema.ResourceData, arn string) error {
 			}
 		}
 		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %#v", create)
+                        log.Printf("[DEBUG] Creating tags: %s", create)
 			_, err := conn.AddTagsToResource(&rds.AddTagsToResourceInput{
 				ResourceName: aws.String(arn),
 				Tags:         create,
@@ -92,4 +93,21 @@ func tagsToMapRDS(ts []*rds.Tag) map[string]string {
 	}
 
 	return result
+}
+
+func saveTagsRDS(conn *rds.RDS, d *schema.ResourceData, arn string) error {
+        resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
+                ResourceName: aws.String(arn),
+        })
+
+        if err != nil {
+                return fmt.Errorf("[DEBUG] Error retreiving tags for ARN: %s", arn)
+        }
+
+        var dt []*rds.Tag
+        if len(resp.TagList) > 0 {
+                dt = resp.TagList
+        }
+
+        return d.Set("tags", tagsToMapRDS(dt))
 }

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -186,6 +186,3 @@ PLATFORMS
 
 DEPENDENCIES
   middleman-hashicorp!
-
-BUNDLED WITH
-   1.10.6

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "aws"
+page_title: "AWS: aws_rds_cluster"
+sidebar_current: "docs-aws-resource-rds-cluster"
+description: |-
+  Provides an RDS Cluster Resource
+---
+
+# aws\_rds\_cluster
+
+Provides an RDS Cluster Resource. A Cluster Resource defines attributes that are
+applied to the entire cluster of [RDS Cluster Instances][3]. Use the RDS Cluster
+resource and RDS Cluster Instances to create and use Amazon Aurora, a MySQL-compatible
+database engine.
+
+For more information on Amazon Aurora, see [Aurora on Amazon RDS][2] in the Amazon RDS User Guide.
+
+## Example Usage
+
+```
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "aurora-cluster-demo"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "bar"
+}
+```
+
+~> **NOTE:** RDS Clusters resources that are created without any matching
+RDS Cluster Instances do not currently display in the AWS Console.
+
+## Argument Reference
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-ModifyDBInstance.html).
+
+The following arguments are supported:
+
+* `cluster_identifier` - (Required) The Cluster Identifier. Must be a lower case
+string.
+* `database_name` - (Optional) The name for your database of up to 8 alpha-numeric
+  characters. If you do not provide a name, Amazon RDS will not create a
+  database in the DB cluster you are creating
+* `master_password` - (Required) Password for the master DB user. Note that this may
+    show up in logs, and it will be stored in the state file
+* `master_username` - (Required) Username for the master DB user
+* `availability_zones` - (Optional) A list of EC2 Availability Zones that
+  instances in the DB cluster can be created in
+* `backup_retention_period` - (Optional) The days to retain backups for. Default
+1
+* `port` - (Optional) The port on which the DB accepts connections
+* `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
+  with the Cluster
+* `apply_immediately` - (Optional) Specifies whether any cluster modifications
+     are applied immediately, or during the next maintenance window. Default is
+     `false`. See [Amazon RDS Documentation for more information.](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
+* `vpc_security_group_ids` - (Optional) List of VPC security groups to associate.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The RDS Cluster Identifier
+* `cluster_identifier` - The RDS Cluster Identifier
+* `cluster_members` – List of RDS Instances that are a part of this cluster
+* `address` - The address of the RDS instance.
+* `allocated_storage` - The amount of allocated storage
+* `availability_zones` - The availability zone of the instance
+* `backup_retention_period` - The backup retention period
+* `backup_window` - The backup window
+* `endpoint` - The primary, writeable connection endpoint
+* `engine` - The database engine
+* `engine_version` - The database engine version
+* `maintenance_window` - The instance maintenance window
+* `database_name` - The database name
+* `port` - The database port
+* `status` - The RDS instance status
+* `username` - The master username for the database
+* `storage_encrypted` - Specifies whether the DB instance is encrypted
+
+[1]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html
+
+[2]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html
+[3]: /docs/providers/aws/r/rds_cluster_instance.html

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -55,7 +55,6 @@ string.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications
      are applied immediately, or during the next maintenance window. Default is
      `false`. See [Amazon RDS Documentation for more information.](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
-* `vpc_security_group_ids` - (Optional) List of VPC security groups to associate.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -45,6 +45,9 @@ string.
 * `master_password` - (Required) Password for the master DB user. Note that this may
     show up in logs, and it will be stored in the state file
 * `master_username` - (Required) Username for the master DB user
+* `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
+    when this DB cluster is deleted. If omitted, no final snapshot will be
+    made.
 * `availability_zones` - (Optional) A list of EC2 Availability Zones that
   instances in the DB cluster can be created in
 * `backup_retention_period` - (Optional) The days to retain backups for. Default

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -47,8 +47,8 @@ the [AWS official documentation](http://docs.aws.amazon.com/AmazonRDS/latest/Com
 
 The following arguments are supported:
 
-* `identifier` - (Required) The Instance Identifier. Must be a lower case
-string.
+* `identifier` - (Optional) The Instance Identifier. Must be a lower case
+string. If omited, a unique identifier will be generated.
 * `cluster_identifier` - (Required) The Cluster Identifier for this Instance to
 join. Must be a lower case
 string.

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -1,0 +1,87 @@
+---
+layout: "aws"
+page_title: "AWS: aws_rds_cluster_instance"
+sidebar_current: "docs-aws-resource-rds-cluster-instance"
+description: |-
+  Provides an RDS Cluster Resource Instance
+---
+
+# aws\_rds\_cluster\_instance
+
+Provides an RDS Cluster Resource Instance. A Cluster Instance Resource defines
+attributes that are specific to a single instance in a [RDS Cluster][3],
+specifically running Amazon Aurora.
+
+Unlike other RDS resources that support replication, with Amazon Aurora you do
+not designate a primary and subsequent replicas. Instead, you simply add RDS
+Instances and Aurora manages the replication. You can use the [count][5]
+meta-parameter to make multiple instances and join them all to the same RDS
+Cluster, or you may specify different Cluster Instance resources with various
+`instance_class` sizes.
+
+For more information on Amazon Aurora, see [Aurora on Amazon RDS][2] in the Amazon RDS User Guide.
+
+## Example Usage
+
+```
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  count = 2
+  identifier = "aurora-cluster-demo"
+  cluster_identifer = "${aws_rds_cluster.default.id}"
+  instance_class = "db.r3.large"
+}
+
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "aurora-cluster-demo"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "bar"
+}
+```
+
+## Argument Reference
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-ModifyDBInstance.html).
+
+The following arguments are supported:
+
+* `identifier` - (Required) The Instance Identifier. Must be a lower case
+string.
+* `cluster_identifier` - (Required) The Cluster Identifier for this Instance to
+join. Must be a lower case
+string.
+* `instance_class` - (Required) The instance class to use. For details on CPU
+and memory, see [Scaling Aurora DB Instances][4]. Aurora currently
+  supports the below instance classes.
+  - db.r3.large
+  - db.r3.xlarge
+  - db.r3.2xlarge
+  - db.r3.4xlarge
+  - db.r3.8xlarge
+
+.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `cluster_identifier` - The RDS Cluster Identifier
+* `identifier` - The Instance identifier
+* `id` - The Instance identifier
+* `writer` – Boolean indicating if this instance is writable. `False` indicates
+this instance is a read replica
+* `allocated_storage` - The amount of allocated storage
+* `availability_zones` - The availability zone of the instance
+* `endpoint` - The IP address for this instance. May not be writable
+* `engine` - The database engine
+* `engine_version` - The database engine version
+* `database_name` - The database name
+* `port` - The database port
+* `status` - The RDS instance status
+
+[2]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html
+[3]: /docs/providers/aws/r/rds_cluster.html
+[4]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html
+[5]: /docs/configuration/resources.html#count

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -48,7 +48,7 @@ the [AWS official documentation](http://docs.aws.amazon.com/AmazonRDS/latest/Com
 The following arguments are supported:
 
 * `identifier` - (Optional) The Instance Identifier. Must be a lower case
-string. If omited, a unique identifier will be generated.
+string. If omitted, a unique identifier will be generated.
 * `cluster_identifier` - (Required) The Cluster Identifier for this Instance to
 join. Must be a lower case
 string.

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -60,8 +60,9 @@ and memory, see [Scaling Aurora DB Instances][4]. Aurora currently
   - db.r3.2xlarge
   - db.r3.4xlarge
   - db.r3.8xlarge
-
-.
+* `publicly_accessible` - (Optional) Bool to control if instance is publicly accessible.
+Default `false`. See the documentation on [Creating DB Instances][6] for more
+details on controlling this property.
 
 ## Attributes Reference
 
@@ -85,3 +86,4 @@ this instance is a read replica
 [3]: /docs/providers/aws/r/rds_cluster.html
 [4]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html
 [5]: /docs/configuration/resources.html#count
+[6]: http://docs.aws.amazon.com/fr_fr/AmazonRDS/latest/APIReference/API_CreateDBInstance.html

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -306,8 +306,7 @@
                     </ul>
                 </li>
 
-
-                <li<%= sidebar_current(/^docs-aws-resource-db/) %>>
+                <li<%= sidebar_current(/^docs-aws-resource-(db|rds)/) %>>
                     <a href="#">RDS Resources</a>
                     <ul class="nav nav-visible">
 
@@ -325,6 +324,14 @@
 
                         <li<%= sidebar_current("docs-aws-resource-db-subnet-group") %>>
                             <a href="/docs/providers/aws/r/db_subnet_group.html">aws_db_subnet_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-rds-cluster") %>>
+                            <a href="/docs/providers/aws/r/rds_cluster.html">aws_rds_cluster</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-rds-cluster-instance") %>>
+                            <a href="/docs/providers/aws/r/rds_cluster_instance.html">aws_rds_cluster_instance</a>
                         </li>
 
                     </ul>


### PR DESCRIPTION
Adds `RDS Cluster` and `RDS Cluster Instance` resources ([Amazon Aurora][1]). 

**Usage:**

```javascript
resource "aws_rds_cluster_instance" "cluster_instances" {
  count = 2
  instance_identifier = "aurora-cluster-demo"
  cluster_identifer = "${aws_rds_cluster.default.id}"
  instance_class = "db.r3.large"
}

resource "aws_rds_cluster" "default" {
  cluster_identifier = "aurora-cluster-demo"
  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
  database_name = "mydb"
  master_username = "foo"
  master_password = "bar"
}
```

Scaling can be done with the `lifecycle` block:

```javascript
resource "aws_rds_cluster" "default" {
  cluster_identifier = "tf-aurora-cluster"
  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
  database_name = "mydb"
  master_username = "foo"
  master_password = "mustbeeightcharaters"

  lifecycle {
    create_before_destroy = true
  }
}

resource "aws_rds_cluster_instance" "replicas" {
  count = 2
  cluster_identifier = "${aws_rds_cluster.default.id}"
  # can change this to add new instances to the cluster
  # which will join and sync before the existing ones are destroyed
  instance_class = "db.r3.xlarge"

  lifecycle {
    create_before_destroy = true
  }
}
```

**Noteworthy:**

- The `cluster` is it's own resource, and does not require any actual database instances
- Without any instances, a cluster doesn't show up in the [RDS Console][2]
- With Aurora, there is no designation of primary or replica instances. You simply add instances, and Aurora sorts that out. This has a bit of auto-promotion included, if the current primary is unavailable or destroyed. It also means that it should, in theory, support Terraforms `count` feature
- The planned implementation is intentionally limited. There are other knobs we can turn, eventually, but what I've planned offers bare minimum functionality

**TODO:**

- [x] Docs
- [x] Implementation
- [x] Tests


[1]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html
[2]: console.aws.amazon.com/rds