### PR TITLE
provider/aws: Allow weight = 0 in Route53 records

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -407,12 +407,9 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 		rec.HealthCheckId = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("weight"); ok {
-		rec.Weight = aws.Int64(int64(v.(int)))
-	}
-
 	if v, ok := d.GetOk("set_identifier"); ok {
 		rec.SetIdentifier = aws.String(v.(string))
+		rec.Weight = aws.Int64(int64(d.Get("weight").(int)))
 	}
 
 	return rec, nil

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -133,6 +133,7 @@ func TestAccAWSRoute53Record_weighted(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53RecordExists("aws_route53_record.www-dev"),
 					testAccCheckRoute53RecordExists("aws_route53_record.www-live"),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-off"),
 				),
 			},
 		},
@@ -405,6 +406,16 @@ resource "aws_route53_record" "www-live" {
   ttl = "5"
   weight = 90
   set_identifier = "live"
+  records = ["dev.notexample.com"]
+}
+
+resource "aws_route53_record" "www-off" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "CNAME"
+  ttl = "5"
+  weight = 0
+  set_identifier = "off"
   records = ["dev.notexample.com"]
 }
 `


### PR DESCRIPTION
Moved the GetOk to a Get in the set_identifier block so
we can create a zero-weighted RR - otherwise this falls foul
of a check in GetOk.

See https://github.com/hashicorp/terraform/issues/3189

My use case for this is that we are currently not using Route53 health checks, and we want to be able to set up a new ELB with its corresponding Route53 entry set to 0 so it doesn't automatically start to receive live traffic.
