### PR TITLE
Document that heredoc syntax is supported

### DIFF
--- a/website/source/docs/configuration/syntax.html.md
+++ b/website/source/docs/configuration/syntax.html.md
@@ -54,6 +54,11 @@ Basic bullet point reference:
     is
     [documented here](/docs/configuration/interpolation.html).
 
+  * Multiline strings can use shell-style "here doc" syntax, with
+    the string starting with a marker like `<<EOT` and then the
+    string ending with `EOT` on a line of its own. The lines of
+    the string and the end marker must *not* be indented.
+
   * Numbers are assumed to be base 10. If you prefix a number with
     `0x`, it is treated as a hexadecimal number.
 


### PR DESCRIPTION
Previously the only "documentation" I could find about this was a pull request in the HCL repository.

This came to my attention because of #3360.