### PR TITLE
Updating EIP Instance to Computed

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -29,6 +29,7 @@ func resourceAwsEip() *schema.Resource {
 
 			"instance": &schema.Schema{
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 


### PR DESCRIPTION
As per https://github.com/hashicorp/terraform/pull/2943

When we attach an instance to an EIP, terraform currently tries to destroy it:

My code works as follows:

```
resource "aws_eip" "nat_ip" {
  vpc = true
  network_interface = "${aws_network_interface.nat_eni.id}"
}

resource "aws_network_interface" "nat_eni" {
  subnet_id = "${aws_subnet.primary-public.id}"
  security_groups = ["${aws_security_group.nat.id}"]
  source_dest_check = false

  tags {
    Name = "NAT ENI"
  }
}
```

When an instance comes up, it attaches itself to the ENI (thanks to the PR above, that stays). But it looks like the EIP is removing itself on the second run:

```
~ aws_eip.nat_ip
    instance: "i-3f8f8092" => ""
```