### PR TITLE
Chef provider

### DIFF
--- a/builtin/bins/provider-chef/main.go
+++ b/builtin/bins/provider-chef/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/chef"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: chef.Provider,
+	})
+}

--- a/builtin/providers/chef/provider.go
+++ b/builtin/providers/chef/provider.go
@@ -46,7 +46,7 @@ func Provider() terraform.ResourceProvider {
 			//"chef_cookbook":      resourceChefCookbook(),
 			"chef_data_bag":      resourceChefDataBag(),
 			"chef_data_bag_item": resourceChefDataBagItem(),
-			//"chef_environment":   resourceChefEnvironment(),
+			"chef_environment":   resourceChefEnvironment(),
 			//"chef_node":          resourceChefNode(),
 			//"chef_role":          resourceChefRole(),
 		},

--- a/builtin/providers/chef/provider.go
+++ b/builtin/providers/chef/provider.go
@@ -1,6 +1,7 @@
 package chef
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"time"
@@ -44,7 +45,7 @@ func Provider() terraform.ResourceProvider {
 			//"chef_client":        resourceChefClient(),
 			//"chef_cookbook":      resourceChefCookbook(),
 			"chef_data_bag":      resourceChefDataBag(),
-			//"chef_data_bag_item": resourceChefDataBagItem(),
+			"chef_data_bag_item": resourceChefDataBagItem(),
 			//"chef_environment":   resourceChefEnvironment(),
 			//"chef_node":          resourceChefNode(),
 			//"chef_role":          resourceChefRole(),
@@ -76,4 +77,21 @@ func providerPrivateKeyEnvDefault() (interface{}, error) {
 	}
 
 	return nil, nil
+}
+
+func jsonStateFunc(value interface{}) string {
+	// Parse and re-stringify the JSON to make sure it's always kept
+	// in a normalized form.
+	in, ok := value.(string)
+	if !ok {
+		return "null"
+	}
+	var tmp map[string]interface{}
+
+	// Assuming the value must be valid JSON since it passed okay through
+	// our prepareDataBagItemContent function earlier.
+	json.Unmarshal([]byte(in), &tmp)
+
+	jsonValue, _ := json.Marshal(&tmp)
+	return string(jsonValue)
 }

--- a/builtin/providers/chef/provider.go
+++ b/builtin/providers/chef/provider.go
@@ -49,7 +49,7 @@ func Provider() terraform.ResourceProvider {
 			"chef_data_bag":      resourceChefDataBag(),
 			"chef_data_bag_item": resourceChefDataBagItem(),
 			"chef_environment":   resourceChefEnvironment(),
-			//"chef_node":          resourceChefNode(),
+			"chef_node":          resourceChefNode(),
 			"chef_role":          resourceChefRole(),
 		},
 

--- a/builtin/providers/chef/provider.go
+++ b/builtin/providers/chef/provider.go
@@ -43,7 +43,7 @@ func Provider() terraform.ResourceProvider {
 			//"chef_acl":           resourceChefAcl(),
 			//"chef_client":        resourceChefClient(),
 			//"chef_cookbook":      resourceChefCookbook(),
-			//"chef_data_bag":      resourceChefDataBag(),
+			"chef_data_bag":      resourceChefDataBag(),
 			//"chef_data_bag_item": resourceChefDataBagItem(),
 			//"chef_environment":   resourceChefEnvironment(),
 			//"chef_node":          resourceChefNode(),

--- a/builtin/providers/chef/provider_test.go
+++ b/builtin/providers/chef/provider_test.go
@@ -1,0 +1,62 @@
+package chef
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// To run these acceptance tests, you will need access to a Chef server.
+// An easy way to get one is to sign up for a hosted Chef server account
+// at https://manage.chef.io/signup , after which your base URL will
+// be something like https://api.opscode.com/organizations/example/ .
+// You will also need to create a "client" and write its private key to
+// a file somewhere.
+//
+// You can then set the following environment variables to make these
+// tests work:
+// CHEF_SERVER_URL to the base URL as described above.
+// CHEF_CLIENT_NAME to the name of the client object you created.
+// CHEF_PRIVATE_KEY_FILE to the path to the private key file you created.
+//
+// You will probably need to edit the global permissions on your Chef
+// Server account to allow this client (or all clients, if you're lazy)
+// to have both List and Create access on all types of object:
+//     https://manage.chef.io/organizations/saymedia/global_permissions
+//
+// With all of that done, you can run like this:
+//    make testacc TEST=./builtin/providers/chef
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"chef": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("CHEF_SERVER_URL"); v == "" {
+		t.Fatal("CHEF_SERVER_URL must be set for acceptance tests")
+	}
+	if v := os.Getenv("CHEF_CLIENT_NAME"); v == "" {
+		t.Fatal("CHEF_CLIENT_NAME must be set for acceptance tests")
+	}
+	if v := os.Getenv("CHEF_PRIVATE_KEY_FILE"); v == "" {
+		t.Fatal("CHEF_PRIVATE_KEY_FILE must be set for acceptance tests")
+	}
+}

