### PR TITLE
provider/aws: Update Security Group Rules to Version 2

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -27,19 +27,19 @@ func resourceAwsEip() *schema.Resource {
 				ForceNew: true,
 			},
 
-                        "instance": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                Computed: true,
-                        },
+			"instance": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 
-                        "network_interface": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                Computed: true,
-                        },
+			"network_interface": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 
-                        "allocation_id": &schema.Schema{
+			"allocation_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -27,19 +27,19 @@ func resourceAwsEip() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"instance": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+                        "instance": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Computed: true,
+                        },
 
-			"network_interface": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+                        "network_interface": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Computed: true,
+                        },
 
-			"allocation_id": &schema.Schema{
+                        "allocation_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -20,7 +20,7 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 		Read:   resourceAwsSecurityGroupRuleRead,
 		Delete: resourceAwsSecurityGroupRuleDelete,
 
-                SchemaVersion: 2,
+		SchemaVersion: 2,
 		MigrateState:  resourceAwsSecurityGroupRuleMigrateState,
 
 		Schema: map[string]*schema.Schema{
@@ -67,15 +67,15 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-                                ConflictsWith: []string{"cidr_blocks", "self"},
+				ConflictsWith: []string{"cidr_blocks", "self"},
 			},
 
 			"self": &schema.Schema{
-                                Type:          schema.TypeBool,
-                                Optional:      true,
-                                Default:       false,
-                                ForceNew:      true,
-                                ConflictsWith: []string{"cidr_blocks"},
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Default:       false,
+				ForceNew:      true,
+				ConflictsWith: []string{"cidr_blocks"},
 			},
 		},
 	}
