### PR TITLE
[WIP] Grafana Provider, with Data Source and Dashboard resources

### DIFF
--- a/builtin/bins/provider-grafana/main.go
+++ b/builtin/bins/provider-grafana/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/grafana"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: grafana.Provider,
+	})
+}

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -26,7 +26,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"grafana_dashboard":                   ResourceDashboard(),
-			//"grafana_dashboard_config":            ResourceDashboardConfig(),
+			"grafana_dashboard_config":            ResourceDashboardConfig(),
 			//"grafana_graph_panel_config":          ResourceGraphPanelConfig(),
 			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),
 			//"grafana_text_panel_config":           ResourceTextPanelConfig(),

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -29,7 +29,7 @@ func Provider() terraform.ResourceProvider {
 			"grafana_dashboard_config":            ResourceDashboardConfig(),
 			//"grafana_graph_panel_config":          ResourceGraphPanelConfig(),
 			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),
-			//"grafana_text_panel_config":           ResourceTextPanelConfig(),
+			"grafana_text_panel_config":           ResourceTextPanelConfig(),
 			//"grafana_dashboard_list_panel_config": ResourceDashboardListPanelConfig(),
 			"grafana_data_source":                 ResourceDataSource(),
 		},

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -1,0 +1,46 @@
+package grafana
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_URL", nil),
+				Description: "URL of the root of the target Grafana server.",
+			},
+			"auth": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
+				Description: "Credentials for accessing the Grafana API.",
+			},
+		},
+
+		ResourcesMap: map[string]*schema.Resource{
+			//"grafana_dashboard":                   ResourceDashboard(),
+			//"grafana_dashboard_config":            ResourceDashboardConfig(),
+			//"grafana_graph_panel_config":          ResourceGraphPanelConfig(),
+			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),
+			//"grafana_text_panel_config":           ResourceTextPanelConfig(),
+			//"grafana_dashboard_list_panel_config": ResourceDashboardListPanelConfig(),
+			//"grafana_data_source":                 ResourceDataSource(),
+		},
+
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	return gapi.New(
+		d.Get("auth").(string),
+		d.Get("url").(string),
+	)
+}

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -31,7 +31,7 @@ func Provider() terraform.ResourceProvider {
 			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),
 			//"grafana_text_panel_config":           ResourceTextPanelConfig(),
 			//"grafana_dashboard_list_panel_config": ResourceDashboardListPanelConfig(),
-			//"grafana_data_source":                 ResourceDataSource(),
+			"grafana_data_source":                 ResourceDataSource(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -25,7 +25,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			//"grafana_dashboard":                   ResourceDashboard(),
+			"grafana_dashboard":                   ResourceDashboard(),
 			//"grafana_dashboard_config":            ResourceDashboardConfig(),
 			//"grafana_graph_panel_config":          ResourceGraphPanelConfig(),
 			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -30,7 +30,7 @@ func Provider() terraform.ResourceProvider {
 			//"grafana_graph_panel_config":          ResourceGraphPanelConfig(),
 			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),
 			"grafana_text_panel_config":           ResourceTextPanelConfig(),
-			//"grafana_dashboard_list_panel_config": ResourceDashboardListPanelConfig(),
+			"grafana_dashboard_list_panel_config": ResourceDashboardListPanelConfig(),
 			"grafana_data_source":                 ResourceDataSource(),
 		},
 

--- a/builtin/providers/grafana/provider_test.go
+++ b/builtin/providers/grafana/provider_test.go
@@ -1,0 +1,54 @@
+package grafana
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// To run these acceptance tests, you will need a Grafana server.
+// Grafana can be downloaded here: http://grafana.org/download/
+//
+// The tests will need an API key to authenticate with the server. To create
+// one, use the menu for one of your installation's organizations (The
+// "Main Org." is fine if you've just done a fresh installation to run these
+// tests) to reach the "API Keys" admin page.
+//
+// Giving the API key the Admin role is the easiest way to ensure enough
+// access is granted to run all of the tests.
+//
+// Once you've created the API key, set the GRAFANA_URL and GRAFANA_AUTH
+// environment variables to the Grafana base URL and the API key respectively,
+// and then run:
+//    make testacc TEST=./builtin/providers/grafana
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"grafana": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("GRAFANA_URL"); v == "" {
+		t.Fatal("GRAFANA_URL must be set for acceptance tests")
+	}
+	if v := os.Getenv("GRAFANA_AUTH"); v == "" {
+		t.Fatal("GRAFANA_AUTH must be set for acceptance tests")
+	}
+}

