### PR TITLE
provider/aws: New Validation Function Tests for ELB Name

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -24,31 +24,11 @@ func resourceAwsElb() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"only alphanumeric characters and hyphens allowed in %q: %q",
-							k, value))
-					}
-					if len(value) > 32 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 32 characters: %q", k, value))
-					}
-					if regexp.MustCompile(`^-`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot begin with a hyphen: %q", k, value))
-					}
-					if regexp.MustCompile(`-$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot end with a hyphen: %q", k, value))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateElbName,
 			},
 
 			"internal": &schema.Schema{
@@ -590,4 +570,27 @@ func resourceAwsElbListenerHash(v interface{}) int {
 func isLoadBalancerNotFound(err error) bool {
 	elberr, ok := err.(awserr.Error)
 	return ok && elberr.Code() == "LoadBalancerNotFound"
+}
+
+func validateElbName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q: %q",
+			k, value))
+	}
+	if len(value) > 32 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 32 characters: %q", k, value))
+	}
+	if regexp.MustCompile(`^-`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot begin with a hyphen: %q", k, value))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen: %q", k, value))
+	}
+	return
+
 }

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -437,6 +437,42 @@ func TestResourceAwsElbListenerHash(t *testing.T) {
 	}
 }
 
+func TestAccAWSELB_validateElbNameCannotBeginWithHyphen(t *testing.T) {
+	var elbName = "-Testing123"
+	_, errors := validateElbName(elbName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the ELB Name to trigger a validation error")
+	}
+}
+
+func TestAccAWSELB_validateElbNameCannotBeLongerThen32Characters(t *testing.T) {
+	var elbName = "Testing123dddddddddddddddddddvvvv"
+	_, errors := validateElbName(elbName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the ELB Name to trigger a validation error")
+	}
+}
+
+func TestAccAWSELB_validateElbNameCannotHaveSpecialCharacters(t *testing.T) {
+	var elbName = "Testing123%%"
+	_, errors := validateElbName(elbName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the ELB Name to trigger a validation error")
+	}
+}
+
+func TestAccAWSELB_validateElbNameCannotEndWithHyphen(t *testing.T) {
+	var elbName = "Testing123-"
+	_, errors := validateElbName(elbName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the ELB Name to trigger a validation error")
+	}
+}
+
 func testAccCheckAWSELBDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).elbconn
 

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -437,7 +437,7 @@ func TestResourceAwsElbListenerHash(t *testing.T) {
 	}
 }
 
-func TestAccAWSELB_validateElbNameCannotBeginWithHyphen(t *testing.T) {
+func TestResourceAWSELB_validateElbNameCannotBeginWithHyphen(t *testing.T) {
 	var elbName = "-Testing123"
 	_, errors := validateElbName(elbName, "SampleKey")
 
@@ -446,7 +446,7 @@ func TestAccAWSELB_validateElbNameCannotBeginWithHyphen(t *testing.T) {
 	}
 }
 
-func TestAccAWSELB_validateElbNameCannotBeLongerThen32Characters(t *testing.T) {
+func TestResourceAWSELB_validateElbNameCannotBeLongerThen32Characters(t *testing.T) {
 	var elbName = "Testing123dddddddddddddddddddvvvv"
 	_, errors := validateElbName(elbName, "SampleKey")
 
@@ -455,7 +455,7 @@ func TestAccAWSELB_validateElbNameCannotBeLongerThen32Characters(t *testing.T) {
 	}
 }
 
-func TestAccAWSELB_validateElbNameCannotHaveSpecialCharacters(t *testing.T) {
+func TestResourceAWSELB_validateElbNameCannotHaveSpecialCharacters(t *testing.T) {
 	var elbName = "Testing123%%"
 	_, errors := validateElbName(elbName, "SampleKey")
 
@@ -464,7 +464,7 @@ func TestAccAWSELB_validateElbNameCannotHaveSpecialCharacters(t *testing.T) {
 	}
 }
 
-func TestAccAWSELB_validateElbNameCannotEndWithHyphen(t *testing.T) {
+func TestResourceAWSELB_validateElbNameCannotEndWithHyphen(t *testing.T) {
 	var elbName = "Testing123-"
 	_, errors := validateElbName(elbName, "SampleKey")
 


### PR DESCRIPTION
Test spike to extract the function that does the validation for ELB Name. This will allow me to test this in isolation to make sure that the validation rules work as expected

If you feel this is useful, I will start extracting other pieces out. By doing this, we can test the validations
