### PR TITLE
provider/aws: add ses_smtp_password to iam_access_key

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_access_key_test.go
+++ b/builtin/providers/aws/resource_aws_iam_access_key_test.go
@@ -116,3 +116,20 @@ resource "aws_iam_access_key" "a_key" {
 	user = "${aws_iam_user.a_user.name}"
 }
 `
+
+func TestSesSmtpPasswordFromSecretKey(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{"some+secret+key", "AnkqhOiWEcszZZzTMCQbOY1sPGoLFgMH9zhp4eNgSjo4"},
+		{"another+secret+key", "Akwqr0Giwi8FsQFgW3DXWCC2DiiQ/jZjqLDWK8TeTBgL"},
+	}
+
+	for _, tc := range cases {
+		actual := sesSmtpPasswordFromSecretKey(&tc.Input)
+		if actual != tc.Expected {
+			t.Fatalf("%q: expected %q, got %q", tc.Input, tc.Expected, actual)
+		}
+	}
+}

--- a/website/source/docs/providers/aws/r/iam_access_key.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_access_key.html.markdown
@@ -55,5 +55,8 @@ The following attributes are exported:
 * `id` - The access key ID.
 * `user` - The IAM user associated with this access key.
 * `secret` - The secret access key. Note that this will be written to the state file.
+* `ses_smtp_password` - The secret access key converted into an SES SMTP
+  password by applying [AWS's documented conversion
+  algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).
 * `status` - "Active" or "Inactive". Keys are initially active, but can be made
 	inactive by other means.


### PR DESCRIPTION
AWS gives instructions for converting AWS credentials into SES SMTP
credentials here:

https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert

This implements their algorithm and yields the result as an attribute on
`iam_access_key`.