### PR TITLE
core: dag errors should cascade to all descendents

### DIFF
--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -226,8 +226,10 @@ func TestAcyclicGraphWalk_error(t *testing.T) {
 	g.Add(1)
 	g.Add(2)
 	g.Add(3)
+	g.Add(4)
+	g.Connect(BasicEdge(4, 3))
 	g.Connect(BasicEdge(3, 2))
-	g.Connect(BasicEdge(3, 1))
+	g.Connect(BasicEdge(2, 1))
 
 	var visits []Vertex
 	var lock sync.Mutex


### PR DESCRIPTION
We weren't marking skipped nodes as failing, so any
grandchild-and-deeper dependencies would still evaluate.

For example:

    A -> B -> C -> D

If B failed, C would be skipped, but D would still be evaluated.

This fixes the behavior so C, D, and any further descendents will all be
skipped when B fails.

Addresses crashing aspect of #2955 and likely a lot of other confusing
failure modes.