### PR TITLE
provider/docker: Add extra_hosts parameter for containers

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -118,16 +118,69 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Elem:     getVolumesElem(),
-				Set:      resourceDockerVolumesHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"from_container": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"container_path": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"host_path": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"read_only": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: resourceDockerVolumesHash,
 			},
 
 			"ports": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Elem:     getPortsElem(),
-				Set:      resourceDockerPortsHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"internal": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"external": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"ip": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"protocol": &schema.Schema{
+							Type:     schema.TypeString,
+							Default:  "tcp",
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: resourceDockerPortsHash,
 			},
 
 			"hosts": &schema.Schema{
@@ -256,67 +309,6 @@ func resourceDockerContainer() *schema.Resource {
 
 			"log_opts": &schema.Schema{
 				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-			},
-		},
-	}
-}
-
-func getVolumesElem() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"from_container": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"container_path": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"host_path": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"read_only": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-		},
-	}
-}
-
-func getPortsElem() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"internal": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"external": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"ip": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"protocol": &schema.Schema{
-				Type:     schema.TypeString,
-				Default:  "tcp",
 				Optional: true,
 				ForceNew: true,
 			},

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -130,6 +130,28 @@ func resourceDockerContainer() *schema.Resource {
 				Set:      resourceDockerPortsHash,
 			},
 
+			"hosts": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"host": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: resourceDockerHostsHash,
+			},
+
 			"env": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -317,6 +339,21 @@ func resourceDockerPortsHash(v interface{}) int {
 	}
 
 	if v, ok := m["protocol"]; ok {
+		buf.WriteString(fmt.Sprintf("%v-", v.(string)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+func resourceDockerHostsHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if v, ok := m["ip"]; ok {
+		buf.WriteString(fmt.Sprintf("%v-", v.(string)))
+	}
+
+	if v, ok := m["host"]; ok {
 		buf.WriteString(fmt.Sprintf("%v-", v.(string)))
 	}
 

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -57,6 +57,7 @@ The following arguments are supported:
   kept running. If false, then as long as the container exists, Terraform
   assumes it is successful.
 * `ports` - (Optional) See [Ports](#ports) below for details.
+* `extra_hosts` - (Optional) See [Extra Hosts](#extra_hosts) below for details.
 * `privileged` - (Optional, bool) Run container in privileged mode.
 * `publish_all_ports` - (Optional, bool) Publish all ports of the container.
 * `volumes` - (Optional) See [Volumes](#volumes) below for details.
@@ -81,6 +82,16 @@ the following:
 * `ip` - (Optional, string) IP address/mask that can access this port.
 * `protocol` - (Optional, string) Protocol that can be used over this port,
   defaults to TCP.
+
+<a id="extra_hosts"></a>
+## Extra Hosts
+
+`extra_hosts` is a block within the configuration that can be repeated to specify
+the extra host mappings for the container. Each `extra_hosts` block supports
+the following:
+
+* `host` - (Required, int) Hostname to add.
+* `ip` - (Required, int) IP address this hostname should resolve to..
 
 <a id="volumes"></a>
 ## Volumes


### PR DESCRIPTION
Usage, as in:

```
resource "docker_container" "example" {
  image = "alpine"
  name = "example"
  command = ["cat", "/etc/hosts"]
  extra_hosts = {
    host = "www.example.com"
    ip = "192.168.1.1"
  }
}
```

It's equivalent to the docker command-line `--add-host host:ip` flag, but I've opted for the docker API version (called `ExtraHosts`), as I feel it works better syntactically.