### PR TITLE
aws_elasticache_subnet_group normalizes name to lowercase.

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,6 +30,12 @@ func resourceAwsElasticacheSubnetGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					// Elasticache normalizes subnet names to lowercase,
+					// so we have to do this too or else we can end up
+					// with non-converging diffs.
+					return strings.ToLower(val.(string))
+				},
 			},
 			"subnet_ids": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -66,7 +73,10 @@ func resourceAwsElasticacheSubnetGroupCreate(d *schema.ResourceData, meta interf
 	}
 
 	// Assign the group name as the resource ID
-	d.SetId(name)
+	// Elasticache always retains the name in lower case, so we have to
+	// mimic that or else we won't be able to refresh a resource whose
+	// name contained uppercase characters.
+	d.SetId(strings.ToLower(name))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
@@ -150,7 +150,10 @@ resource "aws_subnet" "foo" {
 }
 
 resource "aws_elasticache_subnet_group" "bar" {
-    name = "tf-test-cache-subnet-%03d"
+    // Including uppercase letters in this name to ensure
+    // that we correctly handle the fact that the API
+    // normalizes names to lowercase.
+    name = "tf-TEST-cache-subnet-%03d"
     description = "tf-test-cache-subnet-group-descr"
     subnet_ids = ["${aws_subnet.foo.id}"]
 }

--- a/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
@@ -45,8 +45,8 @@ resource "aws_elasticache_subnet_group" "bar" {
 The following arguments are supported:
 
 * `description` – (Required) Description for the cache subnet group
-* `name` – (Required) Name for the cache subnet group. This value is stored as 
-a lowercase string
+* `name` – (Required) Name for the cache subnet group. Elasticache converts
+  this name to lowercase.
 * `subnet_ids` – (Required) List of VPC Subnet IDs for the cache subnet group
 
 ## Attributes Reference


### PR DESCRIPTION
This addresses the broken refresh behavior discussed in #2178.

The Elasticache API accepts a mixed-case subnet group name on create, but normalizes it to lowercase before storing it. When retrieving a subnet group, the name is treated as case-sensitive, so the lowercase version must be used.

Given that the case within subnet group names is not significant, the new ``StateFunc`` on the ``name`` attribute causes the state to reflect the lowercase version that the API uses, and changes in case alone will not show as a diff.

Given that we must look up subnet group names as lowercase, we set the instance id to be a lowercase version of the user's provided name. This then allows a later ``Refresh`` call to succeed even if the user provided a mixed-case name in the config.

Previously users could work around this by just avoiding putting uppercase letters in the name, but that is often inconvenient if e.g. the name is being constructed from variables defined elsewhere that may already have uppercase letters present.
