### PR TITLE
Provider/aws Apply security group after restoring db_instance from snapshot

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -352,11 +352,8 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			var s []*string
-			for _, v := range attr.List() {
-				s = append(s, aws.String(v.(string)))
-			}
-			log.Printf("[INFO] DB is restoring from snapshot with default security, but should be set to %s", v.(string))
+			log.Printf("[INFO] DB is restoring from snapshot with default security, but custom security should be set, will now update after snapshot is restored!");
+
 			// wait for instance to get up and then modify security
 			d.SetId(d.Get("identifier").(string))
 

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -350,6 +350,42 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("Error creating DB Instance: %s", err)
 		}
+
+		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			var s []*string
+			for _, v := range attr.List() {
+				s = append(s, aws.String(v.(string)))
+			}
+			log.Printf("[INFO] DB is restoring from snapshot with default security, but should be set to %s", s)
+			// wait for instance to get up and then modify security
+			d.SetId(d.Get("identifier").(string))
+
+			log.Printf("[INFO] DB Instance ID: %s", d.Id())
+
+			log.Println(
+				"[INFO] Waiting for DB Instance to be available")
+
+			stateConf := &resource.StateChangeConf{
+				Pending:    []string{"creating", "backing-up", "modifying"},
+				Target:     "available",
+				Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
+				Timeout:    40 * time.Minute,
+				MinTimeout: 10 * time.Second,
+				Delay:      30 * time.Second, // Wait 30 secs before starting
+			}
+
+			// Wait, catching any errors
+			_, err := stateConf.WaitForState()
+			if err != nil {
+				return err
+			}
+
+			err = resourceAwsDbInstanceUpdate(d, meta)
+			if err != nil {
+				return err
+			}
+
+		}
 	} else {
 		opts := rds.CreateDBInstanceInput{
 			AllocatedStorage:     aws.Int64(int64(d.Get("allocated_storage").(int))),

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -356,7 +356,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			for _, v := range attr.List() {
 				s = append(s, aws.String(v.(string)))
 			}
-			log.Printf("[INFO] DB is restoring from snapshot with default security, but should be set to %s", s)
+			log.Printf("[INFO] DB is restoring from snapshot with default security, but should be set to %s", v.(string))
 			// wait for instance to get up and then modify security
 			d.SetId(d.Get("identifier").(string))
 

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -352,7 +352,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			log.Printf("[INFO] DB is restoring from snapshot with default security, but custom security should be set, will now update after snapshot is restored!");
+			log.Printf("[INFO] DB is restoring from snapshot with default security, but custom security should be set, will now update after snapshot is restored!")
 
 			// wait for instance to get up and then modify security
 			d.SetId(d.Get("identifier").(string))


### PR DESCRIPTION
Currently awsgosdk (and terraform by extension) assign a newly restored snapshot only the default security group. This patch causes the resource to check if the vpc_security_group_ids list is set, and if it is it waits for the restored DB to become available and then updates it in order to get the settings in the right state. 