### PR TITLE
provider/aws: DynamoDB Table ARN

### DIFF
--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -287,6 +287,10 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 		} else {
 			// No error, set ID and return
 			d.SetId(*output.TableDescription.TableName)
+			if err := d.Set("arn", *output.TableDescription.TableArn); err != nil {
+				return err
+			}
+
 			return nil
 		}
 	}

--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -291,7 +291,7 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 				return err
 			}
 
-			return nil
+			return resourceAwsDynamoDbTableRead(d, meta)
 		}
 	}
 


### PR DESCRIPTION
After the DynamoDB table is created, the ARN wasn't being set. Fixes #3497 

```
terraform [aws-dynamodb-table-arn●] % make testacc TEST=./builtin/providers/aws TESTARGS='-run=DynamoDb' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=DynamoDb -timeout 90m
=== RUN   TestAccAWSDynamoDbTable
[DEBUG] Adding LSI data to the table[DEBUG] Added 1 LSI definitions[DEBUG] Trying to create initial table state![DEBUG] Checking on table TerraformTestTable--- PASS: TestAccAWSDynamoDbTable (125.13s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	125.13s
```