### PR TITLE
core: fix deadlock when dependable node replaced with non-dependable one

### DIFF
--- a/terraform/graph.go
+++ b/terraform/graph.go
@@ -74,7 +74,11 @@ func (g *Graph) Replace(o, n dag.Vertex) bool {
 	// Go through and update our lookaside to point to the new vertex
 	for k, v := range g.dependableMap {
 		if v == o {
-			g.dependableMap[k] = n
+			if _, ok := n.(GraphNodeDependable); ok {
+				g.dependableMap[k] = n
+			} else {
+				delete(g.dependableMap, k)
+			}
 		}
 	}
 

--- a/terraform/test-fixtures/refresh-module-orphan/child/grandchild/main.tf
+++ b/terraform/test-fixtures/refresh-module-orphan/child/grandchild/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "baz" {}
+
+output "id" { value = "${aws_instance.baz.id}" }

--- a/terraform/test-fixtures/refresh-module-orphan/child/main.tf
+++ b/terraform/test-fixtures/refresh-module-orphan/child/main.tf
@@ -1,0 +1,10 @@
+module "grandchild" {
+  source = "./grandchild"
+}
+
+resource "aws_instance" "bar" {
+  grandchildid = "${module.grandchild.id}"
+}
+
+output "id" { value = "${aws_instance.bar.id}" }
+output "grandchild_id" { value = "${module.grandchild.id}" }

--- a/terraform/test-fixtures/refresh-module-orphan/main.tf
+++ b/terraform/test-fixtures/refresh-module-orphan/main.tf
@@ -1,0 +1,10 @@
+/*
+module "child" {
+  source = "./child"
+}
+
+resource "aws_instance" "bar" {
+  childid      = "${module.child.id}"
+  grandchildid = "${module.child.grandchild_id}"
+}
+*/


### PR DESCRIPTION
In #2884, Terraform would hang on graphs with an orphaned resource
depended on an orphaned module.

This is because orphan module nodes (which are dependable) were getting
expanded (replaced) with GraphNodeBasicSubgraph nodes (which are _not_
dependable).

The old `graph.Replace()` code resulted in GraphNodeBasicSubgraph being
entered into the lookaside table, even though it is not dependable.

This resulted in an untraversable edge in the graph, so the graph would
hang and wait forever.

Now, we remove entries from the lookaside table when a dependable node
is being replaced with a non-dependable node. This means we lose an
edge, but we can move forward. It's ~probably~ never correct to be
replacing depenable nodes with non-dependable ones, but this tweak
seemed preferable to tossing a panic in there.