### PR TITLE
provider/openstack: Make Security Groups Computed

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -95,6 +95,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},


### PR DESCRIPTION
This commit makes security groups in the openstack_compute_instance_v2
resource computed. This fixes issues where a security group is omitted
which causes the instance to have the "default" group applied. When
re-applying without this patch, an error will occur.

Fixes #3770 