### PR TITLE
provider/aws: Update to aws-sdk 0.9.0 rc1

### DIFF
--- a/builtin/providers/aws/autoscaling_tags.go
+++ b/builtin/providers/aws/autoscaling_tags.go
@@ -123,7 +123,7 @@ func autoscalingTagsFromMap(m map[string]interface{}, resourceID string) []*auto
 			Key:               aws.String(k),
 			Value:             aws.String(attr["value"].(string)),
 			PropagateAtLaunch: aws.Bool(attr["propagate_at_launch"].(bool)),
-			ResourceID:        aws.String(resourceID),
+			ResourceId:        aws.String(resourceID),
 			ResourceType:      aws.String("auto-scaling-group"),
 		})
 	}

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -217,7 +217,7 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 		return fmt.Errorf("Failed getting account ID from IAM: %s", err)
 	}
 
-	account_id := strings.Split(*out.User.ARN, ":")[4]
+	account_id := strings.Split(*out.User.Arn, ":")[4]
 
 	if c.ForbiddenAccountIds != nil {
 		for _, id := range c.ForbiddenAccountIds {

--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2.NetworkACLEntry, error) {
-	entries := make([]*ec2.NetworkACLEntry, 0, len(configured))
+func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2.NetworkAclEntry, error) {
+	entries := make([]*ec2.NetworkAclEntry, 0, len(configured))
 	for _, eRaw := range configured {
 		data := eRaw.(map[string]interface{})
 		protocol := data["protocol"].(string)
@@ -23,7 +23,7 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2
 			}
 		}
 
-		e := &ec2.NetworkACLEntry{
+		e := &ec2.NetworkAclEntry{
 			Protocol: aws.String(strconv.Itoa(p)),
 			PortRange: &ec2.PortRange{
 				From: aws.Int64(int64(data["from_port"].(int))),
@@ -32,17 +32,17 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2
 			Egress:     aws.Bool((entryType == "egress")),
 			RuleAction: aws.String(data["action"].(string)),
 			RuleNumber: aws.Int64(int64(data["rule_no"].(int))),
-			CIDRBlock:  aws.String(data["cidr_block"].(string)),
+			CidrBlock:  aws.String(data["cidr_block"].(string)),
 		}
 
 		// Specify additional required fields for ICMP
 		if p == 1 {
-			e.ICMPTypeCode = &ec2.ICMPTypeCode{}
+			e.IcmpTypeCode = &ec2.IcmpTypeCode{}
 			if v, ok := data["icmp_code"]; ok {
-				e.ICMPTypeCode.Code = aws.Int64(int64(v.(int)))
+				e.IcmpTypeCode.Code = aws.Int64(int64(v.(int)))
 			}
 			if v, ok := data["icmp_type"]; ok {
-				e.ICMPTypeCode.Type = aws.Int64(int64(v.(int)))
+				e.IcmpTypeCode.Type = aws.Int64(int64(v.(int)))
 			}
 		}
 
@@ -51,7 +51,7 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2
 	return entries, nil
 }
 
-func flattenNetworkAclEntries(list []*ec2.NetworkACLEntry) []map[string]interface{} {
+func flattenNetworkAclEntries(list []*ec2.NetworkAclEntry) []map[string]interface{} {
 	entries := make([]map[string]interface{}, 0, len(list))
 
 	for _, entry := range list {
@@ -61,7 +61,7 @@ func flattenNetworkAclEntries(list []*ec2.NetworkACLEntry) []map[string]interfac
 			"action":     *entry.RuleAction,
 			"rule_no":    *entry.RuleNumber,
 			"protocol":   *entry.Protocol,
-			"cidr_block": *entry.CIDRBlock,
+			"cidr_block": *entry.CidrBlock,
 		})
 	}
 

--- a/builtin/providers/aws/network_acl_entry_test.go
+++ b/builtin/providers/aws/network_acl_entry_test.go
@@ -37,8 +37,8 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 	}
 	expanded, _ := expandNetworkAclEntries(input, "egress")
 
-	expected := []*ec2.NetworkACLEntry{
-		&ec2.NetworkACLEntry{
+	expected := []*ec2.NetworkAclEntry{
+		&ec2.NetworkAclEntry{
 			Protocol: aws.String("6"),
 			PortRange: &ec2.PortRange{
 				From: aws.Int64(22),
@@ -46,10 +46,10 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 			},
 			RuleAction: aws.String("deny"),
 			RuleNumber: aws.Int64(1),
-			CIDRBlock:  aws.String("0.0.0.0/0"),
+			CidrBlock:  aws.String("0.0.0.0/0"),
 			Egress:     aws.Bool(true),
 		},
-		&ec2.NetworkACLEntry{
+		&ec2.NetworkAclEntry{
 			Protocol: aws.String("6"),
 			PortRange: &ec2.PortRange{
 				From: aws.Int64(443),
@@ -57,10 +57,10 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 			},
 			RuleAction: aws.String("deny"),
 			RuleNumber: aws.Int64(2),
-			CIDRBlock:  aws.String("0.0.0.0/0"),
+			CidrBlock:  aws.String("0.0.0.0/0"),
 			Egress:     aws.Bool(true),
 		},
-		&ec2.NetworkACLEntry{
+		&ec2.NetworkAclEntry{
 			Protocol: aws.String("-1"),
 			PortRange: &ec2.PortRange{
 				From: aws.Int64(443),
@@ -68,7 +68,7 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 			},
 			RuleAction: aws.String("deny"),
 			RuleNumber: aws.Int64(2),
-			CIDRBlock:  aws.String("0.0.0.0/0"),
+			CidrBlock:  aws.String("0.0.0.0/0"),
 			Egress:     aws.Bool(true),
 		},
 	}
@@ -84,8 +84,8 @@ func Test_expandNetworkACLEntry(t *testing.T) {
 
 func Test_flattenNetworkACLEntry(t *testing.T) {
 
-	apiInput := []*ec2.NetworkACLEntry{
-		&ec2.NetworkACLEntry{
+	apiInput := []*ec2.NetworkAclEntry{
+		&ec2.NetworkAclEntry{
 			Protocol: aws.String("tcp"),
 			PortRange: &ec2.PortRange{
 				From: aws.Int64(22),
@@ -93,9 +93,9 @@ func Test_flattenNetworkACLEntry(t *testing.T) {
 			},
 			RuleAction: aws.String("deny"),
 			RuleNumber: aws.Int64(1),
-			CIDRBlock:  aws.String("0.0.0.0/0"),
+			CidrBlock:  aws.String("0.0.0.0/0"),
 		},
-		&ec2.NetworkACLEntry{
+		&ec2.NetworkAclEntry{
 			Protocol: aws.String("tcp"),
 			PortRange: &ec2.PortRange{
 				From: aws.Int64(443),
@@ -103,7 +103,7 @@ func Test_flattenNetworkACLEntry(t *testing.T) {
 			},
 			RuleAction: aws.String("deny"),
 			RuleNumber: aws.Int64(2),
-			CIDRBlock:  aws.String("0.0.0.0/0"),
+			CidrBlock:  aws.String("0.0.0.0/0"),
 		},
 	}
 	flattened := flattenNetworkAclEntries(apiInput)

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -480,7 +480,7 @@ func waitForASGCapacity(d *schema.ResourceData, meta interface{}) error {
 		haveELB := 0
 
 		for _, i := range g.Instances {
-			if i.HealthStatus == nil || i.InstanceID == nil || i.LifecycleState == nil {
+			if i.HealthStatus == nil || i.InstanceId == nil || i.LifecycleState == nil {
 				continue
 			}
 
@@ -497,7 +497,7 @@ func waitForASGCapacity(d *schema.ResourceData, meta interface{}) error {
 			if wantELB > 0 {
 				inAllLbs := true
 				for _, states := range lbis {
-					state, ok := states[*i.InstanceID]
+					state, ok := states[*i.InstanceId]
 					if !ok || !strings.EqualFold(state, "InService") {
 						inAllLbs = false
 					}
@@ -535,10 +535,10 @@ func getLBInstanceStates(g *autoscaling.Group, meta interface{}) (map[string]map
 			return nil, err
 		}
 		for _, is := range r.InstanceStates {
-			if is.InstanceID == nil || is.State == nil {
+			if is.InstanceId == nil || is.State == nil {
 				continue
 			}
-			lbInstanceStates[*lbName][*is.InstanceID] = *is.State
+			lbInstanceStates[*lbName][*is.InstanceId] = *is.State
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -219,7 +219,7 @@ func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.Group) resourc
 			Value:             aws.String("foo-bar"),
 			PropagateAtLaunch: aws.Bool(true),
 			ResourceType:      aws.String("auto-scaling-group"),
-			ResourceID:        group.AutoScalingGroupName,
+			ResourceId:        group.AutoScalingGroupName,
 		}
 
 		if !reflect.DeepEqual(group.Tags[0], t) {

--- a/builtin/providers/aws/resource_aws_customer_gateway.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway.go
@@ -48,8 +48,8 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).ec2conn
 
 	createOpts := &ec2.CreateCustomerGatewayInput{
-		BGPASN:   aws.Int64(int64(d.Get("bgp_asn").(int))),
-		PublicIP: aws.String(d.Get("ip_address").(string)),
+		BgpAsn:   aws.Int64(int64(d.Get("bgp_asn").(int))),
+		PublicIp: aws.String(d.Get("ip_address").(string)),
 		Type:     aws.String(d.Get("type").(string)),
 	}
 
@@ -62,14 +62,14 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 
 	// Store the ID
 	customerGateway := resp.CustomerGateway
-	d.SetId(*customerGateway.CustomerGatewayID)
-	log.Printf("[INFO] Customer gateway ID: %s", *customerGateway.CustomerGatewayID)
+	d.SetId(*customerGateway.CustomerGatewayId)
+	log.Printf("[INFO] Customer gateway ID: %s", *customerGateway.CustomerGatewayId)
 
 	// Wait for the CustomerGateway to be available.
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     "available",
-		Refresh:    customerGatewayRefreshFunc(conn, *customerGateway.CustomerGatewayID),
+		Refresh:    customerGatewayRefreshFunc(conn, *customerGateway.CustomerGatewayId),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -79,7 +79,7 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	if stateErr != nil {
 		return fmt.Errorf(
 			"Error waiting for customer gateway (%s) to become ready: %s",
-			*customerGateway.CustomerGatewayID, err)
+			*customerGateway.CustomerGatewayId, err)
 	}
 
 	// Create tags.
@@ -145,8 +145,8 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	customerGateway := resp.CustomerGateways[0]
-	d.Set("bgp_asn", customerGateway.BGPASN)
-	d.Set("ip_address", customerGateway.IPAddress)
+	d.Set("bgp_asn", customerGateway.BgpAsn)
+	d.Set("ip_address", customerGateway.IpAddress)
 	d.Set("type", customerGateway.Type)
 	d.Set("tags", tagsToMap(customerGateway.Tags))
 
@@ -170,7 +170,7 @@ func resourceAwsCustomerGatewayDelete(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).ec2conn
 
 	_, err := conn.DeleteCustomerGateway(&ec2.DeleteCustomerGatewayInput{
-		CustomerGatewayID: aws.String(d.Id()),
+		CustomerGatewayId: aws.String(d.Id()),
 	})
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidCustomerGatewayID.NotFound" {

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -272,7 +272,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			Tags:                       tags,
 		}
 		if attr, ok := d.GetOk("iops"); ok {
-			opts.IOPS = aws.Int64(int64(attr.(int)))
+			opts.Iops = aws.Int64(int64(attr.(int)))
 		}
 
 		if attr, ok := d.GetOk("port"); ok {
@@ -315,7 +315,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr, ok := d.GetOk("iops"); ok {
-			opts.IOPS = aws.Int64(int64(attr.(int)))
+			opts.Iops = aws.Int64(int64(attr.(int)))
 		}
 
 		if attr, ok := d.GetOk("license_model"); ok {
@@ -339,7 +339,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr, ok := d.GetOk("tde_credential_arn"); ok {
-			opts.TDECredentialARN = aws.String(attr.(string))
+			opts.TdeCredentialArn = aws.String(attr.(string))
 		}
 
 		if attr, ok := d.GetOk("storage_type"); ok {
@@ -390,7 +390,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			for _, v := range attr.List() {
 				s = append(s, aws.String(v.(string)))
 			}
-			opts.VPCSecurityGroupIDs = s
+			opts.VpcSecurityGroupIds = s
 		}
 
 		if attr := d.Get("security_group_names").(*schema.Set); attr.Len() > 0 {
@@ -409,7 +409,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr, ok := d.GetOk("iops"); ok {
-			opts.IOPS = aws.Int64(int64(attr.(int)))
+			opts.Iops = aws.Int64(int64(attr.(int)))
 		}
 
 		if attr, ok := d.GetOk("port"); ok {
@@ -533,8 +533,8 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	ids := &schema.Set{
 		F: schema.HashString,
 	}
-	for _, v := range v.VPCSecurityGroups {
-		ids.Add(*v.VPCSecurityGroupID)
+	for _, v := range v.VpcSecurityGroups {
+		ids.Add(*v.VpcSecurityGroupId)
 	}
 	d.Set("vpc_security_group_ids", ids)
 
@@ -638,7 +638,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 	if d.HasChange("iops") {
 		d.SetPartial("iops")
-		req.IOPS = aws.Int64(int64(d.Get("iops").(int)))
+		req.Iops = aws.Int64(int64(d.Get("iops").(int)))
 		requestUpdate = true
 	}
 	if d.HasChange("backup_window") {
@@ -673,7 +673,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 			for _, v := range attr.List() {
 				s = append(s, aws.String(v.(string)))
 			}
-			req.VPCSecurityGroupIDs = s
+			req.VpcSecurityGroupIds = s
 		}
 		requestUpdate = true
 	}
@@ -791,7 +791,7 @@ func buildRDSARN(d *schema.ResourceData, meta interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	userARN := *resp.User.ARN
+	userARN := *resp.User.Arn
 	accountID := strings.Split(userARN, ":")[4]
 	arn := fmt.Sprintf("arn:aws:rds:%s:%s:db:%s", region, accountID, d.Id())
 	return arn, nil

--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -149,8 +149,8 @@ func resourceAwsDbSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	for _, g := range sg.EC2SecurityGroups {
 		rule := map[string]interface{}{
 			"security_group_name":     *g.EC2SecurityGroupName,
-			"security_group_id":       *g.EC2SecurityGroupID,
-			"security_group_owner_id": *g.EC2SecurityGroupOwnerID,
+			"security_group_id":       *g.EC2SecurityGroupId,
+			"security_group_owner_id": *g.EC2SecurityGroupOwnerId,
 		}
 		rules.Add(rule)
 	}
@@ -221,11 +221,11 @@ func resourceAwsDbSecurityGroupAuthorizeRule(ingress interface{}, dbSecurityGrou
 	}
 
 	if attr, ok := ing["security_group_id"]; ok && attr != "" {
-		opts.EC2SecurityGroupID = aws.String(attr.(string))
+		opts.EC2SecurityGroupId = aws.String(attr.(string))
 	}
 
 	if attr, ok := ing["security_group_owner_id"]; ok && attr != "" {
-		opts.EC2SecurityGroupOwnerID = aws.String(attr.(string))
+		opts.EC2SecurityGroupOwnerId = aws.String(attr.(string))
 	}
 
 	log.Printf("[DEBUG] Authorize ingress rule configuration: %#v", opts)

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -72,7 +72,7 @@ func resourceAwsDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) er
 	createOpts := rds.CreateDBSubnetGroupInput{
 		DBSubnetGroupName:        aws.String(d.Get("name").(string)),
 		DBSubnetGroupDescription: aws.String(d.Get("description").(string)),
-		SubnetIDs:                subnetIds,
+		SubnetIds:                subnetIds,
 	}
 
 	log.Printf("[DEBUG] Create DB Subnet Group: %#v", createOpts)

--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -579,7 +579,7 @@ func resourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("global_secondary_index", gsiList)
-	d.Set("arn", table.TableARN)
+	d.Set("arn", table.TableArn)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_ebs_volume.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume.go
@@ -77,16 +77,16 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		request.Encrypted = aws.Bool(value.(bool))
 	}
 	if value, ok := d.GetOk("iops"); ok {
-		request.IOPS = aws.Int64(int64(value.(int)))
+		request.Iops = aws.Int64(int64(value.(int)))
 	}
 	if value, ok := d.GetOk("kms_key_id"); ok {
-		request.KMSKeyID = aws.String(value.(string))
+		request.KmsKeyId = aws.String(value.(string))
 	}
 	if value, ok := d.GetOk("size"); ok {
 		request.Size = aws.Int64(int64(value.(int)))
 	}
 	if value, ok := d.GetOk("snapshot_id"); ok {
-		request.SnapshotID = aws.String(value.(string))
+		request.SnapshotId = aws.String(value.(string))
 	}
 	if value, ok := d.GetOk("type"); ok {
 		request.VolumeType = aws.String(value.(string))
@@ -104,7 +104,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating"},
 		Target:     "available",
-		Refresh:    volumeStateRefreshFunc(conn, *result.VolumeID),
+		Refresh:    volumeStateRefreshFunc(conn, *result.VolumeId),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -114,10 +114,10 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for Volume (%s) to become available: %s",
-			*result.VolumeID, err)
+			*result.VolumeId, err)
 	}
 
-	d.SetId(*result.VolumeID)
+	d.SetId(*result.VolumeId)
 
 	if _, ok := d.GetOk("tags"); ok {
 		setTags(conn, d)
@@ -139,7 +139,7 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 func volumeStateRefreshFunc(conn *ec2.EC2, volumeID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeVolumes(&ec2.DescribeVolumesInput{
-			VolumeIDs: []*string{aws.String(volumeID)},
+			VolumeIds: []*string{aws.String(volumeID)},
 		})
 
 		if err != nil {
@@ -163,7 +163,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	request := &ec2.DescribeVolumesInput{
-		VolumeIDs: []*string{aws.String(d.Id())},
+		VolumeIds: []*string{aws.String(d.Id())},
 	}
 
 	response, err := conn.DescribeVolumes(request)
@@ -182,7 +182,7 @@ func resourceAwsEbsVolumeDelete(d *schema.ResourceData, meta interface{}) error 
 	conn := meta.(*AWSClient).ec2conn
 
 	request := &ec2.DeleteVolumeInput{
-		VolumeID: aws.String(d.Id()),
+		VolumeId: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteVolume(request)
@@ -193,23 +193,23 @@ func resourceAwsEbsVolumeDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func readVolume(d *schema.ResourceData, volume *ec2.Volume) error {
-	d.SetId(*volume.VolumeID)
+	d.SetId(*volume.VolumeId)
 
 	d.Set("availability_zone", *volume.AvailabilityZone)
 	if volume.Encrypted != nil {
 		d.Set("encrypted", *volume.Encrypted)
 	}
-	if volume.IOPS != nil {
-		d.Set("iops", *volume.IOPS)
+	if volume.Iops != nil {
+		d.Set("iops", *volume.Iops)
 	}
-	if volume.KMSKeyID != nil {
-		d.Set("kms_key_id", *volume.KMSKeyID)
+	if volume.KmsKeyId != nil {
+		d.Set("kms_key_id", *volume.KmsKeyId)
 	}
 	if volume.Size != nil {
 		d.Set("size", *volume.Size)
 	}
-	if volume.SnapshotID != nil {
-		d.Set("snapshot_id", *volume.SnapshotID)
+	if volume.SnapshotId != nil {
+		d.Set("snapshot_id", *volume.SnapshotId)
 	}
 	if volume.VolumeType != nil {
 		d.Set("type", *volume.VolumeType)

--- a/builtin/providers/aws/resource_aws_ebs_volume_test.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume_test.go
@@ -56,7 +56,7 @@ func testAccCheckVolumeExists(n string, v *ec2.Volume) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
 		request := &ec2.DescribeVolumesInput{
-			VolumeIDs: []*string{aws.String(rs.Primary.ID)},
+			VolumeIds: []*string{aws.String(rs.Primary.ID)},
 		}
 
 		response, err := conn.DescribeVolumes(request)

--- a/builtin/providers/aws/resource_aws_ecs_cluster.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster.go
@@ -39,9 +39,9 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] ECS cluster %s created", *out.Cluster.ClusterARN)
+	log.Printf("[DEBUG] ECS cluster %s created", *out.Cluster.ClusterArn)
 
-	d.SetId(*out.Cluster.ClusterARN)
+	d.SetId(*out.Cluster.ClusterArn)
 	d.Set("name", *out.Cluster.ClusterName)
 	return nil
 }
@@ -59,7 +59,7 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] Received ECS clusters: %s", out.Clusters)
 
-	d.SetId(*out.Clusters[0].ClusterARN)
+	d.SetId(*out.Clusters[0].ClusterArn)
 	d.Set("name", *out.Clusters[0].ClusterName)
 
 	return nil

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -112,9 +112,9 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	service := *out.Service
 
-	log.Printf("[DEBUG] ECS service created: %s", *service.ServiceARN)
-	d.SetId(*service.ServiceARN)
-	d.Set("cluster", *service.ClusterARN)
+	log.Printf("[DEBUG] ECS service created: %s", *service.ServiceArn)
+	d.SetId(*service.ServiceArn)
+	d.Set("cluster", *service.ClusterArn)
 
 	return resourceAwsEcsServiceUpdate(d, meta)
 }
@@ -140,7 +140,7 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	service := out.Services[0]
 	log.Printf("[DEBUG] Received ECS service %s", service)
 
-	d.SetId(*service.ServiceARN)
+	d.SetId(*service.ServiceArn)
 	d.Set("name", *service.ServiceName)
 
 	// Save task definition in the same format
@@ -152,10 +152,10 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("desired_count", *service.DesiredCount)
-	d.Set("cluster", *service.ClusterARN)
+	d.Set("cluster", *service.ClusterArn)
 
-	if service.RoleARN != nil {
-		d.Set("iam_role", *service.RoleARN)
+	if service.RoleArn != nil {
+		d.Set("iam_role", *service.RoleArn)
 	}
 
 	if service.LoadBalancers != nil {
@@ -259,7 +259,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	log.Printf("[DEBUG] ECS service %s deleted.", *out.Service.ServiceARN)
+	log.Printf("[DEBUG] ECS service %s deleted.", *out.Service.ServiceArn)
 	return nil
 }
 
@@ -299,7 +299,7 @@ func buildTaskDefinitionARN(taskDefinition string, meta interface{}) (string, er
 	}
 
 	// arn:aws:iam::0123456789:user/username
-	userARN := *resp.User.ARN
+	userARN := *resp.User.Arn
 	accountID := strings.Split(userARN, ":")[4]
 
 	// arn:aws:ecs:us-west-2:01234567890:task-definition/mongodb:3

--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -99,10 +99,10 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 	taskDefinition := *out.TaskDefinition
 
 	log.Printf("[DEBUG] ECS task definition registered: %q (rev. %d)",
-		*taskDefinition.TaskDefinitionARN, *taskDefinition.Revision)
+		*taskDefinition.TaskDefinitionArn, *taskDefinition.Revision)
 
 	d.SetId(*taskDefinition.Family)
-	d.Set("arn", *taskDefinition.TaskDefinitionARN)
+	d.Set("arn", *taskDefinition.TaskDefinitionArn)
 
 	return resourceAwsEcsTaskDefinitionRead(d, meta)
 }
@@ -122,7 +122,7 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	taskDefinition := out.TaskDefinition
 
 	d.SetId(*taskDefinition.Family)
-	d.Set("arn", *taskDefinition.TaskDefinitionARN)
+	d.Set("arn", *taskDefinition.TaskDefinitionArn)
 	d.Set("family", *taskDefinition.Family)
 	d.Set("revision", *taskDefinition.Revision)
 	d.Set("container_definitions", taskDefinition.ContainerDefinitions)

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -95,9 +95,9 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 	// it defaults to using the public IP
 	log.Printf("[DEBUG] EIP Allocate: %#v", allocResp)
 	if d.Get("domain").(string) == "vpc" {
-		d.SetId(*allocResp.AllocationID)
+		d.SetId(*allocResp.AllocationId)
 	} else {
-		d.SetId(*allocResp.PublicIP)
+		d.SetId(*allocResp.PublicIp)
 	}
 
 	log.Printf("[INFO] EIP ID: %s (domain: %v)", d.Id(), *allocResp.Domain)
@@ -113,9 +113,9 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	req := &ec2.DescribeAddressesInput{}
 
 	if domain == "vpc" {
-		req.AllocationIDs = []*string{aws.String(id)}
+		req.AllocationIds = []*string{aws.String(id)}
 	} else {
-		req.PublicIPs = []*string{aws.String(id)}
+		req.PublicIps = []*string{aws.String(id)}
 	}
 
 	log.Printf(
@@ -134,8 +134,8 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Verify AWS returned our EIP
 	if len(describeAddresses.Addresses) != 1 ||
-		(domain == "vpc" && *describeAddresses.Addresses[0].AllocationID != id) ||
-		*describeAddresses.Addresses[0].PublicIP != id {
+		(domain == "vpc" && *describeAddresses.Addresses[0].AllocationId != id) ||
+		*describeAddresses.Addresses[0].PublicIp != id {
 		if err != nil {
 			return fmt.Errorf("Unable to find EIP: %#v", describeAddresses.Addresses)
 		}
@@ -143,15 +143,15 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	address := describeAddresses.Addresses[0]
 
-	d.Set("association_id", address.AssociationID)
-	if address.InstanceID != nil {
-		d.Set("instance", address.InstanceID)
+	d.Set("association_id", address.AssociationId)
+	if address.InstanceId != nil {
+		d.Set("instance", address.InstanceId)
 	}
-	if address.NetworkInterfaceID != nil {
-		d.Set("network_interface", address.NetworkInterfaceID)
+	if address.NetworkInterfaceId != nil {
+		d.Set("network_interface", address.NetworkInterfaceId)
 	}
-	d.Set("private_ip", address.PrivateIPAddress)
-	d.Set("public_ip", address.PublicIP)
+	d.Set("private_ip", address.PrivateIpAddress)
+	d.Set("public_ip", address.PublicIp)
 
 	return nil
 }
@@ -170,16 +170,16 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 		networkInterfaceId := v_interface.(string)
 
 		assocOpts := &ec2.AssociateAddressInput{
-			InstanceID: aws.String(instanceId),
-			PublicIP:   aws.String(d.Id()),
+			InstanceId: aws.String(instanceId),
+			PublicIp:   aws.String(d.Id()),
 		}
 
 		// more unique ID conditionals
 		if domain == "vpc" {
 			assocOpts = &ec2.AssociateAddressInput{
-				NetworkInterfaceID: aws.String(networkInterfaceId),
-				InstanceID:         aws.String(instanceId),
-				AllocationID:       aws.String(d.Id()),
+				NetworkInterfaceId: aws.String(networkInterfaceId),
+				InstanceId:         aws.String(instanceId),
+				AllocationId:       aws.String(d.Id()),
 			}
 		}
 
@@ -215,11 +215,11 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 		switch resourceAwsEipDomain(d) {
 		case "vpc":
 			_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{
-				AssociationID: aws.String(d.Get("association_id").(string)),
+				AssociationId: aws.String(d.Get("association_id").(string)),
 			})
 		case "standard":
 			_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{
-				PublicIP: aws.String(d.Get("public_ip").(string)),
+				PublicIp: aws.String(d.Get("public_ip").(string)),
 			})
 		}
 
@@ -247,12 +247,12 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 				"[DEBUG] EIP release (destroy) address allocation: %v",
 				d.Id())
 			_, err = ec2conn.ReleaseAddress(&ec2.ReleaseAddressInput{
-				AllocationID: aws.String(d.Id()),
+				AllocationId: aws.String(d.Id()),
 			})
 		case "standard":
 			log.Printf("[DEBUG] EIP release (destroy) address: %v", d.Id())
 			_, err = ec2conn.ReleaseAddress(&ec2.ReleaseAddressInput{
-				PublicIP: aws.String(d.Id()),
+				PublicIp: aws.String(d.Id()),
 			})
 		}
 

--- a/builtin/providers/aws/resource_aws_eip_test.go
+++ b/builtin/providers/aws/resource_aws_eip_test.go
@@ -87,13 +87,13 @@ func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 		}
 
 		req := &ec2.DescribeAddressesInput{
-			PublicIPs: []*string{aws.String(rs.Primary.ID)},
+			PublicIps: []*string{aws.String(rs.Primary.ID)},
 		}
 		describe, err := conn.DescribeAddresses(req)
 
 		if err == nil {
 			if len(describe.Addresses) != 0 &&
-				*describe.Addresses[0].PublicIP == rs.Primary.ID {
+				*describe.Addresses[0].PublicIp == rs.Primary.ID {
 				return fmt.Errorf("EIP still exists")
 			}
 		}
@@ -114,7 +114,7 @@ func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 
 func testAccCheckAWSEIPAttributes(conf *ec2.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *conf.PublicIP == "" {
+		if *conf.PublicIp == "" {
 			return fmt.Errorf("empty public_ip")
 		}
 
@@ -124,7 +124,7 @@ func testAccCheckAWSEIPAttributes(conf *ec2.Address) resource.TestCheckFunc {
 
 func testAccCheckAWSEIPAssociated(conf *ec2.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *conf.AssociationID == "" {
+		if *conf.AssociationId == "" {
 			return fmt.Errorf("empty association_id")
 		}
 
@@ -147,7 +147,7 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 
 		if strings.Contains(rs.Primary.ID, "eipalloc") {
 			req := &ec2.DescribeAddressesInput{
-				AllocationIDs: []*string{aws.String(rs.Primary.ID)},
+				AllocationIds: []*string{aws.String(rs.Primary.ID)},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {
@@ -155,14 +155,14 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 			}
 
 			if len(describe.Addresses) != 1 ||
-				*describe.Addresses[0].AllocationID != rs.Primary.ID {
+				*describe.Addresses[0].AllocationId != rs.Primary.ID {
 				return fmt.Errorf("EIP not found")
 			}
 			*res = *describe.Addresses[0]
 
 		} else {
 			req := &ec2.DescribeAddressesInput{
-				PublicIPs: []*string{aws.String(rs.Primary.ID)},
+				PublicIps: []*string{aws.String(rs.Primary.ID)},
 			}
 			describe, err := conn.DescribeAddresses(req)
 			if err != nil {
@@ -170,7 +170,7 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 			}
 
 			if len(describe.Addresses) != 1 ||
-				*describe.Addresses[0].PublicIP != rs.Primary.ID {
+				*describe.Addresses[0].PublicIp != rs.Primary.ID {
 				return fmt.Errorf("EIP not found")
 			}
 			*res = *describe.Addresses[0]

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -57,7 +57,7 @@ func testAccCheckAWSElasticacheClusterDestroy(s *terraform.State) error {
 			continue
 		}
 		res, err := conn.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{
-			CacheClusterID: aws.String(rs.Primary.ID),
+			CacheClusterId: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
 			return err
@@ -82,7 +82,7 @@ func testAccCheckAWSElasticacheClusterExists(n string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
 		_, err := conn.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{
-			CacheClusterID: aws.String(rs.Primary.ID),
+			CacheClusterId: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
 			return fmt.Errorf("Elasticache error: %v", err)

--- a/builtin/providers/aws/resource_aws_elasticache_security_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_security_group.go
@@ -69,7 +69,7 @@ func resourceAwsElasticacheSecurityGroupCreate(d *schema.ResourceData, meta inte
 		_, err = conn.AuthorizeCacheSecurityGroupIngress(&elasticache.AuthorizeCacheSecurityGroupIngressInput{
 			CacheSecurityGroupName:  aws.String(name),
 			EC2SecurityGroupName:    aws.String(n),
-			EC2SecurityGroupOwnerID: aws.String(*res.CacheSecurityGroup.OwnerID),
+			EC2SecurityGroupOwnerId: aws.String(*res.CacheSecurityGroup.OwnerId),
 		})
 		if err != nil {
 			log.Printf("[ERROR] Failed to authorize: %v", err)

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -57,7 +57,7 @@ func resourceAwsElasticacheSubnetGroupCreate(d *schema.ResourceData, meta interf
 	req := &elasticache.CreateCacheSubnetGroupInput{
 		CacheSubnetGroupDescription: aws.String(desc),
 		CacheSubnetGroupName:        aws.String(name),
-		SubnetIDs:                   subnetIds,
+		SubnetIds:                   subnetIds,
 	}
 
 	_, err := conn.CreateCacheSubnetGroup(req)
@@ -122,7 +122,7 @@ func resourceAwsElasticacheSubnetGroupUpdate(d *schema.ResourceData, meta interf
 		_, err := conn.ModifyCacheSubnetGroup(&elasticache.ModifyCacheSubnetGroupInput{
 			CacheSubnetGroupName:        aws.String(d.Get("name").(string)),
 			CacheSubnetGroupDescription: aws.String(d.Get("description").(string)),
-			SubnetIDs:                   subnets,
+			SubnetIds:                   subnets,
 		})
 		if err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_flow_log.go
+++ b/builtin/providers/aws/resource_aws_flow_log.go
@@ -85,9 +85,9 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	opts := &ec2.CreateFlowLogsInput{
-		DeliverLogsPermissionARN: aws.String(d.Get("iam_role_arn").(string)),
+		DeliverLogsPermissionArn: aws.String(d.Get("iam_role_arn").(string)),
 		LogGroupName:             aws.String(d.Get("log_group_name").(string)),
-		ResourceIDs:              []*string{aws.String(resourceId)},
+		ResourceIds:              []*string{aws.String(resourceId)},
 		ResourceType:             aws.String(resourceType),
 		TrafficType:              aws.String(d.Get("traffic_type").(string)),
 	}
@@ -99,11 +99,11 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating Flow Log for (%s), error: %s", resourceId, err)
 	}
 
-	if len(resp.FlowLogIDs) > 1 {
+	if len(resp.FlowLogIds) > 1 {
 		return fmt.Errorf("Error: multiple Flow Logs created for (%s)", resourceId)
 	}
 
-	d.SetId(*resp.FlowLogIDs[0])
+	d.SetId(*resp.FlowLogIds[0])
 
 	return resourceAwsLogFlowRead(d, meta)
 }
@@ -112,7 +112,7 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	opts := &ec2.DescribeFlowLogsInput{
-		FlowLogIDs: []*string{aws.String(d.Id())},
+		FlowLogIds: []*string{aws.String(d.Id())},
 	}
 
 	resp, err := conn.DescribeFlowLogs(opts)
@@ -132,7 +132,7 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("traffic_type", fl.TrafficType)
 	d.Set("log_group_name", fl.LogGroupName)
-	d.Set("iam_role_arn", fl.DeliverLogsPermissionARN)
+	d.Set("iam_role_arn", fl.DeliverLogsPermissionArn)
 
 	return nil
 }
@@ -143,7 +143,7 @@ func resourceAwsLogFlowDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf(
 		"[DEBUG] Flow Log Destroy: %s", d.Id())
 	_, err := conn.DeleteFlowLogs(&ec2.DeleteFlowLogsInput{
-		FlowLogIDs: []*string{aws.String(d.Id())},
+		FlowLogIds: []*string{aws.String(d.Id())},
 	})
 
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_flow_log_test.go
+++ b/builtin/providers/aws/resource_aws_flow_log_test.go
@@ -64,7 +64,7 @@ func testAccCheckFlowLogExists(n string, flowLog *ec2.FlowLog) resource.TestChec
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		describeOpts := &ec2.DescribeFlowLogsInput{
-			FlowLogIDs: []*string{aws.String(rs.Primary.ID)},
+			FlowLogIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		resp, err := conn.DescribeFlowLogs(describeOpts)
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_iam_access_key.go
+++ b/builtin/providers/aws/resource_aws_iam_access_key.go
@@ -56,7 +56,7 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	return resourceAwsIamAccessKeyReadResult(d, &iam.AccessKeyMetadata{
-		AccessKeyID: createResp.AccessKey.AccessKeyID,
+		AccessKeyId: createResp.AccessKey.AccessKeyId,
 		CreateDate:  createResp.AccessKey.CreateDate,
 		Status:      createResp.AccessKey.Status,
 		UserName:    createResp.AccessKey.UserName,
@@ -81,7 +81,7 @@ func resourceAwsIamAccessKeyRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	for _, key := range getResp.AccessKeyMetadata {
-		if key.AccessKeyID != nil && *key.AccessKeyID == d.Id() {
+		if key.AccessKeyId != nil && *key.AccessKeyId == d.Id() {
 			return resourceAwsIamAccessKeyReadResult(d, key)
 		}
 	}
@@ -92,7 +92,7 @@ func resourceAwsIamAccessKeyRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsIamAccessKeyReadResult(d *schema.ResourceData, key *iam.AccessKeyMetadata) error {
-	d.SetId(*key.AccessKeyID)
+	d.SetId(*key.AccessKeyId)
 	if err := d.Set("user", key.UserName); err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func resourceAwsIamAccessKeyDelete(d *schema.ResourceData, meta interface{}) err
 	iamconn := meta.(*AWSClient).iamconn
 
 	request := &iam.DeleteAccessKeyInput{
-		AccessKeyID: aws.String(d.Id()),
+		AccessKeyId: aws.String(d.Id()),
 		UserName:    aws.String(d.Get("user").(string)),
 	}
 

--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -81,13 +81,13 @@ func resourceAwsIamGroupReadResult(d *schema.ResourceData, group *iam.Group) err
 	if err := d.Set("name", group.GroupName); err != nil {
 		return err
 	}
-	if err := d.Set("arn", group.ARN); err != nil {
+	if err := d.Set("arn", group.Arn); err != nil {
 		return err
 	}
 	if err := d.Set("path", group.Path); err != nil {
 		return err
 	}
-	if err := d.Set("unique_id", group.GroupID); err != nil {
+	if err := d.Set("unique_id", group.GroupId); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/providers/aws/resource_aws_iam_instance_profile.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile.go
@@ -205,7 +205,7 @@ func instanceProfileReadResult(d *schema.ResourceData, result *iam.InstanceProfi
 	if err := d.Set("name", result.InstanceProfileName); err != nil {
 		return err
 	}
-	if err := d.Set("arn", result.ARN); err != nil {
+	if err := d.Set("arn", result.Arn); err != nil {
 		return err
 	}
 	if err := d.Set("path", result.Path); err != nil {

--- a/builtin/providers/aws/resource_aws_iam_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_policy.go
@@ -69,7 +69,7 @@ func resourceAwsIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
 	request := &iam.GetPolicyInput{
-		PolicyARN: aws.String(d.Id()),
+		PolicyArn: aws.String(d.Id()),
 	}
 
 	response, err := iamconn.GetPolicy(request)
@@ -95,7 +95,7 @@ func resourceAwsIamPolicyUpdate(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 	request := &iam.CreatePolicyVersionInput{
-		PolicyARN:      aws.String(d.Id()),
+		PolicyArn:      aws.String(d.Id()),
 		PolicyDocument: aws.String(d.Get("policy").(string)),
 		SetAsDefault:   aws.Bool(true),
 	}
@@ -114,7 +114,7 @@ func resourceAwsIamPolicyDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	request := &iam.DeletePolicyInput{
-		PolicyARN: aws.String(d.Id()),
+		PolicyArn: aws.String(d.Id()),
 	}
 
 	_, err := iamconn.DeletePolicy(request)
@@ -155,7 +155,7 @@ func iamPolicyPruneVersions(arn string, iamconn *iam.IAM) error {
 		}
 	}
 
-	if err := iamPolicyDeleteVersion(arn, *oldestVersion.VersionID, iamconn); err != nil {
+	if err := iamPolicyDeleteVersion(arn, *oldestVersion.VersionId, iamconn); err != nil {
 		return err
 	}
 	return nil
@@ -171,7 +171,7 @@ func iamPolicyDeleteNondefaultVersions(arn string, iamconn *iam.IAM) error {
 		if *version.IsDefaultVersion {
 			continue
 		}
-		if err := iamPolicyDeleteVersion(arn, *version.VersionID, iamconn); err != nil {
+		if err := iamPolicyDeleteVersion(arn, *version.VersionId, iamconn); err != nil {
 			return err
 		}
 	}
@@ -181,8 +181,8 @@ func iamPolicyDeleteNondefaultVersions(arn string, iamconn *iam.IAM) error {
 
 func iamPolicyDeleteVersion(arn, versionID string, iamconn *iam.IAM) error {
 	request := &iam.DeletePolicyVersionInput{
-		PolicyARN: aws.String(arn),
-		VersionID: aws.String(versionID),
+		PolicyArn: aws.String(arn),
+		VersionId: aws.String(versionID),
 	}
 
 	_, err := iamconn.DeletePolicyVersion(request)
@@ -194,7 +194,7 @@ func iamPolicyDeleteVersion(arn, versionID string, iamconn *iam.IAM) error {
 
 func iamPolicyListVersions(arn string, iamconn *iam.IAM) ([]*iam.PolicyVersion, error) {
 	request := &iam.ListPolicyVersionsInput{
-		PolicyARN: aws.String(arn),
+		PolicyArn: aws.String(arn),
 	}
 
 	response, err := iamconn.ListPolicyVersions(request)
@@ -205,7 +205,7 @@ func iamPolicyListVersions(arn string, iamconn *iam.IAM) ([]*iam.PolicyVersion, 
 }
 
 func readIamPolicy(d *schema.ResourceData, policy *iam.Policy) error {
-	d.SetId(*policy.ARN)
+	d.SetId(*policy.Arn)
 	if policy.Description != nil {
 		// the description isn't present in the response to CreatePolicy.
 		if err := d.Set("description", *policy.Description); err != nil {
@@ -218,7 +218,7 @@ func readIamPolicy(d *schema.ResourceData, policy *iam.Policy) error {
 	if err := d.Set("name", *policy.PolicyName); err != nil {
 		return err
 	}
-	if err := d.Set("arn", *policy.ARN); err != nil {
+	if err := d.Set("arn", *policy.Arn); err != nil {
 		return err
 	}
 	// TODO: set policy

--- a/builtin/providers/aws/resource_aws_iam_policy_attachment.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment.go
@@ -85,7 +85,7 @@ func resourceAwsIamPolicyAttachmentRead(d *schema.ResourceData, meta interface{}
 	name := d.Get("name").(string)
 
 	_, err := conn.GetPolicy(&iam.GetPolicyInput{
-		PolicyARN: aws.String(arn),
+		PolicyArn: aws.String(arn),
 	})
 
 	if err != nil {
@@ -99,7 +99,7 @@ func resourceAwsIamPolicyAttachmentRead(d *schema.ResourceData, meta interface{}
 	}
 
 	policyEntities, err := conn.ListEntitiesForPolicy(&iam.ListEntitiesForPolicyInput{
-		PolicyARN: aws.String(arn),
+		PolicyArn: aws.String(arn),
 	})
 
 	if err != nil {
@@ -191,7 +191,7 @@ func attachPolicyToUsers(conn *iam.IAM, users []*string, arn string) error {
 	for _, u := range users {
 		_, err := conn.AttachUserPolicy(&iam.AttachUserPolicyInput{
 			UserName:  u,
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return err
@@ -203,7 +203,7 @@ func attachPolicyToRoles(conn *iam.IAM, roles []*string, arn string) error {
 	for _, r := range roles {
 		_, err := conn.AttachRolePolicy(&iam.AttachRolePolicyInput{
 			RoleName:  r,
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return err
@@ -215,7 +215,7 @@ func attachPolicyToGroups(conn *iam.IAM, groups []*string, arn string) error {
 	for _, g := range groups {
 		_, err := conn.AttachGroupPolicy(&iam.AttachGroupPolicyInput{
 			GroupName: g,
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return err
@@ -294,7 +294,7 @@ func detachPolicyFromUsers(conn *iam.IAM, users []*string, arn string) error {
 	for _, u := range users {
 		_, err := conn.DetachUserPolicy(&iam.DetachUserPolicyInput{
 			UserName:  u,
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return err
@@ -306,7 +306,7 @@ func detachPolicyFromRoles(conn *iam.IAM, roles []*string, arn string) error {
 	for _, r := range roles {
 		_, err := conn.DetachRolePolicy(&iam.DetachRolePolicyInput{
 			RoleName:  r,
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return err
@@ -318,7 +318,7 @@ func detachPolicyFromGroups(conn *iam.IAM, groups []*string, arn string) error {
 	for _, g := range groups {
 		_, err := conn.DetachGroupPolicy(&iam.DetachGroupPolicyInput{
 			GroupName: g,
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_iam_policy_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment_test.go
@@ -55,7 +55,7 @@ func testAccCheckAWSPolicyAttachmentExists(n string, c int64, out *iam.ListEntit
 		arn := rs.Primary.Attributes["policy_arn"]
 
 		resp, err := conn.GetPolicy(&iam.GetPolicyInput{
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return fmt.Errorf("Error: Policy (%s) not found", n)
@@ -64,7 +64,7 @@ func testAccCheckAWSPolicyAttachmentExists(n string, c int64, out *iam.ListEntit
 			return fmt.Errorf("Error: Policy (%s) has wrong number of entities attached on initial creation", n)
 		}
 		resp2, err := conn.ListEntitiesForPolicy(&iam.ListEntitiesForPolicyInput{
-			PolicyARN: aws.String(arn),
+			PolicyArn: aws.String(arn),
 		})
 		if err != nil {
 			return fmt.Errorf("Error: Failed to get entities for Policy (%s)", arn)

--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -101,13 +101,13 @@ func resourceAwsIamRoleReadResult(d *schema.ResourceData, role *iam.Role) error 
 	if err := d.Set("name", role.RoleName); err != nil {
 		return err
 	}
-	if err := d.Set("arn", role.ARN); err != nil {
+	if err := d.Set("arn", role.Arn); err != nil {
 		return err
 	}
 	if err := d.Set("path", role.Path); err != nil {
 		return err
 	}
-	if err := d.Set("unique_id", role.RoleID); err != nil {
+	if err := d.Set("unique_id", role.RoleId); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/providers/aws/resource_aws_iam_server_certificate.go
+++ b/builtin/providers/aws/resource_aws_iam_server_certificate.go
@@ -89,7 +89,7 @@ func resourceAwsIAMServerCertificateCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("[WARN] Error uploading server certificate, error: %s", err)
 	}
 
-	d.SetId(*resp.ServerCertificateMetadata.ServerCertificateID)
+	d.SetId(*resp.ServerCertificateMetadata.ServerCertificateId)
 
 	return resourceAwsIAMServerCertificateRead(d, meta)
 }
@@ -117,7 +117,7 @@ func resourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("path", resp.ServerCertificate.ServerCertificateMetadata.Path)
-	d.Set("arn", resp.ServerCertificate.ServerCertificateMetadata.ARN)
+	d.Set("arn", resp.ServerCertificate.ServerCertificateMetadata.Arn)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -90,13 +90,13 @@ func resourceAwsIamUserReadResult(d *schema.ResourceData, user *iam.User) error 
 	if err := d.Set("name", user.UserName); err != nil {
 		return err
 	}
-	if err := d.Set("arn", user.ARN); err != nil {
+	if err := d.Set("arn", user.Arn); err != nil {
 		return err
 	}
 	if err := d.Set("path", user.Path); err != nil {
 		return err
 	}
-	if err := d.Set("unique_id", user.UserID); err != nil {
+	if err := d.Set("unique_id", user.UserId); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -326,21 +326,21 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	// Build the creation struct
 	runOpts := &ec2.RunInstancesInput{
 		BlockDeviceMappings:   instanceOpts.BlockDeviceMappings,
-		DisableAPITermination: instanceOpts.DisableAPITermination,
-		EBSOptimized:          instanceOpts.EBSOptimized,
+		DisableApiTermination: instanceOpts.DisableAPITermination,
+		EbsOptimized:          instanceOpts.EBSOptimized,
 		Monitoring:            instanceOpts.Monitoring,
-		IAMInstanceProfile:    instanceOpts.IAMInstanceProfile,
-		ImageID:               instanceOpts.ImageID,
+		IamInstanceProfile:    instanceOpts.IAMInstanceProfile,
+		ImageId:               instanceOpts.ImageID,
 		InstanceType:          instanceOpts.InstanceType,
 		KeyName:               instanceOpts.KeyName,
 		MaxCount:              aws.Int64(int64(1)),
 		MinCount:              aws.Int64(int64(1)),
 		NetworkInterfaces:     instanceOpts.NetworkInterfaces,
 		Placement:             instanceOpts.Placement,
-		PrivateIPAddress:      instanceOpts.PrivateIPAddress,
-		SecurityGroupIDs:      instanceOpts.SecurityGroupIDs,
+		PrivateIpAddress:      instanceOpts.PrivateIPAddress,
+		SecurityGroupIds:      instanceOpts.SecurityGroupIDs,
 		SecurityGroups:        instanceOpts.SecurityGroups,
-		SubnetID:              instanceOpts.SubnetID,
+		SubnetId:              instanceOpts.SubnetID,
 		UserData:              instanceOpts.UserData64,
 	}
 
@@ -366,21 +366,21 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	instance := runResp.Instances[0]
-	log.Printf("[INFO] Instance ID: %s", *instance.InstanceID)
+	log.Printf("[INFO] Instance ID: %s", *instance.InstanceId)
 
 	// Store the resulting ID so we can look this up later
-	d.SetId(*instance.InstanceID)
+	d.SetId(*instance.InstanceId)
 
 	// Wait for the instance to become running so we can get some attributes
 	// that aren't available until later.
 	log.Printf(
 		"[DEBUG] Waiting for instance (%s) to become running",
-		*instance.InstanceID)
+		*instance.InstanceId)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     "running",
-		Refresh:    InstanceStateRefreshFunc(conn, *instance.InstanceID),
+		Refresh:    InstanceStateRefreshFunc(conn, *instance.InstanceId),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -390,21 +390,21 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for instance (%s) to become ready: %s",
-			*instance.InstanceID, err)
+			*instance.InstanceId, err)
 	}
 
 	instance = instanceRaw.(*ec2.Instance)
 
 	// Initialize the connection info
-	if instance.PublicIPAddress != nil {
+	if instance.PublicIpAddress != nil {
 		d.SetConnInfo(map[string]string{
 			"type": "ssh",
-			"host": *instance.PublicIPAddress,
+			"host": *instance.PublicIpAddress,
 		})
-	} else if instance.PrivateIPAddress != nil {
+	} else if instance.PrivateIpAddress != nil {
 		d.SetConnInfo(map[string]string{
 			"type": "ssh",
-			"host": *instance.PrivateIPAddress,
+			"host": *instance.PrivateIpAddress,
 		})
 	}
 
@@ -421,7 +421,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-		InstanceIDs: []*string{aws.String(d.Id())},
+		InstanceIds: []*string{aws.String(d.Id())},
 	})
 	if err != nil {
 		// If the instance was not found, return nil so that we can show
@@ -456,19 +456,19 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("tenancy", instance.Placement.Tenancy)
 	}
 
-	d.Set("ami", instance.ImageID)
+	d.Set("ami", instance.ImageId)
 	d.Set("instance_type", instance.InstanceType)
 	d.Set("key_name", instance.KeyName)
-	d.Set("public_dns", instance.PublicDNSName)
-	d.Set("public_ip", instance.PublicIPAddress)
-	d.Set("private_dns", instance.PrivateDNSName)
-	d.Set("private_ip", instance.PrivateIPAddress)
+	d.Set("public_dns", instance.PublicDnsName)
+	d.Set("public_ip", instance.PublicIpAddress)
+	d.Set("private_dns", instance.PrivateDnsName)
+	d.Set("private_ip", instance.PrivateIpAddress)
 	if len(instance.NetworkInterfaces) > 0 {
-		d.Set("subnet_id", instance.NetworkInterfaces[0].SubnetID)
+		d.Set("subnet_id", instance.NetworkInterfaces[0].SubnetId)
 	} else {
-		d.Set("subnet_id", instance.SubnetID)
+		d.Set("subnet_id", instance.SubnetId)
 	}
-	d.Set("ebs_optimized", instance.EBSOptimized)
+	d.Set("ebs_optimized", instance.EbsOptimized)
 
 	if instance.Monitoring != nil && instance.Monitoring.State != nil {
 		monitoringState := *instance.Monitoring.State
@@ -482,7 +482,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	// we use IDs if we're in a VPC. However, if we previously had an
 	// all-name list of security groups, we use names. Or, if we had any
 	// IDs, we use IDs.
-	useID := instance.SubnetID != nil && *instance.SubnetID != ""
+	useID := instance.SubnetId != nil && *instance.SubnetId != ""
 	if v := d.Get("security_groups"); v != nil {
 		match := useID
 		sgs := v.(*schema.Set).List()
@@ -503,7 +503,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	sgs := make([]string, 0, len(instance.SecurityGroups))
 	if useID {
 		for _, sg := range instance.SecurityGroups {
-			sgs = append(sgs, *sg.GroupID)
+			sgs = append(sgs, *sg.GroupId)
 		}
 		log.Printf("[DEBUG] Setting Security Group IDs: %#v", sgs)
 		if err := d.Set("vpc_security_group_ids", sgs); err != nil {
@@ -540,7 +540,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("subnet_id").(string) != "" {
 		log.Printf("[INFO] Modifying instance %s", d.Id())
 		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceID: aws.String(d.Id()),
+			InstanceId: aws.String(d.Id()),
 			SourceDestCheck: &ec2.AttributeBooleanValue{
 				Value: aws.Bool(d.Get("source_dest_check").(bool)),
 			},
@@ -558,7 +558,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceID: aws.String(d.Id()),
+			InstanceId: aws.String(d.Id()),
 			Groups:     groups,
 		})
 		if err != nil {
@@ -568,8 +568,8 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("disable_api_termination") {
 		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceID: aws.String(d.Id()),
-			DisableAPITermination: &ec2.AttributeBooleanValue{
+			InstanceId: aws.String(d.Id()),
+			DisableApiTermination: &ec2.AttributeBooleanValue{
 				Value: aws.Bool(d.Get("disable_api_termination").(bool)),
 			},
 		})
@@ -583,12 +583,12 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if d.Get("monitoring").(bool) {
 			log.Printf("[DEBUG] Enabling monitoring for Instance (%s)", d.Id())
 			_, mErr = conn.MonitorInstances(&ec2.MonitorInstancesInput{
-				InstanceIDs: []*string{aws.String(d.Id())},
+				InstanceIds: []*string{aws.String(d.Id())},
 			})
 		} else {
 			log.Printf("[DEBUG] Disabling monitoring for Instance (%s)", d.Id())
 			_, mErr = conn.UnmonitorInstances(&ec2.UnmonitorInstancesInput{
-				InstanceIDs: []*string{aws.String(d.Id())},
+				InstanceIds: []*string{aws.String(d.Id())},
 			})
 		}
 		if mErr != nil {
@@ -620,7 +620,7 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 func InstanceStateRefreshFunc(conn *ec2.EC2, instanceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-			InstanceIDs: []*string{aws.String(instanceID)},
+			InstanceIds: []*string{aws.String(instanceID)},
 		})
 		if err != nil {
 			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
@@ -668,8 +668,8 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 
 	instanceBlockDevices := make(map[string]*ec2.InstanceBlockDeviceMapping)
 	for _, bd := range instance.BlockDeviceMappings {
-		if bd.EBS != nil {
-			instanceBlockDevices[*(bd.EBS.VolumeID)] = bd
+		if bd.Ebs != nil {
+			instanceBlockDevices[*(bd.Ebs.VolumeId)] = bd
 		}
 	}
 
@@ -685,18 +685,18 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 	// Need to call DescribeVolumes to get volume_size and volume_type for each
 	// EBS block device
 	volResp, err := conn.DescribeVolumes(&ec2.DescribeVolumesInput{
-		VolumeIDs: volIDs,
+		VolumeIds: volIDs,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	for _, vol := range volResp.Volumes {
-		instanceBd := instanceBlockDevices[*vol.VolumeID]
+		instanceBd := instanceBlockDevices[*vol.VolumeId]
 		bd := make(map[string]interface{})
 
-		if instanceBd.EBS != nil && instanceBd.EBS.DeleteOnTermination != nil {
-			bd["delete_on_termination"] = *instanceBd.EBS.DeleteOnTermination
+		if instanceBd.Ebs != nil && instanceBd.Ebs.DeleteOnTermination != nil {
+			bd["delete_on_termination"] = *instanceBd.Ebs.DeleteOnTermination
 		}
 		if vol.Size != nil {
 			bd["volume_size"] = *vol.Size
@@ -704,8 +704,8 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 		if vol.VolumeType != nil {
 			bd["volume_type"] = *vol.VolumeType
 		}
-		if vol.IOPS != nil {
-			bd["iops"] = *vol.IOPS
+		if vol.Iops != nil {
+			bd["iops"] = *vol.Iops
 		}
 
 		if blockDeviceIsRoot(instanceBd, instance) {
@@ -717,8 +717,8 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 			if vol.Encrypted != nil {
 				bd["encrypted"] = *vol.Encrypted
 			}
-			if vol.SnapshotID != nil {
-				bd["snapshot_id"] = *vol.SnapshotID
+			if vol.SnapshotId != nil {
+				bd["snapshot_id"] = *vol.SnapshotId
 			}
 
 			blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
@@ -741,7 +741,7 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 
 	log.Printf("[DEBUG] Describing AMI %q to get root block device name", ami)
 	res, err := conn.DescribeImages(&ec2.DescribeImagesInput{
-		ImageIDs: []*string{aws.String(ami)},
+		ImageIds: []*string{aws.String(ami)},
 	})
 	if err != nil {
 		return nil, err
@@ -792,12 +792,12 @@ func readBlockDeviceMappingsFromConfig(
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			ebs := &ec2.EBSBlockDevice{
+			ebs := &ec2.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
 			}
 
 			if v, ok := bd["snapshot_id"].(string); ok && v != "" {
-				ebs.SnapshotID = aws.String(v)
+				ebs.SnapshotId = aws.String(v)
 			}
 
 			if v, ok := bd["encrypted"].(bool); ok && v {
@@ -813,12 +813,12 @@ func readBlockDeviceMappingsFromConfig(
 			}
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Int64(int64(v))
+				ebs.Iops = aws.Int64(int64(v))
 			}
 
 			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
 				DeviceName: aws.String(bd["device_name"].(string)),
-				EBS:        ebs,
+				Ebs:        ebs,
 			})
 		}
 	}
@@ -841,7 +841,7 @@ func readBlockDeviceMappingsFromConfig(
 		}
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			ebs := &ec2.EBSBlockDevice{
+			ebs := &ec2.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
 			}
 
@@ -854,7 +854,7 @@ func readBlockDeviceMappingsFromConfig(
 			}
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Int64(int64(v))
+				ebs.Iops = aws.Int64(int64(v))
 			}
 
 			if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {
@@ -866,7 +866,7 @@ func readBlockDeviceMappingsFromConfig(
 
 				blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
 					DeviceName: dn,
-					EBS:        ebs,
+					Ebs:        ebs,
 				})
 			} else {
 				return nil, err
@@ -882,7 +882,7 @@ type awsInstanceOpts struct {
 	DisableAPITermination *bool
 	EBSOptimized          *bool
 	Monitoring            *ec2.RunInstancesMonitoringEnabled
-	IAMInstanceProfile    *ec2.IAMInstanceProfileSpecification
+	IAMInstanceProfile    *ec2.IamInstanceProfileSpecification
 	ImageID               *string
 	InstanceType          *string
 	KeyName               *string
@@ -911,7 +911,7 @@ func buildAwsInstanceOpts(
 		Enabled: aws.Bool(d.Get("monitoring").(bool)),
 	}
 
-	opts.IAMInstanceProfile = &ec2.IAMInstanceProfileSpecification{
+	opts.IAMInstanceProfile = &ec2.IamInstanceProfileSpecification{
 		Name: aws.String(d.Get("iam_instance_profile").(string)),
 	}
 
@@ -964,14 +964,14 @@ func buildAwsInstanceOpts(
 		// to avoid: Network interfaces and an instance-level security groups may not be specified on
 		// the same request
 		ni := &ec2.InstanceNetworkInterfaceSpecification{
-			AssociatePublicIPAddress: aws.Bool(associatePublicIPAddress),
+			AssociatePublicIpAddress: aws.Bool(associatePublicIPAddress),
 			DeviceIndex:              aws.Int64(int64(0)),
-			SubnetID:                 aws.String(subnetID),
+			SubnetId:                 aws.String(subnetID),
 			Groups:                   groups,
 		}
 
 		if v, ok := d.GetOk("private_ip"); ok {
-			ni.PrivateIPAddress = aws.String(v.(string))
+			ni.PrivateIpAddress = aws.String(v.(string))
 		}
 
 		if v := d.Get("vpc_security_group_ids").(*schema.Set); v.Len() > 0 {
@@ -1021,7 +1021,7 @@ func buildAwsInstanceOpts(
 func awsTerminateInstance(conn *ec2.EC2, id string) error {
 	log.Printf("[INFO] Terminating instance: %s", id)
 	req := &ec2.TerminateInstancesInput{
-		InstanceIDs: []*string{aws.String(id)},
+		InstanceIds: []*string{aws.String(id)},
 	}
 	if _, err := conn.TerminateInstances(req); err != nil {
 		return fmt.Errorf("Error terminating instance: %s", err)

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -90,7 +90,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 				Config: testAccInstanceConfig,
 				Check: func(*terraform.State) error {
 					conn := testAccProvider.Meta().(*AWSClient).ec2conn
-					_, err := conn.DeleteVolume(&ec2.DeleteVolumeInput{VolumeID: vol.VolumeID})
+					_, err := conn.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: vol.VolumeId})
 					return err
 				},
 			},
@@ -237,13 +237,13 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 		return func(*terraform.State) error {
 			conn := testAccProvider.Meta().(*AWSClient).ec2conn
 			r, err := conn.DescribeInstanceAttribute(&ec2.DescribeInstanceAttributeInput{
-				InstanceID: v.InstanceID,
+				InstanceId: v.InstanceId,
 				Attribute:  aws.String("disableApiTermination"),
 			})
 			if err != nil {
 				return err
 			}
-			got := *r.DisableAPITermination.Value
+			got := *r.DisableApiTermination.Value
 			if got != expected {
 				return fmt.Errorf("expected: %t, got: %t", expected, got)
 			}
@@ -403,8 +403,8 @@ func TestAccAWSInstance_privateIP(t *testing.T) {
 
 	testCheckPrivateIP := func() resource.TestCheckFunc {
 		return func(*terraform.State) error {
-			if *v.PrivateIPAddress != "10.1.1.42" {
-				return fmt.Errorf("bad private IP: %s", *v.PrivateIPAddress)
+			if *v.PrivateIpAddress != "10.1.1.42" {
+				return fmt.Errorf("bad private IP: %s", *v.PrivateIpAddress)
 			}
 
 			return nil
@@ -432,8 +432,8 @@ func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 
 	testCheckPrivateIP := func() resource.TestCheckFunc {
 		return func(*terraform.State) error {
-			if *v.PrivateIPAddress != "10.1.1.42" {
-				return fmt.Errorf("bad private IP: %s", *v.PrivateIPAddress)
+			if *v.PrivateIpAddress != "10.1.1.42" {
+				return fmt.Errorf("bad private IP: %s", *v.PrivateIpAddress)
 			}
 
 			return nil
@@ -539,7 +539,7 @@ func testAccCheckInstanceDestroyWithProvider(s *terraform.State, provider *schem
 		// Try to find the resource
 		var err error
 		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-			InstanceIDs: []*string{aws.String(rs.Primary.ID)},
+			InstanceIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
 			if len(resp.Reservations) > 0 {
@@ -585,7 +585,7 @@ func testAccCheckInstanceExistsWithProviders(n string, i *ec2.Instance, provider
 
 			conn := provider.Meta().(*AWSClient).ec2conn
 			resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-				InstanceIDs: []*string{aws.String(rs.Primary.ID)},
+				InstanceIds: []*string{aws.String(rs.Primary.ID)},
 			})
 			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
 				continue

--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -42,7 +42,7 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 
 	// Get the ID and store it
 	ig := *resp.InternetGateway
-	d.SetId(*ig.InternetGatewayID)
+	d.SetId(*ig.InternetGatewayId)
 	log.Printf("[INFO] InternetGateway ID: %s", d.Id())
 
 	err = setTags(conn, d)
@@ -72,7 +72,7 @@ func resourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) er
 		// Gateway exists but not attached to the VPC
 		d.Set("vpc_id", "")
 	} else {
-		d.Set("vpc_id", ig.Attachments[0].VPCID)
+		d.Set("vpc_id", ig.Attachments[0].VpcId)
 	}
 
 	d.Set("tags", tagsToMap(ig.Tags))
@@ -116,7 +116,7 @@ func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) 
 
 	return resource.Retry(5*time.Minute, func() error {
 		_, err := conn.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
-			InternetGatewayID: aws.String(d.Id()),
+			InternetGatewayId: aws.String(d.Id()),
 		})
 		if err == nil {
 			return nil
@@ -154,8 +154,8 @@ func resourceAwsInternetGatewayAttach(d *schema.ResourceData, meta interface{}) 
 		d.Get("vpc_id").(string))
 
 	_, err := conn.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
-		InternetGatewayID: aws.String(d.Id()),
-		VPCID:             aws.String(d.Get("vpc_id").(string)),
+		InternetGatewayId: aws.String(d.Id()),
+		VpcId:             aws.String(d.Get("vpc_id").(string)),
 	})
 	if err != nil {
 		return err
@@ -224,8 +224,8 @@ func resourceAwsInternetGatewayDetach(d *schema.ResourceData, meta interface{}) 
 func detachIGStateRefreshFunc(conn *ec2.EC2, instanceID, vpcID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		_, err := conn.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
-			InternetGatewayID: aws.String(instanceID),
-			VPCID:             aws.String(vpcID),
+			InternetGatewayId: aws.String(instanceID),
+			VpcId:             aws.String(vpcID),
 		})
 		if err != nil {
 			ec2err, ok := err.(awserr.Error)
@@ -250,7 +250,7 @@ func detachIGStateRefreshFunc(conn *ec2.EC2, instanceID, vpcID string) resource.
 func IGStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
-			InternetGatewayIDs: []*string{aws.String(id)},
+			InternetGatewayIds: []*string{aws.String(id)},
 		})
 		if err != nil {
 			ec2err, ok := err.(awserr.Error)
@@ -283,7 +283,7 @@ func IGAttachStateRefreshFunc(conn *ec2.EC2, id string, expected string) resourc
 		}
 
 		resp, err := conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
-			InternetGatewayIDs: []*string{aws.String(id)},
+			InternetGatewayIds: []*string{aws.String(id)},
 		})
 		if err != nil {
 			ec2err, ok := err.(awserr.Error)

--- a/builtin/providers/aws/resource_aws_internet_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway_test.go
@@ -22,8 +22,8 @@ func TestAccAWSInternetGateway_basic(t *testing.T) {
 			return fmt.Errorf("IG B is not attached")
 		}
 
-		id1 := v.Attachments[0].VPCID
-		id2 := v2.Attachments[0].VPCID
+		id1 := v.Attachments[0].VpcId
+		id2 := v2.Attachments[0].VpcId
 		if id1 == id2 {
 			return fmt.Errorf("Both attachment IDs are the same")
 		}
@@ -125,7 +125,7 @@ func testAccCheckInternetGatewayDestroy(s *terraform.State) error {
 
 		// Try to find the resource
 		resp, err := conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
-			InternetGatewayIDs: []*string{aws.String(rs.Primary.ID)},
+			InternetGatewayIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
 			if len(resp.InternetGateways) > 0 {
@@ -161,7 +161,7 @@ func testAccCheckInternetGatewayExists(n string, ig *ec2.InternetGateway) resour
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		resp, err := conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
-			InternetGatewayIDs: []*string{aws.String(rs.Primary.ID)},
+			InternetGatewayIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -165,7 +165,7 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 
 	function := getFunctionOutput.Configuration
 	// TODO error checking / handling on the Set() calls.
-	d.Set("arn", function.FunctionARN)
+	d.Set("arn", function.FunctionArn)
 	d.Set("description", function.Description)
 	d.Set("handler", function.Handler)
 	d.Set("memory_size", function.MemorySize)

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -88,7 +88,7 @@ func testAccCheckAWSLambdaAttributes(function *lambda.GetFunctionOutput) resourc
 			return fmt.Errorf("Expected function name %s, got %s", expectedName, *c.FunctionName)
 		}
 
-		if *c.FunctionARN == "" {
+		if *c.FunctionArn == "" {
 			return fmt.Errorf("Could not read Lambda Function's ARN")
 		}
 

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -262,9 +262,9 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	createLaunchConfigurationOpts := autoscaling.CreateLaunchConfigurationInput{
 		LaunchConfigurationName: aws.String(d.Get("name").(string)),
-		ImageID:                 aws.String(d.Get("image_id").(string)),
+		ImageId:                 aws.String(d.Get("image_id").(string)),
 		InstanceType:            aws.String(d.Get("instance_type").(string)),
-		EBSOptimized:            aws.Bool(d.Get("ebs_optimized").(bool)),
+		EbsOptimized:            aws.Bool(d.Get("ebs_optimized").(bool)),
 	}
 
 	if v, ok := d.GetOk("user_data"); ok {
@@ -277,7 +277,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("iam_instance_profile"); ok {
-		createLaunchConfigurationOpts.IAMInstanceProfile = aws.String(v.(string))
+		createLaunchConfigurationOpts.IamInstanceProfile = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("placement_tenancy"); ok {
@@ -285,7 +285,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("associate_public_ip_address"); ok {
-		createLaunchConfigurationOpts.AssociatePublicIPAddress = aws.Bool(v.(bool))
+		createLaunchConfigurationOpts.AssociatePublicIpAddress = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("key_name"); ok {
@@ -307,12 +307,12 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			ebs := &autoscaling.EBS{
+			ebs := &autoscaling.Ebs{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
 			}
 
 			if v, ok := bd["snapshot_id"].(string); ok && v != "" {
-				ebs.SnapshotID = aws.String(v)
+				ebs.SnapshotId = aws.String(v)
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
@@ -324,12 +324,12 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			}
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Int64(int64(v))
+				ebs.Iops = aws.Int64(int64(v))
 			}
 
 			blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 				DeviceName: aws.String(bd["device_name"].(string)),
-				EBS:        ebs,
+				Ebs:        ebs,
 			})
 		}
 	}
@@ -352,7 +352,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		}
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			ebs := &autoscaling.EBS{
+			ebs := &autoscaling.Ebs{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
 			}
 
@@ -365,13 +365,13 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			}
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.IOPS = aws.Int64(int64(v))
+				ebs.Iops = aws.Int64(int64(v))
 			}
 
 			if dn, err := fetchRootDeviceName(d.Get("image_id").(string), ec2conn); err == nil {
 				blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 					DeviceName: dn,
-					EBS:        ebs,
+					Ebs:        ebs,
 				})
 			} else {
 				return err
@@ -453,12 +453,12 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	lc := describConfs.LaunchConfigurations[0]
 
 	d.Set("key_name", lc.KeyName)
-	d.Set("image_id", lc.ImageID)
+	d.Set("image_id", lc.ImageId)
 	d.Set("instance_type", lc.InstanceType)
 	d.Set("name", lc.LaunchConfigurationName)
 
-	d.Set("iam_instance_profile", lc.IAMInstanceProfile)
-	d.Set("ebs_optimized", lc.EBSOptimized)
+	d.Set("iam_instance_profile", lc.IamInstanceProfile)
+	d.Set("ebs_optimized", lc.EbsOptimized)
 	d.Set("spot_price", lc.SpotPrice)
 	d.Set("enable_monitoring", lc.InstanceMonitoring.Enabled)
 	d.Set("security_groups", lc.SecurityGroups)
@@ -534,17 +534,17 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 	}
 	for _, bdm := range lc.BlockDeviceMappings {
 		bd := make(map[string]interface{})
-		if bdm.EBS != nil && bdm.EBS.DeleteOnTermination != nil {
-			bd["delete_on_termination"] = *bdm.EBS.DeleteOnTermination
+		if bdm.Ebs != nil && bdm.Ebs.DeleteOnTermination != nil {
+			bd["delete_on_termination"] = *bdm.Ebs.DeleteOnTermination
 		}
-		if bdm.EBS != nil && bdm.EBS.VolumeSize != nil {
-			bd["volume_size"] = *bdm.EBS.VolumeSize
+		if bdm.Ebs != nil && bdm.Ebs.VolumeSize != nil {
+			bd["volume_size"] = *bdm.Ebs.VolumeSize
 		}
-		if bdm.EBS != nil && bdm.EBS.VolumeType != nil {
-			bd["volume_type"] = *bdm.EBS.VolumeType
+		if bdm.Ebs != nil && bdm.Ebs.VolumeType != nil {
+			bd["volume_type"] = *bdm.Ebs.VolumeType
 		}
-		if bdm.EBS != nil && bdm.EBS.IOPS != nil {
-			bd["iops"] = *bdm.EBS.IOPS
+		if bdm.Ebs != nil && bdm.Ebs.Iops != nil {
+			bd["iops"] = *bdm.Ebs.Iops
 		}
 		if bdm.DeviceName != nil && *bdm.DeviceName == *rootDeviceName {
 			blockDevices["root"] = bd
@@ -556,8 +556,8 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 				bd["virtual_name"] = *bdm.VirtualName
 				blockDevices["ephemeral"] = append(blockDevices["ephemeral"].([]map[string]interface{}), bd)
 			} else {
-				if bdm.EBS != nil && bdm.EBS.SnapshotID != nil {
-					bd["snapshot_id"] = *bdm.EBS.SnapshotID
+				if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
+					bd["snapshot_id"] = *bdm.Ebs.SnapshotId
 				}
 				blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
 			}

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -134,8 +134,8 @@ func testAccCheckAWSLaunchConfigurationDestroy(s *terraform.State) error {
 
 func testAccCheckAWSLaunchConfigurationAttributes(conf *autoscaling.LaunchConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *conf.ImageID != "ami-21f78e11" {
-			return fmt.Errorf("Bad image_id: %s", *conf.ImageID)
+		if *conf.ImageId != "ami-21f78e11" {
+			return fmt.Errorf("Bad image_id: %s", *conf.ImageId)
 		}
 
 		if !strings.HasPrefix(*conf.LaunchConfigurationName, "terraform-") {

--- a/builtin/providers/aws/resource_aws_main_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_main_route_table_association.go
@@ -52,15 +52,15 @@ func resourceAwsMainRouteTableAssociationCreate(d *schema.ResourceData, meta int
 	}
 
 	resp, err := conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{
-		AssociationID: mainAssociation.RouteTableAssociationID,
-		RouteTableID:  aws.String(routeTableId),
+		AssociationId: mainAssociation.RouteTableAssociationId,
+		RouteTableId:  aws.String(routeTableId),
 	})
 	if err != nil {
 		return err
 	}
 
-	d.Set("original_route_table_id", mainAssociation.RouteTableID)
-	d.SetId(*resp.NewAssociationID)
+	d.Set("original_route_table_id", mainAssociation.RouteTableId)
+	d.SetId(*resp.NewAssociationId)
 	log.Printf("[INFO] New main route table association ID: %s", d.Id())
 
 	return nil
@@ -76,7 +76,7 @@ func resourceAwsMainRouteTableAssociationRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	if mainAssociation == nil || *mainAssociation.RouteTableAssociationID != d.Id() {
+	if mainAssociation == nil || *mainAssociation.RouteTableAssociationId != d.Id() {
 		// It seems it doesn't exist anymore, so clear the ID
 		d.SetId("")
 	}
@@ -95,14 +95,14 @@ func resourceAwsMainRouteTableAssociationUpdate(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Updating main route table association: %s => %s", vpcId, routeTableId)
 
 	resp, err := conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{
-		AssociationID: aws.String(d.Id()),
-		RouteTableID:  aws.String(routeTableId),
+		AssociationId: aws.String(d.Id()),
+		RouteTableId:  aws.String(routeTableId),
 	})
 	if err != nil {
 		return err
 	}
 
-	d.SetId(*resp.NewAssociationID)
+	d.SetId(*resp.NewAssociationId)
 	log.Printf("[INFO] New main route table association ID: %s", d.Id())
 
 	return nil
@@ -118,14 +118,14 @@ func resourceAwsMainRouteTableAssociationDelete(d *schema.ResourceData, meta int
 		originalRouteTableId)
 
 	resp, err := conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{
-		AssociationID: aws.String(d.Id()),
-		RouteTableID:  aws.String(originalRouteTableId),
+		AssociationId: aws.String(d.Id()),
+		RouteTableId:  aws.String(originalRouteTableId),
 	})
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[INFO] Resulting Association ID: %s", *resp.NewAssociationID)
+	log.Printf("[INFO] Resulting Association ID: %s", *resp.NewAssociationId)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_main_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_main_route_table_association_test.go
@@ -71,9 +71,9 @@ func testAccCheckMainRouteTableAssociation(
 			return err
 		}
 
-		if *mainAssociation.RouteTableAssociationID != rs.Primary.ID {
+		if *mainAssociation.RouteTableAssociationId != rs.Primary.ID {
 			return fmt.Errorf("Found wrong main association: %s",
-				*mainAssociation.RouteTableAssociationID)
+				*mainAssociation.RouteTableAssociationId)
 		}
 
 		return nil

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -140,20 +140,20 @@ func resourceAwsNetworkAclCreate(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*AWSClient).ec2conn
 
 	// Create the Network Acl
-	createOpts := &ec2.CreateNetworkACLInput{
-		VPCID: aws.String(d.Get("vpc_id").(string)),
+	createOpts := &ec2.CreateNetworkAclInput{
+		VpcId: aws.String(d.Get("vpc_id").(string)),
 	}
 
 	log.Printf("[DEBUG] Network Acl create config: %#v", createOpts)
-	resp, err := conn.CreateNetworkACL(createOpts)
+	resp, err := conn.CreateNetworkAcl(createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating network acl: %s", err)
 	}
 
 	// Get the ID and store it
-	networkAcl := resp.NetworkACL
-	d.SetId(*networkAcl.NetworkACLID)
-	log.Printf("[INFO] Network Acl ID: %s", *networkAcl.NetworkACLID)
+	networkAcl := resp.NetworkAcl
+	d.SetId(*networkAcl.NetworkAclId)
+	log.Printf("[INFO] Network Acl ID: %s", *networkAcl.NetworkAclId)
 
 	// Update rules and subnet association once acl is created
 	return resourceAwsNetworkAclUpdate(d, meta)
@@ -162,8 +162,8 @@ func resourceAwsNetworkAclCreate(d *schema.ResourceData, meta interface{}) error
 func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
-		NetworkACLIDs: []*string{aws.String(d.Id())},
+	resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
+		NetworkAclIds: []*string{aws.String(d.Id())},
 	})
 
 	if err != nil {
@@ -173,9 +173,9 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	networkAcl := resp.NetworkACLs[0]
-	var ingressEntries []*ec2.NetworkACLEntry
-	var egressEntries []*ec2.NetworkACLEntry
+	networkAcl := resp.NetworkAcls[0]
+	var ingressEntries []*ec2.NetworkAclEntry
+	var egressEntries []*ec2.NetworkAclEntry
 
 	// separate the ingress and egress rules
 	for _, e := range networkAcl.Entries {
@@ -192,12 +192,12 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	d.Set("vpc_id", networkAcl.VPCID)
+	d.Set("vpc_id", networkAcl.VpcId)
 	d.Set("tags", tagsToMap(networkAcl.Tags))
 
 	var s []string
 	for _, a := range networkAcl.Associations {
-		s = append(s, *a.SubnetID)
+		s = append(s, *a.SubnetId)
 	}
 	sort.Strings(s)
 	if err := d.Set("subnet_ids", s); err != nil {
@@ -240,9 +240,9 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("Failed to update acl %s with subnet %s: %s", d.Id(), newSubnet, err)
 		}
-		_, err = conn.ReplaceNetworkACLAssociation(&ec2.ReplaceNetworkACLAssociationInput{
-			AssociationID: association.NetworkACLAssociationID,
-			NetworkACLID:  aws.String(d.Id()),
+		_, err = conn.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
+			AssociationId: association.NetworkAclAssociationId,
+			NetworkAclId:  aws.String(d.Id()),
 		})
 		if err != nil {
 			return err
@@ -276,9 +276,9 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 				if err != nil {
 					return fmt.Errorf("Failed to find acl association: acl %s with subnet %s: %s", d.Id(), r, err)
 				}
-				_, err = conn.ReplaceNetworkACLAssociation(&ec2.ReplaceNetworkACLAssociationInput{
-					AssociationID: association.NetworkACLAssociationID,
-					NetworkACLID:  defaultAcl.NetworkACLID,
+				_, err = conn.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
+					AssociationId: association.NetworkAclAssociationId,
+					NetworkAclId:  defaultAcl.NetworkAclId,
 				})
 				if err != nil {
 					return err
@@ -292,9 +292,9 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 				if err != nil {
 					return fmt.Errorf("Failed to find acl association: acl %s with subnet %s: %s", d.Id(), a, err)
 				}
-				_, err = conn.ReplaceNetworkACLAssociation(&ec2.ReplaceNetworkACLAssociationInput{
-					AssociationID: association.NetworkACLAssociationID,
-					NetworkACLID:  aws.String(d.Id()),
+				_, err = conn.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
+					AssociationId: association.NetworkAclAssociationId,
+					NetworkAclId:  aws.String(d.Id()),
 				})
 				if err != nil {
 					return err
@@ -343,8 +343,8 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, conn *ec2
 		}
 
 		// Delete old Acl
-		_, err := conn.DeleteNetworkACLEntry(&ec2.DeleteNetworkACLEntryInput{
-			NetworkACLID: aws.String(d.Id()),
+		_, err := conn.DeleteNetworkAclEntry(&ec2.DeleteNetworkAclEntryInput{
+			NetworkAclId: aws.String(d.Id()),
 			RuleNumber:   remove.RuleNumber,
 			Egress:       remove.Egress,
 		})
@@ -380,20 +380,20 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, conn *ec2
 		// mask provided. This results in hashing inconsistencies between
 		// the local config file and the state returned by the API. Error
 		// if the user provides a CIDR block with an inappropriate mask
-		if err := validateCIDRBlock(*add.CIDRBlock); err != nil {
+		if err := validateCIDRBlock(*add.CidrBlock); err != nil {
 			return err
 		}
 
 		// Add new Acl entry
-		_, connErr := conn.CreateNetworkACLEntry(&ec2.CreateNetworkACLEntryInput{
-			NetworkACLID: aws.String(d.Id()),
-			CIDRBlock:    add.CIDRBlock,
+		_, connErr := conn.CreateNetworkAclEntry(&ec2.CreateNetworkAclEntryInput{
+			NetworkAclId: aws.String(d.Id()),
+			CidrBlock:    add.CidrBlock,
 			Egress:       add.Egress,
 			PortRange:    add.PortRange,
 			Protocol:     add.Protocol,
 			RuleAction:   add.RuleAction,
 			RuleNumber:   add.RuleNumber,
-			ICMPTypeCode: add.ICMPTypeCode,
+			IcmpTypeCode: add.IcmpTypeCode,
 		})
 		if connErr != nil {
 			return fmt.Errorf("Error creating %s entry: %s", entryType, connErr)
@@ -407,8 +407,8 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Deleting Network Acl: %s", d.Id())
 	return resource.Retry(5*time.Minute, func() error {
-		_, err := conn.DeleteNetworkACL(&ec2.DeleteNetworkACLInput{
-			NetworkACLID: aws.String(d.Id()),
+		_, err := conn.DeleteNetworkAcl(&ec2.DeleteNetworkAclInput{
+			NetworkAclId: aws.String(d.Id()),
 		})
 		if err != nil {
 			ec2err := err.(awserr.Error)
@@ -418,7 +418,7 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 			case "DependencyViolation":
 				// In case of dependency violation, we remove the association between subnet and network acl.
 				// This means the subnet is attached to default acl of vpc.
-				var associations []*ec2.NetworkACLAssociation
+				var associations []*ec2.NetworkAclAssociation
 				if v, ok := d.GetOk("subnet_id"); ok {
 
 					a, err := findNetworkAclAssociation(v.(string), conn)
@@ -442,9 +442,9 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 				}
 
 				for _, a := range associations {
-					_, err = conn.ReplaceNetworkACLAssociation(&ec2.ReplaceNetworkACLAssociationInput{
-						AssociationID: a.NetworkACLAssociationID,
-						NetworkACLID:  defaultAcl.NetworkACLID,
+					_, err = conn.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
+						AssociationId: a.NetworkAclAssociationId,
+						NetworkAclId:  defaultAcl.NetworkAclId,
 					})
 				}
 				return resource.RetryError{Err: err}
@@ -493,8 +493,8 @@ func resourceAwsNetworkAclEntryHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func getDefaultNetworkAcl(vpc_id string, conn *ec2.EC2) (defaultAcl *ec2.NetworkACL, err error) {
-	resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
+func getDefaultNetworkAcl(vpc_id string, conn *ec2.EC2) (defaultAcl *ec2.NetworkAcl, err error) {
+	resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
 				Name:   aws.String("default"),
@@ -510,11 +510,11 @@ func getDefaultNetworkAcl(vpc_id string, conn *ec2.EC2) (defaultAcl *ec2.Network
 	if err != nil {
 		return nil, err
 	}
-	return resp.NetworkACLs[0], nil
+	return resp.NetworkAcls[0], nil
 }
 
-func findNetworkAclAssociation(subnetId string, conn *ec2.EC2) (networkAclAssociation *ec2.NetworkACLAssociation, err error) {
-	resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
+func findNetworkAclAssociation(subnetId string, conn *ec2.EC2) (networkAclAssociation *ec2.NetworkAclAssociation, err error) {
+	resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
 				Name:   aws.String("association.subnet-id"),
@@ -526,9 +526,9 @@ func findNetworkAclAssociation(subnetId string, conn *ec2.EC2) (networkAclAssoci
 	if err != nil {
 		return nil, err
 	}
-	if resp.NetworkACLs != nil && len(resp.NetworkACLs) > 0 {
-		for _, association := range resp.NetworkACLs[0].Associations {
-			if *association.SubnetID == subnetId {
+	if resp.NetworkAcls != nil && len(resp.NetworkAcls) > 0 {
+		for _, association := range resp.NetworkAcls[0].Associations {
+			if *association.SubnetId == subnetId {
 				return association, nil
 			}
 		}
@@ -538,13 +538,13 @@ func findNetworkAclAssociation(subnetId string, conn *ec2.EC2) (networkAclAssoci
 
 // networkAclEntriesToMapList turns ingress/egress rules read from AWS into a list
 // of maps.
-func networkAclEntriesToMapList(networkAcls []*ec2.NetworkACLEntry) []map[string]interface{} {
+func networkAclEntriesToMapList(networkAcls []*ec2.NetworkAclEntry) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(networkAcls))
 	for _, entry := range networkAcls {
 		acl := make(map[string]interface{})
 		acl["rule_no"] = *entry.RuleNumber
 		acl["action"] = *entry.RuleAction
-		acl["cidr_block"] = *entry.CIDRBlock
+		acl["cidr_block"] = *entry.CidrBlock
 
 		// The AWS network ACL API only speaks protocol numbers, and
 		// that's all we record.
@@ -562,9 +562,9 @@ func networkAclEntriesToMapList(networkAcls []*ec2.NetworkACLEntry) []map[string
 			acl["to_port"] = *entry.PortRange.To
 		}
 
-		if entry.ICMPTypeCode != nil {
-			acl["icmp_type"] = *entry.ICMPTypeCode.Type
-			acl["icmp_code"] = *entry.ICMPTypeCode.Code
+		if entry.IcmpTypeCode != nil {
+			acl["icmp_type"] = *entry.IcmpTypeCode.Type
+			acl["icmp_code"] = *entry.IcmpTypeCode.Code
 		}
 
 		result = append(result, acl)

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
-	var networkAcl ec2.NetworkACL
+	var networkAcl ec2.NetworkAcl
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,7 +54,7 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 }
 
 func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
-	var networkAcl ec2.NetworkACL
+	var networkAcl ec2.NetworkAcl
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,7 +85,7 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
 }
 
 func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
-	var networkAcl ec2.NetworkACL
+	var networkAcl ec2.NetworkAcl
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -139,7 +139,7 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 }
 
 func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
-	var networkAcl ec2.NetworkACL
+	var networkAcl ec2.NetworkAcl
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -183,9 +183,9 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 }
 
 func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
-	var networkAcl ec2.NetworkACL
+	var networkAcl ec2.NetworkAcl
 
-	checkACLSubnets := func(acl *ec2.NetworkACL, count int) resource.TestCheckFunc {
+	checkACLSubnets := func(acl *ec2.NetworkAcl, count int) resource.TestCheckFunc {
 		return func(*terraform.State) (err error) {
 			if count != len(acl.Associations) {
 				return fmt.Errorf("ACL association count does not match, expected %d, got %d", count, len(acl.Associations))
@@ -234,11 +234,11 @@ func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
 		}
 
 		// Retrieve the network acl
-		resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
-			NetworkACLIDs: []*string{aws.String(rs.Primary.ID)},
+		resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
+			NetworkAclIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
-			if len(resp.NetworkACLs) > 0 && *resp.NetworkACLs[0].NetworkACLID == rs.Primary.ID {
+			if len(resp.NetworkAcls) > 0 && *resp.NetworkAcls[0].NetworkAclId == rs.Primary.ID {
 				return fmt.Errorf("Network Acl (%s) still exists.", rs.Primary.ID)
 			}
 
@@ -258,7 +258,7 @@ func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSNetworkAclExists(n string, networkAcl *ec2.NetworkACL) resource.TestCheckFunc {
+func testAccCheckAWSNetworkAclExists(n string, networkAcl *ec2.NetworkAcl) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -270,15 +270,15 @@ func testAccCheckAWSNetworkAclExists(n string, networkAcl *ec2.NetworkACL) resou
 		}
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-		resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
-			NetworkACLIDs: []*string{aws.String(rs.Primary.ID)},
+		resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
+			NetworkAclIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err != nil {
 			return err
 		}
 
-		if len(resp.NetworkACLs) > 0 && *resp.NetworkACLs[0].NetworkACLID == rs.Primary.ID {
-			*networkAcl = *resp.NetworkACLs[0]
+		if len(resp.NetworkAcls) > 0 && *resp.NetworkAcls[0].NetworkAclId == rs.Primary.ID {
+			*networkAcl = *resp.NetworkAcls[0]
 			return nil
 		}
 
@@ -286,9 +286,9 @@ func testAccCheckAWSNetworkAclExists(n string, networkAcl *ec2.NetworkACL) resou
 	}
 }
 
-func testIngressRuleLength(networkAcl *ec2.NetworkACL, length int) resource.TestCheckFunc {
+func testIngressRuleLength(networkAcl *ec2.NetworkAcl, length int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		var ingressEntries []*ec2.NetworkACLEntry
+		var ingressEntries []*ec2.NetworkAclEntry
 		for _, e := range networkAcl.Entries {
 			if *e.Egress == false {
 				ingressEntries = append(ingressEntries, e)
@@ -309,8 +309,8 @@ func testAccCheckSubnetIsAssociatedWithAcl(acl string, sub string) resource.Test
 		subnet := s.RootModule().Resources[sub]
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
-			NetworkACLIDs: []*string{aws.String(networkAcl.Primary.ID)},
+		resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
+			NetworkAclIds: []*string{aws.String(networkAcl.Primary.ID)},
 			Filters: []*ec2.Filter{
 				&ec2.Filter{
 					Name:   aws.String("association.subnet-id"),
@@ -321,7 +321,7 @@ func testAccCheckSubnetIsAssociatedWithAcl(acl string, sub string) resource.Test
 		if err != nil {
 			return err
 		}
-		if len(resp.NetworkACLs) > 0 {
+		if len(resp.NetworkAcls) > 0 {
 			return nil
 		}
 
@@ -335,8 +335,8 @@ func testAccCheckSubnetIsNotAssociatedWithAcl(acl string, subnet string) resourc
 		subnet := s.RootModule().Resources[subnet]
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeNetworkACLs(&ec2.DescribeNetworkACLsInput{
-			NetworkACLIDs: []*string{aws.String(networkAcl.Primary.ID)},
+		resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
+			NetworkAclIds: []*string{aws.String(networkAcl.Primary.ID)},
 			Filters: []*ec2.Filter{
 				&ec2.Filter{
 					Name:   aws.String("association.subnet-id"),
@@ -348,7 +348,7 @@ func testAccCheckSubnetIsNotAssociatedWithAcl(acl string, subnet string) resourc
 		if err != nil {
 			return err
 		}
-		if len(resp.NetworkACLs) > 0 {
+		if len(resp.NetworkAcls) > 0 {
 			return fmt.Errorf("Network Acl %s is still associated with subnet %s", acl, subnet)
 		}
 		return nil

--- a/builtin/providers/aws/resource_aws_network_interface_test.go
+++ b/builtin/providers/aws/resource_aws_network_interface_test.go
@@ -130,7 +130,7 @@ func testAccCheckAWSENIExists(n string, res *ec2.NetworkInterface) resource.Test
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
-			NetworkInterfaceIDs: []*string{aws.String(rs.Primary.ID)},
+			NetworkInterfaceIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		describeResp, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
 
@@ -139,7 +139,7 @@ func testAccCheckAWSENIExists(n string, res *ec2.NetworkInterface) resource.Test
 		}
 
 		if len(describeResp.NetworkInterfaces) != 1 ||
-			*describeResp.NetworkInterfaces[0].NetworkInterfaceID != rs.Primary.ID {
+			*describeResp.NetworkInterfaces[0].NetworkInterfaceId != rs.Primary.ID {
 			return fmt.Errorf("ENI not found")
 		}
 
@@ -164,8 +164,8 @@ func testAccCheckAWSENIAttributes(conf *ec2.NetworkInterface) resource.TestCheck
 			return fmt.Errorf("expected security group to be foo, but was %#v", conf.Groups)
 		}
 
-		if *conf.PrivateIPAddress != "172.16.10.100" {
-			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIPAddress)
+		if *conf.PrivateIpAddress != "172.16.10.100" {
+			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
 		}
 
 		if *conf.SourceDestCheck != true {
@@ -199,8 +199,8 @@ func testAccCheckAWSENIAttributesWithAttachment(conf *ec2.NetworkInterface) reso
 			return fmt.Errorf("expected security group to be foo, but was %#v", conf.Groups)
 		}
 
-		if *conf.PrivateIPAddress != "172.16.10.100" {
-			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIPAddress)
+		if *conf.PrivateIpAddress != "172.16.10.100" {
+			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
 		}
 
 		return nil
@@ -215,7 +215,7 @@ func testAccCheckAWSENIDestroy(s *terraform.State) error {
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
-			NetworkInterfaceIDs: []*string{aws.String(rs.Primary.ID)},
+			NetworkInterfaceIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		_, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
 
@@ -239,8 +239,8 @@ func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterfa
 		}
 		attach_request := &ec2.AttachNetworkInterfaceInput{
 			DeviceIndex:        aws.Int64(2),
-			InstanceID:         aws.String(rs.Primary.ID),
-			NetworkInterfaceID: conf.NetworkInterfaceID,
+			InstanceId:         aws.String(rs.Primary.ID),
+			NetworkInterfaceId: conf.NetworkInterfaceId,
 		}
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		_, attach_err := conn.AttachNetworkInterface(attach_request)

--- a/builtin/providers/aws/resource_aws_route53_delegation_set.go
+++ b/builtin/providers/aws/resource_aws_route53_delegation_set.go
@@ -55,7 +55,7 @@ func resourceAwsRoute53DelegationSetCreate(d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Route53 reusable delegation set created: %#v", out)
 
 	set := out.DelegationSet
-	d.SetId(cleanDelegationSetId(*set.ID))
+	d.SetId(cleanDelegationSetId(*set.Id))
 	d.Set("name_servers", expandNameServers(set.NameServers))
 	return nil
 }
@@ -64,7 +64,7 @@ func resourceAwsRoute53DelegationSetRead(d *schema.ResourceData, meta interface{
 	r53 := meta.(*AWSClient).r53conn
 
 	input := &route53.GetReusableDelegationSetInput{
-		ID: aws.String(cleanDelegationSetId(d.Id())),
+		Id: aws.String(cleanDelegationSetId(d.Id())),
 	}
 	log.Printf("[DEBUG] Reading Route53 reusable delegation set: %#v", input)
 	out, err := r53.GetReusableDelegationSet(input)
@@ -75,7 +75,7 @@ func resourceAwsRoute53DelegationSetRead(d *schema.ResourceData, meta interface{
 
 	set := out.DelegationSet
 
-	d.SetId(cleanDelegationSetId(*set.ID))
+	d.SetId(cleanDelegationSetId(*set.Id))
 	d.Set("name_servers", expandNameServers(set.NameServers))
 
 	return nil
@@ -85,7 +85,7 @@ func resourceAwsRoute53DelegationSetDelete(d *schema.ResourceData, meta interfac
 	r53 := meta.(*AWSClient).r53conn
 
 	input := &route53.DeleteReusableDelegationSetInput{
-		ID: aws.String(cleanDelegationSetId(d.Id())),
+		Id: aws.String(cleanDelegationSetId(d.Id())),
 	}
 	log.Printf("[DEBUG] Deleting Route53 reusable delegation set: %#v", input)
 	_, err := r53.DeleteReusableDelegationSet(input)

--- a/builtin/providers/aws/resource_aws_route53_delegation_set_test.go
+++ b/builtin/providers/aws/resource_aws_route53_delegation_set_test.go
@@ -58,7 +58,7 @@ func testAccCheckRoute53DelegationSetDestroy(s *terraform.State, provider *schem
 			continue
 		}
 
-		_, err := conn.GetReusableDelegationSet(&route53.GetReusableDelegationSetInput{ID: aws.String(rs.Primary.ID)})
+		_, err := conn.GetReusableDelegationSet(&route53.GetReusableDelegationSetInput{Id: aws.String(rs.Primary.ID)})
 		if err == nil {
 			return fmt.Errorf("Delegation set still exists")
 		}
@@ -79,14 +79,14 @@ func testAccCheckRoute53DelegationSetExists(n string) resource.TestCheckFunc {
 		}
 
 		out, err := conn.GetReusableDelegationSet(&route53.GetReusableDelegationSetInput{
-			ID: aws.String(rs.Primary.ID),
+			Id: aws.String(rs.Primary.ID),
 		})
 
 		if err != nil {
 			return fmt.Errorf("Delegation set does not exist: %#v", rs.Primary.ID)
 		}
 
-		setID := cleanDelegationSetId(*out.DelegationSet.ID)
+		setID := cleanDelegationSetId(*out.DelegationSet.Id)
 		if setID != rs.Primary.ID {
 			return fmt.Errorf("Delegation set ID does not match:\nExpected: %#v\nReturned: %#v", rs.Primary.ID, setID)
 		}
@@ -104,7 +104,7 @@ func testAccCheckRoute53NameServersMatch(delegationSetName, zoneName string) res
 			return fmt.Errorf("Not found: %s", delegationSetName)
 		}
 		delegationSet, err := conn.GetReusableDelegationSet(&route53.GetReusableDelegationSetInput{
-			ID: aws.String(delegationSetLocal.Primary.ID),
+			Id: aws.String(delegationSetLocal.Primary.ID),
 		})
 		if err != nil {
 			return fmt.Errorf("Delegation set does not exist: %#v", delegationSetLocal.Primary.ID)
@@ -115,7 +115,7 @@ func testAccCheckRoute53NameServersMatch(delegationSetName, zoneName string) res
 			return fmt.Errorf("Not found: %s", zoneName)
 		}
 		hostedZone, err := conn.GetHostedZone(&route53.GetHostedZoneInput{
-			ID: aws.String(hostedZoneLocal.Primary.ID),
+			Id: aws.String(hostedZoneLocal.Primary.ID),
 		})
 		if err != nil {
 			return fmt.Errorf("Delegation set does not exist: %#v", hostedZoneLocal.Primary.ID)

--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -64,7 +64,7 @@ func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).r53conn
 
 	updateHealthCheck := &route53.UpdateHealthCheckInput{
-		HealthCheckID: aws.String(d.Id()),
+		HealthCheckId: aws.String(d.Id()),
 	}
 
 	if d.HasChange("failure_threshold") {
@@ -139,7 +139,7 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	d.SetId(*resp.HealthCheck.ID)
+	d.SetId(*resp.HealthCheck.Id)
 
 	if err := setTagsR53(conn, d, "healthcheck"); err != nil {
 		return err
@@ -151,7 +151,7 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 func resourceAwsRoute53HealthCheckRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
 
-	read, err := conn.GetHealthCheck(&route53.GetHealthCheckInput{HealthCheckID: aws.String(d.Id())})
+	read, err := conn.GetHealthCheck(&route53.GetHealthCheckInput{HealthCheckId: aws.String(d.Id())})
 	if err != nil {
 		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHealthCheck" {
 			d.SetId("")
@@ -177,7 +177,7 @@ func resourceAwsRoute53HealthCheckRead(d *schema.ResourceData, meta interface{})
 
 	// read the tags
 	req := &route53.ListTagsForResourceInput{
-		ResourceID:   aws.String(d.Id()),
+		ResourceId:   aws.String(d.Id()),
 		ResourceType: aws.String("healthcheck"),
 	}
 
@@ -202,7 +202,7 @@ func resourceAwsRoute53HealthCheckDelete(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).r53conn
 
 	log.Printf("[DEBUG] Deleteing Route53 health check: %s", d.Id())
-	_, err := conn.DeleteHealthCheck(&route53.DeleteHealthCheckInput{HealthCheckID: aws.String(d.Id())})
+	_, err := conn.DeleteHealthCheck(&route53.DeleteHealthCheckInput{HealthCheckId: aws.String(d.Id())})
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -68,7 +68,7 @@ func testAccCheckRoute53HealthCheckDestroy(s *terraform.State) error {
 		}
 
 		for _, check := range resp.HealthChecks {
-			if *check.ID == rs.Primary.ID {
+			if *check.Id == rs.Primary.ID {
 				return fmt.Errorf("Record still exists: %#v", check)
 			}
 
@@ -103,7 +103,7 @@ func testAccCheckRoute53HealthCheckExists(n string) resource.TestCheckFunc {
 		}
 
 		for _, check := range resp.HealthChecks {
-			if *check.ID == rs.Primary.ID {
+			if *check.Id == rs.Primary.ID {
 				return nil
 			}
 

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -128,7 +128,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	zone := cleanZoneID(d.Get("zone_id").(string))
 
 	var err error
-	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone)})
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	req := &route53.ChangeResourceRecordSetsInput{
-		HostedZoneID: aws.String(cleanZoneID(*zoneRecord.HostedZone.ID)),
+		HostedZoneId: aws.String(cleanZoneID(*zoneRecord.HostedZone.Id)),
 		ChangeBatch:  changeBatch,
 	}
 
@@ -209,7 +209,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
 			changeRequest := &route53.GetChangeInput{
-				ID: aws.String(cleanChangeID(*changeInfo.ID)),
+				Id: aws.String(cleanChangeID(*changeInfo.Id)),
 			}
 			return resourceAwsGoRoute53Wait(conn, changeRequest)
 		},
@@ -228,7 +228,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	zone := cleanZoneID(d.Get("zone_id").(string))
 
 	// get expanded name
-	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone)})
 	if err != nil {
 		return err
 	}
@@ -237,7 +237,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("fqdn", en)
 
 	lopts := &route53.ListResourceRecordSetsInput{
-		HostedZoneID:    aws.String(cleanZoneID(zone)),
+		HostedZoneId:    aws.String(cleanZoneID(zone)),
 		StartRecordName: aws.String(en),
 		StartRecordType: aws.String(d.Get("type").(string)),
 	}
@@ -273,7 +273,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("weight", record.Weight)
 		d.Set("set_identifier", record.SetIdentifier)
 		d.Set("failover", record.Failover)
-		d.Set("health_check_id", record.HealthCheckID)
+		d.Set("health_check_id", record.HealthCheckId)
 
 		break
 	}
@@ -292,7 +292,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Deleting resource records for zone: %s, name: %s",
 		zone, d.Get("name").(string))
 	var err error
-	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone)})
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone)})
 	if err != nil {
 		return err
 	}
@@ -314,7 +314,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	req := &route53.ChangeResourceRecordSetsInput{
-		HostedZoneID: aws.String(cleanZoneID(zone)),
+		HostedZoneId: aws.String(cleanZoneID(zone)),
 		ChangeBatch:  changeBatch,
 	}
 
@@ -386,7 +386,7 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 		rec.AliasTarget = &route53.AliasTarget{
 			DNSName:              aws.String(alias["name"].(string)),
 			EvaluateTargetHealth: aws.Bool(alias["evaluate_target_health"].(bool)),
-			HostedZoneID:         aws.String(alias["zone_id"].(string)),
+			HostedZoneId:         aws.String(alias["zone_id"].(string)),
 		}
 		log.Printf("[DEBUG] Creating alias: %#v", alias)
 	} else {
@@ -404,7 +404,7 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 	}
 
 	if v, ok := d.GetOk("health_check_id"); ok {
-		rec.HealthCheckID = aws.String(v.(string))
+		rec.HealthCheckId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("weight"); ok {

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -235,7 +235,7 @@ func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 		rType := parts[2]
 
 		lopts := &route53.ListResourceRecordSetsInput{
-			HostedZoneID:    aws.String(cleanZoneID(zone)),
+			HostedZoneId:    aws.String(cleanZoneID(zone)),
 			StartRecordName: aws.String(name),
 			StartRecordType: aws.String(rType),
 		}
@@ -275,7 +275,7 @@ func testAccCheckRoute53RecordExists(n string) resource.TestCheckFunc {
 		en := expandRecordName(name, "notexample.com")
 
 		lopts := &route53.ListResourceRecordSetsInput{
-			HostedZoneID:    aws.String(cleanZoneID(zone)),
+			HostedZoneId:    aws.String(cleanZoneID(zone)),
 			StartRecordName: aws.String(en),
 			StartRecordType: aws.String(rType),
 		}

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -80,7 +80,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 	if v := d.Get("vpc_id"); v != "" {
 		req.VPC = &route53.VPC{
-			VPCID:     aws.String(v.(string)),
+			VPCId:     aws.String(v.(string)),
 			VPCRegion: aws.String(meta.(*AWSClient).region),
 		}
 		if w := d.Get("vpc_region"); w != "" {
@@ -90,7 +90,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("delegation_set_id"); ok {
-		req.DelegationSetID = aws.String(v.(string))
+		req.DelegationSetId = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", *req.Name)
@@ -101,7 +101,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Store the zone_id
-	zone := cleanZoneID(*resp.HostedZone.ID)
+	zone := cleanZoneID(*resp.HostedZone.Id)
 	d.Set("zone_id", zone)
 	d.SetId(zone)
 
@@ -114,7 +114,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 		MinTimeout: 2 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
 			changeRequest := &route53.GetChangeInput{
-				ID: aws.String(cleanChangeID(*resp.ChangeInfo.ID)),
+				Id: aws.String(cleanChangeID(*resp.ChangeInfo.Id)),
 			}
 			return resourceAwsGoRoute53Wait(r53, changeRequest)
 		},
@@ -128,7 +128,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
 	r53 := meta.(*AWSClient).r53conn
-	zone, err := r53.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(d.Id())})
+	zone, err := r53.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(d.Id())})
 	if err != nil {
 		// Handle a deleted zone
 		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
@@ -158,7 +158,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 
 		var associatedVPC *route53.VPC
 		for _, vpc := range zone.VPCs {
-			if *vpc.VPCID == d.Get("vpc_id") {
+			if *vpc.VPCId == d.Get("vpc_id") {
 				associatedVPC = vpc
 			}
 		}
@@ -167,13 +167,13 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	if zone.DelegationSet != nil && zone.DelegationSet.ID != nil {
-		d.Set("delegation_set_id", cleanDelegationSetId(*zone.DelegationSet.ID))
+	if zone.DelegationSet != nil && zone.DelegationSet.Id != nil {
+		d.Set("delegation_set_id", cleanDelegationSetId(*zone.DelegationSet.Id))
 	}
 
 	// get tags
 	req := &route53.ListTagsForResourceInput{
-		ResourceID:   aws.String(d.Id()),
+		ResourceId:   aws.String(d.Id()),
 		ResourceType: aws.String("hostedzone"),
 	}
 
@@ -211,7 +211,7 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",
 		d.Get("name").(string), d.Id())
-	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{ID: aws.String(d.Id())})
+	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{Id: aws.String(d.Id())})
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func cleanPrefix(ID, prefix string) string {
 
 func getNameServers(zoneId string, zoneName string, r53 *route53.Route53) ([]string, error) {
 	resp, err := r53.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
-		HostedZoneID:    aws.String(zoneId),
+		HostedZoneId:    aws.String(zoneId),
 		StartRecordName: aws.String(zoneName),
 		StartRecordType: aws.String("NS"),
 	})

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -86,11 +86,11 @@ func testAccCheckRoute53ZoneAssociationDestroyWithProvider(s *terraform.State, p
 
 		zone_id, vpc_id := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
 
-		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone_id)})
+		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone_id)})
 		if err != nil {
 			exists := false
 			for _, vpc := range resp.VPCs {
-				if vpc_id == *vpc.VPCID {
+				if vpc_id == *vpc.VPCId {
 					exists = true
 				}
 			}
@@ -135,14 +135,14 @@ func testAccCheckRoute53ZoneAssociationExistsWithProvider(s *terraform.State, n 
 	zone_id, vpc_id := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
 
 	conn := provider.Meta().(*AWSClient).r53conn
-	resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(zone_id)})
+	resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone_id)})
 	if err != nil {
 		return fmt.Errorf("Hosted zone err: %v", err)
 	}
 
 	exists := false
 	for _, vpc := range resp.VPCs {
-		if vpc_id == *vpc.VPCID {
+		if vpc_id == *vpc.VPCId {
 			exists = true
 		}
 	}

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -159,7 +159,7 @@ func testAccCheckRoute53ZoneDestroyWithProvider(s *terraform.State, provider *sc
 			continue
 		}
 
-		_, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
+		_, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(rs.Primary.ID)})
 		if err == nil {
 			return fmt.Errorf("Hosted zone still exists")
 		}
@@ -198,7 +198,7 @@ func testAccCheckRoute53ZoneExistsWithProvider(s *terraform.State, n string, zon
 	}
 
 	conn := provider.Meta().(*AWSClient).r53conn
-	resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{ID: aws.String(rs.Primary.ID)})
+	resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(rs.Primary.ID)})
 	if err != nil {
 		return fmt.Errorf("Hosted zone err: %v", err)
 	}
@@ -241,12 +241,12 @@ func testAccCheckRoute53ZoneAssociatesWithVpc(n string, zone *route53.GetHostedZ
 
 		var associatedVPC *route53.VPC
 		for _, vpc := range zone.VPCs {
-			if *vpc.VPCID == rs.Primary.ID {
+			if *vpc.VPCId == rs.Primary.ID {
 				associatedVPC = vpc
 			}
 		}
 		if associatedVPC == nil {
-			return fmt.Errorf("VPC: %v is not associated to Zone: %v", n, cleanZoneID(*zone.HostedZone.ID))
+			return fmt.Errorf("VPC: %v is not associated to Zone: %v", n, cleanZoneID(*zone.HostedZone.Id))
 		}
 		return nil
 	}
@@ -256,9 +256,9 @@ func testAccLoadTagsR53(zone *route53.GetHostedZoneOutput, td *route53.ResourceT
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).r53conn
 
-		zone := cleanZoneID(*zone.HostedZone.ID)
+		zone := cleanZoneID(*zone.HostedZone.Id)
 		req := &route53.ListTagsForResourceInput{
-			ResourceID:   aws.String(zone),
+			ResourceId:   aws.String(zone),
 			ResourceType: aws.String("hostedzone"),
 		}
 

--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -81,7 +81,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Create the routing table
 	createOpts := &ec2.CreateRouteTableInput{
-		VPCID: aws.String(d.Get("vpc_id").(string)),
+		VpcId: aws.String(d.Get("vpc_id").(string)),
 	}
 	log.Printf("[DEBUG] RouteTable create config: %#v", createOpts)
 
@@ -92,7 +92,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Get the ID and store it
 	rt := resp.RouteTable
-	d.SetId(*rt.RouteTableID)
+	d.SetId(*rt.RouteTableId)
 	log.Printf("[INFO] Route Table ID: %s", d.Id())
 
 	// Wait for the route table to become available
@@ -127,11 +127,11 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	rt := rtRaw.(*ec2.RouteTable)
-	d.Set("vpc_id", rt.VPCID)
+	d.Set("vpc_id", rt.VpcId)
 
-	propagatingVGWs := make([]string, 0, len(rt.PropagatingVGWs))
-	for _, vgw := range rt.PropagatingVGWs {
-		propagatingVGWs = append(propagatingVGWs, *vgw.GatewayID)
+	propagatingVGWs := make([]string, 0, len(rt.PropagatingVgws))
+	for _, vgw := range rt.PropagatingVgws {
+		propagatingVGWs = append(propagatingVGWs, *vgw.GatewayId)
 	}
 	d.Set("propagating_vgws", propagatingVGWs)
 
@@ -140,7 +140,7 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Loop through the routes and add them to the set
 	for _, r := range rt.Routes {
-		if r.GatewayID != nil && *r.GatewayID == "local" {
+		if r.GatewayId != nil && *r.GatewayId == "local" {
 			continue
 		}
 
@@ -148,7 +148,7 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 			continue
 		}
 
-		if r.DestinationPrefixListID != nil {
+		if r.DestinationPrefixListId != nil {
 			// Skipping because VPC endpoint routes are handled separately
 			// See aws_vpc_endpoint
 			continue
@@ -156,20 +156,20 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 
 		m := make(map[string]interface{})
 
-		if r.DestinationCIDRBlock != nil {
-			m["cidr_block"] = *r.DestinationCIDRBlock
+		if r.DestinationCidrBlock != nil {
+			m["cidr_block"] = *r.DestinationCidrBlock
 		}
-		if r.GatewayID != nil {
-			m["gateway_id"] = *r.GatewayID
+		if r.GatewayId != nil {
+			m["gateway_id"] = *r.GatewayId
 		}
-		if r.InstanceID != nil {
-			m["instance_id"] = *r.InstanceID
+		if r.InstanceId != nil {
+			m["instance_id"] = *r.InstanceId
 		}
-		if r.VPCPeeringConnectionID != nil {
-			m["vpc_peering_connection_id"] = *r.VPCPeeringConnectionID
+		if r.VpcPeeringConnectionId != nil {
+			m["vpc_peering_connection_id"] = *r.VpcPeeringConnectionId
 		}
-		if r.NetworkInterfaceID != nil {
-			m["network_interface_id"] = *r.NetworkInterfaceID
+		if r.NetworkInterfaceId != nil {
+			m["network_interface_id"] = *r.NetworkInterfaceId
 		}
 
 		route.Add(m)
@@ -200,9 +200,9 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			log.Printf(
 				"[INFO] Deleting VGW propagation from %s: %s",
 				d.Id(), id)
-			_, err := conn.DisableVGWRoutePropagation(&ec2.DisableVGWRoutePropagationInput{
-				RouteTableID: aws.String(d.Id()),
-				GatewayID:    aws.String(id),
+			_, err := conn.DisableVgwRoutePropagation(&ec2.DisableVgwRoutePropagationInput{
+				RouteTableId: aws.String(d.Id()),
+				GatewayId:    aws.String(id),
 			})
 			if err != nil {
 				return err
@@ -220,9 +220,9 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			var err error
 			for i := 0; i < 5; i++ {
 				log.Printf("[INFO] Enabling VGW propagation for %s: %s", d.Id(), id)
-				_, err = conn.EnableVGWRoutePropagation(&ec2.EnableVGWRoutePropagationInput{
-					RouteTableID: aws.String(d.Id()),
-					GatewayID:    aws.String(id),
+				_, err = conn.EnableVgwRoutePropagation(&ec2.EnableVgwRoutePropagationInput{
+					RouteTableId: aws.String(d.Id()),
+					GatewayId:    aws.String(id),
 				})
 				if err == nil {
 					break
@@ -261,8 +261,8 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 				"[INFO] Deleting route from %s: %s",
 				d.Id(), m["cidr_block"].(string))
 			_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
-				RouteTableID:         aws.String(d.Id()),
-				DestinationCIDRBlock: aws.String(m["cidr_block"].(string)),
+				RouteTableId:         aws.String(d.Id()),
+				DestinationCidrBlock: aws.String(m["cidr_block"].(string)),
 			})
 			if err != nil {
 				return err
@@ -278,12 +278,12 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			m := route.(map[string]interface{})
 
 			opts := ec2.CreateRouteInput{
-				RouteTableID:           aws.String(d.Id()),
-				DestinationCIDRBlock:   aws.String(m["cidr_block"].(string)),
-				GatewayID:              aws.String(m["gateway_id"].(string)),
-				InstanceID:             aws.String(m["instance_id"].(string)),
-				VPCPeeringConnectionID: aws.String(m["vpc_peering_connection_id"].(string)),
-				NetworkInterfaceID:     aws.String(m["network_interface_id"].(string)),
+				RouteTableId:           aws.String(d.Id()),
+				DestinationCidrBlock:   aws.String(m["cidr_block"].(string)),
+				GatewayId:              aws.String(m["gateway_id"].(string)),
+				InstanceId:             aws.String(m["instance_id"].(string)),
+				VpcPeeringConnectionId: aws.String(m["vpc_peering_connection_id"].(string)),
+				NetworkInterfaceId:     aws.String(m["network_interface_id"].(string)),
 			}
 
 			log.Printf("[INFO] Creating route for %s: %#v", d.Id(), opts)
@@ -321,9 +321,9 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 
 	// Do all the disassociations
 	for _, a := range rt.Associations {
-		log.Printf("[INFO] Disassociating association: %s", *a.RouteTableAssociationID)
+		log.Printf("[INFO] Disassociating association: %s", *a.RouteTableAssociationId)
 		_, err := conn.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
-			AssociationID: a.RouteTableAssociationID,
+			AssociationId: a.RouteTableAssociationId,
 		})
 		if err != nil {
 			return err
@@ -333,7 +333,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 	// Delete the route table
 	log.Printf("[INFO] Deleting Route Table: %s", d.Id())
 	_, err = conn.DeleteRouteTable(&ec2.DeleteRouteTableInput{
-		RouteTableID: aws.String(d.Id()),
+		RouteTableId: aws.String(d.Id()),
 	})
 	if err != nil {
 		ec2err, ok := err.(awserr.Error)
@@ -398,7 +398,7 @@ func resourceAwsRouteTableHash(v interface{}) int {
 func resourceAwsRouteTableStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
-			RouteTableIDs: []*string{aws.String(id)},
+			RouteTableIds: []*string{aws.String(id)},
 		})
 		if err != nil {
 			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidRouteTableID.NotFound" {

--- a/builtin/providers/aws/resource_aws_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_route_table_association.go
@@ -41,8 +41,8 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 		d.Get("route_table_id").(string))
 
 	resp, err := conn.AssociateRouteTable(&ec2.AssociateRouteTableInput{
-		RouteTableID: aws.String(d.Get("route_table_id").(string)),
-		SubnetID:     aws.String(d.Get("subnet_id").(string)),
+		RouteTableId: aws.String(d.Get("route_table_id").(string)),
+		SubnetId:     aws.String(d.Get("subnet_id").(string)),
 	})
 
 	if err != nil {
@@ -50,7 +50,7 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 	}
 
 	// Set the ID and return
-	d.SetId(*resp.AssociationID)
+	d.SetId(*resp.AssociationId)
 	log.Printf("[INFO] Association ID: %s", d.Id())
 
 	return nil
@@ -73,9 +73,9 @@ func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface
 	// Inspect that the association exists
 	found := false
 	for _, a := range rt.Associations {
-		if *a.RouteTableAssociationID == d.Id() {
+		if *a.RouteTableAssociationId == d.Id() {
 			found = true
-			d.Set("subnet_id", *a.SubnetID)
+			d.Set("subnet_id", *a.SubnetId)
 			break
 		}
 	}
@@ -97,8 +97,8 @@ func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interfa
 		d.Get("route_table_id").(string))
 
 	req := &ec2.ReplaceRouteTableAssociationInput{
-		AssociationID: aws.String(d.Id()),
-		RouteTableID:  aws.String(d.Get("route_table_id").(string)),
+		AssociationId: aws.String(d.Id()),
+		RouteTableId:  aws.String(d.Get("route_table_id").(string)),
 	}
 	resp, err := conn.ReplaceRouteTableAssociation(req)
 
@@ -113,7 +113,7 @@ func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	// Update the ID
-	d.SetId(*resp.NewAssociationID)
+	d.SetId(*resp.NewAssociationId)
 	log.Printf("[INFO] Association ID: %s", d.Id())
 
 	return nil
@@ -124,7 +124,7 @@ func resourceAwsRouteTableAssociationDelete(d *schema.ResourceData, meta interfa
 
 	log.Printf("[INFO] Deleting route table association: %s", d.Id())
 	_, err := conn.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
-		AssociationID: aws.String(d.Id()),
+		AssociationId: aws.String(d.Id()),
 	})
 	if err != nil {
 		ec2err, ok := err.(awserr.Error)

--- a/builtin/providers/aws/resource_aws_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_association_test.go
@@ -48,7 +48,7 @@ func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
 
 		// Try to find the resource
 		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
-			RouteTableIDs: []*string{aws.String(rs.Primary.Attributes["route_table_id"])},
+			RouteTableIds: []*string{aws.String(rs.Primary.Attributes["route_table_id"])},
 		})
 		if err != nil {
 			// Verify the error is what we want
@@ -65,7 +65,7 @@ func testAccCheckRouteTableAssociationDestroy(s *terraform.State) error {
 		rt := resp.RouteTables[0]
 		if len(rt.Associations) > 0 {
 			return fmt.Errorf(
-				"route table %s has associations", *rt.RouteTableID)
+				"route table %s has associations", *rt.RouteTableId)
 
 		}
 	}
@@ -86,7 +86,7 @@ func testAccCheckRouteTableAssociationExists(n string, v *ec2.RouteTable) resour
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
-			RouteTableIDs: []*string{aws.String(rs.Primary.Attributes["route_table_id"])},
+			RouteTableIds: []*string{aws.String(rs.Primary.Attributes["route_table_id"])},
 		})
 		if err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -21,7 +21,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 
 		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
-			routes[*r.DestinationCIDRBlock] = r
+			routes[*r.DestinationCidrBlock] = r
 		}
 
 		if _, ok := routes["10.1.0.0/16"]; !ok {
@@ -41,7 +41,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 
 		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
-			routes[*r.DestinationCIDRBlock] = r
+			routes[*r.DestinationCidrBlock] = r
 		}
 
 		if _, ok := routes["10.1.0.0/16"]; !ok {
@@ -93,7 +93,7 @@ func TestAccAWSRouteTable_instance(t *testing.T) {
 
 		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
-			routes[*r.DestinationCIDRBlock] = r
+			routes[*r.DestinationCidrBlock] = r
 		}
 
 		if _, ok := routes["10.1.0.0/16"]; !ok {
@@ -161,7 +161,7 @@ func testAccCheckRouteTableDestroy(s *terraform.State) error {
 
 		// Try to find the resource
 		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
-			RouteTableIDs: []*string{aws.String(rs.Primary.ID)},
+			RouteTableIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
 			if len(resp.RouteTables) > 0 {
@@ -197,7 +197,7 @@ func testAccCheckRouteTableExists(n string, v *ec2.RouteTable) resource.TestChec
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
-			RouteTableIDs: []*string{aws.String(rs.Primary.ID)},
+			RouteTableIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err != nil {
 			return err
@@ -225,7 +225,7 @@ func _TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 
 		routes := make(map[string]*ec2.Route)
 		for _, r := range v.Routes {
-			routes[*r.DestinationCIDRBlock] = r
+			routes[*r.DestinationCidrBlock] = r
 		}
 
 		if _, ok := routes["10.1.0.0/16"]; !ok {
@@ -256,20 +256,20 @@ func _TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 
 func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 	var v ec2.RouteTable
-	var vgw ec2.VPNGateway
+	var vgw ec2.VpnGateway
 
 	testCheck := func(*terraform.State) error {
-		if len(v.PropagatingVGWs) != 1 {
-			return fmt.Errorf("bad propagating vgws: %#v", v.PropagatingVGWs)
+		if len(v.PropagatingVgws) != 1 {
+			return fmt.Errorf("bad propagating vgws: %#v", v.PropagatingVgws)
 		}
 
-		propagatingVGWs := make(map[string]*ec2.PropagatingVGW)
-		for _, gw := range v.PropagatingVGWs {
-			propagatingVGWs[*gw.GatewayID] = gw
+		propagatingVGWs := make(map[string]*ec2.PropagatingVgw)
+		for _, gw := range v.PropagatingVgws {
+			propagatingVGWs[*gw.GatewayId] = gw
 		}
 
-		if _, ok := propagatingVGWs[*vgw.VPNGatewayID]; !ok {
-			return fmt.Errorf("bad propagating vgws: %#v", v.PropagatingVGWs)
+		if _, ok := propagatingVGWs[*vgw.VpnGatewayId]; !ok {
+			return fmt.Errorf("bad propagating vgws: %#v", v.PropagatingVgws)
 		}
 
 		return nil

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -100,12 +100,12 @@ func resourceAwsSecurityGroupRuleCreate(d *schema.ResourceData, meta interface{}
 			sg_id, "Ingress", perm)
 
 		req := &ec2.AuthorizeSecurityGroupIngressInput{
-			GroupID:       sg.GroupID,
-			IPPermissions: []*ec2.IPPermission{perm},
+			GroupId:       sg.GroupId,
+			IpPermissions: []*ec2.IpPermission{perm},
 		}
 
-		if sg.VPCID == nil || *sg.VPCID == "" {
-			req.GroupID = nil
+		if sg.VpcId == nil || *sg.VpcId == "" {
+			req.GroupId = nil
 			req.GroupName = sg.GroupName
 		}
 
@@ -116,8 +116,8 @@ func resourceAwsSecurityGroupRuleCreate(d *schema.ResourceData, meta interface{}
 			sg_id, "Egress", perm)
 
 		req := &ec2.AuthorizeSecurityGroupEgressInput{
-			GroupID:       sg.GroupID,
-			IPPermissions: []*ec2.IPPermission{perm},
+			GroupId:       sg.GroupId,
+			IpPermissions: []*ec2.IpPermission{perm},
 		}
 
 		_, autherr = conn.AuthorizeSecurityGroupEgress(req)
@@ -157,14 +157,14 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 		return nil
 	}
 
-	var rule *ec2.IPPermission
+	var rule *ec2.IpPermission
 	ruleType := d.Get("type").(string)
-	var rl []*ec2.IPPermission
+	var rl []*ec2.IpPermission
 	switch ruleType {
 	case "ingress":
-		rl = sg.IPPermissions
+		rl = sg.IpPermissions
 	default:
-		rl = sg.IPPermissionsEgress
+		rl = sg.IpPermissionsEgress
 	}
 
 	for _, r := range rl {
@@ -182,19 +182,19 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("from_port", rule.FromPort)
 	d.Set("to_port", rule.ToPort)
-	d.Set("protocol", rule.IPProtocol)
+	d.Set("protocol", rule.IpProtocol)
 	d.Set("type", ruleType)
 
 	var cb []string
-	for _, c := range rule.IPRanges {
-		cb = append(cb, *c.CIDRIP)
+	for _, c := range rule.IpRanges {
+		cb = append(cb, *c.CidrIp)
 	}
 
 	d.Set("cidr_blocks", cb)
 
-	if len(rule.UserIDGroupPairs) > 0 {
-		s := rule.UserIDGroupPairs[0]
-		d.Set("source_security_group_id", *s.GroupID)
+	if len(rule.UserIdGroupPairs) > 0 {
+		s := rule.UserIdGroupPairs[0]
+		d.Set("source_security_group_id", *s.GroupId)
 	}
 
 	return nil
@@ -216,8 +216,8 @@ func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Revoking rule (%s) from security group %s:\n%s",
 			"ingress", sg_id, perm)
 		req := &ec2.RevokeSecurityGroupIngressInput{
-			GroupID:       sg.GroupID,
-			IPPermissions: []*ec2.IPPermission{perm},
+			GroupId:       sg.GroupId,
+			IpPermissions: []*ec2.IpPermission{perm},
 		}
 
 		_, err = conn.RevokeSecurityGroupIngress(req)
@@ -232,8 +232,8 @@ func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Revoking security group %#v %s rule: %#v",
 			sg_id, "egress", perm)
 		req := &ec2.RevokeSecurityGroupEgressInput{
-			GroupID:       sg.GroupID,
-			IPPermissions: []*ec2.IPPermission{perm},
+			GroupId:       sg.GroupId,
+			IpPermissions: []*ec2.IpPermission{perm},
 		}
 
 		_, err = conn.RevokeSecurityGroupEgress(req)
@@ -252,7 +252,7 @@ func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}
 
 func findResourceSecurityGroup(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
 	req := &ec2.DescribeSecurityGroupsInput{
-		GroupIDs: []*string{aws.String(id)},
+		GroupIds: []*string{aws.String(id)},
 	}
 	resp, err := conn.DescribeSecurityGroups(req)
 	if err != nil {
@@ -270,13 +270,13 @@ func findResourceSecurityGroup(conn *ec2.EC2, id string) (*ec2.SecurityGroup, er
 
 // ByGroupPair implements sort.Interface for []*ec2.UserIDGroupPairs based on
 // GroupID or GroupName field (only one should be set).
-type ByGroupPair []*ec2.UserIDGroupPair
+type ByGroupPair []*ec2.UserIdGroupPair
 
 func (b ByGroupPair) Len() int      { return len(b) }
 func (b ByGroupPair) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b ByGroupPair) Less(i, j int) bool {
-	if b[i].GroupID != nil && b[j].GroupID != nil {
-		return *b[i].GroupID < *b[j].GroupID
+	if b[i].GroupId != nil && b[j].GroupId != nil {
+		return *b[i].GroupId < *b[j].GroupId
 	}
 	if b[i].GroupName != nil && b[j].GroupName != nil {
 		return *b[i].GroupName < *b[j].GroupName
@@ -285,7 +285,7 @@ func (b ByGroupPair) Less(i, j int) bool {
 	panic("mismatched security group rules, may be a terraform bug")
 }
 
-func ipPermissionIDHash(ruleType string, ip *ec2.IPPermission) string {
+func ipPermissionIDHash(ruleType string, ip *ec2.IpPermission) string {
 	var buf bytes.Buffer
 	if ip.FromPort != nil && *ip.FromPort > 0 {
 		buf.WriteString(fmt.Sprintf("%d-", *ip.FromPort))
@@ -293,15 +293,15 @@ func ipPermissionIDHash(ruleType string, ip *ec2.IPPermission) string {
 	if ip.ToPort != nil && *ip.ToPort > 0 {
 		buf.WriteString(fmt.Sprintf("%d-", *ip.ToPort))
 	}
-	buf.WriteString(fmt.Sprintf("%s-", *ip.IPProtocol))
+	buf.WriteString(fmt.Sprintf("%s-", *ip.IpProtocol))
 	buf.WriteString(fmt.Sprintf("%s-", ruleType))
 
 	// We need to make sure to sort the strings below so that we always
 	// generate the same hash code no matter what is in the set.
-	if len(ip.IPRanges) > 0 {
-		s := make([]string, len(ip.IPRanges))
-		for i, r := range ip.IPRanges {
-			s[i] = *r.CIDRIP
+	if len(ip.IpRanges) > 0 {
+		s := make([]string, len(ip.IpRanges))
+		for i, r := range ip.IpRanges {
+			s[i] = *r.CidrIp
 		}
 		sort.Strings(s)
 
@@ -310,11 +310,11 @@ func ipPermissionIDHash(ruleType string, ip *ec2.IPPermission) string {
 		}
 	}
 
-	if len(ip.UserIDGroupPairs) > 0 {
-		sort.Sort(ByGroupPair(ip.UserIDGroupPairs))
-		for _, pair := range ip.UserIDGroupPairs {
-			if pair.GroupID != nil {
-				buf.WriteString(fmt.Sprintf("%s-", *pair.GroupID))
+	if len(ip.UserIdGroupPairs) > 0 {
+		sort.Sort(ByGroupPair(ip.UserIdGroupPairs))
+		for _, pair := range ip.UserIdGroupPairs {
+			if pair.GroupId != nil {
+				buf.WriteString(fmt.Sprintf("%s-", *pair.GroupId))
 			} else {
 				buf.WriteString("-")
 			}
@@ -329,12 +329,12 @@ func ipPermissionIDHash(ruleType string, ip *ec2.IPPermission) string {
 	return fmt.Sprintf("sg-%d", hashcode.String(buf.String()))
 }
 
-func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IPPermission {
-	var perm ec2.IPPermission
+func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IpPermission {
+	var perm ec2.IpPermission
 
 	perm.FromPort = aws.Int64(int64(d.Get("from_port").(int)))
 	perm.ToPort = aws.Int64(int64(d.Get("to_port").(int)))
-	perm.IPProtocol = aws.String(d.Get("protocol").(string))
+	perm.IpProtocol = aws.String(d.Get("protocol").(string))
 
 	// build a group map that behaves like a set
 	groups := make(map[string]bool)
@@ -343,15 +343,15 @@ func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IPPermissi
 	}
 
 	if v, ok := d.GetOk("self"); ok && v.(bool) {
-		if sg.VPCID != nil && *sg.VPCID != "" {
-			groups[*sg.GroupID] = true
+		if sg.VpcId != nil && *sg.VpcId != "" {
+			groups[*sg.GroupId] = true
 		} else {
 			groups[*sg.GroupName] = true
 		}
 	}
 
 	if len(groups) > 0 {
-		perm.UserIDGroupPairs = make([]*ec2.UserIDGroupPair, len(groups))
+		perm.UserIdGroupPairs = make([]*ec2.UserIdGroupPair, len(groups))
 		// build string list of group name/ids
 		var gl []string
 		for k, _ := range groups {
@@ -364,24 +364,24 @@ func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IPPermissi
 				ownerId, id = items[0], items[1]
 			}
 
-			perm.UserIDGroupPairs[i] = &ec2.UserIDGroupPair{
-				GroupID: aws.String(id),
-				UserID:  aws.String(ownerId),
+			perm.UserIdGroupPairs[i] = &ec2.UserIdGroupPair{
+				GroupId: aws.String(id),
+				UserId:  aws.String(ownerId),
 			}
 
-			if sg.VPCID == nil || *sg.VPCID == "" {
-				perm.UserIDGroupPairs[i].GroupID = nil
-				perm.UserIDGroupPairs[i].GroupName = aws.String(id)
-				perm.UserIDGroupPairs[i].UserID = nil
+			if sg.VpcId == nil || *sg.VpcId == "" {
+				perm.UserIdGroupPairs[i].GroupId = nil
+				perm.UserIdGroupPairs[i].GroupName = aws.String(id)
+				perm.UserIdGroupPairs[i].UserId = nil
 			}
 		}
 	}
 
 	if raw, ok := d.GetOk("cidr_blocks"); ok {
 		list := raw.([]interface{})
-		perm.IPRanges = make([]*ec2.IPRange, len(list))
+		perm.IpRanges = make([]*ec2.IpRange, len(list))
 		for i, v := range list {
-			perm.IPRanges[i] = &ec2.IPRange{CIDRIP: aws.String(v.(string))}
+			perm.IpRanges[i] = &ec2.IpRange{CidrIp: aws.String(v.(string))}
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_security_group_rule_migrate.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_migrate.go
@@ -44,8 +44,8 @@ func migrateSGRuleStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceS
 	return is, nil
 }
 
-func migrateExpandIPPerm(attrs map[string]string) (*ec2.IPPermission, error) {
-	var perm ec2.IPPermission
+func migrateExpandIPPerm(attrs map[string]string) (*ec2.IpPermission, error) {
+	var perm ec2.IpPermission
 	tp, err := strconv.Atoi(attrs["to_port"])
 	if err != nil {
 		return nil, fmt.Errorf("Error converting to_port in Security Group migration")
@@ -58,7 +58,7 @@ func migrateExpandIPPerm(attrs map[string]string) (*ec2.IPPermission, error) {
 
 	perm.ToPort = aws.Int64(int64(tp))
 	perm.FromPort = aws.Int64(int64(fp))
-	perm.IPProtocol = aws.String(attrs["protocol"])
+	perm.IpProtocol = aws.String(attrs["protocol"])
 
 	groups := make(map[string]bool)
 	if attrs["self"] == "true" {
@@ -70,7 +70,7 @@ func migrateExpandIPPerm(attrs map[string]string) (*ec2.IPPermission, error) {
 	}
 
 	if len(groups) > 0 {
-		perm.UserIDGroupPairs = make([]*ec2.UserIDGroupPair, len(groups))
+		perm.UserIdGroupPairs = make([]*ec2.UserIdGroupPair, len(groups))
 		// build string list of group name/ids
 		var gl []string
 		for k, _ := range groups {
@@ -78,8 +78,8 @@ func migrateExpandIPPerm(attrs map[string]string) (*ec2.IPPermission, error) {
 		}
 
 		for i, name := range gl {
-			perm.UserIDGroupPairs[i] = &ec2.UserIDGroupPair{
-				GroupID: aws.String(name),
+			perm.UserIdGroupPairs[i] = &ec2.UserIdGroupPair{
+				GroupId: aws.String(name),
 			}
 		}
 	}
@@ -91,9 +91,9 @@ func migrateExpandIPPerm(attrs map[string]string) (*ec2.IPPermission, error) {
 		}
 	}
 	if len(cb) > 0 {
-		perm.IPRanges = make([]*ec2.IPRange, len(cb))
+		perm.IpRanges = make([]*ec2.IpRange, len(cb))
 		for i, v := range cb {
-			perm.IPRanges[i] = &ec2.IPRange{CIDRIP: aws.String(v)}
+			perm.IpRanges[i] = &ec2.IpRange{CidrIp: aws.String(v)}
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -13,72 +13,72 @@ import (
 )
 
 func TestIpPermissionIDHash(t *testing.T) {
-	simple := &ec2.IPPermission{
-		IPProtocol: aws.String("tcp"),
+	simple := &ec2.IpPermission{
+		IpProtocol: aws.String("tcp"),
 		FromPort:   aws.Int64(int64(80)),
 		ToPort:     aws.Int64(int64(8000)),
-		IPRanges: []*ec2.IPRange{
-			&ec2.IPRange{
-				CIDRIP: aws.String("10.0.0.0/8"),
+		IpRanges: []*ec2.IpRange{
+			&ec2.IpRange{
+				CidrIp: aws.String("10.0.0.0/8"),
 			},
 		},
 	}
 
-	egress := &ec2.IPPermission{
-		IPProtocol: aws.String("tcp"),
+	egress := &ec2.IpPermission{
+		IpProtocol: aws.String("tcp"),
 		FromPort:   aws.Int64(int64(80)),
 		ToPort:     aws.Int64(int64(8000)),
-		IPRanges: []*ec2.IPRange{
-			&ec2.IPRange{
-				CIDRIP: aws.String("10.0.0.0/8"),
+		IpRanges: []*ec2.IpRange{
+			&ec2.IpRange{
+				CidrIp: aws.String("10.0.0.0/8"),
 			},
 		},
 	}
 
-	egress_all := &ec2.IPPermission{
-		IPProtocol: aws.String("-1"),
-		IPRanges: []*ec2.IPRange{
-			&ec2.IPRange{
-				CIDRIP: aws.String("10.0.0.0/8"),
+	egress_all := &ec2.IpPermission{
+		IpProtocol: aws.String("-1"),
+		IpRanges: []*ec2.IpRange{
+			&ec2.IpRange{
+				CidrIp: aws.String("10.0.0.0/8"),
 			},
 		},
 	}
 
-	vpc_security_group_source := &ec2.IPPermission{
-		IPProtocol: aws.String("tcp"),
+	vpc_security_group_source := &ec2.IpPermission{
+		IpProtocol: aws.String("tcp"),
 		FromPort:   aws.Int64(int64(80)),
 		ToPort:     aws.Int64(int64(8000)),
-		UserIDGroupPairs: []*ec2.UserIDGroupPair{
-			&ec2.UserIDGroupPair{
-				UserID:  aws.String("987654321"),
-				GroupID: aws.String("sg-12345678"),
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			&ec2.UserIdGroupPair{
+				UserId:  aws.String("987654321"),
+				GroupId: aws.String("sg-12345678"),
 			},
-			&ec2.UserIDGroupPair{
-				UserID:  aws.String("123456789"),
-				GroupID: aws.String("sg-987654321"),
+			&ec2.UserIdGroupPair{
+				UserId:  aws.String("123456789"),
+				GroupId: aws.String("sg-987654321"),
 			},
-			&ec2.UserIDGroupPair{
-				UserID:  aws.String("123456789"),
-				GroupID: aws.String("sg-12345678"),
+			&ec2.UserIdGroupPair{
+				UserId:  aws.String("123456789"),
+				GroupId: aws.String("sg-12345678"),
 			},
 		},
 	}
 
-	security_group_source := &ec2.IPPermission{
-		IPProtocol: aws.String("tcp"),
+	security_group_source := &ec2.IpPermission{
+		IpProtocol: aws.String("tcp"),
 		FromPort:   aws.Int64(int64(80)),
 		ToPort:     aws.Int64(int64(8000)),
-		UserIDGroupPairs: []*ec2.UserIDGroupPair{
-			&ec2.UserIDGroupPair{
-				UserID:    aws.String("987654321"),
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			&ec2.UserIdGroupPair{
+				UserId:    aws.String("987654321"),
 				GroupName: aws.String("my-security-group"),
 			},
-			&ec2.UserIDGroupPair{
-				UserID:    aws.String("123456789"),
+			&ec2.UserIdGroupPair{
+				UserId:    aws.String("123456789"),
 				GroupName: aws.String("my-security-group"),
 			},
-			&ec2.UserIDGroupPair{
-				UserID:    aws.String("123456789"),
+			&ec2.UserIdGroupPair{
+				UserId:    aws.String("123456789"),
 				GroupName: aws.String("my-other-security-group"),
 			},
 		},
@@ -86,7 +86,7 @@ func TestIpPermissionIDHash(t *testing.T) {
 
 	// hardcoded hashes, to detect future change
 	cases := []struct {
-		Input  *ec2.IPPermission
+		Input  *ec2.IpPermission
 		Type   string
 		Output string
 	}{
@@ -109,12 +109,12 @@ func TestAccAWSSecurityGroupRule_Ingress_VPC(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testRuleCount := func(*terraform.State) error {
-		if len(group.IPPermissions) != 1 {
+		if len(group.IpPermissions) != 1 {
 			return fmt.Errorf("Wrong Security Group rule count, expected %d, got %d",
-				1, len(group.IPPermissions))
+				1, len(group.IpPermissions))
 		}
 
-		rule := group.IPPermissions[0]
+		rule := group.IpPermissions[0]
 		if *rule.FromPort != int64(80) {
 			return fmt.Errorf("Wrong Security Group port setting, expected %d, got %d",
 				80, int(*rule.FromPort))
@@ -146,12 +146,12 @@ func TestAccAWSSecurityGroupRule_Ingress_Classic(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testRuleCount := func(*terraform.State) error {
-		if len(group.IPPermissions) != 1 {
+		if len(group.IpPermissions) != 1 {
 			return fmt.Errorf("Wrong Security Group rule count, expected %d, got %d",
-				1, len(group.IPPermissions))
+				1, len(group.IpPermissions))
 		}
 
-		rule := group.IPPermissions[0]
+		rule := group.IpPermissions[0]
 		if *rule.FromPort != int64(80) {
 			return fmt.Errorf("Wrong Security Group port setting, expected %d, got %d",
 				80, int(*rule.FromPort))
@@ -183,13 +183,13 @@ func TestAccAWSSecurityGroupRule_MultiIngress(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testMultiRuleCount := func(*terraform.State) error {
-		if len(group.IPPermissions) != 2 {
+		if len(group.IpPermissions) != 2 {
 			return fmt.Errorf("Wrong Security Group rule count, expected %d, got %d",
-				2, len(group.IPPermissions))
+				2, len(group.IpPermissions))
 		}
 
-		var rule *ec2.IPPermission
-		for _, r := range group.IPPermissions {
+		var rule *ec2.IpPermission
+		for _, r := range group.IpPermissions {
 			if *r.FromPort == int64(80) {
 				rule = r
 			}
@@ -266,11 +266,11 @@ func testAccCheckAWSSecurityGroupRuleDestroy(s *terraform.State) error {
 
 		// Retrieve our group
 		req := &ec2.DescribeSecurityGroupsInput{
-			GroupIDs: []*string{aws.String(rs.Primary.ID)},
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		resp, err := conn.DescribeSecurityGroups(req)
 		if err == nil {
-			if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupID == rs.Primary.ID {
+			if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupId == rs.Primary.ID {
 				return fmt.Errorf("Security Group (%s) still exists.", rs.Primary.ID)
 			}
 
@@ -303,14 +303,14 @@ func testAccCheckAWSSecurityGroupRuleExists(n string, group *ec2.SecurityGroup) 
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		req := &ec2.DescribeSecurityGroupsInput{
-			GroupIDs: []*string{aws.String(rs.Primary.ID)},
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		resp, err := conn.DescribeSecurityGroups(req)
 		if err != nil {
 			return err
 		}
 
-		if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupID == rs.Primary.ID {
+		if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupId == rs.Primary.ID {
 			*group = *resp.SecurityGroups[0]
 			return nil
 		}
@@ -321,17 +321,17 @@ func testAccCheckAWSSecurityGroupRuleExists(n string, group *ec2.SecurityGroup) 
 
 func testAccCheckAWSSecurityGroupRuleAttributes(group *ec2.SecurityGroup, ruleType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		p := &ec2.IPPermission{
+		p := &ec2.IpPermission{
 			FromPort:   aws.Int64(80),
 			ToPort:     aws.Int64(8000),
-			IPProtocol: aws.String("tcp"),
-			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("10.0.0.0/8")}},
+			IpProtocol: aws.String("tcp"),
+			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
 		}
-		var rules []*ec2.IPPermission
+		var rules []*ec2.IpPermission
 		if ruleType == "ingress" {
-			rules = group.IPPermissions
+			rules = group.IpPermissions
 		} else {
-			rules = group.IPPermissionsEgress
+			rules = group.IpPermissionsEgress
 		}
 
 		if len(rules) == 0 {

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -56,7 +56,7 @@ func TestAccAWSSecurityGroup_self(t *testing.T) {
 			}
 		}()
 
-		if *group.IPPermissions[0].UserIDGroupPairs[0].GroupID != *group.GroupID {
+		if *group.IpPermissions[0].UserIdGroupPairs[0].GroupId != *group.GroupId {
 			return fmt.Errorf("bad: %#v", group)
 		}
 
@@ -95,7 +95,7 @@ func TestAccAWSSecurityGroup_vpc(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testCheck := func(*terraform.State) error {
-		if *group.VPCID == "" {
+		if *group.VpcId == "" {
 			return fmt.Errorf("should have vpc ID")
 		}
 
@@ -147,7 +147,7 @@ func TestAccAWSSecurityGroup_vpcNegOneIngress(t *testing.T) {
 	var group ec2.SecurityGroup
 
 	testCheck := func(*terraform.State) error {
-		if *group.VPCID == "" {
+		if *group.VpcId == "" {
 			return fmt.Errorf("should have vpc ID")
 		}
 
@@ -300,11 +300,11 @@ func testAccCheckAWSSecurityGroupDestroy(s *terraform.State) error {
 
 		// Retrieve our group
 		req := &ec2.DescribeSecurityGroupsInput{
-			GroupIDs: []*string{aws.String(rs.Primary.ID)},
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		resp, err := conn.DescribeSecurityGroups(req)
 		if err == nil {
-			if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupID == rs.Primary.ID {
+			if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupId == rs.Primary.ID {
 				return fmt.Errorf("Security Group (%s) still exists.", rs.Primary.ID)
 			}
 
@@ -337,14 +337,14 @@ func testAccCheckAWSSecurityGroupExists(n string, group *ec2.SecurityGroup) reso
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		req := &ec2.DescribeSecurityGroupsInput{
-			GroupIDs: []*string{aws.String(rs.Primary.ID)},
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		resp, err := conn.DescribeSecurityGroups(req)
 		if err != nil {
 			return err
 		}
 
-		if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupID == rs.Primary.ID {
+		if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupId == rs.Primary.ID {
 			*group = *resp.SecurityGroups[0]
 			return nil
 		}
@@ -355,11 +355,11 @@ func testAccCheckAWSSecurityGroupExists(n string, group *ec2.SecurityGroup) reso
 
 func testAccCheckAWSSecurityGroupAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		p := &ec2.IPPermission{
+		p := &ec2.IpPermission{
 			FromPort:   aws.Int64(80),
 			ToPort:     aws.Int64(8000),
-			IPProtocol: aws.String("tcp"),
-			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("10.0.0.0/8")}},
+			IpProtocol: aws.String("tcp"),
+			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
 		}
 
 		if *group.GroupName != "terraform_acceptance_test_example" {
@@ -370,15 +370,15 @@ func testAccCheckAWSSecurityGroupAttributes(group *ec2.SecurityGroup) resource.T
 			return fmt.Errorf("Bad description: %s", *group.Description)
 		}
 
-		if len(group.IPPermissions) == 0 {
+		if len(group.IpPermissions) == 0 {
 			return fmt.Errorf("No IPPerms")
 		}
 
 		// Compare our ingress
-		if !reflect.DeepEqual(group.IPPermissions[0], p) {
+		if !reflect.DeepEqual(group.IpPermissions[0], p) {
 			return fmt.Errorf(
 				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-				group.IPPermissions[0],
+				group.IpPermissions[0],
 				p)
 		}
 
@@ -388,9 +388,9 @@ func testAccCheckAWSSecurityGroupAttributes(group *ec2.SecurityGroup) resource.T
 
 func testAccCheckAWSSecurityGroupAttributesNegOneProtocol(group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		p := &ec2.IPPermission{
-			IPProtocol: aws.String("-1"),
-			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("10.0.0.0/8")}},
+		p := &ec2.IpPermission{
+			IpProtocol: aws.String("-1"),
+			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
 		}
 
 		if *group.GroupName != "terraform_acceptance_test_example" {
@@ -401,15 +401,15 @@ func testAccCheckAWSSecurityGroupAttributesNegOneProtocol(group *ec2.SecurityGro
 			return fmt.Errorf("Bad description: %s", *group.Description)
 		}
 
-		if len(group.IPPermissions) == 0 {
+		if len(group.IpPermissions) == 0 {
 			return fmt.Errorf("No IPPerms")
 		}
 
 		// Compare our ingress
-		if !reflect.DeepEqual(group.IPPermissions[0], p) {
+		if !reflect.DeepEqual(group.IpPermissions[0], p) {
 			return fmt.Errorf(
 				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-				group.IPPermissions[0],
+				group.IpPermissions[0],
 				p)
 		}
 
@@ -447,23 +447,23 @@ func TestAccAWSSecurityGroup_tags(t *testing.T) {
 
 func testAccCheckAWSSecurityGroupAttributesChanged(group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		p := []*ec2.IPPermission{
-			&ec2.IPPermission{
+		p := []*ec2.IpPermission{
+			&ec2.IpPermission{
 				FromPort:   aws.Int64(80),
 				ToPort:     aws.Int64(9000),
-				IPProtocol: aws.String("tcp"),
-				IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("10.0.0.0/8")}},
+				IpProtocol: aws.String("tcp"),
+				IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
 			},
-			&ec2.IPPermission{
+			&ec2.IpPermission{
 				FromPort:   aws.Int64(80),
 				ToPort:     aws.Int64(8000),
-				IPProtocol: aws.String("tcp"),
-				IPRanges: []*ec2.IPRange{
-					&ec2.IPRange{
-						CIDRIP: aws.String("0.0.0.0/0"),
+				IpProtocol: aws.String("tcp"),
+				IpRanges: []*ec2.IpRange{
+					&ec2.IpRange{
+						CidrIp: aws.String("0.0.0.0/0"),
 					},
-					&ec2.IPRange{
-						CIDRIP: aws.String("10.0.0.0/8"),
+					&ec2.IpRange{
+						CidrIp: aws.String("10.0.0.0/8"),
 					},
 				},
 			},
@@ -478,22 +478,22 @@ func testAccCheckAWSSecurityGroupAttributesChanged(group *ec2.SecurityGroup) res
 		}
 
 		// Compare our ingress
-		if len(group.IPPermissions) != 2 {
+		if len(group.IpPermissions) != 2 {
 			return fmt.Errorf(
 				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-				group.IPPermissions,
+				group.IpPermissions,
 				p)
 		}
 
-		if *group.IPPermissions[0].ToPort == 8000 {
-			group.IPPermissions[1], group.IPPermissions[0] =
-				group.IPPermissions[0], group.IPPermissions[1]
+		if *group.IpPermissions[0].ToPort == 8000 {
+			group.IpPermissions[1], group.IpPermissions[0] =
+				group.IpPermissions[0], group.IpPermissions[1]
 		}
 
-		if !reflect.DeepEqual(group.IPPermissions, p) {
+		if !reflect.DeepEqual(group.IpPermissions, p) {
 			return fmt.Errorf(
 				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-				group.IPPermissions,
+				group.IpPermissions,
 				p)
 		}
 
@@ -514,18 +514,18 @@ func testAccCheckAWSSecurityGroupExistsWithoutDefault(n string) resource.TestChe
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		req := &ec2.DescribeSecurityGroupsInput{
-			GroupIDs: []*string{aws.String(rs.Primary.ID)},
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
 		}
 		resp, err := conn.DescribeSecurityGroups(req)
 		if err != nil {
 			return err
 		}
 
-		if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupID == rs.Primary.ID {
+		if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupId == rs.Primary.ID {
 			group := *resp.SecurityGroups[0]
 
-			if len(group.IPPermissionsEgress) != 1 {
-				return fmt.Errorf("Security Group should have only 1 egress rule, got %d", len(group.IPPermissionsEgress))
+			if len(group.IpPermissionsEgress) != 1 {
+				return fmt.Errorf("Security Group should have only 1 egress rule, got %d", len(group.IpPermissionsEgress))
 			}
 		}
 

--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -70,10 +70,10 @@ func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating SNS topic: %s", err)
 	}
 
-	d.SetId(*output.TopicARN)
+	d.SetId(*output.TopicArn)
 
 	// Write the ARN to the 'arn' field for export
-	d.Set("arn", *output.TopicARN)
+	d.Set("arn", *output.TopicArn)
 
 	return resourceAwsSnsTopicUpdate(d, meta)
 }
@@ -92,7 +92,7 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 				if !(k == "policy" && n == "") {
 					// Make API call to update attributes
 					req := &sns.SetTopicAttributesInput{
-						TopicARN:       aws.String(d.Id()),
+						TopicArn:       aws.String(d.Id()),
 						AttributeName:  aws.String(attrKey),
 						AttributeValue: aws.String(n.(string)),
 					}
@@ -109,7 +109,7 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 	snsconn := meta.(*AWSClient).snsconn
 
 	attributeOutput, err := snsconn.GetTopicAttributes(&sns.GetTopicAttributesInput{
-		TopicARN: aws.String(d.Id()),
+		TopicArn: aws.String(d.Id()),
 	})
 
 	if err != nil {
@@ -143,7 +143,7 @@ func resourceAwsSnsTopicDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] SNS Delete Topic: %s", d.Id())
 	_, err := snsconn.DeleteTopic(&sns.DeleteTopicInput{
-		TopicARN: aws.String(d.Id()),
+		TopicArn: aws.String(d.Id()),
 	})
 	if err != nil {
 		return err

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -65,11 +65,11 @@ func resourceAwsSnsTopicSubscriptionCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	log.Printf("New subscription ARN: %s", *output.SubscriptionARN)
-	d.SetId(*output.SubscriptionARN)
+	log.Printf("New subscription ARN: %s", *output.SubscriptionArn)
+	d.SetId(*output.SubscriptionArn)
 
 	// Write the ARN to the 'arn' field for export
-	d.Set("arn", *output.SubscriptionARN)
+	d.Set("arn", *output.SubscriptionArn)
 
 	return resourceAwsSnsTopicSubscriptionUpdate(d, meta)
 }
@@ -82,7 +82,7 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 		log.Printf("[DEBUG] Updating subscription %s", d.Id())
 		// Unsubscribe
 		_, err := snsconn.Unsubscribe(&sns.UnsubscribeInput{
-			SubscriptionARN: aws.String(d.Id()),
+			SubscriptionArn: aws.String(d.Id()),
 		})
 
 		if err != nil {
@@ -91,7 +91,7 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 
 		// Re-subscribe and set id
 		output, err := subscribeToSNSTopic(d, snsconn)
-		d.SetId(*output.SubscriptionARN)
+		d.SetId(*output.SubscriptionArn)
 
 	}
 
@@ -105,7 +105,7 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 		}
 
 		req := &sns.SetSubscriptionAttributesInput{
-			SubscriptionARN: aws.String(d.Id()),
+			SubscriptionArn: aws.String(d.Id()),
 			AttributeName:   aws.String("RawMessageDelivery"),
 			AttributeValue:  aws.String(attrValue),
 		}
@@ -125,7 +125,7 @@ func resourceAwsSnsTopicSubscriptionRead(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Loading subscription %s", d.Id())
 
 	attributeOutput, err := snsconn.GetSubscriptionAttributes(&sns.GetSubscriptionAttributesInput{
-		SubscriptionARN: aws.String(d.Id()),
+		SubscriptionArn: aws.String(d.Id()),
 	})
 	if err != nil {
 		return err
@@ -149,7 +149,7 @@ func resourceAwsSnsTopicSubscriptionDelete(d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] SNS delete topic subscription: %s", d.Id())
 	_, err := snsconn.Unsubscribe(&sns.UnsubscribeInput{
-		SubscriptionARN: aws.String(d.Id()),
+		SubscriptionArn: aws.String(d.Id()),
 	})
 	if err != nil {
 		return err
@@ -167,7 +167,7 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 	req := &sns.SubscribeInput{
 		Protocol: aws.String(protocol),
 		Endpoint: aws.String(endpoint),
-		TopicARN: aws.String(topic_arn),
+		TopicArn: aws.String(topic_arn),
 	}
 
 	output, err = snsconn.Subscribe(req)

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
@@ -38,7 +38,7 @@ func testAccCheckAWSSNSTopicSubscriptionDestroy(s *terraform.State) error {
 
 		// Try to find key pair
 		req := &sns.GetSubscriptionAttributesInput{
-			SubscriptionARN: aws.String(rs.Primary.ID),
+			SubscriptionArn: aws.String(rs.Primary.ID),
 		}
 
 		_, err := conn.GetSubscriptionAttributes(req)
@@ -71,7 +71,7 @@ func testAccCheckAWSSNSTopicSubscriptionExists(n string) resource.TestCheckFunc 
 		conn := testAccProvider.Meta().(*AWSClient).snsconn
 
 		params := &sns.GetSubscriptionAttributesInput{
-			SubscriptionARN: aws.String(rs.Primary.ID),
+			SubscriptionArn: aws.String(rs.Primary.ID),
 		}
 		_, err := conn.GetSubscriptionAttributes(params)
 

--- a/builtin/providers/aws/resource_aws_sns_topic_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_test.go
@@ -37,7 +37,7 @@ func testAccCheckAWSSNSTopicDestroy(s *terraform.State) error {
 
 		// Check if the topic exists by fetching its attributes
 		params := &sns.GetTopicAttributesInput{
-			TopicARN: aws.String(rs.Primary.ID),
+			TopicArn: aws.String(rs.Primary.ID),
 		}
 		_, err := conn.GetTopicAttributes(params)
 		if err == nil {
@@ -68,7 +68,7 @@ func testAccCheckAWSSNSTopicExists(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).snsconn
 
 		params := &sns.GetTopicAttributesInput{
-			TopicARN: aws.String(rs.Primary.ID),
+			TopicArn: aws.String(rs.Primary.ID),
 		}
 		_, err := conn.GetTopicAttributes(params)
 

--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -81,13 +81,13 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 
 		LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
 			BlockDeviceMappings: instanceOpts.BlockDeviceMappings,
-			EBSOptimized:        instanceOpts.EBSOptimized,
+			EbsOptimized:        instanceOpts.EBSOptimized,
 			Monitoring:          instanceOpts.Monitoring,
-			IAMInstanceProfile:  instanceOpts.IAMInstanceProfile,
-			ImageID:             instanceOpts.ImageID,
+			IamInstanceProfile:  instanceOpts.IAMInstanceProfile,
+			ImageId:             instanceOpts.ImageID,
 			InstanceType:        instanceOpts.InstanceType,
 			Placement:           instanceOpts.SpotPlacement,
-			SecurityGroupIDs:    instanceOpts.SecurityGroupIDs,
+			SecurityGroupIds:    instanceOpts.SecurityGroupIDs,
 			SecurityGroups:      instanceOpts.SecurityGroups,
 			UserData:            instanceOpts.UserData64,
 		},
@@ -105,7 +105,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	}
 
 	sir := *resp.SpotInstanceRequests[0]
-	d.SetId(*sir.SpotInstanceRequestID)
+	d.SetId(*sir.SpotInstanceRequestId)
 
 	if d.Get("wait_for_fulfillment").(bool) {
 		spotStateConf := &resource.StateChangeConf{
@@ -134,7 +134,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).ec2conn
 
 	req := &ec2.DescribeSpotInstanceRequestsInput{
-		SpotInstanceRequestIDs: []*string{aws.String(d.Id())},
+		SpotInstanceRequestIds: []*string{aws.String(d.Id())},
 	}
 	resp, err := conn.DescribeSpotInstanceRequests(req)
 
@@ -166,8 +166,8 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("spot_bid_status", *request.Status.Code)
 	// Instance ID is not set if the request is still pending
-	if request.InstanceID != nil {
-		d.Set("spot_instance_id", *request.InstanceID)
+	if request.InstanceId != nil {
+		d.Set("spot_instance_id", *request.InstanceId)
 	}
 	d.Set("spot_request_state", *request.State)
 	d.Set("tags", tagsToMap(request.Tags))
@@ -195,7 +195,7 @@ func resourceAwsSpotInstanceRequestDelete(d *schema.ResourceData, meta interface
 
 	log.Printf("[INFO] Cancelling spot request: %s", d.Id())
 	_, err := conn.CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{
-		SpotInstanceRequestIDs: []*string{aws.String(d.Id())},
+		SpotInstanceRequestIds: []*string{aws.String(d.Id())},
 	})
 
 	if err != nil {
@@ -219,7 +219,7 @@ func SpotInstanceStateRefreshFunc(
 
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
-			SpotInstanceRequestIDs: []*string{sir.SpotInstanceRequestID},
+			SpotInstanceRequestIds: []*string{sir.SpotInstanceRequestId},
 		})
 
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_spot_instance_request_test.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request_test.go
@@ -44,7 +44,7 @@ func testAccCheckAWSSpotInstanceRequestDestroy(s *terraform.State) error {
 		}
 
 		req := &ec2.DescribeSpotInstanceRequestsInput{
-			SpotInstanceRequestIDs: []*string{aws.String(rs.Primary.ID)},
+			SpotInstanceRequestIds: []*string{aws.String(rs.Primary.ID)},
 		}
 
 		resp, err := conn.DescribeSpotInstanceRequests(req)
@@ -66,7 +66,7 @@ func testAccCheckAWSSpotInstanceRequestDestroy(s *terraform.State) error {
 		// Now check if the associated Spot Instance was also destroyed
 		instId := rs.Primary.Attributes["spot_instance_id"]
 		instResp, instErr := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-			InstanceIDs: []*string{aws.String(instId)},
+			InstanceIds: []*string{aws.String(instId)},
 		})
 		if instErr == nil {
 			if len(instResp.Reservations) > 0 {
@@ -104,7 +104,7 @@ func testAccCheckAWSSpotInstanceRequestExists(
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
 		params := &ec2.DescribeSpotInstanceRequestsInput{
-			SpotInstanceRequestIDs: []*string{&rs.Primary.ID},
+			SpotInstanceRequestIds: []*string{&rs.Primary.ID},
 		}
 		resp, err := conn.DescribeSpotInstanceRequests(params)
 

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -116,7 +116,7 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating SQS queue: %s", err)
 	}
 
-	d.SetId(*output.QueueURL)
+	d.SetId(*output.QueueUrl)
 
 	return resourceAwsSqsQueueUpdate(d, meta)
 }
@@ -143,7 +143,7 @@ func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if len(attributes) > 0 {
 		req := &sqs.SetQueueAttributesInput{
-			QueueURL:   aws.String(d.Id()),
+			QueueUrl:   aws.String(d.Id()),
 			Attributes: attributes,
 		}
 		sqsconn.SetQueueAttributes(req)
@@ -156,7 +156,7 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	sqsconn := meta.(*AWSClient).sqsconn
 
 	attributeOutput, err := sqsconn.GetQueueAttributes(&sqs.GetQueueAttributesInput{
-		QueueURL:       aws.String(d.Id()),
+		QueueUrl:       aws.String(d.Id()),
 		AttributeNames: []*string{aws.String("All")},
 	})
 
@@ -191,7 +191,7 @@ func resourceAwsSqsQueueDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] SQS Delete Queue: %s", d.Id())
 	_, err := sqsconn.DeleteQueue(&sqs.DeleteQueueInput{
-		QueueURL: aws.String(d.Id()),
+		QueueUrl: aws.String(d.Id()),
 	})
 	if err != nil {
 		return err

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -43,7 +43,7 @@ func testAccCheckAWSSQSQueueDestroy(s *terraform.State) error {
 
 		// Check if queue exists by checking for its attributes
 		params := &sqs.GetQueueAttributesInput{
-			QueueURL: aws.String(rs.Primary.ID),
+			QueueUrl: aws.String(rs.Primary.ID),
 		}
 		_, err := conn.GetQueueAttributes(params)
 		if err == nil {
@@ -74,7 +74,7 @@ func testAccCheckAWSSQSExistsWithDefaults(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).sqsconn
 
 		params := &sqs.GetQueueAttributesInput{
-			QueueURL:       aws.String(rs.Primary.ID),
+			QueueUrl:       aws.String(rs.Primary.ID),
 			AttributeNames: []*string{aws.String("All")},
 		}
 		resp, err := conn.GetQueueAttributes(params)
@@ -124,7 +124,7 @@ func testAccCheckAWSSQSExistsWithOverrides(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).sqsconn
 
 		params := &sqs.GetQueueAttributesInput{
-			QueueURL:       aws.String(rs.Primary.ID),
+			QueueUrl:       aws.String(rs.Primary.ID),
 			AttributeNames: []*string{aws.String("All")},
 		}
 		resp, err := conn.GetQueueAttributes(params)

--- a/builtin/providers/aws/resource_aws_subnet_test.go
+++ b/builtin/providers/aws/resource_aws_subnet_test.go
@@ -15,12 +15,12 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 	var v ec2.Subnet
 
 	testCheck := func(*terraform.State) error {
-		if *v.CIDRBlock != "10.1.1.0/24" {
-			return fmt.Errorf("bad cidr: %s", *v.CIDRBlock)
+		if *v.CidrBlock != "10.1.1.0/24" {
+			return fmt.Errorf("bad cidr: %s", *v.CidrBlock)
 		}
 
-		if *v.MapPublicIPOnLaunch != true {
-			return fmt.Errorf("bad MapPublicIpOnLaunch: %t", *v.MapPublicIPOnLaunch)
+		if *v.MapPublicIpOnLaunch != true {
+			return fmt.Errorf("bad MapPublicIpOnLaunch: %t", *v.MapPublicIpOnLaunch)
 		}
 
 		return nil
@@ -53,7 +53,7 @@ func testAccCheckSubnetDestroy(s *terraform.State) error {
 
 		// Try to find the resource
 		resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsInput{
-			SubnetIDs: []*string{aws.String(rs.Primary.ID)},
+			SubnetIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
 			if len(resp.Subnets) > 0 {
@@ -89,7 +89,7 @@ func testAccCheckSubnetExists(n string, v *ec2.Subnet) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsInput{
-			SubnetIDs: []*string{aws.String(rs.Primary.ID)},
+			SubnetIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_volume_attachment.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment.go
@@ -56,8 +56,8 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 
 	opts := &ec2.AttachVolumeInput{
 		Device:     aws.String(name),
-		InstanceID: aws.String(iID),
-		VolumeID:   aws.String(vID),
+		InstanceId: aws.String(iID),
+		VolumeId:   aws.String(vID),
 	}
 
 	log.Printf("[DEBUG] Attaching Volume (%s) to Instance (%s)", vID, iID)
@@ -94,7 +94,7 @@ func volumeAttachmentStateRefreshFunc(conn *ec2.EC2, volumeID, instanceID string
 	return func() (interface{}, string, error) {
 
 		request := &ec2.DescribeVolumesInput{
-			VolumeIDs: []*string{aws.String(volumeID)},
+			VolumeIds: []*string{aws.String(volumeID)},
 			Filters: []*ec2.Filter{
 				&ec2.Filter{
 					Name:   aws.String("attachment.instance-id"),
@@ -114,7 +114,7 @@ func volumeAttachmentStateRefreshFunc(conn *ec2.EC2, volumeID, instanceID string
 		if len(resp.Volumes) > 0 {
 			v := resp.Volumes[0]
 			for _, a := range v.Attachments {
-				if a.InstanceID != nil && *a.InstanceID == instanceID {
+				if a.InstanceId != nil && *a.InstanceId == instanceID {
 					return a, *a.State, nil
 				}
 			}
@@ -127,7 +127,7 @@ func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*AWSClient).ec2conn
 
 	request := &ec2.DescribeVolumesInput{
-		VolumeIDs: []*string{aws.String(d.Get("volume_id").(string))},
+		VolumeIds: []*string{aws.String(d.Get("volume_id").(string))},
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
 				Name:   aws.String("attachment.instance-id"),
@@ -155,8 +155,8 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 
 	opts := &ec2.DetachVolumeInput{
 		Device:     aws.String(d.Get("device_name").(string)),
-		InstanceID: aws.String(iID),
-		VolumeID:   aws.String(vID),
+		InstanceId: aws.String(iID),
+		VolumeId:   aws.String(vID),
 		Force:      aws.Bool(d.Get("force_detach").(bool)),
 	}
 

--- a/builtin/providers/aws/resource_aws_volume_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment_test.go
@@ -49,7 +49,7 @@ func testAccCheckVolumeAttachmentExists(n string, i *ec2.Instance, v *ec2.Volume
 
 		for _, b := range i.BlockDeviceMappings {
 			if rs.Primary.Attributes["device_name"] == *b.DeviceName {
-				if b.EBS.VolumeID != nil && rs.Primary.Attributes["volume_id"] == *b.EBS.VolumeID {
+				if b.Ebs.VolumeId != nil && rs.Primary.Attributes["volume_id"] == *b.Ebs.VolumeId {
 					// pass
 					return nil
 				}

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options_association.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options_association.go
@@ -40,9 +40,9 @@ func resourceAwsVpcDhcpOptionsAssociationCreate(d *schema.ResourceData, meta int
 	optsID := aws.String(d.Get("dhcp_options_id").(string))
 	vpcID := aws.String(d.Get("vpc_id").(string))
 
-	if _, err := conn.AssociateDHCPOptions(&ec2.AssociateDHCPOptionsInput{
-		DHCPOptionsID: optsID,
-		VPCID:         vpcID,
+	if _, err := conn.AssociateDhcpOptions(&ec2.AssociateDhcpOptionsInput{
+		DhcpOptionsId: optsID,
+		VpcId:         vpcID,
 	}); err != nil {
 		return err
 	}
@@ -67,8 +67,8 @@ func resourceAwsVpcDhcpOptionsAssociationRead(d *schema.ResourceData, meta inter
 		return nil
 	}
 
-	vpc := vpcRaw.(*ec2.VPC)
-	if *vpc.VPCID != d.Get("vpc_id") || *vpc.DHCPOptionsID != d.Get("dhcp_options_id") {
+	vpc := vpcRaw.(*ec2.Vpc)
+	if *vpc.VpcId != d.Get("vpc_id") || *vpc.DhcpOptionsId != d.Get("dhcp_options_id") {
 		log.Printf("[INFO] It seems the DHCP Options association is gone. Deleting reference from Graph...")
 		d.SetId("")
 	}
@@ -87,9 +87,9 @@ func resourceAwsVpcDhcpOptionsAssociationDelete(d *schema.ResourceData, meta int
 	conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Disassociating DHCP Options Set %s from VPC %s...", d.Get("dhcp_options_id"), d.Get("vpc_id"))
-	if _, err := conn.AssociateDHCPOptions(&ec2.AssociateDHCPOptionsInput{
-		DHCPOptionsID: aws.String("default"),
-		VPCID:         aws.String(d.Get("vpc_id").(string)),
+	if _, err := conn.AssociateDhcpOptions(&ec2.AssociateDhcpOptionsInput{
+		DhcpOptionsId: aws.String("default"),
+		VpcId:         aws.String(d.Get("vpc_id").(string)),
 	}); err != nil {
 		return err
 	}

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options_association_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options_association_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestAccAWSDHCPOptionsAssociation_basic(t *testing.T) {
-	var v ec2.VPC
-	var d ec2.DHCPOptions
+	var v ec2.Vpc
+	var d ec2.DhcpOptions
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,7 +52,7 @@ func testAccCheckDHCPOptionsAssociationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDHCPOptionsAssociationExist(n string, vpc *ec2.VPC) resource.TestCheckFunc {
+func testAccCheckDHCPOptionsAssociationExist(n string, vpc *ec2.Vpc) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -63,12 +63,12 @@ func testAccCheckDHCPOptionsAssociationExist(n string, vpc *ec2.VPC) resource.Te
 			return fmt.Errorf("No DHCP Options Set association ID is set")
 		}
 
-		if *vpc.DHCPOptionsID != rs.Primary.Attributes["dhcp_options_id"] {
-			return fmt.Errorf("VPC %s does not have DHCP Options Set %s associated", *vpc.VPCID, rs.Primary.Attributes["dhcp_options_id"])
+		if *vpc.DhcpOptionsId != rs.Primary.Attributes["dhcp_options_id"] {
+			return fmt.Errorf("VPC %s does not have DHCP Options Set %s associated", *vpc.VpcId, rs.Primary.Attributes["dhcp_options_id"])
 		}
 
-		if *vpc.VPCID != rs.Primary.Attributes["vpc_id"] {
-			return fmt.Errorf("DHCP Options Set %s is not associated with VPC %s", rs.Primary.Attributes["dhcp_options_id"], *vpc.VPCID)
+		if *vpc.VpcId != rs.Primary.Attributes["vpc_id"] {
+			return fmt.Errorf("DHCP Options Set %s is not associated with VPC %s", rs.Primary.Attributes["dhcp_options_id"], *vpc.VpcId)
 		}
 
 		return nil

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccAWSDHCPOptions_basic(t *testing.T) {
-	var d ec2.DHCPOptions
+	var d ec2.DhcpOptions
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -45,13 +45,13 @@ func testAccCheckDHCPOptionsDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := conn.DescribeDHCPOptions(&ec2.DescribeDHCPOptionsInput{
-			DHCPOptionsIDs: []*string{
+		resp, err := conn.DescribeDhcpOptions(&ec2.DescribeDhcpOptionsInput{
+			DhcpOptionsIds: []*string{
 				aws.String(rs.Primary.ID),
 			},
 		})
 		if err == nil {
-			if len(resp.DHCPOptions) > 0 {
+			if len(resp.DhcpOptions) > 0 {
 				return fmt.Errorf("still exist.")
 			}
 
@@ -71,7 +71,7 @@ func testAccCheckDHCPOptionsDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDHCPOptionsExists(n string, d *ec2.DHCPOptions) resource.TestCheckFunc {
+func testAccCheckDHCPOptionsExists(n string, d *ec2.DhcpOptions) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -83,19 +83,19 @@ func testAccCheckDHCPOptionsExists(n string, d *ec2.DHCPOptions) resource.TestCh
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeDHCPOptions(&ec2.DescribeDHCPOptionsInput{
-			DHCPOptionsIDs: []*string{
+		resp, err := conn.DescribeDhcpOptions(&ec2.DescribeDhcpOptionsInput{
+			DhcpOptionsIds: []*string{
 				aws.String(rs.Primary.ID),
 			},
 		})
 		if err != nil {
 			return err
 		}
-		if len(resp.DHCPOptions) == 0 {
+		if len(resp.DhcpOptions) == 0 {
 			return fmt.Errorf("DHCP Options not found")
 		}
 
-		*d = *resp.DHCPOptions[0]
+		*d = *resp.DhcpOptions[0]
 
 		return nil
 	}

--- a/builtin/providers/aws/resource_aws_vpc_endpoint.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint.go
@@ -48,9 +48,9 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 
 func resourceAwsVPCEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	input := &ec2.CreateVPCEndpointInput{
-		VPCID:         aws.String(d.Get("vpc_id").(string)),
-		RouteTableIDs: expandStringList(d.Get("route_table_ids").(*schema.Set).List()),
+	input := &ec2.CreateVpcEndpointInput{
+		VpcId:         aws.String(d.Get("vpc_id").(string)),
+		RouteTableIds: expandStringList(d.Get("route_table_ids").(*schema.Set).List()),
 		ServiceName:   aws.String(d.Get("service_name").(string)),
 	}
 
@@ -60,25 +60,25 @@ func resourceAwsVPCEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Creating VPC Endpoint: %#v", input)
-	output, err := conn.CreateVPCEndpoint(input)
+	output, err := conn.CreateVpcEndpoint(input)
 	if err != nil {
 		return fmt.Errorf("Error creating VPC Endpoint: %s", err)
 	}
-	log.Printf("[DEBUG] VPC Endpoint %q created.", *output.VPCEndpoint.VPCEndpointID)
+	log.Printf("[DEBUG] VPC Endpoint %q created.", *output.VpcEndpoint.VpcEndpointId)
 
-	d.SetId(*output.VPCEndpoint.VPCEndpointID)
+	d.SetId(*output.VpcEndpoint.VpcEndpointId)
 
 	return resourceAwsVPCEndpointRead(d, meta)
 }
 
 func resourceAwsVPCEndpointRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	input := &ec2.DescribeVPCEndpointsInput{
-		VPCEndpointIDs: []*string{aws.String(d.Id())},
+	input := &ec2.DescribeVpcEndpointsInput{
+		VpcEndpointIds: []*string{aws.String(d.Id())},
 	}
 
 	log.Printf("[DEBUG] Reading VPC Endpoint: %q", d.Id())
-	output, err := conn.DescribeVPCEndpoints(input)
+	output, err := conn.DescribeVpcEndpoints(input)
 
 	if err != nil {
 		ec2err, ok := err.(awserr.Error)
@@ -93,25 +93,25 @@ func resourceAwsVPCEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error reading VPC Endpoint: %s", err.Error())
 	}
 
-	if len(output.VPCEndpoints) != 1 {
+	if len(output.VpcEndpoints) != 1 {
 		return fmt.Errorf("There's no unique VPC Endpoint, but %d endpoints: %#v",
-			len(output.VPCEndpoints), output.VPCEndpoints)
+			len(output.VpcEndpoints), output.VpcEndpoints)
 	}
 
-	vpce := output.VPCEndpoints[0]
+	vpce := output.VpcEndpoints[0]
 
-	d.Set("vpc_id", vpce.VPCID)
+	d.Set("vpc_id", vpce.VpcId)
 	d.Set("policy", normalizeJson(*vpce.PolicyDocument))
 	d.Set("service_name", vpce.ServiceName)
-	d.Set("route_table_ids", vpce.RouteTableIDs)
+	d.Set("route_table_ids", vpce.RouteTableIds)
 
 	return nil
 }
 
 func resourceAwsVPCEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	input := &ec2.ModifyVPCEndpointInput{
-		VPCEndpointID: aws.String(d.Id()),
+	input := &ec2.ModifyVpcEndpointInput{
+		VpcEndpointId: aws.String(d.Id()),
 	}
 
 	if d.HasChange("route_table_ids") {
@@ -121,12 +121,12 @@ func resourceAwsVPCEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 
 		add := expandStringList(os.Difference(ns).List())
 		if len(add) > 0 {
-			input.AddRouteTableIDs = add
+			input.AddRouteTableIds = add
 		}
 
 		remove := expandStringList(ns.Difference(os).List())
 		if len(remove) > 0 {
-			input.RemoveRouteTableIDs = remove
+			input.RemoveRouteTableIds = remove
 		}
 	}
 
@@ -136,23 +136,23 @@ func resourceAwsVPCEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Updating VPC Endpoint: %#v", input)
-	_, err := conn.ModifyVPCEndpoint(input)
+	_, err := conn.ModifyVpcEndpoint(input)
 	if err != nil {
 		return fmt.Errorf("Error updating VPC Endpoint: %s", err)
 	}
-	log.Printf("[DEBUG] VPC Endpoint %q updated", input.VPCEndpointID)
+	log.Printf("[DEBUG] VPC Endpoint %q updated", input.VpcEndpointId)
 
 	return nil
 }
 
 func resourceAwsVPCEndpointDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	input := &ec2.DeleteVPCEndpointsInput{
-		VPCEndpointIDs: []*string{aws.String(d.Id())},
+	input := &ec2.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []*string{aws.String(d.Id())},
 	}
 
 	log.Printf("[DEBUG] Deleting VPC Endpoint: %#v", input)
-	_, err := conn.DeleteVPCEndpoints(input)
+	_, err := conn.DeleteVpcEndpoints(input)
 
 	if err != nil {
 		ec2err, ok := err.(awserr.Error)

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccAWSVpcEndpoint_basic(t *testing.T) {
-	var endpoint ec2.VPCEndpoint
+	var endpoint ec2.VpcEndpoint
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -30,7 +30,7 @@ func TestAccAWSVpcEndpoint_basic(t *testing.T) {
 }
 
 func TestAccAWSVpcEndpoint_withRouteTableAndPolicy(t *testing.T) {
-	var endpoint ec2.VPCEndpoint
+	var endpoint ec2.VpcEndpoint
 	var routeTable ec2.RouteTable
 
 	resource.Test(t, resource.TestCase{
@@ -65,12 +65,12 @@ func testAccCheckVpcEndpointDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the VPC
-		input := &ec2.DescribeVPCEndpointsInput{
-			VPCEndpointIDs: []*string{aws.String(rs.Primary.ID)},
+		input := &ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: []*string{aws.String(rs.Primary.ID)},
 		}
-		resp, err := conn.DescribeVPCEndpoints(input)
+		resp, err := conn.DescribeVpcEndpoints(input)
 
-		if len(resp.VPCEndpoints) > 0 {
+		if len(resp.VpcEndpoints) > 0 {
 			return fmt.Errorf("VPC Endpoints still exist.")
 		}
 
@@ -80,7 +80,7 @@ func testAccCheckVpcEndpointDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckVpcEndpointExists(n string, endpoint *ec2.VPCEndpoint) resource.TestCheckFunc {
+func testAccCheckVpcEndpointExists(n string, endpoint *ec2.VpcEndpoint) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -92,18 +92,18 @@ func testAccCheckVpcEndpointExists(n string, endpoint *ec2.VPCEndpoint) resource
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		input := &ec2.DescribeVPCEndpointsInput{
-			VPCEndpointIDs: []*string{aws.String(rs.Primary.ID)},
+		input := &ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: []*string{aws.String(rs.Primary.ID)},
 		}
-		resp, err := conn.DescribeVPCEndpoints(input)
+		resp, err := conn.DescribeVpcEndpoints(input)
 		if err != nil {
 			return err
 		}
-		if len(resp.VPCEndpoints) == 0 {
+		if len(resp.VpcEndpoints) == 0 {
 			return fmt.Errorf("VPC Endpoint not found")
 		}
 
-		*endpoint = *resp.VPCEndpoints[0]
+		*endpoint = *resp.VpcEndpoints[0]
 
 		return nil
 	}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -53,20 +53,20 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*AWSClient).ec2conn
 
 	// Create the vpc peering connection
-	createOpts := &ec2.CreateVPCPeeringConnectionInput{
-		PeerOwnerID: aws.String(d.Get("peer_owner_id").(string)),
-		PeerVPCID:   aws.String(d.Get("peer_vpc_id").(string)),
-		VPCID:       aws.String(d.Get("vpc_id").(string)),
+	createOpts := &ec2.CreateVpcPeeringConnectionInput{
+		PeerOwnerId: aws.String(d.Get("peer_owner_id").(string)),
+		PeerVpcId:   aws.String(d.Get("peer_vpc_id").(string)),
+		VpcId:       aws.String(d.Get("vpc_id").(string)),
 	}
 	log.Printf("[DEBUG] VPCPeeringCreate create config: %#v", createOpts)
-	resp, err := conn.CreateVPCPeeringConnection(createOpts)
+	resp, err := conn.CreateVpcPeeringConnection(createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating vpc peering connection: %s", err)
 	}
 
 	// Get the ID and store it
-	rt := resp.VPCPeeringConnection
-	d.SetId(*rt.VPCPeeringConnectionID)
+	rt := resp.VpcPeeringConnection
+	d.SetId(*rt.VpcPeeringConnectionId)
 	log.Printf("[INFO] VPC Peering Connection ID: %s", d.Id())
 
 	// Wait for the vpc peering connection to become available
@@ -99,7 +99,7 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	pc := pcRaw.(*ec2.VPCPeeringConnection)
+	pc := pcRaw.(*ec2.VpcPeeringConnection)
 
 	// The failed status is a status that we can assume just means the
 	// connection is gone. Destruction isn't allowed, and it eventually
@@ -110,9 +110,9 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("accept_status", *pc.Status.Code)
-	d.Set("peer_owner_id", pc.AccepterVPCInfo.OwnerID)
-	d.Set("peer_vpc_id", pc.AccepterVPCInfo.VPCID)
-	d.Set("vpc_id", pc.RequesterVPCInfo.VPCID)
+	d.Set("peer_owner_id", pc.AccepterVpcInfo.OwnerId)
+	d.Set("peer_vpc_id", pc.AccepterVpcInfo.VpcId)
+	d.Set("vpc_id", pc.RequesterVpcInfo.VpcId)
 	d.Set("tags", tagsToMap(pc.Tags))
 
 	return nil
@@ -122,12 +122,12 @@ func resourceVPCPeeringConnectionAccept(conn *ec2.EC2, id string) (string, error
 
 	log.Printf("[INFO] Accept VPC Peering Connection with id: %s", id)
 
-	req := &ec2.AcceptVPCPeeringConnectionInput{
-		VPCPeeringConnectionID: aws.String(id),
+	req := &ec2.AcceptVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(id),
 	}
 
-	resp, err := conn.AcceptVPCPeeringConnection(req)
-	pc := resp.VPCPeeringConnection
+	resp, err := conn.AcceptVpcPeeringConnection(req)
+	pc := resp.VpcPeeringConnection
 	return *pc.Status.Code, err
 }
 
@@ -151,7 +151,7 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 			d.SetId("")
 			return nil
 		}
-		pc := pcRaw.(*ec2.VPCPeeringConnection)
+		pc := pcRaw.(*ec2.VpcPeeringConnection)
 
 		if *pc.Status.Code == "pending-acceptance" {
 
@@ -172,9 +172,9 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceAwsVPCPeeringDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	_, err := conn.DeleteVPCPeeringConnection(
-		&ec2.DeleteVPCPeeringConnectionInput{
-			VPCPeeringConnectionID: aws.String(d.Id()),
+	_, err := conn.DeleteVpcPeeringConnection(
+		&ec2.DeleteVpcPeeringConnectionInput{
+			VpcPeeringConnectionId: aws.String(d.Id()),
 		})
 	return err
 }
@@ -184,8 +184,8 @@ func resourceAwsVPCPeeringDelete(d *schema.ResourceData, meta interface{}) error
 func resourceAwsVPCPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
-		resp, err := conn.DescribeVPCPeeringConnections(&ec2.DescribeVPCPeeringConnectionsInput{
-			VPCPeeringConnectionIDs: []*string{aws.String(id)},
+		resp, err := conn.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
+			VpcPeeringConnectionIds: []*string{aws.String(id)},
 		})
 		if err != nil {
 			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpcPeeringConnectionID.NotFound" {
@@ -202,7 +202,7 @@ func resourceAwsVPCPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) r
 			return nil, "", nil
 		}
 
-		pc := resp.VPCPeeringConnections[0]
+		pc := resp.VpcPeeringConnections[0]
 
 		return pc, *pc.Status.Code, nil
 	}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
-	var connection ec2.VPCPeeringConnection
+	var connection ec2.VpcPeeringConnection
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -35,7 +35,7 @@ func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 }
 
 func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
-	var connection ec2.VPCPeeringConnection
+	var connection ec2.VpcPeeringConnection
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,13 +61,13 @@ func testAccCheckAWSVpcPeeringConnectionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		describe, err := conn.DescribeVPCPeeringConnections(
-			&ec2.DescribeVPCPeeringConnectionsInput{
-				VPCPeeringConnectionIDs: []*string{aws.String(rs.Primary.ID)},
+		describe, err := conn.DescribeVpcPeeringConnections(
+			&ec2.DescribeVpcPeeringConnectionsInput{
+				VpcPeeringConnectionIds: []*string{aws.String(rs.Primary.ID)},
 			})
 
 		if err == nil {
-			if len(describe.VPCPeeringConnections) != 0 {
+			if len(describe.VpcPeeringConnections) != 0 {
 				return fmt.Errorf("vpc peering connection still exists")
 			}
 		}
@@ -76,7 +76,7 @@ func testAccCheckAWSVpcPeeringConnectionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VPCPeeringConnection) resource.TestCheckFunc {
+func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VpcPeeringConnection) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -88,18 +88,18 @@ func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VPCPeer
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeVPCPeeringConnections(
-			&ec2.DescribeVPCPeeringConnectionsInput{
-				VPCPeeringConnectionIDs: []*string{aws.String(rs.Primary.ID)},
+		resp, err := conn.DescribeVpcPeeringConnections(
+			&ec2.DescribeVpcPeeringConnectionsInput{
+				VpcPeeringConnectionIds: []*string{aws.String(rs.Primary.ID)},
 			})
 		if err != nil {
 			return err
 		}
-		if len(resp.VPCPeeringConnections) == 0 {
+		if len(resp.VpcPeeringConnections) == 0 {
 			return fmt.Errorf("VPC peering connection not found")
 		}
 
-		*connection = *resp.VPCPeeringConnections[0]
+		*connection = *resp.VpcPeeringConnections[0]
 
 		return nil
 	}

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccAWSVpc_basic(t *testing.T) {
-	var vpc ec2.VPC
+	var vpc ec2.Vpc
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,7 +33,7 @@ func TestAccAWSVpc_basic(t *testing.T) {
 }
 
 func TestAccAWSVpc_dedicatedTenancy(t *testing.T) {
-	var vpc ec2.VPC
+	var vpc ec2.Vpc
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -53,7 +53,7 @@ func TestAccAWSVpc_dedicatedTenancy(t *testing.T) {
 }
 
 func TestAccAWSVpc_tags(t *testing.T) {
-	var vpc ec2.VPC
+	var vpc ec2.Vpc
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -84,7 +84,7 @@ func TestAccAWSVpc_tags(t *testing.T) {
 }
 
 func TestAccAWSVpc_update(t *testing.T) {
-	var vpc ec2.VPC
+	var vpc ec2.Vpc
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -121,12 +121,12 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the VPC
-		DescribeVpcOpts := &ec2.DescribeVPCsInput{
-			VPCIDs: []*string{aws.String(rs.Primary.ID)},
+		DescribeVpcOpts := &ec2.DescribeVpcsInput{
+			VpcIds: []*string{aws.String(rs.Primary.ID)},
 		}
-		resp, err := conn.DescribeVPCs(DescribeVpcOpts)
+		resp, err := conn.DescribeVpcs(DescribeVpcOpts)
 		if err == nil {
-			if len(resp.VPCs) > 0 {
+			if len(resp.Vpcs) > 0 {
 				return fmt.Errorf("VPCs still exist.")
 			}
 
@@ -146,18 +146,18 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckVpcCidr(vpc *ec2.VPC, expected string) resource.TestCheckFunc {
+func testAccCheckVpcCidr(vpc *ec2.Vpc, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		CIDRBlock := vpc.CIDRBlock
+		CIDRBlock := vpc.CidrBlock
 		if *CIDRBlock != expected {
-			return fmt.Errorf("Bad cidr: %s", *vpc.CIDRBlock)
+			return fmt.Errorf("Bad cidr: %s", *vpc.CidrBlock)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckVpcExists(n string, vpc *ec2.VPC) resource.TestCheckFunc {
+func testAccCheckVpcExists(n string, vpc *ec2.Vpc) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -169,18 +169,18 @@ func testAccCheckVpcExists(n string, vpc *ec2.VPC) resource.TestCheckFunc {
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		DescribeVpcOpts := &ec2.DescribeVPCsInput{
-			VPCIDs: []*string{aws.String(rs.Primary.ID)},
+		DescribeVpcOpts := &ec2.DescribeVpcsInput{
+			VpcIds: []*string{aws.String(rs.Primary.ID)},
 		}
-		resp, err := conn.DescribeVPCs(DescribeVpcOpts)
+		resp, err := conn.DescribeVpcs(DescribeVpcOpts)
 		if err != nil {
 			return err
 		}
-		if len(resp.VPCs) == 0 {
+		if len(resp.Vpcs) == 0 {
 			return fmt.Errorf("VPC not found")
 		}
 
-		*vpc = *resp.VPCs[0]
+		*vpc = *resp.Vpcs[0]
 
 		return nil
 	}

--- a/builtin/providers/aws/resource_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection_test.go
@@ -72,8 +72,8 @@ func testAccAwsVpnConnection(
 
 		ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-		_, err := ec2conn.DescribeVPNConnections(&ec2.DescribeVPNConnectionsInput{
-			VPNConnectionIDs: []*string{aws.String(connection.Primary.ID)},
+		_, err := ec2conn.DescribeVpnConnections(&ec2.DescribeVpnConnectionsInput{
+			VpnConnectionIds: []*string{aws.String(connection.Primary.ID)},
 		})
 
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_vpn_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway_test.go
@@ -12,18 +12,18 @@ import (
 )
 
 func TestAccAWSVpnGateway_basic(t *testing.T) {
-	var v, v2 ec2.VPNGateway
+	var v, v2 ec2.VpnGateway
 
 	testNotEqual := func(*terraform.State) error {
-		if len(v.VPCAttachments) == 0 {
+		if len(v.VpcAttachments) == 0 {
 			return fmt.Errorf("VPN gateway A is not attached")
 		}
-		if len(v2.VPCAttachments) == 0 {
+		if len(v2.VpcAttachments) == 0 {
 			return fmt.Errorf("VPN gateway B is not attached")
 		}
 
-		id1 := v.VPCAttachments[0].VPCID
-		id2 := v2.VPCAttachments[0].VPCID
+		id1 := v.VpcAttachments[0].VpcId
+		id2 := v2.VpcAttachments[0].VpcId
 		if id1 == id2 {
 			return fmt.Errorf("Both attachment IDs are the same")
 		}
@@ -57,7 +57,7 @@ func TestAccAWSVpnGateway_basic(t *testing.T) {
 }
 
 func TestAccAWSVpnGateway_delete(t *testing.T) {
-	var vpnGateway ec2.VPNGateway
+	var vpnGateway ec2.VpnGateway
 
 	testDeleted := func(r string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
@@ -88,7 +88,7 @@ func TestAccAWSVpnGateway_delete(t *testing.T) {
 }
 
 func TestAccAWSVpnGateway_tags(t *testing.T) {
-	var v ec2.VPNGateway
+	var v ec2.VpnGateway
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -124,11 +124,11 @@ func testAccCheckVpnGatewayDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := ec2conn.DescribeVPNGateways(&ec2.DescribeVPNGatewaysInput{
-			VPNGatewayIDs: []*string{aws.String(rs.Primary.ID)},
+		resp, err := ec2conn.DescribeVpnGateways(&ec2.DescribeVpnGatewaysInput{
+			VpnGatewayIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err == nil {
-			if len(resp.VPNGateways) > 0 {
+			if len(resp.VpnGateways) > 0 {
 				return fmt.Errorf("still exists")
 			}
 
@@ -148,7 +148,7 @@ func testAccCheckVpnGatewayDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckVpnGatewayExists(n string, ig *ec2.VPNGateway) resource.TestCheckFunc {
+func testAccCheckVpnGatewayExists(n string, ig *ec2.VpnGateway) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -160,17 +160,17 @@ func testAccCheckVpnGatewayExists(n string, ig *ec2.VPNGateway) resource.TestChe
 		}
 
 		ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := ec2conn.DescribeVPNGateways(&ec2.DescribeVPNGatewaysInput{
-			VPNGatewayIDs: []*string{aws.String(rs.Primary.ID)},
+		resp, err := ec2conn.DescribeVpnGateways(&ec2.DescribeVpnGatewaysInput{
+			VpnGatewayIds: []*string{aws.String(rs.Primary.ID)},
 		})
 		if err != nil {
 			return err
 		}
-		if len(resp.VPNGateways) == 0 {
+		if len(resp.VpnGateways) == 0 {
 			return fmt.Errorf("VPNGateway not found")
 		}
 
-		*ig = *resp.VPNGateways[0]
+		*ig = *resp.VpnGateways[0]
 
 		return nil
 	}

--- a/builtin/providers/aws/resource_vpn_connection_route.go
+++ b/builtin/providers/aws/resource_vpn_connection_route.go
@@ -41,20 +41,20 @@ func resourceAwsVpnConnectionRoute() *schema.Resource {
 func resourceAwsVpnConnectionRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	createOpts := &ec2.CreateVPNConnectionRouteInput{
-		DestinationCIDRBlock: aws.String(d.Get("destination_cidr_block").(string)),
-		VPNConnectionID:      aws.String(d.Get("vpn_connection_id").(string)),
+	createOpts := &ec2.CreateVpnConnectionRouteInput{
+		DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
+		VpnConnectionId:      aws.String(d.Get("vpn_connection_id").(string)),
 	}
 
 	// Create the route.
 	log.Printf("[DEBUG] Creating VPN connection route")
-	_, err := conn.CreateVPNConnectionRoute(createOpts)
+	_, err := conn.CreateVpnConnectionRoute(createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating VPN connection route: %s", err)
 	}
 
 	// Store the ID by the only two data we have available to us.
-	d.SetId(fmt.Sprintf("%s:%s", *createOpts.DestinationCIDRBlock, *createOpts.VPNConnectionID))
+	d.SetId(fmt.Sprintf("%s:%s", *createOpts.DestinationCidrBlock, *createOpts.VpnConnectionId))
 
 	return resourceAwsVpnConnectionRouteRead(d, meta)
 }
@@ -79,7 +79,7 @@ func resourceAwsVpnConnectionRouteRead(d *schema.ResourceData, meta interface{})
 	// from its ID, but we still want to catch cases where it changes
 	// outside of terraform and results in a stale state file. Hence,
 	// conduct a read.
-	resp, err := conn.DescribeVPNConnections(&ec2.DescribeVPNConnectionsInput{
+	resp, err := conn.DescribeVpnConnections(&ec2.DescribeVpnConnectionsInput{
 		Filters: routeFilters,
 	})
 	if err != nil {
@@ -91,20 +91,20 @@ func resourceAwsVpnConnectionRouteRead(d *schema.ResourceData, meta interface{})
 			return err
 		}
 	}
-	if resp == nil || len(resp.VPNConnections) == 0 {
+	if resp == nil || len(resp.VpnConnections) == 0 {
 		// This is kind of a weird edge case. I'd rather return an error
 		// instead of just blindly setting the ID to ""... since I don't know
 		// what might cause this.
 		return fmt.Errorf("No VPN connections returned")
 	}
 
-	vpnConnection := resp.VPNConnections[0]
+	vpnConnection := resp.VpnConnections[0]
 
 	var found bool
 	for _, r := range vpnConnection.Routes {
-		if *r.DestinationCIDRBlock == cidrBlock {
-			d.Set("destination_cidr_block", *r.DestinationCIDRBlock)
-			d.Set("vpn_connection_id", *vpnConnection.VPNConnectionID)
+		if *r.DestinationCidrBlock == cidrBlock {
+			d.Set("destination_cidr_block", *r.DestinationCidrBlock)
+			d.Set("vpn_connection_id", *vpnConnection.VpnConnectionId)
 			found = true
 		}
 	}
@@ -119,9 +119,9 @@ func resourceAwsVpnConnectionRouteRead(d *schema.ResourceData, meta interface{})
 func resourceAwsVpnConnectionRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	_, err := conn.DeleteVPNConnectionRoute(&ec2.DeleteVPNConnectionRouteInput{
-		DestinationCIDRBlock: aws.String(d.Get("destination_cidr_block").(string)),
-		VPNConnectionID:      aws.String(d.Get("vpn_connection_id").(string)),
+	_, err := conn.DeleteVpnConnectionRoute(&ec2.DeleteVpnConnectionRouteInput{
+		DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
+		VpnConnectionId:      aws.String(d.Get("vpn_connection_id").(string)),
 	})
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {

--- a/builtin/providers/aws/resource_vpn_connection_route_test.go
+++ b/builtin/providers/aws/resource_vpn_connection_route_test.go
@@ -85,7 +85,7 @@ func testAccAwsVpnConnectionRoute(
 
 		ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-		_, err := ec2conn.DescribeVPNConnections(&ec2.DescribeVPNConnectionsInput{
+		_, err := ec2conn.DescribeVpnConnections(&ec2.DescribeVpnConnectionsInput{
 			Filters: routeFilters,
 		})
 		if err != nil {

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -59,37 +59,37 @@ func TestexpandIPPerms(t *testing.T) {
 		},
 	}
 	group := &ec2.SecurityGroup{
-		GroupID: aws.String("foo"),
-		VPCID:   aws.String("bar"),
+		GroupId: aws.String("foo"),
+		VpcId:   aws.String("bar"),
 	}
 	perms, err := expandIPPerms(group, expanded)
 	if err != nil {
 		t.Fatalf("error expanding perms: %v", err)
 	}
 
-	expected := []ec2.IPPermission{
-		ec2.IPPermission{
-			IPProtocol: aws.String("icmp"),
+	expected := []ec2.IpPermission{
+		ec2.IpPermission{
+			IpProtocol: aws.String("icmp"),
 			FromPort:   aws.Int64(int64(1)),
 			ToPort:     aws.Int64(int64(-1)),
-			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("0.0.0.0/0")}},
-			UserIDGroupPairs: []*ec2.UserIDGroupPair{
-				&ec2.UserIDGroupPair{
-					UserID:  aws.String("foo"),
-					GroupID: aws.String("sg-22222"),
+			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("0.0.0.0/0")}},
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{
+					UserId:  aws.String("foo"),
+					GroupId: aws.String("sg-22222"),
 				},
-				&ec2.UserIDGroupPair{
-					GroupID: aws.String("sg-22222"),
+				&ec2.UserIdGroupPair{
+					GroupId: aws.String("sg-22222"),
 				},
 			},
 		},
-		ec2.IPPermission{
-			IPProtocol: aws.String("icmp"),
+		ec2.IpPermission{
+			IpProtocol: aws.String("icmp"),
 			FromPort:   aws.Int64(int64(1)),
 			ToPort:     aws.Int64(int64(-1)),
-			UserIDGroupPairs: []*ec2.UserIDGroupPair{
-				&ec2.UserIDGroupPair{
-					UserID: aws.String("foo"),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{
+					UserId: aws.String("foo"),
 				},
 			},
 		},
@@ -105,18 +105,18 @@ func TestexpandIPPerms(t *testing.T) {
 			*exp.FromPort)
 	}
 
-	if *exp.IPRanges[0].CIDRIP != *perm.IPRanges[0].CIDRIP {
+	if *exp.IpRanges[0].CidrIp != *perm.IpRanges[0].CidrIp {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.IPRanges[0].CIDRIP,
-			*exp.IPRanges[0].CIDRIP)
+			*perm.IpRanges[0].CidrIp,
+			*exp.IpRanges[0].CidrIp)
 	}
 
-	if *exp.UserIDGroupPairs[0].UserID != *perm.UserIDGroupPairs[0].UserID {
+	if *exp.UserIdGroupPairs[0].UserId != *perm.UserIdGroupPairs[0].UserId {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIDGroupPairs[0].UserID,
-			*exp.UserIDGroupPairs[0].UserID)
+			*perm.UserIdGroupPairs[0].UserId,
+			*exp.UserIdGroupPairs[0].UserId)
 	}
 
 }
@@ -137,8 +137,8 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 		},
 	}
 	group := &ec2.SecurityGroup{
-		GroupID: aws.String("foo"),
-		VPCID:   aws.String("bar"),
+		GroupId: aws.String("foo"),
+		VpcId:   aws.String("bar"),
 	}
 
 	perms, err := expandIPPerms(group, expanded)
@@ -146,19 +146,19 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 		t.Fatalf("error expanding perms: %v", err)
 	}
 
-	expected := []ec2.IPPermission{
-		ec2.IPPermission{
-			IPProtocol: aws.String("-1"),
+	expected := []ec2.IpPermission{
+		ec2.IpPermission{
+			IpProtocol: aws.String("-1"),
 			FromPort:   aws.Int64(int64(0)),
 			ToPort:     aws.Int64(int64(0)),
-			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("0.0.0.0/0")}},
-			UserIDGroupPairs: []*ec2.UserIDGroupPair{
-				&ec2.UserIDGroupPair{
-					UserID:  aws.String("foo"),
-					GroupID: aws.String("sg-22222"),
+			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("0.0.0.0/0")}},
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{
+					UserId:  aws.String("foo"),
+					GroupId: aws.String("sg-22222"),
 				},
-				&ec2.UserIDGroupPair{
-					GroupID: aws.String("sg-22222"),
+				&ec2.UserIdGroupPair{
+					GroupId: aws.String("sg-22222"),
 				},
 			},
 		},
@@ -174,18 +174,18 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 			*exp.FromPort)
 	}
 
-	if *exp.IPRanges[0].CIDRIP != *perm.IPRanges[0].CIDRIP {
+	if *exp.IpRanges[0].CidrIp != *perm.IpRanges[0].CidrIp {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.IPRanges[0].CIDRIP,
-			*exp.IPRanges[0].CIDRIP)
+			*perm.IpRanges[0].CidrIp,
+			*exp.IpRanges[0].CidrIp)
 	}
 
-	if *exp.UserIDGroupPairs[0].UserID != *perm.UserIDGroupPairs[0].UserID {
+	if *exp.UserIdGroupPairs[0].UserId != *perm.UserIdGroupPairs[0].UserId {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIDGroupPairs[0].UserID,
-			*exp.UserIDGroupPairs[0].UserID)
+			*perm.UserIdGroupPairs[0].UserId,
+			*exp.UserIdGroupPairs[0].UserId)
 	}
 
 	// Now test the error case. This *should* error when either from_port
@@ -203,8 +203,8 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 		},
 	}
 	securityGroups := &ec2.SecurityGroup{
-		GroupID: aws.String("foo"),
-		VPCID:   aws.String("bar"),
+		GroupId: aws.String("foo"),
+		VpcId:   aws.String("bar"),
 	}
 
 	_, expandErr := expandIPPerms(securityGroups, errorCase)
@@ -242,27 +242,27 @@ func TestExpandIPPerms_nonVPC(t *testing.T) {
 		t.Fatalf("error expanding perms: %v", err)
 	}
 
-	expected := []ec2.IPPermission{
-		ec2.IPPermission{
-			IPProtocol: aws.String("icmp"),
+	expected := []ec2.IpPermission{
+		ec2.IpPermission{
+			IpProtocol: aws.String("icmp"),
 			FromPort:   aws.Int64(int64(1)),
 			ToPort:     aws.Int64(int64(-1)),
-			IPRanges:   []*ec2.IPRange{&ec2.IPRange{CIDRIP: aws.String("0.0.0.0/0")}},
-			UserIDGroupPairs: []*ec2.UserIDGroupPair{
-				&ec2.UserIDGroupPair{
+			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("0.0.0.0/0")}},
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{
 					GroupName: aws.String("sg-22222"),
 				},
-				&ec2.UserIDGroupPair{
+				&ec2.UserIdGroupPair{
 					GroupName: aws.String("sg-22222"),
 				},
 			},
 		},
-		ec2.IPPermission{
-			IPProtocol: aws.String("icmp"),
+		ec2.IpPermission{
+			IpProtocol: aws.String("icmp"),
 			FromPort:   aws.Int64(int64(1)),
 			ToPort:     aws.Int64(int64(-1)),
-			UserIDGroupPairs: []*ec2.UserIDGroupPair{
-				&ec2.UserIDGroupPair{
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{
 					GroupName: aws.String("foo"),
 				},
 			},
@@ -279,11 +279,11 @@ func TestExpandIPPerms_nonVPC(t *testing.T) {
 			*exp.FromPort)
 	}
 
-	if *exp.IPRanges[0].CIDRIP != *perm.IPRanges[0].CIDRIP {
+	if *exp.IpRanges[0].CidrIp != *perm.IpRanges[0].CidrIp {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.IPRanges[0].CIDRIP,
-			*exp.IPRanges[0].CIDRIP)
+			*perm.IpRanges[0].CidrIp,
+			*exp.IpRanges[0].CidrIp)
 	}
 }
 
@@ -481,8 +481,8 @@ func TestflattenElasticacheParameters(t *testing.T) {
 func TestexpandInstanceString(t *testing.T) {
 
 	expected := []*elb.Instance{
-		&elb.Instance{InstanceID: aws.String("test-one")},
-		&elb.Instance{InstanceID: aws.String("test-two")},
+		&elb.Instance{InstanceId: aws.String("test-one")},
+		&elb.Instance{InstanceId: aws.String("test-two")},
 	}
 
 	ids := []interface{}{
@@ -498,9 +498,9 @@ func TestexpandInstanceString(t *testing.T) {
 }
 
 func TestflattenNetworkInterfacesPrivateIPAddesses(t *testing.T) {
-	expanded := []*ec2.NetworkInterfacePrivateIPAddress{
-		&ec2.NetworkInterfacePrivateIPAddress{PrivateIPAddress: aws.String("192.168.0.1")},
-		&ec2.NetworkInterfacePrivateIPAddress{PrivateIPAddress: aws.String("192.168.0.2")},
+	expanded := []*ec2.NetworkInterfacePrivateIpAddress{
+		&ec2.NetworkInterfacePrivateIpAddress{PrivateIpAddress: aws.String("192.168.0.1")},
+		&ec2.NetworkInterfacePrivateIpAddress{PrivateIpAddress: aws.String("192.168.0.2")},
 	}
 
 	result := flattenNetworkInterfacesPrivateIPAddesses(expanded)
@@ -524,8 +524,8 @@ func TestflattenNetworkInterfacesPrivateIPAddesses(t *testing.T) {
 
 func TestflattenGroupIdentifiers(t *testing.T) {
 	expanded := []*ec2.GroupIdentifier{
-		&ec2.GroupIdentifier{GroupID: aws.String("sg-001")},
-		&ec2.GroupIdentifier{GroupID: aws.String("sg-002")},
+		&ec2.GroupIdentifier{GroupId: aws.String("sg-001")},
+		&ec2.GroupIdentifier{GroupId: aws.String("sg-002")},
 	}
 
 	result := flattenGroupIdentifiers(expanded)
@@ -558,20 +558,20 @@ func TestexpandPrivateIPAddesses(t *testing.T) {
 		t.Fatalf("expected result had %d elements, but got %d", 2, len(result))
 	}
 
-	if *result[0].PrivateIPAddress != "192.168.0.1" || !*result[0].Primary {
-		t.Fatalf("expected ip to be 192.168.0.1 and Primary, but got %v, %t", *result[0].PrivateIPAddress, *result[0].Primary)
+	if *result[0].PrivateIpAddress != "192.168.0.1" || !*result[0].Primary {
+		t.Fatalf("expected ip to be 192.168.0.1 and Primary, but got %v, %t", *result[0].PrivateIpAddress, *result[0].Primary)
 	}
 
-	if *result[1].PrivateIPAddress != "192.168.0.2" || *result[1].Primary {
-		t.Fatalf("expected ip to be 192.168.0.2 and not Primary, but got %v, %t", *result[1].PrivateIPAddress, *result[1].Primary)
+	if *result[1].PrivateIpAddress != "192.168.0.2" || *result[1].Primary {
+		t.Fatalf("expected ip to be 192.168.0.2 and not Primary, but got %v, %t", *result[1].PrivateIpAddress, *result[1].Primary)
 	}
 }
 
 func TestflattenAttachment(t *testing.T) {
 	expanded := &ec2.NetworkInterfaceAttachment{
-		InstanceID:   aws.String("i-00001"),
+		InstanceId:   aws.String("i-00001"),
 		DeviceIndex:  aws.Int64(int64(1)),
-		AttachmentID: aws.String("at-002"),
+		AttachmentId: aws.String("at-002"),
 	}
 
 	result := flattenAttachment(expanded)

--- a/builtin/providers/aws/tags_route53.go
+++ b/builtin/providers/aws/tags_route53.go
@@ -24,7 +24,7 @@ func setTagsR53(conn *route53.Route53, d *schema.ResourceData, resourceType stri
 		}
 		log.Printf("[DEBUG] Changing tags: \n\tadding: %#v\n\tremoving:%#v", create, remove)
 		req := &route53.ChangeTagsForResourceInput{
-			ResourceID:   aws.String(d.Id()),
+			ResourceId:   aws.String(d.Id()),
 			ResourceType: aws.String(resourceType),
 		}
 


### PR DESCRIPTION
AWS SDK v0.9.0rc1 is out, and introduces breaking changes:

- http://aws.amazon.com/releasenotes/2948141298714307

This PR is the result of running the migration tool mentioned:

    $ awsmigrate-renamer -verbose github.com/hashicorp/terraform/builtin/providers/aws

After running that, a simple `make dev` and `make test` both passed, so I assume everything is :+1: 