### PR TITLE
Adding Build Status to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Terraform
 =========
 
+[![Build Status](https://travis-ci.org/hashicorp/terraform.svg?branch=master)](https://travis-ci.org/hashicorp/terraform)
+
 -	Website: http://www.terraform.io
 -	IRC: `#terraform-tool` on Freenode
 -	Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)


### PR DESCRIPTION
I was caught this week when the build was failing - I thought it was my local machine and killed my repo and re-cloned

Adding a simple indicator of the status (from the travis master build) would be a useful addition to the README IMO
