### PR TITLE
provider/aws: Added a set of tests for the DBParamGroup Name

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -25,33 +25,10 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 		Delete: resourceAwsDbParameterGroupDelete,
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"only lowercase alphanumeric characters and hyphens allowed in %q", k))
-					}
-					if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"first character of %q must be a letter", k))
-					}
-					if regexp.MustCompile(`--`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot contain two consecutive hyphens", k))
-					}
-					if regexp.MustCompile(`-$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot end with a hyphen", k))
-					}
-					if len(value) > 255 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be greater than 255 characters", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateDbParamGroupName,
 			},
 			"family": &schema.Schema{
 				Type:     schema.TypeString,
@@ -251,4 +228,30 @@ func resourceAwsDbParameterHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["value"].(string))))
 
 	return hashcode.String(buf.String())
+}
+
+func validateDbParamGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 255 characters", k))
+	}
+	return
+
 }

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -141,6 +141,7 @@ func TestResourceAWSDBParameterGroupName_validation(t *testing.T) {
 
 	for _, tc := range cases {
 		_, errors := validateDbParamGroupName(tc.Value, "aws_db_parameter_group_name")
+
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
 		}

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -106,6 +106,51 @@ func TestAccAWSDBParameterGroupOnly(t *testing.T) {
 	})
 }
 
+func TestResourceAWSDBParameterGroupName_uppercaseCharacter(t *testing.T) {
+	var dbParamGroupName = "tEsting123"
+	_, errors := validateDbParamGroupName(dbParamGroupName, "aws_db_parameter_group_name")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+	}
+}
+
+func TestResourceAWSDBParameterGroupName_specialCharacters(t *testing.T) {
+	var dbParamGroupName = "testing123!"
+	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+	}
+}
+
+func TestResourceAWSDBParameterGroupName_firstCharacterNumber(t *testing.T) {
+	var dbParamGroupName = "1testing123"
+	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+	}
+}
+
+func TestResourceAWSDBParameterGroupName_doubleHyphen(t *testing.T) {
+	var dbParamGroupName = "testing--123"
+	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+	}
+}
+
+func TestResourceAWSDBParameterGroupName_trailingHyphen(t *testing.T) {
+	var dbParamGroupName = "testing123-"
+	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+	}
+}
+
 func testAccCheckAWSDBParameterGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -108,57 +108,42 @@ func TestAccAWSDBParameterGroupOnly(t *testing.T) {
 	})
 }
 
-func TestResourceAWSDBParameterGroupName_uppercaseCharacter(t *testing.T) {
-	var dbParamGroupName = "tEsting123"
-	_, errors := validateDbParamGroupName(dbParamGroupName, "aws_db_parameter_group_name")
-
-	if len(errors) != 1 {
-		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+func TestResourceAWSDBParameterGroupName_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1testing123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing--123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123-",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(256),
+			ErrCount: 1,
+		},
 	}
-}
 
-func TestResourceAWSDBParameterGroupName_specialCharacters(t *testing.T) {
-	var dbParamGroupName = "testing123!"
-	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
-
-	if len(errors) != 1 {
-		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
-	}
-}
-
-func TestResourceAWSDBParameterGroupName_firstCharacterNumber(t *testing.T) {
-	var dbParamGroupName = "1testing123"
-	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
-
-	if len(errors) != 1 {
-		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
-	}
-}
-
-func TestResourceAWSDBParameterGroupName_doubleHyphen(t *testing.T) {
-	var dbParamGroupName = "testing--123"
-	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
-
-	if len(errors) != 1 {
-		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
-	}
-}
-
-func TestResourceAWSDBParameterGroupName_trailingHyphen(t *testing.T) {
-	var dbParamGroupName = "testing123-"
-	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
-
-	if len(errors) != 1 {
-		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
-	}
-}
-
-func TestResourceAWSDBParameterGroupName_tooManyCharacters(t *testing.T) {
-	dbParamGroupName := RandomString(256)
-	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
-
-	if len(errors) != 1 {
-		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+	for _, tc := range cases {
+		_, errors := validateDbParamGroupName(tc.Value, "aws_db_parameter_group_name")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+		}
 	}
 }
 
@@ -249,7 +234,7 @@ func testAccCheckAWSDBParameterGroupExists(n string, v *rds.DBParameterGroup) re
 	}
 }
 
-func RandomString(strlen int) string {
+func randomString(strlen int) string {
 	rand.Seed(time.Now().UTC().UnixNano())
 	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
 	result := make([]byte, strlen)

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -151,6 +153,15 @@ func TestResourceAWSDBParameterGroupName_trailingHyphen(t *testing.T) {
 	}
 }
 
+func TestResourceAWSDBParameterGroupName_tooManyCharacters(t *testing.T) {
+	dbParamGroupName := RandomString(256)
+	_, errors := validateDbParamGroupName(dbParamGroupName, "SampleKey")
+
+	if len(errors) != 1 {
+		t.Fatalf("Expected the DB Parameter Group Name to trigger a validation error")
+	}
+}
+
 func testAccCheckAWSDBParameterGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
@@ -236,6 +247,16 @@ func testAccCheckAWSDBParameterGroupExists(n string, v *rds.DBParameterGroup) re
 
 		return nil
 	}
+}
+
+func RandomString(strlen int) string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(result)
 }
 
 const testAccAWSDBParameterGroupConfig = `

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -237,7 +237,7 @@ func testAccCheckAWSDBParameterGroupExists(n string, v *rds.DBParameterGroup) re
 
 func randomString(strlen int) string {
 	rand.Seed(time.Now().UTC().UnixNano())
-	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const chars = "abcdefghijklmnopqrstuvwxyz"
 	result := make([]byte, strlen)
 	for i := 0; i < strlen; i++ {
 		result[i] = chars[rand.Intn(len(chars))]


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=DBParameterGroup' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=DBParameterGroup -timeout 90m
=== RUN   TestAccAWSDBParameterGroup_basic
--- PASS: TestAccAWSDBParameterGroup_basic (6.04s)
=== RUN   TestAccAWSDBParameterGroupOnly
--- PASS: TestAccAWSDBParameterGroupOnly (3.76s)
=== RUN   TestResourceAWSDBParameterGroupName_uppercaseCharacter
--- PASS: TestResourceAWSDBParameterGroupName_uppercaseCharacter (0.00s)
=== RUN   TestResourceAWSDBParameterGroupName_specialCharacters
--- PASS: TestResourceAWSDBParameterGroupName_specialCharacters (0.00s)
=== RUN   TestResourceAWSDBParameterGroupName_firstCharacterNumber
--- PASS: TestResourceAWSDBParameterGroupName_firstCharacterNumber (0.00s)
=== RUN   TestResourceAWSDBParameterGroupName_doubleHyphen
--- PASS: TestResourceAWSDBParameterGroupName_doubleHyphen (0.00s)
=== RUN   TestResourceAWSDBParameterGroupName_trailingHyphen
--- PASS: TestResourceAWSDBParameterGroupName_trailingHyphen (0.00s)
=== RUN   TestResourceAWSDBParameterGroupName_tooManyCharacters
--- PASS: TestResourceAWSDBParameterGroupName_tooManyCharacters (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	9.815s
```

@radeksimko as requested in #3279