### PR TITLE
Issue #3742 - terraform destroy fails if Google Compute Instance no...

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+	"strings"
 )
 
 func stringHashcode(v interface{}) int {
@@ -285,9 +286,10 @@ func getInstance(config *Config, d *schema.ResourceData) (*compute.Instance, err
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
+			id := d.Id()
 			d.SetId("")
 
-			return nil, fmt.Errorf("Resource %s no longer exists", config.Project)
+			return nil, fmt.Errorf("Resource %s no longer exists", id)
 		}
 
 		return nil, fmt.Errorf("Error reading instance: %s", err)
@@ -549,6 +551,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 
 	instance, err := getInstance(config, d)
 	if err != nil {
+		if strings.Contains(err.Error(), "no longer exists") {
+			return nil
+		}
 		return err
 	}
 

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -549,9 +549,11 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	id := d.Id()
 	instance, err := getInstance(config, d)
 	if err != nil {
 		if strings.Contains(err.Error(), "no longer exists") {
+			log.Printf("[WARN] Google Compute Instance (%s) not found", id)
 			return nil
 		}
 		return err


### PR DESCRIPTION
…longer exists

Google resource_compute_instance now behaves the same as the AWS equivalent, and simply returns no error from the Read operation if the instance no longer exists.
