### PR TITLE
provider/cloudstack: add `computed` flag to the `network_domain` parameter

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_vpc.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_vpc.go
@@ -43,6 +43,7 @@ func resourceCloudStackVPC() *schema.Resource {
 			"network_domain": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 


### PR DESCRIPTION
Without this flag you will get a diff based on the `network_domain`
parameter, if you not specify the parameter.