### PR TITLE
providers/aws: Add ElastiCache replication group support (fixes #1799)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ website/node_modules
 *.bak
 *~
 .*.swp
+config/lang/y.go

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -177,6 +177,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_eip":                          resourceAwsEip(),
 			"aws_elasticache_cluster":          resourceAwsElasticacheCluster(),
 			"aws_elasticache_parameter_group":  resourceAwsElasticacheParameterGroup(),
+			"aws_elasticache_replication_group":resourceAwsElasticacheReplicationGroup(),
 			"aws_elasticache_security_group":   resourceAwsElasticacheSecurityGroup(),
 			"aws_elasticache_subnet_group":     resourceAwsElasticacheSubnetGroup(),
 			"aws_elb":                          resourceAwsElb(),

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -72,6 +72,11 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"replication_group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"security_group_names": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -155,6 +160,7 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 	subnetGroupName := d.Get("subnet_group_name").(string)
 	securityNameSet := d.Get("security_group_names").(*schema.Set)
 	securityIdSet := d.Get("security_group_ids").(*schema.Set)
+	replicationGroupID := d.Get("replication_group_id").(string)
 
 	securityNames := expandStringList(securityNameSet.List())
 	securityIds := expandStringList(securityIdSet.List())
@@ -171,6 +177,7 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		CacheSecurityGroupNames: securityNames,
 		SecurityGroupIds:        securityIds,
 		Tags:                    tags,
+		ReplicationGroupID:      aws.String(replicationGroupID),
 	}
 
 	// parameter groups are optional and can be defaulted by AWS

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -177,7 +177,7 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		CacheSecurityGroupNames: securityNames,
 		SecurityGroupIds:        securityIds,
 		Tags:                    tags,
-		ReplicationGroupID:      aws.String(replicationGroupID),
+		ReplicationGroupId:      aws.String(replicationGroupID),
 	}
 
 	// parameter groups are optional and can be defaulted by AWS

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -117,17 +117,17 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 	prefferedAZs := expandStringList(prefferedCacheClusterAZs.List())
 
 	req := &elasticache.CreateReplicationGroupInput{
-		ReplicationGroupID:          aws.String(replicationGroupID),
+		ReplicationGroupId:          aws.String(replicationGroupID),
 		ReplicationGroupDescription: aws.String(description),
 		CacheNodeType:               aws.String(cacheNodeType),
 		AutomaticFailoverEnabled:    aws.Bool(automaticFailover),
 		NumCacheClusters:            aws.Int64(int64(numCacheClusters)),
-		PrimaryClusterID:            aws.String(primaryClusterID),
+		PrimaryClusterId:            aws.String(primaryClusterID),
 		Engine:                      aws.String(engine),
 		CacheSubnetGroupName:        aws.String(subnetGroupName),
 		EngineVersion:               aws.String(engineVersion),
 		CacheSecurityGroupNames:     securityNames,
-		SecurityGroupIDs:            securityIds,
+		SecurityGroupIds:            securityIds,
 		PreferredCacheClusterAZs:    prefferedAZs,
 	}
 
@@ -170,7 +170,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 	conn := meta.(*AWSClient).elasticacheconn
 
 	req := &elasticache.DescribeReplicationGroupsInput{
-		ReplicationGroupID: aws.String(d.Id()),
+		ReplicationGroupId: aws.String(d.Id()),
 	}
 
 	res, err := conn.DescribeReplicationGroups(req)
@@ -189,7 +189,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		if *c.Status != "available" {
 			return nil
 		}
-		d.Set("replication_group_id", c.ReplicationGroupID)
+		d.Set("replication_group_id", c.ReplicationGroupId)
 		d.Set("description", c.Description)
 		d.Set("automatic_failover", c.AutomaticFailover)
 		d.Set("num_cache_clusters", len(c.MemberClusters))
