### PR TITLE
Create a scrollable and fixed navigation bar

### DIFF
--- a/website/source/assets/javascripts/docs.js
+++ b/website/source/assets/javascripts/docs.js
@@ -2,7 +2,7 @@
 
 var Init = {
 
-  start: function(){ 
+  start: function(){
     var classname = this.hasClass(document.body, 'page-sub');
 
     if (classname) {
@@ -36,7 +36,7 @@ var Init = {
     if(withMinHeight >  bodyHeight ){
       var newHeight = (vp - (hHeight+fHeight)) + 'px';
       main.style.height = newHeight;
-    }    
+    }
   }
 
 };

--- a/website/source/assets/javascripts/docs.js
+++ b/website/source/assets/javascripts/docs.js
@@ -44,3 +44,73 @@ var Init = {
 Init.start();
 
 })();
+
+(function($){
+  // functions to handle the documentation scroll bar
+  // these functions will ensure that
+  //   the selected link is scrolled to on page load (ie visible so the user does not loose context)
+  //   the documentation side bar does not overlap the footer or header
+  //
+  // these functions should only be applied to a 'desktop' display – the mobile layout is incompatible
+
+  // scrolls the nav to the active link in the side bar
+  // called only on load
+  function scrollNavIntoContext(sb){
+    var path = window.location.pathname
+      , link = sb.find("a[href='"+path+"']")
+      , padding = link.height() * 2;
+
+    if(link[0]){
+      sb.scrollTop(
+        (link.offset().top - (sb.offset().top + padding))
+      )
+    }
+  }
+
+  // this function will resize the top and the bottom of the side bar to fit nicely
+  // between the header and footer.
+  //
+  // it would be great to avoid this level of complexity, but I do not know of a CSS rule
+  // set to pull this off – if there is one.
+  function monitorScroll(sb){
+    var header = $('#header')
+      , footer = $('#footer')
+      , doc = $(document)
+      , win = $(window)
+      , p   // current scroll position
+      , hb  // header bottom
+      , ft; // footer top
+
+    $(window).on('resize', function(){
+      hb = header.offset().top + header.height();
+      ft = footer.offset().top;
+    })
+
+    $(window, document).on('scroll resize',function(){
+      // do nothing for mobile/small screens
+      // the css will define the position via media rules
+      if(sb.css('position') != 'fixed') { return; }
+
+      p = doc.scrollTop();
+      sb.css('top', Math.max(hb - p, 0)+'px')
+      sb.css('bottom', Math.max((p - (ft - win.height())), 0)+'px')
+    })
+  }
+
+  function monitorResize(sb){
+    $(window, document).on('scroll', function(){
+      sb.css('width', sb.parent().width())
+    })
+  }
+
+  function init(){
+    var sb = $('.docs-sidebar');
+
+    scrollNavIntoContext(sb);
+    monitorScroll(sb);
+    monitorResize(sb);
+    $(window).scroll().resize();
+  }
+
+  $(init);
+})(jQuery);

--- a/website/source/assets/stylesheets/_docs.scss
+++ b/website/source/assets/stylesheets/_docs.scss
@@ -211,6 +211,22 @@ body.layout-intro{
     }
 }
 
+// on 'large' screens the document side bar is a fixed element
+// see /assets/javascripts/docs.js for functions treating this element
+@media (min-width:993px) {
+  .docs-sidebar{
+    position: fixed;
+    z-index: 20000;
+    top: 90px;
+    bottom: 0px;
+    padding: 0px;
+    overflow-y: scroll;
+    margin-top:0;
+    margin-bottom: 0;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}
 
 @media (max-width: 992px) {
 	body.layout-docs,


### PR DESCRIPTION
The last few days I was pretty heavily in the Terraform docs.  Lots of going back and forth between links, trying to find the right link, or just browsing the Provider resources.

It was frustrating.

Since the navigation and document are static, context would be lost.  Say I clicked on aws_db_instance.  I would no longer see the related RDS Resources.  If I would scroll down to those I would no longer see the documentation.

So I created this patch.

![docs-scroll-sample](https://cloud.githubusercontent.com/assets/49975/10255220/cc43d5c2-68fd-11e5-9757-5292f41ba3ed.gif)

It would be awesome if there were a pure CSS rule set to do this.  And perhaps there is?

Caveats:  How will this look in browsers which always show scroll bars?  It will need some styling. And, it works on an iPad, but has some artifacts. 