### PR TITLE
Clarify that you get the AMI id from metadata, not id

### DIFF
--- a/website/source/docs/providers/atlas/r/artifact.html.markdown
+++ b/website/source/docs/providers/atlas/r/artifact.html.markdown
@@ -33,7 +33,7 @@ resource "atlas_artifact" "web" {
 
 # Start our instance with the dynamic ami value
 resource "aws_instance" "app" {
-    ami = "${atlas_artifact.web.id}"
+    ami = "${atlas_artifact.web.metadata_full.region-us-east-1}"
     ...
 }
 ```


### PR DESCRIPTION
I'm not sure what the final UX will be around artifacts, region metadata, and artifact IDs, but this update should clarify a bit