### PR TITLE
Added DigitalOcean Floating IP resource to DO provider.

### DIFF
--- a/builtin/providers/digitalocean/provider.go
+++ b/builtin/providers/digitalocean/provider.go
@@ -22,6 +22,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_droplet": resourceDigitalOceanDroplet(),
 			"digitalocean_record":  resourceDigitalOceanRecord(),
 			"digitalocean_ssh_key": resourceDigitalOceanSSHKey(),
+			"digitalocean_floating_ip": resourceDigitalOceanFloatingIP(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
@@ -1,0 +1,122 @@
+package digitalocean
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDigitalOceanFloatingIP() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalOceanFloatingIPCreate,
+		Read:   resourceDigitalOceanFloatingIPRead,
+		Update: resourceDigitalOceanFloatingIPUpdate,
+		Delete: resourceDigitalOceanFloatingIPDelete,
+
+		Schema: map[string]*schema.Schema{
+			"droplet_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanFloatingIPCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	newFloatingIP := godo.FloatingIPCreateRequest{
+		DropletID: d.Get("droplet_id").(int),
+		Region: d.Get("region").(string),
+	}
+
+	log.Printf("[DEBUG] Floating IP create configuration: %#v", newFloatingIP)
+
+	var err	error
+	fip, _, err := client.FloatingIPs.Create(&newFloatingIP)
+	if err != nil {
+		return fmt.Errorf("Failed to create Floating IP: %s", err)
+	}
+
+	d.SetId(fip.IP)
+	log.Printf("[INFO] Floating IP: %s", d.Id())
+
+	return resourceDigitalOceanFloatingIPRead(d, meta)
+}
+
+func resourceDigitalOceanFloatingIPRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	ip := d.Id();
+
+	fip, _, err := client.FloatingIPs.Get(ip)
+	if err != nil {
+		// If the Floating IP is somehow already destroyed, mark as
+		// successfully gone
+		if strings.Contains(err.Error(), "404 Not Found") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Floating IP: %s", err)
+	}
+
+	d.Set("region", fip.Region);
+
+	if fip.Droplet != nil {
+		d.Set("droplet_id", fip.Droplet.ID);
+	}
+
+	return nil
+}
+
+func resourceDigitalOceanFloatingIPUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	id := d.Id();
+
+	var err error
+	if d.HasChange("droplet_id") {
+		if droplet_id := d.Get("droplet_id").(int); &droplet_id != nil {
+			_, _, err = client.FloatingIPActions.Assign(id, droplet_id);
+		} else {
+			_, _, err = client.FloatingIPActions.Unassign(id);
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error updating Floating IP: %s", err)
+	}
+
+	return resourceDigitalOceanFloatingIPRead(d, meta)
+}
+
+func resourceDigitalOceanFloatingIPDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	id := d.Id()
+
+	log.Printf("[INFO] Deleting Floating IP: %s", id);
+
+	_, err := client.FloatingIPs.Delete(id)
+	if err != nil {
+		// If the Floating IP is somehow already destroyed, mark as
+		// successfully gone
+		if strings.Contains(err.Error(), "404 Not Found") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error deleting Floating IP: %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -1,0 +1,94 @@
+package digitalocean
+
+import (
+	"fmt"
+	"testing"
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDigitalOceanFloatingIP_Basic(t *testing.T) {
+	var floatingIP godo.FloatingIP
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanFloatingIPConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
+					testAccCheckDigitalOceanFloatingIPAttributes(&floatingIP),
+					resource.TestCheckResourceAttr("digitalocean_floating_ip.foobar", "region", "ams3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanFloatingIPDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*godo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_floating_ip" {
+			continue
+		}
+
+		// Try to find the Floatin IP
+		_, _, err := client.FloatingIPs.Get(rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Floating IP still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDigitalOceanFloatingIPAttributes(floatingIP *godo.FloatingIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if floatingIP.Region.Slug != "ams3" {
+			return fmt.Errorf("Bad value: %s", floatingIP.Region.Slug)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanFloatingIPExists(n string, floatingIP *godo.FloatingIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Floating IP ID is set")
+		}
+
+		client := testAccProvider.Meta().(*godo.Client)
+
+		foundFloatingIP, _, err := client.FloatingIPs.Get(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundFloatingIP.IP != rs.Primary.ID {
+			return fmt.Errorf("Floating IP not found")
+		}
+
+		*floatingIP = *foundFloatingIP
+
+		return nil
+	}
+}
+
+const testAccCheckDigitalOceanFloatingIPConfig_basic = `
+resource "digitalocean_floating_ip" "foobar" {
+    region = "ams3"
+}`

--- a/website/source/docs/providers/do/r/floating_ip.html.markdown
+++ b/website/source/docs/providers/do/r/floating_ip.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_floating_ip"
+sidebar_current: "docs-do-resource-floating-ip"
+description: |-
+  Provides a DigitalOcean Floating IP resource.
+---
+
+# digitalocean\_floating_ip
+
+Provides a DigitalOcean Floating IP for the specified region. If the droplet_id 
+is given, the Floating IP will be assigned to that droplet.
+
+## Example Usage
+
+```
+# Create a new Floating IP
+resource "digitalocean_floating_ip" "foobar" {
+    region = "${digitalocean_droplet.foo.region}"
+    droplet_id = "${digitalocean_droplet.foo.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region to create the Floating IP in
+* `droplet_id` - (Optional) The ID of the droplet to assign the Floating IP to
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique ID of the Floating IP. This is the actual IPv4 address.
+* `region` - The region of the Floating IP
+* `droplet_id` - The ID of the droplet to which the Floating IP is assigned


### PR DESCRIPTION
Added some basic support for Floating IPs as per #3580. Not sure yet how to handle assignment to a droplet. If you directly assign an IP to a droplet, you also get back a region. Should this be reflected back on the resource config? If you would unassign the Floating IP from a droplet, you'd need to provide a region for the config to be valid. This must be the same region as the one that the Floating IP was already in: Floating IPs cannot be moved from region to region. 

Does it make sense to do the droplet assignment in terraform or should you do this with something like chef or ansible?