### PR TITLE
Added measure_latency option to Route 53 Health Check resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -55,6 +55,11 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"measure_latency": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -128,6 +133,10 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 		healthConfig.ResourcePath = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("measure_latency"); ok {
+		healthConfig.MeasureLatency = aws.Bool(v.(bool))
+	}
+
 	input := &route53.CreateHealthCheckInput{
 		CallerReference:   aws.String(time.Now().Format(time.RFC3339Nano)),
 		HealthCheckConfig: healthConfig,
@@ -174,6 +183,7 @@ func resourceAwsRoute53HealthCheckRead(d *schema.ResourceData, meta interface{})
 	d.Set("ip_address", updated.IPAddress)
 	d.Set("port", updated.Port)
 	d.Set("resource_path", updated.ResourcePath)
+	d.Set("measure_latency", updated.MeasureLatency)
 
 	// read the tags
 	req := &route53.ListTagsForResourceInput{

--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -59,6 +59,7 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 			"tags": tagsSchema(),
 		},
@@ -133,8 +134,10 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 		healthConfig.ResourcePath = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("measure_latency"); ok {
-		healthConfig.MeasureLatency = aws.Bool(v.(bool))
+	if *healthConfig.Type != route53.HealthCheckTypeCalculated {
+		if v, ok := d.GetOk("measure_latency"); ok {
+			healthConfig.MeasureLatency = aws.Bool(v.(bool))
+		}
 	}
 
 	input := &route53.CreateHealthCheckInput{

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -20,6 +20,8 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 				Config: testAccRoute53HealthCheckConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_health_check.foo", "measure_latency", "true"),
 				),
 			},
 			resource.TestStep{

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -124,6 +124,7 @@ resource "aws_route53_health_check" "foo" {
   resource_path = "/"
   failure_threshold = "2"
   request_interval = "30"
+  measure_latency = true
 
   tags = {
     Name = "tf-test-health-check"


### PR DESCRIPTION
Adds `measure_latency` option to Route 53 Health Check resource.

This allows for the health check to record request latency and graph it within the Route 53 UI.

Related to #3273