### PR TITLE
docs: AWS launch configuration

### DIFF
--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -23,10 +23,10 @@ resource "aws_launch_configuration" "as_conf" {
 ## Using with AutoScaling Groups
 
 Launch Configurations cannot be updated after creation with the Amazon
-Web Service API. In order to update a Launch Configuration, Terraform will 
-destroy the existing resource and create a replacement. In order to effectively 
-use a Launch Configuration resource with an [AutoScaling Group resource][1], 
-it's recommend to omit the Launch Configuration `name` attribute, and 
+Web Service API. In order to update a Launch Configuration, Terraform will
+destroy the existing resource and create a replacement. In order to effectively
+use a Launch Configuration resource with an [AutoScaling Group resource][1],
+it's recommend to omit the Launch Configuration `name` attribute, and
 specify `create_before_destroy` in a [lifecycle][2] block, as shown:
 
 ```
@@ -53,6 +53,35 @@ With this setup Terraform generates a unique name for your Launch
 Configuration and can then update the AutoScaling Group without conflict before
 destroying the previous Launch Configuration.
 
+## Using with Spot Instances
+
+Launch configurations can set the spot instance pricing to be used for the
+Auto Scaling Group to reserve instances. Simply specifying the `spot_price`
+parameter will set the price on the Launch Configuration which will attempt to
+reserve your instances at this price.  See the [AWS Spot Instance
+documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html)
+for more information or how to launch [Spot Instances][3] with Terraform.
+
+```
+resource "aws_launch_configuration" "as_conf" {
+    image_id = "ami-1234"
+    instance_type = "m1.small"
+    spot_price = "0.001"
+    lifecycle {
+      create_before_destroy = true
+    }
+}
+
+resource "aws_autoscaling_group" "bar" {
+    name = "terraform-asg-example"
+    launch_configuration = "${aws_launch_configuration.as_conf.name}"
+
+    lifecycle {
+      create_before_destroy = true
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -70,6 +99,7 @@ The following arguments are supported:
 * `enable_monitoring` - (Optional) Enables/disables detailed monitoring. This is enabled by default.
 * `ebs_optimized` - (Optional) If true, the launched EC2 instance will be EBS-optimized.
 * `block_device_mapping` - (Optional) A list of block devices to add. Their keys are documented below.
+* `spot_price` - (Optional) The price to use for reserving spot instances.
 
 <a id="block-devices"></a>
 ## Block devices
@@ -134,3 +164,4 @@ The following attributes are exported:
 
 [1]: /docs/providers/aws/r/autoscaling_group.html
 [2]: /docs/configuration/resources.html#lifecycle
+[3]: /docs/providers/aws/r/spot_instance_request.html


### PR DESCRIPTION
* Spot instance documentation

Searching for how to implement spot pricing on AWS launch configurations led me to #1339 as there were no docs on how to achieve that. This pull request adds some basic docs on how to do so.