### PR TITLE
providers/aws: do not run getCredDefault for token

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -102,9 +102,7 @@ func Provider() terraform.ResourceProvider {
 				Type:     schema.TypeString,
 				Optional: true,
 				DefaultFunc: func() (interface{}, error) {
-					return getCredDefault("", func() string {
-						return credVal.SessionToken
-					})
+					return credVal.SessionToken, nil
 				},
 				Description: descriptions["token"],
 			},


### PR DESCRIPTION
In the case, running terraform in aws ec2 instance with ec2-role enabled, 
if you pass a different aws key pair that does not belong to that role 
`getCredDefault` causes a token generation which causes 
`InvalidClientTokenId: The security token included in the request is invalid` error