### PR TITLE
core: store deeply nested modules in a consistent order in the state

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1207,9 +1207,8 @@ func (s moduleStateSort) Less(i, j int) bool {
 		return len(a.Path) < len(b.Path)
 	}
 
-	// Otherwise, compare by last path element
-	idx := len(a.Path) - 1
-	return a.Path[idx] < b.Path[idx]
+	// Otherwise, compare lexically
+	return strings.Join(a.Path, ".") < strings.Join(b.Path, ".")
 }
 
 func (s moduleStateSort) Swap(i, j int) {

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -40,6 +40,23 @@ func TestStateAddModule(t *testing.T) {
 				[]string{"root", "foo", "bar"},
 			},
 		},
+		// Same last element, different middle element
+		{
+			[][]string{
+				[]string{"root", "foo", "bar"}, // This one should sort after...
+				[]string{"root", "foo"},
+				[]string{"root"},
+				[]string{"root", "bar", "bar"}, // ...this one.
+				[]string{"root", "bar"},
+			},
+			[][]string{
+				[]string{"root"},
+				[]string{"root", "bar"},
+				[]string{"root", "foo"},
+				[]string{"root", "bar", "bar"},
+				[]string{"root", "foo", "bar"},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
We were only comparing the last element of the module, which meant that
deeply nested modules with the same name but different ancestry had an
undefined sort order, which could cause inconsistencies in state
storage and potentially break remote state MD5 checksumming.