### PR TITLE
provider/digitalocean: Fixing the DigitalOcean Droplet 404 potential on refresh of state

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -189,7 +189,7 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	droplet, _, err := client.Droplets.Get(id)
 	if err != nil {
 		// check if the droplet no longer exists.
-		if err.Error() == "Error retrieving droplet: API Error: 404 Not Found" {
+		if strings.Contains(err.Error(), "404 The resource you were accessing could not be found") {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -190,6 +190,7 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		// check if the droplet no longer exists.
 		if resp.StatusCode == 404 {
+			log.Printf("[WARN] DigitalOcean Droplet (%s) not found", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -186,10 +186,10 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Retrieve the droplet properties for updating the state
-	droplet, _, err := client.Droplets.Get(id)
+	droplet, resp, err := client.Droplets.Get(id)
 	if err != nil {
 		// check if the droplet no longer exists.
-		if strings.Contains(err.Error(), "404 The resource you were accessing could not be found") {
+		if resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Fixes #3670

Changing the DigitalOcean Droplet resource to use the new SDK message response when a Droplet isn't found

Current behavious in master:

```
digitalocean_droplet.foobar: Refreshing state... (ID: 8624387)
Error refreshing state: 1 error(s) occurred:

* digitalocean_droplet.foobar: Error retrieving droplet: GET https://api.digitalocean.com/v2/droplets/8624387: 404 The resource you were accessing could not be found.
```

Then changing the code to cater for the new API lets me do the following:

```
terraform refresh
digitalocean_droplet.foobar: Refreshing state... (ID: 8624387)
bin % terraform plan
Refreshing Terraform state prior to plan...


The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ digitalocean_droplet.foobar
    image:                "" => "centos-5-8-x32"
    ipv4_address:         "" => "<computed>"
    ipv4_address_private: "" => "<computed>"
    ipv6_address:         "" => "<computed>"
    ipv6_address_private: "" => "<computed>"
    locked:               "" => "<computed>"
    name:                 "" => "foo"
    region:               "" => "nyc3"
    size:                 "" => "512mb"
    status:               "" => "<computed>"
    user_data:            "" => "foobar"


Plan: 1 to add, 0 to change, 0 to destroy.
```
