### PR TITLE
provider/aws: ignore association not exist on route table destroy [GH-3615]

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -326,6 +326,14 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 			AssociationId: a.RouteTableAssociationId,
 		})
 		if err != nil {
+			// First check if the association ID is not found. If this
+			// is the case, then it was already disassociated somehow,
+			// and that is okay.
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAssociationID.NotFound" {
+				err = nil
+			}
+		}
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #3615 

This ignores if the association is gone for a route table during the destruction phase.

This fix is similar to #2543.
