### PR TITLE
Fixed Access_Token difference between code and docs

### DIFF
--- a/website/source/docs/commands/remote-config.html.markdown
+++ b/website/source/docs/commands/remote-config.html.markdown
@@ -46,7 +46,7 @@ The following backends are supported:
   variables. The `address` variable can optionally be provided.
 
 * Consul - Stores the state in the KV store at a given path.
-  Requires the `path` variable. The `address` and `access-token`
+  Requires the `path` variable. The `address` and `access_token`
   variables can optionally be provided. Address is assumed to be the
   local agent if not provided.
 


### PR DESCRIPTION
The documentation has the Consul variable for ACLs as **access-token**. The code has it as **access_token**. I've fixed the docs since it has less issues than changing the CLI interface.