@@ -206,7 +206,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 
 	req := &elasticache.ModifyReplicationGroupInput{
 		ApplyImmediately:   aws.Bool(true),
-		ReplicationGroupID: aws.String(d.Id()),
+		ReplicationGroupId: aws.String(d.Id()),
 	}
 
 	if d.HasChange("automatic_failover") {
@@ -227,7 +227,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 	if d.HasChange("security_group_ids") {
 		securityIDSet := d.Get("security_group_ids").(*schema.Set)
 		securityIds := expandStringList(securityIDSet.List())
-		req.SecurityGroupIDs = securityIds
+		req.SecurityGroupIds = securityIds
 	}
 
 	if d.HasChange("security_group_names") {
@@ -248,7 +248,7 @@ func resourceAwsElasticacheReplicationGroupDelete(d *schema.ResourceData, meta i
 	conn := meta.(*AWSClient).elasticacheconn
 
 	req := &elasticache.DeleteReplicationGroupInput{
-		ReplicationGroupID: aws.String(d.Id()),
+		ReplicationGroupId: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteReplicationGroup(req)
@@ -283,7 +283,7 @@ func resourceAwsElasticacheReplicationGroupDelete(d *schema.ResourceData, meta i
 func replicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replicationGroupID, givenState string, pending []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
-			ReplicationGroupID: aws.String(replicationGroupID),
+			ReplicationGroupId: aws.String(replicationGroupID),
 		})
 		if err != nil {
 			ec2err, ok := err.(awserr.Error)

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -81,6 +81,13 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"preferred_cache_cluster_azs": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 		},
 	}
 }
@@ -98,9 +105,11 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 	securityNameSet := d.Get("security_group_names").(*schema.Set)
 	securityIdSet := d.Get("security_group_ids").(*schema.Set)
 	subnetGroupName := d.Get("subnet_group_name").(string)
+	prefferedCacheClusterAZs := d.Get("preferred_cache_cluster_azs").(*schema.Set)
 
 	securityNames := expandStringList(securityNameSet.List())
 	securityIds := expandStringList(securityIdSet.List())
+	prefferedAZs := expandStringList(prefferedCacheClusterAZs.List())
 
 	req := &elasticache.CreateReplicationGroupInput{
 		ReplicationGroupID:          aws.String(replicationGroupId),
@@ -113,6 +122,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		EngineVersion:               aws.String(engineVersion),
 		CacheSecurityGroupNames:     securityNames,
 		SecurityGroupIDs:            securityIds,
+		PreferredCacheClusterAZs:    prefferedAZs,
 	}
 
 	if v, ok := d.GetOk("parameter_group_name"); ok {

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -1,0 +1,289 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awserr"
+	"github.com/awslabs/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsElasticacheReplicationGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsElasticacheReplicationGroupCreate,
+		Read:   resourceAwsElasticacheReplicationGroupRead,
+		Update: resourceAwsElasticacheReplicationGroupUpdate,
+		Delete: resourceAwsElasticacheReplicationGroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"replication_group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cache_node_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"automatic_failover": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"num_cache_clusters": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+				ForceNew: true,
+			},
+			"parameter_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subnet_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"security_group_names": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"security_group_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"engine": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "redis",
+			},
+			"engine_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	replicationGroupId := d.Get("replication_group_id").(string)
+	description := d.Get("description").(string)
+	cacheNodeType := d.Get("cache_node_type").(string)
+	automaticFailover := d.Get("automatic_failover").(bool)
+	numCacheClusters := d.Get("num_cache_clusters").(int)
+	engine := d.Get("engine").(string)
+	engineVersion := d.Get("engine_version").(string)
+	securityNameSet := d.Get("security_group_names").(*schema.Set)
+	securityIdSet := d.Get("security_group_ids").(*schema.Set)
+
+	securityNames := expandStringList(securityNameSet.List())
+	securityIds := expandStringList(securityIdSet.List())
+
+	req := &elasticache.CreateReplicationGroupInput{
+		ReplicationGroupID:		aws.String(replicationGroupId),
+		ReplicationGroupDescription:	aws.String(description),
+		CacheNodeType:            	aws.String(cacheNodeType),
+		AutomaticFailoverEnabled: 	aws.Boolean(automaticFailover),
+		NumCacheClusters:         	aws.Long(int64(numCacheClusters)),
+		Engine:				aws.String(engine),
+		EngineVersion:			aws.String(engineVersion),
+		CacheSecurityGroupNames:	securityNames,
+		SecurityGroupIDs:		securityIds,
+	}
+
+	if v, ok := d.GetOk("parameter_group_name"); ok {
+		req.CacheParameterGroupName = aws.String(v.(string))
+	}
+
+	_, err := conn.CreateReplicationGroup(req)
+	if err != nil {
+		return fmt.Errorf("Error creating Elasticache replication group: %s", err)
+	}
+
+	pending := []string{"creating"}
+	stateConf := &resource.StateChangeConf{
+		Pending:    pending,
+		Target:     "available",
+		Refresh:    ReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
+		Timeout:    15 * time.Minute,
+		Delay:      20 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	log.Printf("[DEBUG] Waiting for state to become available: %v", d.Id())
+	_, sterr := stateConf.WaitForState()
+	if sterr != nil {
+		return fmt.Errorf("Error waiting for elasticache (%s) to be created: %s", d.Id(), sterr)
+	}
+
+	d.SetId(replicationGroupId)
+
+	return nil
+}
+
+func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	req := &elasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupID: aws.String(d.Id()),
+	}
+
+	res, err := conn.DescribeReplicationGroups(req)
+	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "ReplicationGroupNotFoundFault" {
+			// Update state to indicate the replication group no longer exists.
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	if len(res.ReplicationGroups) == 1 {
+		c := res.ReplicationGroups[0]
+		d.Set("replication_group_id", c.ReplicationGroupID)
+		d.Set("description", c.Description)
+		d.Set("automatic_failover", c.AutomaticFailover)
+		d.Set("num_cache_clusters", len(c.MemberClusters))
+	}
+
+	return nil
+}
+
+func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	req := &elasticache.ModifyReplicationGroupInput {
+		ApplyImmediately:   aws.Boolean(true),
+		ReplicationGroupID: aws.String(d.Id()),
+	}
+
+	if d.HasChange("automatic_failover") {
+		automaticFailover := d.Get("automatic_failover").(bool)
+		req.AutomaticFailoverEnabled = aws.Boolean(automaticFailover)
+	}
+
+	if d.HasChange("description") {
+		description := d.Get("description").(string)
+		req.ReplicationGroupDescription = aws.String(description)
+	}
+
+	if d.HasChange("engine_version") {
+		engine_version := d.Get("engine_version").(string)
+		req.EngineVersion = aws.String(engine_version)
+	}
+
+	if d.HasChange("security_group_ids") {
+		securityIdSet := d.Get("security_group_ids").(*schema.Set)
+		securityIds := expandStringList(securityIdSet.List())
+		req.SecurityGroupIDs = securityIds
+	}
+
+	if d.HasChange("security_group_names") {
+		securityNameSet := d.Get("security_group_names").(*schema.Set)
+		securityNames := expandStringList(securityNameSet.List())
+		req.CacheSecurityGroupNames = securityNames
+	}
+
+	_, err := conn.ModifyReplicationGroup(req)
+	if err != nil {
+		return fmt.Errorf("Error updating Elasticache replication group: %s", err)
+	}
+
+	return resourceAwsElasticacheReplicationGroupRead(d, meta)
+}
+
+func resourceAwsElasticacheReplicationGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	req := &elasticache.DeleteReplicationGroupInput{
+		ReplicationGroupID: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteReplicationGroup(req)
+	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "ReplicationGroupNotFoundFault" {
+			// Update state to indicate the replication group no longer exists.
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error deleting Elasticache replication group: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for deletion: %v", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating", "available", "deleting"},
+		Target:     "",
+		Refresh:    ReplicationGroupStateRefreshFunc(conn, d.Id(), "", []string{}),
+		Timeout:    15 * time.Minute,
+		Delay:      20 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	_, sterr := stateConf.WaitForState()
+	if sterr != nil {
+		return fmt.Errorf("Error waiting for replication group (%s) to delete: %s", d.Id(), sterr)
+	}
+
+	return nil
+}
+
+func ReplicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replicationGroupID, givenState string, pending []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
+			ReplicationGroupID: aws.String(replicationGroupID),
+		})
+		if err != nil {
+			ec2err, ok := err.(awserr.Error)
+
+			if ok {
+				log.Printf("[DEBUG] message: %v, code: %v", ec2err.Message(), ec2err.Code())
+				if ec2err.Code() == "ReplicationGroupNotFoundFault" {
+					log.Printf("[DEBUG] Detect deletion")
+					return nil, "", nil
+				}
+			}
+
+			log.Printf("[ERROR] ReplicationGroupStateRefreshFunc: %s", err)
+			return nil, "", err
+		}
+
+		c := resp.ReplicationGroups[0]
+		log.Printf("[DEBUG] status: %v", *c.Status)
+
+		// return the current state if it's in the pending array
+		for _, p := range pending {
+			s := *c.Status
+			if p == s {
+				log.Printf("[DEBUG] Return with status: %v", *c.Status)
+				return c, p, nil
+			}
+		}
+
+		// return given state if it's not in pending
+		if givenState != "" {
+			return c, givenState, nil
+		}
+		log.Printf("[DEBUG] current status: %v", *c.Status)
+		return c, *c.Status, nil
+	}
+}

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -186,11 +186,16 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 
 	if len(res.ReplicationGroups) == 1 {
 		c := res.ReplicationGroups[0]
+		if *c.Status != "available" {
+			return nil
+		}
 		d.Set("replication_group_id", c.ReplicationGroupID)
 		d.Set("description", c.Description)
 		d.Set("automatic_failover", c.AutomaticFailover)
 		d.Set("num_cache_clusters", len(c.MemberClusters))
-		d.Set("primary_endpoint", res.ReplicationGroups[0].NodeGroups[0].PrimaryEndpoint.Address)
+		if len(c.NodeGroups) >= 1 && c.NodeGroups[0].PrimaryEndpoint != nil {
+			d.Set("primary_endpoint", c.NodeGroups[0].PrimaryEndpoint.Address)
+		}
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"log"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -35,7 +35,7 @@ func testAccCheckAWSEcacheReplicationGroupDestroy(s *terraform.State) error {
 			continue
 		}
 		res, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
-			ReplicationGroupID: aws.String(rs.Primary.ID),
+			ReplicationGroupId: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
 			return err
@@ -56,7 +56,7 @@ func testAccCheckAWSEcacheReplicationGroupExists(n string) resource.TestCheckFun
 
 		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
 		res, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
-			ReplicationGroupID: aws.String(rs.Primary.ID),
+			ReplicationGroupId: aws.String(rs.Primary.ID),
 		})
 
 		if err != nil {
@@ -64,7 +64,7 @@ func testAccCheckAWSEcacheReplicationGroupExists(n string) resource.TestCheckFun
 		}
 
 		if len(res.ReplicationGroups) != 1 ||
