### PR TITLE
provider/aws: db_parameter_group name validation

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -27,6 +28,30 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+					}
+					if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"first character of %q must be a letter", k))
+					}
+					if regexp.MustCompile(`--`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot contain two consecutive hyphens", k))
+					}
+					if regexp.MustCompile(`-$`).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot end with a hyphen", k))
+					}
+					if len(value) > 255 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be greater than 255 characters", k))
+					}
+					return
+				},
 			},
 			"family": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
Adding a small note to the docs for db_parameter_group to show it needs to be lowercase. The use of UpperCase characters will continually show changes to the resource

This was reported in IRC http://paste.in.ua/543/