### PR TITLE
Allow special "unlimited" resource ID and add project param to templates

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_template.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_template.go
@@ -239,7 +239,7 @@ func resourceCloudStackTemplateRead(d *schema.ResourceData, meta interface{}) er
 	setValueOrUUID(d, "project", t.Project, t.Projectid)
 
 	if t.Zoneid == "" {
-		setValueOrUUID(d, "zone", t.Zonename, UnlimitedResourceID)
+		setValueOrUUID(d, "zone", UnlimitedResourceID, UnlimitedResourceID)
 	} else {
 		setValueOrUUID(d, "zone", t.Zonename, t.Zoneid)
 	}

--- a/builtin/providers/cloudstack/resource_cloudstack_template.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_template.go
@@ -238,8 +238,8 @@ func resourceCloudStackTemplateRead(d *schema.ResourceData, meta interface{}) er
 
 	setValueOrUUID(d, "project", t.Project, t.Projectid)
 
-	if t.Zoneid == IS_GLOBAL_RESOURCE {
-		setValueOrUUID(d, "zone", t.Zonename, IS_GLOBAL_RESOURCE)
+	if t.Zoneid == UnlimitedResourceID {
+		setValueOrUUID(d, "zone", t.Zonename, UnlimitedResourceID)
 	} else {
 		setValueOrUUID(d, "zone", t.Zonename, t.Zoneid)
 	}

--- a/builtin/providers/cloudstack/resource_cloudstack_template.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_template.go
@@ -51,6 +51,12 @@ func resourceCloudStackTemplate() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -122,6 +128,17 @@ func resourceCloudStackTemplateCreate(d *schema.ResourceData, meta interface{}) 
 	ostypeid, e := retrieveUUID(cs, "os_type", d.Get("os_type").(string))
 	if e != nil {
 		return e.Error()
+	}
+
+	// If there is a project supplied, we retrieve and set the project id
+	if project, ok := d.GetOk("project"); ok {
+		// Retrieve the project UUID
+		projectid, e := retrieveUUID(cs, "project", project.(string))
+		if e != nil {
+			return e.Error()
+		}
+		// Set the default project ID
+		p.SetProjectid(projectid)
 	}
 
 	// Retrieve the zone UUID
@@ -218,6 +235,8 @@ func resourceCloudStackTemplateRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("is_public", t.Ispublic)
 	d.Set("password_enabled", t.Passwordenabled)
 	d.Set("is_ready", t.Isready)
+
+	setValueOrUUID(d, "project", t.Project, t.Projectid)
 
 	if t.Zoneid == IS_GLOBAL_RESOURCE {
 		setValueOrUUID(d, "zone", t.Zonename, IS_GLOBAL_RESOURCE)

--- a/builtin/providers/cloudstack/resource_cloudstack_template.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_template.go
@@ -219,9 +219,14 @@ func resourceCloudStackTemplateRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("password_enabled", t.Passwordenabled)
 	d.Set("is_ready", t.Isready)
 
+	if t.Zoneid == "" {
+		d.Set("zone", "-1")
+	} else {
+		setValueOrUUID(d, "zone", t.Zonename, t.Zoneid)
+	}
+	
 	setValueOrUUID(d, "os_type", t.Ostypename, t.Ostypeid)
-	setValueOrUUID(d, "zone", t.Zonename, t.Zoneid)
-
+	
 	return nil
 }
 

--- a/builtin/providers/cloudstack/resource_cloudstack_template.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_template.go
@@ -130,17 +130,6 @@ func resourceCloudStackTemplateCreate(d *schema.ResourceData, meta interface{}) 
 		return e.Error()
 	}
 
