### PR TITLE
Added Policyfile support to the Chef provisioner

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -310,6 +310,8 @@ validation_client_name  "validator"
 node_name               "nodename1"
 
 
+
+
 http_proxy          "http://proxy.local"
 ENV['http_proxy'] = "http://proxy.local"
 ENV['HTTP_PROXY'] = "http://proxy.local"

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -342,6 +342,8 @@ validation_client_name  "validator"
 node_name               "nodename1"
 
 
+
+
 http_proxy          "http://proxy.local"
 ENV['http_proxy'] = "http://proxy.local"
 ENV['HTTP_PROXY'] = "http://proxy.local"


### PR DESCRIPTION
This Adds three new arguments `use_policyfile`, `policy_group` and `policy_name` to the Chef
provisioner. If `use_policyfile` == true, then the other arguments are required.