### PR TITLE
provider/aws: Elasticache cluster describe instances CacheClusterNotFound err handling

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -241,6 +241,11 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 
 	res, err := conn.DescribeCacheClusters(req)
 	if err != nil {
+		if eccErr, ok := err.(awserr.Error); ok && eccErr.Code() == "CacheClusterNotFound" {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -242,6 +242,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 	res, err := conn.DescribeCacheClusters(req)
 	if err != nil {
 		if eccErr, ok := err.(awserr.Error); ok && eccErr.Code() == "CacheClusterNotFound" {
+			log.Printf("[WARN] ElastiCache Cluster (%s) not found", d.Id())
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Fixing the Read method to take into account that an elasticache cluster may have been deleted manually

Fixes #3689

//cc @apparentlymart 