--- a/builtin/providers/grafana/resource_dashboard.go
+++ b/builtin/providers/grafana/resource_dashboard.go
@@ -1,0 +1,127 @@
+package grafana
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+)
+
+func ResourceDashboard() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDashboard,
+		Delete: DeleteDashboard,
+		Read:   ReadDashboard,
+
+		Schema: map[string]*schema.Schema{
+			"slug": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"config_json": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				StateFunc:    NormalizeDashboardConfigJSON,
+				ValidateFunc: ValidateDashboardConfigJSON,
+			},
+		},
+	}
+}
+
+func CreateDashboard(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	model := prepareDashboardModel(d.Get("config_json").(string))
+
+	resp, err := client.SaveDashboard(model, false)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resp.Slug)
+
+	return ReadDashboard(d, meta)
+}
+
+func ReadDashboard(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	slug := d.Id()
+
+	dashboard, err := client.Dashboard(slug)
+	if err != nil {
+		return err
+	}
+
+	configJSONBytes, err := json.Marshal(dashboard.Model)
+	if err != nil {
+		return err
+	}
+
+	configJSON := NormalizeDashboardConfigJSON(string(configJSONBytes))
+
+	d.SetId(dashboard.Meta.Slug)
+	d.Set("slug", dashboard.Meta.Slug)
+	d.Set("config_json", configJSON)
+
+	return nil
+}
+
+func DeleteDashboard(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	slug := d.Id()
+	return client.DeleteDashboard(slug)
+}
+
+func prepareDashboardModel(configJSON string) map[string]interface{} {
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		// The validate function should've taken care of this.
+		panic(fmt.Errorf("Invalid JSON got into prepare func"))
+	}
+
+	delete(configMap, "id")
+	configMap["version"] = 0
+
+	return configMap
+}
+
+func ValidateDashboardConfigJSON(configI interface{}, k string) ([]string, []error) {
+	configJSON := configI.(string)
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
+}
+
+func NormalizeDashboardConfigJSON(configI interface{}) string {
+	configJSON := configI.(string)
+
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		// The validate function should've taken care of this.
+		return ""
+	}
+
+	// Some properties are managed by this provider and are thus not
+	// significant when included in the JSON.
+	delete(configMap, "id")
+	delete(configMap, "version")
+
+	ret, err := json.Marshal(configMap)
+	if err != nil {
+		// Should never happen.
+		return configJSON
+	}
+
+	return string(ret)
+}