--- a/builtin/providers/chef/resource_data_bag.go
+++ b/builtin/providers/chef/resource_data_bag.go
@@ -1,0 +1,77 @@
+package chef
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+
+	chefc "github.com/go-chef/chef"
+)
+
+func resourceChefDataBag() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDataBag,
+		Read:   ReadDataBag,
+		Delete: DeleteDataBag,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"api_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func CreateDataBag(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	dataBag := &chefc.DataBag{
+		Name: d.Get("name").(string),
+	}
+
+	result, err := client.DataBags.Create(dataBag)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(dataBag.Name)
+	d.Set("api_uri", result.URI)
+	return nil
+}
+
+func ReadDataBag(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	// The Chef API provides no API to read a data bag's metadata,
+	// but we can try to read its items and use that as a proxy for
+	// whether it still exists.
+
+	name := d.Id()
+
+	_, err := client.DataBags.ListItems(name)
+	if err != nil {
+		if errRes, ok := err.(*chefc.ErrorResponse); ok {
+			if errRes.Response.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+	}
+	return err
+}
+
+func DeleteDataBag(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	name := d.Id()
+
+	_, err := client.DataBags.Delete(name)
+	if err == nil {
+		d.SetId("")
+	}
+	return err
+}

--- a/builtin/providers/chef/resource_data_bag_item.go
+++ b/builtin/providers/chef/resource_data_bag_item.go
@@ -1,0 +1,120 @@
+package chef
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	chefc "github.com/go-chef/chef"
+)
+
+func resourceChefDataBagItem() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDataBagItem,
+		Read:   ReadDataBagItem,
+		Delete: DeleteDataBagItem,
+
+		Schema: map[string]*schema.Schema{
+			"data_bag_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"content_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: jsonStateFunc,
+			},
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func CreateDataBagItem(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	dataBagName := d.Get("data_bag_name").(string)
+	itemId, itemContent, err := prepareDataBagItemContent(d.Get("content_json").(string))
+	if err != nil {
+		return err
+	}
+
+	err = client.DataBags.CreateItem(dataBagName, itemContent)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(itemId)
+	d.Set("id", itemId)
+	return nil
+}
+
+func ReadDataBagItem(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	// The Chef API provides no API to read a data bag's metadata,
+	// but we can try to read its items and use that as a proxy for
+	// whether it still exists.
+
+	itemId := d.Id()
+	dataBagName := d.Get("data_bag_name").(string)
+
+	value, err := client.DataBags.GetItem(dataBagName, itemId)
+	if err != nil {
+		if errRes, ok := err.(*chefc.ErrorResponse); ok {
+			if errRes.Response.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		} else {
+			return err
+		}
+	}
+
+	jsonContent, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	d.Set("content_json", string(jsonContent))
+
+	return nil
+}
+
+func DeleteDataBagItem(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	itemId := d.Id()
+	dataBagName := d.Get("data_bag_name").(string)
+
+	err := client.DataBags.DeleteItem(dataBagName, itemId)
+	if err == nil {
+		d.SetId("")
+		d.Set("id", "")
+	}
+	return err
+}
+
+func prepareDataBagItemContent(contentJson string) (string, interface{}, error) {
+	var value map[string]interface{}
+	err := json.Unmarshal([]byte(contentJson), &value)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var itemId string
+	if itemIdI, ok := value["id"]; ok {
+		itemId, _ = itemIdI.(string)
+	}
+
+	if itemId == "" {
+		return "", nil, fmt.Errorf("content_json must have id attribute, set to a string")
+	}
+
+	return itemId, value, nil
+}

