### PR TITLE
Make it easier to run the cloudstack acceptance tests

### DIFF
--- a/builtin/providers/cloudstack/provider_test.go
+++ b/builtin/providers/cloudstack/provider_test.go
@@ -117,9 +117,6 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("CLOUDSTACK_PUBLIC_IPADDRESS"); v == "" {
 		t.Fatal("CLOUDSTACK_PUBLIC_IPADDRESS must be set for acceptance tests")
 	}
-	if v := os.Getenv("CLOUDSTACK_SSH_KEYPAIR"); v == "" {
-		t.Fatal("CLOUDSTACK_SSH_KEYPAIR must be set for acceptance tests")
-	}
 	if v := os.Getenv("CLOUDSTACK_SSH_PUBLIC_KEY"); v == "" {
 		t.Fatal("CLOUDSTACK_SSH_PUBLIC_KEY must be set for acceptance tests")
 	}
@@ -146,30 +143,77 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-var CLOUDSTACK_2ND_NIC_IPADDRESS = os.Getenv("CLOUDSTACK_2ND_NIC_IPADDRESS")
-var CLOUDSTACK_2ND_NIC_NETWORK = os.Getenv("CLOUDSTACK_2ND_NIC_NETWORK")
+// Name of a valid disk offering
 var CLOUDSTACK_DISK_OFFERING_1 = os.Getenv("CLOUDSTACK_DISK_OFFERING_1")
+
+// Name of a disk offering that CLOUDSTACK_DISK_OFFERING_1 can resize to
 var CLOUDSTACK_DISK_OFFERING_2 = os.Getenv("CLOUDSTACK_DISK_OFFERING_2")
-var CLOUDSTACK_HYPERVISOR = os.Getenv("CLOUDSTACK_HYPERVISOR")
+
+// Name of a valid service offering
 var CLOUDSTACK_SERVICE_OFFERING_1 = os.Getenv("CLOUDSTACK_SERVICE_OFFERING_1")
+
+// Name of a service offering that CLOUDSTACK_SERVICE_OFFERING_1 can resize to
 var CLOUDSTACK_SERVICE_OFFERING_2 = os.Getenv("CLOUDSTACK_SERVICE_OFFERING_2")
+
+// Name of a network that already exists
 var CLOUDSTACK_NETWORK_1 = os.Getenv("CLOUDSTACK_NETWORK_1")
+
+// A valid IP address in CLOUDSTACK_NETWORK_1
 var CLOUDSTACK_NETWORK_1_IPADDRESS = os.Getenv("CLOUDSTACK_NETWORK_1_IPADDRESS")
+
+// Name for a network that will be created
 var CLOUDSTACK_NETWORK_2 = os.Getenv("CLOUDSTACK_NETWORK_2")
+
+// Any range
 var CLOUDSTACK_NETWORK_2_CIDR = os.Getenv("CLOUDSTACK_NETWORK_2_CIDR")
+
+// Name of an available network offering with specifyvlan=false
 var CLOUDSTACK_NETWORK_2_OFFERING = os.Getenv("CLOUDSTACK_NETWORK_2_OFFERING")
+
+// An IP address in CLOUDSTACK_NETWORK_2_CIDR
 var CLOUDSTACK_NETWORK_2_IPADDRESS = os.Getenv("CLOUDSTACK_NETWORK_2_IPADDRESS")
+
+// A network that already exists and isnt CLOUDSTACK_NETWORK_1
+var CLOUDSTACK_2ND_NIC_NETWORK = os.Getenv("CLOUDSTACK_2ND_NIC_NETWORK")
+
+// An IP address in CLOUDSTACK_2ND_NIC_NETWORK
+var CLOUDSTACK_2ND_NIC_IPADDRESS = os.Getenv("CLOUDSTACK_2ND_NIC_IPADDRESS")
+
+// Any range
 var CLOUDSTACK_VPC_CIDR_1 = os.Getenv("CLOUDSTACK_VPC_CIDR_1")
+
+// Any range that doesn't overlap to CLOUDSTACK_VPC_CIDR_1, will be VPNed
 var CLOUDSTACK_VPC_CIDR_2 = os.Getenv("CLOUDSTACK_VPC_CIDR_2")
+
+// An available VPC offering
 var CLOUDSTACK_VPC_OFFERING = os.Getenv("CLOUDSTACK_VPC_OFFERING")
+
+// A sub-range of CLOUDSTACK_VPC_CIDR_1 with same starting point
 var CLOUDSTACK_VPC_NETWORK_CIDR = os.Getenv("CLOUDSTACK_VPC_NETWORK_CIDR")
+
+// Name of an available network offering with forvpc=true
 var CLOUDSTACK_VPC_NETWORK_OFFERING = os.Getenv("CLOUDSTACK_VPC_NETWORK_OFFERING")
+
+// Path to a public IP that exists for CLOUDSTACK_NETWORK_1
 var CLOUDSTACK_PUBLIC_IPADDRESS = os.Getenv("CLOUDSTACK_PUBLIC_IPADDRESS")
