### PR TITLE
Corrected example on rundeck provider index page

### DIFF
--- a/website/source/docs/providers/rundeck/index.html.markdown
+++ b/website/source/docs/providers/rundeck/index.html.markdown
@@ -70,6 +70,6 @@ resource "rundeck_public_key" "anvils" {
 
 resource "rundeck_private_key" "anvils" {
     path = "anvils/id_rsa"
-    key_material_file = "${path.module}/id_rsa.pub"
+    key_material = "${file(\"id_rsa.pub\")}"
 }
 ```


### PR DESCRIPTION
An earlier version of the provider implementation accepted ``key_material_file`` instead of ``key_material``. This was updated in the resource-specific docs but not in this provider-wide example.