### PR TITLE
Update aws_db_instance `db_subnet_group_name`

### DIFF
--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate.
 * `security_group_names` - (Optional/Deprecated) List of DB Security Groups to associate.
     Only used for [DB Instances on the _EC2-Classic_ Platform](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.html#USER_VPC.FindDefaultVPC).
-* `db_subnet_group_name` - (Optional) Name of DB subnet group
+* `db_subnet_group_name` - (Optional) Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the `default` VPC, or in EC2 Classic, if available.
 * `parameter_group_name` - (Optional) Name of the DB parameter group to associate.
 * `storage_encrypted` - (Optional) Specifies whether the DB instance is encrypted. The default is `false` if not specified.
 * `apply_immediately` - (Optional) Specifies whether any database modifications


### PR DESCRIPTION
When launching a new RDS instance in a VPC-default AWS account, trying to control which VPC the new RDS instance lands in is not apparent from the parameters available.
The following works:

```
resource "aws_db_subnet_group" "foo" {
  name = "foo"
  description = "DB Subnet for foo"
  subnet_ids = ["${aws_subnet.foo_1a.id}", "${aws_subnet.foo_1b.id}"]
}

resource "aws_db_instance" "bar" {
...
  db_subnet_group_name   = "${aws_db_subnet_group.foo.name}"
...
}
```

Hopefully this doc update will help others