--- a/builtin/providers/chef/resource_data_bag_item_test.go
+++ b/builtin/providers/chef/resource_data_bag_item_test.go
@@ -1,0 +1,95 @@
+package chef
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	chefc "github.com/go-chef/chef"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataBagItem_basic(t *testing.T) {
+	var dataBagItemName string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDataBagItemCheckDestroy(dataBagItemName),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataBagItemConfig_basic,
+				Check: testAccDataBagItemCheck(
+					"chef_data_bag_item.test", &dataBagItemName,
+				),
+			},
+		},
+	})
+}
+
+func testAccDataBagItemCheck(rn string, name *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("data bag item id not set")
+		}
+
+		client := testAccProvider.Meta().(*chefc.Client)
+		content, err := client.DataBags.GetItem("terraform-acc-test-bag-item-basic", rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting data bag item: %s", err)
+		}
+
+		expectedContent := map[string]interface{}{
+			"id":             "terraform_acc_test",
+			"something_else": true,
+		}
+		if !reflect.DeepEqual(content, expectedContent) {
+			return fmt.Errorf("wrong content: expected %#v, got %#v", expectedContent, content)
+		}
+
+		if expected := "terraform_acc_test"; rs.Primary.Attributes["id"] != expected {
+			return fmt.Errorf("wrong id; expected %#v, got %#v", expected, rs.Primary.Attributes["id"])
+		}
+
+		*name = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func testAccDataBagItemCheckDestroy(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*chefc.Client)
+		_, err := client.DataBags.GetItem("terraform-acc-test-bag-item-basic", name)
+		if err == nil {
+			return fmt.Errorf("data bag item still exists")
+		}
+		if _, ok := err.(*chefc.ErrorResponse); err != nil && !ok {
+			return fmt.Errorf("got something other than an HTTP error (%v) when getting data bag item", err)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataBagItemConfig_basic = `
+resource "chef_data_bag" "test" {
+  name = "terraform-acc-test-bag-item-basic"
+}
+resource "chef_data_bag_item" "test" {
+  data_bag_name = "terraform-acc-test-bag-item-basic"
+  depends_on = ["chef_data_bag.test"]
+  content_json = <<EOT
+{
+    "id": "terraform_acc_test",
+    "something_else": true
+}
+EOT
+}
+`

--- a/builtin/providers/chef/resource_data_bag_test.go
+++ b/builtin/providers/chef/resource_data_bag_test.go
@@ -1,0 +1,70 @@
+package chef
+
+import (
+	"fmt"
+	"testing"
+
+	chefc "github.com/go-chef/chef"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataBag_basic(t *testing.T) {
+	var dataBagName string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDataBagCheckDestroy(dataBagName),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataBagConfig_basic,
+				Check: testAccDataBagCheckExists("chef_data_bag.test", &dataBagName),
+			},
+		},
+	})
+}
+
+func testAccDataBagCheckExists(rn string, name *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("data bag id not set")
+		}
+
+		client := testAccProvider.Meta().(*chefc.Client)
+		_, err := client.DataBags.ListItems(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting data bag: %s", err)
+		}
+
+		*name = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func testAccDataBagCheckDestroy(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*chefc.Client)
+		result, err := client.DataBags.ListItems(name)
+		if err == nil && len(*result) != 0 {
+			return fmt.Errorf("data bag still exists")
+		}
+		if _, ok := err.(*chefc.ErrorResponse); err != nil && !ok {
+			return fmt.Errorf("got something other than an HTTP error (%v) when getting data bag", err)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataBagConfig_basic = `
+resource "chef_data_bag" "test" {
+  name = "terraform-acc-test-basic"
+}
+`

--- a/builtin/providers/chef/resource_environment.go
+++ b/builtin/providers/chef/resource_environment.go
@@ -1,0 +1,183 @@
+package chef
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	chefc "github.com/go-chef/chef"
+)
+
+func resourceChefEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateEnvironment,
+		Update: UpdateEnvironment,
+		Read:   ReadEnvironment,
+		Delete: DeleteEnvironment,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+			"default_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"override_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"cookbook_constraints": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func CreateEnvironment(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	env, err := environmentFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Environments.Create(env)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(env.Name)
+	return ReadEnvironment(d, meta)
+}
+
+func UpdateEnvironment(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	env, err := environmentFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Environments.Put(env)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(env.Name)
+	return ReadEnvironment(d, meta)
+}
+
+func ReadEnvironment(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	name := d.Id()
+
+	env, err := client.Environments.Get(name)
+	if err != nil {
+		if errRes, ok := err.(*chefc.ErrorResponse); ok {
+			if errRes.Response.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		} else {
+			return err
+		}
+	}
+
+	d.Set("name", env.Name)
+	d.Set("description", env.Description)
+
+	defaultAttrJson, err := json.Marshal(env.DefaultAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("default_attributes_json", defaultAttrJson)
+
+	overrideAttrJson, err := json.Marshal(env.OverrideAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("override_attributes_json", overrideAttrJson)
+
+	cookbookVersionsI := map[string]interface{}{}
+	for k, v := range env.CookbookVersions {
+		cookbookVersionsI[k] = v
+	}
+	d.Set("cookbook_constraints", cookbookVersionsI)
+
+	return nil
+}
+
+func DeleteEnvironment(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	name := d.Id()
+
+	// For some reason Environments.Delete is not exposed by the
+	// underlying client library, so we have to do this manually.
+
+	path := fmt.Sprintf("environments/%s", name)
+
+	httpReq, err := client.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Do(httpReq, nil)
+	if err == nil {
+		d.SetId("")
+	}
+
+	return err
+}
+
+func environmentFromResourceData(d *schema.ResourceData) (*chefc.Environment, error) {
+
+	env := &chefc.Environment{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		ChefType:    "environment",
+	}
+
+	var err error
+
+	err = json.Unmarshal(
+		[]byte(d.Get("default_attributes_json").(string)),
+		&env.DefaultAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("default_attributes_json: %s", err)
+	}
+
+	err = json.Unmarshal(
+		[]byte(d.Get("override_attributes_json").(string)),
+		&env.OverrideAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("override_attributes_json: %s", err)
+	}
+
+	env.CookbookVersions = make(map[string]string)
+	for k, vI := range d.Get("cookbook_constraints").(map[string]interface{}) {
+		env.CookbookVersions[k] = vI.(string)
+	}
+
+	return env, nil
+}

--- a/builtin/providers/chef/resource_environment_test.go
+++ b/builtin/providers/chef/resource_environment_test.go
@@ -1,0 +1,120 @@
+package chef
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	chefc "github.com/go-chef/chef"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccEnvironment_basic(t *testing.T) {
+	var env chefc.Environment
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccEnvironmentCheckDestroy(&env),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccEnvironmentConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccEnvironmentCheckExists("chef_environment.test", &env),
+					func(s *terraform.State) error {
+
+						if expected := "terraform-acc-test-basic"; env.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, env.Name)
+						}
+						if expected := "Terraform Acceptance Tests"; env.Description != expected {
+							return fmt.Errorf("wrong description; expected %v, got %v", expected, env.Description)
+						}
+
+						expectedConstraints := map[string]string{
+							"terraform": "= 1.0.0",
+						}
+						if !reflect.DeepEqual(env.CookbookVersions, expectedConstraints) {
+							return fmt.Errorf("wrong cookbook constraints; expected %#v, got %#v", expectedConstraints, env.CookbookVersions)
+						}
+
+						var expectedAttributes interface{}
+						expectedAttributes = map[string]interface{}{
+							"terraform_acc_test": true,
+						}
+						if !reflect.DeepEqual(env.DefaultAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong default attributes; expected %#v, got %#v", expectedAttributes, env.DefaultAttributes)
+						}
+						if !reflect.DeepEqual(env.OverrideAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong override attributes; expected %#v, got %#v", expectedAttributes, env.OverrideAttributes)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccEnvironmentCheckExists(rn string, env *chefc.Environment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("environment id not set")
+		}
+
+		client := testAccProvider.Meta().(*chefc.Client)
+		gotEnv, err := client.Environments.Get(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting environment: %s", err)
+		}
+
+		*env = *gotEnv
+
+		return nil
+	}
+}
+
+func testAccEnvironmentCheckDestroy(env *chefc.Environment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*chefc.Client)
+		_, err := client.Environments.Get(env.Name)
+		if err == nil {
+			return fmt.Errorf("environment still exists")
+		}
+		if _, ok := err.(*chefc.ErrorResponse); !ok {
+			// A more specific check is tricky because Chef Server can return
+			// a few different error codes in this case depending on which
+			// part of its stack catches the error.
+			return fmt.Errorf("got something other than an HTTP error (%v) when getting environment", err)
+		}
+
+		return nil
+	}
+}
+
+const testAccEnvironmentConfig_basic = `
+resource "chef_environment" "test" {
+  name = "terraform-acc-test-basic"
+  description = "Terraform Acceptance Tests"
+  default_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  override_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  cookbook_constraints = {
+    "terraform" = "= 1.0.0"
+  }
+}
+`

