### PR TITLE
log: support for user defined log levels

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,28 +2,68 @@ package main
 
 import (
 	"io"
+	"log"
 	"os"
+	"strings"
+
+	"github.com/hashicorp/logutils"
 )
 
 // These are the environmental variables that determine if we log, and if
 // we log whether or not the log should go to a file.
-const EnvLog = "TF_LOG"          //Set to True
-const EnvLogFile = "TF_LOG_PATH" //Set to a file
+const (
+	EnvLog      = "TF_LOG"       // Set to True
+	EnvLogLevel = "TF_LOG_LEVEL" // Set to a log level
+	EnvLogFile  = "TF_LOG_PATH"  // Set to a file
+)
 
-// logOutput determines where we should send logs (if anywhere).
+var validLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
+
+// logOutput determines where we should send logs (if anywhere) and the log level.
 func logOutput() (logOutput io.Writer, err error) {
 	logOutput = nil
-	if os.Getenv(EnvLog) != "" {
-		logOutput = os.Stderr
+	if os.Getenv(EnvLog) == "" {
+		return
+	}
 
-		if logPath := os.Getenv(EnvLogFile); logPath != "" {
-			var err error
-			logOutput, err = os.Create(logPath)
-			if err != nil {
-				return nil, err
-			}
+	logOutput = os.Stderr
+
+	if logPath := os.Getenv(EnvLogFile); logPath != "" {
+		var err error
+		logOutput, err = os.Create(logPath)
+		if err != nil {
+			return nil, err
 		}
 	}
 
+	// This was the default since the beginning
+	logLevel := logutils.LogLevel("TRACE")
+
+	if level := os.Getenv(EnvLogLevel); level != "" {
+		if isValidLevel(level) {
+			// allow following for better ux: info, Info or INFO
+			logLevel = logutils.LogLevel(strings.ToUpper(level))
+		} else {
+			log.Printf("[WARN] Invalid log level: %q. Valid levels are: %+v",
+				level, validLevels)
+		}
+	}
+
+	logOutput = &logutils.LevelFilter{
+		Levels:   validLevels,
+		MinLevel: logLevel,
+		Writer:   logOutput,
+	}
+
 	return
+}
+
+func isValidLevel(level string) bool {
+	for _, l := range validLevels {
+		if strings.ToUpper(level) == string(l) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/log.go
+++ b/log.go
@@ -12,9 +12,8 @@ import (
 // These are the environmental variables that determine if we log, and if
 // we log whether or not the log should go to a file.
 const (
-	EnvLog      = "TF_LOG"       // Set to True
-	EnvLogLevel = "TF_LOG_LEVEL" // Set to a log level
-	EnvLogFile  = "TF_LOG_PATH"  // Set to a file
+	EnvLog     = "TF_LOG"      // Set to True
+	EnvLogFile = "TF_LOG_PATH" // Set to a file
 )
 
 var validLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
@@ -22,12 +21,12 @@ var validLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 // logOutput determines where we should send logs (if anywhere) and the log level.
 func logOutput() (logOutput io.Writer, err error) {
 	logOutput = nil
-	if os.Getenv(EnvLog) == "" {
+	envLevel := os.Getenv(EnvLog)
+	if envLevel == "" {
 		return
 	}
 
 	logOutput = os.Stderr
-
 	if logPath := os.Getenv(EnvLogFile); logPath != "" {
 		var err error
 		logOutput, err = os.Create(logPath)
@@ -39,14 +38,12 @@ func logOutput() (logOutput io.Writer, err error) {
 	// This was the default since the beginning
 	logLevel := logutils.LogLevel("TRACE")
 
-	if level := os.Getenv(EnvLogLevel); level != "" {
-		if isValidLevel(level) {
-			// allow following for better ux: info, Info or INFO
-			logLevel = logutils.LogLevel(strings.ToUpper(level))
-		} else {
-			log.Printf("[WARN] Invalid log level: %q. Valid levels are: %+v",
-				level, validLevels)
-		}
+	if isValidLevel(envLevel) {
+		// allow following for better ux: info, Info or INFO
+		logLevel = logutils.LogLevel(strings.ToUpper(envLevel))
+	} else {
+		log.Printf("[WARN] Invalid log level: %q. Defaulting to level: TRACE. Valid levels are: %+v",
+			envLevel, validLevels)
 	}
 
 	logOutput = &logutils.LevelFilter{


### PR DESCRIPTION
This PR brings support for better log level handling. Terraform logs
are already written in the form which
https://github.com/hashicorp/logutils can understand easily. Based on
this fact we know have the followings:

* A new `TF_LOG_LEVEL` environment variable which the user can control
* Users can pass levels in the form of "info", "Info" or "INFO"
* If an invalid log level is passed, we print a warning but still
  continue
* All changes are backwards compatible with the current logs

Some pictures:

Without any changes:

![screen shot on 2015-10-01 at 22_49_14](https://cloud.githubusercontent.com/assets/438920/10232088/33eff0d0-688f-11e5-93b8-61ac39849f10.png)


With `TF_LOG_LEVEL=info`:

![screen shot on 2015-10-01 at 22_51_04](https://cloud.githubusercontent.com/assets/438920/10232094/3864edd2-688f-11e5-9ea5-115acfe0105d.png)


With a wrong log level:

![screen shot 2015-10-01 at 22 53 00](https://cloud.githubusercontent.com/assets/438920/10232098/3c6d2a66-688f-11e5-98e8-692d0905aa23.png)

