### PR TITLE
schema: Make validation more strict

### DIFF
--- a/builtin/providers/atlas/resource_artifact.go
+++ b/builtin/providers/atlas/resource_artifact.go
@@ -19,7 +19,6 @@ func resourceArtifact() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArtifactRead,
 		Read:   resourceArtifactRead,
-		Update: resourceArtifactRead,
 		Delete: resourceArtifactDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy.go
@@ -15,8 +15,6 @@ func resourceAwsAppCookieStickinessPolicy() *schema.Resource {
 		// There is no concept of "updating" an App Stickiness policy in
 		// the AWS API.
 		Create: resourceAwsAppCookieStickinessPolicyCreate,
-		Update: resourceAwsAppCookieStickinessPolicyCreate,
-
 		Read:   resourceAwsAppCookieStickinessPolicyRead,
 		Delete: resourceAwsAppCookieStickinessPolicyDelete,
 

--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -15,8 +15,6 @@ func resourceAwsLBCookieStickinessPolicy() *schema.Resource {
 		// There is no concept of "updating" an LB Stickiness policy in
 		// the AWS API.
 		Create: resourceAwsLBCookieStickinessPolicyCreate,
-		Update: resourceAwsLBCookieStickinessPolicyCreate,
-
 		Read:   resourceAwsLBCookieStickinessPolicyRead,
 		Delete: resourceAwsLBCookieStickinessPolicyDelete,
 

--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -16,7 +16,6 @@ func resourceAwsS3BucketObject() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsS3BucketObjectPut,
 		Read:   resourceAwsS3BucketObjectRead,
-		Update: resourceAwsS3BucketObjectPut,
 		Delete: resourceAwsS3BucketObjectDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_vpn_connection_route.go
+++ b/builtin/providers/aws/resource_vpn_connection_route.go
@@ -17,8 +17,6 @@ func resourceAwsVpnConnectionRoute() *schema.Resource {
 		// You can't update a route. You can just delete one and make
 		// a new one.
 		Create: resourceAwsVpnConnectionRouteCreate,
-		Update: resourceAwsVpnConnectionRouteCreate,
-
 		Read:   resourceAwsVpnConnectionRouteRead,
 		Delete: resourceAwsVpnConnectionRouteDelete,
 

--- a/builtin/providers/azure/resource_azure_storage_blob.go
+++ b/builtin/providers/azure/resource_azure_storage_blob.go
@@ -13,7 +13,6 @@ func resourceAzureStorageBlob() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAzureStorageBlobCreate,
 		Read:   resourceAzureStorageBlobRead,
-		Update: resourceAzureStorageBlobUpdate,
 		Exists: resourceAzureStorageBlobExists,
 		Delete: resourceAzureStorageBlobDelete,
 
@@ -120,17 +119,6 @@ func resourceAzureStorageBlobRead(d *schema.ResourceData, meta interface{}) erro
 	// NOTE: no need to unset the ID here, as resourceAzureStorageBlobExists
 	// already should have done so if it were required.
 	return nil
-}
-
-// resourceAzureStorageBlobUpdate does all the necessary API calls to
-// update a blob on Azure.
-func resourceAzureStorageBlobUpdate(d *schema.ResourceData, meta interface{}) error {
-	// NOTE: although empty as most parameters have ForceNew set; this is
-	// still required in case of changes to the storage_service_key
-
-	// run the ExistsFunc beforehand to ensure the resource's existence nonetheless:
-	_, err := resourceAzureStorageBlobExists(d, meta)
-	return err
 }
 
 // resourceAzureStorageBlobExists does all the necessary API calls to

--- a/builtin/providers/google/resource_storage_bucket_object.go
+++ b/builtin/providers/google/resource_storage_bucket_object.go
@@ -1,8 +1,8 @@
 package google
 
 import (
-	"os"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -13,7 +13,6 @@ func resourceStorageBucketObject() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceStorageBucketObjectCreate,
 		Read:   resourceStorageBucketObjectRead,
-		Update: resourceStorageBucketObjectUpdate,
 		Delete: resourceStorageBucketObjectDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -104,12 +103,6 @@ func resourceStorageBucketObjectRead(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(objectGetId(res))
 
-	return nil
-}
-
-func resourceStorageBucketObjectUpdate(d *schema.ResourceData, meta interface{}) error {
-	// The Cloud storage API doesn't support updating object data contents,
-	// only metadata. So once we implement metadata we'll have work to do here
 	return nil
 }
 

--- a/builtin/providers/null/resource.go
+++ b/builtin/providers/null/resource.go
@@ -16,7 +16,6 @@ func resource() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCreate,
 		Read:   resourceRead,
-		Update: resourceUpdate,
 		Delete: resourceDelete,
 
 		Schema: map[string]*schema.Schema{},
@@ -29,10 +28,6 @@ func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceRead(d *schema.ResourceData, meta interface{}) error {
-	return nil
-}
-
-func resourceUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -244,7 +244,20 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap) error {
 				return fmt.Errorf(
 					"No Update defined, must set ForceNew on: %#v", nonForceNewAttrs)
 			}
+		} else {
+			nonUpdateableAttrs := make([]string, 0)
+			for k, v := range r.Schema {
+				if v.ForceNew || (v.Computed && !v.Optional) {
+					nonUpdateableAttrs = append(nonUpdateableAttrs, k)
+				}
+			}
+			updateableAttrs := len(r.Schema) - len(nonUpdateableAttrs)
+			if updateableAttrs == 0 {
+				return fmt.Errorf(
+					"All fields are ForceNew or Computed w/out Optional, Update is superfluous")
+			}
 		}
+
 		tsm = schemaMap(r.Schema)
 	}
 

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -335,6 +335,36 @@ func TestResourceInternalValidate(t *testing.T) {
 			},
 			true,
 		},
+
+		// Update undefined for non-ForceNew field
+		{
+			&Resource{
+				Create: func(d *ResourceData, meta interface{}) error { return nil },
+				Schema: map[string]*Schema{
+					"boo": &Schema{
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+			},
+			true,
+		},
+
+		// Update defined for ForceNew field
+		{
+			&Resource{
+				Create: func(d *ResourceData, meta interface{}) error { return nil },
+				Update: func(d *ResourceData, meta interface{}) error { return nil },
+				Schema: map[string]*Schema{
+					"goo": &Schema{
+						Type:     TypeInt,
+						Optional: true,
+						ForceNew: true,
+					},
+				},
+			},
+			true,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
There's a few resources which have all fields set to `ForceNew: true` or `Computed` and still have `Update` function, which I believe will never get called.

I have tightened the validation and removed these update functions where applicable.

If I'm wrong and there's a reason behind the Update function & ForceNew/Computed, then I think documentation or something should be updated with explanation to these cases.