### PR TITLE
[WIP] Add cli command to export provider/provisioner/resource schemas

### DIFF
--- a/builtin/bins/provisioner-chef/main.go
+++ b/builtin/bins/provisioner-chef/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/chef"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(chef.ResourceProvisioner)
-		},
+		ProvisionerFunc: chef.GetProvisioner,
 	})
 }

--- a/builtin/bins/provisioner-file/main.go
+++ b/builtin/bins/provisioner-file/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/file"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(file.ResourceProvisioner)
-		},
+		ProvisionerFunc: file.Provisioner,
 	})
 }

--- a/builtin/bins/provisioner-local-exec/main.go
+++ b/builtin/bins/provisioner-local-exec/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/local-exec"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(localexec.ResourceProvisioner)
-		},
+		ProvisionerFunc: localexec.Provisioner,
 	})
 }

--- a/builtin/bins/provisioner-remote-exec/main.go
+++ b/builtin/bins/provisioner-remote-exec/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(remoteexec.ResourceProvisioner)
-		},
+		ProvisionerFunc: remoteexec.Provisioner,
 	})
 }

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/communicator/remote"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/go-linereader"
@@ -129,7 +130,17 @@ type Provisioner struct {
 }
 
 // ResourceProvisioner represents a generic chef provisioner
-type ResourceProvisioner struct{}
+type ResourceProvisioner struct {
+	schema.Provisioner
+}
+
+func GetProvisioner() terraform.ResourceProvisioner {
+	return &ResourceProvisioner{
+		schema.Provisioner{Schema: map[string]*schema.Schema{
+		// TODO: Fill from Provisioner struct, note 'required' tag
+		}},
+	}
+}
 
 // Apply executes the file provisioner
 func (r *ResourceProvisioner) Apply(

--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/communicator"
-	"github.com/hashicorp/terraform/helper/config"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"

--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -25,6 +25,10 @@ func Provisioner() terraform.ResourceProvisioner {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"content": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"destination": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -8,12 +8,31 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/helper/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 )
 
 // ResourceProvisioner represents a file provisioner
-type ResourceProvisioner struct{}
+type ResourceProvisioner struct {
+	schema.Provisioner
+}
+
+func Provisioner() terraform.ResourceProvisioner {
+	return &ResourceProvisioner{
+		schema.Provisioner{Schema: map[string]*schema.Schema{
+			"source": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"destination": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		}},
+	}
+}
 
 // Apply executes the file provisioner
 func (p *ResourceProvisioner) Apply(

--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/terraform/helper/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-linereader"
 )
@@ -19,7 +20,20 @@ const (
 	maxBufSize = 8 * 1024
 )
 
-type ResourceProvisioner struct{}
+type ResourceProvisioner struct {
+	schema.Provisioner
+}
+
+func Provisioner() terraform.ResourceProvisioner {
+	return &ResourceProvisioner{
+		schema.Provisioner{Schema: map[string]*schema.Schema{
+			"command": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		}},
+	}
+}
 
 func (p *ResourceProvisioner) Apply(
 	o terraform.UIOutput,

--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -12,12 +12,35 @@ import (
 
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/communicator/remote"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-linereader"
 )
 
 // ResourceProvisioner represents a remote exec provisioner
-type ResourceProvisioner struct{}
+type ResourceProvisioner struct {
+	schema.Provisioner
+}
+
+func Provisioner() terraform.ResourceProvisioner {
+	return &ResourceProvisioner{
+		schema.Provisioner{Schema: map[string]*schema.Schema{
+			"script": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"scripts", "inline"},
+			},
+			"scripts": {
+				Type:          schema.TypeList,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"script", "inline"},
+			},
+			"inline": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"script", "scripts"},
+			},
+		}},
+	}
+}
 
 // Apply executes the remote exec provisioner
 func (p *ResourceProvisioner) Apply(

--- a/command/format_schema.go
+++ b/command/format_schema.go
@@ -1,0 +1,89 @@
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"encoding/json"
+	"encoding/xml"
+	"github.com/mitchellh/colorstring"
+)
+
+// FormatSchemaOpts are the options for formatting a schema.
+type FormatSchemaOpts struct {
+	// Name of schema to format. This is required.
+	Name string
+
+	// Schema is the schema to format. This is required.
+	Schema *interface{}
+
+	// Output format. Either 'json' or 'xml'. This is required.
+	Format string
+
+	// Is output should be indented. This is optional.
+	Indent bool
+
+	// This is optional.
+	Colorize bool
+
+	// Colorizer is the colorizer. This is required only if Colorize == true.
+	Colorizer *colorstring.Colorize
+}
+
+// FormatState takes a state and returns a string
+func FormatSchema(opts *FormatSchemaOpts) string {
+	if opts.Colorize && opts.Colorizer == nil {
+		panic("Colorizer not given")
+	}
+
+	s := opts.Schema
+
+	var buf bytes.Buffer
+	//	buf.WriteString("[reset]")
+
+	var ser []byte
+	var err error
+	format := strings.ToLower(opts.Format)
+	switch format {
+	case "json":
+		if opts.Indent {
+			ser, err = json.MarshalIndent(s, "", "  ")
+		} else {
+			ser, err = json.Marshal(s)
+		}
+	case "xml":
+		// FIXME: Use custom serializer for map[string]interface{} (SchemaInfo)
+		if opts.Indent {
+			ser, err = xml.MarshalIndent(s, "", "  ")
+		} else {
+			ser, err = xml.Marshal(s)
+		}
+	case "plain":
+		ser, err = marshalPlain(s, opts.Indent)
+	default:
+		panic(fmt.Sprintf("Unsupported format %s", format))
+	}
+
+	if err != nil {
+		return fmt.Sprintf("Cannot serialize schema for '%s': %s\n", opts.Name, err)
+	}
+	buf.Write(ser)
+
+	trimmed := strings.TrimSpace(buf.String())
+	if opts.Colorize {
+		return opts.Colorizer.Color(trimmed)
+	}
+	return trimmed
+}
+
+func marshalPlain(in *interface{}, indent bool) ([]byte, error) {
+	var b bytes.Buffer
+	// TODO: Implement
+	//	enc := NewEncoder(&b)
+	//	enc.Indent(prefix, indent)
+	//	if err := enc.Encode(v); err != nil {
+	//		return nil, err
+	//	}
+	return b.Bytes(), nil
+}