@@ -143,7 +143,7 @@ information and instructions for recovery. Error message: %s`, awsErr.Message())
 			ruleType, autherr)
 	}
 
-        d.SetId(ipPermissionIDHash(sg_id, ruleType, perm))
+	d.SetId(ipPermissionIDHash(sg_id, ruleType, perm))
 
 	return resourceAwsSecurityGroupRuleRead(d, meta)
 }
@@ -159,69 +159,69 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	var rule *ec2.IpPermission
-        var rules []*ec2.IpPermission
+	var rules []*ec2.IpPermission
 	ruleType := d.Get("type").(string)
 	switch ruleType {
 	case "ingress":
-                rules = sg.IpPermissions
+		rules = sg.IpPermissions
 	default:
-                rules = sg.IpPermissionsEgress
+		rules = sg.IpPermissionsEgress
 	}
 
-        p := expandIPPerm(d, sg)
+	p := expandIPPerm(d, sg)
 
-        if len(rules) == 0 {
-                return fmt.Errorf(
-                        "[WARN] No %s rules were found for Security Group (%s) looking for Security Group Rule (%s)",
-                        ruleType, *sg.GroupName, d.Id())
-        }
+	if len(rules) == 0 {
+		return fmt.Errorf(
+			"[WARN] No %s rules were found for Security Group (%s) looking for Security Group Rule (%s)",
+			ruleType, *sg.GroupName, d.Id())
+	}
 
-        for _, r := range rules {
-                if r.ToPort != nil && *p.ToPort != *r.ToPort {
-                        continue
-                }
-
-                if r.FromPort != nil && *p.FromPort != *r.FromPort {
-                        continue
-                }
-
-                if r.IpProtocol != nil && *p.IpProtocol != *r.IpProtocol {
-                        continue
-                }
-
-                remaining := len(p.IpRanges)
-                for _, ip := range p.IpRanges {
-                        for _, rip := range r.IpRanges {
-                                if *ip.CidrIp == *rip.CidrIp {
-                                        remaining--
-                                }
-                        }
-                }
-
-                if remaining > 0 {
-                        continue
-                }
-
-                remaining = len(p.UserIdGroupPairs)
-                for _, ip := range p.UserIdGroupPairs {
-                        for _, rip := range r.UserIdGroupPairs {
-                                if *ip.GroupId == *rip.GroupId {
-                                        remaining--
-                                }
-                        }
-                }
-
-                if remaining > 0 {
-                        continue
+	for _, r := range rules {
+		if r.ToPort != nil && *p.ToPort != *r.ToPort {
+			continue
 		}
 
-                log.Printf("[DEBUG] Found rule for Security Group Rule (%s): %s", d.Id(), r)
-                rule = r
+		if r.FromPort != nil && *p.FromPort != *r.FromPort {
+			continue
+		}
+
+		if r.IpProtocol != nil && *p.IpProtocol != *r.IpProtocol {
+			continue
+		}
+
+		remaining := len(p.IpRanges)
+		for _, ip := range p.IpRanges {
+			for _, rip := range r.IpRanges {
+				if *ip.CidrIp == *rip.CidrIp {
+					remaining--
+				}
+			}
+		}
+
+		if remaining > 0 {
+			continue
+		}
+
+		remaining = len(p.UserIdGroupPairs)
+		for _, ip := range p.UserIdGroupPairs {
+			for _, rip := range r.UserIdGroupPairs {
+				if *ip.GroupId == *rip.GroupId {
+					remaining--
+				}
+			}
+		}
+
+		if remaining > 0 {
+			continue
+		}
+
+		log.Printf("[DEBUG] Found rule for Security Group Rule (%s): %s", d.Id(), r)
+		rule = r
 	}
 
 	if rule == nil {
-                log.Printf("[DEBUG] Unable to find matching %s Security Group Rule (%s) for Group %s",
-                        ruleType, d.Id(), sg_id)
+		log.Printf("[DEBUG] Unable to find matching %s Security Group Rule (%s) for Group %s",
+			ruleType, d.Id(), sg_id)
 		d.SetId("")
 		return nil
 	}
@@ -232,14 +232,14 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("type", ruleType)
 
 	var cb []string
-        for _, c := range p.IpRanges {
+	for _, c := range p.IpRanges {
 		cb = append(cb, *c.CidrIp)
 	}
 
 	d.Set("cidr_blocks", cb)
 
-        if len(p.UserIdGroupPairs) > 0 {
-                s := p.UserIdGroupPairs[0]
+	if len(p.UserIdGroupPairs) > 0 {
+		s := p.UserIdGroupPairs[0]
 		d.Set("source_security_group_id", *s.GroupId)
 	}
 
@@ -333,7 +333,7 @@ func (b ByGroupPair) Less(i, j int) bool {
 
 func ipPermissionIDHash(sg_id, ruleType string, ip *ec2.IpPermission) string {
 	var buf bytes.Buffer
-        buf.WriteString(fmt.Sprintf("%s-", sg_id))
+	buf.WriteString(fmt.Sprintf("%s-", sg_id))
 	if ip.FromPort != nil && *ip.FromPort > 0 {
 		buf.WriteString(fmt.Sprintf("%d-", *ip.FromPort))
 	}
@@ -373,7 +373,7 @@ func ipPermissionIDHash(sg_id, ruleType string, ip *ec2.IpPermission) string {
 		}
 	}
 
-	return fmt.Sprintf("sg-%d", hashcode.String(buf.String()))
+	return fmt.Sprintf("sgrule-%d", hashcode.String(buf.String()))
 }
 
 func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IpPermission {

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -171,7 +171,9 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
         p := expandIPPerm(d, sg)
 
         if len(rules) == 0 {
-                return fmt.Errorf("No IPPerms")
+                return fmt.Errorf(
+                        "[WARN] No %s rules were found for Security Group (%s) looking for Security Group Rule (%s)",
+                        ruleType, *sg.GroupName, d.Id())
         }
 
         for _, r := range rules {
@@ -198,7 +200,7 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 
                 if remaining > 0 {
                         continue
-		}
+                }
 
                 remaining = len(p.UserIdGroupPairs)
                 for _, ip := range p.UserIdGroupPairs {
@@ -211,7 +213,7 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 
                 if remaining > 0 {
                         continue
-                }
+		}
 
                 log.Printf("[DEBUG] Found rule for Security Group Rule (%s): %s", d.Id(), r)
                 rule = r

--- a/builtin/providers/aws/resource_aws_security_group_rule_migrate.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_migrate.go
@@ -17,6 +17,12 @@ func resourceAwsSecurityGroupRuleMigrateState(
 	case 0:
 		log.Println("[INFO] Found AWS Security Group State v0; migrating to v1")
 		return migrateSGRuleStateV0toV1(is)
+        case 1:
+                log.Println("[INFO] Found AWS Security Group State v1; migrating to v2")
+                // migrating to version 2 of the schema is the same as 0->1, since the
+                // method signature has changed now and will use the security group id in
+                // the hash
+                return migrateSGRuleStateV0toV1(is)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
@@ -37,7 +43,7 @@ func migrateSGRuleStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceS
 	}
 
 	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
-	newID := ipPermissionIDHash(is.Attributes["type"], perm)
+        newID := ipPermissionIDHash(is.Attributes["security_group_id"], is.Attributes["type"], perm)
 	is.Attributes["id"] = newID
 	is.ID = newID
 	log.Printf("[DEBUG] Attributes after migration: %#v, new id: %s", is.Attributes, newID)

--- a/builtin/providers/aws/resource_aws_security_group_rule_migrate.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_migrate.go
@@ -17,12 +17,12 @@ func resourceAwsSecurityGroupRuleMigrateState(
 	case 0:
 		log.Println("[INFO] Found AWS Security Group State v0; migrating to v1")
 		return migrateSGRuleStateV0toV1(is)
-        case 1:
-                log.Println("[INFO] Found AWS Security Group State v1; migrating to v2")
-                // migrating to version 2 of the schema is the same as 0->1, since the
-                // method signature has changed now and will use the security group id in
-                // the hash
-                return migrateSGRuleStateV0toV1(is)
+	case 1:
+		log.Println("[INFO] Found AWS Security Group State v1; migrating to v2")
+		// migrating to version 2 of the schema is the same as 0->1, since the
+		// method signature has changed now and will use the security group id in
+		// the hash
+		return migrateSGRuleStateV0toV1(is)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
@@ -43,7 +43,7 @@ func migrateSGRuleStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceS
 	}
 
 	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
-        newID := ipPermissionIDHash(is.Attributes["security_group_id"], is.Attributes["type"], perm)
+	newID := ipPermissionIDHash(is.Attributes["security_group_id"], is.Attributes["type"], perm)
 	is.Attributes["id"] = newID
 	is.ID = newID
 	log.Printf("[DEBUG] Attributes after migration: %#v, new id: %s", is.Attributes, newID)

--- a/builtin/providers/aws/resource_aws_security_group_rule_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_migrate_test.go
@@ -27,7 +27,7 @@ func TestAWSSecurityGroupRuleMigrateState(t *testing.T) {
 				"from_port":                "0",
 				"source_security_group_id": "sg-11877275",
 			},
-                        Expected: "sg-2889201120",
+			Expected: "sg-2889201120",
 		},
 		"v0_2": {
 			StateVersion: 0,
@@ -44,7 +44,7 @@ func TestAWSSecurityGroupRuleMigrateState(t *testing.T) {
 				"cidr_blocks.2":     "172.16.3.0/24",
 				"cidr_blocks.3":     "172.16.4.0/24",
 				"cidr_blocks.#":     "4"},
-                        Expected: "sg-1826358977",
+			Expected: "sg-1826358977",
 		},
 	}
 

--- a/builtin/providers/aws/resource_aws_security_group_rule_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_migrate_test.go
@@ -27,7 +27,7 @@ func TestAWSSecurityGroupRuleMigrateState(t *testing.T) {
 				"from_port":                "0",
 				"source_security_group_id": "sg-11877275",
 			},
-			Expected: "sg-3766347571",
+                        Expected: "sg-2889201120",
 		},
 		"v0_2": {
 			StateVersion: 0,
@@ -44,7 +44,7 @@ func TestAWSSecurityGroupRuleMigrateState(t *testing.T) {
 				"cidr_blocks.2":     "172.16.3.0/24",
 				"cidr_blocks.3":     "172.16.4.0/24",
 				"cidr_blocks.#":     "4"},
-			Expected: "sg-4100229787",
+                        Expected: "sg-1826358977",
 		},
 	}
 

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -257,7 +257,7 @@ func TestAccAWSSecurityGroupRule_SelfReference(t *testing.T) {
 }
 
 // testing partial match implementation
-func TestAccAWSSecurityGroupRule_PartialMatching_Basic(t *testing.T) {
+func TestAccAWSSecurityGroupRule_PartialMatching_basic(t *testing.T) {
         var group ec2.SecurityGroup
 
         p := ec2.IpPermission{

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -2,7 +2,7 @@ package aws
 
 import (
 	"fmt"
-	"reflect"
+        "log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -90,15 +90,15 @@ func TestIpPermissionIDHash(t *testing.T) {
 		Type   string
 		Output string
 	}{
-		{simple, "ingress", "sg-82613597"},
-		{egress, "egress", "sg-363054720"},
-		{egress_all, "egress", "sg-2766285362"},
-		{vpc_security_group_source, "egress", "sg-2661404947"},
-		{security_group_source, "egress", "sg-1841245863"},
+                {simple, "ingress", "sg-3403497314"},
+                {egress, "egress", "sg-1173186295"},
+                {egress_all, "egress", "sg-766323498"},
+                {vpc_security_group_source, "egress", "sg-351225364"},
+                {security_group_source, "egress", "sg-2198807188"},
 	}
 
 	for _, tc := range cases {
-		actual := ipPermissionIDHash(tc.Type, tc.Input)
+                actual := ipPermissionIDHash("sg-12345", tc.Type, tc.Input)
 		if actual != tc.Output {
 			t.Errorf("input: %s - %s\noutput: %s", tc.Type, tc.Input, actual)
 		}
@@ -132,7 +132,7 @@ func TestAccAWSSecurityGroupRule_Ingress_VPC(t *testing.T) {
 				Config: testAccAWSSecurityGroupRuleIngressConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-					testAccCheckAWSSecurityGroupRuleAttributes(&group, "ingress"),
+                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
 					resource.TestCheckResourceAttr(
 						"aws_security_group_rule.ingress_1", "from_port", "80"),
 					testRuleCount,
@@ -169,7 +169,7 @@ func TestAccAWSSecurityGroupRule_Ingress_Classic(t *testing.T) {
 				Config: testAccAWSSecurityGroupRuleIngressClassicConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-					testAccCheckAWSSecurityGroupRuleAttributes(&group, "ingress"),
+                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
 					resource.TestCheckResourceAttr(
 						"aws_security_group_rule.ingress_1", "from_port", "80"),
 					testRuleCount,
@@ -231,7 +231,7 @@ func TestAccAWSSecurityGroupRule_Egress(t *testing.T) {
 				Config: testAccAWSSecurityGroupRuleEgressConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-					testAccCheckAWSSecurityGroupRuleAttributes(&group, "egress"),
+                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
 				),
 			},
 		},
@@ -254,6 +254,92 @@ func TestAccAWSSecurityGroupRule_SelfReference(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testing partial match implementation
+func TestAccAWSSecurityGroupRule_PartialMatching_Basic(t *testing.T) {
+        var group ec2.SecurityGroup
+
+        p := ec2.IpPermission{
+                FromPort:   aws.Int64(80),
+                ToPort:     aws.Int64(80),
+                IpProtocol: aws.String("tcp"),
+                IpRanges: []*ec2.IpRange{
+                        &ec2.IpRange{CidrIp: aws.String("10.0.2.0/24")},
+                        &ec2.IpRange{CidrIp: aws.String("10.0.3.0/24")},
+                        &ec2.IpRange{CidrIp: aws.String("10.0.4.0/24")},
+                },
+        }
+
+        o := ec2.IpPermission{
+                FromPort:   aws.Int64(80),
+                ToPort:     aws.Int64(80),
+                IpProtocol: aws.String("tcp"),
+                IpRanges: []*ec2.IpRange{
+                        &ec2.IpRange{CidrIp: aws.String("10.0.5.0/24")},
+                },
+        }
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccAWSSecurityGroupRulePartialMatching,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress", &group, &p, "ingress"),
+                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.other", &group, &o, "ingress"),
+                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.nat_ingress", &group, &o, "ingress"),
+                                ),
+                        },
+                },
+        })
+}
+
+func TestAccAWSSecurityGroupRule_PartialMatching_Source(t *testing.T) {
+        var group ec2.SecurityGroup
+        var nat ec2.SecurityGroup
+        var p ec2.IpPermission
+
+        // This function creates the expected IPPermission with the group id from an
+        // external security group, needed because Security Group IDs are generated on
+        // AWS side and can't be known ahead of time.
+        setupSG := func(*terraform.State) error {
+                if nat.GroupId == nil {
+                        return fmt.Errorf("Error: nat group has nil GroupID")
+                }
+
+                p = ec2.IpPermission{
+                        FromPort:   aws.Int64(80),
+                        ToPort:     aws.Int64(80),
+                        IpProtocol: aws.String("tcp"),
+                        UserIdGroupPairs: []*ec2.UserIdGroupPair{
+                                &ec2.UserIdGroupPair{GroupId: nat.GroupId},
+                        },
+                }
+
+                return nil
+        }
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccAWSSecurityGroupRulePartialMatching_Source,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+                                        testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
+                                        setupSG,
+                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.source_ingress", &group, &p, "ingress"),
+                                ),
+                        },
+                },
+        })
+
 }
 
 func testAccCheckAWSSecurityGroupRuleDestroy(s *terraform.State) error {
@@ -319,14 +405,27 @@ func testAccCheckAWSSecurityGroupRuleExists(n string, group *ec2.SecurityGroup) 
 	}
 }
 
-func testAccCheckAWSSecurityGroupRuleAttributes(group *ec2.SecurityGroup, ruleType string) resource.TestCheckFunc {
+func testAccCheckAWSSecurityGroupRuleAttributes(n string, group *ec2.SecurityGroup, p *ec2.IpPermission, ruleType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		p := &ec2.IpPermission{
-			FromPort:   aws.Int64(80),
-			ToPort:     aws.Int64(8000),
-			IpProtocol: aws.String("tcp"),
-			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
+                rs, ok := s.RootModule().Resources[n]
+                if !ok {
+                        return fmt.Errorf("Security Group Rule Not found: %s", n)
+                }
+
+                if rs.Primary.ID == "" {
+                        return fmt.Errorf("No Security Group Rule is set")
 		}
+
+                if p == nil {
+                        p = &ec2.IpPermission{
+                                FromPort:   aws.Int64(80),
+                                ToPort:     aws.Int64(8000),
+                                IpProtocol: aws.String("tcp"),
+                                IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
+                        }
+                }
+
+                var matchingRule *ec2.IpPermission
 		var rules []*ec2.IpPermission
 		if ruleType == "ingress" {
 			rules = group.IpPermissions
@@ -338,15 +437,53 @@ func testAccCheckAWSSecurityGroupRuleAttributes(group *ec2.SecurityGroup, ruleTy
 			return fmt.Errorf("No IPPerms")
 		}
 
-		// Compare our ingress
-		if !reflect.DeepEqual(rules[0], p) {
-			return fmt.Errorf(
-				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-				rules[0],
-				p)
+                for _, r := range rules {
+                        if r.ToPort != nil && *p.ToPort != *r.ToPort {
+                                continue
+                        }
+
+                        if r.FromPort != nil && *p.FromPort != *r.FromPort {
+                                continue
+                        }
+
+                        if r.IpProtocol != nil && *p.IpProtocol != *r.IpProtocol {
+                                continue
+                        }
+
+                        remaining := len(p.IpRanges)
+                        for _, ip := range p.IpRanges {
+                                for _, rip := range r.IpRanges {
+                                        if *ip.CidrIp == *rip.CidrIp {
+                                                remaining--
+                                        }
+                                }
+                        }
+
+                        if remaining > 0 {
+                                continue
+                        }
+
+                        remaining = len(p.UserIdGroupPairs)
+                        for _, ip := range p.UserIdGroupPairs {
+                                for _, rip := range r.UserIdGroupPairs {
+                                        if *ip.GroupId == *rip.GroupId {
+                                                remaining--
+                                        }
+                                }
+                        }
+
+                        if remaining > 0 {
+                                continue
+                        }
+                        matchingRule = r
 		}
 
-		return nil
+                if matchingRule != nil {
+                        log.Printf("[DEBUG] Matching rule found : %s", matchingRule)
+                        return nil
+                }
+
+                return fmt.Errorf("Error here\n\tlooking for %s, wasn't found in %s", p, rules)
 	}
 }
 
@@ -478,5 +615,106 @@ resource "aws_security_group_rule" "self" {
   to_port = 0
   self = true
   security_group_id = "${aws_security_group.web.id}"
+}
+`
+
+const testAccAWSSecurityGroupRulePartialMatching = `
+resource "aws_vpc" "default" {
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "tf-sg-rule-bug"
+  }
+}
+
+resource "aws_security_group" "web" {
+    name = "tf-other"
+    vpc_id = "${aws_vpc.default.id}"
+    tags {
+        Name        = "tf-other-sg"
+    }
+}
+
+resource "aws_security_group" "nat" {
+    name = "tf-nat"
+    vpc_id = "${aws_vpc.default.id}"
+    tags {
+        Name        = "tf-nat-sg"
+    }
+}
+
+resource "aws_security_group_rule" "ingress" {
+    type        = "ingress"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+
+   security_group_id = "${aws_security_group.web.id}"
+}
+
+resource "aws_security_group_rule" "other" {
+    type        = "ingress"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.5.0/24"]
+
+   security_group_id = "${aws_security_group.web.id}"
+}
+
+// same a above, but different group, to guard against bad hashing
+resource "aws_security_group_rule" "nat_ingress" {
+    type        = "ingress"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+
+   security_group_id = "${aws_security_group.nat.id}"
+}
+`
+
+const testAccAWSSecurityGroupRulePartialMatching_Source = `
+resource "aws_vpc" "default" {
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "tf-sg-rule-bug"
+  }
+}
+
+resource "aws_security_group" "web" {
+    name = "tf-other"
+    vpc_id = "${aws_vpc.default.id}"
+    tags {
+        Name        = "tf-other-sg"
+    }
+}
+
+resource "aws_security_group" "nat" {
+    name = "tf-nat"
+    vpc_id = "${aws_vpc.default.id}"
+    tags {
+        Name        = "tf-nat-sg"
+    }
+}
+
+resource "aws_security_group_rule" "source_ingress" {
+    type        = "ingress"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+
+                source_security_group_id = "${aws_security_group.nat.id}"
+   security_group_id = "${aws_security_group.web.id}"
+}
+
+resource "aws_security_group_rule" "other_ingress" {
+    type        = "ingress"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+
+   security_group_id = "${aws_security_group.web.id}"
 }
 `

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -2,7 +2,7 @@ package aws
 
 import (
 	"fmt"
-        "log"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -90,15 +90,15 @@ func TestIpPermissionIDHash(t *testing.T) {
 		Type   string
 		Output string
 	}{
-                {simple, "ingress", "sg-3403497314"},
-                {egress, "egress", "sg-1173186295"},
-                {egress_all, "egress", "sg-766323498"},
-                {vpc_security_group_source, "egress", "sg-351225364"},
-                {security_group_source, "egress", "sg-2198807188"},
+		{simple, "ingress", "sgrule-3403497314"},
+		{egress, "egress", "sgrule-1173186295"},
+		{egress_all, "egress", "sgrule-766323498"},
+		{vpc_security_group_source, "egress", "sgrule-351225364"},
+		{security_group_source, "egress", "sgrule-2198807188"},
 	}
 
 	for _, tc := range cases {
-                actual := ipPermissionIDHash("sg-12345", tc.Type, tc.Input)
+		actual := ipPermissionIDHash("sg-12345", tc.Type, tc.Input)
 		if actual != tc.Output {
 			t.Errorf("input: %s - %s\noutput: %s", tc.Type, tc.Input, actual)
 		}
@@ -132,7 +132,7 @@ func TestAccAWSSecurityGroupRule_Ingress_VPC(t *testing.T) {
 				Config: testAccAWSSecurityGroupRuleIngressConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
 					resource.TestCheckResourceAttr(
 						"aws_security_group_rule.ingress_1", "from_port", "80"),
 					testRuleCount,
@@ -169,7 +169,7 @@ func TestAccAWSSecurityGroupRule_Ingress_Classic(t *testing.T) {
 				Config: testAccAWSSecurityGroupRuleIngressClassicConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
 					resource.TestCheckResourceAttr(
 						"aws_security_group_rule.ingress_1", "from_port", "80"),
 					testRuleCount,
@@ -231,7 +231,7 @@ func TestAccAWSSecurityGroupRule_Egress(t *testing.T) {
 				Config: testAccAWSSecurityGroupRuleEgressConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
 				),
 			},
 		},
@@ -258,87 +258,87 @@ func TestAccAWSSecurityGroupRule_SelfReference(t *testing.T) {
 
 // testing partial match implementation
 func TestAccAWSSecurityGroupRule_PartialMatching_basic(t *testing.T) {
-        var group ec2.SecurityGroup
+	var group ec2.SecurityGroup
 
-        p := ec2.IpPermission{
-                FromPort:   aws.Int64(80),
-                ToPort:     aws.Int64(80),
-                IpProtocol: aws.String("tcp"),
-                IpRanges: []*ec2.IpRange{
-                        &ec2.IpRange{CidrIp: aws.String("10.0.2.0/24")},
-                        &ec2.IpRange{CidrIp: aws.String("10.0.3.0/24")},
-                        &ec2.IpRange{CidrIp: aws.String("10.0.4.0/24")},
-                },
-        }
+	p := ec2.IpPermission{
+		FromPort:   aws.Int64(80),
+		ToPort:     aws.Int64(80),
+		IpProtocol: aws.String("tcp"),
+		IpRanges: []*ec2.IpRange{
+			&ec2.IpRange{CidrIp: aws.String("10.0.2.0/24")},
+			&ec2.IpRange{CidrIp: aws.String("10.0.3.0/24")},
+			&ec2.IpRange{CidrIp: aws.String("10.0.4.0/24")},
+		},
+	}
 
-        o := ec2.IpPermission{
-                FromPort:   aws.Int64(80),
-                ToPort:     aws.Int64(80),
-                IpProtocol: aws.String("tcp"),
-                IpRanges: []*ec2.IpRange{
-                        &ec2.IpRange{CidrIp: aws.String("10.0.5.0/24")},
-                },
-        }
+	o := ec2.IpPermission{
+		FromPort:   aws.Int64(80),
+		ToPort:     aws.Int64(80),
+		IpProtocol: aws.String("tcp"),
+		IpRanges: []*ec2.IpRange{
+			&ec2.IpRange{CidrIp: aws.String("10.0.5.0/24")},
+		},
+	}
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
-                Steps: []resource.TestStep{
-                        resource.TestStep{
-                                Config: testAccAWSSecurityGroupRulePartialMatching,
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress", &group, &p, "ingress"),
-                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.other", &group, &o, "ingress"),
-                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.nat_ingress", &group, &o, "ingress"),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupRulePartialMatching,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress", &group, &p, "ingress"),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.other", &group, &o, "ingress"),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.nat_ingress", &group, &o, "ingress"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSSecurityGroupRule_PartialMatching_Source(t *testing.T) {
-        var group ec2.SecurityGroup
-        var nat ec2.SecurityGroup
-        var p ec2.IpPermission
+	var group ec2.SecurityGroup
+	var nat ec2.SecurityGroup
+	var p ec2.IpPermission
 
-        // This function creates the expected IPPermission with the group id from an
-        // external security group, needed because Security Group IDs are generated on
-        // AWS side and can't be known ahead of time.
-        setupSG := func(*terraform.State) error {
-                if nat.GroupId == nil {
-                        return fmt.Errorf("Error: nat group has nil GroupID")
-                }
+	// This function creates the expected IPPermission with the group id from an
+	// external security group, needed because Security Group IDs are generated on
+	// AWS side and can't be known ahead of time.
+	setupSG := func(*terraform.State) error {
+		if nat.GroupId == nil {
+			return fmt.Errorf("Error: nat group has nil GroupID")
+		}
 
-                p = ec2.IpPermission{
-                        FromPort:   aws.Int64(80),
-                        ToPort:     aws.Int64(80),
-                        IpProtocol: aws.String("tcp"),
-                        UserIdGroupPairs: []*ec2.UserIdGroupPair{
-                                &ec2.UserIdGroupPair{GroupId: nat.GroupId},
-                        },
-                }
+		p = ec2.IpPermission{
+			FromPort:   aws.Int64(80),
+			ToPort:     aws.Int64(80),
+			IpProtocol: aws.String("tcp"),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{GroupId: nat.GroupId},
+			},
+		}
 
-                return nil
-        }
+		return nil
+	}
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
-                Steps: []resource.TestStep{
-                        resource.TestStep{
-                                Config: testAccAWSSecurityGroupRulePartialMatching_Source,
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-                                        testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
-                                        setupSG,
-                                        testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.source_ingress", &group, &p, "ingress"),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupRulePartialMatching_Source,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
+					setupSG,
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.source_ingress", &group, &p, "ingress"),
+				),
+			},
+		},
+	})
 
 }
 
@@ -407,25 +407,25 @@ func testAccCheckAWSSecurityGroupRuleExists(n string, group *ec2.SecurityGroup) 
 
 func testAccCheckAWSSecurityGroupRuleAttributes(n string, group *ec2.SecurityGroup, p *ec2.IpPermission, ruleType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-                rs, ok := s.RootModule().Resources[n]
-                if !ok {
-                        return fmt.Errorf("Security Group Rule Not found: %s", n)
-                }
-
-                if rs.Primary.ID == "" {
-                        return fmt.Errorf("No Security Group Rule is set")
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Security Group Rule Not found: %s", n)
 		}
 
-                if p == nil {
-                        p = &ec2.IpPermission{
-                                FromPort:   aws.Int64(80),
-                                ToPort:     aws.Int64(8000),
-                                IpProtocol: aws.String("tcp"),
-                                IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
-                        }
-                }
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Security Group Rule is set")
+		}
 
-                var matchingRule *ec2.IpPermission
+		if p == nil {
+			p = &ec2.IpPermission{
+				FromPort:   aws.Int64(80),
+				ToPort:     aws.Int64(8000),
+				IpProtocol: aws.String("tcp"),
+				IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("10.0.0.0/8")}},
+			}
+		}
+
+		var matchingRule *ec2.IpPermission
 		var rules []*ec2.IpPermission
 		if ruleType == "ingress" {
 			rules = group.IpPermissions
@@ -437,53 +437,53 @@ func testAccCheckAWSSecurityGroupRuleAttributes(n string, group *ec2.SecurityGro
 			return fmt.Errorf("No IPPerms")
 		}
 
-                for _, r := range rules {
-                        if r.ToPort != nil && *p.ToPort != *r.ToPort {
-                                continue
-                        }
+		for _, r := range rules {
+			if r.ToPort != nil && *p.ToPort != *r.ToPort {
+				continue
+			}
 
-                        if r.FromPort != nil && *p.FromPort != *r.FromPort {
-                                continue
-                        }
+			if r.FromPort != nil && *p.FromPort != *r.FromPort {
+				continue
+			}
 
-                        if r.IpProtocol != nil && *p.IpProtocol != *r.IpProtocol {
-                                continue
-                        }
+			if r.IpProtocol != nil && *p.IpProtocol != *r.IpProtocol {
+				continue
+			}
 
-                        remaining := len(p.IpRanges)
-                        for _, ip := range p.IpRanges {
-                                for _, rip := range r.IpRanges {
-                                        if *ip.CidrIp == *rip.CidrIp {
-                                                remaining--
-                                        }
-                                }
-                        }
+			remaining := len(p.IpRanges)
+			for _, ip := range p.IpRanges {
+				for _, rip := range r.IpRanges {
+					if *ip.CidrIp == *rip.CidrIp {
+						remaining--
+					}
+				}
+			}
 
-                        if remaining > 0 {
-                                continue
-                        }
+			if remaining > 0 {
+				continue
+			}
 
-                        remaining = len(p.UserIdGroupPairs)
-                        for _, ip := range p.UserIdGroupPairs {
-                                for _, rip := range r.UserIdGroupPairs {
-                                        if *ip.GroupId == *rip.GroupId {
-                                                remaining--
-                                        }
-                                }
-                        }
+			remaining = len(p.UserIdGroupPairs)
+			for _, ip := range p.UserIdGroupPairs {
+				for _, rip := range r.UserIdGroupPairs {
+					if *ip.GroupId == *rip.GroupId {
+						remaining--
+					}
+				}
+			}
 
-                        if remaining > 0 {
-                                continue
-                        }
-                        matchingRule = r
+			if remaining > 0 {
+				continue
+			}
+			matchingRule = r
 		}
 
-                if matchingRule != nil {
-                        log.Printf("[DEBUG] Matching rule found : %s", matchingRule)
-                        return nil
-                }
+		if matchingRule != nil {
+			log.Printf("[DEBUG] Matching rule found : %s", matchingRule)
+			return nil
+		}
 
-                return fmt.Errorf("Error here\n\tlooking for %s, wasn't found in %s", p, rules)
+		return fmt.Errorf("Error here\n\tlooking for %s, wasn't found in %s", p, rules)
 	}
 }
 


