### PR TITLE
Nicer error when list/map assigned to string argument

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1178,8 +1178,25 @@ func (m schemaMap) validatePrimitive(
 	raw interface{},
 	schema *Schema,
 	c *terraform.ResourceConfig) ([]string, []error) {
+
+	// Catch if the user gave a complex type where a primitive was
+	// expected, so we can return a friendly error message that
+	// doesn't contain Go type system terminology.
+	switch reflect.ValueOf(raw).Type().Kind() {
+	case reflect.Slice:
+		return nil, []error{
+			fmt.Errorf("%s must be a single value, not a list", k),
+		}
+	case reflect.Map:
+		return nil, []error{
+			fmt.Errorf("%s must be a single value, not a map", k),
+		}
+	default: // ok
+	}
+
 	if c.IsComputed(k) {
-		// If the key is being computed, then it is not an error
+		// If the key is being computed, then it is not an error as
+		// long as it's not a slice or map.
 		return nil, nil
 	}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3409,6 +3409,36 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Err: true,
 		},
 
+		"Bad, should not allow lists to be assigned to string attributes": {
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Required: true,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"availability_zone": []interface{}{"foo", "bar", "baz"},
+			},
+
+			Err: true,
+		},
+
+		"Bad, should not allow maps to be assigned to string attributes": {
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Required: true,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"availability_zone": map[string]interface{}{"foo": "bar", "baz": "thing"},
+			},
+
+			Err: true,
+		},
+
 		"Deprecated attribute usage generates warning, but not error": {
 			Schema: map[string]*Schema{
 				"old_news": &Schema{


### PR DESCRIPTION
For example:

```js
resource "aws_route_table_association" "foo" {
    route_table_id = "baz"
    subnet_id = ["a", "b"] // this is supposed to be just a string
}
```

Previous this would return the following sort of error:

```
expected type 'string', got unconvertible type '[]interface {}'
```

This is the raw error returned by the underlying mapstructure library. This is not a helpful error message for anyone who doesn't know Go's type system, and it exposes Terraform's internals to the UI.

Instead, catch these cases before we try to use mapstructure and return a more straightforward message.

This also fixes a crash caused when a computed list is assigned to a string attribute. Previously this was not caught at all due to the short-circuit for computed attributes, but now we check for lists and maps before we check for computed, and so we can fail in a nicer way in this case rather than crashing during the later ``Diff`` operation. This is safe because a computed list is materially different than a computed primitive: it's a ``[]interface{}`` with some of the values being interpolated strings, instead of just a single interpolated string.

This issue was exposed by #2984.