### PR TITLE
provider/aws: Ignore errors in S3 JSON bucket policies

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -548,7 +548,8 @@ func normalizeJson(jsonString interface{}) string {
 	j := make(map[string]interface{})
 	err := json.Unmarshal([]byte(jsonString.(string)), &j)
 	if err != nil {
-		return fmt.Sprintf("Error parsing JSON: %s", err)
+		log.Printf("[DEBUG] Error parsing S3 JSON policy: %s", err)
+		return jsonString.(string)
 	}
 	b, _ := json.Marshal(j)
 	return string(b[:])


### PR DESCRIPTION
With this PR the following works:

```
resource "aws_s3_bucket" "main" {
  bucket = "${var.bucket_name}"
  policy = "${template_file.policy.rendered}"

  website {
    index_document = "index.html"
  }
}

resource "template_file" "policy" {
  filename = "policy.json"

  vars {
    bucket_name = "${var.bucket_name}"
  }
}
```

Previously the value of policy would be `"${template_file.policy.rendered}"` which would result in the value `"Error parsing JSON: invalid character '$' looking for beginning of value"` and not the rendered template file. 

It is not up to terraform to validate input anyway.