### PR TITLE
provider/aws: Migrate KeyPair to version 1

### DIFF
--- a/builtin/providers/aws/resource_aws_key_pair_migrate.go
+++ b/builtin/providers/aws/resource_aws_key_pair_migrate.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsKeyPairMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Key Pair State v0; migrating to v1")
+		return migrateKeyPairStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+
+	return is, nil
+}
+
+func migrateKeyPairStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	// replace public_key with a stripped version, removing `\n` from the end
+	// see https://github.com/hashicorp/terraform/issues/3455
+	is.Attributes["public_key"] = strings.TrimSpace(is.Attributes["public_key"])
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/aws/resource_aws_key_pair_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_migrate_test.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSKeyPairMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			ID:           "tf-testing-file",
+			Attributes: map[string]string{
+				"fingerprint": "1d:cd:46:31:a9:4a:e0:06:8a:a1:22:cb:3b:bf:8e:42",
+				"key_name":    "tf-testing-file",
+				"public_key":  "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cnOwRTZCJCzPSzq0dl3== ctshryock",
+			},
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cnOwRTZCJCzPSzq0dl3== ctshryock",
+		},
+		"v0_2": {
+			StateVersion: 0,
+			ID:           "tf-testing-file",
+			Attributes: map[string]string{
+				"fingerprint": "1d:cd:46:31:a9:4a:e0:06:8a:a1:22:cb:3b:bf:8e:42",
+				"key_name":    "tf-testing-file",
+				"public_key":  "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cnOwRTZCJCzPSzq0dl3== ctshryock\n",
+			},
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cnOwRTZCJCzPSzq0dl3== ctshryock",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsKeyPairMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.Attributes["public_key"] != tc.Expected {
+			t.Fatalf("Bad public_key migration: %s\n\n expected: %s", is.Attributes["public_key"], tc.Expected)
+		}
+	}
+}


### PR DESCRIPTION
This PR upgrades `resource_aws_key_pair` to version 1. 
It fixes https://github.com/hashicorp/terraform/issues/3455 , where reading a key with the `file()` included a trailing `\n`. 

Copying and pasting that same public key (typically?) did not include this `\n`.
For example, swapping out the `public_key` method for the full string below should result in no change:

```hcl
resource "aws_key_pair" "ssh_thing" {
  key_name = "tf-testing-file"
  public_key = "${file("~/.ssh/github_rsa.pub")}"
  #public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cn== ctshryock"
}
```

Gives this plan:

```console
+ aws_key_pair.ssh_thing
    fingerprint: "" => "<computed>"
    key_name:    "" => "tf-testing-file"
    public_key:  "" => "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cn== ctshryock\n"
```

vs. 

```hcl
resource "aws_key_pair" "ssh_thing" {
  key_name = "tf-testing-file"
  #public_key = "${file("~/.ssh/github_rsa.pub")}"
  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cn== ctshryock"
}
```

and 

```
+ aws_key_pair.ssh_thing
    fingerprint: "" => "<computed>"
    key_name:    "" => "tf-testing-file"
    public_key:  "" => "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4LBtwcFsQAYWw1cn== ctshryock"
```

Swapping `file()` and the full string in-line should not produce a change, but on `master` it does. 

This PR uses `strings.TrimSpace()` to trim off the trailing `\n`. 
