### PR TITLE
provider/gce: Make region optional for remaining GCE resources

### DIFF
--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -66,6 +66,12 @@ func resourceComputeBackendService() *schema.Resource {
 				Optional: true,
 			},
 
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+
 			"health_checks": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -19,6 +19,7 @@ resource "google_compute_backend_service" "foobar" {
     port_name = "http"
     protocol = "HTTP"
     timeout_sec = 10
+    region = us-central1
 
     backend {
         group = "${google_compute_instance_group_manager.foo.instance_group}"
@@ -67,6 +68,7 @@ The following arguments are supported:
     for checking the health of the backend service.
 * `description` - (Optional) The textual description for the backend service.
 * `backend` - (Optional) The list of backends that serve this BackendService. See *Backend* below.
+* `region` - (Optional) The region the service sits in. If not specified, the project region is used.
 * `port_name` - (Optional) The name of a service that has been added to
 	an instance group in this backend. See [related docs](https://cloud.google.com/compute/docs/instance-groups/#specifying_service_endpoints)
     for details. Defaults to http.

--- a/website/source/docs/providers/google/r/compute_target_pool.html.markdown
+++ b/website/source/docs/providers/google/r/compute_target_pool.html.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 
 * `session_affinity` - (Optional) How to distribute load.  Options are "NONE" (no affinity).  "CLIENT\_IP" (hash of the source/dest addresses / ports), and "CLIENT\_IP\_PROTO" also includes the protocol (default "NONE").
 
+* `region` - (Optional) Where the target pool resides. Defaults to project region.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Now the `region` attribute is optional (defaults to the Project's region) for all GCE resources. 

The relevant documentation reflects this as well.