### PR TITLE
docker provider additions

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -172,6 +172,12 @@ func resourceDockerContainer() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"labels": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"memory": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -182,18 +182,39 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(int)
+					if value < 0 {
+						es = append(es, fmt.Errorf("%q must be greater than or equal to 0", k))
+					}
+					return
+				},
 			},
 
 			"memory_swap": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(int)
+					if value < -1 {
+						es = append(es, fmt.Errorf("%q must be greater than or equal to -1", k))
+					}
+					return
+				},
 			},
 
 			"cpu_shares": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(int)
+					if value < 0 {
+						es = append(es, fmt.Errorf("%q must be greater than or equal to 0", k))
+					}
+					return
+				},
 			},
 
 			"log_driver": &schema.Schema{

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -171,6 +171,24 @@ func resourceDockerContainer() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"memory": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"memory_swap": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"cpu_shares": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -195,6 +195,27 @@ func resourceDockerContainer() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"log_driver": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "json-file",
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^(json-file|syslog|journald|gelf|fluentd)$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"%q must be one of \"json-file\", \"syslog\", \"journald\", \"gelf\", or \"fluentd\"", k))
+					}
+					return
+				},
+			},
+
+			"log_opts": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -71,6 +71,13 @@ func resourceDockerContainer() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"entrypoint": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"dns": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"regexp"
 )
 
 func resourceDockerContainer() *schema.Resource {
@@ -88,6 +89,27 @@ func resourceDockerContainer() *schema.Resource {
 
 			"publish_all_ports": &schema.Schema{
 				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"restart": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "no",
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^(no|on-failure|always)$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"%q must be one of \"no\", \"on-failure\", or \"always\"", k))
+					}
+					return
+				},
+			},
+
+			"max_retry_count": &schema.Schema{
+				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 			},

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -82,6 +82,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		createOpts.Config.Volumes = volumes
 	}
 
+	if v, ok := d.GetOk("labels"); ok {
+		createOpts.Config.Labels = mapLabels(v.(map[string]interface{}))
+	}
+
 	var retContainer *dc.Container
 	if retContainer, err = client.CreateContainer(createOpts); err != nil {
 		return fmt.Errorf("Unable to create container: %s", err)
@@ -253,6 +257,14 @@ func stringSetToStringSlice(stringSet *schema.Set) []string {
 		ret = append(ret, envVal.(string))
 	}
 	return ret
+}
+
+func mapLabels(labels map[string]interface{}) map[string]string {
+	mapped := make(map[string]string, len(labels))
+	for k, v := range labels {
+		mapped[k] = v.(string)
+	}
+	return mapped
 }
 
 func fetchDockerContainer(name string, client *dc.Client) (*dc.APIContainers, error) {

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -54,6 +54,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		createOpts.Config.Cmd = stringListToStringSlice(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("entrypoint"); ok {
+		createOpts.Config.Entrypoint = stringListToStringSlice(v.([]interface{}))
+	}
+
 	exposedPorts := map[dc.Port]struct{}{}
 	portBindings := map[dc.Port][]dc.PortBinding{}
 

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -83,7 +83,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if v, ok := d.GetOk("labels"); ok {
-		createOpts.Config.Labels = mapLabels(v.(map[string]interface{}))
+		createOpts.Config.Labels = mapTypeMapValsToString(v.(map[string]interface{}))
 	}
 
 	var retContainer *dc.Container
@@ -102,6 +102,9 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		RestartPolicy: dc.RestartPolicy{
 			Name:              d.Get("restart").(string),
 			MaximumRetryCount: d.Get("max_retry_count").(int),
+		},
+		LogConfig: dc.LogConfig{
+			Type: d.Get("log_driver").(string),
 		},
 	}
 
@@ -146,6 +149,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		if shares > 0 {
 			hostConfig.CPUShares = shares
 		}
+	}
+
+	if v, ok := d.GetOk("log_opts"); ok {
+		hostConfig.LogConfig.Config = mapTypeMapValsToString(v.(map[string]interface{}))
 	}
 
 	creationTime = time.Now()
@@ -259,9 +266,9 @@ func stringSetToStringSlice(stringSet *schema.Set) []string {
 	return ret
 }
 
