### PR TITLE
core: state metadata difference should bump serial

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -965,6 +965,21 @@ func (s *InstanceState) Equal(other *InstanceState) bool {
 		}
 	}
 
+	// Meta must be equal
+	if len(s.Meta) != len(other.Meta) {
+		return false
+	}
+	for k, v := range s.Meta {
+		otherV, ok := other.Meta[k]
+		if !ok {
+			return false
+		}
+
+		if v != otherV {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -188,6 +188,43 @@ func TestStateEqual(t *testing.T) {
 				},
 			},
 		},
+
+		// Meta differs
+		{
+			false,
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: rootModulePath,
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Primary: &InstanceState{
+									Meta: map[string]string{
+										"schema_version": "1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: rootModulePath,
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Primary: &InstanceState{
+									Meta: map[string]string{
+										"schema_version": "2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range cases {
@@ -223,6 +260,41 @@ func TestStateIncrementSerialMaybe(t *testing.T) {
 				},
 			},
 			1,
+		},
+		"S2 is different, but only via Instance Metadata": {
+			&State{
+				Serial: 3,
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: rootModulePath,
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Primary: &InstanceState{
+									Meta: map[string]string{},
+								},
+							},
+						},
+					},
+				},
+			},
+			&State{
+				Serial: 3,
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: rootModulePath,
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Primary: &InstanceState{
+									Meta: map[string]string{
+										"schema_version": "1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			4,
 		},
 		"S1 serial is higher": {
 			&State{Serial: 5},


### PR DESCRIPTION
Remote state includes MD5-based checksumming to protect against State
conflicts. This can generate improper conflicts with states that differ
only in their Schema version.

We began to see this issue with
https://github.com/hashicorp/terraform/pull/3470 which changes the
"schema_version" of aws_key_pairs.