### PR TITLE
Update AWS provider documentation

### DIFF
--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -57,5 +57,5 @@ The following arguments are supported in the `provider` block:
 
 * `dynamodb_endpoint` - (Optional) Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to dynamodb-local.
 
-In addition to the above parameters, the `AWS_SECURITY_TOKEN` environmental
+In addition to the above parameters, the `AWS_SESSION_TOKEN` environmental
 variable can be set to set an MFA token.


### PR DESCRIPTION
Changed `AWS_SECURITY_TOKEN` to `AWS_SESSION_TOKEN`.

This change worked for me; I was not able to authenticate using `AWS_SECURITY_TOKEN`, but`AWS_SESSION_TOKEN` worked for me.