### PR TITLE
Fix ValidateAccountId for IAM Instance Profiles

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -221,7 +221,7 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 			// User may be an IAM instance profile, so fail silently.
 			// If it is an IAM instance profile
 			// validating account might be superfluous
-      return nil
+			return nil
 		} else {
 			return fmt.Errorf("Failed getting account ID from IAM: %s", err)
 			// return error if the account id is explicitly not authorised

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -221,6 +221,7 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 			// User may be an IAM instance profile, so fail silently.
 			// If it is an IAM instance profile
 			// validating account might be superfluous
+      return nil
 		} else {
 			return fmt.Errorf("Failed getting account ID from IAM: %s", err)
 			// return error if the account id is explicitly not authorised


### PR DESCRIPTION
Currently while running terraform plan against IAM instance profiles terraform crashes . It was throwing an exception and exiting on 0.6.3 and prior but #3001 missed to exit out of the function .  This PR fixes that .  Testing this version  on IAM instance profiles, no more crashes terraform and throws up exception but works as expected. 