### PR TITLE
RFC: implement interface to AWS LoadBalancerPolicies for Backend Auth

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -221,6 +221,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lambda_function":                  resourceAwsLambdaFunction(),
 			"aws_launch_configuration":             resourceAwsLaunchConfiguration(),
 			"aws_lb_cookie_stickiness_policy":      resourceAwsLBCookieStickinessPolicy(),
+                        "aws_load_balancer_policy":             resourceAwsLoadBalancerPolicy(),
 			"aws_main_route_table_association":     resourceAwsMainRouteTableAssociation(),
 			"aws_network_acl":                      resourceAwsNetworkAcl(),
 			"aws_network_interface":                resourceAwsNetworkInterface(),

--- a/builtin/providers/aws/resource_aws_load_balancer_policy.go
+++ b/builtin/providers/aws/resource_aws_load_balancer_policy.go
@@ -1,0 +1,240 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLoadBalancerPolicy() *schema.Resource {
+	return &schema.Resource{
+		// There is no concept of "updating" a Load Balancer Policy in
+		// the AWS API.
+		Create: resourceAwsLoadBalancerPolicyCreate,
+		Update: resourceAwsLoadBalancerPolicyCreate,
+
+		Read:   resourceAwsLoadBalancerPolicyRead,
+		Delete: resourceAwsLoadBalancerPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"load_balancer_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"instance_port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				ForceNew: true,
+			},
+
+			"policy_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy_type_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy_attribute": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				ForceNew: true,
+				Set:      resourceAwsLoadBalancerPolicyAttributeHash,
+			},
+		},
+	}
+}
+
+func resourceAwsLoadBalancerPolicyAttributeHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if v, ok := m["name"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["value"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+func resourceAwsLoadBalancerPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	attributes := []*elb.PolicyAttribute{}
+	if attributedata, ok := d.GetOk("policy_attribute"); ok {
+		attributeSet := attributedata.(*schema.Set)
+		for _, attribute := range attributeSet.List() {
+			attr := attribute.(map[string]interface{})
+			attributes = append(attributes, &elb.PolicyAttribute{
+				AttributeName:  aws.String(attr["name"].(string)),
+				AttributeValue: aws.String(attr["value"].(string)),
+			})
+		}
+	}
+
+	// Provision the LoadBalancerPolicy
+	lbspOpts := &elb.CreateLoadBalancerPolicyInput{
+		LoadBalancerName: aws.String(d.Get("load_balancer_name").(string)),
+		PolicyName:       aws.String(d.Get("policy_name").(string)),
+		PolicyTypeName:   aws.String(d.Get("policy_type_name").(string)),
+		PolicyAttributes: attributes,
+	}
+
+	if _, err := elbconn.CreateLoadBalancerPolicy(lbspOpts); err != nil {
+		return fmt.Errorf("Error creating LoadBalancerPolicy: %s", err)
+	}
+
+	instancePort := int64(0)
+	if v, ok := d.GetOk("instance_port"); ok {
+		instancePort = int64(v.(int))
+	}
+	policyTypeName := lbspOpts.PolicyTypeName
+
+	if (instancePort > 0) && (*policyTypeName == "BackendServerAuthenticationPolicyType") {
+		dlbOpts := &elb.DescribeLoadBalancersInput{
+			LoadBalancerNames: []*string{lbspOpts.LoadBalancerName},
+		}
+
+		lbDesc, err := elbconn.DescribeLoadBalancers(dlbOpts)
+		if err != nil {
+			return fmt.Errorf("Error retrieving ELB: %s", err)
+		}
+
+		policyNames := []*string{}
+
+		for _, backendServerDesc := range lbDesc.LoadBalancerDescriptions[0].BackendServerDescriptions {
+			foundInstancePort := backendServerDesc.InstancePort
+			if instancePort == *foundInstancePort {
+				policyNames = append(backendServerDesc.PolicyNames, lbspOpts.PolicyName)
+			}
+		}
+
+		if len(policyNames) == 0 {
+			policyNames = append(policyNames, lbspOpts.PolicyName)
+		}
+
+		lbpbsOpts := &elb.SetLoadBalancerPoliciesForBackendServerInput{
+			InstancePort:     aws.Int64(int64(instancePort)),
+			LoadBalancerName: lbspOpts.LoadBalancerName,
+			PolicyNames:      policyNames,
+		}
+
+		if _, err := elbconn.SetLoadBalancerPoliciesForBackendServer(lbpbsOpts); err != nil {
+			return fmt.Errorf("Error setting BackendServerAuthenticationPolicyType: %s", err)
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%s:%d:%s",
+		*lbspOpts.LoadBalancerName,
+		instancePort,
+		*lbspOpts.PolicyName))
+	return nil
+}
+
+func resourceAwsLoadBalancerPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	lbName, _, policyName := resourceAwsLoadBalancerPolicyParseId(d.Id())
+
+	request := &elb.DescribeLoadBalancerPoliciesInput{
+		LoadBalancerName: aws.String(lbName),
+		PolicyNames:      []*string{aws.String(policyName)},
+	}
+
+	getResp, err := elbconn.DescribeLoadBalancerPolicies(request)
+	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "PolicyNotFound" {
+			// The policy is gone.
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving policy: %s", err)
+	}
+
+	if len(getResp.PolicyDescriptions) != 1 {
+		return fmt.Errorf("Unable to find policy %#v", getResp.PolicyDescriptions)
+	}
+
+	policyDesc := getResp.PolicyDescriptions[0]
+	policyTypeName := policyDesc.PolicyTypeName
+
+	d.Set("policy_name", policyName)
+	d.Set("policy_type_name", policyTypeName)
+	d.Set("load_balancer_name", lbName)
+
+	return nil
+}
+
+func resourceAwsLoadBalancerPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	lbName, _, policyName := resourceAwsLoadBalancerPolicyParseId(d.Id())
+
+	instancePortInt := d.Get("instance_port")
+	if instancePortInt == 0 {
+		instancePortInt = 1
+	}
+
+	policyTypeName := d.Get("policy_type_name")
+
+	if policyTypeName == "BackendServerAuthenticationPolicyType" {
+		policyNames := []*string{}
+
+		lbpbsOpts := &elb.SetLoadBalancerPoliciesForBackendServerInput{
+			InstancePort:     aws.Int64(int64(instancePortInt.(int))),
+			LoadBalancerName: aws.String(lbName),
+			PolicyNames:      policyNames,
+		}
+
+		if _, err := elbconn.SetLoadBalancerPoliciesForBackendServer(lbpbsOpts); err != nil {
+			return fmt.Errorf("Error clearing BackendServerAuthenticationPolicyType: %s", err)
+		}
+	}
+
+	request := &elb.DeleteLoadBalancerPolicyInput{
+		LoadBalancerName: aws.String(lbName),
+		PolicyName:       aws.String(policyName),
+	}
+
+	if _, err := elbconn.DeleteLoadBalancerPolicy(request); err != nil {
+		return fmt.Errorf("Error deleting Load Balancer Policy %s: %s", d.Id(), err)
+	}
+	return nil
+}
+
+// resourceAwsLoadBalancerPolicyParseId takes an ID and parses it into
+// it's constituent parts. You need three axes (LB name, instance port,
+// and policy name) to create or identify a stickiness policy in AWS's API.
+func resourceAwsLoadBalancerPolicyParseId(id string) (string, string, string) {
+	parts := strings.SplitN(id, ":", 3)
+	return parts[0], parts[1], parts[2]
+}

