### PR TITLE
aws_db_parameter_group: Support more than 20 parameters in a single update

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -161,18 +161,29 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		if len(parameters) > 0 {
-			modifyOpts := rds.ModifyDBParameterGroupInput{
-				DBParameterGroupName: aws.String(d.Get("name").(string)),
-				Parameters:           parameters,
-			}
+			// We can only modify 20 parameters at a time, so walk them until
+			// we've got them all.
+			maxParams := 20
+			for parameters != nil {
+				paramsToModify := make([]*rds.Parameter, 0)
+				if len(parameters) <= maxParams {
+					paramsToModify, parameters = parameters[:], nil
+				} else {
+					paramsToModify, parameters = parameters[:maxParams], parameters[maxParams:]
+				}
+				modifyOpts := rds.ModifyDBParameterGroupInput{
+					DBParameterGroupName: aws.String(d.Get("name").(string)),
+					Parameters:           paramsToModify,
+				}
 
-			log.Printf("[DEBUG] Modify DB Parameter Group: %s", modifyOpts)
-			_, err = rdsconn.ModifyDBParameterGroup(&modifyOpts)
-			if err != nil {
-				return fmt.Errorf("Error modifying DB Parameter Group: %s", err)
+				log.Printf("[DEBUG] Modify DB Parameter Group: %s", modifyOpts)
+				_, err = rdsconn.ModifyDBParameterGroup(&modifyOpts)
+				if err != nil {
+					return fmt.Errorf("Error modifying DB Parameter Group: %s", err)
+				}
 			}
+			d.SetPartial("parameter")
 		}
-		d.SetPartial("parameter")
 	}
 
 	d.Partial(false)


### PR DESCRIPTION
You can't modify a parameter group with more than 20 parameters in a single request, but terraform doesn't know about that requirement. This commit teaches terraform to modify parameters in sets up to 20, until the total number of parameters is exhausted. This corrects a bug in terraform's behavior.

I'm going to be honest here: I tried adding a test with 30 params, and I couldn't actually get the db parameter group tests working properly. It's almost like the test framework broke on it, but I couldn't suss out why. I've confirmed this doesn't break any existing tests, and otherwise verified the functionality. Let me know if there's more you'd like.