### PR TITLE
Fix issues with destroying VIPs, Pools and monitors.

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/lbaas/members"
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/lbaas/pools"
 	"github.com/rackspace/gophercloud/pagination"
+	"time"
 )
 
 func resourceLBPoolV1() *schema.Resource {
@@ -276,6 +277,16 @@ func resourceLBPoolV1Delete(d *schema.ResourceData, meta interface{}) error {
 	err = pools.Delete(networkingClient, d.Id()).ExtractErr()
 	if err != nil {
 		return fmt.Errorf("Error deleting OpenStack LB Pool: %s", err)
+	}
+
+	for {
+		_, err := pools.Get(networkingClient, d.Id()).Extract()
+		if err == nil {
+			log.Printf("[DEBUG] Pool (%s) is not deleted yet, waiting for 1 second", d.Id())
+			time.Sleep(1000 * time.Millisecond)
+		} else {
+			break;
+		}
 	}
 
 	d.SetId("")

--- a/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/lbaas/vips"
+	"time"
 )
 
 func resourceLBVipV1() *schema.Resource {
@@ -285,6 +286,16 @@ func resourceLBVipV1Delete(d *schema.ResourceData, meta interface{}) error {
 	err = vips.Delete(networkingClient, d.Id()).ExtractErr()
 	if err != nil {
 		return fmt.Errorf("Error deleting OpenStack LB VIP: %s", err)
+	}
+
+	for {
+		_, err := vips.Get(networkingClient, d.Id()).Extract()
+		if err == nil {
+			log.Printf("[DEBUG] VIP (%s) is not deleted yet, waiting for 1 second", d.Id())
+			time.Sleep(1000 * time.Millisecond)
+		} else {
+			break;
+		}
 	}
 
 	d.SetId("")


### PR DESCRIPTION
The current implementation of the openstack provider for destorying VIPs
and pools assumes the delete function deletes straight away.

This is not true, the delete function just schedules a delete.
For this reason it is necessary to poll until the VIP/Pool
returns a 404.

This assumption seems to be made in a few places throughout
the openstack provider, as seen in issue #1715

Thanks.

Signed-off-by: Ian Duffy <ian@ianduffy.ie>