### PR TITLE
doc: Correct VPC customer gw type in examples.

### DIFF
--- a/website/source/docs/providers/aws/r/customer_gateway.html.markdown
+++ b/website/source/docs/providers/aws/r/customer_gateway.html.markdown
@@ -18,7 +18,7 @@ Provides a customer gateway inside a VPC. These objects can be connected to VPN 
 resource "aws_customer_gateway" "main" {
     bgp_asn = 60000
     ip_address = "172.83.124.10"
-    type = ipsec.1
+    type = "ipsec.1"
     tags {
         Name = "main-customer-gateway"
     }

--- a/website/source/docs/providers/aws/r/vpn_connection_route.html.markdown
+++ b/website/source/docs/providers/aws/r/vpn_connection_route.html.markdown
@@ -24,7 +24,7 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 resource "aws_customer_gateway" "customer_gateway" {
 	  bgp_asn = 60000
 	  ip_address = "172.0.0.1"
-	  type = ipsec.1
+	  type = "ipsec.1"
 }
 
 resource "aws_vpn_connection" "main" {


### PR DESCRIPTION
The `aws_customer_gateway` attribute `type` needs to be quoted.