### PR TITLE
provider/digitalocean : Floating IPs

### DIFF
--- a/builtin/providers/digitalocean/provider.go
+++ b/builtin/providers/digitalocean/provider.go
@@ -18,10 +18,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"digitalocean_domain":  resourceDigitalOceanDomain(),
-			"digitalocean_droplet": resourceDigitalOceanDroplet(),
-			"digitalocean_record":  resourceDigitalOceanRecord(),
-			"digitalocean_ssh_key": resourceDigitalOceanSSHKey(),
+			"digitalocean_domain":      resourceDigitalOceanDomain(),
+			"digitalocean_droplet":     resourceDigitalOceanDroplet(),
+			"digitalocean_floating_ip": resourceDigitalOceanFloatingIp(),
+			"digitalocean_record":      resourceDigitalOceanRecord(),
+			"digitalocean_ssh_key":     resourceDigitalOceanSSHKey(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
@@ -1,0 +1,78 @@
+package digitalocean
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDigitalOceanFloatingIp() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalOceanFloatingIpCreate,
+		Read:   resourceDigitalOceanFloatingIpRead,
+		Delete: resourceDigitalOceanFloatingIpDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanFloatingIpCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	// Build up our creation options
+
+	opts := &godo.FloatingIPCreateRequest{
+		Region: d.Get("region").(string),
+	}
+
+	log.Printf("[DEBUG] FloatingIP Create: %#v", opts)
+	floatingIp, _, err := client.FloatingIPs.Create(opts)
+	if err != nil {
+		return fmt.Errorf("Error creating FloatingIP: %s", err)
+	}
+
+	d.SetId(floatingIp.IP)
+	log.Printf("[INFO] Floating IP: %s", floatingIp.IP)
+
+	return resourceDigitalOceanFloatingIpRead(d, meta)
+}
+
+func resourceDigitalOceanFloatingIpRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	floatingIp, _, err := client.FloatingIPs.Get(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error retrieving FloatingIP: %s", err)
+	}
+
+	d.Set("region", floatingIp.Region)
+
+	return nil
+}
+
+func resourceDigitalOceanFloatingIpDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	log.Printf("[INFO] Deleting FloatingIP: %s", d.Id())
+	_, err := client.FloatingIPs.Delete(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting FloatingIP: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -1,0 +1,85 @@
+package digitalocean
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDigitalOceanFloatingIP_Basic(t *testing.T) {
+	var floatingIP godo.FloatingIP
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanFloatingIPConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
+					resource.TestCheckResourceAttr(
+						"digitalocean_floating_ip.foobar", "region", "nyc3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanFloatingIPDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*godo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_floating_ip" {
+			continue
+		}
+
+		// Try to find the key
+		_, _, err := client.FloatingIPs.Get(rs.Primary.ID)
+
+		if err == nil {
+			fmt.Errorf("Floating IP still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDigitalOceanFloatingIPExists(n string, floatingIP *godo.FloatingIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*godo.Client)
+
+		// Try to find the FloatingIP
+		foundFloatingIP, _, err := client.FloatingIPs.Get(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundFloatingIP.IP != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		*floatingIP = *foundFloatingIP
+
+		return nil
+	}
+}
+
+var testAccCheckDigitalOceanFloatingIPConfig_basic = `
+resource "digitalocean_floating_ip" "foobar" {
+    region = "nyc3"
+}`

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -117,4 +117,5 @@ resource "digitalocean_droplet" "foobar" {
 
 resource "digitalocean_floating_ip" "foobar" {
     droplet_id = "${digitalocean_droplet.foobar.id}"
+    region = "${digitalocean_droplet.foobar.region}"
 }`

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDigitalOceanFloatingIP_Basic(t *testing.T) {
+func TestAccDigitalOceanFloatingIP_Region(t *testing.T) {
 	var floatingIP godo.FloatingIP
 
 	resource.Test(t, resource.TestCase{
@@ -18,11 +18,31 @@ func TestAccDigitalOceanFloatingIP_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckDigitalOceanFloatingIPConfig_basic,
+				Config: testAccCheckDigitalOceanFloatingIPConfig_region,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
 					resource.TestCheckResourceAttr(
 						"digitalocean_floating_ip.foobar", "region", "nyc3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
+	var floatingIP godo.FloatingIP
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
+					resource.TestCheckResourceAttr(
+						"digitalocean_floating_ip.foobar", "region", "sgp1"),
 				),
 			},
 		},
@@ -79,7 +99,22 @@ func testAccCheckDigitalOceanFloatingIPExists(n string, floatingIP *godo.Floatin
 	}
 }
 
-var testAccCheckDigitalOceanFloatingIPConfig_basic = `
+var testAccCheckDigitalOceanFloatingIPConfig_region = `
 resource "digitalocean_floating_ip" "foobar" {
     region = "nyc3"
+}`
+
+var testAccCheckDigitalOceanFloatingIPConfig_droplet = `
+
+resource "digitalocean_droplet" "foobar" {
+    name = "baz"
+    size = "1gb"
+    image = "centos-5-8-x32"
+    region = "sgp1"
+    ipv6 = true
+    private_networking = true
+}
+
+resource "digitalocean_floating_ip" "foobar" {
+    droplet_id = "${digitalocean_droplet.foobar.id}"
 }`

--- a/website/source/docs/providers/do/r/floating_ip.html.markdown
+++ b/website/source/docs/providers/do/r/floating_ip.html.markdown
@@ -24,6 +24,7 @@ resource "digitalocean_droplet" "foobar" {
 
 resource "digitalocean_floating_ip" "foobar" {
     droplet_id = "${digitalocean_droplet.foobar.id}"
+    region = "${digitalocean_droplet.foobar.region}"
 }
 ```
 
@@ -31,7 +32,7 @@ resource "digitalocean_floating_ip" "foobar" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region that the Floating IP is reserved to. 
+* `region` - (Required) The region that the Floating IP is reserved to.
 * `droplet_id` - (Optional) The ID of Droplet that the Floating IP will be assigned to.
 
 ~> **NOTE:** A Floating IP can be assigned to a region OR a droplet_id. If both region AND droplet_id are specified, then the Floating IP will be assigned to the droplet and use that region

--- a/website/source/docs/providers/do/r/floating_ip.html.markdown
+++ b/website/source/docs/providers/do/r/floating_ip.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_floating_ip"
+sidebar_current: "docs-do-resource-floating-ip"
+description: |-
+  Provides a DigitalOcean Floating IP resource.
+---
+
+# digitalocean\_floating_ip
+
+Provides a DigitalOcean Floating IP to represent a publicly-accessible static IP addresses that can be mapped to one of your Droplets.
+
+## Example Usage
+
+```
+resource "digitalocean_droplet" "foobar" {
+    name = "baz"
+    size = "1gb"
+    image = "centos-5-8-x32"
+    region = "sgp1"
+    ipv6 = true
+    private_networking = true
+}
+
+resource "digitalocean_floating_ip" "foobar" {
+    droplet_id = "${digitalocean_droplet.foobar.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region that the Floating IP is reserved to. 
+* `droplet_id` - (Optional) The ID of Droplet that the Floating IP will be assigned to.
+
+~> **NOTE:** A Floating IP can be assigned to a region OR a droplet_id. If both region AND droplet_id are specified, then the Floating IP will be assigned to the droplet and use that region
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ip_address` - The IP Address of the resource

--- a/website/source/layouts/digitalocean.erb
+++ b/website/source/layouts/digitalocean.erb
@@ -21,6 +21,10 @@
 					<a href="/docs/providers/do/r/droplet.html">digitalocean_droplet</a>
                     </li>
 
+                  <li<%= sidebar_current("docs-do-resource-floating-ip") %>>
+                    <a href="/docs/providers/do/r/floating_ip.html">digitalocean_floating_ip</a>
+                  </li>
+
                     <li<%= sidebar_current("docs-do-resource-record") %>>
 					<a href="/docs/providers/do/r/record.html">digitalocean_record</a>
                     </li>


### PR DESCRIPTION
* [x] schema
* [x] Acceptance Tests
* [x] Documentation

There is a potential race condition in the Acceptance Test that means we may not be able to destroy the Floating IP at the end of the test as it is still being assigned and that event has not been marked as complete

To get around this, I had to sacrifice some kittens and add a time.Sleep. This really upsets me but I cannot find any way around the need to wait a little bit for these changes to propagate :( 

@phinze I'd love some advice about whether this is actually a good thing in the TF codebase

This acceptance tests now work as follows:

```
make testacc TEST=./builtin/providers/digitalocean TESTARGS='-run=DigitalOceanFloatingIP' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=DigitalOceanFloatingIP -timeout 90m
=== RUN   TestAccDigitalOceanFloatingIP_Region
--- PASS: TestAccDigitalOceanFloatingIP_Region (24.08s)
=== RUN   TestAccDigitalOceanFloatingIP_Droplet
--- PASS: TestAccDigitalOceanFloatingIP_Droplet (93.20s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/digitalocean	117.288s
```