### PR TITLE
provider/aws: aws_elasticache_cluster normalizes name to lowercase

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -28,6 +28,12 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					// Elasticache normalizes cluster ids to lowercase,
+					// so we have to do this too or else we can end up
+					// with non-converging diffs.
+					return strings.ToLower(val.(string))
+				},
 			},
 			"engine": &schema.Schema{
 				Type:     schema.TypeString,
@@ -190,7 +196,11 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error creating Elasticache: %s", err)
 	}
 
-	d.SetId(*resp.CacheCluster.CacheClusterId)
+	// Assign the cluster id as the resource ID
+	// Elasticache always retains the id in lower case, so we have to
+	// mimic that or else we won't be able to refresh a resource whose
+	// name contained uppercase characters.
+	d.SetId(strings.ToLower(*resp.CacheCluster.CacheClusterId))
 
 	pending := []string{"creating"}
 	stateConf := &resource.StateChangeConf{

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -163,7 +163,10 @@ resource "aws_security_group" "bar" {
 }
 
 resource "aws_elasticache_cluster" "bar" {
-    cluster_id = "tf-test-%03d"
+    // Including uppercase letters in this name to ensure
+    // that we correctly handle the fact that the API
+    // normalizes names to lowercase.
+    cluster_id = "tf-TEST-%03d"
     node_type = "cache.m1.small"
     num_cache_nodes = 1
     engine = "redis"

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -27,8 +27,8 @@ resource "aws_elasticache_cluster" "bar" {
 
 The following arguments are supported:
 
-* `cluster_id` – (Required) Group identifier. This parameter is stored as a
-lowercase string
+* `cluster_id` – (Required) Group identifier. Elasticache converts
+  this name to lowercase
 
 * `engine` – (Required) Name of the cache engine to be used for this cache cluster.
  Valid values for this parameter are `memcached` or `redis`


### PR DESCRIPTION
This is a similar issue to #3120. That patch fixes the `aws_elasticache_subnet_group` while this patch fixes the `aws_elasticache_cluster`. It's nearly the same change.

AWS forces `aws_elasticache_cluster.cluster_id` to be lower case. Each time `terraform apply` is run it cannot find the matching case `cluster_id` in it's state and tries to create a new one. This patch forces the `cluster_id` in Terraform to be lower case so the state can keep track of the correct `cluster_id`.

The `cluster_id` string in my project is generated with a variable with mixed case values, so I couldn't just make it lower case as a work-around.

I've tweaked the `TestAccAWSElasticacheCluster_vpc` acceptance test to include a mixed case version of the `cluster_id`. The acceptance tests pass when running `make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheCluster_vpc'`. The regular tests pass as well.