### PR TITLE
Add project parameter to more Cloudstack resources

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
@@ -32,6 +32,12 @@ func resourceCloudStackIPAddress() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -45,6 +51,17 @@ func resourceCloudStackIPAddressCreate(d *schema.ResourceData, meta interface{})
 
 	// Create a new parameter struct
 	p := cs.Address.NewAssociateIpAddressParams()
+
+	// If there is a project supplied, we retreive and set the project id
+	if project, ok := d.GetOk("project"); ok {
+		// Retrieve the project UUID
+		projectid, e := retrieveUUID(cs, "project", project.(string))
+		if e != nil {
+			return e.Error()
+		}
+		// Set the default project ID
+		p.SetProjectid(projectid)
+	}
 
 	if network, ok := d.GetOk("network"); ok {
 		// Retrieve the network UUID
@@ -117,6 +134,8 @@ func resourceCloudStackIPAddressRead(d *schema.ResourceData, meta interface{}) e
 
 		setValueOrUUID(d, "vpc", v.Name, f.Vpcid)
 	}
+
+	setValueOrUUID(d, "project", f.Project, f.Projectid)
 
 	return nil
 }

--- a/builtin/providers/cloudstack/resource_cloudstack_network.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_network.go
@@ -57,6 +57,12 @@ func resourceCloudStackNetwork() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -86,6 +92,17 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 
 	// Create a new parameter struct
 	p := cs.Network.NewCreateNetworkParams(displaytext.(string), name, networkofferingid, zoneid)
+
+	// If there is a project supplied, we retreive and set the project id
+	if project, ok := d.GetOk("project"); ok {
+		// Retrieve the project UUID
+		projectid, e := retrieveUUID(cs, "project", project.(string))
+		if e != nil {
+			return e.Error()
+		}
+		// Set the default project ID
+		p.SetProjectid(projectid)
+	}
 
 	// Get the network details from the CIDR
 	m, err := parseCIDR(d.Get("cidr").(string))
@@ -152,6 +169,7 @@ func resourceCloudStackNetworkRead(d *schema.ResourceData, meta interface{}) err
 
 	setValueOrUUID(d, "network_offering", n.Networkofferingname, n.Networkofferingid)
 	setValueOrUUID(d, "zone", n.Zonename, n.Zoneid)
+	setValueOrUUID(d, "project", n.Project, n.Projectid)
 
 	return nil
 }

--- a/builtin/providers/cloudstack/resource_cloudstack_vpc.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_vpc.go
@@ -45,6 +45,11 @@ func resourceCloudStackVPC() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -74,6 +79,17 @@ func resourceCloudStackVPCCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Create a new parameter struct
 	p := cs.VPC.NewCreateVPCParams(d.Get("cidr").(string), displaytext.(string), name, vpcofferingid, zoneid)
+
+    // If there is a project supplied, we retreive and set the project id
+	if project, ok := d.GetOk("project"); ok {
+		// Retrieve the project UUID
+		projectid, e := retrieveUUID(cs, "project", project.(string))
+		if e != nil {
+			return e.Error()
+		}
+		// Set the default project ID
+		p.SetProjectid(projectid)
+	}
 
 	// Create the new VPC
 	r, err := cs.VPC.CreateVPC(p)
@@ -115,6 +131,7 @@ func resourceCloudStackVPCRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	setValueOrUUID(d, "vpc_offering", o.Name, v.Vpcofferingid)
+	setValueOrUUID(d, "project", v.Project, v.Projectid)
 
 	return nil
 }


### PR DESCRIPTION
With some Cloudstack implementations, the `projectid` query parameter is required to be passed to most API calls. It appears the underlying [xanzy/go-cloudstack](https://github.com/xanzy/go-cloudstack) library has support for this. This PR adds this parameters to the following Cloudstack resources:

- `cloudstack_vpc`
- `cloudstack_network`
- `cloudstack_ip`

It's possible that more resources will require this parameter, but I haven't come across those situations yet.