### PR TITLE
Ignore missing variables during destroy phase

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -292,7 +292,11 @@ func (c *Context) Apply() (*State, error) {
 	}
 
 	// Do the walk
-	_, err = c.walk(graph, walkApply)
+	if c.destroy {
+		_, err = c.walk(graph, walkDestroy)
+	} else {
+		_, err = c.walk(graph, walkApply)
+	}
 
 	// Clean out any unused things
 	c.state.prune()

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -71,7 +71,7 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 
 	// Apply stuff
 	seq = append(seq, &EvalOpFilter{
-		Ops: []walkOperation{walkRefresh, walkPlan, walkApply},
+		Ops: []walkOperation{walkRefresh, walkPlan, walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalGetProvider{
@@ -98,7 +98,7 @@ func ProviderEvalTree(n string, config *config.RawConfig) EvalNode {
 	// We configure on everything but validate, since validate may
 	// not have access to all the variables.
 	seq = append(seq, &EvalOpFilter{
-		Ops: []walkOperation{walkRefresh, walkPlan, walkApply},
+		Ops: []walkOperation{walkRefresh, walkPlan, walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalConfigProvider{

--- a/terraform/graph_config_node_output.go
+++ b/terraform/graph_config_node_output.go
@@ -44,7 +44,7 @@ func (n *GraphNodeConfigOutput) DependentOn() []string {
 // GraphNodeEvalable impl.
 func (n *GraphNodeConfigOutput) EvalTree() EvalNode {
 	return &EvalOpFilter{
-		Ops: []walkOperation{walkRefresh, walkPlan, walkApply},
+		Ops: []walkOperation{walkRefresh, walkPlan, walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalWriteOutput{

--- a/terraform/graph_walk_operation.go
+++ b/terraform/graph_walk_operation.go
@@ -13,4 +13,5 @@ const (
 	walkPlanDestroy
 	walkRefresh
 	walkValidate
+	walkDestroy
 )

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -342,7 +342,7 @@ func (i *Interpolater) computeResourceVariable(
 	// TODO: test by creating a state and configuration that is referencing
 	// a non-existent variable "foo.bar" where the state only has "foo"
 	// and verify plan works, but apply doesn't.
-	if i.Operation == walkApply {
+	if i.Operation == walkApply || i.Operation == walkDestroy {
 		goto MISSING
 	}
 
@@ -384,7 +384,7 @@ MISSING:
 	//
 	// For an input walk, computed values are okay to return because we're only
 	// looking for missing variables to prompt the user for.
-	if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkInput {
+	if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkDestroy || i.Operation == walkInput {
 		return config.UnknownVariableValue, nil
 	}
 
@@ -481,7 +481,7 @@ func (i *Interpolater) computeResourceMultiVariable(
 		//
 		// For an input walk, computed values are okay to return because we're only
 		// looking for missing variables to prompt the user for.
-		if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkInput {
+		if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkDestroy || i.Operation == walkInput {
 			return config.UnknownVariableValue, nil
 		}
 

--- a/terraform/test-fixtures/apply-destroy-cross-providers/child/main.tf
+++ b/terraform/test-fixtures/apply-destroy-cross-providers/child/main.tf
@@ -1,0 +1,5 @@
+variable "value" {}
+
+resource "aws_vpc" "bar" {
+    value = "${var.value}"
+}

--- a/terraform/test-fixtures/apply-destroy-cross-providers/main.tf
+++ b/terraform/test-fixtures/apply-destroy-cross-providers/main.tf
@@ -1,0 +1,6 @@
+resource "terraform_remote_state" "shared" {}
+
+module "child" {
+    source = "./child"
+    value = "${terraform_remote_state.shared.output.env_name}"
+}

--- a/terraform/transform_deposed.go
+++ b/terraform/transform_deposed.go
@@ -110,7 +110,7 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 	var diff *InstanceDiff
 	var err error
 	seq.Nodes = append(seq.Nodes, &EvalOpFilter{
-		Ops: []walkOperation{walkApply},
+		Ops: []walkOperation{walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalGetProvider{

--- a/terraform/transform_orphan.go
+++ b/terraform/transform_orphan.go
@@ -263,7 +263,7 @@ func (n *graphNodeOrphanResource) EvalTree() EvalNode {
 	// Apply
 	var err error
 	seq.Nodes = append(seq.Nodes, &EvalOpFilter{
-		Ops: []walkOperation{walkApply},
+		Ops: []walkOperation{walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalReadDiff{

--- a/terraform/transform_output.go
+++ b/terraform/transform_output.go
@@ -62,7 +62,7 @@ func (n *graphNodeOrphanOutput) Name() string {
 
 func (n *graphNodeOrphanOutput) EvalTree() EvalNode {
 	return &EvalOpFilter{
-		Ops: []walkOperation{walkApply, walkRefresh},
+		Ops: []walkOperation{walkApply, walkDestroy, walkRefresh},
 		Node: &EvalDeleteOutput{
 			Name: n.OutputName,
 		},
@@ -90,7 +90,7 @@ func (n *graphNodeOrphanOutputFlat) Name() string {
 
 func (n *graphNodeOrphanOutputFlat) EvalTree() EvalNode {
 	return &EvalOpFilter{
-		Ops: []walkOperation{walkApply, walkRefresh},
+		Ops: []walkOperation{walkApply, walkDestroy, walkRefresh},
 		Node: &EvalDeleteOutput{
 			Name: n.OutputName,
 		},

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -255,7 +255,7 @@ func (n *graphNodeDisabledProvider) EvalTree() EvalNode {
 	var resourceConfig *ResourceConfig
 
 	return &EvalOpFilter{
-		Ops: []walkOperation{walkInput, walkValidate, walkRefresh, walkPlan, walkApply},
+		Ops: []walkOperation{walkInput, walkValidate, walkRefresh, walkPlan, walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalInterpolate{

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -369,7 +369,7 @@ func (n *graphNodeExpandedResource) EvalTree() EvalNode {
 	var createNew, tainted bool
 	var createBeforeDestroyEnabled bool
 	seq.Nodes = append(seq.Nodes, &EvalOpFilter{
-		Ops: []walkOperation{walkApply},
+		Ops: []walkOperation{walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				// Get the saved diff for apply
@@ -591,7 +591,7 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 	var state *InstanceState
 	var err error
 	return &EvalOpFilter{
-		Ops: []walkOperation{walkApply},
+		Ops: []walkOperation{walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				// Get the saved diff for apply

--- a/terraform/transform_tainted.go
+++ b/terraform/transform_tainted.go
@@ -114,7 +114,7 @@ func (n *graphNodeTaintedResource) EvalTree() EvalNode {
 	// Apply
 	var diff *InstanceDiff
 	seq.Nodes = append(seq.Nodes, &EvalOpFilter{
-		Ops: []walkOperation{walkApply},
+		Ops: []walkOperation{walkApply, walkDestroy},
 		Node: &EvalSequence{
 			Nodes: []EvalNode{
 				&EvalGetProvider{

--- a/terraform/walkoperation_string.go
+++ b/terraform/walkoperation_string.go
@@ -4,9 +4,9 @@ package terraform
 
 import "fmt"
 
-const _walkOperation_name = "walkInvalidwalkInputwalkApplywalkPlanwalkPlanDestroywalkRefreshwalkValidate"
+const _walkOperation_name = "walkInvalidwalkInputwalkApplywalkPlanwalkPlanDestroywalkRefreshwalkValidatewalkDestroy"
 
-var _walkOperation_index = [...]uint8{0, 11, 20, 29, 37, 52, 63, 75}
+var _walkOperation_index = [...]uint8{0, 11, 20, 29, 37, 52, 63, 75, 86}
 
 func (i walkOperation) String() string {
 	if i >= walkOperation(len(_walkOperation_index)-1) {


### PR DESCRIPTION
This is fixing https://github.com/hashicorp/terraform/issues/2892

I think Mitchell aimed to fix it in https://github.com/hashicorp/terraform/pull/2775/files#diff-6baa6e1e203f1aabf89e2169ec8c89b1R373 but it only covers `plan -destroy`, not the actual `destroy`.

I'm not quite sure why there was no `walkDestroy` operation until now - if there's an obvious reason that I don't see, please tell me.