### PR TITLE
provider/google: OAuth2 support

### DIFF
--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -15,7 +15,7 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"account_file": &schema.Schema{
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				DefaultFunc:  schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
 				ValidateFunc: validateAccountFile,
 			},
@@ -78,6 +78,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 func validateAccountFile(v interface{}, k string) (warnings []string, errors []error) {
+	if v == nil {
+		return
+	}
+
 	value := v.(string)
 
 	if value == "" {


### PR DESCRIPTION
If the `account_file` provider attribute is not specified, Terraform will attempt to authentical using OAuth2

@sparkprime 