### PR TITLE
Adding optional content field to s3_bucket_object

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -1,11 +1,11 @@
 package aws
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"os"
-	"io"
-        "bytes"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -35,18 +35,18 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			},
 
 			"source": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{"content"},
 			},
 
-                        "content": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                ForceNew: true,
+			"content": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{"source"},
-                        },
+			},
 
 			"etag": &schema.Schema{
 				Type:     schema.TypeString,
@@ -138,3 +138,4 @@ func resourceAwsS3BucketObjectDelete(d *schema.ResourceData, meta interface{}) e
 	}
 	return nil
 }
+

--- a/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
@@ -15,7 +15,7 @@ import (
 
 var tf, err = ioutil.TempFile("", "tf")
 
-func TestAccAWSS3BucketObject_basic(t *testing.T) {
+func TestAccAWSS3BucketObject_source(t *testing.T) {
 	// first write some data to the tempfile just so it's not 0 bytes.
 	ioutil.WriteFile(tf.Name(), []byte("{anything will do }"), 0644)
 	resource.Test(t, resource.TestCase{
@@ -29,7 +29,26 @@ func TestAccAWSS3BucketObject_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSS3BucketObjectConfig,
+				Config: testAccAWSS3BucketObjectConfigSource,
+				Check:  testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object"),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketObject_content(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if err != nil {
+				panic(err)
+			}
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketObjectConfigContent,
 				Check:  testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object"),
 			},
 		},
@@ -86,7 +105,7 @@ func testAccCheckAWSS3BucketObjectExists(n string) resource.TestCheckFunc {
 }
 
 var randomBucket = randInt
-var testAccAWSS3BucketObjectConfig = fmt.Sprintf(`
+var testAccAWSS3BucketObjectConfigSource = fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
 	bucket = "tf-object-test-bucket-%d"
 }
@@ -97,3 +116,17 @@ resource "aws_s3_bucket_object" "object" {
 	source = "%s"
 }
 `, randomBucket, tf.Name())
+
+
+var testAccAWSS3BucketObjectConfigContent = fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket" {
+        bucket = "tf-object-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "object" {
+        bucket = "${aws_s3_bucket.object_bucket.bucket}"
+        key = "test-key"
+        content = "some_bucket_content"
+}
+`, randomBucket)
+

--- a/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
@@ -107,22 +107,19 @@ func testAccCheckAWSS3BucketObjectExists(n string) resource.TestCheckFunc {
 var randomBucket = randInt
 var testAccAWSS3BucketObjectConfigSource = fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+    bucket = "tf-object-test-bucket-%d"
 }
-
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "test-key"
-	source = "%s"
+    bucket = "${aws_s3_bucket.object_bucket.bucket}"
+    key = "test-key"
+    source = "%s"
 }
 `, randomBucket, tf.Name())
-
 
 var testAccAWSS3BucketObjectConfigContent = fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
         bucket = "tf-object-test-bucket-%d"
 }
-
 resource "aws_s3_bucket_object" "object" {
         bucket = "${aws_s3_bucket.object_bucket.bucket}"
         key = "test-key"

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -28,7 +28,11 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to put the file in.
 * `key` - (Required) The name of the object once it is in the bucket.
-* `source` - (Required) The path to the source file being uploaded to the bucket.
+* `source` - (Required unless `content` given) The path to the source file being uploaded to the bucket.
+* `content` - (Required unless `source` given) The literal content being uploaded to the bucket.
+
+Either `source` or `content` must be provided to specify the bucket content.
+These two arguments are mutually-exclusive.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Added an optional field, `content`, for an easy way to pass things like rendered templates to s3:
```
resource "aws_s3_bucket_object" "example" {
    bucket = "some_bucket"
    key = "/path/to/file.txt"
    content = "${template_file.example.rendered}"
}

resource "template_file" "example" {
    filename = "/templates/example.txt"
    vars {
        name = "${var.name}"
    }
}
```

I also made `source` optional + conflicting with `content`.