### PR TITLE
digitalocean: update index docs for do_token var

### DIFF
--- a/website/source/docs/providers/do/index.html.markdown
+++ b/website/source/docs/providers/do/index.html.markdown
@@ -17,6 +17,9 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```
+# Set the variable value in *.tfvars file or using -var="do_token=..." CLI option
+variable "do_token" {}
+
 # Configure the DigitalOcean Provider
 provider "digitalocean" {
     token = "${var.do_token}"


### PR DESCRIPTION
Updates the docs and clarifies the usage of `do_token` variable.

I was experiencing an issue mentioned here https://github.com/hashicorp/terraform/issues/124 and so adding more docs should be helpful.