### PR TITLE
Update init and remote config command docs

### DIFF
--- a/website/source/docs/commands/init.html.markdown
+++ b/website/source/docs/commands/init.html.markdown
@@ -31,17 +31,34 @@ a remote state configuration if provided.
 
 The command-line flags are all optional. The list of available flags are:
 
-* `-address=url` - URL of the remote storage server. Required for HTTP backend,
-  optional for Atlas and Consul.
-
-* `-access-token=token` - Authentication token for state storage server.
-  Required for Atlas backend, optional for Consul.
-
 * `-backend=atlas` - Specifies the type of remote backend. Must be one
-  of Atlas, Consul, or HTTP. Defaults to atlas.
+  of Atlas, Consul, S3, or HTTP. Defaults to Atlas.
 
-* `-name=name` - Name of the state file in the state storage server.
-  Required for Atlas backend.
+* `-backend-config="k=v"` - Specify a configuration variable for a backend. This is how you set the required variables for the selected backend (as detailed in the [remote command documentation](/docs/command/remote.html).
 
-* `-path=path` - Path of the remote state in Consul. Required for the Consul backend.
 
+## Example: Consul
+
+This example will initialize the current directory and configure Consul remote storage:
+
+```
+$ terraform init \
+    -backend=consul \
+    -backend-config="address=your.consul.endpoint:443" \
+    -backend-config="scheme=https" \
+    -backend-config="path=tf/path/for/project" \
+    /path/to/source/module
+```
+
+## Example: S3
+
+This example will initialize the current directory and configure S3 remote storage:
+
+```
+$ terraform init \
+    -backend=s3 \
+    -backend-config="bucket=your-s3-bucket" \
+    -backend-config="key=tf/path/for/project.json" \
+    -backend-config="acl=bucket-owner-full-control" \
+    /path/to/source/module
+```

--- a/website/source/docs/commands/remote-config.html.markdown
+++ b/website/source/docs/commands/remote-config.html.markdown
@@ -45,10 +45,18 @@ The following backends are supported:
 * Atlas - Stores the state in Atlas. Requires the `name` and `access_token`
   variables. The `address` variable can optionally be provided.
 
-* Consul - Stores the state in the KV store at a given path.
-  Requires the `path` variable. The `address` and `access_token`
-  variables can optionally be provided. Address is assumed to be the
-  local agent if not provided.
+* Consul - Stores the state in the KV store at a given path. Requires the
+  `path` variable. Supports the `CONSUL_HTTP_TOKEN` environment variable
+  for specifying access credentials, or the `access_token` variable may
+  be provided, but this is not recommended since it would be included in
+  cleartext inside the persisted, shard state. Other supported parameters
+  include:
+  * `address` - DNS name and port of your Consul endpoint specified in the
+    format `dnsname:port`. Defaults to the local agent HTTP listener. This
+    may also be specified using the `CONSUL_HTTP_ADDR` environment variable.
+  * `scheme` - Specifies what protocol to use when talking to the given
+    `address`, either `http` or `https`. SSL support can also be triggered
+    by setting then environment variable `CONSUL_HTTP_SSL` to `true`.
 
 * S3 - Stores the state as a given key in a given bucket on Amazon S3.
   Requires the `bucket` and `key` variables. Supports and honors the standard


### PR DESCRIPTION
Docs for `terraform init` were out of date and needed some corrections. I also provided a couple of usage examples.

Docs for `terraform remote config` needed a little more detail on the Consul backend configuration. I mirrored the language of the S3 backend in regards to hardcoding credentials as well. And I added details of Consul client environment variables that can be used to configure that access.