### PR TITLE
Pass key_name and subnetId to spot instance request - resolves issue #2919

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -86,9 +86,11 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 			IAMInstanceProfile:  instanceOpts.IAMInstanceProfile,
 			ImageID:             instanceOpts.ImageID,
 			InstanceType:        instanceOpts.InstanceType,
+			KeyName:             instanceOpts.KeyName,
 			Placement:           instanceOpts.SpotPlacement,
 			SecurityGroupIDs:    instanceOpts.SecurityGroupIDs,
 			SecurityGroups:      instanceOpts.SecurityGroups,
+			SubnetID:            instanceOpts.SubnetID,
 			UserData:            instanceOpts.UserData64,
 		},
 	}


### PR DESCRIPTION
This PR resolves the issue reported in  #2919 where AWS spot requests were ignoring `key_name` and VPC `subnetId` settings.

