### PR TITLE
Fix OpenStack provider idempotency bugs

### DIFF
--- a/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
@@ -40,7 +40,7 @@ func resourceFWFirewallV1() *schema.Resource {
 			"admin_state_up": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
@@ -68,6 +68,7 @@ func resourceLBMonitorV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -37,7 +37,7 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 			"port_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "",
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/openstack/resource_openstack_networking_network_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2.go
@@ -32,6 +32,7 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 			"shared": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -32,6 +32,7 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 			"external_gateway": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
After the first `apply` some resources show a change on each subsequent `apply` although there's no change. This is caused by some computed fields not marked as computed.

For instance, the `admin_state_up` field for network resource is optional and the value is computed when not provided.

Considering the configuration

```
provider "openstack" {
}

resource "openstack_networking_network_v2" "web_net" {
    name = "web-net"
}
```

The first `terraform apply` do the job correctly but any subsequent `apply` show a change

```
$ terraform apply
openstack_networking_network_v2.web_net: Refreshing state... (ID: d5b20f32-b541-4895-998e-808ece5972be)
openstack_networking_network_v2.web_net: Modifying...
  admin_state_up: "true" => ""
openstack_networking_network_v2.web_net: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```