### PR TITLE
provider/docker remove docker_image on destroy

### DIFF
--- a/builtin/providers/docker/resource_docker_image_funcs.go
+++ b/builtin/providers/docker/resource_docker_image_funcs.go
@@ -41,6 +41,11 @@ func resourceDockerImageUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDockerImageDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*dc.Client)
+	err := removeImage(d, client)
+	if err != nil {
+		return fmt.Errorf("Unable to remove Docker image: %s", err)
+	}
 	d.SetId("")
 	return nil
 }
@@ -135,6 +140,17 @@ func getImageTag(image string) string {
 	return ""
 }
 
+func searchLocalImages(data Data, imageName string) *dc.APIImages {
+	if apiImage, ok := data.DockerImages[imageName]; ok {
+		return apiImage
+	}
+	if apiImage, ok := data.DockerImages[imageName+":latest"]; ok {
+		imageName = imageName + ":latest"
+		return apiImage
+	}
+	return nil
+}
+
 func findImage(d *schema.ResourceData, client *dc.Client) (*dc.APIImages, error) {
 	var data Data
 	if err := fetchLocalImages(&data, client); err != nil {
@@ -146,18 +162,7 @@ func findImage(d *schema.ResourceData, client *dc.Client) (*dc.APIImages, error)
 		return nil, fmt.Errorf("Empty image name is not allowed")
 	}
 
-	searchLocal := func() *dc.APIImages {
-		if apiImage, ok := data.DockerImages[imageName]; ok {
-			return apiImage
-		}
-		if apiImage, ok := data.DockerImages[imageName+":latest"]; ok {
-			imageName = imageName + ":latest"
-			return apiImage
-		}
-		return nil
-	}
-
-	foundImage := searchLocal()
+	foundImage := searchLocalImages(data, imageName)
 
 	if d.Get("keep_updated").(bool) || foundImage == nil {
 		if err := pullImage(&data, client, imageName); err != nil {
@@ -165,10 +170,34 @@ func findImage(d *schema.ResourceData, client *dc.Client) (*dc.APIImages, error)
 		}
 	}
 
-	foundImage = searchLocal()
+	foundImage = searchLocalImages(data, imageName)
 	if foundImage != nil {
 		return foundImage, nil
 	}
 
 	return nil, fmt.Errorf("Unable to find or pull image %s", imageName)
+}
+
+func removeImage(d *schema.ResourceData, client *dc.Client) error {
+	var data Data
+	if err := fetchLocalImages(&data, client); err != nil {
+		return err
+	}
+
+	imageName := d.Get("name").(string)
+
+	if imageName == "" {
+		return fmt.Errorf("Empty image name is not allowed")
+	}
+
+	foundImage := searchLocalImages(data, imageName)
+
+	if foundImage != nil {
+		err := client.RemoveImage(foundImage.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/builtin/providers/docker/resource_docker_image_test.go
+++ b/builtin/providers/docker/resource_docker_image_test.go
@@ -3,13 +3,17 @@ package docker
 import (
 	"testing"
 
+	"fmt"
+	dc "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDockerImage_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDockerImageDestroy(basicImageID),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDockerImageConfig,
@@ -17,7 +21,7 @@ func TestAccDockerImage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"docker_image.foo",
 						"latest",
-						"b7cf8f0d9e82c9d96bd7afd22c600bfdb86b8d66c50d29164e5ad2fb02f7187b"),
+						basicImageID),
 				),
 			},
 		},
@@ -26,8 +30,9 @@ func TestAccDockerImage_basic(t *testing.T) {
 
 func TestAddDockerImage_private(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDockerImageDestroy(privateImageID),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAddDockerPrivateImageConfig,
@@ -35,19 +40,35 @@ func TestAddDockerImage_private(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"docker_image.foobar",
 						"latest",
-						"2c40b0526b6358710fd09e7b8c022429268cc61703b4777e528ac9d469a07ca1"),
+						privateImageID),
 				),
 			},
 		},
 	})
 }
 
+func testAccDockerImageDestroy(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*dc.Client)
+		_, err := client.InspectImage(n)
+		if err == nil {
+			return fmt.Errorf("Image still exists")
+		} else if err != dc.ErrNoSuchImage {
+			return err
+		}
+		return nil
+	}
+}
+
+const basicImageID = "f4fddc471ec22fc1f7d37768132f1753bc171121e30ac2af7fcb0302588197c0"
+
 const testAccDockerImageConfig = `
 resource "docker_image" "foo" {
-	name = "ubuntu:trusty-20150320"
+	name = "alpine:3.2"
 	keep_updated = true
 }
 `
+const privateImageID = "2c40b0526b6358710fd09e7b8c022429268cc61703b4777e528ac9d469a07ca1"
 
 const testAddDockerPrivateImageConfig = `
 resource "docker_image" "foobar" {


### PR DESCRIPTION
This updates the docker_image resource to remove the image when running `terraform destroy`. I asked about the intended behavior in #3609 but I think this is probably more consistent with other Terraform providers.