### PR TITLE
Allow non-persistent spot requests

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -36,6 +36,11 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			}
+			s["spot_type"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "persistent",
+			}
 			s["wait_for_fulfillment"] = &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -69,10 +74,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 
 	spotOpts := &ec2.RequestSpotInstancesInput{
 		SpotPrice: aws.String(d.Get("spot_price").(string)),
-
-		// We always set the type to "persistent", since the imperative-like
-		// behavior of "one-time" does not map well to TF's declarative domain.
-		Type: aws.String("persistent"),
+		Type:      aws.String(d.Get("spot_type").(string)),
 
 		// Though the AWS API supports creating spot instance requests for multiple
 		// instances, for TF purposes we fix this to one instance per request.

--- a/website/source/docs/providers/aws/r/spot_instance_request.html.markdown
+++ b/website/source/docs/providers/aws/r/spot_instance_request.html.markdown
@@ -51,6 +51,9 @@ Spot Instance Requests support all the same arguments as
 * `wait_for_fulfillment` - (Optional; Default: false) If set, Terraform will
   wait for the Spot Request to be fulfilled, and will throw an error if the
   timeout of 10m is reached.
+* `spot_type` - (Optional; Default: "persistent") If set to "one-time", after
+  the instance is terminated, the spot request will be closed. Also, Terraform
+  can't manage one-time spot requests, just launch them.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Where I work we are using terraform to scale our CI workers, with spot instances. The workers will shutdown after some time of inactivity, and the instance shutdown behavior is set to terminate.

But, since terraform forces us to create the spot request as persistent, when we shut the instance down and terminate it, another instance will be launched, so, we can't automatically scale down.

Note that we don't use terraform to manage those instances, just to launch them.

This change should enable us to do that.

I also updated docs.

Thanks!