### PR TITLE
terraform_synthetic_state resource

### DIFF
--- a/builtin/providers/terraform/provider.go
+++ b/builtin/providers/terraform/provider.go
@@ -10,6 +10,7 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"terraform_remote_state": resourceRemoteState(),
+			"terraform_synthetic_state": resourceSyntheticState(),
 		},
 	}
 }

--- a/builtin/providers/terraform/resource_synthetic_state.go
+++ b/builtin/providers/terraform/resource_synthetic_state.go
@@ -1,0 +1,113 @@
+package terraform
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/state/remote"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceSyntheticState() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSyntheticStateWrite,
+		Update: resourceSyntheticStateWrite,
+		Read:   resourceSyntheticStateRead,
+		Delete: resourceSyntheticStateDelete,
+
+		Schema: map[string]*schema.Schema{
+			"backend": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"outputs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceSyntheticStateWrite(d *schema.ResourceData, meta interface{}) error {
+	_, remoteState, err := resourceSyntheticStateClient(d)
+	if err != nil {
+		return err
+	}
+
+	newState := terraform.NewState()
+	rootState := newState.RootModule()
+	rootState.Outputs = make(map[string]string)
+
+	newOutputs := d.Get("outputs").(map[string]interface{})
+	for k, v := range newOutputs {
+		rootState.Outputs[k] = v.(string)
+	}
+
+	if err = remoteState.WriteState(newState); err != nil {
+		return err
+	}
+
+	if err = remoteState.PersistState(); err != nil {
+		return err
+	}
+
+	return resourceRemoteStateRead(d, meta)
+}
+
+func resourceSyntheticStateRead(d *schema.ResourceData, meta interface{}) error {
+	_, state, err := resourceSyntheticStateClient(d)
+	if err != nil {
+		return err
+	}
+
+	if err := state.RefreshState(); err != nil {
+		return err
+	}
+
+	var outputs map[string]string
+	if !state.State().Empty() {
+		outputs = state.State().RootModule().Outputs
+	}
+
+	d.SetId("synth-state")
+	d.Set("output", outputs)
+	return nil
+}
+
+func resourceSyntheticStateDelete(d *schema.ResourceData, meta interface{}) error {
+	client, _, err := resourceSyntheticStateClient(d)
+	if err != nil {
+		return err
+	}
+
+	err = client.Delete()
+	if err == nil {
+		d.SetId("")
+	}
+	return err
+}
+
+func resourceSyntheticStateClient(d *schema.ResourceData) (remote.Client, *remote.State, error) {
+	backend := d.Get("backend").(string)
+	config := make(map[string]string)
+	for k, v := range d.Get("config").(map[string]interface{}) {
+		config[k] = v.(string)
+	}
+
+	// Create the client to access our remote state
+	log.Printf("[DEBUG] Initializing remote state client: %s", backend)
+	client, err := remote.NewClient(backend, config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, &remote.State{Client: client}, nil
+}


### PR DESCRIPTION
The normal way to share a state for consumption by downstream ``terraform_remote_state`` is to just point consumers at the same configuration used to persist the configuration state itself.

This is fine most of the time, but sometimes it's desirable to present downstream consumers with a different level of abstraction than the physical configuration represents. For example, one might create AWS infrastructure on a per-region basis but expose it to downstream configurations on a per-availability-zone basis.

This resource thus allows a Terraform configuration to produce additional "synthetic" remote states, containing only outputs, that are intended only for downstream consumption and are not used to actually manage any resources. They contain only outputs, and no resource states.

This is a real use-case I have: we maintain environments as a collection of "physical" configurations, which create resources on a per-AWS-region basis, and then we currently maintain a collection of "logical" configurations that do nothing except read the physical remote states and project their data into an availability-zone-oriented basis that our downstream app infrastructure deployments expect.

I'd like to simplify by eliminating that extra level of logical configuration, and just have the physical configurations write out a set of synthetic states for our downstream configs to consume:

```js
resource "terraform_synthetic_state" "usw1a" {
    backend = "consul"
    config = { ... }
    outputs = {
        availability_zone = "us-west-1a"
        region = "us-west-1"
        vpc_id = "${aws_vpc.main.id}"
        subnet_id = "${aws_subnet.usw1a.id}"
        // ...
    }
}

resource "terraform_synthetic_state" "usw1b" {
    backend = "consul"
    config = { ... }
    outputs = {
        availability_zone = "us-west-1b"
        region = "us-west-1"
        vpc_id = "${aws_vpc.main.id}"
        subnet_id = "${aws_subnet.usw1b.id}"
        // ...
    }
}
```

While I'm sure we could share such configuration data a different way if forced to, I think it's convenient for downstream consumers to not have to think about two different mechanisms for consuming upstream data depending on whether it's a "real" Terraform state or just some derived outputs.

So far I just wrote the main implementation to get some feedback. If this seems like something that would be accepted into Terraform then I'll follow up with some tests and documentation.
