### PR TITLE
provider/aws: Fail silently in ValidateCredentials for IAM users

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -188,7 +188,7 @@ func (c *Config) ValidateCredentials(iamconn *iam.IAM) error {
 
 	if awsErr, ok := err.(awserr.Error); ok {
 
-		if awsErr.Code() == "AccessDenied" {
+		if awsErr.Code() == "AccessDenied" || awsErr.Code() == "ValidationError" {
 			log.Printf("[WARN] AccessDenied Error with iam.GetUser, assuming IAM profile")
 			// User may be an IAM instance profile, or otherwise IAM role without the
 			// GetUser permissions, so fail silently

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -180,11 +180,21 @@ func (c *Config) ValidateRegion() error {
 	return fmt.Errorf("Not a valid region: %s", c.Region)
 }
 
-// Validate credentials early and fail before we do any graph walking
+// Validate credentials early and fail before we do any graph walking.
+// In the case of an IAM role/profile with insuffecient privileges, fail
+// silently
 func (c *Config) ValidateCredentials(iamconn *iam.IAM) error {
 	_, err := iamconn.GetUser(nil)
 
 	if awsErr, ok := err.(awserr.Error); ok {
+
+		if awsErr.Code() == "AccessDenied" {
+			log.Printf("[WARN] AccessDenied Error with iam.GetUser, assuming IAM profile")
+			// User may be an IAM instance profile, or otherwise IAM role without the
+			// GetUser permissions, so fail silently
+			return nil
+		}
+
 		if awsErr.Code() == "SignatureDoesNotMatch" {
 			return fmt.Errorf("Failed authenticating with AWS: please verify credentials")
 		}


### PR DESCRIPTION
~~WIP, don't merge yet~~

This should ~~help~~ fix https://github.com/hashicorp/terraform/issues/2828 and https://github.com/hashicorp/terraform/issues/2955 (introduced by https://github.com/hashicorp/terraform/pull/2730) by failing silently in the event of an `AccessDenied` or `ValidationError` error message from the `iam.GetUser` call. Instance Profiles may not have this role/permission, but right now we're failing here. If there exists any hierarchy of nodes (dependencies), you can trigger a crash (patched in https://github.com/hashicorp/terraform/pull/2963).

- If a role has **no** IAM policy attached, any authentication via `iam.GetUser` with an IAM profile will receive an `AccessDenied` error message. 
- If the role **does** have an IAM policy, any authentication via `iam.GetUser` will return a `ValidationError` regarding a missing user name

~~Testing this now, may change to specifically confirm the `awsErr.Message()` contains `iam:GetUser` message~~ Good To Go