### PR TITLE
provider/aws: add name_prefix option to launch config

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -30,6 +30,14 @@ func TestAccAWSLaunchConfiguration_basic(t *testing.T) {
 						"aws_launch_configuration.bar", "terraform-"),
 				),
 			},
+			resource.TestStep{
+				Config: testAccAWSLaunchConfigurationPrefixNameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
+					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(
+						"aws_launch_configuration.baz", "baz-"),
+				),
+			},
 		},
 	})
 }
@@ -249,6 +257,16 @@ resource "aws_launch_configuration" "bar" {
 
 const testAccAWSLaunchConfigurationNoNameConfig = `
 resource "aws_launch_configuration" "bar" {
+   image_id = "ami-21f78e11"
+   instance_type = "t1.micro"
+   user_data = "foobar-user-data-change"
+   associate_public_ip_address = false
+}
+`
+
+const testAccAWSLaunchConfigurationPrefixNameConfig = `
+resource "aws_launch_configuration" "baz" {
+   name_prefix = "baz-"
    image_id = "ami-21f78e11"
    instance_type = "t1.micro"
    user_data = "foobar-user-data-change"

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -26,11 +26,13 @@ Launch Configurations cannot be updated after creation with the Amazon
 Web Service API. In order to update a Launch Configuration, Terraform will
 destroy the existing resource and create a replacement. In order to effectively
 use a Launch Configuration resource with an [AutoScaling Group resource][1],
-it's recommend to omit the Launch Configuration `name` attribute, and
-specify `create_before_destroy` in a [lifecycle][2] block, as shown:
+it's recommended to specify `create_before_destroy` in a [lifecycle][2] block.
+Either omit the Launch Configuration `name` attribute, or specify a partial name
+with `name_prefix`.  Example:
 
 ```
 resource "aws_launch_configuration" "as_conf" {
+    name_prefix = "terraform-lc-example-"
     image_id = "ami-1234"
     instance_type = "m1.small"
 
@@ -87,7 +89,9 @@ resource "aws_autoscaling_group" "bar" {
 The following arguments are supported:
 
 * `name` - (Optional) The name of the launch configuration. If you leave
-  this blank, Terraform will auto-generate it.
+  this blank, Terraform will auto-generate a unique name.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
 * `image_id` - (Required) The EC2 image ID to launch.
 * `instance_type` - (Required) The size of instance to launch.
 * `iam_instance_profile` - (Optional) The IAM instance profile to associate


### PR DESCRIPTION
Fixes Issue #2911.

This adds a `name_prefix` option to `aws_launch_configuration` resources, making the `create_before_destroy` lifecycle pattern a bit more understandable in large configs.

When specified, `name_prefix` is used instead of "terraform-" as the prefix for the launch configuration name, with the 26-character uuid appended.  It's set to Conflict with `name`, so existing functionality is unchanged.  `name` still sets the name explicitly.

Added an acceptance test, and updated the site documentation.

Let me know if there's anything out of place or that you'd like to change.

Thanks!