### PR TITLE
Avoid nil map assign in aws instance migrateStateV0toV1

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_migrate.go
+++ b/builtin/providers/aws/resource_aws_instance_migrate.go
@@ -24,7 +24,7 @@ func resourceAwsInstanceMigrateState(
 }
 
 func migrateStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
-	if is.Empty() {
+	if is.Empty() || is.Attributes == nil {
 		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
 		return is, nil
 	}


### PR DESCRIPTION
When terraform.tfstate contains an aws_instance without an attributes section there's a crash with "assignment to entry in nil map" during `terraform refresh`

```
...
2015/09/26 18:09:14 terraform-provider-aws: 2015/09/26 18:09:14 [DEBUG] Attributes before migration: map[string]string(nil)
2015/09/26 18:09:14 terraform-provider-aws: panic: assignment to entry in nil map
2015/09/26 18:09:14 terraform-provider-aws:
2015/09/26 18:09:14 terraform-provider-aws: goroutine 54 [running]:
2015/09/26 18:09:14 terraform-provider-aws: github.com/hashicorp/terraform/builtin/providers/aws.migrateStateV0toV1(0xc2082ca090, 0x1, 0x0, 0x0)
2015/09/26 18:09:14 terraform-provider-aws:     /opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_instance_migrate.go:42 +0x34d
2015/09/26 18:09:14 terraform-provider-aws: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsInstanceMigrateState(0x0, 0xc2082ca090, 0xadfa20, 0xc208058360, 0x5400000000000000, 0x0, 0x0)
2015/09/26 18:09:14 terraform-provider-aws:     /opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_instance_migrate.go:18 +0x123
2015/09/26 18:09:14 terraform-provider-aws: github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc20813d040, 0xc2082ca090, 0xadfa20, 0xc208058360, 0xc208068ee0, 0x0, 0x0)
2015/09/26 18:09:14 terraform-provider-aws:     /opt/gopath/src/github.com/hashicorp/terraform/helper/schema/resource.go:198 +0x2cb
2015/09/26 18:09:14 terraform-provider-aws: github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc208142150, 0xc2080f3a80, 0xc2082ca090, 0xae0ec0, 0x0, 0x0)
2015/09/26 18:09:14 terraform-provider-aws:     /opt/gopath/src/github.com/hashicorp/terraform/helper/schema/provider.go:187 +0x1c7
2015/09/26 18:09:14 terraform-provider-aws: github.com/hashicorp/terraform/rpc.(*ResourceProviderServer).Refresh(0xc20813eec0, 0xc2082926a0, 0xc208292720, 0x0, 0x0)
2015/09/26 18:09:14 terraform-provider-aws:     /opt/gopath/src/github.com/hashicorp/terraform/rpc/resource_provider.go:345 +0x73
2015/09/26 18:09:14 terraform-provider-aws: reflect.Value.call(0xca09a0, 0xe8cb20, 0x13, 0xefe5d0, 0x4, 0xc2082eff28, 0x3, 0x3, 0x0, 0x0, ...)
2015/09/26 18:09:14 terraform-provider-aws:     /usr/local/go/src/reflect/value.go:419 +0x10e5
2015/09/26 18:09:14 terraform-provider-aws: reflect.Value.Call(0xca09a0, 0xe8cb20, 0x13, 0xc2082eff28, 0x3, 0x3, 0x0, 0x0, 0x0)
2015/09/26 18:09:14 terraform-provider-aws:     /usr/local/go/src/reflect/value.go:296 +0xbc
2015/09/26 18:09:14 terraform-provider-aws: net/rpc.(*service).call(0xc208130600, 0xc2081305c0, 0xc208140ae8, 0xc2080a2380, 0xc20813fb60, 0xae0e60, 0xc2082926a0, 0x16, 0xae0ec0, 0xc208292720, ...)
2015/09/26 18:09:14 terraform-provider-aws:     /usr/local/go/src/net/rpc/server.go:382 +0x1f7
2015/09/26 18:09:14 terraform-provider-aws: created by net/rpc.(*Server).ServeCodec
2015/09/26 18:09:14 terraform-provider-aws:     /usr/local/go/src/net/rpc/server.go:476 +0x44a
...
```

This 1-line change checks to see if is.Attributes is nil and considers them empty if so.