### PR TITLE
schema: delete non existing values

### DIFF
--- a/helper/schema/field_writer_map.go
+++ b/helper/schema/field_writer_map.go
@@ -207,7 +207,8 @@ func (w *MapFieldWriter) setPrimitive(
 	k := strings.Join(addr, ".")
 
 	if v == nil {
-		delete(w.result, k)
+		// The empty string here means the value is removed.
+		w.result[k] = ""
 		return nil
 	}
 

--- a/helper/schema/field_writer_map_test.go
+++ b/helper/schema/field_writer_map_test.go
@@ -97,6 +97,15 @@ func TestMapFieldWriter(t *testing.T) {
 			},
 		},
 
+		"string nil": {
+			[]string{"string"},
+			nil,
+			false,
+			map[string]string{
+				"string": "",
+			},
+		},
+
 		"list of resources": {
 			[]string{"listResource"},
 			[]interface{}{


### PR DESCRIPTION
We need to set the value to an empty value so the state file does
indeed change the value. Otherwise the obsolote value is still
intact and doesn't get changed at all. This means `terraform show`
still shows the obsolote value when the particular value is not
existing anymore. This is due the AWS API which is returning a null
instead of an empty string.

Fixes #3251 