### PR TITLE
provider/aws: Downcase Route 53 record names in statefile

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -196,12 +196,13 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	// Generate an ID
 	vars := []string{
 		zone,
-		d.Get("name").(string),
+		strings.ToLower(d.Get("name").(string)),
 		d.Get("type").(string),
 	}
 	if v, ok := d.GetOk("set_identifier"); ok {
 		vars = append(vars, v.(string))
 	}
+
 	d.SetId(strings.Join(vars, "_"))
 
 	// Wait until we are done
@@ -447,7 +448,7 @@ func cleanRecordName(name string) string {
 // If it does not, add the zone name to form a fully qualified name
 // and keep AWS happy.
 func expandRecordName(name, zone string) string {
-	rn := strings.TrimSuffix(name, ".")
+	rn := strings.ToLower(strings.TrimSuffix(name, "."))
 	zone = strings.TrimSuffix(zone, ".")
 	if !strings.HasSuffix(rn, zone) {
 		rn = strings.Join([]string{name, zone}, ".")

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -291,7 +291,7 @@ func testAccCheckRoute53RecordExists(n string) resource.TestCheckFunc {
 		// rec := resp.ResourceRecordSets[0]
 		for _, rec := range resp.ResourceRecordSets {
 			recName := cleanRecordName(*rec.Name)
-			if FQDN(recName) == FQDN(en) && *rec.Type == rType {
+			if FQDN(strings.ToLower(recName)) == FQDN(strings.ToLower(en)) && *rec.Type == rType {
 				return nil
 			}
 		}
@@ -306,7 +306,7 @@ resource "aws_route53_zone" "main" {
 
 resource "aws_route53_record" "default" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
-	name = "www.notexample.com"
+	name = "www.NOTexamplE.com"
 	type = "A"
 	ttl = "30"
 	records = ["127.0.0.1", "127.0.0.27"]


### PR DESCRIPTION
Route 53 apparently down cases any record name you send it, though this is not documented anywhere I could find. 

Currently, if you supply a mixed case name like so:
```
resource "aws_route53_record" "other" {
    zone_id = "${aws_route53_zone.primary.id}"
    name = "TesTing"
    type = "A"
    ttl = "30"
    records = ["127.0.0.3"]
}
```

The record will be created, but with a lower case name `testing` and not `TesTing`. The resource compares the names as is, so there is no match found.

- https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_route53_record.go#L254

This PR does 3 things:

- stores a lowercase version of the Route 53 `name` in the state
- uses lowercase for comparison of records from the API 
- updates a test to prevent regressions 



Fixes https://github.com/hashicorp/terraform/issues/3564 , and should be backwards compatible safe, because if you have a mixed case name right now, then Terraform is giving you a plan/apply loop. 
