### PR TITLE
provider/openstack: add state 'creating' to blockstorage_volume_v1

### DIFF
--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -136,7 +136,7 @@ func resourceBlockStorageVolumeV1Create(d *schema.ResourceData, meta interface{}
 		v.ID)
 
 	stateConf := &resource.StateChangeConf{
-                Pending:    []string{"downloading"},
+		Pending:    []string{"downloading", "creating"},
 		Target:     "available",
 		Refresh:    VolumeV1StateRefreshFunc(blockStorageClient, v.ID),
 		Timeout:    10 * time.Minute,


### PR DESCRIPTION
This commit adds the "creating" status to the Pending phases of creating a
block storage device.

Fixes #3045 