### PR TITLE
provider/digitalocean: Making user_data force a new droplet

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -100,6 +100,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			"user_data": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -71,6 +71,36 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
+	var droplet godo.Droplet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanDropletConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
+					testAccCheckDigitalOceanDropletAttributes(&droplet),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanDropletConfig_userdata_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar",
+						"user_data",
+						"foobar foobar"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanDroplet_PrivateNetworkingIpv6(t *testing.T) {
 	var droplet godo.Droplet
 
@@ -258,6 +288,16 @@ resource "digitalocean_droplet" "foobar" {
     image = "centos-5-8-x32"
     region = "nyc3"
     user_data  = "foobar"
+}
+`
+
+const testAccCheckDigitalOceanDropletConfig_userdata_update = `
+resource "digitalocean_droplet" "foobar" {
+    name = "foo"
+    size = "512mb"
+    image = "centos-5-8-x32"
+    region = "nyc3"
+    user_data  = "foobar foobar"
 }
 `
 


### PR DESCRIPTION
Fixes #3734 

user_data is only run on instance first boot, therefore, changing the user_data will have no effect unless the instance is recreated. This follows the same behaviour as an AWS Instance

There is no way in the Digital Ocean UI to change the user_data. So it requires an instance to be recreated

Added an acceptance test to prove that it destroys and then recreates:

```
make testacc TEST=./builtin/providers/digitalocean TESTARGS='-run=DigitalOceanDroplet_UpdateUserData' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=DigitalOceanDroplet_UpdateUserData -timeout 90m
=== RUN   TestAccDigitalOceanDroplet_UpdateUserData
--- PASS: TestAccDigitalOceanDroplet_UpdateUserData (76.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/digitalocean	76.965s
```