--- a/builtin/providers/grafana/resource_dashboard_config.go
+++ b/builtin/providers/grafana/resource_dashboard_config.go
@@ -1,0 +1,551 @@
+package grafana
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func ResourceDashboardConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDashboardConfig,
+		Delete: DeleteDashboardConfig,
+		Read:   ReadDashboardConfig,
+
+		Schema: map[string]*schema.Schema{
+			"json": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"title": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"tags": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"timezone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "browser",
+			},
+
+			"editable": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
+			"hide_controls": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+
+			"shared_crosshair": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
+			"row": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+
+						"collapse": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"editable": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"height": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "250px",
+						},
+
+						"title": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							// This is what the Grafana UI sets the title to
+							// if the user doesn't specify one.
+							Default: "New Row",
+						},
+
+						"show_title": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"panel": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+
+									"id": &schema.Schema{
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+
+									"span": &schema.Schema{
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+
+									"config_json": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"annotation": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"data_source_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"index_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"show_line": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  true,
+						},
+
+						"icon_color": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "#C0C6BE",
+						},
+
+						"line_color": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "rgba(255, 96, 96, 0.592157)",
+						},
+
+						"icon_size": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Default:  13,
+						},
+
+						"enable": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  true,
+						},
+
+						"query": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"title_column": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"title_field": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"time_field": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"tags_column": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"tags_field": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"text_column": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"text_field": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+
+			"link": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"icon": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "external link",
+						},
+
+						"tags": &schema.Schema{
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						"open_new_window": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"title": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"tooltip": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "",
+						},
+
+						"url": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "",
+						},
+
+						"keep_time_range": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"keep_variable_values": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"as_dropdown_menu": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+
+			"template_variable": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"data_source_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"refresh_on_load": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"label": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"hide_label": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"include_all_option": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"all_value_format": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "regex wildcard",
+						},
+
+						"allow_multiple_values": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+							Default:  false,
+						},
+
+						"multiple_values_format": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "regex values",
+						},
+
+						"query": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func CreateDashboardConfig(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("logical")
+
+	rows := []map[string]interface{}{}
+	annotations := []map[string]interface{}{}
+	templateVars := []map[string]interface{}{}
+	links := []map[string]interface{}{}
+
+	for _, rowI := range d.Get("row").([]interface{}) {
+		rowM := rowI.(map[string]interface{})
+
+		panels := []map[string]interface{}{}
+		for _, panelI := range rowM["panel"].([]interface{}) {
+			panelM := panelI.(map[string]interface{})
+			id := panelM["id"].(int)
+			span := panelM["span"].(int)
+			configJSON := panelM["config_json"].(string)
+			panel := make(map[string]interface{})
+			err := json.Unmarshal([]byte(configJSON), &panel)
+			if err != nil {
+				return fmt.Errorf("Invalid config_json for panel %d: %s", id, err)
+			}
+
+			// We override the id and span here, since they are significant
+			// only in the context of the whole dashboard and so this makes
+			// things a little more composable.
+			panel["id"] = id
+			panel["span"] = span
+
+			panels = append(panels, panel)
+		}
+
+		rows = append(rows, map[string]interface{}{
+			"collapse":  rowM["collapse"],
+			"editable":  rowM["editable"],
+			"height":    rowM["height"],
+			"title":     rowM["title"],
+			"showTitle": rowM["show_title"],
+			"panels":    panels,
+		})
+	}
+
+	for _, annotI := range d.Get("annotation").([]interface{}) {
+		annotM := annotI.(map[string]interface{})
+		annotations = append(annotations, map[string]interface{}{
+			"name":        annotM["name"],
+			"datasource":  annotM["data_source_name"],
+			"showLine":    annotM["show_line"],
+			"iconColor":   annotM["icon_color"],
+			"lineColor":   annotM["line_color"],
+			"iconSize":    annotM["icon_size"],
+			"enable":      annotM["enable"],
+			"index":       annotM["index_name"],
+			"query":       annotM["query"],
+			"timeField":   annotM["time_field"],
+			"titleColumn": annotM["title_column"],
+			"titleField":  annotM["title_field"],
+			"tagsColumn":  annotM["tags_column"],
+			"tagsField":   annotM["tags_field"],
+			"textColumn":  annotM["text_column"],
+			"textField":   annotM["text_field"],
+		})
+	}
+
+	for _, linkI := range d.Get("link").([]interface{}) {
+		linkM := linkI.(map[string]interface{})
+		links = append(links, map[string]interface{}{
+			"title":       linkM["title"],
+			"type":        linkM["type"],
+			"icon":        linkM["icon"],
+			"tags":        linkM["tags"].(*schema.Set).List(),
+			"targetBlank": linkM["open_new_window"],
+			"tooltip":     linkM["tooltip"],
+			"url":         linkM["url"],
+			"keepTime":    linkM["keep_time_range"],
+			"includeVars": linkM["keep_variable_values"],
+			"asDropdown":  linkM["as_dropdown_menu"],
+		})
+	}
+
+	for _, varI := range d.Get("template_variable").([]interface{}) {
+		varM := varI.(map[string]interface{})
+		templateVars = append(templateVars, map[string]interface{}{
+			"type":        varM["type"],
+			"datasource":  varM["data_source_name"],
+			"name":        varM["name"],
+			"label":       varM["label"],
+			"hideLabel":   varM["hide_label"],
+			"includeAll":  varM["include_all_option"],
+			"allFormat":   varM["all_value_format"],
+			"multi":       varM["allow_multiple_values"],
+			"multiFormat": varM["multiple_values_format"],
+			"query":       varM["query"],
+
+			// Using underscores for this one is not a mistake; this is an
+			// inconsistency in the Grafana dashboard model format.
+			"refresh_on_load": varM["refresh_on_load"],
+		})
+	}
+
+	model := map[string]interface{}{
+		"title":           d.Get("title").(string),
+		"timezone":        d.Get("timezone").(string),
+		"tags":            d.Get("tags").(*schema.Set).List(),
+		"editable":        d.Get("editable").(bool),
+		"hideControls":    d.Get("hide_controls").(bool),
+		"sharedCrosshair": d.Get("shared_crosshair").(bool),
+		"rows":            rows,
+		"annotations": map[string]interface{}{
+			"list": annotations,
+		},
+		"templating": map[string]interface{}{
+			"list": templateVars,
+		},
+		"links":         links,
+		"schemaVersion": 6,
+	}
+
+	modelBytes, err := json.Marshal(model)
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+
+	d.Set("json", string(modelBytes))
+
+	return nil
+}
+
+func DeleteDashboardConfig(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+
+	return nil
+}
+
+func ReadDashboardConfig(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/builtin/providers/grafana/resource_dashboard_config_test.go
+++ b/builtin/providers/grafana/resource_dashboard_config_test.go
@@ -1,0 +1,79 @@
+package grafana
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDashboardConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDashboardConfigConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"grafana_dashboard_config.test", "json", testAccDashboardConfigExpected,
+					),
+				),
+			},
+		},
+	})
+}
+
+const testAccDashboardConfigConfig = `
+resource "grafana_dashboard_config" "test" {
+    title = "Terraform Acceptance Tests"
+    tags = ["terraform", "acctest"]
+
+    row {
+        title = "First Row"
+
+        panel {
+            id = 1
+            span = 6
+            config_json = "{}"
+        }
+
+        panel {
+            id = 2
+            span = 6
+            config_json = "{}"
+        }
+    }
+
+    annotation {
+        data_source_name = "terraform-acc-test"
+        query = "SELECT foo FROM baz"
+        name = "Test Annotation"
+        index_name = "stuff"
+    }
+
+    link {
+        type = "link"
+        title = "example.com"
+        url = "http://example.com/"
+        open_new_window = true
+        tooltip = "Example Link"
+        tags = ["terraform"]
+        as_dropdown_menu = true
+        keep_time_range = true
+        keep_variable_values = true
+    }
+
+    template_variable {
+        type = "query"
+        data_source_name = "terraform-test"
+        refresh_on_load = true
+        name = "another"
+        include_all_option = true
+        query = "SELECT foo FROM baz"
+        hide_label = true
+        label = "Another Thing"
+    }
+}
+`
+
+const testAccDashboardConfigExpected = "{\"annotations\":{\"list\":[{\"datasource\":\"terraform-acc-test\",\"enable\":true,\"iconColor\":\"#C0C6BE\",\"iconSize\":13,\"index\":\"stuff\",\"lineColor\":\"rgba(255, 96, 96, 0.592157)\",\"name\":\"Test Annotation\",\"query\":\"SELECT foo FROM baz\",\"showLine\":true,\"tagsColumn\":\"\",\"tagsField\":\"\",\"textColumn\":\"\",\"textField\":\"\",\"timeField\":\"\",\"titleColumn\":\"\",\"titleField\":\"\"}]},\"editable\":false,\"hideControls\":true,\"links\":[{\"asDropdown\":true,\"icon\":\"external link\",\"includeVars\":true,\"keepTime\":true,\"tags\":[\"terraform\"],\"targetBlank\":true,\"title\":\"example.com\",\"tooltip\":\"Example Link\",\"type\":\"link\",\"url\":\"http://example.com/\"}],\"rows\":[{\"collapse\":false,\"editable\":false,\"height\":\"250px\",\"panels\":[{\"id\":1,\"span\":6},{\"id\":2,\"span\":6}],\"showTitle\":false,\"title\":\"First Row\"}],\"schemaVersion\":6,\"sharedCrosshair\":false,\"tags\":[\"terraform\",\"acctest\"],\"templating\":{\"list\":[{\"allFormat\":\"regex wildcard\",\"datasource\":\"terraform-test\",\"hideLabel\":true,\"includeAll\":true,\"label\":\"Another Thing\",\"multi\":false,\"multiFormat\":\"regex values\",\"name\":\"another\",\"query\":\"SELECT foo FROM baz\",\"refresh_on_load\":true,\"type\":\"query\"}]},\"timezone\":\"browser\",\"title\":\"Terraform Acceptance Tests\"}"