--- a/builtin/providers/chef/resource_node.go
+++ b/builtin/providers/chef/resource_node.go
@@ -1,0 +1,216 @@
+package chef
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	chefc "github.com/go-chef/chef"
+)
+
+func resourceChefNode() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateNode,
+		Update: UpdateNode,
+		Read:   ReadNode,
+		Delete: DeleteNode,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"environment_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "_default",
+			},
+			"automatic_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"normal_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"default_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"override_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"run_list": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:      schema.TypeString,
+					StateFunc: runListEntryStateFunc,
+				},
+			},
+		},
+	}
+}
+
+func CreateNode(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	node, err := nodeFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Nodes.Post(*node)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(node.Name)
+	return ReadNode(d, meta)
+}
+
+func UpdateNode(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	node, err := nodeFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Nodes.Put(*node)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(node.Name)
+	return ReadNode(d, meta)
+}
+
+func ReadNode(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	name := d.Id()
+
+	node, err := client.Nodes.Get(name)
+	if err != nil {
+		if errRes, ok := err.(*chefc.ErrorResponse); ok {
+			if errRes.Response.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		} else {
+			return err
+		}
+	}
+
+	d.Set("name", node.Name)
+	d.Set("environment_name", node.Environment)
+
+	automaticAttrJson, err := json.Marshal(node.AutomaticAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("automatic_attributes_json", automaticAttrJson)
+
+	normalAttrJson, err := json.Marshal(node.NormalAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("normal_attributes_json", normalAttrJson)
+
+	defaultAttrJson, err := json.Marshal(node.DefaultAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("default_attributes_json", defaultAttrJson)
+
+	overrideAttrJson, err := json.Marshal(node.OverrideAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("override_attributes_json", overrideAttrJson)
+
+	runListI := make([]interface{}, len(node.RunList))
+	for i, v := range node.RunList {
+		runListI[i] = v
+	}
+	d.Set("run_list", runListI)
+
+	return nil
+}
+
+func DeleteNode(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	name := d.Id()
+	err := client.Nodes.Delete(name)
+
+	if err == nil {
+		d.SetId("")
+	}
+
+	return err
+}
+
+func nodeFromResourceData(d *schema.ResourceData) (*chefc.Node, error) {
+
+	node := &chefc.Node{
+		Name:        d.Get("name").(string),
+		Environment: d.Get("environment_name").(string),
+		ChefType:    "node",
+		JsonClass:   "Chef::Node",
+	}
+
+	var err error
+
+	err = json.Unmarshal(
+		[]byte(d.Get("automatic_attributes_json").(string)),
+		&node.AutomaticAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("automatic_attributes_json: %s", err)
+	}
+
+	err = json.Unmarshal(
+		[]byte(d.Get("normal_attributes_json").(string)),
+		&node.NormalAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("normal_attributes_json: %s", err)
+	}
+
+	err = json.Unmarshal(
+		[]byte(d.Get("default_attributes_json").(string)),
+		&node.DefaultAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("default_attributes_json: %s", err)
+	}
+
+	err = json.Unmarshal(
+		[]byte(d.Get("override_attributes_json").(string)),
+		&node.OverrideAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("override_attributes_json: %s", err)
+	}
+
+	runListI := d.Get("run_list").([]interface{})
+	node.RunList = make([]string, len(runListI))
+	for i, vI := range runListI {
+		node.RunList[i] = vI.(string)
+	}
+
+	return node, nil
+}

--- a/builtin/providers/chef/resource_node_test.go
+++ b/builtin/providers/chef/resource_node_test.go
@@ -1,0 +1,139 @@
+package chef
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	chefc "github.com/go-chef/chef"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNode_basic(t *testing.T) {
+	var node chefc.Node
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccNodeCheckDestroy(&node),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNodeConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNodeCheckExists("chef_node.test", &node),
+					func(s *terraform.State) error {
+
+						if expected := "terraform-acc-test-basic"; node.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, node.Name)
+						}
+						if expected := "terraform-acc-test-node-basic"; node.Environment != expected {
+							return fmt.Errorf("wrong environment; expected %v, got %v", expected, node.Environment)
+						}
+
+						expectedRunList := []string{
+							"recipe[terraform@1.0.0]",
+							"recipe[consul]",
+							"role[foo]",
+						}
+						if !reflect.DeepEqual(node.RunList, expectedRunList) {
+							return fmt.Errorf("wrong runlist; expected %#v, got %#v", expectedRunList, node.RunList)
+						}
+
+						var expectedAttributes interface{}
+						expectedAttributes = map[string]interface{}{
+							"terraform_acc_test": true,
+						}
+						if !reflect.DeepEqual(node.AutomaticAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong automatic attributes; expected %#v, got %#v", expectedAttributes, node.AutomaticAttributes)
+						}
+						if !reflect.DeepEqual(node.NormalAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong normal attributes; expected %#v, got %#v", expectedAttributes, node.NormalAttributes)
+						}
+						if !reflect.DeepEqual(node.DefaultAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong default attributes; expected %#v, got %#v", expectedAttributes, node.DefaultAttributes)
+						}
+						if !reflect.DeepEqual(node.OverrideAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong override attributes; expected %#v, got %#v", expectedAttributes, node.OverrideAttributes)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccNodeCheckExists(rn string, node *chefc.Node) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("node id not set")
+		}
+
+		client := testAccProvider.Meta().(*chefc.Client)
+		gotNode, err := client.Nodes.Get(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting node: %s", err)
+		}
+
+		*node = gotNode
+
+		return nil
+	}
+}
+
+func testAccNodeCheckDestroy(node *chefc.Node) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*chefc.Client)
+		_, err := client.Nodes.Get(node.Name)
+		if err == nil {
+			return fmt.Errorf("node still exists")
+		}
+		if _, ok := err.(*chefc.ErrorResponse); !ok {
+			// A more specific check is tricky because Chef Server can return
+			// a few different error codes in this case depending on which
+			// part of its stack catches the error.
+			return fmt.Errorf("got something other than an HTTP error (%v) when getting node", err)
+		}
+
+		return nil
+	}
+}
+
+const testAccNodeConfig_basic = `
+resource "chef_environment" "test" {
+  name = "terraform-acc-test-node-basic"
+}
+resource "chef_node" "test" {
+  name = "terraform-acc-test-basic"
+  environment_name = "terraform-acc-test-node-basic"
+  automatic_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  normal_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  default_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  override_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  run_list = ["terraform@1.0.0", "recipe[consul]", "role[foo]"]
+}
+`

