### PR TITLE
docs: Correct logging option example

### DIFF
--- a/website/source/docs/configuration/environment-variables.html.md
+++ b/website/source/docs/configuration/environment-variables.html.md
@@ -13,7 +13,7 @@ description: |-
 If set to any value, enables detailed logs to appear on stderr which is useful for debugging. For example:
 
 ```
-export TF_LOG=1
+export TF_LOG=TRACE
 ```
 
 To disable, either unset it or set it to empty. When unset, logging will default to stderr. For example:


### PR DESCRIPTION
ref. 0090c063e8c29d8af226b00bffd31e8eb3b35f77

`TF_LOG=1` is now obsolete.

```
% TF_LOG=1 terraform plan
2015/10/29 18:35:22 [WARN] Invalid log level: "1". Defaulting to level: TRACE. Valid levels are: [TRACE DEBUG INFO WARN ERROR]
Refreshing Terraform state prior to plan...
```