--- a/builtin/providers/grafana/resource_dashboard_list_panel_config.go
+++ b/builtin/providers/grafana/resource_dashboard_list_panel_config.go
@@ -1,0 +1,89 @@
+package grafana
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func ResourceDashboardListPanelConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDashboardListPanelConfig,
+		Delete: DeleteDashboardListPanelConfig,
+		Read:   ReadDashboardListPanelConfig,
+
+		Schema: map[string]*schema.Schema{
+			"json": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"title": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"limit": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  10,
+			},
+
+			"query": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"tags": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func CreateDashboardListPanelConfig(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("logical")
+
+	model := map[string]interface{}{
+		"type":  "dashlist",
+		"title": d.Get("title").(string),
+		"mode":  d.Get("mode").(string),
+		"limit": d.Get("limit").(int),
+		"query": d.Get("query").(string),
+		"tags":  d.Get("tags").(*schema.Set).List(),
+	}
+
+	modelBytes, err := json.Marshal(model)
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+
+	d.Set("json", string(modelBytes))
+
+	return nil
+}
+
+func DeleteDashboardListPanelConfig(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+
+	return nil
+}
+
+func ReadDashboardListPanelConfig(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/builtin/providers/grafana/resource_dashboard_list_panel_config_test.go
+++ b/builtin/providers/grafana/resource_dashboard_list_panel_config_test.go
@@ -1,0 +1,36 @@
+package grafana
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDashboardListPanelConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDashboardListPanelConfigConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"grafana_dashboard_list_panel_config.test", "json", testAccDashboardListPanelConfigExpected,
+					),
+				),
+			},
+		},
+	})
+}
+
+const testAccDashboardListPanelConfigConfig = `
+resource "grafana_dashboard_list_panel_config" "test" {
+    title = "Terraform-related Dashboards"
+    mode = "search"
+    tags = ["terraform"]
+    query = "Terraform"
+    limit = 100
+}
+`
+
+const testAccDashboardListPanelConfigExpected = "{\"limit\":100,\"mode\":\"search\",\"query\":\"Terraform\",\"tags\":[\"terraform\"],\"title\":\"Terraform-related Dashboards\",\"type\":\"dashlist\"}"

