### PR TITLE
aws: Only fail on missing TF_ACC_ID if we're actually running acc. tests

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -219,7 +219,7 @@ func TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 	var v ec2.RouteTable
 
 	acctId := os.Getenv("TF_ACC_ID")
-	if acctId == "" {
+	if acctId == "" && os.Getenv(resource.TestEnvVar) != "" {
 		t.Fatal("Error: Test TestAccAWSRouteTable_vpcPeering requires an Account ID in TF_ACC_ID ")
 	}
 


### PR DESCRIPTION
cc @catsby 

Otherwise tests will fail (as we can see in Travis) and there's no point in asking for that variable if it's not needed.

--------

We could probably separate acceptance tests in a slightly more elegant and cleaner way at some point, but that will require more significant changes and the goal here is at least to not block other PRs that are currently red.