+
+// Path to a public key on local disk
 var CLOUDSTACK_SSH_PUBLIC_KEY = os.Getenv("CLOUDSTACK_SSH_PUBLIC_KEY")
+
+// Name of a template that exists already for building VMs
 var CLOUDSTACK_TEMPLATE = os.Getenv("CLOUDSTACK_TEMPLATE")
+
+// Details of a template that will be added
 var CLOUDSTACK_TEMPLATE_FORMAT = os.Getenv("CLOUDSTACK_TEMPLATE_FORMAT")
+var CLOUDSTACK_HYPERVISOR = os.Getenv("CLOUDSTACK_HYPERVISOR")
 var CLOUDSTACK_TEMPLATE_URL = os.Getenv("CLOUDSTACK_TEMPLATE_URL")
 var CLOUDSTACK_TEMPLATE_OS_TYPE = os.Getenv("CLOUDSTACK_TEMPLATE_OS_TYPE")
+
+// Name of a project that exists already
 var CLOUDSTACK_PROJECT_NAME = os.Getenv("CLOUDSTACK_PROJECT_NAME")
+
+// Name of a network that exists already in CLOUDSTACK_PROJECT_NAME
 var CLOUDSTACK_PROJECT_NETWORK = os.Getenv("CLOUDSTACK_PROJECT_NETWORK")
+
+// Name of a zone that exists already
 var CLOUDSTACK_ZONE = os.Getenv("CLOUDSTACK_ZONE")

--- a/builtin/providers/cloudstack/resource_cloudstack_egress_firewall_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_egress_firewall_test.go
@@ -2,15 +2,19 @@ package cloudstack
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/xanzy/go-cloudstack/cloudstack"
 )
 
 func TestAccCloudStackEgressFirewall_basic(t *testing.T) {
+	hash := makeTestCloudStackEgressFirewallRuleHash([]interface{}{"1000-2000", "80"})
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -24,16 +28,16 @@ func TestAccCloudStackEgressFirewall_basic(t *testing.T) {
 						"cloudstack_egress_firewall.foo", "network", CLOUDSTACK_NETWORK_1),
 					resource.TestCheckResourceAttr(
 						"cloudstack_egress_firewall.foo",
-						"rule.411689741.source_cidr",
+						"rule."+hash+".source_cidr",
 						CLOUDSTACK_NETWORK_1_IPADDRESS+"/32"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.protocol", "tcp"),
+						"cloudstack_egress_firewall.foo", "rule."+hash+".protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.#", "2"),
+						"cloudstack_egress_firewall.foo", "rule."+hash+".ports.#", "2"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.1209010669", "1000-2000"),
+						"cloudstack_egress_firewall.foo", "rule."+hash+".ports.1209010669", "1000-2000"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.1889509032", "80"),
+						"cloudstack_egress_firewall.foo", "rule."+hash+".ports.1889509032", "80"),
 				),
 			},
 		},
@@ -41,6 +45,9 @@ func TestAccCloudStackEgressFirewall_basic(t *testing.T) {
 }
 
 func TestAccCloudStackEgressFirewall_update(t *testing.T) {
+	hash1 := makeTestCloudStackEgressFirewallRuleHash([]interface{}{"1000-2000", "80"})
+	hash2 := makeTestCloudStackEgressFirewallRuleHash([]interface{}{"443"})
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -56,16 +63,16 @@ func TestAccCloudStackEgressFirewall_update(t *testing.T) {
 						"cloudstack_egress_firewall.foo", "rule.#", "1"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_egress_firewall.foo",
-						"rule.411689741.source_cidr",
+						"rule."+hash1+".source_cidr",
 						CLOUDSTACK_NETWORK_1_IPADDRESS+"/32"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.protocol", "tcp"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.#", "2"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".ports.#", "2"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.1209010669", "1000-2000"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".ports.1209010669", "1000-2000"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.1889509032", "80"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".ports.1889509032", "80"),
 				),
 			},
 
@@ -79,26 +86,26 @@ func TestAccCloudStackEgressFirewall_update(t *testing.T) {
 						"cloudstack_egress_firewall.foo", "rule.#", "2"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_egress_firewall.foo",
-						"rule.411689741.source_cidr",
+						"rule."+hash1+".source_cidr",
 						CLOUDSTACK_NETWORK_1_IPADDRESS+"/32"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.protocol", "tcp"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.#", "2"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".ports.#", "2"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.1209010669", "1000-2000"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".ports.1209010669", "1000-2000"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.411689741.ports.1889509032", "80"),
+						"cloudstack_egress_firewall.foo", "rule."+hash1+".ports.1889509032", "80"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_egress_firewall.foo",
-						"rule.845479598.source_cidr",
+						"rule."+hash2+".source_cidr",
 						CLOUDSTACK_NETWORK_1_IPADDRESS+"/32"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.845479598.protocol", "tcp"),
