### PR TITLE
Add option to aws provider to skip credential validation.

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	ForbiddenAccountIds []interface{}
 
 	DynamoDBEndpoint string
+
+	SkipValidateCredentials bool
 }
 
 type AWSClient struct {
@@ -217,6 +219,9 @@ func (c *Config) ValidateRegion() error {
 // In the case of an IAM role/profile with insuffecient privileges, fail
 // silently
 func (c *Config) ValidateCredentials(iamconn *iam.IAM) error {
+	if c.SkipValidateCredentials {
+		return nil
+	}
 	_, err := iamconn.GetUser(nil)
 
 	if awsErr, ok := err.(awserr.Error); ok {

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -153,6 +153,13 @@ func Provider() terraform.ResourceProvider {
 				Default:     "",
 				Description: descriptions["dynamodb_endpoint"],
 			},
+
+			"skip_validate_credentials": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["skip_validate_credentials"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -279,17 +286,21 @@ func init() {
 
 		"dynamodb_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n" +
 			"It's typically used to connect to dynamodb-local.",
+
+		"skip_validate_credentials": "Use this to bypass credential validation.\n" +
+			"This is usefull when only using dynamodb-local without valid credentials.",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AccessKey:        d.Get("access_key").(string),
-		SecretKey:        d.Get("secret_key").(string),
-		Token:            d.Get("token").(string),
-		Region:           d.Get("region").(string),
-		MaxRetries:       d.Get("max_retries").(int),
-		DynamoDBEndpoint: d.Get("dynamodb_endpoint").(string),
+		AccessKey:               d.Get("access_key").(string),
+		SecretKey:               d.Get("secret_key").(string),
+		Token:                   d.Get("token").(string),
+		Region:                  d.Get("region").(string),
+		MaxRetries:              d.Get("max_retries").(int),
+		DynamoDBEndpoint:        d.Get("dynamodb_endpoint").(string),
+		SkipValidateCredentials: d.Get("skip_validate_credentials").(bool),
 	}
 
 	if v, ok := d.GetOk("allowed_account_ids"); ok {

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -55,7 +55,11 @@ The following arguments are supported in the `provider` block:
   to prevent you mistakenly using a wrong one (and end up destroying live environment).
   Conflicts with `allowed_account_ids`.
 
-* `dynamodb_endpoint` - (Optional) Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to dynamodb-local.
+* `dynamodb_endpoint` - (Optional) Use this to override the default endpoint URL
+  constructed from the `region`. It's typically used to connect to dynamodb-local.
+
+* `skip_validate_credentials` - (Optional) Use this to bypass credential validation.
+  This is usefull when only using dynamodb-local without valid credentials.
 
 In addition to the above parameters, the `AWS_SESSION_TOKEN` environmental
 variable can be set to set an MFA token.


### PR DESCRIPTION
Experimenting with `terraform` and `dynamodb-local` I was getting this error:

```
Error refreshing state: 1 error(s) occurred:

* 1 error(s) occurred:

* InvalidClientTokenId: The security token included in the request is invalid.
        status code: 403, request id: xxxx
```

I tracked it down to the `c.ValidateCredentials()` call in `builtin/providers/aws/config.go` that verifies IAM credentials with AWS even if only working with local dynamo resources.

I added a new config option to the aws provider that skips credential validation. I don't like that this adds more noise to the aws provider config, but I wasn't sure what would be a better way to solve this issue. Is there a better way? Or am I maybe missing something?