### PR TITLE
Rename base64enc/dec to encode/decode

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -20,18 +20,18 @@ var Funcs map[string]ast.Function
 
 func init() {
 	Funcs = map[string]ast.Function{
-		"concat":     interpolationFuncConcat(),
-		"element":    interpolationFuncElement(),
-		"file":       interpolationFuncFile(),
-		"format":     interpolationFuncFormat(),
-		"formatlist": interpolationFuncFormatList(),
-		"index":      interpolationFuncIndex(),
-		"join":       interpolationFuncJoin(),
-		"length":     interpolationFuncLength(),
-		"replace":    interpolationFuncReplace(),
-		"split":      interpolationFuncSplit(),
-		"base64enc":  interpolationFuncBase64Encode(),
-		"base64dec":  interpolationFuncBase64Decode(),
+		"concat":       interpolationFuncConcat(),
+		"element":      interpolationFuncElement(),
+		"file":         interpolationFuncFile(),
+		"format":       interpolationFuncFormat(),
+		"formatlist":   interpolationFuncFormatList(),
+		"index":        interpolationFuncIndex(),
+		"join":         interpolationFuncJoin(),
+		"length":       interpolationFuncLength(),
+		"replace":      interpolationFuncReplace(),
+		"split":        interpolationFuncSplit(),
+		"base64encode": interpolationFuncBase64Encode(),
+		"base64decode": interpolationFuncBase64Decode(),
 	}
 }
 
@@ -396,8 +396,8 @@ func interpolationFuncValues(vs map[string]ast.Variable) ast.Function {
 	}
 }
 
-// interpolationFuncBase64Encode implements the "base64enc" function that allows
-// Base64 encoding.
+// interpolationFuncBase64Encode implements the "base64encode" function that
+// allows Base64 encoding.
 func interpolationFuncBase64Encode() ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeString},
@@ -409,8 +409,8 @@ func interpolationFuncBase64Encode() ast.Function {
 	}
 }
 
-// interpolationFuncBase64Decode implements the "base64dec" function that allows
-// Base64 decoding.
+// interpolationFuncBase64Decode implements the "base64decode" function that
+// allows Base64 decoding.
 func interpolationFuncBase64Decode() ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeString},

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -589,7 +589,7 @@ func TestInterpolateFuncBase64Encode(t *testing.T) {
 		Cases: []testFunctionCase{
 			// Regular base64 encoding
 			{
-				`${base64enc("abc123!?$*&()'-=@~")}`,
+				`${base64encode("abc123!?$*&()'-=@~")}`,
 				"YWJjMTIzIT8kKiYoKSctPUB+",
 				false,
 			},
@@ -602,14 +602,14 @@ func TestInterpolateFuncBase64Decode(t *testing.T) {
 		Cases: []testFunctionCase{
 			// Regular base64 decoding
 			{
-				`${base64dec("YWJjMTIzIT8kKiYoKSctPUB+")}`,
+				`${base64decode("YWJjMTIzIT8kKiYoKSctPUB+")}`,
 				"abc123!?$*&()'-=@~",
 				false,
 			},
 
 			// Invalid base64 data decoding
 			{
-				`${base64dec("this-is-an-invalid-base64-data")}`,
+				`${base64decode("this-is-an-invalid-base64-data")}`,
 				nil,
 				true,
 			},

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -74,10 +74,10 @@ are documented below.
 
 The supported built-in functions are:
 
-  * `base64dec(string)` - Given a base64-encoded string, decodes it and
+  * `base64decode(string)` - Given a base64-encoded string, decodes it and
     returns the original string.
 
-  * `base64enc(string)` - Returns a base64-encoded representation of the
+  * `base64encode(string)` - Returns a base64-encoded representation of the
     given string.
 
   * `concat(list1, list2)` - Combines two or more lists into a single list.


### PR DESCRIPTION
There isn't any precedent for abbreviating words in the interpolation function names, and it may not be clear to all users what "enc" and "dec" are short for, so instead we'll prefer to spell out the whole words for improved readability.

This is per discussion in #3325, where @radeksimko suggested the update and I agreed.