### PR TITLE
Add support for aws autoscaling lifecycle hooks.

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -164,6 +164,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_autoscaling_notification":     resourceAwsAutoscalingNotification(),
 			"aws_autoscaling_policy":           resourceAwsAutoscalingPolicy(),
 			"aws_cloudwatch_log_group":         resourceAwsCloudWatchLogGroup(),
+			"aws_autoscaling_lifecycle_hook":   resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":      resourceAwsCloudWatchMetricAlarm(),
 			"aws_customer_gateway":             resourceAwsCustomerGateway(),
 			"aws_db_instance":                  resourceAwsDbInstance(),

--- a/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -1,0 +1,175 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsAutoscalingLifecycleHook() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAutoscalingLifecycleHookPut,
+		Read:   resourceAwsAutoscalingLifecycleHookRead,
+		Update: resourceAwsAutoscalingLifecycleHookPut,
+		Delete: resourceAwsAutoscalingLifecycleHookDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"autoscaling_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"default_result": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"heartbeat_timeout": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"lifecycle_transition": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"notification_metadata": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"notification_target_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"role_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsAutoscalingLifecycleHookPut(d *schema.ResourceData, meta interface{}) error {
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
+
+	params := getAwsAutoscalingPutLifecycleHookInput(d)
+
+	log.Printf("[DEBUG] AutoScaling PutLifecyleHook: %#v", params)
+	_, err := autoscalingconn.PutLifecycleHook(&params)
+	if err != nil {
+		return fmt.Errorf("Error putting lifecycle hook: %s", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	return resourceAwsAutoscalingLifecycleHookRead(d, meta)
+}
+
+func resourceAwsAutoscalingLifecycleHookRead(d *schema.ResourceData, meta interface{}) error {
+	p, err := getAwsAutoscalingLifecycleHook(d, meta)
+	if err != nil {
+		return err
+	}
+	if p == nil {
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Read Lifecycle Hook: ASG: %s, SH: %s, Obj: %#v", d.Get("autoscaling_group_name"), d.Get("name"), p)
+
+	d.Set("default_result", p.DefaultResult)
+	d.Set("heartbeat_timeout", p.HeartbeatTimeout)
+	d.Set("lifecycle_transition", p.LifecycleTransition)
+	d.Set("notification_metadata", p.NotificationMetadata)
+	d.Set("notification_target_arn", p.NotificationTargetARN)
+	d.Set("name", p.LifecycleHookName)
+	d.Set("role_arn", p.RoleARN)
+
+	return nil
+}
+
+func resourceAwsAutoscalingLifecycleHookDelete(d *schema.ResourceData, meta interface{}) error {
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
+	p, err := getAwsAutoscalingLifecycleHook(d, meta)
+	if err != nil {
+		return err
+	}
+	if p == nil {
+		return nil
+	}
+
+	params := autoscaling.DeleteLifecycleHookInput{
+		AutoScalingGroupName: aws.String(d.Get("autoscaling_group_name").(string)),
+		LifecycleHookName:    aws.String(d.Get("name").(string)),
+	}
+	if _, err := autoscalingconn.DeleteLifecycleHook(&params); err != nil {
+		return fmt.Errorf("Autoscaling Lifecycle Hook: %s ", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func getAwsAutoscalingPutLifecycleHookInput(d *schema.ResourceData) autoscaling.PutLifecycleHookInput {
+	var params = autoscaling.PutLifecycleHookInput{
+		AutoScalingGroupName: aws.String(d.Get("autoscaling_group_name").(string)),
+		LifecycleHookName:    aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("default_result"); ok {
+		params.DefaultResult = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("heartbeat_timeout"); ok {
+		params.HeartbeatTimeout = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("lifecycle_transition"); ok {
+		params.LifecycleTransition = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("notification_metadata"); ok {
+		params.NotificationMetadata = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("notification_target_arn"); ok {
+		params.NotificationTargetARN = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("role_arn"); ok {
+		params.RoleARN = aws.String(v.(string))
+	}
+
+	return params
+}
+
+func getAwsAutoscalingLifecycleHook(d *schema.ResourceData, meta interface{}) (*autoscaling.LifecycleHook, error) {
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
+
+	params := autoscaling.DescribeLifecycleHooksInput{
+		AutoScalingGroupName: aws.String(d.Get("autoscaling_group_name").(string)),
+		LifecycleHookNames:   []*string{aws.String(d.Get("name").(string))},
+	}
+
+	log.Printf("[DEBUG] AutoScaling Lifecycle Hook Describe Params: %#v", params)
+	resp, err := autoscalingconn.DescribeLifecycleHooks(&params)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving lifecycle hooks: %s", err)
+	}
+
+	// find lifecycle hooks
+	name := d.Get("name")
+	for idx, sp := range resp.LifecycleHooks {
+		if *sp.LifecycleHookName == name {
+			return resp.LifecycleHooks[idx], nil
+		}
+	}
+
+	// lifecycle hook not found
+	return nil, nil
+}

--- a/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook_test.go
@@ -1,0 +1,168 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSAutoscalingLifecycleHook_basic(t *testing.T) {
+	var hook autoscaling.LifecycleHook
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoscalingLifecycleHookDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAutoscalingLifecycleHookConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecycleHookExists("aws_autoscaling_lifecycle_hook.foobar", &hook),
+					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "autoscaling_group_name", "terraform-test-foobar5"),
+					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "default_result", "CONTINUE"),
+					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "heartbeat_timeout", "2000"),
+					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "lifecycle_transition", "autoscaling:EC2_INSTANCE_LAUNCHING"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLifecycleHookExists(n string, hook *autoscaling.LifecycleHook) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			rs = rs
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
+		params := &autoscaling.DescribeLifecycleHooksInput{
+			AutoScalingGroupName: aws.String(rs.Primary.Attributes["autoscaling_group_name"]),
+			LifecycleHookNames:   []*string{aws.String(rs.Primary.ID)},
+		}
+		resp, err := conn.DescribeLifecycleHooks(params)
+		if err != nil {
+			return err
+		}
+		if len(resp.LifecycleHooks) == 0 {
+			return fmt.Errorf("LifecycleHook not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAutoscalingLifecycleHookDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_autoscaling_group" {
+			continue
+		}
+
+		params := autoscaling.DescribeLifecycleHooksInput{
+			AutoScalingGroupName: aws.String(rs.Primary.Attributes["autoscaling_group_name"]),
+			LifecycleHookNames:   []*string{aws.String(rs.Primary.ID)},
+		}
+
+		resp, err := conn.DescribeLifecycleHooks(&params)
+
+		if err == nil {
+			if len(resp.LifecycleHooks) != 0 &&
+				*resp.LifecycleHooks[0].LifecycleHookName == rs.Primary.ID {
+				return fmt.Errorf("Lifecycle Hook Still Exists: %s", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+var testAccAWSAutoscalingLifecycleHookConfig = fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+    name = "terraform-test-foobar5"
+    image_id = "ami-21f78e11"
+    instance_type = "t1.micro"
+}
+
+resource "aws_sqs_queue" "foobar" {
+  name = "foobar"
+  delay_seconds = 90
+  max_message_size = 2048
+  message_retention_seconds = 86400
+  receive_wait_time_seconds = 10
+}
+
+resource "aws_iam_role" "foobar" {
+    name = "foobar"
+    assume_role_policy = <<EOF
+{
+  "Version" : "2012-10-17",
+  "Statement": [ {
+    "Effect": "Allow",
+    "Principal": {"AWS": "*"},
+    "Action": [ "sts:AssumeRole" ]
+  } ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "foobar" {
+    name = "foobar"
+    role = "${aws_iam_role.foobar.id}"
+    policy = <<EOF
+{
+    "Version" : "2012-10-17",
+    "Statement": [ {
+      "Effect": "Allow",
+      "Action": [
+	"sqs:SendMessage",
+	"sqs:GetQueueUrl",
+	"sns:Publish"
+      ],
+      "Resource": [
+	"${aws_sqs_queue.foobar.arn}"
+      ]
+    } ]
+}
+EOF
+}
+
+
+resource "aws_autoscaling_group" "foobar" {
+    availability_zones = ["us-west-2a"]
+    name = "terraform-test-foobar5"
+    max_size = 5
+    min_size = 2
+    health_check_grace_period = 300
+    health_check_type = "ELB"
+    force_delete = true
+    termination_policies = ["OldestInstance"]
+    launch_configuration = "${aws_launch_configuration.foobar.name}"
+    tag {
+        key = "Foo"
+        value = "foo-bar"
+        propagate_at_launch = true
+    }
+}
+
+resource "aws_autoscaling_lifecycle_hook" "foobar" {
+    name = "foobar"
+    autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+    default_result = "CONTINUE"
+    heartbeat_timeout = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+    notification_target_arn = "${aws_sqs_queue.foobar.arn}"
+    role_arn = "${aws_iam_role.foobar.arn}"
+}
+`)

--- a/website/source/docs/providers/aws/r/autoscaling_lifecycle_hooks.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_lifecycle_hooks.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "aws"
+page_title: "AWS: aws_autoscaling_lifecycle_hook"
+sidebar_current: "docs-aws-resource-autoscaling-lifecycle-hook"
+description: |-
+  Provides an AutoScaling Lifecycle Hooks resource.
+---
+
+# aws\_autoscaling\_lifecycle\_hook
+
+Provides an AutoScaling Lifecycle Hook resource.
+
+## Example Usage
+
+```
+resource "aws_autoscaling_group" "foobar" {
+    availability_zones = ["us-west-2a"]
+    name = "terraform-test-foobar5"
+    health_check_type = "EC2"
+    termination_policies = ["OldestInstance"]
+    tag {
+        key = "Foo"
+        value = "foo-bar"
+        propagate_at_launch = true
+    }
+}
+
+resource "aws_autoscaling_lifecycle_hook" "foobar" {
+    name = "foobar"
+    autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+    default_result = "CONTINUE"
+    heartbeat_timeout = 2000
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+    notification_metadata = <<EOF
+{
+  "foo": "bar"
+}
+EOF
+    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
+    role_arn = "arn:aws:iam::123456789012:role/S3Access"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the lifecycle hook.
+* `autoscaling_group_name` - (Requred) The name of the Auto Scaling group to which you want to assign the lifecycle hook
+* `default_result` - (Optional) Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs.
+* `heartbeat_timeout` - (Optional) Defines the amount of time, in seconds, that can elapse before the lifecycle hook times out. When the lifecycle hook times out, Auto Scaling performs the action defined in the DefaultResult parameter
+* `lifecycle_transition` - (Optional) The instance state to which you want to attach the lifecycle hook. For a list of lifecycle hook types, see [describe-lifecycle-hook-types](http://docs.aws.amazon.com/cli/latest/reference/autoscaling/describe-lifecycle-hook-types.html#examples)
+* `notification_metadata` - (Optional) Contains additional information that you want to include any time Auto Scaling sends a message to the notification target.
+* `notification_target_arn` - (Required) The ARN of the notification target that Auto Scaling will use to notify you when an instance is in the transition state for the lifecycle hook. This ARN target can be either an SQS queue or an SNS topic.
+* `role_arn` - (Required) The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -63,6 +63,10 @@
                             <a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-autoscaling-lifecycle-hook") %>>
+                            <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hooks</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-autoscaling-notification") %>>
                             <a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
                         </li>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -64,7 +64,7 @@
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-autoscaling-lifecycle-hook") %>>
-                            <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hooks</a>
+                            <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hook</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-autoscaling-notification") %>>


### PR DESCRIPTION
This PR adds the ability to manage AWS Autoscaling Group Lifecycle Hooks.
It adds a new resource `aws_autoscaling_lifecycle_hook` which has a few attributes the can be set, like:

```
resource "aws_autoscaling_lifecycle_hook" "foobar" {
    name = "foobar"
    default_result = "CONTINUE"
    heartbeat_timeout = 2000
    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
    notification_metadata = <<EOF
{
  "foo": "bar"
}
EOF
    notification_target_arn = "arn:aws:sqs:us-east-1:444455556666:queue1*"
    role_arn = "arn:aws:iam::123456789012:role/S3Access"
}
```