### PR TITLE
website: switch to aws.ami instead of amazon.ami for artifacts

### DIFF
--- a/website/source/docs/providers/atlas/r/artifact.html.markdown
+++ b/website/source/docs/providers/atlas/r/artifact.html.markdown
@@ -24,7 +24,7 @@ to this artifact will trigger a change to that instance.
 # Read the AMI
 resource "atlas_artifact" "web" {
     name = "hashicorp/web"
-    type = "amazon.ami"
+    type = "aws.ami"
     build = "latest"
     metadata {
         arch = "386"


### PR DESCRIPTION
This makes things more consistent across different product documentation.