### PR TITLE
Example for the command arg on docker_container.

### DIFF
--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -35,7 +35,8 @@ The following arguments are supported:
   as is shown in the example above.
 
 * `command` - (Optional, list of strings) The command to use to start the
-    container.
+    container. For example, to run `/usr/bin/myprogram -f baz.conf` set the
+    command to be `["/usr/bin/myprogram", "-f", "baz.conf"]`.
 * `dns` - (Optional, set of strings) Set of DNS servers.
 * `env` - (Optional, set of strings) Environmental variables to set.
 * `links` - (Optional, set of strings) Set of links for link based


### PR DESCRIPTION
For those accustomed to running commands via a shell it may not be clear why this argument is a list and what the elements of that list should be. Hopefully giving an example will help people understand what is expected.

This is in response to the misunderstanding discovered in #3011.