### PR TITLE
helper/schema: arbitrary JSON attributes

### DIFF
--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -270,6 +271,22 @@ func stringToPrimitive(
 		returnVal = int(v)
 	case TypeString:
 		returnVal = value
+	case TypeJSON:
+		if value == "" {
+			returnVal = map[string]interface{}{}
+			break
+		}
+		if computed {
+			break
+		}
+
+		returnMap := map[string]interface{}{}
+		err := json.Unmarshal([]byte(value), &returnMap)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding JSON: %s", err)
+		}
+
+		returnVal = returnMap
 	default:
 		panic(fmt.Sprintf("Unknown type: %s", schema.Type))
 	}

--- a/helper/schema/field_reader_config_test.go
+++ b/helper/schema/field_reader_config_test.go
@@ -45,6 +45,13 @@ func TestConfigFieldReader(t *testing.T) {
 						"value": "bar",
 					},
 				},
+
+				"json": map[string]interface{}{
+					"hello_json": true,
+					"nested": map[string]interface{}{
+						"number": float64(2),
+					},
+				},
 			}),
 		}
 	})

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -39,7 +39,7 @@ func (r *DiffFieldReader) ReadField(address []string) (FieldReadResult, error) {
 
 	schema := schemaList[len(schemaList)-1]
 	switch schema.Type {
-	case TypeBool, TypeInt, TypeFloat, TypeString:
+	case TypeBool, TypeInt, TypeFloat, TypeString, TypeJSON:
 		return r.readPrimitive(address, schema)
 	case TypeList:
 		return readListField(r, address, schema)

--- a/helper/schema/field_reader_diff_test.go
+++ b/helper/schema/field_reader_diff_test.go
@@ -361,6 +361,18 @@ func TestDiffFieldReader(t *testing.T) {
 						Old: "",
 						New: "bar",
 					},
+
+					"json": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: `
+                            {
+                                "hello_json": true,
+                                "nested": {
+                                    "number": 2
+                                }
+                            }
+                        `,
+					},
 				},
 			},
 

--- a/helper/schema/field_reader_map.go
+++ b/helper/schema/field_reader_map.go
@@ -21,7 +21,7 @@ func (r *MapFieldReader) ReadField(address []string) (FieldReadResult, error) {
 
 	schema := schemaList[len(schemaList)-1]
 	switch schema.Type {
-	case TypeBool, TypeInt, TypeFloat, TypeString:
+	case TypeBool, TypeInt, TypeFloat, TypeString, TypeJSON:
 		return r.readPrimitive(address, schema)
 	case TypeList:
 		return readListField(r, address, schema)

--- a/helper/schema/field_reader_map_test.go
+++ b/helper/schema/field_reader_map_test.go
@@ -41,6 +41,15 @@ func TestMapFieldReader(t *testing.T) {
 				"setDeep.10.value": "foo",
 				"setDeep.50.index": "50",
 				"setDeep.50.value": "bar",
+
+				"json": `
+                    {
+                        "hello_json": true,
+                        "nested": {
+                            "number": 2
+                        }
+                    }
+                `,
 			}),
 		}
 	})

--- a/helper/schema/field_reader_test.go
+++ b/helper/schema/field_reader_test.go
@@ -239,6 +239,9 @@ func testFieldReader(t *testing.T, f func(map[string]*Schema) FieldReader) {
 				return a.(int)
 			},
 		},
+
+		// JSON
+		"json": &Schema{Type: TypeJSON},
 	}
 
 	cases := map[string]struct {
@@ -382,6 +385,21 @@ func testFieldReader(t *testing.T, f func(map[string]*Schema) FieldReader) {
 			},
 			false,
 		},
+
+		"json": {
+			[]string{"json"},
+			FieldReadResult{
+				Value: map[string]interface{}{
+					"hello_json": true,
+					"nested": map[string]interface{}{
+						"number": float64(2),
+					},
+				},
+				Exists:   true,
+				Computed: false,
+			},
+			false,
+		},
 	}
 
 	for name, tc := range cases {
@@ -395,7 +413,7 @@ func testFieldReader(t *testing.T, f func(map[string]*Schema) FieldReader) {
 			out.Value = s.List()
 		}
 		if !reflect.DeepEqual(tc.Result, out) {
-			t.Fatalf("%s: bad: %#v", name, out)
+			t.Fatalf("%s: bad: %#v; want %#v", name, out, tc.Result)
 		}
 	}
 }

--- a/helper/schema/valuetype.go
+++ b/helper/schema/valuetype.go
@@ -14,6 +14,7 @@ const (
 	TypeList
 	TypeMap
 	TypeSet
+	TypeJSON // arbitrary JSON-serializable data structure
 	typeObject
 )
 

--- a/helper/schema/valuetype_string.go
+++ b/helper/schema/valuetype_string.go
@@ -4,9 +4,9 @@ package schema
 
 import "fmt"
 
-const _ValueType_name = "TypeInvalidTypeBoolTypeIntTypeFloatTypeStringTypeListTypeMapTypeSettypeObject"
+const _ValueType_name = "TypeInvalidTypeBoolTypeIntTypeFloatTypeStringTypeListTypeMapTypeSetTypeJSONtypeObject"
 
-var _ValueType_index = [...]uint8{0, 11, 19, 26, 35, 45, 53, 60, 67, 77}
+var _ValueType_index = [...]uint8{0, 11, 19, 26, 35, 45, 53, 60, 67, 75, 85}
 
 func (i ValueType) String() string {
 	if i < 0 || i >= ValueType(len(_ValueType_index)-1) {


### PR DESCRIPTION
Since provisioners implement directly their own configuration decoding, it's possible for them to have parameters that take arbitrary data structures, as we see in the ``attributes`` parameter of the ``chef`` provisioner:

```js
    provisioner "chef"  {
        attributes {
            "key" = "value"
            "app" {
                "cluster1" {
                    "nodes" = ["webserver1", "webserver2"]
                }
            }
        }
    }
    // ...
```

For the OpsWorks support I've been working on in #2162 I'd like to be able to include a similar structure in a resource, since OpsWorks is essentially an interface to running Chef and thus I'd like it to follow the conventions of the Chef provisioner as much as possible.

Thus I'd like to propose a new schema type called ``TypeJSON``, which represents any arbitrary JSON-friendly data structure as long as it is rooted in an object (a ``map[string]interface{}``). When writing a config file, the user may either assign a native HCL data structure like in the Chef example above, or they may assign a string containing a valid JSON-serialized data structure.

Allowing both a native structure and a string has a few different advantages:
* When assigning a string it's possible to use the ``file()`` interpolation function, in cases where the JSON structure is fixed and more convenient to maintain in a separate file.
* When assigning a native structure it's possible to do normal Terraform interpolations such as list globbing.
* Accepting a string containing JSON also provides backward-compatibility with existing resources that currently accept JSON strings, like ``aws_iam_policy``, allowing them to be retroactively switched to ``TypeJSON`` without breaking existing configurations.

I've attached a prototype of this. It's has some known omissions, such as native structures containing nested computed interpolations, and there are no tests. However, my main goal here was to make this proposal and see what folks think about it before I try to push too much further in this direction.

```js
resource "opsworks_stack" "foo" {
    chef_attributes {
        something {
            arbitrary = true
        }
    }
}
```