+						"cloudstack_egress_firewall.foo", "rule."+hash2+".protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.845479598.ports.#", "1"),
+						"cloudstack_egress_firewall.foo", "rule."+hash2+".ports.#", "1"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_egress_firewall.foo", "rule.845479598.ports.3638101695", "443"),
+						"cloudstack_egress_firewall.foo", "rule."+hash2+".ports.3638101695", "443"),
 				),
 			},
 		},
@@ -162,6 +169,16 @@ func testAccCheckCloudStackEgressFirewallDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func makeTestCloudStackEgressFirewallRuleHash(ports []interface{}) string {
+	return strconv.Itoa(resourceCloudStackEgressFirewallRuleHash(map[string]interface{}{
+		"source_cidr": CLOUDSTACK_NETWORK_1_IPADDRESS + "/32",
+		"protocol":    "tcp",
+		"ports":       schema.NewSet(schema.HashString, ports),
+		"icmp_type":   0,
+		"icmp_code":   0,
+	}))
 }
 
 var testAccCloudStackEgressFirewall_basic = fmt.Sprintf(`


### PR DESCRIPTION
This PR is based on my experience getting the acceptance tests running locally

I've documented in slightly more detail what should go in the environment variables - I had to decode this information from usage, so hopefully it'll now help future developers

I've also updated the egress test to generate set hash for egress firewall based on selected public IP, it previously had a hard-coded value which relied on the value of the PUBLIC_IP variable.


I was able to successfully run all but one of these tests locally using https://github.com/bvbharatk/VagrantSimulator and the `4.4.4` tag of cloudstack (with a little bit of manual poking around). The "Simulator" hypervisor means I was able to run the whole suite in around 10 minutes - but unfortunately it doesn't support the disk resize action - so I couldn't quite complete the set.

These are the values I used with the simulator to get the tests passing, after having done a bit of manual setup. I'm not sure where else to document this at the moment (keys are safe, as they only exist on a VM of mine that's not on the internet)

```sh
export \
    CLOUDSTACK_API_URL=http://localhost:8081/client/api \
    CLOUDSTACK_API_KEY=On9yoOplojrOMV1GK587hnSKP-f4K94FxkCgeAAtnGws7lEpRTvxz9UoQCylkRhcamoWlMznPuHGCBtCtCXD9g \
    CLOUDSTACK_SECRET_KEY=kKOrZ0XeuMJ-YR4p4a_2pr8JdDSSTYjodQe1CoKT2MSP5libE0iyeLmSwHH4zeKI8r6M4Fu1PVVvwwqCr_3vDA \
    CLOUDSTACK_2ND_NIC_IPADDRESS=10.1.10.10 \
    CLOUDSTACK_2ND_NIC_NETWORK=network-nic \
    CLOUDSTACK_DISK_OFFERING_1=Small \
    CLOUDSTACK_DISK_OFFERING_2=Medium \
    CLOUDSTACK_HYPERVISOR=Simulator \
    CLOUDSTACK_SERVICE_OFFERING_1="Small Instance" \
    CLOUDSTACK_SERVICE_OFFERING_2="Medium Instance" \
    CLOUDSTACK_NETWORK_1=network1 \
    CLOUDSTACK_NETWORK_1_IPADDRESS=10.1.1.50 \
    CLOUDSTACK_NETWORK_2=network2 \
    CLOUDSTACK_NETWORK_2_CIDR=10.1.2.0/24 \
    CLOUDSTACK_NETWORK_2_OFFERING="DefaultIsolatedNetworkOfferingWithSourceNatService" \
    CLOUDSTACK_NETWORK_2_IPADDRESS=10.1.2.50 \
    CLOUDSTACK_VPC_CIDR_1=10.2.1.0/24 \
    CLOUDSTACK_VPC_CIDR_2=10.2.2.0/24 \
    CLOUDSTACK_VPC_OFFERING=6683b8cb-7294-4768-b920-097a7b99a0b4 \
    CLOUDSTACK_VPC_NETWORK_CIDR=10.2.1.0/29 \
    CLOUDSTACK_VPC_NETWORK_OFFERING=DefaultIsolatedNetworkOfferingForVpcNetworks \
    CLOUDSTACK_PUBLIC_IPADDRESS=192.168.2.4 \
    CLOUDSTACK_SSH_PUBLIC_KEY=~/.ssh/id_rsa.pub \
    CLOUDSTACK_TEMPLATE="CentOS 5.3(64-bit) no GUI (Simulator)" \
    CLOUDSTACK_TEMPLATE_FORMAT=OVA \
    CLOUDSTACK_TEMPLATE_URL=http://google.com \
    CLOUDSTACK_TEMPLATE_OS_TYPE=None \
    CLOUDSTACK_PROJECT_NAME=abc \
    CLOUDSTACK_PROJECT_NETWORK=network-abc \
    CLOUDSTACK_ZONE=Sandbox-simulator
```