### PR TITLE
aws: store and read instance state

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -132,6 +132,11 @@ func resourceAwsInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"instance_state": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"private_dns": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -449,10 +454,14 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	instance := resp.Reservations[0].Instances[0]
 
-	// If the instance is terminated, then it is gone
-	if *instance.State.Name == "terminated" {
-		d.SetId("")
-		return nil
+	if instance.State != nil {
+		// If the instance is terminated, then it is gone
+		if *instance.State.Name == "terminated" {
+			d.SetId("")
+			return nil
+		}
+
+		d.Set("instance_state", instance.State.Name)
 	}
 
 	if instance.Placement != nil {


### PR DESCRIPTION
This allows us to store the instance state into the state file. This
means we can now easily see the instance state with `terraform show`.

An example terraform show result:

![image](https://cloud.githubusercontent.com/assets/438920/9930959/1b223bee-5d40-11e5-9ffd-9bbb089bade0.png)
