### PR TITLE
Atlas environment information sent with remote state

### DIFF
--- a/state/remote/atlas.go
+++ b/state/remote/atlas.go
@@ -51,6 +51,11 @@ func atlasFactory(conf map[string]string) (Client, error) {
 		return nil, fmt.Errorf("malformed name '%s', expected format '<account>/<name>'", name)
 	}
 
+	// If it exists, add the `ATLAS_RUN_ID` environment
+	// variable as a param, which is injected during Atlas Terraform
+	// runs. This is completely optional.
+	client.RunId = os.Getenv("ATLAS_RUN_ID")
+
 	client.Server = server
 	client.ServerURL = url
 	client.AccessToken = token
@@ -67,6 +72,7 @@ type AtlasClient struct {
 	User        string
 	Name        string
 	AccessToken string
+	RunId       string
 }
 
 func (c *AtlasClient) Get() (*Payload, error) {
@@ -218,10 +224,15 @@ func (c *AtlasClient) readBody(b io.Reader) string {
 }
 
 func (c *AtlasClient) url() *url.URL {
+	values := url.Values{}
+
+	values.Add("atlas_run_id", c.RunId)
+	values.Add("access_token", c.AccessToken)
+
 	return &url.URL{
 		Scheme:   c.ServerURL.Scheme,
 		Host:     c.ServerURL.Host,
 		Path:     path.Join("api/v1/terraform/state", c.User, c.Name),
-		RawQuery: fmt.Sprintf("access_token=%s", c.AccessToken),
+		RawQuery: values.Encode(),
 	}
 }

--- a/state/remote/atlas.go
+++ b/state/remote/atlas.go
@@ -143,15 +143,6 @@ func (c *AtlasClient) Put(state []byte) error {
 	hash := md5.Sum(state)
 	b64 := base64.StdEncoding.EncodeToString(hash[:])
 
-	/*
-		// Set the force query parameter if needed
-		if force {
-			values := base.Query()
-			values.Set("force", "true")
-			base.RawQuery = values.Encode()
-		}
-	*/
-
 	// Make the HTTP client and request
 	req, err := http.NewRequest("PUT", base.String(), bytes.NewReader(state))
 	if err != nil {


### PR DESCRIPTION
When Terraform is [run in Atlas](https://atlas.hashicorp.com/learn/terraform) we can improve the user experience of where state changes are coming from (the specific "run" that caused the state change, in Atlas terminology representing a plan/apply) by sending the optional `ATLAS_RUN_ID` environment variable with state saves, if it exists.

Atlas will inject this environment variable. This does not affect any state operations, and is used in the background for Atlas to tie the "run" to the state save.

I also removed some old commented out param manipulation I found while doing this.