### PR TITLE
Replace tangling reference to github.com/awslabs/aws-sdk-go

### DIFF
--- a/builtin/providers/aws/conversions.go
+++ b/builtin/providers/aws/conversions.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 


### PR DESCRIPTION
I'm we really want to reference github.com/aws/aws-sdk-go here, because this is the sole remaining reference to the different package.