### PR TITLE
fix illegal char in the policy name

### DIFF
--- a/website/source/docs/providers/aws/r/lb_cookie_stickiness_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/lb_cookie_stickiness_policy.html.markdown
@@ -25,7 +25,7 @@ resource "aws_elb" "lb" {
 }
 
 resource "aws_lb_cookie_stickiness_policy" "foo" {
-	  name = "foo_policy"
+	  name = "foo-policy"
 	  load_balancer = "${aws_elb.lb.id}"
 	  lb_port = 80
 	  cookie_expiration_period = 600


### PR DESCRIPTION
aws_lb_cookie_stickiness_policy.elbland: Error creating LBCookieStickinessPolicy: ValidationError: Policy name cannot contain characters that are not letters, or digits or the dash.

I edited the example because it contained a illegal char.