--- a/builtin/providers/chef/resource_role.go
+++ b/builtin/providers/chef/resource_role.go
@@ -1,0 +1,185 @@
+package chef
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	chefc "github.com/go-chef/chef"
+)
+
+func resourceChefRole() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateRole,
+		Update: UpdateRole,
+		Read:   ReadRole,
+		Delete: DeleteRole,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+			"default_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"override_attributes_json": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "{}",
+				StateFunc: jsonStateFunc,
+			},
+			"run_list": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:      schema.TypeString,
+					StateFunc: runListEntryStateFunc,
+				},
+			},
+		},
+	}
+}
+
+func CreateRole(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	role, err := roleFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Roles.Create(role)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(role.Name)
+	return ReadRole(d, meta)
+}
+
+func UpdateRole(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	role, err := roleFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Roles.Put(role)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(role.Name)
+	return ReadRole(d, meta)
+}
+
+func ReadRole(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	name := d.Id()
+
+	role, err := client.Roles.Get(name)
+	if err != nil {
+		if errRes, ok := err.(*chefc.ErrorResponse); ok {
+			if errRes.Response.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		} else {
+			return err
+		}
+	}
+
+	d.Set("name", role.Name)
+	d.Set("description", role.Description)
+
+	defaultAttrJson, err := json.Marshal(role.DefaultAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("default_attributes_json", defaultAttrJson)
+
+	overrideAttrJson, err := json.Marshal(role.OverrideAttributes)
+	if err != nil {
+		return err
+	}
+	d.Set("override_attributes_json", overrideAttrJson)
+
+	runListI := make([]interface{}, len(role.RunList))
+	for i, v := range role.RunList {
+		runListI[i] = v
+	}
+	d.Set("run_list", runListI)
+
+	return nil
+}
+
+func DeleteRole(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*chefc.Client)
+
+	name := d.Id()
+
+	// For some reason Roles.Delete is not exposed by the
+	// underlying client library, so we have to do this manually.
+
+	path := fmt.Sprintf("roles/%s", name)
+
+	httpReq, err := client.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Do(httpReq, nil)
+	if err == nil {
+		d.SetId("")
+	}
+
+	return err
+}
+
+func roleFromResourceData(d *schema.ResourceData) (*chefc.Role, error) {
+
+	role := &chefc.Role{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		ChefType:    "role",
+	}
+
+	var err error
+
+	err = json.Unmarshal(
+		[]byte(d.Get("default_attributes_json").(string)),
+		&role.DefaultAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("default_attributes_json: %s", err)
+	}
+
+	err = json.Unmarshal(
+		[]byte(d.Get("override_attributes_json").(string)),
+		&role.OverrideAttributes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("override_attributes_json: %s", err)
+	}
+
+	runListI := d.Get("run_list").([]interface{})
+	role.RunList = make([]string, len(runListI))
+	for i, vI := range runListI {
+		role.RunList[i] = vI.(string)
+	}
+
+	return role, nil
+}

