### PR TITLE
provider/Azure: various bugfixes

### DIFF
--- a/builtin/providers/azure/config.go
+++ b/builtin/providers/azure/config.go
@@ -35,8 +35,6 @@ type Client struct {
 
 	hostedServiceClient hostedservice.HostedServiceClient
 
-	secGroupClient networksecuritygroup.SecurityGroupClient
-
 	osImageClient osimage.OSImageClient
 
 	sqlClient sql.SQLDatabaseClient
@@ -52,7 +50,11 @@ type Client struct {
 	// unfortunately; because of how Azure's network API works; doing networking operations
 	// concurrently is very hazardous, and we need a mutex to guard the VirtualNetworkClient.
 	vnetClient virtualnetwork.VirtualNetworkClient
-	mutex      *sync.Mutex
+	vnetMutex  *sync.Mutex
+
+	// same as the above for security group rule operations:
+	secGroupClient networksecuritygroup.SecurityGroupClient
+	secGroupMutex  *sync.Mutex
 }
 
 // getStorageClientForStorageService is helper method which returns the
@@ -106,6 +108,7 @@ func (c *Config) NewClientFromSettingsData() (*Client, error) {
 		affinityGroupClient:  affinitygroup.NewClient(mc),
 		hostedServiceClient:  hostedservice.NewClient(mc),
 		secGroupClient:       networksecuritygroup.NewClient(mc),
+		secGroupMutex:        &sync.Mutex{},
 		osImageClient:        osimage.NewClient(mc),
 		sqlClient:            sql.NewClient(mc),
 		storageServiceClient: storageservice.NewClient(mc),
@@ -113,7 +116,7 @@ func (c *Config) NewClientFromSettingsData() (*Client, error) {
 		vmDiskClient:         virtualmachinedisk.NewClient(mc),
 		vmImageClient:        virtualmachineimage.NewClient(mc),
 		vnetClient:           virtualnetwork.NewClient(mc),
-		mutex:                &sync.Mutex{},
+		vnetMutex:            &sync.Mutex{},
 	}, nil
 }
 
@@ -130,6 +133,7 @@ func (c *Config) NewClient() (*Client, error) {
 		affinityGroupClient:  affinitygroup.NewClient(mc),
 		hostedServiceClient:  hostedservice.NewClient(mc),
 		secGroupClient:       networksecuritygroup.NewClient(mc),
+		secGroupMutex:        &sync.Mutex{},
 		osImageClient:        osimage.NewClient(mc),
 		sqlClient:            sql.NewClient(mc),
 		storageServiceClient: storageservice.NewClient(mc),
@@ -137,6 +141,6 @@ func (c *Config) NewClient() (*Client, error) {
 		vmDiskClient:         virtualmachinedisk.NewClient(mc),
 		vmImageClient:        virtualmachineimage.NewClient(mc),
 		vnetClient:           virtualnetwork.NewClient(mc),
-		mutex:                &sync.Mutex{},
+		vnetMutex:            &sync.Mutex{},
 	}, nil
 }

--- a/builtin/providers/azure/resource_azure_dns_server.go
+++ b/builtin/providers/azure/resource_azure_dns_server.go
@@ -43,8 +43,8 @@ func resourceAzureDnsServerCreate(d *schema.ResourceData, meta interface{}) erro
 	vnetClient := azureClient.vnetClient
 
 	log.Println("[INFO] Fetching current network configuration from Azure.")
-	azureClient.mutex.Lock()
-	defer azureClient.mutex.Unlock()
+	azureClient.vnetMutex.Lock()
+	defer azureClient.vnetMutex.Unlock()
 	netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {
 		if management.IsResourceNotFoundError(err) {
@@ -124,8 +124,8 @@ func resourceAzureDnsServerUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("dns_address") {
 		log.Println("[DEBUG] DNS server address has changes; updating it on Azure.")
 		log.Println("[INFO] Fetching current network configuration from Azure.")
-		azureClient.mutex.Lock()
-		defer azureClient.mutex.Unlock()
+		azureClient.vnetMutex.Lock()
+		defer azureClient.vnetMutex.Unlock()
 		netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 		if err != nil {
 			return fmt.Errorf("Failed to get the current network configuration from Azure: %s", err)
@@ -198,8 +198,8 @@ func resourceAzureDnsServerDelete(d *schema.ResourceData, meta interface{}) erro
 	vnetClient := azureClient.vnetClient
 
 	log.Println("[INFO] Fetching current network configuration from Azure.")
-	azureClient.mutex.Lock()
-	defer azureClient.mutex.Unlock()
+	azureClient.vnetMutex.Lock()
+	defer azureClient.vnetMutex.Unlock()
 	netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {
 		return fmt.Errorf("Failed to get the current network configuration from Azure: %s", err)

--- a/builtin/providers/azure/resource_azure_local_network.go
+++ b/builtin/providers/azure/resource_azure_local_network.go
@@ -51,8 +51,8 @@ func resourceAzureLocalNetworkConnectionCreate(d *schema.ResourceData, meta inte
 	vnetClient := azureClient.vnetClient
 
 	log.Println("[INFO] Fetching current network configuration from Azure.")
-	azureClient.mutex.Lock()
-	defer azureClient.mutex.Unlock()
+	azureClient.vnetMutex.Lock()
+	defer azureClient.vnetMutex.Unlock()
 	netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {
 		if management.IsResourceNotFoundError(err) {
@@ -138,8 +138,8 @@ func resourceAzureLocalNetworkConnectionUpdate(d *schema.ResourceData, meta inte
 	vnetClient := azureClient.vnetClient
 
 	log.Println("[INFO] Fetching current network configuration from Azure.")
-	azureClient.mutex.Lock()
-	defer azureClient.mutex.Unlock()
+	azureClient.vnetMutex.Lock()
+	defer azureClient.vnetMutex.Unlock()
 	netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {
 		return fmt.Errorf("Failed to get the current network configuration from Azure: %s", err)
@@ -217,8 +217,8 @@ func resourceAzureLocalNetworkConnectionDelete(d *schema.ResourceData, meta inte
 	vnetClient := azureClient.vnetClient
 
 	log.Println("[INFO] Fetching current network configuration from Azure.")
-	azureClient.mutex.Lock()
-	defer azureClient.mutex.Unlock()
+	azureClient.vnetMutex.Lock()
+	defer azureClient.vnetMutex.Unlock()
 	netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {
 		return fmt.Errorf("Failed to get the current network configuration from Azure: %s", err)

--- a/builtin/providers/azure/resource_azure_security_group_rule.go
+++ b/builtin/providers/azure/resource_azure_security_group_rule.go
@@ -86,6 +86,9 @@ func resourceAzureSecurityGroupRuleCreate(d *schema.ResourceData, meta interface
 	mgmtClient := azureClient.mgmtClient
 	secGroupClient := azureClient.secGroupClient
 
+	azureClient.secGroupMutex.Lock()
+	defer azureClient.secGroupMutex.Unlock()
+
 	// create and configure the RuleResponse:
 	name := d.Get("name").(string)
 	rule := netsecgroup.RuleRequest{
@@ -183,6 +186,9 @@ func resourceAzureSecurityGroupRuleUpdate(d *schema.ResourceData, meta interface
 	mgmtClient := azureClient.mgmtClient
 	secGroupClient := azureClient.secGroupClient
 
+	azureClient.secGroupMutex.Lock()
+	defer azureClient.secGroupMutex.Unlock()
+
 	var found bool
 	name := d.Get("name").(string)
 	newRule := netsecgroup.RuleRequest{
@@ -261,6 +267,9 @@ func resourceAzureSecurityGroupRuleDelete(d *schema.ResourceData, meta interface
 	azureClient := meta.(*Client)
 	mgmtClient := azureClient.mgmtClient
 	secGroupClient := azureClient.secGroupClient
+
+	azureClient.secGroupMutex.Lock()
+	defer azureClient.secGroupMutex.Unlock()
 
 	name := d.Get("name").(string)
 	secGroupNames := d.Get("security_group_names").(*schema.Set).List()

--- a/builtin/providers/azure/resource_azure_virtual_network.go
+++ b/builtin/providers/azure/resource_azure_virtual_network.go
@@ -82,8 +82,8 @@ func resourceAzureVirtualNetworkCreate(d *schema.ResourceData, meta interface{})
 
 	// Lock the client just before we get the virtual network configuration and immediately
 	// set an defer to unlock the client again whenever this function exits
-	ac.mutex.Lock()
-	defer ac.mutex.Unlock()
+	ac.vnetMutex.Lock()
+	defer ac.vnetMutex.Unlock()
 
 	nc, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {
@@ -181,8 +181,8 @@ func resourceAzureVirtualNetworkUpdate(d *schema.ResourceData, meta interface{})
 
 	// Lock the client just before we get the virtual network configuration and immediately
 	// set an defer to unlock the client again whenever this function exits
-	ac.mutex.Lock()
-	defer ac.mutex.Unlock()
+	ac.vnetMutex.Lock()
+	defer ac.vnetMutex.Unlock()
 
 	nc, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {
@@ -227,8 +227,8 @@ func resourceAzureVirtualNetworkDelete(d *schema.ResourceData, meta interface{})
 
 	// Lock the client just before we get the virtual network configuration and immediately
 	// set an defer to unlock the client again whenever this function exits
-	ac.mutex.Lock()
-	defer ac.mutex.Unlock()
+	ac.vnetMutex.Lock()
+	defer ac.vnetMutex.Unlock()
 
 	nc, err := vnetClient.GetVirtualNetworkConfiguration()
 	if err != nil {

--- a/website/source/docs/providers/azure/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/azure/r/security_group_rule.html.markdown
@@ -8,7 +8,19 @@ description: |-
 
 # azure\_security\_group\_rule
 
-Creates a new network security rule to be associated with a given security group.
+Creates a new network Security Group Rule to be associated with a number of
+given Security Groups.
+
+~> **NOTE on Security Group Rules**: for usability purposes; Terraform allows the
+addition of a single Security Group Rule to multiple Security Groups, despite
+it having to define each rule individually per Security Group on Azure. As a
+result; in the event that one of the Rules on one of the Groups is modified by
+external factors, Terraform cannot reason as to whether or not that change
+should be propagated to the others; let alone choose one changed Rule
+configuration over another in case of a conflic. As such; `terraform refresh`
+only checks that the rule is still defined for each of the specified
+`security_group_names`; ignoring the actual parameters of the Rule and **not**
+updating the state with regards to them.
 
 ## Example Usage
 


### PR DESCRIPTION
* added instance flag to clearly denote whether an instance had a custom hosted_service created for it to avoid the deletion of one if it was created separately but given the same name as the instance.
* added wait on instance deletion for associated blob deletion; fixes https://github.com/hashicorp/terraform/issues/3109; fixes part of https://github.com/hashicorp/terraform/issues/2416
* added guarding Mutex for secgroup-rule-related concurrent operations; fixes https://github.com/hashicorp/terraform/issues/3111
* added usage warning on secgroup rules; addresses part of https://github.com/hashicorp/terraform/issues/3111

I cannot thank @keymon enough for the most absolutely outrageously amazing bug reports I've received in my life.