-	// If there is a project supplied, we retrieve and set the project id
-	if project, ok := d.GetOk("project"); ok {
-		// Retrieve the project UUID
-		projectid, e := retrieveUUID(cs, "project", project.(string))
-		if e != nil {
-			return e.Error()
-		}
-		// Set the default project ID
-		p.SetProjectid(projectid)
-	}
-
 	// Retrieve the zone UUID
 	zoneid, e := retrieveUUID(cs, "zone", d.Get("zone").(string))
 	if e != nil {
@@ -176,6 +165,17 @@ func resourceCloudStackTemplateCreate(d *schema.ResourceData, meta interface{}) 
 
 	if v, ok := d.GetOk("password_enabled"); ok {
 		p.SetPasswordenabled(v.(bool))
+	}
+
+	// If there is a project supplied, we retrieve and set the project id
+	if project, ok := d.GetOk("project"); ok {
+		// Retrieve the project UUID
+		projectid, e := retrieveUUID(cs, "project", project.(string))
+		if e != nil {
+			return e.Error()
+		}
+		// Set the default project ID
+		p.SetProjectid(projectid)
 	}
 
 	// Create the new template

--- a/builtin/providers/cloudstack/resource_cloudstack_template.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_template.go
@@ -238,7 +238,7 @@ func resourceCloudStackTemplateRead(d *schema.ResourceData, meta interface{}) er
 
 	setValueOrUUID(d, "project", t.Project, t.Projectid)
 
-	if t.Zoneid == UnlimitedResourceID {
+	if t.Zoneid == "" {
 		setValueOrUUID(d, "zone", t.Zonename, UnlimitedResourceID)
 	} else {
 		setValueOrUUID(d, "zone", t.Zonename, t.Zoneid)

--- a/builtin/providers/cloudstack/resource_cloudstack_template.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_template.go
@@ -219,12 +219,12 @@ func resourceCloudStackTemplateRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("password_enabled", t.Passwordenabled)
 	d.Set("is_ready", t.Isready)
 
-	if t.Zoneid == "" {
-		d.Set("zone", "-1")
+	if t.Zoneid == IS_GLOBAL_RESOURCE {
+		setValueOrUUID(d, "zone", t.Zonename, IS_GLOBAL_RESOURCE)
 	} else {
 		setValueOrUUID(d, "zone", t.Zonename, t.Zoneid)
 	}
-	
+
 	setValueOrUUID(d, "os_type", t.Ostypename, t.Ostypeid)
 	
 	return nil

--- a/builtin/providers/cloudstack/resources.go
+++ b/builtin/providers/cloudstack/resources.go
@@ -10,6 +10,8 @@ import (
 	"github.com/xanzy/go-cloudstack/cloudstack"
 )
 
+const IS_GLOBAL_RESOURCE = "-1"
+
 type retrieveError struct {
 	name  string
 	value string
@@ -53,7 +55,7 @@ func retrieveUUID(cs *cloudstack.CloudStackClient, name, value string) (uuid str
 	case "network":
 		uuid, err = cs.Network.GetNetworkID(value)
 	case "zone":
-		if value == "-1" {
+		if value == IS_GLOBAL_RESOURCE {
 			return value, nil
 		}
 		uuid, err = cs.Zone.GetZoneID(value)

--- a/builtin/providers/cloudstack/resources.go
+++ b/builtin/providers/cloudstack/resources.go
@@ -53,6 +53,9 @@ func retrieveUUID(cs *cloudstack.CloudStackClient, name, value string) (uuid str
 	case "network":
 		uuid, err = cs.Network.GetNetworkID(value)
 	case "zone":
+		if value == "-1" {
+			return value, nil
+		}
 		uuid, err = cs.Zone.GetZoneID(value)
 	case "ipaddress":
 		p := cs.Address.NewListPublicIpAddressesParams()

--- a/builtin/providers/cloudstack/resources.go
+++ b/builtin/providers/cloudstack/resources.go
@@ -10,7 +10,8 @@ import (
 	"github.com/xanzy/go-cloudstack/cloudstack"
 )
 
-const IS_GLOBAL_RESOURCE = "-1"
+// CloudStack uses a "special" ID of -1 to define an unlimited resource
+const UnlimitedResourceID = "-1"
 
 type retrieveError struct {
 	name  string
@@ -55,7 +56,7 @@ func retrieveUUID(cs *cloudstack.CloudStackClient, name, value string) (uuid str
 	case "network":
 		uuid, err = cs.Network.GetNetworkID(value)
 	case "zone":
-		if value == IS_GLOBAL_RESOURCE {
+		if value == UnlimitedResourceID {
 			return value, nil
 		}
 		uuid, err = cs.Zone.GetZoneID(value)


### PR DESCRIPTION
This PR does a few things:

- Creates a new `UnlimitedResourceID` constant. CloudStack has a concept of [unlimited resources](http://cloudstack-administration.readthedocs.org/en/latest/usage.html#limiting-resource-usage-in-a-domain). We had a use-case which required us to set an ID of `-1` for the `zone` parameter on a template.
- Add `project` to the `cloudstack_template` resource.

Related to hashicorp/terraform#3271. Feedback welcome.