-			*res.ReplicationGroups[0].ReplicationGroupID != rs.Primary.ID {
+			*res.ReplicationGroups[0].ReplicationGroupId != rs.Primary.ID {
 			return fmt.Errorf("Replication group not found")
 		}
 		log.Printf("[DEBUG] Rep group found")

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -1,0 +1,82 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"log"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSEcacheReplicationGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcacheReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcacheReplicationGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcacheReplicationGroupExists("aws_elasticache_replication_group.bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEcacheReplicationGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elasticache_replication_group" {
+			continue
+		}
+		res, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
+			ReplicationGroupID: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+		if len(res.ReplicationGroups) > 0 {
+			return fmt.Errorf("still exist.")
+		}
+	}
+	return nil
+}
+
+func testAccCheckAWSEcacheReplicationGroupExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+		res, err := conn.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
+			ReplicationGroupID: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("CacheReplicationGroup error: %v", err)
+		}
+
+		if len(res.ReplicationGroups) != 1 ||
+			*res.ReplicationGroups[0].ReplicationGroupID != rs.Primary.ID {
+			return fmt.Errorf("Replication group not found")
+		}
+		log.Printf("[DEBUG] Rep group found")
+		return nil
+	}
+}
+
+var testAccAWSEcacheReplicationGroupConfig = fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "bar" {
+    replication_group_id = "tf-repgrp-%03d"
+    cache_node_type = "cache.m1.small"
+    num_cache_clusters = 2
+    description = "tf-test-replication-group-descr"
+}
+`, genRandInt())

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -2,8 +2,8 @@ package aws
 
 import (
 	"fmt"
-	"testing"
 	"log"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -49,6 +49,12 @@ supported node types
 cache cluster will have. For Redis, this value must be 1. For Memcache, this
 value must be between 1 and 20
 
+* `replication_group_id` – (Optional, Redis only) The ID of the replication
+group to which this cache cluster should belong. If specified, the cache cluster
+will be added to the specified replication group as a read replica;
+otherwise, the cache cluster will be a standalone primary that is not part of
+any replication group.
+
 * `parameter_group_name` – (Required) Name of the parameter group to associate
 with this cache cluster
 

--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elasticache_replication_group"
+sidebar_current: "docs-aws-resource-elasticache-replication-group"
+description: |-
+  Provides an ElastiCache Replication Group resource.
+---
+
+# aws\_elasticache\_replication\_group
+
+Provides an ElastiCache Replication Group resource.
+
+## Example Usage
+
+```
+resource "aws_elasticache_replication_group" "redis" {
+    replication_group_id = "users-redis"
+    description = "users redis"
+    engine = "redis"
+    cache_node_type = "cache.m3.medium"
+    num_cache_clusters = 2
+    automatic_failover = true
+    subnet_group_name = "${aws_elasticache_subnet_group.redis.name}"
+    security_group_ids = ["${aws_security_group.redis.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `replication_group_id` – (Required) Replication group identifier. This
+parameter is stored as a lowercase string
+
+* `description` – (Required) The description of the replication group.
+
+* `engine` – (Optional) The name of the cache engine to be used for the cache clusters in this replication group.
+ The only current valid value is `redis`
+
+* `engine_version` – (Optional) Version number of the cache engine to be used.
+See [Selecting a Cache Engine and Version](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html)
+in the AWS Documentation center for supported versions
+
+* `cache_node_type` – (Required) The compute and memory capacity of the nodes. See
+[Available Cache Node Types](http://aws.amazon.com/elasticache/details#Available_Cache_Node_Types) for
+supported node types
+
+* `automatic_failover` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails.
+If true, Multi-AZ is enabled for this replication group. If false, Multi-AZ is disabled for this replication group.
+
+* `num_cache_clusters` – (Optional) The number of cache clusters this replication group will initially have. If `automatic_failover` is enabled, the value of this parameter must be at least 2.
+Either this or `primary_cluster_id` is required.
+
+* `primary_cluster_id` - (Optional) The identifier of the cache cluster that
+will serve as the primary for this replication group. This cache cluster must already exist and have a status of available.
+Either this or `num_cache_clusters` is required.
+
+* `parameter_group_name` – (Required) Name of the parameter group to associate
+with this cache cluster
+
+* `preferred_cache_cluster_azs` - (Optional) A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important. If not provided, AWS will chose them for you.
+
+* `subnet_group_name` – (Optional, VPC only) Name of the subnet group to be used
+for the cache cluster.
+
+* `security_group_names` – (Optional, EC2 Classic only) List of security group
+names to associate with this cache cluster
+
+* `security_group_ids` – (Optional, VPC only) One or more VPC security groups associated
+ with the cache cluster
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `primary_endpoint` - The address of the primary node.


### PR DESCRIPTION
This is based off of @inferiorhumanorgans work in #1799. I fixed some import paths and added a `primary_endpoint` attribute, so it can be used like this:

```
resource "aws_elasticache_replication_group" "default" {
    replication_group_id = "redis.fun"

    description = "redis fun"
    engine = "redis"
    cache_node_type = "${var.node_type}"
    num_cache_clusters = 2
    automatic_failover = true
    subnet_group_name = "${var.subnet_group_name}"
    security_group_ids  = ["${var.security_group_id}"]
}

resource "aws_route53_record" "default" {
    zone_id = "${var.zone_id}"
    name = "${var.engine}-${var.name}.${var.zone_name}"
    type = "CNAME"
    ttl = "30"
    records = [
        "${aws_elasticache_replication_group.default.primary_endpoint}."
    ]
}
```