### PR TITLE
[WIP] Add interpolate uuid function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/config/lang/ast"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/mitchellh/go-homedir"
 )
 
@@ -33,6 +34,7 @@ func init() {
 		"split":        interpolationFuncSplit(),
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64decode": interpolationFuncBase64Decode(),
+		"uuid": interpolationFuncUuid(),
 	}
 }
 
@@ -439,6 +441,28 @@ func interpolationFuncBase64Decode() ast.Function {
 				return "", fmt.Errorf("failed to decode base64 data '%s'", s)
 			}
 			return string(sDec), nil
+		},
+	}
+}
+
+// interpolationFuncUuid implements an uuid v4 generator with an optional 
+// prefix string. Refer to pkg helper/resource/id for implementation details
+// of the uuid generator.
+func interpolationFuncUuid() ast.Function {
+	return ast.Function{
+		Variadic:     true,
+		VariadicType: ast.TypeString,
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			var prefix string
+
+			if len(args) == 1 {
+				if v, ok := args[0].(string); ok {
+					prefix = v
+				}
+			}
+
+			return resource.PrefixedUniqueId(prefix), nil
 		},
 	}
 }

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -74,6 +74,11 @@ are documented below.
 
 The supported built-in functions are:
 
+  * `uuid(string)` - Returns a uuid string, with an optional prefix. This 
+  uses a RFC 4122 v4 UUID with some basic cosmetic filters 
+  applied (base32, remove padding, downcase) to make visually distinguishing 
+  identifiers easier. This is the format used internally.
+
   * `base64decode(string)` - Given a base64-encoded string, decodes it and
     returns the original string.
 


### PR DESCRIPTION
Mostly just an exposed version of the uuid function added by @phinze and @radeksimko for resources.

I thought about adding a size parameter to control the length of the generated id (would make it more of a uid than a legit uuid though), thoughts?

To Do

 - [x] discuss size limit
 - [ ] cleanup test to use testFunctionCase
 - [x] docs