--- a/builtin/providers/grafana/resource_dashboard_test.go
+++ b/builtin/providers/grafana/resource_dashboard_test.go
@@ -1,0 +1,83 @@
+package grafana
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDashboard_basic(t *testing.T) {
+	var dashboard gapi.Dashboard
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDashboardCheckDestroy(&dashboard),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDashboardConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
+					resource.TestMatchResourceAttr(
+						"grafana_dashboard.test", "id", regexp.MustCompile(`terraform-acceptance-test.*`),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		client := testAccProvider.Meta().(*gapi.Client)
+		gotDashboard, err := client.Dashboard(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting dashboard: %s", err)
+		}
+
+		*dashboard = *gotDashboard
+
+		return nil
+	}
+}
+
+func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*gapi.Client)
+		_, err := client.Dashboard(dashboard.Meta.Slug)
+		if err == nil {
+			return fmt.Errorf("dashboard still exists")
+		}
+		return nil
+	}
+}
+
+// The "id" and "version" properties in the config below are there to test
+// that we correctly normalize them away. They are not actually used by this
+// resource, since it uses slugs for identification and never modifies an
+// existing dashboard.
+const testAccDashboardConfig_basic = `
+resource "grafana_dashboard" "test" {
+    config_json = <<EOT
+{
+    "title": "Terraform Acceptance Test",
+    "id": 12,
+    "version": "43"
+}
+EOT
+}
+`