--- a/builtin/providers/aws/resource_aws_load_balancer_policy.go
+++ b/builtin/providers/aws/resource_aws_load_balancer_policy.go
@@ -17,7 +17,6 @@ func resourceAwsLoadBalancerPolicy() *schema.Resource {
 		// There is no concept of "updating" a Load Balancer Policy in
 		// the AWS API.
 		Create: resourceAwsLoadBalancerPolicyCreate,
-		Update: resourceAwsLoadBalancerPolicyCreate,
 
 		Read:   resourceAwsLoadBalancerPolicyRead,
 		Delete: resourceAwsLoadBalancerPolicyDelete,


### PR DESCRIPTION
My first swing at a Go PR to a project larger than a toy... so this is primarily opened at the moment to request feedback on code style as well as the exposed resource.

Depending on how workable what's here is I'm happy to continue on to add tests, acceptance tests, and update the docs.

Primary goal is to expose the necessary hooks to enable [Backend Authentication](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-create-https-ssl-load-balancer.html#configure_backendauth_clt) for ELBs.

A sample configuration is as follows:

```
provider "aws" {
    region = "us-east-1"
}

resource "aws_elb" "wu-tang" {
  name = "wu-tang"
  availability_zones = ["us-east-1a"]

  listener {
    instance_port = 443
    instance_protocol = "http"
    lb_port = 443
    lb_protocol = "https"
    ssl_certificate_id = "arn:aws:iam::000000000000:server-certificate/star.example.com"
  }

  tags {
    Name = "wu-tang"
  }
}

resource "aws_load_balancer_policy" "foo" {
  load_balancer_name = "${aws_elb.wu-tang.name}"
  policy_name = "foo-policy"
  policy_type_name = "PublicKeyPolicyType"
  policy_attribute {
    name = "PublicKey"
    value = "${file(\"cert.pem\")}"
  }
}

resource "aws_load_balancer_policy" "bar" {
  load_balancer_name = "${aws_elb.wu-tang.name}"
  instance_port = 443
  policy_name = "bar-policy"
  policy_type_name = "BackendServerAuthenticationPolicyType"
  policy_attribute {
    name = "PublicKeyPolicyName"
    value = "${aws_load_balancer_policy.foo.policy_name}"
  }
}
```

Where `cert.pem` is an existing TLS Public Key to be trusted for backend servers.