### PR TITLE
Fix security group rule

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -417,8 +417,8 @@ func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) *ec2.IpPermissi
 			}
 
 			if sg.VpcId == nil || *sg.VpcId == "" {
-				perm.UserIdGroupPairs[i].GroupId = nil
-				perm.UserIdGroupPairs[i].GroupName = aws.String(id)
+				perm.UserIdGroupPairs[i].GroupId = aws.String(id)
+				perm.UserIdGroupPairs[i].GroupName = nil
 				perm.UserIdGroupPairs[i].UserId = nil
 			}
 		}


### PR DESCRIPTION
This fixes #3518 for EC2 classic security groups. It passes all tests (assuming `make test` can be trusted), and it fixes the bug I reported, but I have not personally tried it with a VPC of any kind.