### PR TITLE
Use a faster middleman deploy

### DIFF
--- a/scripts/website_push.sh
+++ b/scripts/website_push.sh
@@ -1,12 +1,38 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+# Set the tmpdir
+if [ -z "$TMPDIR" ]; then
+  TMPDIR="/tmp"
+fi
+
+# Create a temporary build dir and make sure we clean it up. For
+# debugging, comment out the trap line.
+DEPLOY=`mktemp -d $TMPDIR/terraform-www-XXXXXX`
+trap "rm -rf $DEPLOY" INT TERM EXIT
 
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
-# Change into that directory
-cd $DIR
+# Copy into tmpdir
+cp -R $DIR/website/ $DEPLOY/
 
-# Push the subtree (force)
-git push heroku `git subtree split --prefix website HEAD`:master --force
+# Change into that directory
+pushd $DEPLOY &>/dev/null
+
+# Ignore some stuff
+touch .gitignore
+echo ".sass-cache" >> .gitignore
+echo "build" >> .gitignore
+
+# Add everything
+git init -q .
+git add .
+git commit -q -m "Deploy by $USER"
+
+git remote add heroku git@heroku.com:terraform-www.git
+git push -f heroku master
+
+# Go back to our root
+popd &>/dev/null


### PR DESCRIPTION
We migrated to this in Vagrant. The reason to do a subtree split is for preserving history. We don't actually care about history since this is just the static site and we force-push to heroku anyway.

This PR copies the website into a staging directory and creates a fresh git repository in there. This severely reduces the amount of time required for a deploy :smile:

/cc @phinze @catsby 