### PR TITLE
provider/aws: Allow cluster name, not only ARN for aws_ecs_service

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -137,7 +137,6 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] ECS service created: %s", *service.ServiceArn)
 	d.SetId(*service.ServiceArn)
-	d.Set("cluster", *service.ClusterArn)
 
 	return resourceAwsEcsServiceUpdate(d, meta)
 }
@@ -175,14 +174,21 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("desired_count", *service.DesiredCount)
-	d.Set("cluster", *service.ClusterArn)
+
+	// Save cluster in the same format
+	if strings.HasPrefix(d.Get("cluster").(string), "arn:aws:ecs:") {
+		d.Set("cluster", *service.ClusterArn)
+	} else {
+		clusterARN := getNameFromARN(*service.ClusterArn)
+		d.Set("cluster", clusterARN)
+	}
 
 	// Save IAM role in the same format
 	if service.RoleArn != nil {
 		if strings.HasPrefix(d.Get("iam_role").(string), "arn:aws:iam:") {
 			d.Set("iam_role", *service.RoleArn)
 		} else {
-			roleARN := buildIamRoleNameFromARN(*service.RoleArn)
+			roleARN := getNameFromARN(*service.RoleArn)
 			d.Set("iam_role", roleARN)
 		}
 	}
@@ -306,8 +312,10 @@ func buildFamilyAndRevisionFromARN(arn string) string {
 	return strings.Split(arn, "/")[1]
 }
 
-func buildIamRoleNameFromARN(arn string) string {
-	// arn:aws:iam::0123456789:role/EcsService
+// Expects the following ARNs:
+// arn:aws:iam::0123456789:role/EcsService
+// arn:aws:ecs:us-west-2:0123456789:cluster/radek-cluster
+func getNameFromARN(arn string) string {
 	return strings.Split(arn, "/")[1]
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/3361

### Test plan
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=EcsService' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=EcsService -timeout 90m
=== RUN   TestAccAWSEcsServiceWithARN
--- PASS: TestAccAWSEcsServiceWithARN (34.38s)
=== RUN   TestAccAWSEcsServiceWithFamilyAndRevision
--- PASS: TestAccAWSEcsServiceWithFamilyAndRevision (32.85s)
=== RUN   TestAccAWSEcsServiceWithRenamedCluster
--- PASS: TestAccAWSEcsServiceWithRenamedCluster (133.63s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (114.89s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (37.41s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	353.186s
```