-func mapLabels(labels map[string]interface{}) map[string]string {
-	mapped := make(map[string]string, len(labels))
-	for k, v := range labels {
+func mapTypeMapValsToString(typeMap map[string]interface{}) map[string]string {
+	mapped := make(map[string]string, len(typeMap))
+	for k, v := range typeMap {
 		mapped[k] = v.(string)
 	}
 	return mapped

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -118,27 +118,19 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if v, ok := d.GetOk("memory"); ok {
-		memory := int64(v.(int))
-		if memory > 0 {
-			hostConfig.Memory = memory * 1024 * 1024
-		}
+		hostConfig.Memory = int64(v.(int)) * 1024 * 1024
 	}
 
 	if v, ok := d.GetOk("memory_swap"); ok {
 		swap := int64(v.(int))
-		if swap != 0 {
-			if swap > 0 { // only convert positive #s to bytes
-				swap = swap * 1024 * 1024
-			}
-			hostConfig.MemorySwap = swap
+		if swap > 0 {
+			swap = swap * 1024 * 1024
 		}
+		hostConfig.MemorySwap = swap
 	}
 
 	if v, ok := d.GetOk("cpu_shares"); ok {
-		shares := int64(v.(int))
-		if shares > 0 {
-			hostConfig.CPUShares = shares
-		}
+		hostConfig.CPUShares = int64(v.(int))
 	}
 
 	if v, ok := d.GetOk("log_opts"); ok {

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -95,6 +95,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	hostConfig := &dc.HostConfig{
 		Privileged:      d.Get("privileged").(bool),
 		PublishAllPorts: d.Get("publish_all_ports").(bool),
+		RestartPolicy: dc.RestartPolicy{
+			Name:              d.Get("restart").(string),
+			MaximumRetryCount: d.Get("max_retry_count").(int),
+		},
 	}
 
 	if len(portBindings) != 0 {

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -120,6 +120,30 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		hostConfig.Links = stringSetToStringSlice(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("memory"); ok {
+		memory := int64(v.(int))
+		if memory > 0 {
+			hostConfig.Memory = memory * 1024 * 1024
+		}
+	}
+
+	if v, ok := d.GetOk("memory_swap"); ok {
+		swap := int64(v.(int))
+		if swap != 0 {
+			if swap > 0 { // only convert positive #s to bytes
+				swap = swap * 1024 * 1024
+			}
+			hostConfig.MemorySwap = swap
+		}
+	}
+
+	if v, ok := d.GetOk("cpu_shares"); ok {
+		shares := int64(v.(int))
+		if shares > 0 {
+			hostConfig.CPUShares = shares
+		}
+	}
+
 	creationTime = time.Now()
 	if err := client.StartContainer(retContainer.ID, hostConfig); err != nil {
 		return fmt.Errorf("Unable to start container: %s", err)

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -55,6 +55,11 @@ func TestAccDockerContainer_customized(t *testing.T) {
 		if c.HostConfig.CPUShares != 512 {
 			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
 		}
+
+		if c.Config.Labels["env"] != "prod" || c.Config.Labels["role"] != "test" {
+			return fmt.Errorf("Container does not have the correct labels")
+		}
+
 		return nil
 	}
 
@@ -129,5 +134,9 @@ resource "docker_container" "foo" {
   memory = 128
   memory_swap = 128
   cpu_shares = 512
+  labels {
+    env = "prod"
+    role = "test"
+  }
 }
 `

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -60,6 +60,18 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container does not have the correct labels")
 		}
 
+		if c.HostConfig.LogConfig.Type != "json-file" {
+			return fmt.Errorf("Container does not have the correct log config: %s", c.HostConfig.LogConfig.Type)
+		}
+
+		if c.HostConfig.LogConfig.Config["max-size"] != "10m" {
+			return fmt.Errorf("Container does not have the correct max-size log option: %v", c.HostConfig.LogConfig.Config["max-size"])
+		}
+
+		if c.HostConfig.LogConfig.Config["max-file"] != "20" {
+			return fmt.Errorf("Container does not have the correct max-file log option: %v", c.HostConfig.LogConfig.Config["max-file"])
+		}
+
 		return nil
 	}
 
@@ -138,5 +150,10 @@ resource "docker_container" "foo" {
     env = "prod"
     role = "test"
   }
+  log_driver = "json-file"
+  log_opts = {
+    max-size = "10m"
+    max-file = 20
+	}
 }
 `

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -44,15 +44,15 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has wrong restart policy: %s", c.HostConfig.RestartPolicy.Name)
 		}
 
-		if c.HostConfig.Memory != (128 * 1024 * 1024) {
+		if c.HostConfig.Memory != (512 * 1024 * 1024) {
 			return fmt.Errorf("Container has wrong memory setting: %d", c.HostConfig.Memory)
 		}
 
-		if c.HostConfig.MemorySwap != (128 * 1024 * 1024) {
-			return fmt.Errorf("Container has wrong memory swap setting: %d", c.HostConfig.Memory)
+		if c.HostConfig.MemorySwap != (2048 * 1024 * 1024) {
+			return fmt.Errorf("Container has wrong memory swap setting: %d", c.HostConfig.MemorySwap)
 		}
 
-		if c.HostConfig.CPUShares != 512 {
+		if c.HostConfig.CPUShares != 32 {
 			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
 		}
 
@@ -143,9 +143,9 @@ resource "docker_container" "foo" {
   entrypoint = ["/bin/bash", "-c", "ping localhost"]
   restart = "on-failure"
   max_retry_count = 5
-  memory = 128
-  memory_swap = 128
-  cpu_shares = 512
+  memory = 512
+  memory_swap = 2048
+  cpu_shares = 32
   labels {
     env = "prod"
     role = "test"

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -44,6 +44,17 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has wrong restart policy: %s", c.HostConfig.RestartPolicy.Name)
 		}
 
+		if c.HostConfig.Memory != (128 * 1024 * 1024) {
+			return fmt.Errorf("Container has wrong memory setting: %d", c.HostConfig.Memory)
+		}
+
+		if c.HostConfig.MemorySwap != (128 * 1024 * 1024) {
+			return fmt.Errorf("Container has wrong memory swap setting: %d", c.HostConfig.Memory)
+		}
+
+		if c.HostConfig.CPUShares != 512 {
+			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
+		}
 		return nil
 	}
 
@@ -115,5 +126,8 @@ resource "docker_container" "foo" {
   entrypoint = ["/bin/bash", "-c", "ping localhost"]
   restart = "on-failure"
   max_retry_count = 5
+  memory = 128
+  memory_swap = 128
+  cpu_shares = 512
 }
 `

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
     `["/usr/bin/myprogram"]`.
 * `dns` - (Optional, set of strings) Set of DNS servers.
 * `env` - (Optional, set of strings) Environmental variables to set.
+* `labels` - (Optional) Key/value pairs to set as labels on the container.
 * `links` - (Optional, set of strings) Set of links for link based
   connectivity between containers that are running on the same host.
 * `hostname` - (Optional, string) Hostname of the container.

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -48,6 +48,10 @@ The following arguments are supported:
   connectivity between containers that are running on the same host.
 * `hostname` - (Optional, string) Hostname of the container.
 * `domainname` - (Optional, string) Domain name of the container.
+* `restart` - (Optional, string) The restart policy for the container. Must be
+  one of "no", "on-failure", "always".
+* `max_retry_count` - (Optional, int) The maximum amount of times to an attempt
+  a restart when `restart` is set to "on-failure"
 * `must_run` - (Optional, bool) If true, then the Docker container will be
   kept running. If false, then as long as the container exists, Terraform
   assumes it is successful.

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -64,6 +64,10 @@ The following arguments are supported:
 * `memory_swap` - (Optional, int) The total memory limit (memory + swap) for the
   container in MBs.
 * `cpu_shares` - (Optional, int) CPU shares (relative weight) for the container.
+* `log_driver` - (Optional, string) The logging driver to use for the container.
+  Defaults to "json-file".
+* `log_opts` - (Optional) Key/value pairs to use as options for the logging
+  driver.
 
 <a id="ports"></a>
 ## Ports

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -37,6 +37,11 @@ The following arguments are supported:
 * `command` - (Optional, list of strings) The command to use to start the
     container. For example, to run `/usr/bin/myprogram -f baz.conf` set the
     command to be `["/usr/bin/myprogram", "-f", "baz.conf"]`.
+* `entrypoint` - (Optional, list of strings) The command to use as the
+    Entrypoint for the container. The Entrypoint allows you to configure a
+    container to run as an executable. For example, to run `/usr/bin/myprogram`
+    when starting a container, set the entrypoint to be
+    `["/usr/bin/myprogram"]`.
 * `dns` - (Optional, set of strings) Set of DNS servers.
 * `env` - (Optional, set of strings) Environmental variables to set.
 * `links` - (Optional, set of strings) Set of links for link based

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -59,6 +59,10 @@ The following arguments are supported:
 * `privileged` - (Optional, bool) Run container in privileged mode.
 * `publish_all_ports` - (Optional, bool) Publish all ports of the container.
 * `volumes` - (Optional) See [Volumes](#volumes) below for details.
+* `memory` - (Optional, int) The memory limit for the container in MBs.
+* `memory_swap` - (Optional, int) The total memory limit (memory + swap) for the
+  container in MBs.
+* `cpu_shares` - (Optional, int) CPU shares (relative weight) for the container.
 
 <a id="ports"></a>
 ## Ports


### PR DESCRIPTION
Adds the following functionality to the `docker_container` resource:

* support for setting the entrypoint
* support for setting the restart policy (off|on-failure|always)
* support for setting memory, memory-swap, and cpu-shares runtime constraints 
* support for docker labels
* support for log-driver and log-options
* includes HostConfig when creating container