--- a/builtin/providers/grafana/resource_data_source.go
+++ b/builtin/providers/grafana/resource_data_source.go
@@ -1,0 +1,184 @@
+package grafana
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+)
+
+func ResourceDataSource() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDataSource,
+		Update: UpdateDataSource,
+		Delete: DeleteDataSource,
+		Read:   ReadDataSource,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"is_default": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"basic_auth_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"basic_auth_username": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"basic_auth_password": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"username": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"database_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"access_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "proxy",
+			},
+		},
+	}
+}
+
+func CreateDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	dataSource, err := makeDataSource(d)
+	if err != nil {
+		return err
+	}
+
+	id, err := client.NewDataSource(dataSource)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(id, 10))
+
+	return ReadDataSource(d, meta)
+}
+
+func UpdateDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	dataSource, err := makeDataSource(d)
+	if err != nil {
+		return err
+	}
+
+	return client.UpdateDataSource(dataSource)
+}
+
+func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	idStr := d.Id()
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid id: %#v", idStr)
+	}
+
+	dataSource, err := client.DataSource(id)
+	if err != nil {
+		return err
+	}
+
+	d.Set("id", dataSource.Id)
+	d.Set("access_mode", dataSource.Access)
+	d.Set("basic_auth_enabled", dataSource.BasicAuth)
+	d.Set("basic_auth_username", dataSource.BasicAuthUser)
+	d.Set("basic_auth_password", dataSource.BasicAuthPassword)
+	d.Set("database_name", dataSource.Database)
+	d.Set("is_default", dataSource.IsDefault)
+	d.Set("name", dataSource.Name)
+	d.Set("password", dataSource.Password)
+	d.Set("type", dataSource.Type)
+	d.Set("url", dataSource.URL)
+	d.Set("username", dataSource.User)
+
+	return nil
+}
+
+func DeleteDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	idStr := d.Id()
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid id: %#v", idStr)
+	}
+
+	return client.DeleteDataSource(id)
+}
+
+func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {
+	idStr := d.Id()
+	var id int64
+	var err error
+	if idStr != "" {
+		id, err = strconv.ParseInt(idStr, 10, 64)
+	}
+
+	return &gapi.DataSource{
+		Id:                id,
+		Name:              d.Get("name").(string),
+		Type:              d.Get("type").(string),
+		URL:               d.Get("url").(string),
+		Access:            d.Get("access_mode").(string),
+		Database:          d.Get("database_name").(string),
+		User:              d.Get("username").(string),
+		Password:          d.Get("password").(string),
+		IsDefault:         d.Get("is_default").(bool),
+		BasicAuth:         d.Get("basic_auth_enabled").(bool),
+		BasicAuthUser:     d.Get("basic_auth_username").(string),
+		BasicAuthPassword: d.Get("basic_auth_password").(string),
+	}, err
+}

