### PR TITLE
Fix panic I see when upgrading to 0.6.6

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -47,7 +47,10 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ForceNew: false,
 				Computed: true,
 				StateFunc: func(v interface{}) string {
-					jsonb := []byte(v.(string))
+					jsonb := []byte{}
+					if v != nil {
+						jsonb = []byte(v.(string))
+					}
 					buffer := new(bytes.Buffer)
 					if err := json.Compact(buffer, jsonb); err != nil {
 						log.Printf("[WARN] Error compacting JSON for Policy in SNS Topic")


### PR DESCRIPTION
Check if the policy is nil or not before type casting it

Otherwise I get this error:

    panic: interface conversion: interface is nil, not string
    2015/11/04 04:02:04 [DEBUG] terraform-provider-aws:
    2015/11/04 04:02:04 [DEBUG] terraform-provider-aws: goroutine 263 [running]:
    2015/11/04 04:02:04 [DEBUG] terraform-provider-aws: github.com/hashicorp/terraform/builtin/providers/aws.func·123(0x0, 0x0, 0x0, 0x0)
    2015/11/04 04:02:04 [DEBUG] terraform-provider-aws:     /root/build/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_sns_topic.go:50 +0x64
    2015/11/04 04:02:04 [DEBUG] terraform-provider-aws: github.com/hashicorp/terraform/helper/schema.schemaMap.diffString(0xc2090603f0, 0x112aab0, 0x6, 0xc20906c5b0, 0xc20910b050, 0xc2091443c0, 0xc20906c400, 0x0, 0x0)