### PR TITLE
provider/openstack: Documentation update for Security Group "self"

### DIFF
--- a/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
@@ -71,7 +71,8 @@ from which to forward traffic to the parent group. Changing
 this creates a new security group rule.
 
 * `self` - (Optional) Required if `cidr` and `from_group_id` is empty. If true,
-the security group itself will be added as a source to this ingress rule.
+the security group itself will be added as a source to this ingress rule. `cidr`
+and `from_group_id` will be ignored if either are set while `self` is true.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This commit adds a note about `cidr` and `from_group_id` being ignored
if `self` is set to true.

Fixes #3448