--- a/builtin/providers/chef/resource_role_test.go
+++ b/builtin/providers/chef/resource_role_test.go
@@ -1,0 +1,120 @@
+package chef
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	chefc "github.com/go-chef/chef"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccRole_basic(t *testing.T) {
+	var role chefc.Role
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccRoleCheckDestroy(&role),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoleConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccRoleCheckExists("chef_role.test", &role),
+					func(s *terraform.State) error {
+
+						if expected := "terraform-acc-test-basic"; role.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, role.Name)
+						}
+						if expected := "Terraform Acceptance Tests"; role.Description != expected {
+							return fmt.Errorf("wrong description; expected %v, got %v", expected, role.Description)
+						}
+
+						expectedRunList := chefc.RunList{
+							"recipe[terraform@1.0.0]",
+							"recipe[consul]",
+							"role[foo]",
+						}
+						if !reflect.DeepEqual(role.RunList, expectedRunList) {
+							return fmt.Errorf("wrong runlist; expected %#v, got %#v", expectedRunList, role.RunList)
+						}
+
+						var expectedAttributes interface{}
+						expectedAttributes = map[string]interface{}{
+							"terraform_acc_test": true,
+						}
+						if !reflect.DeepEqual(role.DefaultAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong default attributes; expected %#v, got %#v", expectedAttributes, role.DefaultAttributes)
+						}
+						if !reflect.DeepEqual(role.OverrideAttributes, expectedAttributes) {
+							return fmt.Errorf("wrong override attributes; expected %#v, got %#v", expectedAttributes, role.OverrideAttributes)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccRoleCheckExists(rn string, role *chefc.Role) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("role id not set")
+		}
+
+		client := testAccProvider.Meta().(*chefc.Client)
+		gotRole, err := client.Roles.Get(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting role: %s", err)
+		}
+
+		*role = *gotRole
+
+		return nil
+	}
+}
+
+func testAccRoleCheckDestroy(role *chefc.Role) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*chefc.Client)
+		_, err := client.Roles.Get(role.Name)
+		if err == nil {
+			return fmt.Errorf("role still exists")
+		}
+		if _, ok := err.(*chefc.ErrorResponse); !ok {
+			// A more specific check is tricky because Chef Server can return
+			// a few different error codes in this case depending on which
+			// part of its stack catches the error.
+			return fmt.Errorf("got something other than an HTTP error (%v) when getting role", err)
+		}
+
+		return nil
+	}
+}
+
+const testAccRoleConfig_basic = `
+resource "chef_role" "test" {
+  name = "terraform-acc-test-basic"
+  description = "Terraform Acceptance Tests"
+  default_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  override_attributes_json = <<EOT
+{
+     "terraform_acc_test": true
+}
+EOT
+  run_list = ["terraform@1.0.0", "recipe[consul]", "role[foo]"]
+}
+`

