### PR TITLE
provider/aws: Allow Instance to be computed in EIPs

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -30,13 +30,13 @@ func resourceAwsEip() *schema.Resource {
 			"instance": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+                                Computed: true,
 			},
 
 			"network_interface": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"instance"},
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Computed: true,
 			},
 
 			"allocation_id": &schema.Schema{

--- a/website/source/docs/providers/aws/r/eip.html.markdown
+++ b/website/source/docs/providers/aws/r/eip.html.markdown
@@ -27,6 +27,11 @@ The following arguments are supported:
 * `instance` - (Optional) EC2 instance ID.
 * `network_interface` - (Optional) Network interface ID to associate with.
 
+~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID, 
+but not both. Including both will **not** return an error from the AWS API, but will
+have undefined behavior. See the relevant [AssociateAddress API Call][1] for
+more information.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -36,3 +41,5 @@ The following attributes are exported:
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
 
+
+[1]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_AssociateAddress.html


### PR DESCRIPTION
If you have an EIP attached to a network interface, which then has an Instance attached to it, Terraform plans will want to remove the instance attachment of the EIP, even though there is no explicit connection made by the user:

```javascript
resource "aws_eip" "nat_ip" {
  network_interface = "${aws_network_interface.nat_eni.id}"
}

resource "aws_network_interface" "nat_eni" {
	# other attributes
  attachment {
    instance = "${aws_instance.nat.id}"
    device_index = 1
  }
}

resource "aws_instance" "nat" {
  ami = "ami-21f78e11"
	# other attributes
}
```

After applying, future plans will show this:

```
~ aws_eip.nat_ip
    instance: "i-<instance_id>" => ""
```

This PR make `instance` a computed attribute, and also removes the `ConflictsWith` restraint from `network_interface`. Oddly enough, the [AssociateAddress API][1] docs say you can't have both of these specified, but we do here and get no error.


Fixes #2952 


[1]: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateAddress.html