### PR TITLE
Split of "" should be empty. Length of empty array should be 0

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -506,6 +506,12 @@ func TestInterpolateFuncLength(t *testing.T) {
 				"5",
 				false,
 			},
+			// Want length 0 if we split an empty string then compact
+			{
+				`${length(compact(split(",", "")))}`,
+				"0",
+				false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
In place we want to do: `count = "${length(split(",", var.list_of_things))}"` and in some cases have an empty list (i.e. ""), and therefore get 0 resources.

To do this, splitting the string "" needs to return an empty array (rather than an array with one item which is empty), and the length function needs to do the right thing if it sees an empty array.