### PR TITLE
Prototype of Initial Resource State

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -18,6 +18,11 @@ func resourceAwsIamGroup() *schema.Resource {
 		//Update: resourceAwsIamGroupUpdate,
 		Delete: resourceAwsIamGroupDelete,
 
+		SetInitialState: func(d *schema.ResourceData, meta interface {}) error {
+			d.SetId(d.Get("name").(string))
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -19,6 +19,11 @@ func resourceAwsIamRole() *schema.Resource {
 		//Update: resourceAwsIamRoleUpdate,
 		Delete: resourceAwsIamRoleDelete,
 
+		SetInitialState: func(d *schema.ResourceData, meta interface {}) error {
+			d.SetId(d.Get("name").(string))
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,
@@ -108,6 +113,9 @@ func resourceAwsIamRoleReadResult(d *schema.ResourceData, role *iam.Role) error 
 		return err
 	}
 	if err := d.Set("unique_id", role.RoleId); err != nil {
+		return err
+	}
+	if err := d.Set("assume_role_policy", role.AssumeRolePolicyDocument); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -19,6 +19,11 @@ func resourceAwsIamUser() *schema.Resource {
 		//Update: resourceAwsIamUserUpdate,
 		Delete: resourceAwsIamUserDelete,
 
+		SetInitialState: func(d *schema.ResourceData, meta interface {}) error {
+			d.SetId(d.Get("name").(string))
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -18,6 +18,22 @@ func resourceAwsKeyPair() *schema.Resource {
 		Update: nil,
 		Delete: resourceAwsKeyPairDelete,
 
+		SetInitialState: func(d *schema.ResourceData, meta interface {}) error {
+			// If the configuration is forcing a particular key name
+			// then we'll prime our initial state with it so that
+			// we can determine if we're going to collide with an
+			// existing key.
+			keyName := d.Get("key_name").(string)
+			if keyName != "" {
+				d.SetId(keyName)
+
+				// Don't set the public_key since we don't actually know
+				// what the remote state says, and Read can't fetch it.
+				d.Set("public_key", "")
+			}
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"key_name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -19,6 +19,11 @@ func resourceAwsS3Bucket() *schema.Resource {
 		Update: resourceAwsS3BucketUpdate,
 		Delete: resourceAwsS3BucketDelete,
 
+		SetInitialState: func(d *schema.ResourceData, meta interface {}) error {
+			d.SetId(d.Get("bucket").(string))
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"bucket": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/terraform/resource_state.go
+++ b/builtin/providers/terraform/resource_state.go
@@ -10,9 +10,17 @@ import (
 
 func resourceRemoteState() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceRemoteStateCreate,
+		Create: resourceRemoteStateRead,
 		Read:   resourceRemoteStateRead,
 		Delete: resourceRemoteStateDelete,
+
+		SetInitialState: func(d *schema.ResourceData, meta interface {}) error {
+			// Just need to set the id to *something* non-empty, and then
+			// we'll get an opportunity to fill the initial state for real
+			// when the "Read" function is called.
+			d.SetId(time.Now().UTC().String())
+			return nil
+		},
 
 		Schema: map[string]*schema.Schema{
 			"backend": &schema.Schema{
@@ -33,10 +41,6 @@ func resourceRemoteState() *schema.Resource {
 			},
 		},
 	}
-}
-
-func resourceRemoteStateCreate(d *schema.ResourceData, meta interface{}) error {
-	return resourceRemoteStateRead(d, meta)
 }
 
 func resourceRemoteStateRead(d *schema.ResourceData, meta interface{}) error {

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -48,31 +48,23 @@ func (c *RefreshCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Verify that the state path exists. The "ContextArg" function below
+	// Verify that the state path can be read. The "ContextArg" function below
 	// will actually do this, but we want to provide a richer error message
 	// if possible.
+	// It is okay to refresh without a state since the configuration may
+	// contain logical resources or resources that do not explicitly need to
+	// be created first.
 	if !state.State().IsRemote() {
 		if _, err := os.Stat(c.Meta.statePath); err != nil {
-			if os.IsNotExist(err) {
+			if !os.IsNotExist(err) {
 				c.Ui.Error(fmt.Sprintf(
-					"The Terraform state file for your infrastructure does not\n"+
-						"exist. The 'refresh' command only works and only makes sense\n"+
-						"when there is existing state that Terraform is managing. Please\n"+
-						"double-check the value given below and try again. If you\n"+
-						"haven't created infrastructure with Terraform yet, use the\n"+
-						"'terraform apply' command.\n\n"+
-						"Path: %s",
-					c.Meta.statePath))
-				return 1
-			}
-
-			c.Ui.Error(fmt.Sprintf(
-				"There was an error reading the Terraform state that is needed\n"+
+					"There was an error reading the Terraform state that is needed\n"+
 					"for refreshing. The path and error are shown below.\n\n"+
 					"Path: %s\n\nError: %s",
-				c.Meta.statePath,
-				err))
-			return 1
+					c.Meta.statePath,
+					err))
+				return 1
+			}
 		}
 	}
 

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -175,6 +175,18 @@ func (p *Provider) Diff(
 	return r.Diff(s, c)
 }
 
+// InitialState implementation of terraform.ResourceProvider interface.
+func (p *Provider) InitialState(
+	info *terraform.InstanceInfo,
+	c *terraform.ResourceConfig) (*terraform.InstanceState, error) {
+	r, ok := p.ResourcesMap[info.Type]
+	if !ok {
+		return nil, fmt.Errorf("unknown resource type: %s", info.Type)
+	}
+
+	return r.InitialState(c, p.meta)
+}
+
 // Refresh implementation of terraform.ResourceProvider interface.
 func (p *Provider) Refresh(
 	info *terraform.InstanceInfo,

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -254,6 +254,15 @@ func (m schemaMap) Data(
 	}, nil
 }
 
+// ConfigData returns a ResourceData for the given config.
+func (m schemaMap) ConfigData(
+	c *terraform.ResourceConfig) (*ResourceData, error) {
+	return &ResourceData{
+		schema: m,
+		config: c,
+	}, nil
+}
+
 // Diff returns the diff for a resource given the schema map,
 // state, and configuration.
 func (m schemaMap) Diff(

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -66,6 +66,11 @@ type ResourceProvider interface {
 		*InstanceState,
 		*ResourceConfig) (*InstanceDiff, error)
 
+	// InitialState produces an initial state for a new resource instance
+	// using its configuration alone. It may return a nil *InstanceState
+	// if the state cannot be determined until its first Apply.
+	InitialState(*InstanceInfo, *ResourceConfig) (*InstanceState, error)
+
 	// Refresh refreshes a resource and updates all of its attributes
 	// with the latest information.
 	Refresh(*InstanceInfo, *InstanceState) (*InstanceState, error)

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -263,9 +263,25 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 		Ops: []walkOperation{walkRefresh},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
+				&EvalInterpolate{
+					Config:   n.Resource.RawConfig.Copy(),
+					Resource: resource,
+					Output:   &resourceConfig,
+				},
 				&EvalGetProvider{
 					Name:   n.ProvidedBy()[0],
 					Output: &provider,
+				},
+				&EvalSetInitialState{
+					Name:         n.stateId(),
+					Info:         info,
+					ResourceType: n.Resource.Type,
+					Config:       &resourceConfig,
+					Provider:     &provider,
+					ProviderName: n.Resource.Provider,
+					Dependencies: n.StateDependencies(),
+					State:        &state,
+					Output:       &state,
 				},
 				&EvalReadState{
 					Name:   n.stateId(),


### PR DESCRIPTION
This is a prototype of one possible solution to the issue discussed in #2976.

It adds a new mechanism to allow resource implementations to provide an "initial state", based entirely on what's in the configuration, that gets processed during ``terraform refresh`` when a new resource is encountered that doesn't yet exist in the state.

If a resource provides an initial state for an instance then the ``Refresh`` step is executed for that resource just as would've happened for a resource that already existed in the state.

This supports two different use-cases:
* It allows read-only and logical resources, like ``terraform_remote_state``, to be initialized immediately during an initial plan, so their data is available during the planning phase and can thus be used within provider configurations.
* It allows resources that have user-provided unique names, like ``aws_iam_user``, to recognize when a resource of the same name already exists and present an update diff rather than a create diff. This makes the diff more accurate and thus reduces surprises during ``apply``.

This is intended just as a prototype for discussion, not as a final solution. Consequently it doesn't yet have any tests.

I've included some subsequent commits that show how this new facility might be used in ``terraform_remote_state``, ``aws_s3_bucket`` and various IAM objects as examples.
