### PR TITLE
provider/aws: fix bug with reading GSIs from dynamodb

### DIFF
--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -571,14 +571,23 @@ func resourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) erro
 			}
 		}
 
-		gsi["projection_type"] = *gsiObject.Projection.ProjectionType
-		gsi["non_key_attributes"] = gsiObject.Projection.NonKeyAttributes
+		gsi["projection_type"] = *(gsiObject.Projection.ProjectionType)
+
+		nonKeyAttrs := make([]string, 0, len(gsiObject.Projection.NonKeyAttributes))
+		for _, nonKeyAttr := range gsiObject.Projection.NonKeyAttributes {
+			nonKeyAttrs = append(nonKeyAttrs, *nonKeyAttr)
+		}
+		gsi["non_key_attributes"] = nonKeyAttrs
 
 		gsiList = append(gsiList, gsi)
 		log.Printf("[DEBUG] Added GSI: %s - Read: %d / Write: %d", gsi["name"], gsi["read_capacity"], gsi["write_capacity"])
 	}
 
-	d.Set("global_secondary_index", gsiList)
+	err = d.Set("global_secondary_index", gsiList)
+	if err != nil {
+		return err
+	}
+
 	d.Set("arn", table.TableArn)
 
 	return nil


### PR DESCRIPTION
Reading from a dynamodb table with a GSI with any `non_key_attributes` is currently broken due to the following error returned from `d.Set("global_secondary_index", gsiList)`:

`global_secondary_index.1.non_key_attributes.0: '' expected type 'string', got unconvertible type '*string'`

The error occurs because the aws sdk returns a list of string pointers, not strings. 
http://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb.html#type-Projection

 This fixes that issue by dereferencing in a new list.