### PR TITLE
provider/aws: Paginate the notifications returned for ASG Notifications

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_notification.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_notification.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -64,22 +65,32 @@ func resourceAwsAutoscalingNotificationRead(d *schema.ResourceData, meta interfa
 		AutoScalingGroupNames: gl,
 	}
 
-	resp, err := conn.DescribeNotificationConfigurations(opts)
-	if err != nil {
-		return fmt.Errorf("Error describing notifications")
-	}
-
 	topic := d.Get("topic_arn").(string)
 	// Grab all applicable notifcation configurations for this Topic.
 	// Each NotificationType will have a record, so 1 Group with 3 Types results
 	// in 3 records, all with the same Group name
 	gRaw := make(map[string]bool)
 	nRaw := make(map[string]bool)
-	for _, n := range resp.NotificationConfigurations {
-		if *n.TopicARN == topic {
-			gRaw[*n.AutoScalingGroupName] = true
-			nRaw[*n.NotificationType] = true
+
+	i := 0
+	err := conn.DescribeNotificationConfigurationsPages(opts, func(resp *autoscaling.DescribeNotificationConfigurationsOutput, lastPage bool) bool {
+		if resp != nil {
+			i++
+			log.Println("[DEBUG] Paging DescribeNotificationConfigurations for (%s), page: %d", d.Id(), i)
+		} else {
+			log.Println("[DEBUG] Paging finished for DescribeNotificationConfigurations (%s)", d.Id())
 		}
+
+		for _, n := range resp.NotificationConfigurations {
+			if *n.TopicARN == topic {
+				gRaw[*n.AutoScalingGroupName] = true
+				nRaw[*n.NotificationType] = true
+			}
+		}
+		return true // return false to stop paging
+	})
+	if err != nil {
+		return err
 	}
 
 	// Grab the keys here as the list of Groups

--- a/builtin/providers/aws/resource_aws_autoscaling_notification.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_notification.go
@@ -76,9 +76,9 @@ func resourceAwsAutoscalingNotificationRead(d *schema.ResourceData, meta interfa
 	err := conn.DescribeNotificationConfigurationsPages(opts, func(resp *autoscaling.DescribeNotificationConfigurationsOutput, lastPage bool) bool {
 		if resp != nil {
 			i++
-			log.Println("[DEBUG] Paging DescribeNotificationConfigurations for (%s), page: %d", d.Id(), i)
+			log.Printf("[DEBUG] Paging DescribeNotificationConfigurations for (%s), page: %d", d.Id(), i)
 		} else {
-			log.Println("[DEBUG] Paging finished for DescribeNotificationConfigurations (%s)", d.Id())
+			log.Printf("[DEBUG] Paging finished for DescribeNotificationConfigurations (%s)", d.Id())
 		}
 
 		for _, n := range resp.NotificationConfigurations {

--- a/builtin/providers/aws/resource_aws_autoscaling_notification_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_notification_test.go
@@ -57,6 +57,47 @@ func TestAccAWSASGNotification_update(t *testing.T) {
 	})
 }
 
+func TestAccAWSASGNotification_Pagination(t *testing.T) {
+	var asgn autoscaling.DescribeNotificationConfigurationsOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckASGNDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccASGNotificationConfig_pagination,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASGNotificationExists("aws_autoscaling_notification.example",
+						[]string{
+							"foobar3-terraform-test-0",
+							"foobar3-terraform-test-1",
+							"foobar3-terraform-test-2",
+							"foobar3-terraform-test-3",
+							"foobar3-terraform-test-4",
+							"foobar3-terraform-test-5",
+							"foobar3-terraform-test-6",
+							"foobar3-terraform-test-7",
+							"foobar3-terraform-test-8",
+							"foobar3-terraform-test-9",
+							"foobar3-terraform-test-10",
+							"foobar3-terraform-test-11",
+							"foobar3-terraform-test-12",
+							"foobar3-terraform-test-13",
+							"foobar3-terraform-test-14",
+							"foobar3-terraform-test-15",
+							"foobar3-terraform-test-16",
+							"foobar3-terraform-test-17",
+							"foobar3-terraform-test-18",
+							"foobar3-terraform-test-19",
+						}, &asgn),
+					testAccCheckAWSASGNotificationAttributes("aws_autoscaling_notification.example", &asgn),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckASGNotificationExists(n string, groups []string, asgn *autoscaling.DescribeNotificationConfigurationsOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -68,19 +109,15 @@ func testAccCheckASGNotificationExists(n string, groups []string, asgn *autoscal
 			return fmt.Errorf("No ASG Notification ID is set")
 		}
 
-		var gl []*string
-		for _, g := range groups {
-			gl = append(gl, aws.String(g))
-		}
-
 		conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
 		opts := &autoscaling.DescribeNotificationConfigurationsInput{
-			AutoScalingGroupNames: gl,
+			AutoScalingGroupNames: aws.StringSlice(groups),
+			MaxRecords:            aws.Int64(100),
 		}
 
 		resp, err := conn.DescribeNotificationConfigurations(opts)
 		if err != nil {
-			return fmt.Errorf("Error describing notifications")
+			return fmt.Errorf("Error describing notifications: %s", err)
 		}
 
 		*asgn = *resp
@@ -132,6 +169,7 @@ func testAccCheckAWSASGNotificationAttributes(n string, asgn *autoscaling.Descri
 		// build a unique list of groups, notification types
 		gRaw := make(map[string]bool)
 		nRaw := make(map[string]bool)
+
 		for _, n := range asgn.NotificationConfigurations {
 			if *n.TopicARN == rs.Primary.Attributes["topic_arn"] {
 				gRaw[*n.AutoScalingGroupName] = true
@@ -248,5 +286,41 @@ resource "aws_autoscaling_notification" "example" {
 		"autoscaling:EC2_INSTANCE_TERMINATE",
 		"autoscaling:EC2_INSTANCE_LAUNCH_ERROR"
 	]
+	topic_arn = "${aws_sns_topic.user_updates.arn}"
+}`
+
+const testAccASGNotificationConfig_pagination = `
+resource "aws_sns_topic" "user_updates" {
+  name = "user-updates-topic"
+}
+
+resource "aws_launch_configuration" "foobar" {
+  image_id = "ami-21f78e11"
+  instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "bar" {
+  availability_zones = ["us-west-2a"]
+  count = 20
+  name = "foobar3-terraform-test-${count.index}"
+  max_size = 1
+  min_size = 0
+  health_check_grace_period = 300
+  health_check_type = "ELB"
+  desired_capacity = 0
+  force_delete = true
+  termination_policies = ["OldestInstance"]
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+}
+
+resource "aws_autoscaling_notification" "example" {
+  group_names = [
+    "${aws_autoscaling_group.bar.*.name}",
+  ]
+  notifications  = [
+    "autoscaling:EC2_INSTANCE_LAUNCH",
+    "autoscaling:EC2_INSTANCE_TERMINATE",
+    "autoscaling:TEST_NOTIFICATION"
+  ]
 	topic_arn = "${aws_sns_topic.user_updates.arn}"
 }`


### PR DESCRIPTION
Update AutoScaling Group Notifications to page through results of `DescribeNotificationConfigurations`. There is a result for each Notification Type : Group pair, so the list can be long if you have a lot, like so:

```hcl
resource "aws_autoscaling_group" "bar" {
  count = 20
  name = "foobar3-terraform-test-${count.index}"
  [...]
}

resource "aws_autoscaling_notification" "example" {
  group_names = [
    "${aws_autoscaling_group.bar.*.name}",
  ]
  notifications  = [
    "autoscaling:EC2_INSTANCE_LAUNCH",
    "autoscaling:EC2_INSTANCE_TERMINATE",
    "autoscaling:TEST_NOTIFICATION"
  ]
	topic_arn = "${aws_sns_topic.user_updates.arn}"
}
```

That will generate 60 results in the `DescribeNotificationConfigurations` call, but it's paginated unless you specify the max records. Max records is limited to 200, so it's better to just paginate since it's provided for us.

Fixes #2852