### PR TITLE
provider/openstack: Ignore order of security_groups in instance

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -93,10 +93,11 @@ func resourceComputeInstanceV2() *schema.Resource {
 				},
 			},
 			"security_groups": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 			"availability_zone": &schema.Schema{
 				Type:     schema.TypeString,
@@ -807,7 +808,7 @@ func ServerV2StateRefreshFunc(client *gophercloud.ServiceClient, instanceID stri
 }
 
 func resourceInstanceSecGroupsV2(d *schema.ResourceData) []string {
-	rawSecGroups := d.Get("security_groups").([]interface{})
+	rawSecGroups := d.Get("security_groups").(*schema.Set).List()
 	secgroups := make([]string, len(rawSecGroups))
 	for i, raw := range rawSecGroups {
 		secgroups[i] = raw.(string)

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -601,9 +601,8 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 
 	if d.HasChange("security_groups") {
 		oldSGRaw, newSGRaw := d.GetChange("security_groups")
-		oldSGSlice, newSGSlice := oldSGRaw.([]interface{}), newSGRaw.([]interface{})
-		oldSGSet := schema.NewSet(func(v interface{}) int { return hashcode.String(v.(string)) }, oldSGSlice)
-		newSGSet := schema.NewSet(func(v interface{}) int { return hashcode.String(v.(string)) }, newSGSlice)
+		oldSGSet := oldSGRaw.(*schema.Set)
+		newSGSet := newSGRaw.(*schema.Set)
 		secgroupsToAdd := newSGSet.Difference(oldSGSet)
 		secgroupsToRemove := oldSGSet.Difference(newSGSet)
 


### PR DESCRIPTION
Problems
----------------
When execute `terraform plan` after `terraform apply` with same template by provider/openstack, sometimes output some changes of securitygroups.
This problem is occurred when created securitygroups have mismatched between order of ID and order of `security_groups` attribute in template like below.

```
resource "openstack_compute_instance_v2" "server" {
  name = "terraform-server"
  security_groups = ["${openstack_compute_secgroup_v2.sg1.name}", "${openstack_compute_secgroup_v2.sg2.name}"]
}
```

```
# nova secgroup-list
+--------------------------------------+---------+---------------------------+
| Id                                   | Name    | Description               |
+--------------------------------------+---------+---------------------------+
| 483d055e-54f3-43f5-b24f-2e33610c4ad6 | default | default                   |
| ab3ac38f-c185-4232-a4bd-cac3b1455aa2 | sg1     | terraform_security_group1 |
| 71834dc8-e73e-41f5-a191-66f8007b92ae | sg2     | terraform_security_group2 |
+--------------------------------------+---------+---------------------------+
```

If assigned ID of `sg1` larger than ID of `sg2`, `terraform plan` will output following changes.

```
$ terraform plan

~ openstack_compute_instance_v2.ap_server
    security_groups.0: "sg2" => "sg1"
    security_groups.1: "sg1" => "sg2"


Plan: 0 to add, 1 to change, 0 to destroy.
```

I think this problem is relevant to openstack API response to get server information.
Following request return security_groups that is sorted by ascending order on ID. In addition, these response hasn't ID attribute.

```
curl -H "X-Auth-Token: *****************" http://localhost:8774/v2/*************/servers/***************** | jq .server.security_groups
[
  {
    "name": "sg2"
  },
  {
    "name": "sg1"
  }
]
```

Fix
----------------
Order of SecurityGroups can be ignored. I changed security group from `TypeList` to `TypeSet`.
