### PR TITLE
provider/aws: Renable TestAccAWSRouteTable_vpcPeering

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -213,7 +213,6 @@ func testAccCheckRouteTableExists(n string, v *ec2.RouteTable) resource.TestChec
 	}
 }
 
-// TODO: re-enable this test.
 // VPC Peering connections are prefixed with pcx
 // Right now there is no VPC Peering resource
 func TestAccAWSRouteTable_vpcPeering(t *testing.T) {


### PR DESCRIPTION
This required some additional config and a pre-set `TF_ACC_ID` environment variable, but the test now works. Supersedes #2915 