### PR TITLE
[WIP] provider/aws elb Add access logs setting (fixes #2315)

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -128,8 +128,8 @@ func resourceAwsElb() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enabled": &schema.Schema{
 							Type:     schema.TypeBool,
-							Required: true,
-							Default:  false,
+							Optional: true,
+							Default:  true,
 						},
 						"interval": &schema.Schema{
 							Type:     schema.TypeInt,
@@ -139,15 +139,14 @@ func resourceAwsElb() *schema.Resource {
 						"bucket": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
-							Default:  "",
 						},
 						"bucket_prefix": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "",
 						},
 					},
 				},
+				Set: resourceAwsElbAccessLogsHash,
 			},
 
 			"listener": &schema.Schema{
@@ -475,8 +474,12 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 				Enabled:      aws.Bool(log["enabled"].(bool)),
 				EmitInterval: aws.Int64(log["interval"].(int64)),
 				S3BucketName: aws.String(log["bucket"].(string)),
-				S3BucketPrefix: aws.String(log["bucket"].(string)),
 			}
+
+			if log["bucket_prefix"] != "" {
+				accessLogs.S3BucketPrefix = aws.String(log["bucket_prefix"].(string))
+			}
+
 			attrs.LoadBalancerAttributes.AccessLog = accessLogs
 		}
 
@@ -608,6 +611,20 @@ func resourceAwsElbHealthCheckHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["target"].(string)))
 	buf.WriteString(fmt.Sprintf("%d-", m["interval"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", m["timeout"].(int)))
+
+	return hashcode.String(buf.String())
+}
+
+func resourceAwsElbAccessLogsHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%t-", m["enabled"].(bool)))
+	buf.WriteString(fmt.Sprintf("%d-", m["interval"].(int)))
+	buf.WriteString(fmt.Sprintf("%s-",
+		strings.ToLower(m["bucket"].(string))))
+	if v, ok := m["bucket_prefix"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
+	}
 
 	return hashcode.String(buf.String())
 }

--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -121,6 +121,35 @@ func resourceAwsElb() *schema.Resource {
 				Default:  300,
 			},
 
+			"access_logs": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": &schema.Schema{
+							Type:     schema.TypeBool,
+							Required: true,
+							Default:  false,
+						},
+						"interval": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  60,
+						},
+						"bucket": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							Default:  "",
+						},
+						"bucket_prefix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+					},
+				},
+			},
+
 			"listener": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
@@ -325,6 +354,7 @@ func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("idle_timeout", lbAttrs.ConnectionSettings.IdleTimeout)
 	d.Set("connection_draining", lbAttrs.ConnectionDraining.Enabled)
 	d.Set("connection_draining_timeout", lbAttrs.ConnectionDraining.Timeout)
+	d.Set("access_logs", lbAttrs.AccessLog)
 
 	resp, err := elbconn.DescribeTags(&elb.DescribeTagsInput{
 		LoadBalancerNames: []*string{lb.LoadBalancerName},
@@ -425,7 +455,7 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.SetPartial("instances")
 	}
 
-	if d.HasChange("cross_zone_load_balancing") || d.HasChange("idle_timeout") {
+	if d.HasChange("cross_zone_load_balancing") || d.HasChange("idle_timeout") || d.HasChange("access_logs") {
 		attrs := elb.ModifyLoadBalancerAttributesInput{
 			LoadBalancerName: aws.String(d.Get("name").(string)),
 			LoadBalancerAttributes: &elb.LoadBalancerAttributes{
@@ -436,6 +466,18 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 					IdleTimeout: aws.Int64(int64(d.Get("idle_timeout").(int))),
 				},
 			},
+		}
+
+		logs := d.Get("access_logs").(*schema.Set).List()
+		if len(logs) > 0 {
+			log := logs[0].(map[string]interface{})
+			accessLogs := &elb.AccessLog{
+				Enabled:      aws.Bool(log["enabled"].(bool)),
+				EmitInterval: aws.Int64(log["interval"].(int64)),
+				S3BucketName: aws.String(log["bucket"].(string)),
+				S3BucketPrefix: aws.String(log["bucket"].(string)),
+			}
+			attrs.LoadBalancerAttributes.AccessLog = accessLogs
 		}
 
 		_, err := elbconn.ModifyLoadBalancerAttributes(&attrs)


### PR DESCRIPTION
This PR adds the ability to set the ELB access logs facility for AWS.
AWS documentation: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html