### PR TITLE
Add support for unary operators + and - to the interpolation syntax

### DIFF
--- a/config/lang/ast/unary_arithmetic.go
+++ b/config/lang/ast/unary_arithmetic.go
@@ -1,0 +1,42 @@
+package ast
+
+import (
+	"fmt"
+)
+
+// UnaryArithmetic represents a node where the result is arithmetic of
+// one operands
+type UnaryArithmetic struct {
+	Op   ArithmeticOp
+	Expr Node
+	Posx Pos
+}
+
+func (n *UnaryArithmetic) Accept(v Visitor) Node {
+	n.Expr = n.Expr.Accept(v)
+
+	return v(n)
+}
+
+func (n *UnaryArithmetic) Pos() Pos {
+	return n.Posx
+}
+
+func (n *UnaryArithmetic) GoString() string {
+	return fmt.Sprintf("*%#v", *n)
+}
+
+func (n *UnaryArithmetic) String() string {
+	var sign rune
+	switch n.Op {
+	case ArithmeticOpAdd:
+		sign = '+'
+	case ArithmeticOpSub:
+		sign = '-'
+	}
+	return fmt.Sprintf("%c%s", sign, n.Expr)
+}
+
+func (n *UnaryArithmetic) Type(Scope) (Type, error) {
+	return TypeInt, nil
+}

--- a/config/lang/builtins.go
+++ b/config/lang/builtins.go
@@ -24,9 +24,51 @@ func registerBuiltins(scope *ast.BasicScope) *ast.BasicScope {
 	scope.FuncMap["__builtin_StringToInt"] = builtinStringToInt()
 
 	// Math operations
+	scope.FuncMap["__builtin_UnaryIntMath"] = builtinUnaryIntMath()
+	scope.FuncMap["__builtin_UnaryFloatMath"] = builtinUnaryFloatMath()
 	scope.FuncMap["__builtin_IntMath"] = builtinIntMath()
 	scope.FuncMap["__builtin_FloatMath"] = builtinFloatMath()
 	return scope
+}
+
+func builtinUnaryIntMath() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeInt},
+		Variadic:   false,
+		ReturnType: ast.TypeInt,
+		Callback: func(args []interface{}) (interface{}, error) {
+			op := args[0].(ast.ArithmeticOp)
+			result := args[1].(int)
+			switch op {
+			case ast.ArithmeticOpAdd:
+				result = result
+			case ast.ArithmeticOpSub:
+				result = -result
+			}
+
+			return result, nil
+		},
+	}
+}
+
+func builtinUnaryFloatMath() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeFloat},
+		Variadic:   false,
+		ReturnType: ast.TypeFloat,
+		Callback: func(args []interface{}) (interface{}, error) {
+			op := args[0].(ast.ArithmeticOp)
+			result := args[1].(float64)
+			switch op {
+			case ast.ArithmeticOpAdd:
+				result = result
+			case ast.ArithmeticOpSub:
+				result = -result
+			}
+
+			return result, nil
+		},
+	}
 }
 
 func builtinFloatMath() ast.Function {

--- a/config/lang/eval_test.go
+++ b/config/lang/eval_test.go
@@ -251,6 +251,60 @@ func TestEval(t *testing.T) {
 			"foo 43",
 			ast.TypeString,
 		},
+
+		{
+			"foo ${-46}",
+			nil,
+			false,
+			"foo -46",
+			ast.TypeString,
+		},
+
+		{
+			"foo ${-46 + 5}",
+			nil,
+			false,
+			"foo -41",
+			ast.TypeString,
+		},
+
+		{
+			"foo ${46 + -5}",
+			nil,
+			false,
+			"foo 41",
+			ast.TypeString,
+		},
+
+		{
+			"foo ${-bar}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: 41,
+						Type:  ast.TypeInt,
+					},
+				},
+			},
+			false,
+			"foo -41",
+			ast.TypeString,
+		},
+
+		{
+			"foo ${5 + -bar}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: 41,
+						Type:  ast.TypeInt,
+					},
+				},
+			},
+			false,
+			"foo -36",
+			ast.TypeString,
+		},
 	}
 
 	for _, tc := range cases {

--- a/config/lang/lang.y
+++ b/config/lang/lang.y
@@ -130,6 +130,14 @@ expr:
             Posx:  $1.Pos(),
         }
     }
