### PR TITLE
provider/google: Misc. cleanups for tests to pass

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -809,9 +809,10 @@ func resourceInstanceMetadata(d *schema.ResourceData) (*compute.Metadata, error)
 	if len(mdMap) > 0 {
 		m.Items = make([]*compute.MetadataItems, 0, len(mdMap))
 		for key, val := range mdMap {
+			v := val.(string)
 			m.Items = append(m.Items, &compute.MetadataItems{
 				Key:   key,
-				Value: val.(string),
+				Value: &v,
 			})
 		}
 

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -132,11 +132,11 @@ func testAccCheckComputeInstanceTemplateMetadata(
 				continue
 			}
 
-			if v == item.Value {
+			if item.Value != nil && v == *item.Value {
 				return nil
 			}
 
-			return fmt.Errorf("bad value for %s: %s", k, item.Value)
+			return fmt.Errorf("bad value for %s: %s", k, *item.Value)
 		}
 
 		return fmt.Errorf("metadata not found: %s", k)

--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -332,11 +332,11 @@ func testAccCheckComputeInstanceMetadata(
 				continue
 			}
 
-			if v == item.Value {
+			if item.Value != nil && v == *item.Value {
 				return nil
 			}
 
-			return fmt.Errorf("bad value for %s: %s", k, item.Value)
+			return fmt.Errorf("bad value for %s: %s", k, *item.Value)
 		}
 
 		return fmt.Errorf("metadata not found: %s", k)

--- a/builtin/providers/google/resource_compute_project_metadata_test.go
+++ b/builtin/providers/google/resource_compute_project_metadata_test.go
@@ -150,13 +150,13 @@ func testAccCheckComputeProjectMetadataContains(project *compute.Project, key st
 			return fmt.Errorf("Error, failed to load project service for %s: %s", config.Project, err)
 		}
 
-		for _, kv := range(project.CommonInstanceMetadata.Items) {
+		for _, kv := range project.CommonInstanceMetadata.Items {
 			if kv.Key == key {
-				if (kv.Value == value) {
+				if kv.Value != nil && *kv.Value == value {
 					return nil
 				} else {
 					return fmt.Errorf("Error, key value mismatch, wanted (%s, %s), got (%s, %s)",
-						key, value, kv.Key, kv.Value);
+						key, value, kv.Key, *kv.Value)
 				}
 			}
 		}
@@ -174,7 +174,7 @@ func testAccCheckComputeProjectMetadataSize(project *compute.Project, size int) 
 		}
 
 		if size > len(project.CommonInstanceMetadata.Items) {
-			return fmt.Errorf("Error, expected at least %d metadata items, got %d", size, 
+			return fmt.Errorf("Error, expected at least %d metadata items, got %d", size,
 				len(project.CommonInstanceMetadata.Items))
 		}
 


### PR DESCRIPTION
TravisCI was reporting test failing for `master`, mostly `go vet` type things. 
This PR cleans up some `string` != `*string` type things. 

`compute.MetadataItems` seems to take a `*string` for `Value`, is this a recent upstream change?

cc @sparkprime for a quick review :smile: 