### PR TITLE
remote/s3: Add support for ACL

### DIFF
--- a/website/source/docs/commands/remote-config.html.markdown
+++ b/website/source/docs/commands/remote-config.html.markdown
@@ -57,6 +57,13 @@ The following backends are supported:
   in the `access_key`, `secret_key` and `region` variables
   respectively, but passing credentials this way is not recommended since they
   will be included in cleartext inside the persisted state.
+  Other supported parameters include:
+  * `bucket` - the name of the S3 bucket
+  * `key` - path where to place/look for state file inside the bucket
+  * `encrypt` - whether to enable [server side encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)
+    of the state file
+  * `acl` - [Canned ACL](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl)
+    to be applied to the state file.
 
 * HTTP - Stores the state using a simple REST client. State will be fetched
   via GET, updated via POST, and purged with DELETE. Requires the `address` variable.


### PR DESCRIPTION
See https://github.com/hashicorp/terraform/issues/3143

### Example:

```sh
terraform remote config \
    -backend=S3 \
    -backend-config="bucket=terraform-state" \
    -backend-config="key=shared-state/terraform.tfstate" \
    -backend-config="region=us-east-1" \
    -backend-config="acl=bucket-owner-full-control"
```