### PR TITLE
provider/aws: Fix issue with disabling source dest check on first run

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -414,11 +414,6 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		})
 	}
 
-	// Set our attributes
-	if err := resourceAwsInstanceRead(d, meta); err != nil {
-		return err
-	}
-
 	// Update if we need to
 	return resourceAwsInstanceUpdate(d, meta)
 }
@@ -548,16 +543,23 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// SourceDestCheck can only be set on VPC instances
-	if d.Get("subnet_id").(string) != "" {
-		log.Printf("[INFO] Modifying instance %s", d.Id())
-		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceId: aws.String(d.Id()),
-			SourceDestCheck: &ec2.AttributeBooleanValue{
-				Value: aws.Bool(d.Get("source_dest_check").(bool)),
-			},
-		})
-		if err != nil {
-			return err
+	// AWS will return an error of InvalidParameterCombination if we attempt
+	// to modify the source_dest_check of an instance in EC2 Classic
+	log.Printf("[INFO] Modifying instance %s", d.Id())
+	_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
+		InstanceId: aws.String(d.Id()),
+		SourceDestCheck: &ec2.AttributeBooleanValue{
+			Value: aws.Bool(d.Get("source_dest_check").(bool)),
+		},
+	})
+	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok {
+			// Toloerate InvalidParameterCombination error in Classic, otherwise
+			// return the error
+			if "InvalidParameterCombination" != ec2err.Code() {
+				return err
+			}
+			log.Printf("[WARN] Attempted to modify SourceDestCheck on non VPC instance: %s", ec2err.Message())
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -190,6 +190,9 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 
 	testCheck := func(enabled bool) resource.TestCheckFunc {
 		return func(*terraform.State) error {
+			if v.SourceDestCheck == nil {
+				return fmt.Errorf("bad source_dest_check: got nil")
+			}
 			if *v.SourceDestCheck != enabled {
 				return fmt.Errorf("bad source_dest_check: %#v", *v.SourceDestCheck)
 			}


### PR DESCRIPTION
This PR fixes an issue where setting `source_dest_check` to `false` will fail to apply the `false` value on initial creation. 

Amazon defaults `source_dest_check` to true, and you cannot change that in the `RunInstances` API call, so we follow up and do so in the `update` method.

Right now, we call `create` -> `read` -> `update` -> `read` 

In the initial create, the first `read` reads the default value (`true`) and sets it into the state. The follow up `update` method will read the value from this state, _not_ the config, and thus again send `true` to the API. 

After Terraform completes, a follow up `plan` will recognize the diff and apply the correct value, sorting things out. 

From digging, it seems the initial `create` -> `read` was established so that we'd have a `subnet_id` set, in order to determine if we needed to (or could, even) send the `source_dest_check` update. 

This PR foregoes that, and instead sends the update call anyway. If we attempt to modify `source_dest_check` in a non-vpc, it throws a `InvalidParameterCombination` error, which we swallow. 

It also fixes the failing `TestAccAWSInstance_sourceDestCheck` test. 