### PR TITLE
In plan summary, be more honest about force-new changes.

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -136,9 +136,9 @@ func (c *PlanCommand) Run(args []string) int {
 	c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
 		"[reset][bold]Plan:[reset] "+
 			"%d to add, %d to change, %d to destroy.",
-		countHook.ToAdd,
-		(countHook.ToChange + countHook.ToRemoveAndAdd),
-		countHook.ToRemove)))
+		countHook.ToAdd+countHook.ToRemoveAndAdd,
+		countHook.ToChange,
+		countHook.ToRemove+countHook.ToRemoveAndAdd)))
 
 	if detailed {
 		return 2


### PR DESCRIPTION
Previously the plan summary output would consider ``-/+`` diffs as changes even though they actually destroy and create instances. This was misleadning and inconsistent with the accounting that gets done for the similar summary written out after "apply".

Instead we now count the ``-/+`` diffs as both adds and removes, which should mean that the counts output in the plan summary should match those in the apply summary, as long as no errors occur during apply.

This fixes #3163.