--- a/builtin/providers/grafana/resource_data_source_test.go
+++ b/builtin/providers/grafana/resource_data_source_test.go
@@ -1,0 +1,87 @@
+package grafana
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSource_basic(t *testing.T) {
+	var dataSource gapi.DataSource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDataSourceCheckDestroy(&dataSource),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceCheckExists("grafana_data_source.test", &dataSource),
+					resource.TestCheckResourceAttr(
+						"grafana_data_source.test", "type", "influxdb",
+					),
+					resource.TestMatchResourceAttr(
+						"grafana_data_source.test", "id", regexp.MustCompile(`\d+`),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCheckExists(rn string, dataSource *gapi.DataSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("resource id is malformed")
+		}
+
+		client := testAccProvider.Meta().(*gapi.Client)
+		gotDataSource, err := client.DataSource(id)
+		if err != nil {
+			return fmt.Errorf("error getting data source: %s", err)
+		}
+
+		*dataSource = *gotDataSource
+
+		return nil
+	}
+}
+
+func testAccDataSourceCheckDestroy(dataSource *gapi.DataSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*gapi.Client)
+		_, err := client.DataSource(dataSource.Id)
+		if err == nil {
+			return fmt.Errorf("data source still exists")
+		}
+		return nil
+	}
+}
+
+const testAccDataSourceConfig_basic = `
+resource "grafana_data_source" "test" {
+    type = "influxdb"
+    name = "terraform-acc-test"
+    database_name = "terraform-acc-test"
+    url = "http://terraform-acc-test.invalid/"
+    username = "terraform_user"
+    password = "terraform_password"
+}
+`

--- a/builtin/providers/grafana/resource_text_panel_config.go
+++ b/builtin/providers/grafana/resource_text_panel_config.go
@@ -1,0 +1,82 @@
+package grafana
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func ResourceTextPanelConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateTextPanelConfig,
+		Delete: DeleteTextPanelConfig,
+		Read:   ReadTextPanelConfig,
+
+		Schema: map[string]*schema.Schema{
+			"json": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"title": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "markdown",
+			},
+
+			"content": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"style": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func CreateTextPanelConfig(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("logical")
+
+	model := map[string]interface{}{
+		"type":    "text",
+		"title":   d.Get("title").(string),
+		"mode":    d.Get("mode").(string),
+		"content": d.Get("content").(string),
+		"style":   d.Get("style"),
+	}
+
+	modelBytes, err := json.Marshal(model)
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+
+	d.Set("json", string(modelBytes))
+
+	return nil
+}
+
+func DeleteTextPanelConfig(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+
+	return nil
+}
+
+func ReadTextPanelConfig(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/builtin/providers/grafana/resource_text_panel_config_test.go
+++ b/builtin/providers/grafana/resource_text_panel_config_test.go
@@ -1,0 +1,33 @@
+package grafana
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccTextPanelConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTextPanelConfigConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"grafana_text_panel_config.test", "json", testAccTextPanelConfigExpected,
+					),
+				),
+			},
+		},
+	})
+}
+
+const testAccTextPanelConfigConfig = `
+resource "grafana_text_panel_config" "test" {
+    title = "Text Panel"
+    content = "Foo bar baz"
+}
+`
+
+const testAccTextPanelConfigExpected = "{\"content\":\"Foo bar baz\",\"mode\":\"markdown\",\"style\":{},\"title\":\"Text Panel\",\"type\":\"text\"}"


### PR DESCRIPTION
A provider for Grafana, including data source and dashboard resources.

* [x] Provider
* [x] `grafana_data_source` resource.
* [x] `grafana_dashboard` resource.
* [x] `grafana_dashboard_config` logical resource.
* [ ] `grafana_graph_panel_config` logical resource.
* [ ] `grafana_single_stat_panel_config` logical resource.
* [x] `grafana_text_panel_config` logical resource.
* [x] `grafana_dashboard_list_panel_config` logical resource.
* [ ] Documentation

Grafana uses a documented JSON-based format for importing and exporting dashboards and panels. It is expected that many users of this provider will design dashboards/panels interactively in the Grafana UI, export them as JSON, and then include them in a Terraform config via the `file(...)` function, and so the `grafana_dashboard` resource just accepts a raw JSON string for the dashboard configuration.

However, the provider also includes a number of logical resources to help in dynamically constructing dashboards and panels within the Terraform config itself, allowing the configuration to be more easily edited within the Terraform config and to contain interpolations so that, for example, the range of a particular graph can depend on the number of instances that were created for a particular resource.
