### PR TITLE
provider/aws: Add AutoMinorVersionUpgrade to RDS. (continuation of #2637)

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -246,8 +246,8 @@ func resourceAwsDbInstance() *schema.Resource {
 
 			"auto_minor_version_upgrade": &schema.Schema{
 				Type:     schema.TypeBool,
-				Computed: false,
 				Optional: true,
+				Default:  true,
 			},
 
 			"allow_major_version_upgrade": &schema.Schema{
@@ -294,14 +294,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	} else if _, ok := d.GetOk("snapshot_identifier"); ok {
 		opts := rds.RestoreDBInstanceFromDBSnapshotInput{
-			DBInstanceClass:      aws.String(d.Get("instance_class").(string)),
-			DBInstanceIdentifier: aws.String(d.Get("identifier").(string)),
-			DBSnapshotIdentifier: aws.String(d.Get("snapshot_identifier").(string)),
-			Tags:                 tags,
-		}
-
-		if attr, ok := d.GetOk("auto_minor_version_upgrade"); ok {
-			opts.AutoMinorVersionUpgrade = aws.Bool(attr.(bool))
+			DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
+			DBInstanceIdentifier:    aws.String(d.Get("identifier").(string)),
+			DBSnapshotIdentifier:    aws.String(d.Get("snapshot_identifier").(string)),
+			AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
+			Tags: tags,
 		}
 
 		if attr, ok := d.GetOk("availability_zone"); ok {
@@ -510,6 +507,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("engine_version", v.EngineVersion)
 	d.Set("allocated_storage", v.AllocatedStorage)
 	d.Set("copy_tags_to_snapshot", v.CopyTagsToSnapshot)
+	d.Set("auto_minor_version_upgrade", v.AutoMinorVersionUpgrade)
 	d.Set("storage_type", v.StorageType)
 	d.Set("instance_class", v.DBInstanceClass)
 	d.Set("availability_zone", v.AvailabilityZone)

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -387,17 +387,17 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	} else {
 		opts := rds.CreateDBInstanceInput{
-			AllocatedStorage:     aws.Int64(int64(d.Get("allocated_storage").(int))),
-			CopyTagsToSnapshot:   aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
-			DBName:               aws.String(d.Get("name").(string)),
-			DBInstanceClass:      aws.String(d.Get("instance_class").(string)),
-			DBInstanceIdentifier: aws.String(d.Get("identifier").(string)),
-			MasterUsername:       aws.String(d.Get("username").(string)),
-			MasterUserPassword:   aws.String(d.Get("password").(string)),
-			Engine:               aws.String(d.Get("engine").(string)),
-			EngineVersion:        aws.String(d.Get("engine_version").(string)),
-			StorageEncrypted:     aws.Bool(d.Get("storage_encrypted").(bool)),
-			Tags:                 tags,
+			AllocatedStorage:        aws.Int64(int64(d.Get("allocated_storage").(int))),
+			DBName:                  aws.String(d.Get("name").(string)),
+			DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
+			DBInstanceIdentifier:    aws.String(d.Get("identifier").(string)),
+			MasterUsername:          aws.String(d.Get("username").(string)),
+			MasterUserPassword:      aws.String(d.Get("password").(string)),
+			Engine:                  aws.String(d.Get("engine").(string)),
+			EngineVersion:           aws.String(d.Get("engine_version").(string)),
+			StorageEncrypted:        aws.Bool(d.Get("storage_encrypted").(bool)),
+			AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
+			Tags: tags,
 		}
 
 		attr := d.Get("backup_retention_period")
@@ -710,6 +710,11 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("storage_type") {
 		d.SetPartial("storage_type")
 		req.StorageType = aws.String(d.Get("storage_type").(string))
+		requestUpdate = true
+	}
+	if d.HasChange("auto_minor_version_upgrade") {
+		d.SetPartial("auto_minor_version_upgrade")
+		req.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
 		requestUpdate = true
 	}
 


### PR DESCRIPTION
Builds off of #2637 and updates how we handle `auto_minor_version_upgrade`

- default to `true`, matching AWS's default
- no longer computed
- updates on `read`

Supersedes https://github.com/hashicorp/terraform/pull/2637