--- a/command/schemas.go
+++ b/command/schemas.go
@@ -33,7 +33,7 @@ type resourceResourceSchema struct {
 
 type provisionerResourceSchemaInfo struct {
 	resultBase
-	terraform.ResourceProvisionerSchema
+	*terraform.ResourceProvisionerSchema
 }
 
 type errorResult struct {

--- a/command/schemas.go
+++ b/command/schemas.go
@@ -70,7 +70,8 @@ func (c *SchemasCommand) Run(args []string) int {
 	cmdFlags := flag.NewFlagSet("schemas", flag.ContinueOnError)
 	cmdFlags.BoolVar(&indent, "indent", false, "Indent output")
 	cmdFlags.BoolVar(&inJson, "json", false, "In JSON format")
-	cmdFlags.StringVar(&expectedType, "type", "any", "In JSON format")
+	cmdFlags.StringVar(&expectedType, "type", "any", "Type of object: provisioner, provider, resource, "+
+		"data-source, function. Should be specified if there's two objects with same name")
 	expectedType = strings.ToLower(expectedType)
 	// Temporarily disabled due to not-implemented xml serializer for SchemaInfo (which is map[string]interface{})
 	//cmdFlags.BoolVar(&inXml, "xml", false, "In XML format")

--- a/command/schemas.go
+++ b/command/schemas.go
@@ -1,0 +1,92 @@
+package command
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+	"strings"
+)
+
+// SchemasCommand is a Command implementation that reads and outputs the
+// schemas of all installed Terraform providers and resource types.
+type SchemasCommand struct {
+	Meta
+}
+
+type extendedResourceSchema struct {
+	terraform.ResourceSchema
+	Name string `json:"name"`
+}
+
+func (c *SchemasCommand) Run(args []string) int {
+	var indent bool
+	var inJson bool
+
+	args = c.Meta.process(args, false)
+
+	cmdFlags := flag.NewFlagSet("schemas", flag.ContinueOnError)
+	cmdFlags.BoolVar(&indent, "indent", false, "Indent output")
+	// 'inJson' ignored for now, always true
+	cmdFlags.BoolVar(&inJson, "json", true, "In JSON format")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = cmdFlags.Args()
+	if len(args) != 1 {
+		c.Ui.Error("The schemas command expects one argument with the type of provider/resource.")
+		cmdFlags.Usage()
+		return 1
+	}
+
+	for k, v := range c.Meta.ContextOpts.Providers {
+		if len(args) == 1 && args[0] != k {
+			continue
+		}
+		if provider, err := v(); err == nil {
+			export, err := provider.Export()
+			if err != nil {
+				fmt.Printf("Cannot get schema for provider '%s': %s\n", k, err)
+				continue
+			}
+			extended := extendedResourceSchema{export, k}
+			var ser []byte
+			var err2 error
+			if indent {
+				ser, err2 = json.MarshalIndent(extended, "", "  ")
+			} else {
+				ser, err2 = json.Marshal(extended)
+			}
+			if err2 != nil {
+				fmt.Printf("Cannot serialize schema for provider '%s': %s\n", k, err)
+				continue
+			}
+			fmt.Println(string(ser))
+		}
+	}
+
+	return 0
+}
+
+func (c *SchemasCommand) Help() string {
+	// TODO: Support more than one name element, all probably return everything at once
+	helpText := `
+Usage: terraform schemas [options] name
+
+  Reads and outputs the schema of specified ('name') Terraform provider
+  or resource in machine- or human-readable form.
+
+Options:
+
+  -indent		      If specified, output would be indented.
+
+  -json		          If specified, output would be in JSON format.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *SchemasCommand) Synopsis() string {
+	return "Shows schemas of Terraform providers/resources"
+}

--- a/command/schemas.go
+++ b/command/schemas.go
@@ -22,7 +22,7 @@ type resultBase struct {
 
 type providerResourceSchema struct {
 	resultBase
-	terraform.ResourceProviderSchema
+	*terraform.ResourceProviderSchema
 }
 
 type resourceResourceSchema struct {

--- a/command/schemas.go
+++ b/command/schemas.go
@@ -15,15 +15,15 @@ type SchemasCommand struct {
 }
 
 type providerResourceSchema struct {
-	terraform.ResourceSchema
+	terraform.ResourceProviderSchema
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
 type provisionerResourceSchemaInfo struct {
-	terraform.ResourceSchemaInfo `json:"provisioner"`
-	Name                         string `json:"name"`
-	Type                         string `json:"type"`
+	terraform.ResourceProvisionerSchema
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 func (c *SchemasCommand) Run(args []string) int {
@@ -47,6 +47,8 @@ func (c *SchemasCommand) Run(args []string) int {
 		cmdFlags.Usage()
 		return 1
 	}
+
+	// TODO: Use c.Ui.Output(FormatSchema ...
 
 	for k, v := range c.Meta.ContextOpts.Providers {
 		if len(args) == 1 && args[0] != k {

--- a/commands.go
+++ b/commands.go
@@ -127,6 +127,12 @@ func init() {
 			}, nil
 		},
 
+		"schemas": func() (cli.Command, error) {
+			return &command.SchemasCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"taint": func() (cli.Command, error) {
 			return &command.TaintCommand{
 				Meta: meta,

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1613,7 +1613,7 @@ func TestInterpolateFuncUUID(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		result, err := hil.Eval(ast, langEvalConfig(nil))
+		result, err := hil.Eval(ast, LangEvalConfig(nil))
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1644,7 +1644,7 @@ func testFunction(t *testing.T, config testFunctionConfig) {
 			t.Fatalf("Case #%d: input: %#v\nerr: %v", i, tc.Input, err)
 		}
 
-		result, err := hil.Eval(ast, langEvalConfig(config.Vars))
+		result, err := hil.Eval(ast, LangEvalConfig(config.Vars))
 		t.Logf("err: %v", err)
 		if err != nil != tc.Error {
 			t.Fatalf("Case #%d:\ninput: %#v\nerr: %v", i, tc.Input, err)

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -121,7 +121,7 @@ func (r *RawConfig) Interpolate(vs map[string]ast.Variable) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	config := langEvalConfig(vs)
+	config := LangEvalConfig(vs)
 	return r.interpolate(func(root ast.Node) (interface{}, error) {
 		// We detect the variables again and check if the value of any
 		// of the variables is the computed value. If it is, then we
@@ -321,8 +321,8 @@ type gobRawConfig struct {
 	Raw map[string]interface{}
 }
 
-// langEvalConfig returns the evaluation configuration we use to execute.
-func langEvalConfig(vs map[string]ast.Variable) *hil.EvalConfig {
+// LangEvalConfig returns the evaluation configuration we use to execute.
+func LangEvalConfig(vs map[string]ast.Variable) *hil.EvalConfig {
 	funcMap := make(map[string]ast.Function)
 	for k, v := range Funcs() {
 		funcMap[k] = v

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -93,8 +93,8 @@ func (p *Provider) InternalValidate() error {
 
 // ExportSchema should be called to export the structure
 // of the provider.
-func (p *Provider) Export() (terraform.ResourceProviderSchema, error) {
-	result := terraform.ResourceProviderSchema{}
+func (p *Provider) Export() (*terraform.ResourceProviderSchema, error) {
+	result := new(terraform.ResourceProviderSchema)
 
 	result.Schema = schemaMap(p.Schema).Export()
 	result.Resources = make(map[string]terraform.SchemaInfo)

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -93,11 +93,11 @@ func (p *Provider) InternalValidate() error {
 
 // ExportSchema should be called to export the structure
 // of the provider.
-func (p *Provider) Export() (terraform.ResourceSchema, error) {
-	result := terraform.ResourceSchema{}
+func (p *Provider) Export() (terraform.ResourceProviderSchema, error) {
+	result := terraform.ResourceProviderSchema{}
 
-	result.Provider = schemaMap(p.Schema).Export()
-	result.Resources = make(map[string]terraform.ResourceSchemaInfo)
+	result.Schema = schemaMap(p.Schema).Export()
+	result.Resources = make(map[string]terraform.SchemaInfo)
 
 	for k, r := range p.ResourcesMap {
 		result.Resources[k] = r.Export()

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -98,9 +98,13 @@ func (p *Provider) Export() (*terraform.ResourceProviderSchema, error) {
 
 	result.Schema = schemaMap(p.Schema).Export()
 	result.Resources = make(map[string]terraform.SchemaInfo)
+	result.DataSources = make(map[string]terraform.SchemaInfo)
 
 	for k, r := range p.ResourcesMap {
 		result.Resources[k] = r.Export()
+	}
+	for k, ds := range p.DataSourcesMap {
+		result.DataSources[k] = ds.Export()
 	}
 
 	return result, nil

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -91,6 +91,21 @@ func (p *Provider) InternalValidate() error {
 	return validationErrors
 }
 
+// ExportSchema should be called to export the structure
+// of the provider.
+func (p *Provider) Export() (terraform.ResourceSchema, error) {
+	result := terraform.ResourceSchema{}
+
+	result.Provider = schemaMap(p.Schema).Export()
+	result.Resources = make(map[string]terraform.ResourceSchemaInfo)
+
+	for k, r := range p.ResourcesMap {
+		result.Resources[k] = r.Export()
+	}
+
+	return result, nil
+}
+
 // Meta returns the metadata associated with this provider that was
 // returned by the Configure call. It will be nil until Configure is called.
 func (p *Provider) Meta() interface{} {

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -1,0 +1,13 @@
+package schema
+
+import (
+	"github.com/hashicorp/terraform/terraform"
+)
+
+type Provisioner struct {
+	Schema map[string]*Schema
+}
+
+func (p *Provisioner) Export() (terraform.ResourceSchemaInfo, error) {
+	return schemaMap(p.Schema).Export(), nil
+}

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -8,9 +8,8 @@ type Provisioner struct {
 	Schema map[string]*Schema
 }
 
-func (p *Provisioner) Export() (terraform.ResourceProvisionerSchema, error) {
-	schema := schemaMap(p.Schema).Export()
-	result := terraform.ResourceProvisionerSchema{}
-	result.Schema = schema
+func (p *Provisioner) Export() (*terraform.ResourceProvisionerSchema, error) {
+	result := new(terraform.ResourceProvisionerSchema)
+	result.Schema = schemaMap(p.Schema).Export()
 	return result, nil
 }

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -8,6 +8,9 @@ type Provisioner struct {
 	Schema map[string]*Schema
 }
 
-func (p *Provisioner) Export() (terraform.ResourceSchemaInfo, error) {
-	return schemaMap(p.Schema).Export(), nil
+func (p *Provisioner) Export() (terraform.ResourceProvisionerSchema, error) {
+	schema := schemaMap(p.Schema).Export()
+	result := terraform.ResourceProvisionerSchema{}
+	result.Schema = schema
+	return result, nil
 }

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -367,7 +367,7 @@ func (r *Resource) TestResourceData() *ResourceData {
 // Provider.ExportSchema() will automatically call this for all of
 // the resources it manages, so you don't need to call this manually if it
 // is part of a Provider.
-func (r *Resource) Export() terraform.ResourceSchemaInfo {
+func (r *Resource) Export() terraform.SchemaInfo {
 	return schemaMap(r.Schema).Export()
 }
 

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -361,6 +361,16 @@ func (r *Resource) TestResourceData() *ResourceData {
 	}
 }
 
+// ExportSchema should be called to export the structure
+// of the resource.
+//
+// Provider.ExportSchema() will automatically call this for all of
+// the resources it manages, so you don't need to call this manually if it
+// is part of a Provider.
+func (r *Resource) Export() terraform.ResourceSchemaInfo {
+	return schemaMap(r.Schema).Export()
+}
+
 // Returns true if the resource is "top level" i.e. not a sub-resource.
 func (r *Resource) isTopLevel() bool {
 	// TODO: This is a heuristic; replace with a definitive attribute?

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -619,6 +619,31 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 	return nil
 }
 
+// Export exports the format of this schema.
+func (m schemaMap) Export() terraform.ResourceSchemaInfo {
+	result := make(terraform.ResourceSchemaInfo)
+	for k, v := range m {
+		item := []terraform.ResourceSchemaElement{}
+		s := reflect.ValueOf(v).Elem()
+		typeOfV := s.Type()
+		for i := 0; i < s.NumField(); i++ {
+			f := s.Field(i)
+			var iv string
+			f.Type().Kind()
+			if f.Interface() != nil {
+				iv = fmt.Sprintf("%v", f.Interface())
+			} else {
+				iv = ""
+			}
+			el := terraform.ResourceSchemaElement{typeOfV.Field(i).Name, fmt.Sprintf("%s", f.Type()), iv}
+			item = append(item, el)
+		}
+		result[k] = item
+	}
+
+	return result
+}
+
 func (m schemaMap) diff(
 	k string,
 	schema *Schema,

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -620,8 +620,8 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 }
 
 // Export exports the format of this schema.
-func (m schemaMap) Export() terraform.ResourceSchemaInfo {
-	result := make(terraform.ResourceSchemaInfo)
+func (m schemaMap) Export() terraform.SchemaInfo {
+	result := make(terraform.SchemaInfo)
 	for k, v := range m {
 		item := export(v)
 		result[k] = item
@@ -631,8 +631,8 @@ func (m schemaMap) Export() terraform.ResourceSchemaInfo {
 
 var myDefaultSchema = Schema{}
 
-func export(v *Schema) terraform.ResourceSchemaElements {
-	item := terraform.ResourceSchemaElements{}
+func export(v *Schema) terraform.SchemaElements {
+	item := terraform.SchemaElements{}
 	s := reflect.ValueOf(v).Elem()
 	dd := reflect.ValueOf(&myDefaultSchema).Elem()
 	typeOfV := s.Type()
@@ -653,19 +653,19 @@ func export(v *Schema) terraform.ResourceSchemaElements {
 	return item
 }
 
-func exportValue(value interface{}, name string, t string) terraform.ResourceSchemaElement {
+func exportValue(value interface{}, name string, t string) terraform.SchemaElement {
 	s2, ok := value.(*Schema)
 	if ok {
-		return terraform.ResourceSchemaElement{Name: name, Type: "ResourceSchemaElements", Value: export(s2)}
+		return terraform.SchemaElement{Name: name, Type: "ResourceSchemaElements", Value: export(s2)}
 	}
 	r2, ok := value.(*Resource)
 	if ok {
-		return terraform.ResourceSchemaElement{Name: name, Type: "ResourceSchemaInfo", Value: r2.Export()}
+		return terraform.SchemaElement{Name: name, Type: "ResourceSchemaInfo", Value: r2.Export()}
 	}
 	if value != nil {
-		return terraform.ResourceSchemaElement{Name: name, Type: t, Value: fmt.Sprintf("%v", value)}
+		return terraform.SchemaElement{Name: name, Type: t, Value: fmt.Sprintf("%v", value)}
 	}
-	return terraform.ResourceSchemaElement{Name: name, Type: t, Value: ""}
+	return terraform.SchemaElement{Name: name, Type: t, Value: ""}
 }
 
 var myExportable = []string{"Type", "Optional", "Required", "Description", "Deprecated", "Removed", "Default", "Elem"}

--- a/plugin/resource_provider.go
+++ b/plugin/resource_provider.go
@@ -284,6 +284,15 @@ func (p *ResourceProvider) DataSources() []terraform.DataSource {
 	return result
 }
 
+func (p *ResourceProvider) Export() (terraform.ResourceSchema, error) {
+	var result terraform.ResourceSchema
+	err := p.Client.Call("Plugin.Export", new(interface{}), &result)
+	if err != nil {
+		// TODO: panic, log, what?
+	}
+	return result, err
+}
+
 func (p *ResourceProvider) Close() error {
 	return p.Client.Close()
 }
@@ -546,5 +555,14 @@ func (s *ResourceProviderServer) DataSources(
 	nothing interface{},
 	result *[]terraform.DataSource) error {
 	*result = s.Provider.DataSources()
+	return nil
+}
+
+func (s *ResourceProviderServer) Export(nothing interface{}, result *terraform.ResourceSchema) error {
+	r, err := s.Provider.Export()
+	if err != nil {
+		return err
+	}
+	*result = r
 	return nil
 }

--- a/plugin/resource_provider.go
+++ b/plugin/resource_provider.go
@@ -284,8 +284,8 @@ func (p *ResourceProvider) DataSources() []terraform.DataSource {
 	return result
 }
 
-func (p *ResourceProvider) Export() (terraform.ResourceSchema, error) {
-	var result terraform.ResourceSchema
+func (p *ResourceProvider) Export() (terraform.ResourceProviderSchema, error) {
+	var result terraform.ResourceProviderSchema
 	err := p.Client.Call("Plugin.Export", new(interface{}), &result)
 	if err != nil {
 		// TODO: panic, log, what?
@@ -558,7 +558,7 @@ func (s *ResourceProviderServer) DataSources(
 	return nil
 }
 
-func (s *ResourceProviderServer) Export(nothing interface{}, result *terraform.ResourceSchema) error {
+func (s *ResourceProviderServer) Export(nothing interface{}, result *terraform.ResourceProviderSchema) error {
 	r, err := s.Provider.Export()
 	if err != nil {
 		return err

--- a/plugin/resource_provisioner.go
+++ b/plugin/resource_provisioner.go
@@ -81,8 +81,8 @@ func (p *ResourceProvisioner) Close() error {
 	return p.Client.Close()
 }
 
-func (p *ResourceProvisioner) Export() (terraform.ResourceSchemaInfo, error) {
-	var result terraform.ResourceSchemaInfo
+func (p *ResourceProvisioner) Export() (terraform.ResourceProvisionerSchema, error) {
+	var result terraform.ResourceProvisionerSchema
 	err := p.Client.Call("Plugin.Export", new(interface{}), &result)
 	if err != nil {
 		// TODO: panic, log, what?
@@ -153,7 +153,7 @@ func (s *ResourceProvisionerServer) Validate(
 	return nil
 }
 
-func (s *ResourceProvisionerServer) Export(nothing interface{}, result *terraform.ResourceSchemaInfo) error {
+func (s *ResourceProvisionerServer) Export(nothing interface{}, result *terraform.ResourceProvisionerSchema) error {
 	r, err := s.Provisioner.Export()
 	if err != nil {
 		return err

--- a/plugin/resource_provisioner.go
+++ b/plugin/resource_provisioner.go
@@ -81,6 +81,15 @@ func (p *ResourceProvisioner) Close() error {
 	return p.Client.Close()
 }
 
+func (p *ResourceProvisioner) Export() (terraform.ResourceSchemaInfo, error) {
+	var result terraform.ResourceSchemaInfo
+	err := p.Client.Call("Plugin.Export", new(interface{}), &result)
+	if err != nil {
+		// TODO: panic, log, what?
+	}
+	return result, err
+}
+
 type ResourceProvisionerValidateArgs struct {
 	Config *terraform.ResourceConfig
 }
@@ -141,5 +150,14 @@ func (s *ResourceProvisionerServer) Validate(
 		Warnings: warns,
 		Errors:   berrs,
 	}
+	return nil
+}
+
+func (s *ResourceProvisionerServer) Export(nothing interface{}, result *terraform.ResourceSchemaInfo) error {
+	r, err := s.Provisioner.Export()
+	if err != nil {
+		return err
+	}
+	*result = r
 	return nil
 }

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -130,7 +130,7 @@ type ResourceProvider interface {
 	ReadDataApply(*InstanceInfo, *InstanceDiff) (*InstanceState, error)
 
 	// Export exports provider and resources schema
-	Export() (ResourceSchema, error)
+	Export() (ResourceProviderSchema, error)
 }
 
 // ResourceProviderCloser is an interface that providers that can close
@@ -150,26 +150,25 @@ type DataSource struct {
 	Name string `json:"name"`
 }
 
-type ResourceSchemaElement struct {
+type SchemaElement struct {
 	Name  string      `json:"name"`
 	Type  string      `json:"type"`
 	Value interface{} `json:"value"`
 }
 
-type ResourceSchemaElements []ResourceSchemaElement
+type SchemaElements []SchemaElement
 
-type ResourceSchemaInfo map[string]ResourceSchemaElements
+type SchemaInfo map[string]SchemaElements
 
-// ResourceSchema
-type ResourceSchema struct {
-	Provider  ResourceSchemaInfo            `json:"provider"`
-	Resources map[string]ResourceSchemaInfo `json:"resources"`
+type ResourceProviderSchema struct {
+	Schema    SchemaInfo            `json:"schema"`
+	Resources map[string]SchemaInfo `json:"resources"`
 }
 
 func init() {
 	// Required to return such elements from ResourceSchemaElement#Value
-	gob.Register(make(ResourceSchemaElements, 0))
-	gob.Register(ResourceSchemaInfo{})
+	gob.Register(make(SchemaElements, 0))
+	gob.Register(SchemaInfo{})
 }
 
 // ResourceProviderFactory is a function type that creates a new instance

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -161,8 +161,9 @@ type SchemaElements []SchemaElement
 type SchemaInfo map[string]SchemaElements
 
 type ResourceProviderSchema struct {
-	Schema    SchemaInfo            `json:"schema"`
-	Resources map[string]SchemaInfo `json:"resources"`
+	Schema      SchemaInfo            `json:"schema"`
+	Resources   map[string]SchemaInfo `json:"resources"`
+	DataSources map[string]SchemaInfo `json:"data-sources"`
 }
 
 func init() {

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -126,6 +126,9 @@ type ResourceProvider interface {
 	// ReadDataApply initializes a data instance using the configuration
 	// in a diff produced by ReadDataDiff.
 	ReadDataApply(*InstanceInfo, *InstanceDiff) (*InstanceState, error)
+
+	// Export exports provider and resources schema
+	Export() (ResourceSchema, error)
 }
 
 // ResourceProviderCloser is an interface that providers that can close
@@ -136,13 +139,27 @@ type ResourceProviderCloser interface {
 
 // ResourceType is a type of resource that a resource provider can manage.
 type ResourceType struct {
-	Name       string // Name of the resource, example "instance" (no provider prefix)
-	Importable bool   // Whether this resource supports importing
+	Name       string `json:"name"`       // Name of the resource, example "instance" (no provider prefix)
+	Importable bool   `json:"importable"` // Whether this resource supports importing
 }
 
 // DataSource is a data source that a resource provider implements.
 type DataSource struct {
-	Name string
+	Name string `json:"name"`
+}
+
+type ResourceSchemaElement struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Interface string `json:"interface"`
+}
+
+type ResourceSchemaInfo map[string][]ResourceSchemaElement
+
+// ResourceSchema
+type ResourceSchema struct {
+	Provider  ResourceSchemaInfo            `json:"provider"`
+	Resources map[string]ResourceSchemaInfo `json:"resources"`
 }
 
 // ResourceProviderFactory is a function type that creates a new instance

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -130,7 +130,7 @@ type ResourceProvider interface {
 	ReadDataApply(*InstanceInfo, *InstanceDiff) (*InstanceState, error)
 
 	// Export exports provider and resources schema
-	Export() (ResourceProviderSchema, error)
+	Export() (*ResourceProviderSchema, error)
 }
 
 // ResourceProviderCloser is an interface that providers that can close

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -1,5 +1,7 @@
 package terraform
 
+import "encoding/gob"
+
 // ResourceProvider is an interface that must be implemented by any
 // resource provider: the thing that creates and manages the resources in
 // a Terraform configuration.
@@ -149,17 +151,25 @@ type DataSource struct {
 }
 
 type ResourceSchemaElement struct {
-	Name      string `json:"name"`
-	Type      string `json:"type"`
-	Interface string `json:"interface"`
+	Name  string      `json:"name"`
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
 }
 
-type ResourceSchemaInfo map[string][]ResourceSchemaElement
+type ResourceSchemaElements []ResourceSchemaElement
+
+type ResourceSchemaInfo map[string]ResourceSchemaElements
 
 // ResourceSchema
 type ResourceSchema struct {
 	Provider  ResourceSchemaInfo            `json:"provider"`
 	Resources map[string]ResourceSchemaInfo `json:"resources"`
+}
+
+func init() {
+	// Required to return such elements from ResourceSchemaElement#Value
+	gob.Register(make(ResourceSchemaElements, 0))
+	gob.Register(ResourceSchemaInfo{})
 }
 
 // ResourceProviderFactory is a function type that creates a new instance

--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -37,7 +37,7 @@ type MockResourceProvider struct {
 	DiffReturn                     *InstanceDiff
 	DiffReturnError                error
 	ExportCalled                   bool
-	ExportFn                       func() (ResourceProviderSchema, error)
+	ExportFn                       func() (*ResourceProviderSchema, error)
 	ExportReturn                   *ResourceProviderSchema
 	ExportReturnError              error
 	RefreshCalled                  bool
@@ -182,7 +182,7 @@ func (p *MockResourceProvider) Diff(
 	return p.DiffReturn, p.DiffReturnError
 }
 
-func (p *MockResourceProvider) Export() (ResourceProviderSchema, error) {
+func (p *MockResourceProvider) Export() (*ResourceProviderSchema, error) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -191,7 +191,7 @@ func (p *MockResourceProvider) Export() (ResourceProviderSchema, error) {
 		return p.ExportFn()
 	}
 
-	return *p.ExportReturn, p.ExportReturnError
+	return p.ExportReturn, p.ExportReturnError
 }
 
 func (p *MockResourceProvider) Refresh(

--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -36,6 +36,10 @@ type MockResourceProvider struct {
 	DiffFn                         func(*InstanceInfo, *InstanceState, *ResourceConfig) (*InstanceDiff, error)
 	DiffReturn                     *InstanceDiff
 	DiffReturnError                error
+	ExportCalled                   bool
+	ExportFn                       func() (ResourceProviderSchema, error)
+	ExportReturn                   *ResourceProviderSchema
+	ExportReturnError              error
 	RefreshCalled                  bool
 	RefreshInfo                    *InstanceInfo
 	RefreshState                   *InstanceState
@@ -176,6 +180,18 @@ func (p *MockResourceProvider) Diff(
 	}
 
 	return p.DiffReturn, p.DiffReturnError
+}
+
+func (p *MockResourceProvider) Export() (ResourceProviderSchema, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.ExportCalled = true
+	if p.ExportFn != nil {
+		return p.ExportFn()
+	}
+
+	return *p.ExportReturn, p.ExportReturnError
 }
 
 func (p *MockResourceProvider) Refresh(

--- a/terraform/resource_provisioner.go
+++ b/terraform/resource_provisioner.go
@@ -21,6 +21,9 @@ type ResourceProvisioner interface {
 	// is provided since provisioners only run after a resource has been
 	// newly created.
 	Apply(UIOutput, *InstanceState, *ResourceConfig) error
+
+	// Export exports provisioner schema
+	Export() (ResourceSchemaInfo, error)
 }
 
 // ResourceProvisionerCloser is an interface that provisioners that can close

--- a/terraform/resource_provisioner.go
+++ b/terraform/resource_provisioner.go
@@ -23,7 +23,7 @@ type ResourceProvisioner interface {
 	Apply(UIOutput, *InstanceState, *ResourceConfig) error
 
 	// Export exports provisioner schema
-	Export() (ResourceProvisionerSchema, error)
+	Export() (*ResourceProvisionerSchema, error)
 }
 
 // ResourceProvisionerCloser is an interface that provisioners that can close

--- a/terraform/resource_provisioner.go
+++ b/terraform/resource_provisioner.go
@@ -23,7 +23,7 @@ type ResourceProvisioner interface {
 	Apply(UIOutput, *InstanceState, *ResourceConfig) error
 
 	// Export exports provisioner schema
-	Export() (ResourceSchemaInfo, error)
+	Export() (ResourceProvisionerSchema, error)
 }
 
 // ResourceProvisionerCloser is an interface that provisioners that can close
@@ -35,3 +35,7 @@ type ResourceProvisionerCloser interface {
 // ResourceProvisionerFactory is a function type that creates a new instance
 // of a resource provisioner.
 type ResourceProvisionerFactory func() (ResourceProvisioner, error)
+
+type ResourceProvisionerSchema struct {
+	Schema SchemaInfo `json:"schema"`
+}

--- a/terraform/resource_provisioner_mock.go
+++ b/terraform/resource_provisioner_mock.go
@@ -21,6 +21,11 @@ type MockResourceProvisioner struct {
 	ValidateFn           func(c *ResourceConfig) ([]string, []error)
 	ValidateReturnWarns  []string
 	ValidateReturnErrors []error
+
+	ExportCalled      bool
+	ExportFn          func() (ResourceProvisionerSchema, error)
+	ExportReturn      *ResourceProvisionerSchema
+	ExportReturnError error
 }
 
 func (p *MockResourceProvisioner) Validate(c *ResourceConfig) ([]string, []error) {
@@ -50,4 +55,13 @@ func (p *MockResourceProvisioner) Apply(
 		return p.ApplyFn(state, c)
 	}
 	return p.ApplyReturnError
+}
+
+func (p *MockResourceProvisioner) Export() (ResourceProvisionerSchema, error) {
+	p.ExportCalled = true
+	if p.ExportFn != nil {
+		return p.ExportFn()
+	}
+
+	return *p.ExportReturn, p.ExportReturnError
 }

--- a/terraform/resource_provisioner_mock.go
+++ b/terraform/resource_provisioner_mock.go
@@ -23,7 +23,7 @@ type MockResourceProvisioner struct {
 	ValidateReturnErrors []error
 
 	ExportCalled      bool
-	ExportFn          func() (ResourceProvisionerSchema, error)
+	ExportFn          func() (*ResourceProvisionerSchema, error)
 	ExportReturn      *ResourceProvisionerSchema
 	ExportReturnError error
 }
@@ -57,11 +57,11 @@ func (p *MockResourceProvisioner) Apply(
 	return p.ApplyReturnError
 }
 
-func (p *MockResourceProvisioner) Export() (ResourceProvisionerSchema, error) {
+func (p *MockResourceProvisioner) Export() (*ResourceProvisionerSchema, error) {
 	p.ExportCalled = true
 	if p.ExportFn != nil {
 		return p.ExportFn()
 	}
 
-	return *p.ExportReturn, p.ExportReturnError
+	return p.ExportReturn, p.ExportReturnError
 }


### PR DESCRIPTION
This feature allows to run command like `terraform schemas aws` and get json with information about required/optional properties of providers/provisioners/resources and their types. (and much more info)

Originally it was required to add 'properties completion' and 'required properties inspection' features in [IntelliJ HCL/Terraform plugin](https://github.com/VladRassokhin/intellij-hcl) and I think it could be shared with community, so vim/emacs/etc users could use it.

Example of generated output for provisioner `local-exec` (`terraform schemas -indent -json local-exec`) could be found [here](https://github.com/VladRassokhin/intellij-hcl/blob/df48a537bbee63c7d8b219c982962aef52e805fe/res/terraform/model/local-exec.json). There are other files for other providers/provisioners in the same directory, look around.

Still some things should be done:
- [ ] Documentation
- [ ] Tests
- [ ] Output formats
  - [X] JSON
  - [ ] XML
  - [ ] plain text (could be useful for bash completion or something like that)
- [ ] Check backward compatibility of third party plugins (new command added for provisioners and providers, at least recompilation required)
  - [ ] Source compatibility
  - [ ] Binary compatibility