### PR TITLE
Colorize the 'forces new resource' message.

### DIFF
--- a/command/format_plan.go
+++ b/command/format_plan.go
@@ -131,7 +131,7 @@ func formatPlanModuleExpand(
 
 			newResource := ""
 			if attrDiff.RequiresNew && rdiff.Destroy {
-				newResource = " (forces new resource)"
+				newResource = opts.Color.Color(" [red](forces new resource)")
 			}
 
 			buf.WriteString(fmt.Sprintf(


### PR DESCRIPTION
Sometimes in all the output from ```terraform plan```, it is difficult
to see the ```(forces new resource)``` message.
This patch adds a little bit of color.