### PR TITLE
command: Ask for user variables before validation.

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -65,11 +65,11 @@ func (c *PlanCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-	if !validateContext(ctx, c.Ui) {
-		return 1
-	}
 	if err := ctx.Input(c.InputMode()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
+		return 1
+	}
+	if !validateContext(ctx, c.Ui) {
 		return 1
 	}
 

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -85,11 +85,11 @@ func (c *RefreshCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-	if !validateContext(ctx, c.Ui) {
-		return 1
-	}
 	if err := ctx.Input(c.InputMode()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
+		return 1
+	}
+	if !validateContext(ctx, c.Ui) {
 		return 1
 	}
 

--- a/command/test-fixtures/plan-input/main.tf
+++ b/command/test-fixtures/plan-input/main.tf
@@ -1,0 +1,3 @@
+variable "foo" {}
+
+resource "test_instance" "foo" {}

--- a/command/test-fixtures/refresh-input/main.tf
+++ b/command/test-fixtures/refresh-input/main.tf
@@ -1,0 +1,3 @@
+variable "foo" {}
+
+resource "test_instance" "foo" {}


### PR DESCRIPTION
Fixes an issue where user variables are not prompted for prior to validation. It is an almost identical fix to issue #736 (commit fb3f10efb0f672f6a7d8c4ad511b32e2d4a92f71) but for the plan and refresh commands.

Error without fix.
```
$ terraform refresh
There are warnings and/or errors related to your configuration. Please fix these before continuing.

Errors:

  * 1 error(s) occurred:

* Required variable not set: foo
```