### PR TITLE
aws_kinesis_stream: shard_count state fix

### DIFF
--- a/builtin/providers/aws/resource_aws_kinesis_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_stream.go
@@ -82,7 +82,6 @@ func resourceAwsKinesisStreamRead(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*AWSClient).kinesisconn
 	describeOpts := &kinesis.DescribeStreamInput{
 		StreamName: aws.String(d.Get("name").(string)),
-		Limit:      aws.Int64(1),
 	}
 	resp, err := conn.DescribeStream(describeOpts)
 	if err != nil {
@@ -138,7 +137,6 @@ func streamStateRefreshFunc(conn *kinesis.Kinesis, sn string) resource.StateRefr
 	return func() (interface{}, string, error) {
 		describeOpts := &kinesis.DescribeStreamInput{
 			StreamName: aws.String(sn),
-			Limit:      aws.Int64(1),
 		}
 		resp, err := conn.DescribeStream(describeOpts)
 		if err != nil {


### PR DESCRIPTION
currently state always records `shard_count` as 1. this tests exposes
the issue in https://github.com/hashicorp/terraform/issues/2977

to run test: 
```
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
make testacc TEST=./builtin/providers/aws TESTARGS='-run=KinesisStream'
```
output:
```
--- FAIL: TestAccAWSKinesisStream_basic (74.28s)
	testing.go:136: Step 0 error: Check failed: Bad Stream Shard Count
			 expected: 2
			got: 1
		
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/aws	74.296s
```