### PR TITLE
provider/aws: RDS Cluster additions

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -127,12 +127,17 @@ func resourceAwsRDSCluster() *schema.Resource {
 			"preferred_backup_window": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"preferred_maintenance_window": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				StateFunc: func(val interface{}) string {
+					if val == nil {
+						return ""
+					}
 					return strings.ToLower(val.(string))
 				},
 			},

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -310,12 +310,12 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		req.PreferredBackupWindow = aws.String(d.Get("preferred_backup_window").(string))
 	}
 
-	if d.HasChange("preferred_maintaince_window") {
-		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintaince_window").(string))
+	if d.HasChange("preferred_maintenance_window") {
+		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintenance_window").(string))
 	}
 
-	if d.HasChange("backup_retention_limit") {
-		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_limit").(int)))
+	if d.HasChange("backup_retention_period") {
+		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_period").(int)))
 	}
 
 	_, err := conn.ModifyDBCluster(req)

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -122,6 +123,33 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
+			"preferred_backup_window": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"preferred_maintenance_window": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+			},
+
+			"backup_retention_period": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(int)
+					if value > 35 {
+						es = append(es, fmt.Errorf(
+							"backup retention period cannot be more than 35 days"))
+					}
+					return
+				},
+			},
 		},
 	}
 }
@@ -154,6 +182,18 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 	if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
 		createOpts.AvailabilityZones = expandStringList(attr.List())
+	}
+
+	if v, ok := d.GetOk("backup_retention_period"); ok {
+		createOpts.BackupRetentionPeriod = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("preferred_backup_window"); ok {
+		createOpts.PreferredBackupWindow = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("preferred_maintenance_window"); ok {
+		createOpts.PreferredMaintenanceWindow = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] RDS Cluster create options: %s", createOpts)
@@ -223,6 +263,9 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("engine", dbc.Engine)
 	d.Set("master_username", dbc.MasterUsername)
 	d.Set("port", dbc.Port)
+	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
+	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
+	d.Set("preferred_maintenance_window", dbc.PreferredMaintenanceWindow)
 
 	var vpcg []string
 	for _, g := range dbc.VpcSecurityGroups {
@@ -261,6 +304,18 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		} else {
 			req.VpcSecurityGroupIds = []*string{}
 		}
+	}
+
+	if d.HasChange("preferred_backup_window") {
+		req.PreferredBackupWindow = aws.String(d.Get("preferred_backup_window").(string))
+	}
+
+	if d.HasChange("preferred_maintaince_window") {
+		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintaince_window").(string))
+	}
+
+	if d.HasChange("backup_retention_limit") {
+		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_limit").(int)))
 	}
 
 	_, err := conn.ModifyDBCluster(req)

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -29,6 +29,27 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSCluster_backups(t *testing.T) {
+	var v rds.DBCluster
+
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	config := fmt.Sprintf(testAccAWSClusterConfig_backups, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster.default", "preferred_backup_window", "07:00-09:00"),
 					resource.TestCheckResourceAttr(
@@ -41,12 +62,12 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSCluster_update(t *testing.T) {
+func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 	var v rds.DBCluster
 
 	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	preConfig := fmt.Sprintf(testAccAWSClusterConfig, ri)
-	postConfig := fmt.Sprintf(testAccAWSClusterConfig_update, ri)
+	preConfig := fmt.Sprintf(testAccAWSClusterConfig_backups, ri)
+	postConfig := fmt.Sprintf(testAccAWSClusterConfig_backupsUpdate, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -147,8 +168,16 @@ func testAccCheckAWSClusterExists(n string, v *rds.DBCluster) resource.TestCheck
 	}
 }
 
-// Add some random to the name, to avoid collision
 var testAccAWSClusterConfig = `
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+}`
+
+var testAccAWSClusterConfig_backups = `
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-%d"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
@@ -160,8 +189,7 @@ resource "aws_rds_cluster" "default" {
   preferred_maintenance_window = "tue:04:00-tue:04:30"
 }`
 
-// Add some random to the name, to avoid collision
-var testAccAWSClusterConfig_update = `
+var testAccAWSClusterConfig_backupsUpdate = `
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-%d"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -26,6 +26,12 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 				Config: testAccAWSClusterConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "preferred_backup_window", "07:00-09:00"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "backup_retention_period", "5"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
 				),
 			},
 		},
@@ -105,4 +111,7 @@ resource "aws_rds_cluster" "default" {
   database_name = "mydb"
   master_username = "foo"
   master_password = "mustbeeightcharaters"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  preferred_maintenance_window = "tue:04:00-tue:04:30"
 }`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -35,33 +35,6 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSCluster_backups(t *testing.T) {
-	var v rds.DBCluster
-
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	config := fmt.Sprintf(testAccAWSClusterConfig_backups, ri)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSClusterDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "preferred_backup_window", "07:00-09:00"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "backup_retention_period", "5"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 	var v rds.DBCluster
 

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -17,13 +17,16 @@ import (
 func TestAccAWSRDSCluster_basic(t *testing.T) {
 	var v rds.DBCluster
 
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	config := fmt.Sprintf(testAccAWSClusterConfig, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSClusterConfig,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
 					resource.TestCheckResourceAttr(
@@ -32,6 +35,47 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 						"aws_rds_cluster.default", "backup_retention_period", "5"),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSCluster_update(t *testing.T) {
+	var v rds.DBCluster
+
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	preConfig := fmt.Sprintf(testAccAWSClusterConfig, ri)
+	postConfig := fmt.Sprintf(testAccAWSClusterConfig_update, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "preferred_backup_window", "07:00-09:00"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "backup_retention_period", "5"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "preferred_backup_window", "03:00-09:00"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "backup_retention_period", "10"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "preferred_maintenance_window", "wed:01:00-wed:01:30"),
 				),
 			},
 		},
@@ -104,7 +148,7 @@ func testAccCheckAWSClusterExists(n string, v *rds.DBCluster) resource.TestCheck
 }
 
 // Add some random to the name, to avoid collision
-var testAccAWSClusterConfig = fmt.Sprintf(`
+var testAccAWSClusterConfig = `
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-%d"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
@@ -114,4 +158,18 @@ resource "aws_rds_cluster" "default" {
   backup_retention_period = 5
   preferred_backup_window = "07:00-09:00"
   preferred_maintenance_window = "tue:04:00-tue:04:30"
-}`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+}`
+
+// Add some random to the name, to avoid collision
+var testAccAWSClusterConfig_update = `
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  backup_retention_period = 10
+  preferred_backup_window = "03:00-09:00"
+  preferred_maintenance_window = "wed:01:00-wed:01:30"
+  apply_immediately = true
+}`

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -24,6 +24,8 @@ resource "aws_rds_cluster" "default" {
   database_name = "mydb"
   master_username = "foo"
   master_password = "bar"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
 }
 ```
 
