### PR TITLE
provider/aws: Changing the db_instance resource to mark the engine_version as Optional

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -55,6 +55,7 @@ func resourceAwsDbInstance() *schema.Resource {
 			"engine_version": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"storage_encrypted": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -54,7 +54,7 @@ func resourceAwsDbInstance() *schema.Resource {
 
 			"engine_version": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"storage_encrypted": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -49,6 +49,25 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_withoutEngineVersion(t *testing.T) {
+	var v rds.DBInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBInstanceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
+					testAccCheckAWSDBInstanceAttributes(&v),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBInstanceReplica(t *testing.T) {
 	var s, r rds.DBInstance
 
@@ -186,6 +205,28 @@ resource "aws_db_instance" "bar" {
 
 	# Maintenance Window is stored in lower case in the API, though not strictly 
 	# documented. Terraform will downcase this to match (as opposed to throw a 
+	# validation error).
+	maintenance_window = "Fri:09:00-Fri:09:30"
+
+	backup_retention_period = 0
+
+	parameter_group_name = "default.mysql5.6"
+}`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+
+var testAccAWSDBInstanceConfig_withoutEngineVersion = fmt.Sprintf(`
+resource "aws_db_instance" "bar" {
+	identifier = "foobarbaz-test-terraform-%d"
+
+	allocated_storage = 10
+	engine = "MySQL"
+	instance_class = "db.t1.micro"
+	name = "baz"
+	password = "barbarbarbar"
+	username = "foo"
+
+
+	# Maintenance Window is stored in lower case in the API, though not strictly
+	# documented. Terraform will downcase this to match (as opposed to throw a
 	# validation error).
 	maintenance_window = "Fri:09:00-Fri:09:30"
 

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -32,8 +32,6 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_instance.bar", "engine", "mysql"),
 					resource.TestCheckResourceAttr(
-						"aws_db_instance.bar", "engine_version", "5.6.21"),
-					resource.TestCheckResourceAttr(
 						"aws_db_instance.bar", "license_model", "general-public-license"),
 					resource.TestCheckResourceAttr(
 						"aws_db_instance.bar", "instance_class", "db.t1.micro"),
@@ -43,25 +41,6 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 						"aws_db_instance.bar", "username", "foo"),
 					resource.TestCheckResourceAttr(
 						"aws_db_instance.bar", "parameter_group_name", "default.mysql5.6"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSDBInstance_withoutEngineVersion(t *testing.T) {
-	var v rds.DBInstance
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSDBInstanceConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
-					testAccCheckAWSDBInstanceAttributes(&v),
 				),
 			},
 		},
@@ -130,7 +109,7 @@ func testAccCheckAWSDBInstanceAttributes(v *rds.DBInstance) resource.TestCheckFu
 			return fmt.Errorf("bad engine: %#v", *v.Engine)
 		}
 
-		if *v.EngineVersion != "5.6.21" {
+		if *v.EngineVersion == "" {
 			return fmt.Errorf("bad engine_version: %#v", *v.EngineVersion)
 		}
 
@@ -205,28 +184,6 @@ resource "aws_db_instance" "bar" {
 
 	# Maintenance Window is stored in lower case in the API, though not strictly 
 	# documented. Terraform will downcase this to match (as opposed to throw a 
-	# validation error).
-	maintenance_window = "Fri:09:00-Fri:09:30"
-
-	backup_retention_period = 0
-
-	parameter_group_name = "default.mysql5.6"
-}`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
-
-var testAccAWSDBInstanceConfig_withoutEngineVersion = fmt.Sprintf(`
-resource "aws_db_instance" "bar" {
-	identifier = "foobarbaz-test-terraform-%d"
-
-	allocated_storage = 10
-	engine = "MySQL"
-	instance_class = "db.t1.micro"
-	name = "baz"
-	password = "barbarbarbar"
-	username = "foo"
-
-
-	# Maintenance Window is stored in lower case in the API, though not strictly
-	# documented. Terraform will downcase this to match (as opposed to throw a
 	# validation error).
 	maintenance_window = "Fri:09:00-Fri:09:30"
 

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `allocated_storage` - (Required) The allocated storage in gigabytes.
 * `engine` - (Required) The database engine to use.
-* `engine_version` - (Required) The engine version to use.
+* `engine_version` - (Optional) The engine version to use.
 * `identifier` - (Required) The name of the RDS instance
 * `instance_class` - (Required) The instance type of the RDS instance.
 * `storage_type` - (Optional) One of "standard" (magnetic), "gp2" (general


### PR DESCRIPTION
Fixes #3465 

The [docs](http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-CreateDBInstance.html) actually specify that this is not a required field. Added a test to prove this and I still get an instance up and running

