### PR TITLE
provider/aws: Add configuration to enable copying RDS tags to final snapshot

### DIFF
--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -45,6 +45,9 @@ The following arguments are supported:
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
     when this DB instance is deleted. If omitted, no final snapshot will be
     made.
+* `copy_tags_to_snapshot` – (Optional, boolean) On delete, copy all Instance `tags` to
+the final snapshot (if `final_snapshot_identifier` is specified). Default
+`false`
 * `name` - (Optional) The DB name to create. If omitted, no database is created
     initially.
 * `password` - (Required) Password for the master DB user. Note that this may


### PR DESCRIPTION
RDS by default does not copy any RDS Instance tags over to the final snapshot when you destroy a database. This PR adds an optional boolean to enable applying all RDS Instance tags to it's snapshot. It works in conjunction with the `final_snapshot_identifier`. 

It doesn't look like RDS Clusters have this ability. 

Unfortunately I can't seem to find how to view these tags on a snapshot in the console, but you can see them with the `aws` CLI, though you have to figure out the ARN:

```
$ aws rds list-tags-for-resource --resource-name "arn:aws:rds:us-west-2:<my account>:snapshot:<the name of my final snapshot>"
----------------------
| ListTagsForResource|
+--------------------+
||      TagList     ||
|+--------+---------+|
||   Key  |  Value  ||
|+--------+---------+|
||  Tag1  |  tags1  ||
||  Tag2  |  tags2  ||
|+--------+---------+|
```



Implements https://github.com/hashicorp/terraform/issues/3492