### PR TITLE
provider/aws: ElastiCache (Redis) snapshot window and retention limits

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -287,7 +287,9 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 		d.Set("security_group_ids", c.SecurityGroups)
 		d.Set("parameter_group_name", c.CacheParameterGroup)
 		d.Set("maintenance_window", c.PreferredMaintenanceWindow)
+		log.Printf("[INFO] Found %s as the Snapshow Window", *c.SnapshotWindow)
 		d.Set("snapshot_window", c.SnapshotWindow)
+		log.Printf("[INFO] Found %d as the Snapshow Retention Limit", *c.SnapshotRetentionLimit)
 		d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
 		if c.NotificationConfiguration != nil {
 			if *c.NotificationConfiguration.TopicStatus == "active" {

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -205,14 +205,12 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		req.CacheParameterGroupName = aws.String(v.(string))
 	}
 
-	if !strings.Contains(d.Get("node_type").(string), "cache.t2") {
-		if v, ok := d.GetOk("snapshot_retention_limit"); ok {
-			req.SnapshotRetentionLimit = aws.Int64(int64(v.(int)))
-		}
+	if v, ok := d.GetOk("snapshot_retention_limit"); ok {
+		req.SnapshotRetentionLimit = aws.Int64(int64(v.(int)))
+	}
 
-		if v, ok := d.GetOk("snapshot_window"); ok {
-			req.SnapshotWindow = aws.String(v.(string))
-		}
+	if v, ok := d.GetOk("snapshot_window"); ok {
+		req.SnapshotWindow = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("maintenance_window"); ok {
@@ -289,12 +287,8 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 		d.Set("security_group_ids", c.SecurityGroups)
 		d.Set("parameter_group_name", c.CacheParameterGroup)
 		d.Set("maintenance_window", c.PreferredMaintenanceWindow)
-		if c.SnapshotWindow != nil {
-			d.Set("snapshot_window", c.SnapshotWindow)
-		}
-		if c.SnapshotRetentionLimit != nil {
-			d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
-		}
+		d.Set("snapshot_window", c.SnapshotWindow)
+		d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
 		if c.NotificationConfiguration != nil {
 			if *c.NotificationConfiguration.TopicStatus == "active" {
 				d.Set("notification_topic_arn", c.NotificationConfiguration.TopicArn)
@@ -377,16 +371,15 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		req.EngineVersion = aws.String(d.Get("engine_version").(string))
 		requestUpdate = true
 	}
-	if !strings.Contains(d.Get("node_type").(string), "cache.t2") {
-		if d.HasChange("snapshot_window") {
-			req.SnapshotWindow = aws.String(d.Get("snapshot_window").(string))
-			requestUpdate = true
-		}
 
-		if d.HasChange("snapshot_retention_limit") {
-			req.SnapshotRetentionLimit = aws.Int64(int64(d.Get("snapshot_retention_limit").(int)))
-			requestUpdate = true
-		}
+	if d.HasChange("snapshot_window") {
+		req.SnapshotWindow = aws.String(d.Get("snapshot_window").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("snapshot_retention_limit") {
+		req.SnapshotRetentionLimit = aws.Int64(int64(d.Get("snapshot_retention_limit").(int)))
+		requestUpdate = true
 	}
 
 	if d.HasChange("num_cache_nodes") {

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -373,12 +373,11 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("snapshot_window") {
-		req.EngineVersion = aws.String(d.Get("snapshot_window").(string))
-		requestUpdate = true
+		req.SnapshotWindow = aws.String(d.Get("snapshot_window").(string))
 	}
 
 	if d.HasChange("snapshot_retention_limit") {
-		req.NumCacheNodes = aws.Int64(int64(d.Get("snapshot_retention_limit").(int)))
+		req.SnapshotRetentionLimit = aws.Int64(int64(d.Get("snapshot_retention_limit").(int)))
 	}
 
 	if d.HasChange("num_cache_nodes") {

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -33,37 +33,12 @@ func TestAccAWSElasticacheCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheCluster_snapshots(t *testing.T) {
-	var ec elasticache.CacheCluster
-
-	ri := genRandInt()
-	config := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshots, ri)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
-					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_cluster.bar", "snapshot_window", "05:00-09:00"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_cluster.bar", "snapshot_retention_limit", "3"),
-				),
-			},
-		},
-	})
-}
 func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 	var ec elasticache.CacheCluster
 
 	ri := genRandInt()
-	preConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshots, ri)
-	postConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshotsUpdated, ri)
+	preConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshots, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshotsUpdated, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -221,7 +196,7 @@ provider "aws" {
 	region = "us-east-1"
 }
 resource "aws_security_group" "bar" {
-    name = "tf-test-security-group"
+    name = "tf-test-security-group-%03d"
     description = "tf-test-security-group-descr"
     ingress {
         from_port = -1
@@ -232,7 +207,7 @@ resource "aws_security_group" "bar" {
 }
 
 resource "aws_elasticache_security_group" "bar" {
-    name = "tf-test-security-group"
+    name = "tf-test-security-group-%03d"
     description = "tf-test-security-group-descr"
     security_group_names = ["${aws_security_group.bar.name}"]
 }
@@ -240,7 +215,7 @@ resource "aws_elasticache_security_group" "bar" {
 resource "aws_elasticache_cluster" "bar" {
     cluster_id = "tf-test-%03d"
     engine = "redis"
-    node_type = "cache.m1.small"
+    node_type = "cache.t2.small"
     num_cache_nodes = 1
     port = 6379
   	parameter_group_name = "default.redis2.8"

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -33,6 +33,28 @@ func TestAccAWSElasticacheCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSElasticacheCluster_snapshots(t *testing.T) {
+	var ec elasticache.CacheCluster
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheClusterConfig_snapshots,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
+					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_cluster.bar", "snapshot_window", "05:00-09:00"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_cluster.bar", "snapshot_retention_limit", "3"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticacheCluster_vpc(t *testing.T) {
 	var csg elasticache.CacheSubnetGroup
 	var ec elasticache.CacheCluster
@@ -149,6 +171,42 @@ resource "aws_elasticache_cluster" "bar" {
     port = 11211
     parameter_group_name = "default.memcached1.4"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
+    snapshot_window = "05:00-09:00"
+    snapshot_retention_limit = 3
+}
+`, genRandInt(), genRandInt(), genRandInt())
+
+var testAccAWSElasticacheClusterConfig_snapshots = fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+resource "aws_security_group" "bar" {
+    name = "tf-test-security-group-%03d"
+    description = "tf-test-security-group-descr"
+    ingress {
+        from_port = -1
+        to_port = -1
+        protocol = "icmp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_elasticache_security_group" "bar" {
+    name = "tf-test-security-group-%03d"
+    description = "tf-test-security-group-descr"
+    security_group_names = ["${aws_security_group.bar.name}"]
+}
+
+resource "aws_elasticache_cluster" "bar" {
+    cluster_id = "tf-test-%03d"
+    engine = "redis"
+    node_type = "cache.m1.small"
+    num_cache_nodes = 1
+    port = 6379
+  	parameter_group_name = "default.redis2.8"
+    security_group_names = ["${aws_elasticache_security_group.bar.name}"]
+    snapshot_window = "05:00-09:00"
+    snapshot_retention_limit = 3
 }
 `, genRandInt(), genRandInt(), genRandInt())
 

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -35,13 +35,17 @@ func TestAccAWSElasticacheCluster_basic(t *testing.T) {
 
 func TestAccAWSElasticacheCluster_snapshots(t *testing.T) {
 	var ec elasticache.CacheCluster
+
+	ri := genRandInt()
+	config := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshots, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSElasticacheClusterConfig_snapshots,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
@@ -56,13 +60,18 @@ func TestAccAWSElasticacheCluster_snapshots(t *testing.T) {
 }
 func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 	var ec elasticache.CacheCluster
+
+	ri := genRandInt()
+	preConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshots, ri)
+	postConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshotsUpdated, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSElasticacheClusterConfig_snapshots,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
@@ -74,7 +83,7 @@ func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAWSElasticacheClusterConfig_snapshotsUpdated,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
@@ -204,17 +213,15 @@ resource "aws_elasticache_cluster" "bar" {
     port = 11211
     parameter_group_name = "default.memcached1.4"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
-    snapshot_window = "05:00-09:00"
-    snapshot_retention_limit = 3
 }
 `, genRandInt(), genRandInt(), genRandInt())
 
-var testAccAWSElasticacheClusterConfig_snapshots = fmt.Sprintf(`
+var testAccAWSElasticacheClusterConfig_snapshots = `
 provider "aws" {
 	region = "us-east-1"
 }
 resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
+    name = "tf-test-security-group"
     description = "tf-test-security-group-descr"
     ingress {
         from_port = -1
@@ -225,7 +232,7 @@ resource "aws_security_group" "bar" {
 }
 
 resource "aws_elasticache_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
+    name = "tf-test-security-group"
     description = "tf-test-security-group-descr"
     security_group_names = ["${aws_security_group.bar.name}"]
 }
@@ -241,14 +248,14 @@ resource "aws_elasticache_cluster" "bar" {
     snapshot_window = "05:00-09:00"
     snapshot_retention_limit = 3
 }
-`, genRandInt(), genRandInt(), genRandInt())
+`
 
-var testAccAWSElasticacheClusterConfig_snapshotsUpdated = fmt.Sprintf(`
+var testAccAWSElasticacheClusterConfig_snapshotsUpdated = `
 provider "aws" {
 	region = "us-east-1"
 }
 resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
+    name = "tf-test-security-group"
     description = "tf-test-security-group-descr"
     ingress {
         from_port = -1
@@ -259,7 +266,7 @@ resource "aws_security_group" "bar" {
 }
 
 resource "aws_elasticache_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
+    name = "tf-test-security-group"
     description = "tf-test-security-group-descr"
     security_group_names = ["${aws_security_group.bar.name}"]
 }
@@ -274,8 +281,9 @@ resource "aws_elasticache_cluster" "bar" {
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     snapshot_window = "07:00-09:00"
     snapshot_retention_limit = 7
+    apply_immediately = true
 }
-`, genRandInt(), genRandInt(), genRandInt())
+`
 
 var testAccAWSElasticacheClusterInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -73,6 +73,15 @@ names to associate with this cache cluster
 Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. 
 Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
 
+* `snapshot_window` - (Optional) The daily time range (in UTC) during which ElastiCache will 
+begin taking a daily snapshot of your cache cluster. Can only be used for the Redis engine. Example: 05:00-09:00
+
+* `snapshow_retention_limit` - (Optional) The number of days for which ElastiCache will 
+retain automatic cache cluster snapshots before deleting them. For example, if you set 
+SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days 
+before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. 
+Can only be used for the Redis engine.
+
 * `notification_topic_arn` – (Optional) An Amazon Resource Name (ARN) of an 
 SNS topic to send ElastiCache notifications to. Example: 
 `arn:aws:sns:us-east-1:012345678999:my_sns_topic`

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -88,6 +88,7 @@ SNS topic to send ElastiCache notifications to. Example:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+~> **NOTE:** Snapshotting functionality is not compatible with t2 instance types.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This fixes #3075

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=ElasticacheCluster_snapshots' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=ElasticacheCluster_snapshots -timeout 90m
=== RUN   TestAccAWSElasticacheCluster_snapshots
--- PASS: TestAccAWSElasticacheCluster_snapshots (366.93s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	366.946s
```

Also tested the ValidateFunc:
```
terraform [aws-elasticache-cluster-snapshoting●] % make testacc TEST=./builtin/providers/aws TESTARGS='-run=ElasticacheCluster_snapshots' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=ElasticacheCluster_snapshots -timeout 90m
=== RUN   TestAccAWSElasticacheCluster_snapshots
--- FAIL: TestAccAWSElasticacheCluster_snapshots (0.11s)
	testing.go:137: Step 0 error: Configuration is invalid.

		Warnings: []string(nil)

		Errors: []string{"aws_elasticache_cluster.bar: snapshot retention limit cannot be more than 35 days"}
FAIL
```
Creates the values as can be seen in the console:

<img width="977" alt="screen shot 2015-10-30 at 23 57 53" src="https://cloud.githubusercontent.com/assets/227823/10860577/1f53ae2a-7f62-11e5-8fcc-8b2262cbfd1b.png">