### PR DESCRIPTION
This patch aims to resolve a lingering issue with Security Group Rules, 
where different resources generate rules that are consolidated on Amazon's 
side, as a result resulting in loss of local resources in the state file 
and duplication errors on AWS's side. 

Example:

```
resource "aws_security_group_rule" "first" {
    type        = "ingress"
    from_port   = 80
    to_port     = 80
    protocol    = "tcp"
    cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24"]

   security_group_id = "${aws_security_group.nat.id}"
}
```

After applying this rule, our security group `nat` looks like this:

```
{
  Description: "Managed by Terraform",
  GroupId: "sg-87eb46e3",
  GroupName: "secg-nat",
  IpPermissions: [{
      FromPort: 80,
      IpProtocol: "tcp",
      IpRanges: [{
          CidrIp: "10.0.2.0/24"
        },{
          CidrIp: "10.0.3.0/24"
        }],
      ToPort: 80
    }],
  OwnerId: "470663696735",
  VpcId: "vpc-0806716d"
}
```

This rule, with 2 `cidr_block` entires, is a single IPPermission rule according to the API.

At present, the Security Group Rule resource hashes it's values (ports, cidrs, security groups) 
to generate a key. This breaks down however, when another rule is added with a new `cidr_block`. 

Now, adding a second rule that also uses a `cidr_block` like so, will reveal the bug:

