### PR TITLE
[WIP] Add CloudInit Provider

### DIFF
--- a/builtin/bins/provider-cloudinit/main.go
+++ b/builtin/bins/provider-cloudinit/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/cloudinit"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: cloudinit.Provider,
+	})
+}

--- a/builtin/providers/cloudinit/provider.go
+++ b/builtin/providers/cloudinit/provider.go
@@ -1,0 +1,14 @@
+package cloudinit
+
+import (
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"cloudinit_config": resource(),
+		},
+	}
+}

--- a/builtin/providers/cloudinit/provider_test.go
+++ b/builtin/providers/cloudinit/provider_test.go
@@ -1,0 +1,13 @@
+package cloudinit
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}

--- a/builtin/providers/cloudinit/resource.go
+++ b/builtin/providers/cloudinit/resource.go
@@ -1,0 +1,271 @@
+package cloudinit
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/textproto"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resource() *schema.Resource {
+	return &schema.Resource{
+		Create: Create,
+		Delete: Delete,
+		Exists: Exists,
+		Read:   Read,
+
+		Schema: map[string]*schema.Schema{
+			"part": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"order": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(int)
+
+								if value < 0 {
+									errors = append(errors, fmt.Errorf("Order must be zero or greater"))
+								}
+
+								return
+							},
+						},
+						"content_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(string)
+
+								if _, supported := supportedContentTypes[value]; !supported {
+									errors = append(errors, fmt.Errorf("Unsupported content type: %s", v))
+								}
+
+								return
+							},
+						},
+						"content": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"filename": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"merge_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Set: resourceCloudInitConfigPartHash,
+			},
+			"gzip": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+			"base64_encode": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+			"rendered": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "rendered cloudinit configuration",
+			},
+		},
+	}
+}
+
+func Create(d *schema.ResourceData, meta interface{}) error {
+	rendered, err := render(d)
+	if err != nil {
+		return err
+	}
+
+	d.Set("rendered", rendered)
+	d.SetId(strconv.Itoa(hashcode.String(rendered)))
+	return nil
+}
+
+func Delete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func Exists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	rendered, err := render(d)
+	if err != nil {
+		return false, err
+	}
+
+	return strconv.Itoa(hashcode.String(rendered)) == d.Id(), nil
+}
+
+func Read(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func render(d *schema.ResourceData) (string, error) {
+	gzipOutput := d.Get("gzip").(bool)
+	base64Output := d.Get("base64_encode").(bool)
+
+	var buffer bytes.Buffer
+
+	var err error
+	if gzipOutput {
+		gzipWriter := gzip.NewWriter(&buffer)
+		err = renderToWriter(d, gzipWriter)
+		gzipWriter.Close()
+	} else {
+		err = renderToWriter(d, &buffer)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	output := ""
+	if base64Output {
+		output = base64.StdEncoding.EncodeToString(buffer.Bytes())
+	} else {
+		output = buffer.String()
+	}
+
+	return output, nil
+}
+
+func renderToWriter(d *schema.ResourceData, writer io.Writer) error {
+	partsValue, hasParts := d.GetOk("part")
+	if !hasParts {
+		return fmt.Errorf("No parts found in the cloudinit resource declaration")
+	}
+	partsSet, ok := partsValue.(*schema.Set)
+	if !ok {
+		return fmt.Errorf("Parts must be a set TODO error message")
+	}
+
+	cloudInitParts := make(cloudInitParts, partsSet.Len())
+	for i, v := range partsSet.List() {
+		partMap := v.(map[string]interface{})
+		part := cloudInitPart{}
+		if v, ok := partMap["order"]; ok {
+			part.Order = v.(int)
+		}
+		if v, ok := partMap["content_type"]; ok {
+			part.ContentType = v.(string)
+		}
+		if v, ok := partMap["content"]; ok {
+			part.Content = v.(string)
+		}
+		if v, ok := partMap["merge_type"]; ok {
+			part.MergeType = v.(string)
+		}
+		if v, ok := partMap["filename"]; ok {
+			part.Filename = v.(string)
+		}
+		cloudInitParts[i] = part
+	}
+	sort.Sort(cloudInitParts)
+
+	mimeWriter := multipart.NewWriter(writer)
+	defer mimeWriter.Close()
+
+	for _, part := range cloudInitParts {
+		header := textproto.MIMEHeader{}
+		if part.ContentType == "" {
+			header.Set("Content-Type", "text/plain")
+		} else {
+			header.Set("Content-Type", part.ContentType)
+		}
+
+		if part.Filename != "" {
+			header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, part.Filename))
+		}
+
+		if part.MergeType != "" {
+			header.Set("X-Merge-Type", part.MergeType)
+		}
+
+		partWriter, err := mimeWriter.CreatePart(header)
+		if err != nil {
+			return err
+		}
+
+		_, err = partWriter.Write([]byte(part.Content))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceCloudInitConfigPartHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if v, ok := m["order"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(int)))
+	}
+	if v, ok := m["content_type"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["content"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["merge_type"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	t := hashcode.String(buf.String())
+	fmt.Println("hashcode is", t)
+	return t
+}
+
+type cloudInitPart struct {
+	Order       int
+	ContentType string
+	MergeType   string
+	Filename    string
+	Content     string
+}
+
+type cloudInitParts []cloudInitPart
+
+func (slice cloudInitParts) Len() int {
+	return len(slice)
+}
+
+func (slice cloudInitParts) Less(i, j int) bool {
+	return slice[i].Order < slice[j].Order
+}
+
+func (slice cloudInitParts) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+var supportedContentTypes = map[string]bool{
+	"text/x-include-once-url":   true,
+	"text/x-include-url":        true,
+	"text/cloud-config-archive": true,
+	"text/upstart-job":          true,
+	"text/cloud-config":         true,
+	"text/part-handler":         true,
+	"text/x-shellscript":        true,
+	"text/cloud-boothook":       true,
+}

--- a/builtin/providers/cloudinit/resource.go
+++ b/builtin/providers/cloudinit/resource.go
@@ -220,7 +220,7 @@ func resourceCloudInitConfigPartHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	if v, ok := m["order"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", v.(int)))
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
 	if v, ok := m["content_type"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))

--- a/builtin/providers/cloudinit/resource_test.go
+++ b/builtin/providers/cloudinit/resource_test.go
@@ -1,0 +1,29 @@
+package cloudinit
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestPartOrdering(t *testing.T) {
+	parts := cloudInitParts{
+		cloudInitPart{
+			Order:   1,
+			Content: "bar",
+		},
+		cloudInitPart{
+			Order:   0,
+			Content: "foo",
+		},
+		cloudInitPart{
+			Order:   2,
+			Content: "baz",
+		},
+	}
+
+	sort.Sort(parts)
+
+	if parts[0].Order != 0 || parts[1].Order != 1 || parts[2].Order != 2 {
+		t.Error("CloudInit part ordering is incorrect: %+v", parts)
+	}
+}


### PR DESCRIPTION
This adds an initial version of a cloudinit provider which can be used to construct multipart, gzipped, base64 encoded configurations for use as userdata for various different clouds. It is currently presented as a work-in-progress in order to solicit feedback, but needs improved testing prior to merging.

## Example

```tf
provider "cloudinit" {}

resource "cloudinit_config" "myconfig" {
  gzip = false
  base64_encode = true

  part {
    # Note this is needed since the set does not maintain ordering and the config scripts are not commutative
    order = 2
    content_type = "text/x-shellscript"
    content = "${file("shellscript1.sh")}"
  }

  part {
    order = 1
    content_type = "text/x-shellscript"
    content = "${file("shellscript2.sh")}"
  }

  part {
    order = 3
    content_type = "text/cloud-config"
    merge_type = "list(append)+dict(recurse_array)+str()"
    content = "${file("cloudconfig.yaml")}"
  }
}

output "content" {
  value = "${cloudinit_config.myconfig.rendered}"
}
```

Output:

```
--7e8c268155c51af5992d6f61fa35cc04afb47a4fb3ad3676d0339613fab8
Content-Type: text/x-shellscript

#!/usr/bin/env bash

touch /.testscript2

--7e8c268155c51af5992d6f61fa35cc04afb47a4fb3ad3676d0339613fab8
Content-Type: text/x-shellscript

#!/usr/bin/env bash

touch /.testscript1

--7e8c268155c51af5992d6f61fa35cc04afb47a4fb3ad3676d0339613fab8
Content-Type: text/cloud-config
X-Merge-Type: list(append)+dict(recurse_array)+str()

#cloud-config

runcmd:
 - touch /testfile

--7e8c268155c51af5992d6f61fa35cc04afb47a4fb3ad3676d0339613fab8
Content-Type: text/cloud-config

#cloud-config

runcmd:
 - touch /testfile2

--7e8c268155c51af5992d6f61fa35cc04afb47a4fb3ad3676d0339613fab8--
```

## TODO

- [x] Deal correctly with multi-part content header (not currently implemented)
- [ ] Add resource tests for the config format
- [ ] Fix up error messages to be reasonable and informative
- [ ] Update documentation with resource
- [ ] Document with GoDoc
- [ ] Update ChangeLog