### PR TITLE
get profile name even if profile path exists

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1082,5 +1082,6 @@ func iamInstanceProfileArnToName(ip *ec2.IamInstanceProfile) string {
 	if ip == nil || ip.Arn == nil {
 		return ""
 	}
-	return strings.Split(*ip.Arn, "/")[1]
+	parts := strings.Split(*ip.Arn, "/")
+	return parts[len(parts)-1]
 }


### PR DESCRIPTION
When terraform started persisting the instance profile name to the state the code used the second part of the instance profile ARN split on "/" where it should be using the last part of the ARN split on "/"