### PR TITLE
dag: use hashcodes to as map key to edge sets

### DIFF
--- a/dag/graph_test.go
+++ b/dag/graph_test.go
@@ -1,6 +1,7 @@
 package dag
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -77,6 +78,36 @@ func TestGraph_replaceSelf(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("bad: %s", actual)
 	}
+}
+
+// This tests that connecting edges works based on custom Hashcode
+// implementations for uniqueness.
+func TestGraph_hashcode(t *testing.T) {
+	var g Graph
+	g.Add(&hashVertex{code: 1})
+	g.Add(&hashVertex{code: 2})
+	g.Add(&hashVertex{code: 3})
+	g.Connect(BasicEdge(
+		&hashVertex{code: 1},
+		&hashVertex{code: 3}))
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testGraphBasicStr)
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+type hashVertex struct {
+	code interface{}
+}
+
+func (v *hashVertex) Hashcode() interface{} {
+	return v.code
+}
+
+func (v *hashVertex) Name() string {
+	return fmt.Sprintf("%#v", v.code)
 }
 
 const testGraphBasicStr = `

--- a/dag/set.go
+++ b/dag/set.go
@@ -17,22 +17,31 @@ type Hashable interface {
 	Hashcode() interface{}
 }
 
+// hashcode returns the hashcode used for set elements.
+func hashcode(v interface{}) interface{} {
+	if h, ok := v.(Hashable); ok {
+		return h.Hashcode()
+	}
+
+	return v
+}
+
 // Add adds an item to the set
 func (s *Set) Add(v interface{}) {
 	s.once.Do(s.init)
-	s.m[s.code(v)] = v
+	s.m[hashcode(v)] = v
 }
 
 // Delete removes an item from the set.
 func (s *Set) Delete(v interface{}) {
 	s.once.Do(s.init)
-	delete(s.m, s.code(v))
+	delete(s.m, hashcode(v))
 }
 
 // Include returns true/false of whether a value is in the set.
 func (s *Set) Include(v interface{}) bool {
 	s.once.Do(s.init)
-	_, ok := s.m[s.code(v)]
+	_, ok := s.m[hashcode(v)]
 	return ok
 }
 
@@ -71,14 +80,6 @@ func (s *Set) List() []interface{} {
 	}
 
 	return r
-}
-
-func (s *Set) code(v interface{}) interface{} {
-	if h, ok := v.(Hashable); ok {
-		return h.Hashcode()
-	}
-
-	return v
 }
 
 func (s *Set) init() {


### PR DESCRIPTION
We were keying the mapping of source/dest vertices to the edge sets using the Vertex itself. This is a pointer reference in Go. We use `Hashable` everywhere else as a mechanism for providing unique identity. We should use that here. Failing test (and now passing) given.