### PR TITLE
provider/aws: Additional error checking to VPC Peering conn

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -127,6 +127,9 @@ func resourceVPCPeeringConnectionAccept(conn *ec2.EC2, id string) (string, error
 	}
 
 	resp, err := conn.AcceptVpcPeeringConnection(req)
+	if err != nil {
+		return "", err
+	}
 	pc := resp.VpcPeeringConnection
 	return *pc.Status.Code, err
 }
@@ -153,16 +156,15 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 		pc := pcRaw.(*ec2.VpcPeeringConnection)
 
-		if *pc.Status.Code == "pending-acceptance" {
+		if pc.Status != nil && *pc.Status.Code == "pending-acceptance" {
 
 			status, err := resourceVPCPeeringConnectionAccept(conn, d.Id())
-
-			log.Printf(
-				"[DEBUG] VPC Peering connection accept status %s",
-				status)
 			if err != nil {
 				return err
 			}
+			log.Printf(
+				"[DEBUG] VPC Peering connection accept status: %s",
+				status)
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -117,6 +117,7 @@ resource "aws_vpc" "bar" {
 resource "aws_vpc_peering_connection" "foo" {
 		vpc_id = "${aws_vpc.foo.id}"
 		peer_vpc_id = "${aws_vpc.bar.id}"
+		auto_accept = true
 }
 `
 


### PR DESCRIPTION
Add additional error checking to VPC Peering connection, to try and catch/prevent https://github.com/hashicorp/terraform/issues/3145 and https://github.com/hashicorp/terraform/issues/2690

Unfortunately I have not been able to reproduce either using this config:

```hcl
resource "aws_vpc" "foo" {
		cidr_block = "10.0.0.0/16"
}

resource "aws_vpc" "bar" {
		cidr_block = "10.1.0.0/16"
}

resource "aws_vpc_peering_connection" "foo" {
		vpc_id = "${aws_vpc.foo.id}"
		peer_vpc_id = "${aws_vpc.bar.id}"
		tags {
			foo = "bar"
		}
    auto_accept = true
}
```

Regardless, there were some places in the code that could use some additional checks