### PR TITLE
Fixing the cloudwatch_metric_alarm auto scale example

### DIFF
--- a/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
@@ -45,6 +45,9 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
     period = "120"
     statistic = "Average"
     threshold = "80"
+    dimensions {
+        AutoScalingGroupName = "${aws_autoscaling_group.bar.name}"
+    }
     alarm_description = "This metric monitor ec2 cpu utilization"
     alarm_actions = ["${aws_autoscaling_policy.bat.arn}"]
 }


### PR DESCRIPTION
The current example does not include the dimensions setting.  Without this set, the CloudWatchAlarm will scale on the CPUUtilization of all instances, rather then scaling on the CPUUtilization of just the ASG instances.