### PR TITLE
aws_iam_policy_document logical resource

### DIFF
--- a/builtin/providers/aws/iam_policy_model.go
+++ b/builtin/providers/aws/iam_policy_model.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"encoding/json"
+)
+
+type IAMPolicyDoc struct {
+	Id         string                `json:",omitempty"`
+	Version    string                `json:",omitempty"`
+	Statements []*IAMPolicyStatement `json:"Statement"`
+}
+
+type IAMPolicyStatement struct {
+	Sid           string                         `json:",omitempty"`
+	Effect        string                         `json:",omitempty"`
+	Actions       []string                       `json:"Action,omitempty"`
+	NotActions    []string                       `json:"NotAction,omitempty"`
+	Resources     []string                       `json:"Resource,omitempty"`
+	NotResources  []string                       `json:"NotResource,omitempty"`
+	Principals    IAMPolicyStatementPrincipalSet `json:"Principal,omitempty"`
+	NotPrincipals IAMPolicyStatementPrincipalSet `json:"NotPrincipal,omitempty"`
+	Conditions    IAMPolicyStatementConditionSet `json:"Condition,omitempty"`
+}
+
+type IAMPolicyStatementPrincipal struct {
+	Type        string
+	Identifiers []string
+}
+
+type IAMPolicyStatementCondition struct {
+	Test     string
+	Variable string
+	Values   []string
+}
+
+type IAMPolicyStatementPrincipalSet []IAMPolicyStatementPrincipal
+type IAMPolicyStatementConditionSet []IAMPolicyStatementCondition
+
+func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
+	raw := map[string][]string{}
+
+	for _, p := range ps {
+		if _, ok := raw[p.Type]; !ok {
+			raw[p.Type] = make([]string, 0, len(p.Identifiers))
+		}
+		raw[p.Type] = append(raw[p.Type], p.Identifiers...)
+	}
+
+	return json.Marshal(&raw)
+}
+
+func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
+	raw := map[string]map[string][]string{}
+
+	for _, c := range cs {
+		if _, ok := raw[c.Test]; !ok {
+			raw[c.Test] = map[string][]string{}
+		}
+		if _, ok := raw[c.Test][c.Variable]; !ok {
+			raw[c.Test][c.Variable] = make([]string, 0, len(c.Values))
+		}
+		raw[c.Test][c.Variable] = append(raw[c.Test][c.Variable], c.Values...)
+	}
+
+	return json.Marshal(&raw)
+}
+
+func iamPolicyDecodeConfigStringList(lI []interface{}) []string {
+	ret := make([]string, len(lI))
+	for i, vI := range lI {
+		ret[i] = vI.(string)
+	}
+	return ret
+}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -176,6 +176,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_instance_profile":                     resourceAwsIamInstanceProfile(),
 			"aws_iam_policy":                               resourceAwsIamPolicy(),
 			"aws_iam_policy_attachment":                    resourceAwsIamPolicyAttachment(),
+			"aws_iam_policy_document":                      resourceAwsIamPolicyDocument(),
 			"aws_iam_role_policy":                          resourceAwsIamRolePolicy(),
 			"aws_iam_role":                                 resourceAwsIamRole(),
 			"aws_iam_saml_provider":                        resourceAwsIamSamlProvider(),

