### PR TITLE
S3 remote state use application/json Content-Type

### DIFF
--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -133,7 +133,7 @@ func (c *S3Client) Get() (*Payload, error) {
 }
 
 func (c *S3Client) Put(data []byte) error {
-	contentType := "application/octet-stream"
+	contentType := "application/json"
 	contentLength := int64(len(data))
 
 	i := &s3.PutObjectInput{


### PR DESCRIPTION
The state is always JSON, in spite of the fact that this interface presents it as an opaque byte array. It's more helpful to those interacting with the state object outside of Terraform for it to have a more specific content-type.

This addresses #3342.