### PR TITLE
Initial stab at JSON plan output

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -16,7 +16,7 @@ type PlanCommand struct {
 }
 
 func (c *PlanCommand) Run(args []string) int {
-	var destroy, refresh, detailed bool
+	var destroy, refresh, detailed, outJson bool
 	var outPath string
 	var moduleDepth int
 
@@ -27,6 +27,7 @@ func (c *PlanCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
 	c.addModuleDepthFlag(cmdFlags, &moduleDepth)
 	cmdFlags.StringVar(&outPath, "out", "", "path")
+	cmdFlags.BoolVar(&outJson, "out-json", false, "out-json")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
@@ -111,7 +112,11 @@ func (c *PlanCommand) Run(args []string) int {
 		f, err := os.Create(outPath)
 		if err == nil {
 			defer f.Close()
-			err = terraform.WritePlan(plan, f)
+			if outJson {
+				err = terraform.WriteJsonPlan(plan, f)
+			} else {
+				err = terraform.WritePlan(plan, f)
+			}
 		}
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error writing plan file: %s", err))

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -124,9 +124,11 @@ func (d *Diff) init() {
 // ModuleDiff tracks the differences between resources to apply within
 // a single module.
 type ModuleDiff struct {
-	Path      []string
-	Resources map[string]*InstanceDiff
-	Destroy   bool // Set only by the destroy plan
+	Path      []string                 `json:"path"`
+	Resources map[string]*InstanceDiff `json:"resources"`
+
+	// Set only by the destroy plan
+	Destroy bool `json:"destroy"`
 }
 
 func (d *ModuleDiff) init() {
@@ -270,20 +272,20 @@ func (d *ModuleDiff) String() string {
 
 // InstanceDiff is the diff of a resource from some state to another.
 type InstanceDiff struct {
-	Attributes     map[string]*ResourceAttrDiff
-	Destroy        bool
-	DestroyTainted bool
+	Attributes     map[string]*ResourceAttrDiff `json:"attributes"`
+	Destroy        bool                         `json:"destroy"`
+	DestroyTainted bool                         `json:"tainted"`
 }
 
 // ResourceAttrDiff is the diff of a single attribute of a resource.
 type ResourceAttrDiff struct {
-	Old         string      // Old Value
-	New         string      // New Value
-	NewComputed bool        // True if new value is computed (unknown currently)
-	NewRemoved  bool        // True if this attribute is being removed
-	NewExtra    interface{} // Extra information for the provider
-	RequiresNew bool        // True if change requires new resource
-	Type        DiffAttrType
+	Old         string       `json:"old"`          // Old Value
+	New         string       `json:"new"`          // New Value
+	NewComputed bool         `json:"new_computed"` // True if new value is computed (unknown currently)
+	NewRemoved  bool         `json:"new_removed"`  // True if this attribute is being removed
+	NewExtra    interface{}  `json:"new_extra"`    // Extra information for the provider
+	RequiresNew bool         `json:"requires_new"` // True if change requires new resource
+	Type        DiffAttrType `json:"-"`
 }
 
 func (d *ResourceAttrDiff) GoString() string {

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -113,6 +114,23 @@ func ReadPlan(src io.Reader) (*Plan, error) {
 	}
 
 	return result, nil
+}
+
+// WriteJsonPlan writes a plan somewhere in a JSON format.
+func WriteJsonPlan(d *Plan, dst io.Writer) error {
+
+	// Encode the data in a human-friendly way
+	data, err := json.MarshalIndent(d.Diff.Modules, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	// We append a newline to the data because MarshalIndent doesn't
+	data = append(data, '\n')
+
+	_, err = dst.Write(data)
+
+	return err
 }
 
 // WritePlan writes a plan somewhere in a binary format.


### PR DESCRIPTION
Guidelines said to submit even if it's early work, so here goes.

I'm pretty new to go, but have found it pretty easy to onboard into a build environment and navigating the codebase, good work everyone!

This relates to #2460 - specifically supporting JSON as plan output.

The particular scenario that led me to implement this went like this:
1. Run terraform apply to create a VM (via cloudstack)
2. VM takes ages to provision, terraform times out
3. VM was actually created, but terraform doesn't know about it

At this point, one option is to manually fill in the state file with a name and id for the resource, and terraform is then able to refresh and figure out where it got to.

My thinking was that it'd be nice to be able to machine read the plan (or the whole config perhaps?), and then consume this with a different tool that knows which fields should be unique, and can go fill out my state file based on what the plan might have acheived.

What do you think?