@@ -52,6 +54,9 @@ string.
   instances in the DB cluster can be created in
 * `backup_retention_period` - (Optional) The days to retain backups for. Default
 1
+* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter. 
+Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
+* `preferred_maintenance_window` - (Optional) The weekly time range during which system maintenance can occur, in (UTC) e.g. wed:04:00-wed:04:30
 * `port` - (Optional) The port on which the DB accepts connections
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
   with the Cluster
@@ -70,7 +75,8 @@ The following attributes are exported:
 * `allocated_storage` - The amount of allocated storage
 * `availability_zones` - The availability zone of the instance
 * `backup_retention_period` - The backup retention period
-* `backup_window` - The backup window
+* `preferred_backup_window` - The backup window
+* `preferred_maintenance_window` - The maintenance window
 * `endpoint` - The primary, writeable connection endpoint
 * `engine` - The database engine
 * `engine_version` - The database engine version
@@ -80,6 +86,7 @@ The following attributes are exported:
 * `status` - The RDS instance status
 * `username` - The master username for the database
 * `storage_encrypted` - Specifies whether the DB instance is encrypted
+* `preferred_backup_window` - The daily time range during which the backups happen
 
 [1]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html
 


### PR DESCRIPTION
Adding backup_retention_period, preferred_backup_window and preferred_maintenance_window to RDS Cluster

Fixes #3755 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=RDSCluster_' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=RDSCluster_ -timeout 90m
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (112.39s)
=== RUN   TestAccAWSRDSCluster_backups
--- PASS: TestAccAWSRDSCluster_backups (111.10s)
=== RUN   TestAccAWSRDSCluster_backupsUpdate
--- PASS: TestAccAWSRDSCluster_backupsUpdate (125.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	349.436s
```