### PR TITLE
A script must have executable permissions.

### DIFF
--- a/website/source/docs/provisioners/remote-exec.html.markdown
+++ b/website/source/docs/provisioners/remote-exec.html.markdown
@@ -63,7 +63,10 @@ resource "aws_instance" "web" {
     }
 
     provisioner "remote-exec" {
-        inline = ["/tmp/script.sh args"]
+        inline = [
+          "chmod +x /tmp/script.sh",
+          "/tmp/script.sh args"
+        ]
     }
 }
 ```


### PR DESCRIPTION
Why:

* The current example for passing arguments to a local script does not
  include making the uploaded file executable.

This change addresses the need by:

* Add a step to make the uploaded script executable to the example
  showing how to pass arguments to an uploaded script.