### PR TITLE
provider/aws: read iam_instance_profile for instance and save to state

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -469,6 +469,13 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("public_ip", instance.PublicIpAddress)
 	d.Set("private_dns", instance.PrivateDnsName)
 	d.Set("private_ip", instance.PrivateIpAddress)
+
+	if instance.IamInstanceProfile != nil {
+		d.Set("iam_instance_profile", iamInstanceProfileArnToName(instance.IamInstanceProfile.Arn))
+	} else if _, ok := d.GetOk("iam_instance_profile"); ok {
+		d.Set("iam_instance_profile", "")
+	}
+
 	if len(instance.NetworkInterfaces) > 0 {
 		d.Set("subnet_id", instance.NetworkInterfaces[0].SubnetId)
 	} else {
@@ -1069,4 +1076,8 @@ func awsTerminateInstance(conn *ec2.EC2, id string) error {
 	}
 
 	return nil
+}
+
+func iamInstanceProfileArnToName(arn *string) string {
+	return strings.Split(*arn, "/")[1]
 }


### PR DESCRIPTION
This is another attribute that doesn't read and save to state properly.

I didn't see a way to remove an attribute from the state, so if the state is wrong and there's no IAM instance profile set on the instance, I'm setting it to `""` in the state.

Splitting out the ARN parsing into it's own function might be overkill, and I can change that if want.

Thanks!

review: @phinze @catsby 
cc: @baldowl