+|   ARITH_OP expr
+    {
+        $$ = &ast.UnaryArithmetic{
+            Op:    $1.Value.(ast.ArithmeticOp),
+            Expr:  $2,
+            Posx:  $1.Pos,
+        }
+    }
 |   IDENTIFIER
     {
         $$ = &ast.VariableAccess{Name: $1.Value.(string), Posx: $1.Pos}

--- a/config/lang/lex_test.go
+++ b/config/lang/lex_test.go
@@ -64,10 +64,33 @@ func TestLex(t *testing.T) {
 		},
 
 		{
+			"${bar(-42)}",
+			[]int{PROGRAM_BRACKET_LEFT,
+				IDENTIFIER, PAREN_LEFT, ARITH_OP, INTEGER, PAREN_RIGHT,
+				PROGRAM_BRACKET_RIGHT, lexEOF},
+		},
+
+		{
+			"${bar(-42.0)}",
+			[]int{PROGRAM_BRACKET_LEFT,
+				IDENTIFIER, PAREN_LEFT, ARITH_OP, FLOAT, PAREN_RIGHT,
+				PROGRAM_BRACKET_RIGHT, lexEOF},
+		},
+
+		{
 			"${bar(42+1)}",
 			[]int{PROGRAM_BRACKET_LEFT,
 				IDENTIFIER, PAREN_LEFT,
 				INTEGER, ARITH_OP, INTEGER,
+				PAREN_RIGHT,
+				PROGRAM_BRACKET_RIGHT, lexEOF},
+		},
+
+		{
+			"${bar(42+-1)}",
+			[]int{PROGRAM_BRACKET_LEFT,
+				IDENTIFIER, PAREN_LEFT,
+				INTEGER, ARITH_OP, ARITH_OP, INTEGER,
 				PAREN_RIGHT,
 				PROGRAM_BRACKET_RIGHT, lexEOF},
 		},

--- a/config/lang/y.go
+++ b/config/lang/y.go
@@ -53,7 +53,7 @@ const parserEofCode = 1
 const parserErrCode = 2
 const parserMaxDepth = 200
 
-//line lang.y:165
+//line lang.y:173
 
 //line yacctab:1
 var parserExca = [...]int{
@@ -62,51 +62,52 @@ var parserExca = [...]int{
 	-2, 0,
 }
 
-const parserNprod = 19
+const parserNprod = 20
 const parserPrivate = 57344
 
 var parserTokenNames []string
 var parserStates []string
 
-const parserLast = 30
+const parserLast = 34
 
 var parserAct = [...]int{
 
-	9, 20, 16, 16, 7, 7, 3, 18, 10, 8,
-	1, 17, 14, 12, 13, 6, 6, 19, 8, 22,
-	15, 23, 24, 11, 2, 25, 16, 21, 4, 5,
+	9, 7, 3, 16, 22, 8, 17, 17, 20, 17,
+	1, 18, 6, 23, 8, 19, 25, 26, 21, 11,
+	2, 24, 7, 4, 5, 0, 10, 27, 0, 14,
+	15, 12, 13, 6,
 }
 var parserPact = [...]int{
 
-	1, -1000, 1, -1000, -1000, -1000, -1000, 0, -1000, 15,
-	0, 1, -1000, -1000, -1, -1000, 0, -8, 0, -1000,
-	-1000, 12, -9, -1000, 0, -9,
+	-3, -1000, -3, -1000, -1000, -1000, -1000, 18, -1000, -2,
+	18, -3, -1000, -1000, 18, 0, -1000, 18, -5, -1000,
+	18, -1000, -1000, 7, -4, -1000, 18, -4,
 }
 var parserPgo = [...]int{
 
-	0, 0, 29, 28, 23, 6, 27, 10,
+	0, 0, 24, 23, 19, 2, 13, 10,
 }
 var parserR1 = [...]int{
 
 	0, 7, 7, 4, 4, 5, 5, 2, 1, 1,
-	1, 1, 1, 1, 1, 6, 6, 6, 3,
+	1, 1, 1, 1, 1, 1, 6, 6, 6, 3,
 }
 var parserR2 = [...]int{
 
 	0, 0, 1, 1, 2, 1, 1, 3, 3, 1,
-	1, 1, 3, 1, 4, 0, 3, 1, 1,
+	1, 1, 3, 2, 1, 4, 0, 3, 1, 1,
 }
 var parserChk = [...]int{
 
 	-1000, -7, -4, -5, -3, -2, 15, 4, -5, -1,
-	8, -4, 13, 14, 12, 5, 11, -1, 8, -1,
-	9, -6, -1, 9, 10, -1,
+	8, -4, 13, 14, 11, 12, 5, 11, -1, -1,
+	8, -1, 9, -6, -1, 9, 10, -1,
 }
 var parserDef = [...]int{
 
-	1, -2, 2, 3, 5, 6, 18, 0, 4, 0,
-	0, 9, 10, 11, 13, 7, 0, 0, 15, 12,
-	8, 0, 17, 14, 0, 16,
+	1, -2, 2, 3, 5, 6, 19, 0, 4, 0,
+	0, 9, 10, 11, 0, 14, 7, 0, 0, 13,
+	16, 12, 8, 0, 18, 15, 0, 17,
 }
 var parserTok1 = [...]int{
 
@@ -577,38 +578,48 @@ parserdefault:
 			}
 		}
 	case 13:
-		parserDollar = parserS[parserpt-1 : parserpt+1]
+		parserDollar = parserS[parserpt-2 : parserpt+1]
 		//line lang.y:134
+		{
+			parserVAL.node = &ast.UnaryArithmetic{
+				Op:   parserDollar[1].token.Value.(ast.ArithmeticOp),
+				Expr: parserDollar[2].node,
+				Posx: parserDollar[1].token.Pos,
+			}
+		}
+	case 14:
+		parserDollar = parserS[parserpt-1 : parserpt+1]
+		//line lang.y:142
 		{
 			parserVAL.node = &ast.VariableAccess{Name: parserDollar[1].token.Value.(string), Posx: parserDollar[1].token.Pos}
 		}
-	case 14:
+	case 15:
 		parserDollar = parserS[parserpt-4 : parserpt+1]
-		//line lang.y:138
+		//line lang.y:146
 		{
 			parserVAL.node = &ast.Call{Func: parserDollar[1].token.Value.(string), Args: parserDollar[3].nodeList, Posx: parserDollar[1].token.Pos}
 		}
-	case 15:
+	case 16:
 		parserDollar = parserS[parserpt-0 : parserpt+1]
-		//line lang.y:143
+		//line lang.y:151
 		{
 			parserVAL.nodeList = nil
 		}
-	case 16:
+	case 17:
 		parserDollar = parserS[parserpt-3 : parserpt+1]
-		//line lang.y:147
+		//line lang.y:155
 		{
 			parserVAL.nodeList = append(parserDollar[1].nodeList, parserDollar[3].node)
 		}
-	case 17:
+	case 18:
 		parserDollar = parserS[parserpt-1 : parserpt+1]
-		//line lang.y:151
+		//line lang.y:159
 		{
 			parserVAL.nodeList = append(parserVAL.nodeList, parserDollar[1].node)
 		}
-	case 18:
+	case 19:
 		parserDollar = parserS[parserpt-1 : parserpt+1]
-		//line lang.y:157
+		//line lang.y:165
 		{
 			parserVAL.node = &ast.LiteralNode{
 				Value: parserDollar[1].token.Value.(string),

--- a/config/lang/y.output
+++ b/config/lang/y.output
@@ -51,9 +51,9 @@ state 5
 
 
 state 6
-	literal:  STRING.    (18)
+	literal:  STRING.    (19)
 
-	.  reduce 18 (src line 155)
+	.  reduce 19 (src line 163)
 
 
 state 7
@@ -61,7 +61,8 @@ state 7
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	IDENTIFIER  shift 14
+	ARITH_OP  shift 14
+	IDENTIFIER  shift 15
 	INTEGER  shift 12
 	FLOAT  shift 13
 	STRING  shift 6
@@ -83,8 +84,8 @@ state 9
 	interpolation:  PROGRAM_BRACKET_LEFT expr.PROGRAM_BRACKET_RIGHT 
 	expr:  expr.ARITH_OP expr 
 
-	PROGRAM_BRACKET_RIGHT  shift 15
-	ARITH_OP  shift 16
+	PROGRAM_BRACKET_RIGHT  shift 16
+	ARITH_OP  shift 17
 	.  error
 
 
@@ -93,13 +94,14 @@ state 10
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	IDENTIFIER  shift 14
+	ARITH_OP  shift 14
+	IDENTIFIER  shift 15
 	INTEGER  shift 12
 	FLOAT  shift 13
 	STRING  shift 6
 	.  error
 
-	expr  goto 17
+	expr  goto 18
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
@@ -130,25 +132,12 @@ state 13
 
 
 state 14
-	expr:  IDENTIFIER.    (13)
-	expr:  IDENTIFIER.PAREN_LEFT args PAREN_RIGHT 
-
-	PAREN_LEFT  shift 18
-	.  reduce 13 (src line 133)
-
-
-state 15
-	interpolation:  PROGRAM_BRACKET_LEFT expr PROGRAM_BRACKET_RIGHT.    (7)
-
-	.  reduce 7 (src line 94)
-
-
-state 16
-	expr:  expr ARITH_OP.expr 
+	expr:  ARITH_OP.expr 
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	IDENTIFIER  shift 14
+	ARITH_OP  shift 14
+	IDENTIFIER  shift 15
 	INTEGER  shift 12
 	FLOAT  shift 13
 	STRING  shift 6
@@ -160,104 +149,145 @@ state 16
 	literalModeTop  goto 11
 	literalModeValue  goto 3
 
+state 15
+	expr:  IDENTIFIER.    (14)
+	expr:  IDENTIFIER.PAREN_LEFT args PAREN_RIGHT 
+
+	PAREN_LEFT  shift 20
+	.  reduce 14 (src line 141)
+
+
+state 16
+	interpolation:  PROGRAM_BRACKET_LEFT expr PROGRAM_BRACKET_RIGHT.    (7)
+
+	.  reduce 7 (src line 94)
+
+
 state 17
-	expr:  PAREN_LEFT expr.PAREN_RIGHT 
-	expr:  expr.ARITH_OP expr 
-
-	PAREN_RIGHT  shift 20
-	ARITH_OP  shift 16
-	.  error
-
-
-state 18
-	expr:  IDENTIFIER PAREN_LEFT.args PAREN_RIGHT 
-	args: .    (15)
+	expr:  expr ARITH_OP.expr 
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	IDENTIFIER  shift 14
+	ARITH_OP  shift 14
+	IDENTIFIER  shift 15
 	INTEGER  shift 12
 	FLOAT  shift 13
 	STRING  shift 6
-	.  reduce 15 (src line 142)
+	.  error
 
-	expr  goto 22
+	expr  goto 21
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
 	literalModeValue  goto 3
-	args  goto 21
+
+state 18
+	expr:  PAREN_LEFT expr.PAREN_RIGHT 
+	expr:  expr.ARITH_OP expr 
+
+	PAREN_RIGHT  shift 22
+	ARITH_OP  shift 17
+	.  error
+
 
 state 19
+	expr:  expr.ARITH_OP expr 
+	expr:  ARITH_OP expr.    (13)
+
+	.  reduce 13 (src line 133)
+
+
+state 20
+	expr:  IDENTIFIER PAREN_LEFT.args PAREN_RIGHT 
+	args: .    (16)
+
+	PROGRAM_BRACKET_LEFT  shift 7
+	PAREN_LEFT  shift 10
+	ARITH_OP  shift 14
+	IDENTIFIER  shift 15
+	INTEGER  shift 12
+	FLOAT  shift 13
+	STRING  shift 6
+	.  reduce 16 (src line 150)
+
+	expr  goto 24
+	interpolation  goto 5
+	literal  goto 4
+	literalModeTop  goto 11
+	literalModeValue  goto 3
+	args  goto 23
+
+state 21
 	expr:  expr.ARITH_OP expr 
 	expr:  expr ARITH_OP expr.    (12)
 
 	.  reduce 12 (src line 125)
 
 
-state 20
+state 22
 	expr:  PAREN_LEFT expr PAREN_RIGHT.    (8)
 
 	.  reduce 8 (src line 100)
 
 
-state 21
+state 23
 	expr:  IDENTIFIER PAREN_LEFT args.PAREN_RIGHT 
 	args:  args.COMMA expr 
 
-	PAREN_RIGHT  shift 23
-	COMMA  shift 24
+	PAREN_RIGHT  shift 25
+	COMMA  shift 26
 	.  error
 
 
-state 22
-	expr:  expr.ARITH_OP expr 
-	args:  expr.    (17)
-
-	ARITH_OP  shift 16
-	.  reduce 17 (src line 150)
-
-
-state 23
-	expr:  IDENTIFIER PAREN_LEFT args PAREN_RIGHT.    (14)
-
-	.  reduce 14 (src line 137)
-
-
 state 24
+	expr:  expr.ARITH_OP expr 
+	args:  expr.    (18)
+
+	ARITH_OP  shift 17
+	.  reduce 18 (src line 158)
+
+
+state 25
+	expr:  IDENTIFIER PAREN_LEFT args PAREN_RIGHT.    (15)
+
+	.  reduce 15 (src line 145)
+
+
+state 26
 	args:  args COMMA.expr 
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	IDENTIFIER  shift 14
+	ARITH_OP  shift 14
+	IDENTIFIER  shift 15
 	INTEGER  shift 12
 	FLOAT  shift 13
 	STRING  shift 6
 	.  error
 
-	expr  goto 25
+	expr  goto 27
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
 	literalModeValue  goto 3
 
-state 25
+state 27
 	expr:  expr.ARITH_OP expr 
-	args:  args COMMA expr.    (16)
+	args:  args COMMA expr.    (17)
 
-	ARITH_OP  shift 16
-	.  reduce 16 (src line 146)
+	ARITH_OP  shift 17
+	.  reduce 17 (src line 154)
 
 
 15 terminals, 8 nonterminals
-19 grammar rules, 26/2000 states
+20 grammar rules, 28/2000 states
 0 shift/reduce, 0 reduce/reduce conflicts reported
 57 working sets used
-memory: parser 35/30000
-21 extra closures
-45 shift entries, 1 exceptions
-14 goto entries
-23 entries saved by goto default
-Optimizer space used: output 30/30000
-30 table entries, 0 zero
-maximum spread: 15, maximum offset: 24
+memory: parser 40/30000
+23 extra closures
+57 shift entries, 1 exceptions
+15 goto entries
+27 entries saved by goto default
+Optimizer space used: output 34/30000
+34 table entries, 2 zero
+maximum spread: 15, maximum offset: 26


### PR DESCRIPTION
This adds support to the configuration interpolation syntax for + and -
as unary operators, specifically to represent negative numbers.

This is the first time I've touched the AST code, so I'm sure that I did something wrong.