### PR TITLE
[Vagrantfile] set resources for the provider 'virtualbox'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,4 +53,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       v.vmx["numvcpus"] = "2"
     end
   end
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 4096
+    v.cpus = 2
+  end
 end


### PR DESCRIPTION
The default resources (384 MByte memory and 1 VCPU)  of the used
box are not sufficient to create binaries for testing Terraform
locally.