### PR TITLE
Add triggers to the null_resource

### DIFF
--- a/builtin/providers/null/resource.go
+++ b/builtin/providers/null/resource.go
@@ -19,7 +19,13 @@ func resource() *schema.Resource {
 		Update: resourceUpdate,
 		Delete: resourceDelete,
 
-		Schema: map[string]*schema.Schema{},
+		Schema: map[string]*schema.Schema{
+			"triggers": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Looking through issues it appears that a fair amount of people, including people at hashicorp, use the null_resource as a container for running provisioners at specific times in the graph heirarchy. This is because provisioners are not a first class concept in the graph like resources are.

There's a problem with this, the null_resource will never re-run unless it's tainted. So for example if an aws_instance gets tainted or rolled for one reason or another and someone is using a null_resource to provision things on that box at a later stage of graph execution then a subsequent apply won't know to re-run the null_resource provisioners without also tainting it as well. This becomes a hassle in sufficiently large terraform codebases, imo.

What is introduced here is the concept of an optional, ForceNew, ListMap worth of "triggers" that write computed values to the statefile. When these computed values change, like the private_ip of an aws_instance, then the null_resource participates in the graph execution as would be expected and re-runs the provisioners.

After I wrote this I found that it's conceptually similar to #2696. The main difference is that this does not define a new resource and that it allows for multiple triggers instead of just one. I'm of the opinion that since the null_resource provisioner pattern is already used in codebases out in the wild that it makes sense to provide this as an optional parameter to the null_resource. That way the null_resource becomes a more fully featured interim solution before provisioners eventually get lifted up as first class citizens in the execution graph.

See: #580, #1181, #2677, #3080, #3220

Here's an example of how it could be used. This implementation happens to put a watch trigger on two computed values of an aws_instance. There isn't a reason to watch both other than to show off the syntax of how it could be used to trigger upon change of multiple resource values.

```
resource "aws_instance" "example" {
	ami = "ami-aa7ab6c2"
	instance_type = "t1.micro"
}

resource "null_resource" "trigger_test" {
	triggers {
        PRIVATE_IP = "${aws_instance.example.private}"
		PUBLIC_IP  = "${aws_instance.example.public_ip}"	
	}

	connection {
		user = "ubuntu"
		host = "${aws_instance.example.public_ip}"
		key_file = "~/.ssh/id_rsa"
	}

	provisioner "remote-exec" {
		inline = [
			"hostname"
		]
	}
	
}
```