```
resource "aws_security_group_rule" "second" {
    type        = "ingress"
    from_port   = 80
    to_port     = 80
    protocol    = "tcp"
    cidr_blocks = ["10.0.5.0/24"]

   security_group_id = "${aws_security_group.nat.id}"
}
```

The IPPermissions now look like this:

```
Full Security Group: {
  Description: "Managed by Terraform",
  GroupId: "sg-87eb46e3",
  GroupName: "secg-nat",
  IpPermissions: [{
      FromPort: 80,
      IpProtocol: "tcp",
      IpRanges: [{
          CidrIp: "10.0.2.0/24"
        },{
          CidrIp: "10.0.3.0/24"
        },{
          CidrIp: "10.0.5.0/24"
        }],
      ToPort: 80
    }],
  OwnerId: "470663696735",
  VpcId: "vpc-0806716d"
}
```

The API has consolidated this new `cidr_block` into an existing rule, based on the port and 
protocol it applies to. Because of the way Terraform hashes the rules locally, it can no longer find 
either resource, as it hashes the **entire IPPermission** looking for a match.

This pull request resolves this by iterating through `IpPermissions` and looking for matching criteria, 
ensuring that each `cidr_block` or `security_group_id` is found in a set. 

This patch also fixes another issue, where similar rules applied to different security groups caused the 
same kind of conflict, because we were not hashing the security group id itself into the id of the rule. 
We now consider the id in the hash for the rule to avoid this. 

Refs:

- https://github.com/hashicorp/terraform/issues/2584#issuecomment-120088474
- https://github.com/hashicorp/terraform/issues/2837
- https://github.com/hashicorp/terraform/issues/2463