--- a/builtin/providers/aws/resource_aws_iam_policy_document.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_document.go
@@ -1,0 +1,225 @@
+package aws
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+var resourceAwsIamPolicyDocumentVarReplacer = strings.NewReplacer("&{", "${")
+
+func resourceAwsIamPolicyDocument() *schema.Resource {
+	setOfString := &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+
+	return &schema.Resource{
+		Create: resourceAwsIamPolicyDocumentUpdate,
+		Read:   resourceAwsIamPolicyDocumentNoop,
+		Update: resourceAwsIamPolicyDocumentUpdate,
+		Delete: resourceAwsIamPolicyDocumentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"statement": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"effect": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Allow",
+						},
+						"actions":        setOfString,
+						"not_actions":    setOfString,
+						"resources":      setOfString,
+						"not_resources":  setOfString,
+						"principals":     resourceAwsIamPolicyPrincipalSchema(),
+						"not_principals": resourceAwsIamPolicyPrincipalSchema(),
+						"condition": &schema.Schema{
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"test": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"variable": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": &schema.Schema{
+										Type:     schema.TypeSet,
+										Required: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"json": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsIamPolicyDocumentUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	doc := &IAMPolicyDoc{
+		Version: "2012-10-17",
+	}
+
+	id := d.Get("id").(string)
+	if id != "" {
+		doc.Id = id
+	}
+
+	var cfgStmts = d.Get("statement").(*schema.Set).List()
+	stmts := make([]*IAMPolicyStatement, len(cfgStmts))
+	doc.Statements = stmts
+	for i, stmtI := range cfgStmts {
+		cfgStmt := stmtI.(map[string]interface{})
+		stmt := &IAMPolicyStatement{
+			Effect: cfgStmt["effect"].(string),
+		}
+
+		if actions := cfgStmt["actions"].(*schema.Set).List(); len(actions) > 0 {
+			stmt.Actions = iamPolicyDecodeConfigStringList(actions)
+		}
+		if actions := cfgStmt["not_actions"].(*schema.Set).List(); len(actions) > 0 {
+			stmt.NotActions = iamPolicyDecodeConfigStringList(actions)
+		}
+
+		if resources := cfgStmt["resources"].(*schema.Set).List(); len(resources) > 0 {
+			stmt.Resources = resourceAwsIamPolicyDocumentReplaceVarsInList(
+				iamPolicyDecodeConfigStringList(resources),
+			)
+		}
+		if resources := cfgStmt["not_resources"].(*schema.Set).List(); len(resources) > 0 {
+			stmt.NotResources = resourceAwsIamPolicyDocumentReplaceVarsInList(
+				iamPolicyDecodeConfigStringList(resources),
+			)
+		}
+
+		if principals := cfgStmt["principals"].(*schema.Set).List(); len(principals) > 0 {
+			stmt.Principals = resourceAwsIamPolicyDocumentMakePrincipals(principals)
+		}
+
+		if principals := cfgStmt["not_principals"].(*schema.Set).List(); len(principals) > 0 {
+			stmt.NotPrincipals = resourceAwsIamPolicyDocumentMakePrincipals(principals)
+		}
+
+		if conditions := cfgStmt["condition"].(*schema.Set).List(); len(conditions) > 0 {
+			stmt.Conditions = resourceAwsIamPolicyDocumentMakeConditions(conditions)
+		}
+
+		stmts[i] = stmt
+	}
+
+	jsonDoc, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		// should never happen if the above code is correct
+		return err
+	}
+
+	d.Set("json", string(jsonDoc))
+	if id != "" {
+		d.SetId(id)
+	} else {
+		d.SetId("anon")
+	}
+
+	return nil
+}
+
+func resourceAwsIamPolicyDocumentReplaceVarsInList(in []string) []string {
+	out := make([]string, len(in))
+	for i, item := range in {
+		out[i] = resourceAwsIamPolicyDocumentVarReplacer.Replace(item)
+	}
+	return out
+}
+
+func resourceAwsIamPolicyDocumentMakeConditions(in []interface{}) IAMPolicyStatementConditionSet {
+	out := make([]IAMPolicyStatementCondition, len(in))
+	for i, itemI := range in {
+		item := itemI.(map[string]interface{})
+		out[i] = IAMPolicyStatementCondition{
+			Test:     item["test"].(string),
+			Variable: item["variable"].(string),
+			Values: resourceAwsIamPolicyDocumentReplaceVarsInList(
+				iamPolicyDecodeConfigStringList(
+					item["values"].(*schema.Set).List(),
+				),
+			),
+		}
+	}
+	return IAMPolicyStatementConditionSet(out)
+}
+
+func resourceAwsIamPolicyDocumentMakePrincipals(in []interface{}) IAMPolicyStatementPrincipalSet {
+	out := make([]IAMPolicyStatementPrincipal, len(in))
+	for i, itemI := range in {
+		item := itemI.(map[string]interface{})
+		out[i] = IAMPolicyStatementPrincipal{
+			Type: item["type"].(string),
+			Identifiers: resourceAwsIamPolicyDocumentReplaceVarsInList(
+				iamPolicyDecodeConfigStringList(
+					item["identifiers"].(*schema.Set).List(),
+				),
+			),
+		}
+	}
+	return IAMPolicyStatementPrincipalSet(out)
+}
+
+func resourceAwsIamPolicyDocumentDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsIamPolicyDocumentNoop(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsIamPolicyPrincipalSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": &schema.Schema{
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"identifiers": &schema.Schema{
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+}

--- a/builtin/providers/aws/resource_aws_iam_policy_document_test.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_document_test.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSIAMPolicyDocument(t *testing.T) {
+	// This really ought to be able to be a unit test rather than an
+	// acceptance test, but just instantiating the AWS provider requires
+	// some AWS API calls, and so this needs valid AWS credentials to work.
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSIAMPolicyDocumentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_iam_policy_document.test", "json",
+						testAccAWSIAMPolicyDocumentExpectedJSON,
+					),
+				),
+			},
+		},
+	})
+}
+
+var testAccAWSIAMPolicyDocumentConfig = `
+resource "aws_iam_policy_document" "test" {
+
+    statement {
+        actions = [
+            "s3:ListAllMyBuckets",
+            "s3:GetBucketLocation",
+        ]
+        resources = [
+            "arn:aws:s3:::*",
+        ]
+    }
+
+    statement {
+        actions = [
+            "s3:ListBucket",
+        ]
+        resources = [
+            "arn:aws:s3:::foo",
+        ]
+        condition {
+            test = "StringLike"
+            variable = "s3:prefix"
+            values = [
+                "",
+                "home/",
+                "home/&{aws:username}/",
+            ]
+        }
+
+        not_principals {
+            type = "AWS"
+            identifiers = ["arn:blahblah:example"]
+        }
+    }
+
+    statement {
+        actions = [
+            "s3:*",
+        ]
+        resources = [
+            "arn:aws:s3:::foo/home/&{aws:username}",
+            "arn:aws:s3:::foo/home/&{aws:username}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["arn:blahblah:example"]
+        }
+    }
+
+    statement {
+        effect = "Deny"
+        not_actions = ["s3:*"]
+        not_resources = ["arn:aws:s3:::*"]
+    }
+
+}
+`
+
+var testAccAWSIAMPolicyDocumentExpectedJSON = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": [
+        "arn:aws:s3:::*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::foo"
+      ],
+      "NotPrincipal": {
+        "AWS": [
+          "arn:blahblah:example"
+        ]
+      },
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "",
+            "home/",
+            "home/${aws:username}/"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::foo/home/${aws:username}/*",
+        "arn:aws:s3:::foo/home/${aws:username}"
+      ],
+      "Principal": {
+        "AWS": [
+          "arn:blahblah:example"
+        ]
+      }
+    },
+    {
+      "Effect": "Deny",
+      "NotAction": [
+        "s3:*"
+      ],
+      "NotResource": [
+        "arn:aws:s3:::*"
+      ]
+    }
+  ]
+}`

--- a/website/source/docs/providers/aws/r/iam_policy_document.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy_document.html.markdown
@@ -1,0 +1,147 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_policy_document"
+sidebar_current: "docs-aws-resource-iam-policy-document"
+description: |-
+  Generates an IAM policy document in JSON format
+---
+
+# aws\_iam\_policy\_document
+
+Generates an IAM policy document in JSON format.
+
+This is a *logical* resource, meaning that it doesn't actually generate any
+AWS objects itself but rather just transforms its input values into a JSON
+string that can be used with the various other resources that expect IAM
+policy documents, such as `aws_iam_policy` as shown below.
+
+```
+resource "aws_iam_policy_document" "example" {
+
+    statement {
+        actions = [
+            "s3:ListAllMyBuckets",
+            "s3:GetBucketLocation",
+        ]
+        resources = [
+            "arn:aws:s3:::*",
+        ]
+    }
+
+    statement {
+        actions = [
+            "s3:ListBucket",
+        ]
+        resources = [
+            "arn:aws:s3:::${var.s3_bucket_name}",
+        ]
+        condition {
+            test = "StringLike"
+            variable = "s3:prefix"
+            values = [
+                "",
+                "home/",
+                "home/&{aws:username}/",
+            ]
+        }
+    }
+
+    statement {
+        actions = [
+            "s3:*",
+        ]
+        resources = [
+            "arn:aws:s3:::${var.s3_bucket_name}/home/&{aws:username}",
+            "arn:aws:s3:::${var.s3_bucket_name}/home/&{aws:username}/*",
+        ]
+    }
+
+}
+
+resource "aws_iam_policy" "example" {
+    name = "example_policy"
+    path = "/"
+    policy = "${aws_iam_policy.example.json}"
+}
+```
+
+Using this resource to generate policy documents is *optional*. It is also
+valid to use literal JSON strings within your configuration, or to use the
+`file` interpolation function to read a raw JSON policy document from a file.
+
+This resource is particularly useful when part of the policy document is
+computed based on other resource attributes, such as the ``s3_bucket_name``
+variable featured in the above example.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` (Optional) - An id for the policy document.
+* `statement` (Required) - A nested configuration block (described below)
+  configuring one *statement* to be included in the policy document.
+
+Each document configuration must have one or more `statement` blocks, which
+each accept the following arguments:
+
+* `id` (Optional) - An id for the policy statement.
+* `effect` (Optional) - Either "Allow" or "Deny", to specify whether this
+  statement allows or denies the given actions. The default is "Allow".
+* `actions` (Optional) - A list of actions that this statement either allows
+  or denies. For example, ``["ec2:RunInstances", "s3:*"]``.
+* `not_actions` (Optional) - A list of actions that this statement does *not*
+  apply to. Used to apply a policy statement to all actions *except* those
+  listed.
+* `resources` (Optional) - A list of resource ARNs that this statement applies
+  to.
+* `not_resources` (Optional) - A list of resource ARNs that this statement
+  does *not* apply to. Used to apply a policy statement to all resources
+  *except* those listed.
+* `principals` (Optional) - A nested configuration block (described below)
+  specifying a resource (or resource pattern) to which this statement applies.
+* `not_principals` (Optional) - Like `principals` except gives resources that
+  the statement does *not* apply to.
+* `condition` (Optional) - A nested configuration block (described below)
+  that defines a further, possibly-service-specific condition that constrains
+  whether this statement applies.
+
+Each policy may have either zero or more `principals` blocks or zero or more
+`not_principals` blocks, both of which each accept the following arguments:
+
+* `type` (Required) The type of principal. For AWS accounts this is "AWS".
+* `identifiers` (Required) List of identifiers for principals. When `type`
+  is "AWS", these are IAM user or role ARNs.
+
+Each policy statement may have zero or more `condition` blocks, which each
+accept the following arguments:
+
+* `test` (Required) The name of the
+  [IAM condition type](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AccessPolicyLanguage_ConditionType)
+  to evaluate.
+* `variable` (Required) The name of a
+  [Context Variable](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys)
+  to apply the condition to. Context variables may either be standard AWS
+  variables starting with `aws:`, or service-specific variables prefixed with
+  the service name.
+* `values` (Required) The values to evaluate the condition against. If multiple
+  values are provided, the condition matches if at least one of them applies.
+  (That is, the tests are combined with the "OR" boolean operation.)
+
+When multiple `condition` blocks are provided, they must *all* evaluate to true
+for the policy statement to apply. (In other words, the conditions are combined
+with the "AND" boolean operation.)
+
+## Context Variable Interpolation
+
+The IAM policy document format allows context variables to be interpolated
+into various strings within a statement. The native IAM policy document format
+uses `${...}`-style syntax that is in conflict with Terraform's interpolation
+syntax, so this resource instead uses `&{...}` syntax for interpolations that
+should be processed by AWS rather than by Terraform.
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `json` - The above arguments serialized as a standard JSON policy document.
+

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -372,8 +372,13 @@
                         <li<%= sidebar_current("docs-aws-resource-iam-policy") %>>
                             <a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
                         </li>
+
                         <li<%= sidebar_current("docs-aws-resource-iam-policy-attachment") %>>
                             <a href="/docs/providers/aws/r/iam_policy_attachment.html">aws_iam_policy_attachment</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-iam-policy-document") %>>
+                            <a href="/docs/providers/aws/r/iam_policy_document.html">aws_iam_policy_document</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-iam-role") %>>


### PR DESCRIPTION
A helper to construct IAM policy documents using familiar Terraform concepts. Makes Terraform-style interpolations easier and resolves the syntax conflict between Terraform interpolations and IAM policy variables by changing the latter to use ``&{...}`` for its interpolations.

Its use is completely optional and users are free to go on using literal heredocs, file interpolations or whatever else; this just adds another option that fits more naturally into a Terraform config.

* [x] Resource Implementation
* [x] Tests
* [x] Documentation

