### PR TITLE
provider/openstack: ICMP Documentation

### DIFF
--- a/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
@@ -81,3 +81,20 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `rule` - See Argument Reference above.
+
+## Notes
+
+### ICMP Rules
+
+When using ICMP as the `ip_protocol`, the `from_port` sets the ICMP _type_ and the `to_port` sets the ICMP _code_. To allow all ICMP types, set each value to `-1`, like so:
+
+```
+rule {
+  from_port = -1
+  to_port = -1
+  ip_protocol = "icmp"
+  cidr = "0.0.0.0/0"
+}
+```
+
+A list of ICMP types and codes can be found [here](https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages).


### PR DESCRIPTION
Adds a note to the compute_secgroup_v2 documentation to clarify ICMP usage.

Fixes #2345 