### PR TITLE
provider/aws: allow local kinesis

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	ForbiddenAccountIds []interface{}
 
 	DynamoDBEndpoint string
+	KinesisEndpoint  string
 }
 
 type AWSClient struct {
@@ -108,12 +109,6 @@ func (c *Config) Client() (interface{}, error) {
 			errs = append(errs, err)
 		}
 
-		awsDynamoDBConfig := &aws.Config{
-			Credentials: creds,
-			Region:      aws.String(c.Region),
-			MaxRetries:  aws.Int(c.MaxRetries),
-			Endpoint:    aws.String(c.DynamoDBEndpoint),
-		}
 		// Some services exist only in us-east-1, e.g. because they manage
 		// resources that can span across multiple regions, or because
 		// signature format v4 requires region to be us-east-1 for global
@@ -125,8 +120,11 @@ func (c *Config) Client() (interface{}, error) {
 			MaxRetries:  aws.Int(c.MaxRetries),
 		}
 
+		awsDynamoDBConfig := *awsConfig
+		awsDynamoDBConfig.Endpoint = aws.String(c.DynamoDBEndpoint)
+
 		log.Println("[INFO] Initializing DynamoDB connection")
-		client.dynamodbconn = dynamodb.New(awsDynamoDBConfig)
+		client.dynamodbconn = dynamodb.New(&awsDynamoDBConfig)
 
 		log.Println("[INFO] Initializing ELB connection")
 		client.elbconn = elb.New(awsConfig)
@@ -143,8 +141,11 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing RDS Connection")
 		client.rdsconn = rds.New(awsConfig)
 
+		awsKinesisConfig := *awsConfig
+		awsKinesisConfig.Endpoint = aws.String(c.KinesisEndpoint)
+
 		log.Println("[INFO] Initializing Kinesis Connection")
-		client.kinesisconn = kinesis.New(awsConfig)
+		client.kinesisconn = kinesis.New(&awsKinesisConfig)
 
 		authErr := c.ValidateAccountId(client.iamconn)
 		if authErr != nil {

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -153,6 +153,13 @@ func Provider() terraform.ResourceProvider {
 				Default:     "",
 				Description: descriptions["dynamodb_endpoint"],
 			},
+
+			"kinesis_endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["kinesis_endpoint"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -279,6 +286,9 @@ func init() {
 
 		"dynamodb_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n" +
 			"It's typically used to connect to dynamodb-local.",
+
+		"kinesis_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n" +
+			"It's typically used to connect to kinesalite.",
 	}
 }
 
@@ -290,6 +300,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Region:           d.Get("region").(string),
 		MaxRetries:       d.Get("max_retries").(int),
 		DynamoDBEndpoint: d.Get("dynamodb_endpoint").(string),
+		KinesisEndpoint:  d.Get("kinesis_endpoint").(string),
 	}
 
 	if v, ok := d.GetOk("allowed_account_ids"); ok {

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -57,5 +57,7 @@ The following arguments are supported in the `provider` block:
 
 * `dynamodb_endpoint` - (Optional) Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to dynamodb-local.
 
+* `kinesis_endpoint` - (Optional) Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to kinesalite.
+
 In addition to the above parameters, the `AWS_SESSION_TOKEN` environmental
 variable can be set to set an MFA token.


### PR DESCRIPTION
Allow providing a custom endpoint for kinesis so that Terraform can provision locally (via tools like kinesalite).

The one thing I'm still not happy with is that valid IAM credentials are required even when only provisioning locally due to the early `ValidateCredentials` call. This also affects `dynamodb_endpoint`. Suggestions on how to fix this are welcome.

Thanks!