### PR TITLE
provider/digitalocean - Droplet Size Lowercase

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -39,6 +39,10 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			"size": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				StateFunc: func(val interface{}) string {
+					// DO API V2 size slug is always lowercase
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"status": &schema.Schema{


### PR DESCRIPTION
Not sure if this is actually valid *but*

Fixes #3283 

Enforcing lowercase on the DO Size. This is used for the sizeslug property of API calls - according to their [docs](https://developers.digitalocean.com/documentation/v1/sizes/) this always looks to be lowercase on the slug. I cannot find any definite answer to this question though