### PR TITLE
provider/aws: add support for group name and path changes with group update function

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -105,10 +105,6 @@ func resourceAwsIamGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err := iamconn.UpdateGroup(request)
 		if err != nil {
-			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
-				d.SetId("")
-				return nil
-			}
 			return fmt.Errorf("Error updating IAM Group %s: %s", d.Id(), err)
 		}
 		return resourceAwsIamGroupRead(d, meta)

--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -97,7 +97,7 @@ func resourceAwsIamGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		iamconn := meta.(*AWSClient).iamconn
 		on, nn := d.GetChange("name")
 		op, np := d.GetChange("path")
-		fmt.Println(on, nn, op, np)
+
 		request := &iam.UpdateGroupInput{
 			GroupName:    aws.String(on.(string)),
 			NewGroupName: aws.String(nn.(string)),

--- a/builtin/providers/aws/resource_aws_iam_group_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_test.go
@@ -23,14 +23,14 @@ func TestAccAWSIAMGroup_basic(t *testing.T) {
 				Config: testAccAWSGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
-					testAccCheckAWSGroupAttributes(&conf),
+					testAccCheckAWSGroupAttributes(&conf, "test-group", "/"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccAWSGroupConfig2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
-					testAccCheckAWSGroupAttributes(&conf),
+					testAccCheckAWSGroupAttributes(&conf, "test-group2", "/funnypath/"),
 				),
 			},
 		},
@@ -92,14 +92,14 @@ func testAccCheckAWSGroupExists(n string, res *iam.GetGroupOutput) resource.Test
 	}
 }
 
-func testAccCheckAWSGroupAttributes(group *iam.GetGroupOutput) resource.TestCheckFunc {
+func testAccCheckAWSGroupAttributes(group *iam.GetGroupOutput, name string, path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *group.Group.GroupName != "test-group" {
-			return fmt.Errorf("Bad name: %s", *group.Group.GroupName)
+		if *group.Group.GroupName != name {
+			return fmt.Errorf("Bad name: %s when %s was expected", *group.Group.GroupName, name)
 		}
 
-		if *group.Group.Path != "/" {
-			return fmt.Errorf("Bad path: %s", *group.Group.Path)
+		if *group.Group.Path != path {
+			return fmt.Errorf("Bad path: %s when %s was expected", *group.Group.Path, path)
 		}
 
 		return nil

--- a/builtin/providers/aws/resource_aws_iam_group_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_test.go
@@ -26,6 +26,13 @@ func TestAccAWSIAMGroup_basic(t *testing.T) {
 					testAccCheckAWSGroupAttributes(&conf),
 				),
 			},
+			resource.TestStep{
+				Config: testAccAWSGroupConfig2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
+					testAccCheckAWSGroupAttributes(&conf),
+				),
+			},
 		},
 	})
 }
@@ -103,5 +110,11 @@ const testAccAWSGroupConfig = `
 resource "aws_iam_group" "group" {
 	name = "test-group"
 	path = "/"
+}
+`
+const testAccAWSGroupConfig2 = `
+resource "aws_iam_group" "group" {
+	name = "test-group2"
+	path = "/funnypath/"
 }
 `


### PR DESCRIPTION
This provides support for updating groups. It removes the need to delete and then recreate the resource.