--- a/website/source/assets/stylesheets/_docs.scss
+++ b/website/source/assets/stylesheets/_docs.scss
@@ -9,6 +9,7 @@ body.page-sub{
 body.layout-atlas,
 body.layout-aws,
 body.layout-azure,
+body.layout-chef,
 body.layout-cloudflare,
 body.layout-cloudstack,
 body.layout-consul,

--- a/website/source/docs/providers/chef/index.html.markdown
+++ b/website/source/docs/providers/chef/index.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "chef"
+page_title: "Provider: Chef"
+sidebar_current: "docs-chef-index"
+description: |-
+  Chef is a systems and cloud infrastructure automation framework.
+---
+
+# Chef Provider
+
+[Chef](https://www.chef.io/) is a systems and cloud infrastructure automation
+framework. The Chef provider allows Terraform to manage various resources
+that exist within [Chef Server](http://docs.chef.io/chef_server.html).
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```
+# Configure the Chef provider
+provider "chef" {
+     "server_url" = "https://api.opscode.com/organizations/example/"
+
+     // You can set up a "Client" within the Chef Server management console.
+     "client_name" = "terraform"
+     "private_key_pem" = "${file(\"chef-terraform.pem\")}"
+}
+
+# Create a Chef Environment
+resource "chef_environment" "production" {
+    name = "production"
+}
+
+# Create a Chef Role
+resource "chef_role" "app_server" {
+    name = "app_server"
+    run_list = [
+        "recipe[terraform]"
+    ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `server_url` - (Required) The HTTP(S) API URL of the Chef server to use. If
+  the target Chef server supports organizations, use the full URL of the
+  organization you wish to configure. May be provided instead via the
+  ``CHEF_SERVER_URL`` environment variable.
+* `client_name` - (Required) The name of the client account to use when making
+  requests. This must have been already configured on the Chef server.
+  May be provided instead via the ``CHEF_CLIENT_NAME`` environment variable.
+* `private_key_pem` - (Required) The PEM-formatted private key belonging to
+  the configured client. This is issued by the server when a new client object
+  is created. May be provided instead in a file whose path is in the
+  ``CHEF_PRIVATE_KEY_FILE`` environment variable.
+* `allow_unverified_ssl` - (Optional) Boolean indicating whether to make
+  requests to a Chef server whose SSL certicate cannot be verified. Defaults
+  to ``false``.

--- a/website/source/docs/providers/chef/r/data_bag.html.markdown
+++ b/website/source/docs/providers/chef/r/data_bag.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "chef"
+page_title: "Chef: chef_data_bag"
+sidebar_current: "docs-chef-resource-data-bag"
+description: |-
+  Creates and manages a data bag in Chef Server.
+---
+
+# chef\_data\_bag
+
+A [data bag](http://docs.chef.io/data_bags.html) is a collection of
+configuration objects that are stored as JSON in Chef Server and can be
+retrieved and used in Chef recipes.
+
+This resource creates the data bag itself. Inside each data bag is a collection
+of items which can be created using the ``chef_data_bag_item`` resource.
+
+## Example Usage
+
+```
+resource "chef_data_bag" "example" {
+    name = "example-data-bag"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The unique name to assign to the data bag. This is the
+  name that other server clients will use to find and retrieve data from the
+  data bag.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `api_url` - The URL representing this data bag in the Chef server API.

--- a/website/source/docs/providers/chef/r/data_bag_item.html.markdown
+++ b/website/source/docs/providers/chef/r/data_bag_item.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "chef"
+page_title: "Chef: chef_data_bag_item"
+sidebar_current: "docs-chef-resource-data-bag-item"
+description: |-
+  Creates and manages an object within a data bag in Chef Server.
+---
+
+# chef\_data\_bag\_item
+
+A [data bag](http://docs.chef.io/data_bags.html) is a collection of
+configuration objects that are stored as JSON in Chef Server and can be
+retrieved and used in Chef recipes.
+
+This resource creates objects within an existing data bag. To create the
+data bag itself, use the ``chef_data_bag`` resource.
+
+## Example Usage
+
+```
+resource "chef_data_bag_item" "example" {
+    data_bag_name = "example-data-bag"
+    content_json = <<EOT
+{
+    "id": "example-item",
+    "any_arbitrary_data": true
+}
+EOT
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `data_bag_name` - (Required) The name of the data bag into which this item
+  will be placed.
+* `content_json` - (Required) A string containing a JSON object that will be
+  the content of the item. Must at minimum contain a property called "id"
+  that is unique within the data bag, which will become the identifier of
+  the created item.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The value of the "id" property in the ``content_json`` JSON object,
+  which can be used by clients to retrieve this item's content.

--- a/website/source/docs/providers/chef/r/environment.html.markdown
+++ b/website/source/docs/providers/chef/r/environment.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "chef"
+page_title: "Chef: chef_environment"
+sidebar_current: "docs-chef-resource-environment"
+description: |-
+  Creates and manages an environment in Chef Server.
+---
+
+# chef\_environment
+
+An [environment](http://docs.chef.io/environments.html) is a container for
+Chef nodes that share a set of attribute values and may have a set of version
+constraints for which cookbook versions may be used on its nodes.
+
+## Example Usage
+
+```
+resource "chef_environment" "example" {
+    name = "example-environment"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The unique name to assign to the environment. This name
+  will be used when nodes are created within the environment.
+* `description` - (Optional) A human-friendly description of the environment.
+  If not set, a placeholder of "Managed by Terraform" will be set.
+* `default_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the default attributes for the environment.
+* `override_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the override attributes for the environment.
+* `cookbook_constraints` - (Optional) Mapping of cookbook names to cookbook
+  version constraints that should apply for this environment.
+
+## Attributes Reference
+
+This resource exports no further attributes.

--- a/website/source/docs/providers/chef/r/node.html.markdown
+++ b/website/source/docs/providers/chef/r/node.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "chef"
+page_title: "Chef: chef_node"
+sidebar_current: "docs-chef-resource-node"
+description: |-
+  Creates and manages a node in Chef Server.
+---
+
+# chef\_node
+
+A [node](http://docs.chef.io/nodes.html) is a computer whose
+configuration is managed by Chef.
+
+Although this resource allows a node to be registered, it does not actually
+configure the computer in question to interact with Chef. In most cases it
+is better to use [the `chef` provisioner](/docs/provisioners/chef.html) to
+configure the Chef client on a computer and have it register itself with the
+Chef server.
+
+## Example Usage
+
+```
+resource "chef_node" "example" {
+    name = "example-environment"
+    environment_name = "${chef_environment.example.name}"
+    run_list = ["recipe[example]", "role[app_server]"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The unique name to assign to the node.
+* `automatic_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the automatic attributes for the node.
+* `normal_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the normal attributes for the node.
+* `default_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the default attributes for the node.
+* `override_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the override attributes for the node.
+* `run_list` - (Optional) List of strings to set as the
+  [run list](https://docs.chef.io/run_lists.html) for the node.
+
+## Attributes Reference
+
+This resource exports no further attributes.

--- a/website/source/docs/providers/chef/r/role.html.markdown
+++ b/website/source/docs/providers/chef/r/role.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "chef"
+page_title: "Chef: chef_role"
+sidebar_current: "docs-chef-resource-role"
+description: |-
+  Creates and manages a role in Chef Server.
+---
+
+# chef\_role
+
+A [role](http://docs.chef.io/roles.html) is a set of standard configuration
+that can apply across multiple nodes that perform the same function.
+
+## Example Usage
+
+```
+resource "chef_role" "example" {
+    name = "example-role"
+    run_list = ["recipe[example]"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The unique name to assign to the role.
+* `description` - (Optional) A human-friendly description of the role.
+  If not set, a placeholder of "Managed by Terraform" will be set.
+* `default_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the default attributes for the role.
+* `override_attributes_json` - (Optional) String containing a JSON-serialized
+  object containing the override attributes for the role.
+* `run_list` - (Optional) List of strings to set as the
+  [run list](https://docs.chef.io/run_lists.html) for any nodes that belong
+  to this role.
+
+## Attributes Reference
+
+This resource exports no further attributes.

--- a/website/source/layouts/chef.erb
+++ b/website/source/layouts/chef.erb
@@ -1,0 +1,38 @@
+<% wrap_layout :inner do %>
+	<% content_for :sidebar do %>
+		<div class="docs-sidebar hidden-print affix-top" role="complementary">
+			<ul class="nav docs-sidenav">
+				<li<%= sidebar_current("docs-home") %>>
+				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
+                </li>
+
+				<li<%= sidebar_current("docs-chef-index") %>>
+				<a href="/docs/providers/consul/index.html">Chef Provider</a>
+                </li>
+
+				<li<%= sidebar_current(/^docs-chef-resource/) %>>
+				<a href="#">Resources</a>
+                <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-chef-resource-data-bag") %>>
+					<a href="/docs/providers/chef/r/data_bag.html">chef_data_bag</a>
+					</li>
+                    <li<%= sidebar_current("docs-chef-resource-data-bag-item") %>>
+					<a href="/docs/providers/chef/r/data_bag_item.html">chef_data_bag_item</a>
+					</li>
+                    <li<%= sidebar_current("docs-chef-resource-environment") %>>
+					<a href="/docs/providers/chef/r/environment.html">chef_environment</a>
+					</li>
+                    <li<%= sidebar_current("docs-chef-resource-node") %>>
+					<a href="/docs/providers/chef/r/node.html">chef_node</a>
+					</li>
+                    <li<%= sidebar_current("docs-chef-resource-role") %>>
+					<a href="/docs/providers/chef/r/role.html">chef_role</a>
+					</li>
+				</ul>
+				</li>
+			</ul>
+		</div>
+	<% end %>
+
+	<%= yield %>
+	<% end %>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -133,6 +133,10 @@
 					<a href="/docs/providers/azure/index.html">Azure</a>
 					</li>
 
+					<li<%= sidebar_current("docs-providers-chef") %>>
+					<a href="/docs/providers/chef/index.html">Chef</a>
+					</li>
+
 					<li<%= sidebar_current("docs-providers-cloudflare") %>>
 					<a href="/docs/providers/cloudflare/index.html">CloudFlare</a>
 					</li>


### PR DESCRIPTION
Allows Terraform to create and manage resources on a Chef server.

* [x] Data Bag
* [x] Data Bag Item
* [x] Environment
* [x] Node
* [x] Role
* ~~Client~~ (hard to set things up so that a client has access to create another client, so skipping this for now)
* ~~Cookbook~~ (not supported by the underlying client library yet, and more complex than the others anyway so better tackled as a separate change)

...and then of course:
* [x] Acceptance Tests
* [x] Documentation
