### PR TITLE
provider/aws: use single import path for aws-sdk-go

### DIFF
--- a/builtin/providers/aws/conversions.go
+++ b/builtin/providers/aws/conversions.go
@@ -1,8 +1,9 @@
 package aws
 
 import (
-	"github.com/awslabs/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 func makeAwsStringList(in []interface{}) []*string {

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -5,11 +5,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/awslabs/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 )
 
 // Provider returns a terraform.ResourceProvider.

--- a/builtin/providers/aws/resource_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
@@ -49,7 +50,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   custom_cookbooks_source {
     type = "git"
     revision = "master"
-    url = "https://github.com/awslabs/opsworks-example-cookbooks.git"
+    url = "https://github.com/aws/opsworks-example-cookbooks.git"
   }
 }
 `
@@ -129,7 +130,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   custom_cookbooks_source {
     type = "git"
     revision = "master"
-    url = "https://github.com/awslabs/opsworks-example-cookbooks.git"
+    url = "https://github.com/aws/opsworks-example-cookbooks.git"
   }
 }
 `
@@ -259,7 +260,7 @@ var testAccAwsOpsworksStackCheckResourceAttrsUpdate = resource.ComposeTestCheckF
 	resource.TestCheckResourceAttr(
 		"aws_opsworks_stack.tf-acc",
 		"custom_cookbooks_source.0.url",
-		"https://github.com/awslabs/opsworks-example-cookbooks.git",
+		"https://github.com/aws/opsworks-example-cookbooks.git",
 	),
 )
 

--- a/contrib/api-coverage/aws_api_coverage.rb
+++ b/contrib/api-coverage/aws_api_coverage.rb
@@ -23,7 +23,7 @@ module APIs
 
   module AWS
     def self.path
-      @path ||= Pathname(`go list -f '{{.Dir}}' github.com/awslabs/aws-sdk-go/aws`.chomp).parent
+      @path ||= Pathname(`go list -f '{{.Dir}}' github.com/aws/aws-sdk-go/aws`.chomp).parent
     end
 
     def self.api_json_files


### PR DESCRIPTION
Even though github.com/awslabs is an alias for github.com/aws and both paths reference the same package, mixing both duplicates aws-sdk-go packages that need to be vendored (e.g. [this](https://github.com/hashicorp/terraform/blob/master/deps/v0-6-6.json#L207) and [that](https://github.com/hashicorp/terraform/blob/master/deps/v0-6-6.json#L42)).

This CL fixes the above issue and may by accident fix the coverage script, however I did not test it.