### PR TITLE
Fail silently when account validation fails while from instance profile 

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -214,17 +214,17 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 
 	out, err := iamconn.GetUser(nil)
 
-  if err != nil {
-    awsErr, _ := err.(awserr.Error)
-    if awsErr.Code() == "ValidationError" {
-      log.Printf("[WARN] ValidationError with iam.GetUser, assuming its an IAM profile")
-      // User may be an IAM instance profile, so fail silently.
-      // If it is an IAM instance profile
-      // validating account might be superfluous
-    } else {
-		  return fmt.Errorf("Failed getting account ID from IAM: %s", err)
-      // return error if the account id is explicitly not authorised
-    }
+	if err != nil {
+		awsErr, _ := err.(awserr.Error)
+		if awsErr.Code() == "ValidationError" {
+			log.Printf("[WARN] ValidationError with iam.GetUser, assuming its an IAM profile")
+			// User may be an IAM instance profile, so fail silently.
+			// If it is an IAM instance profile
+			// validating account might be superfluous
+		} else {
+			return fmt.Errorf("Failed getting account ID from IAM: %s", err)
+			// return error if the account id is explicitly not authorised
+		}
 	}
 
 	account_id := strings.Split(*out.User.ARN, ":")[4]

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -213,8 +213,18 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 	log.Printf("[INFO] Validating account ID")
 
 	out, err := iamconn.GetUser(nil)
-	if err != nil {
-		return fmt.Errorf("Failed getting account ID from IAM: %s", err)
+
+  if err != nil {
+    awsErr, _ := err.(awserr.Error)
+    if awsErr.Code() == "ValidationError" {
+      log.Printf("[WARN] ValidationError with iam.GetUser, assuming its an IAM profile")
+      // User may be an IAM instance profile, so fail silently.
+      // If it is an IAM instance profile
+      // validating account might be superfluous
+    } else {
+		  return fmt.Errorf("Failed getting account ID from IAM: %s", err)
+      // return error if the account id is explicitly not authorised
+    }
 	}
 
 	account_id := strings.Split(*out.User.ARN, ":")[4]


### PR DESCRIPTION
As far as I know, cross account IAM instance profiles are not possible, so when iam.GetUser() fails for non-User credentials , its better that it fails silently and prints the warning instead of halting the entire run.
This is similar to #2959. If there are better ways of handling (or if its better to explicitly specify) this that would be great aws well. Thanks !