### PR TITLE
[WIP] Import resources into Terraform during refresh

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_migrate.go
+++ b/builtin/providers/aws/resource_aws_instance_migrate.go
@@ -24,7 +24,7 @@ func resourceAwsInstanceMigrateState(
 }
 
 func migrateStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
-	if is.Empty() {
+	if is.Empty() || is.Attributes == nil {
 		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
 		return is, nil
 	}

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -198,30 +198,8 @@ func (c *RefreshCommand) Run(args []string) int {
 			return 1
 		}
 
-		log.Printf("[INFO] Writing state output to: %s", c.Meta.StateOutPath())
-		// TODO: Would be ncie to avoid persisting the state here and
-		// reload the Context to get our chanes. There doesn't appear to be
-		// a way to do that as things currently work, but seems doable
-		if err := c.Meta.PersistState(s); err != nil {
-			c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
-			return 1
-		}
-
-		ctx, _, err = c.Context(contextOpts{
-			Path:      configPath,
-			StatePath: c.Meta.statePath,
-		})
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
-		if !validateContext(ctx, c.Ui) {
-			return 1
-		}
-		if err := ctx.Input(c.InputMode()); err != nil {
-			c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
-			return 1
-		}
+		log.Printf("[INFO] Updating context state")
+		ctx.UpdateState(s)
 	}
 
 	newState, err := ctx.Refresh()

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -58,6 +58,10 @@ func (c *RefreshCommand) importResources(s *terraform.State, configuredResources
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
+		if line == "" || line[0] == '#' {
+			// blank line or comment
+			continue
+		}
 		pieces := strings.Split(line, " ")
 		if len(pieces) != 3 {
 			c.Ui.Error(fmt.Sprintf("Error malformed import line %s", line))

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -63,7 +63,7 @@ func (c *RefreshCommand) importResources(s *terraform.State, configuredResources
 			continue
 		}
 		pieces := strings.Split(line, " ")
-		if len(pieces) != 3 {
+		if len(pieces) < 3 {
 			c.Ui.Error(fmt.Sprintf("Error malformed import line %s", line))
 			return false
 		}
@@ -87,11 +87,22 @@ func (c *RefreshCommand) importResources(s *terraform.State, configuredResources
 				continue
 			}
 
+			// Pull in any extra attributes
+			attributes := make(map[string]string)
+			for _, pair := range pieces[3:] {
+				kv := strings.Split(pair, "=")
+				if len(kv) != 2 {
+					c.Ui.Error(fmt.Sprintf("Error malformed import line %s", line))
+					return false
+				}
+				attributes[kv[0]] = kv[1]
+			}
 			// Minimally add it
 			mod.Resources[pieces[1]] = &terraform.ResourceState{
 				Type: strings.Split(pieces[1], ".")[0],
 				Primary: &terraform.InstanceState{
-					ID: pieces[2],
+					ID:         pieces[2],
+					Attributes: attributes,
 				},
 			}
 		}

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -16,35 +17,37 @@ type RefreshCommand struct {
 	Meta
 }
 
-func (c *RefreshCommand) importResource(s *terraform.State, module string, name string, id string) bool {
-	// Find our target module
-	mod := s.ModuleByPath(strings.Split(module, "."))
-	if mod == nil {
-		c.Ui.Error(fmt.Sprintf("Failed to find module %s", module))
-		return false
+func walkModule(parent string, mod *module.Tree, resources map[string]bool) {
+	var modName string
+	if parent == "" {
+		modName = mod.Name()
+	} else {
+		modName = fmt.Sprintf("%s.%s", parent, mod.Name())
 	}
-
-	// Ignore resources that already exist
-	if _, ok := mod.Resources[name]; ok {
-		log.Printf("[INFO] resource %s already exists in module %s, skipping",
-			name, module)
-		return true
+	for _, resource := range mod.Config().Resources {
+		key := fmt.Sprintf("%s/%s.%s", modName, resource.Type, resource.Name)
+		resources[key] = true
 	}
-
-	// TODO: Ignore resources that aren't present in the current
-	// configuration
-
-	mod.Resources[name] = &terraform.ResourceState{
-		Type: strings.Split(name, ".")[0],
-		Primary: &terraform.InstanceState{
-			ID: id,
-		},
+	for _, child := range mod.Children() {
+		walkModule(modName, child, resources)
 	}
-
-	return true
 }
 
-func (c *RefreshCommand) importResources(s *terraform.State, importPath string) bool {
+// Builds a "set" of module/resource so that we can easily lookup what's
+// configured
+func (c *RefreshCommand) findConfiguredResources(ctx *terraform.Context) map[string]bool {
+	ret := make(map[string]bool)
+
+	mod := ctx.Module()
+	walkModule("", mod, ret)
+
+	return ret
+}
+
+// Import existing (configured) resources by minimally adding them to their
+// module's resources so that a subsequent refresh will pull down their
+// details.
+func (c *RefreshCommand) importResources(s *terraform.State, configuredResources map[string]bool, importPath string) bool {
 	f, err := os.Open(importPath)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error opening import file (%s): %s",
@@ -56,19 +59,37 @@ func (c *RefreshCommand) importResources(s *terraform.State, importPath string) 
 	for scanner.Scan() {
 		line := scanner.Text()
 		pieces := strings.Split(line, " ")
-		switch len(pieces) {
-		case 2:
-			if !c.importResource(s, "root", pieces[0], pieces[1]) {
-				return false
-			}
-		case 3:
-			if !c.importResource(s, pieces[2], pieces[0], pieces[1]) {
-				return false
-			}
-		default:
-			c.Ui.Error(fmt.Sprintf("Error malformed import line %s",
-				line))
+		if len(pieces) != 3 {
+			c.Ui.Error(fmt.Sprintf("Error malformed import line %s", line))
 			return false
+		}
+		// Make sure we have a config for this resource
+		key := fmt.Sprintf("%s/%s", pieces[0], pieces[1])
+		if _, ok := configuredResources[key]; ok {
+			// if so try adding it
+			log.Printf("[INFO] adding %s -> %s", key, pieces[2])
+
+			// Find our target module
+			mod := s.ModuleByPath(strings.Split(pieces[0], "."))
+			if mod == nil {
+				c.Ui.Error(fmt.Sprintf("Failed to find module %s", pieces[0]))
+				return false
+			}
+
+			// Ignore resources that already exist
+			if _, ok := mod.Resources[pieces[1]]; ok {
+				log.Printf("[INFO] resource %s already exists in module %s, skipping",
+					pieces[1], pieces[0])
+				continue
+			}
+
+			// Minimally add it
+			mod.Resources[pieces[1]] = &terraform.ResourceState{
+				Type: strings.Split(pieces[1], ".")[0],
+				Primary: &terraform.InstanceState{
+					ID: pieces[2],
+				},
+			}
 		}
 	}
 	if err = scanner.Err(); err != nil {
@@ -147,25 +168,6 @@ func (c *RefreshCommand) Run(args []string) int {
 		}
 	}
 
-	if importPath != "" {
-		s := state.State()
-		log.Printf("[INFO] Importing resources from %s", importPath)
-		if !c.importResources(s, importPath) {
-			// importResources will have provided an error message
-			return 1
-		}
-
-		log.Printf("[INFO] Writing state output to: %s", c.Meta.StateOutPath())
-		// TODO: Would be ncie to avoid persisting the state here and
-		// just have the Context use the modified version. There
-		// doesn't appear to be a way to do that with Meta.Context( as
-		// it currently works.
-		if err := c.Meta.PersistState(s); err != nil {
-			c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
-			return 1
-		}
-	}
-
 	// Build the context based on the arguments given
 	ctx, _, err := c.Context(contextOpts{
 		Path:        configPath,
@@ -182,6 +184,44 @@ func (c *RefreshCommand) Run(args []string) int {
 	if err := ctx.Input(c.InputMode()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
 		return 1
+	}
+
+	if importPath != "" {
+		log.Printf("[INFO] Importing resources from %s", importPath)
+
+		configuredResources := c.findConfiguredResources(ctx)
+
+		s := state.State()
+		resourceMappings := c.importResources(s, configuredResources, importPath)
+		if !resourceMappings {
+			// importResources will have provided an error message
+			return 1
+		}
+
+		log.Printf("[INFO] Writing state output to: %s", c.Meta.StateOutPath())
+		// TODO: Would be ncie to avoid persisting the state here and
+		// reload the Context to get our chanes. There doesn't appear to be
+		// a way to do that as things currently work, but seems doable
+		if err := c.Meta.PersistState(s); err != nil {
+			c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
+			return 1
+		}
+
+		ctx, _, err = c.Context(contextOpts{
+			Path:      configPath,
+			StatePath: c.Meta.statePath,
+		})
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		if !validateContext(ctx, c.Ui) {
+			return 1
+		}
+		if err := ctx.Input(c.InputMode()); err != nil {
+			c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
+			return 1
+		}
 	}
 
 	newState, err := ctx.Refresh()
@@ -221,14 +261,13 @@ Options:
                       ".backup" extension. Set to "-" to disable backup.
 
   -import=path        Path to a file containing a mapping, one per line,
-                      between resource name, identifier, and module to
-                      allow bringing exiting resources under terraform
-                      management. Module defaults to "root" if not
-                      specified E.g.
+                      between module, resource, and identifier to allow
+                      bringing exiting resources under terraform
+                      management. E.g.
 
-		          resource_name resource_id [module]
-                          aws_vpc.primary subnet-24ba370e
-                          aws_subnet.public subnet-42ba370e
+                          module resource id
+                          root aws_vpc.primary vpc-24bd392c
+                          root aws_subnet.public subnet-42ba370e
 
   -input=true         Ask for input for variables if not directly set.
 

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -702,8 +702,10 @@ test_instance.foo:
 `
 
 const importFile = `
-# this is a comment
+# this is an actual instance we care about
 root test_instance.foo 42
+# this is some junk that'll be ignored
+root test_instance.unknown 53
 `
 
 const testRefreshImportState = `

--- a/command/test-fixtures/refresh-import/main.tf
+++ b/command/test-fixtures/refresh-import/main.tf
@@ -1,0 +1,9 @@
+variable "foo" {
+    default = "bar"
+}
+
+provider "test" {
+    value = "${var.foo}"
+}
+
+resource "test_instance" "foo" {}

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -517,3 +517,7 @@ func (c *Context) walk(
 	walker := &ContextGraphWalker{Context: c, Operation: operation}
 	return walker, graph.Walk(walker)
 }
+
+func (c *Context) UpdateState(s *State) {
+	c.state = s
+}


### PR DESCRIPTION
Adds an optional parameter to `terraform refresh`, `-import=path` that enables existing resources to be pulled under terraform management. It's a different take on #2022 that I believe allows a bit more functionality/flexibility. 

It ignores resource mappings when the resource is already under terraform management. It also allows ignoring mappings for things that aren't yet configured. Those two things allow you to build a large list of mappings (mechanism not included) and then iterate piece by piece on config for them until you're happy with plan's changes for them, ideally nothing. You'll only see the plan for things that are configured so if you start working on a single resource that'll be the only thing included. As soon as you add others to the .tf's they'll start showing up. As #2022 mentions there are gaps in the schema of some resources that cause small plan changes and in some situations even suggest/require resource replacement. Doesn't seem like those should be tackled as part of this PR, but it would be nice to knock them out.

The mapping format is pretty simplistic: module, resource, and id.

```
root aws_vpc.primary vpc-a12345bc
...
```

New to the innards of terraform so there's likely things that could be done more cleanly were I more deeply familiar with it. The only thing I'm not particularly happy with was `Context.UpdateState`. Since Context.state isn't accessible it was either that, making it public, or completely reloading the context prior to refreshing. None of the options seemed great, but this route avoids double verifying and re-reading inputs.

* [x] Unit Tests
* [ ] Verify that things work as expected with (sub-)modules
* [ ] Documentation

Thoughts & suggestions welcome.

fixes #581 