### PR TITLE
provider/aws: Supporting New AWS Route53 HealthCheck additions

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -26,11 +27,11 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 			},
 			"failure_threshold": &schema.Schema{
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 			},
 			"request_interval": &schema.Schema{
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 				ForceNew: true, // todo this should be updateable but the awslabs route53 service doesnt have the ability
 			},
 			"ip_address": &schema.Schema{
@@ -50,6 +51,7 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 			"measure_latency": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true, // todo this should be updateable but the awslabs route53 service doesnt have the ability
 			},
 
 			"invert_healthcheck": &schema.Schema{
@@ -65,6 +67,25 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 			"search_string": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+
+			"child_healthchecks": &schema.Schema{
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Set:      schema.HashString,
+			},
+			"child_health_threshold": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(int)
+					if value > 256 {
+						es = append(es, fmt.Errorf(
+							"Child HealthThreshold cannot be more than 256"))
+					}
+					return
+				},
 			},
 
 			"tags": tagsSchema(),
@@ -99,6 +120,14 @@ func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{
 		updateHealthCheck.Inverted = aws.Bool(d.Get("invert_healthcheck").(bool))
 	}
 
+	if d.HasChange("child_healthchecks") {
+		updateHealthCheck.ChildHealthChecks = expandStringList(d.Get("child_healthchecks").(*schema.Set).List())
+
+	}
+	if d.HasChange("child_health_threshold") {
+		updateHealthCheck.HealthThreshold = aws.Int64(int64(d.Get("child_health_threshold").(int)))
+	}
+
 	_, err := conn.UpdateHealthCheck(updateHealthCheck)
 	if err != nil {
 		return err
@@ -115,9 +144,15 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).r53conn
 
 	healthConfig := &route53.HealthCheckConfig{
-		Type:             aws.String(d.Get("type").(string)),
-		FailureThreshold: aws.Int64(int64(d.Get("failure_threshold").(int))),
-		RequestInterval:  aws.Int64(int64(d.Get("request_interval").(int))),
+		Type: aws.String(d.Get("type").(string)),
+	}
+
+	if v, ok := d.GetOk("request_interval"); ok {
+		healthConfig.RequestInterval = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("failure_threshold"); ok {
+		healthConfig.FailureThreshold = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("fqdn"); ok {
@@ -140,12 +175,24 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 		healthConfig.ResourcePath = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("measure_latency"); ok {
-		healthConfig.MeasureLatency = aws.Bool(v.(bool))
+	if *healthConfig.Type != route53.HealthCheckTypeCalculated {
+		if v, ok := d.GetOk("measure_latency"); ok {
+			healthConfig.MeasureLatency = aws.Bool(v.(bool))
+		}
 	}
 
 	if v, ok := d.GetOk("invert_healthcheck"); ok {
 		healthConfig.Inverted = aws.Bool(v.(bool))
+	}
+
+	if *healthConfig.Type == route53.HealthCheckTypeCalculated {
+		if v, ok := d.GetOk("child_healthchecks"); ok {
+			healthConfig.ChildHealthChecks = expandStringList(v.(*schema.Set).List())
+		}
+
+		if v, ok := d.GetOk("child_health_threshold"); ok {
+			healthConfig.HealthThreshold = aws.Int64(int64(v.(int)))
+		}
 	}
 
 	input := &route53.CreateHealthCheckInput{
@@ -196,6 +243,8 @@ func resourceAwsRoute53HealthCheckRead(d *schema.ResourceData, meta interface{})
 	d.Set("resource_path", updated.ResourcePath)
 	d.Set("measure_latency", updated.MeasureLatency)
 	d.Set("invent_healthcheck", updated.Inverted)
+	d.Set("child_healthchecks", updated.ChildHealthChecks)
+	d.Set("child_health_threshold", updated.HealthThreshold)
 
 	// read the tags
 	req := &route53.ListTagsForResourceInput{

--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToUpper(val.(string))
+				},
 			},
 			"failure_threshold": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -20,6 +20,10 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 				Config: testAccRoute53HealthCheckConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_health_check.foo", "measure_latency", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_health_check.foo", "invert_healthcheck", "true"),
 				),
 			},
 			resource.TestStep{
@@ -28,6 +32,8 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
 					resource.TestCheckResourceAttr(
 						"aws_route53_health_check.foo", "failure_threshold", "5"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_health_check.foo", "invert_healthcheck", "false"),
 				),
 			},
 		},
