### PR TITLE
provider/aws: read instance source_dest_check and save to state

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -475,6 +475,9 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("subnet_id", instance.SubnetId)
 	}
 	d.Set("ebs_optimized", instance.EbsOptimized)
+	if instance.SubnetId != nil && *instance.SubnetId != "" {
+		d.Set("source_dest_check", instance.SourceDestCheck)
+	}
 
 	if instance.Monitoring != nil && instance.Monitoring.State != nil {
 		monitoringState := *instance.Monitoring.State


### PR DESCRIPTION
For some reason the `source_dest_check` attribute is never being read from AWS and saved to the state. This means the state and plan are often wrong.

Recently this caused an outage for us. The real value on the instance was `false`. The config was set to `true` (via the default value) and the state was (incorrectly) set to `true`. A plan revealed no change to the attribute, but when the plan was applied, terraform changed the value to `true`.