### PR TITLE
providers/aws: Provide source security group id for ELBs

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -314,7 +314,7 @@ func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		sgId, err := sourceSGIdByName(meta, *lb.SourceSecurityGroup.GroupName, elbVpc)
 		if err != nil {
-			log.Printf("[WARN] Error looking up ELB Security Group ID: %s", err)
+			return fmt.Errorf("[WARN] Error looking up ELB Security Group ID: %s", err)
 		} else {
 			d.Set("source_security_group_id", sgId)
 		}

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -611,6 +611,15 @@ func testAccCheckAWSELBExists(n string, res *elb.LoadBalancerDescription) resour
 
 		*res = *describe.LoadBalancerDescriptions[0]
 
+		// Confirm source_security_group_id for ELBs in a VPC
+		// 	See https://github.com/hashicorp/terraform/pull/3780
+		if res.VPCId != nil {
+			sgid := rs.Primary.Attributes["source_security_group_id"]
+			if sgid == "" {
+				return fmt.Errorf("Expected to find source_security_group_id for ELB, but was empty")
+			}
+		}
+
 		return nil
 	}
 }

--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -100,5 +100,8 @@ The following attributes are exported:
 * `instances` - The list of instances in the ELB
 * `source_security_group` - The name of the security group that you can use as
   part of your inbound rules for your load balancer's back-end application
-  instances.
+  instances. Use this for Classic or Default VPC only.
+* `source_security_group_id` - The ID of the security group that you can use as
+  part of your inbound rules for your load balancer's back-end application
+  instances. Only available on ELBs launch in a VPC.
 * `zone_id` - The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record)


### PR DESCRIPTION
The `source_security_group` returned for an ELB is the name of the security group... the API only returns the name to us.

You cannot use the Security Group name as a reference in the AWS API for security group ingress unless you're in EC2 Classic, or the default VPC. So, if you're trying to ingress from this ELB, and you are not in classic or default VPC, you will hit error(s) (see https://github.com/hashicorp/terraform/issues/2420)

This PR looks up the SG Id and adds `source_security_group_id` as an attribute, if found successfully 

**Remaining:**

- [x] Docs
- [x] Tests to verify 