@@ -124,6 +130,8 @@ resource "aws_route53_health_check" "foo" {
   resource_path = "/"
   failure_threshold = "2"
   request_interval = "30"
+  measure_latency = true
+  invert_healthcheck = true
 
   tags = {
     Name = "tf-test-health-check"
@@ -139,6 +147,8 @@ resource "aws_route53_health_check" "foo" {
   resource_path = "/"
   failure_threshold = "5"
   request_interval = "30"
+  measure_latency = true
+  invert_healthcheck = false
 
   tags = {
     Name = "tf-test-health-check"

--- a/website/source/docs/providers/aws/r/route53_health_check.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_health_check.html.markdown
@@ -12,7 +12,7 @@ Provides a Route53 health check.
 ## Example Usage
 
 ```
-resource "aws_route53_health_check" "foo" {
+resource "aws_route53_health_check" "child1" {
   fqdn = "foobar.terraform.com"
   port = 80
   type = "HTTP"
@@ -22,6 +22,16 @@ resource "aws_route53_health_check" "foo" {
 
   tags = {
     Name = "tf-test-health-check"
+   }
+}
+
+resource "aws_route53_health_check" "foo" {
+  type = "CALCULATED"
+  child_health_threshold = 1
+  child_healthchecks = ["${aws_route53_health_check.child1.id}"]
+
+  tags = {
+    Name = "tf-test-calculated-health-check"
    }
 }
 ```
@@ -38,6 +48,8 @@ The following arguments are supported:
 * `search_string` - (Optional) String searched in respoonse body for check to considered healthy.
 * `measure_latency` - (Optional) A Boolean value that indicates whether you want Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint and to display CloudWatch latency graphs in the Route 53 console.
 * `invert_healthcheck` - (Optional) A boolean value that indicates whether the status of health check should be inverted. For example, if a health check is healthy but Inverted is True , then Route 53 considers the health check to be unhealthy.
+* `child_healthchecks` - (Optional) For a specified parent health check, a list of HealthCheckId values for the associated child health checks.
+* `child_health_threshold` - (Optional) The minimum number of child health checks that must be healthy for Route 53 to consider the parent health check to be healthy. Valid values are integers between 0 and 256, inclusive
 * `tags` - (Optional) A mapping of tags to assign to the health check.
 
 Exactly one of `fqdn` or `ip_address` must be specified.

--- a/website/source/docs/providers/aws/r/route53_health_check.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_health_check.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
 * `request_interval` - (Required) The number of seconds between the time that Amazon Route 53 gets a response from your endpoint and the time that it sends the next health-check request.
 * `resource_path` - (Optional) The path that you want Amazon Route 53 to request when performing health checks.
 * `search_string` - (Optional) String searched in respoonse body for check to considered healthy.
+* `measure_latency` - (Optional) A Boolean value that indicates whether you want Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint and to display CloudWatch latency graphs in the Route 53 console.
+* `invert_healthcheck` - (Optional) A boolean value that indicates whether the status of health check should be inverted. For example, if a health check is healthy but Inverted is True , then Route 53 considers the health check to be unhealthy.
 * `tags` - (Optional) A mapping of tags to assign to the health check.
 
 Exactly one of `fqdn` or `ip_address` must be specified.


### PR DESCRIPTION
Added:

* [x] measure_latency
* [x] invert_healthcheck
* [x] child_healthchecks
* [x] acceptance tests
* [x] documentation

There were a couple of key changes required here:

1. failure_threshold was changed to optional as it is only required for non Calculated checks
2. request_interval was changed to optional as it is only required for non Calculated checks