### PR TITLE
Support tags for aws_db_subnet_group

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -139,7 +139,7 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*AWSClient).rdsconn
 	arn, err := buildRDSARN(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] Error building ARN for DB Subnet Group, not setting Tags for group %s", subnetGroup.DBSubnetGroupName)
+		log.Printf("[DEBUG] Error building ARN for DB Subnet Group, not setting Tags for group %s", *subnetGroup.DBSubnetGroupName)
 	} else {
 		resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
 			ResourceName: aws.String(arn),
@@ -182,6 +182,15 @@ func resourceAwsDbSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 	}
+
+	if arn, err := buildRDSARN(d, meta); err == nil {
+		if err := setTagsRDS(conn, d, arn); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
+	}
+
 	return resourceAwsDbSubnetGroupRead(d, meta)
 }
 

--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -150,6 +150,9 @@ resource "aws_db_subnet_group" "foo" {
 	name = "FOO"
 	description = "foo description"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+	tags {
+		Name = "tf-dbsubnet-group-test"
+	}
 }
 `
 

--- a/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
@@ -17,6 +17,9 @@ resource "aws_db_subnet_group" "default" {
     name = "main"
     description = "Our main group of subnets"
     subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
+    tags {
+        Name = "My DB subnet group"
+    }
 }
 ```
 
@@ -27,6 +30,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the DB subnet group.
 * `description` - (Required) The description of the DB subnet group.
 * `subnet_ids` - (Required) A list of VPC subnet IDs.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Tags support was missing from the aws_db_subnet_group.

Disclaimer: First time I've "written" something in go, inspired by resource_aws_db_instance.go

![](http://www.ludumdare.com/compo/wp-content/uploads/2013/04/i-have-no-idea-what-im-doing-dog.jpg)
