### PR TITLE
provider/aws: Support scratch volumes in ecs_task_definition

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -58,7 +58,7 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 
 						"host_path": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 					},
 				},

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -62,9 +62,13 @@ func expandEcsVolumes(configured []interface{}) ([]*ecs.Volume, error) {
 
 		l := &ecs.Volume{
 			Name: aws.String(data["name"].(string)),
-			Host: &ecs.HostVolumeProperties{
-				SourcePath: aws.String(data["host_path"].(string)),
-			},
+		}
+
+		hostPath := data["host_path"].(string)
+		if hostPath != "" {
+			l.Host = &ecs.HostVolumeProperties{
+				SourcePath: aws.String(hostPath),
+			}
 		}
 
 		volumes = append(volumes, l)
@@ -314,9 +318,13 @@ func flattenEcsVolumes(list []*ecs.Volume) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, volume := range list {
 		l := map[string]interface{}{
-			"name":      *volume.Name,
-			"host_path": *volume.Host.SourcePath,
+			"name": *volume.Name,
 		}
+
+		if volume.Host.SourcePath != nil {
+			l["host_path"] = *volume.Host.SourcePath
+		}
+
 		result = append(result, l)
 	}
 	return result


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/2370

Originally terraform was constructing the struct with sourcePath being empty string (when not defined in the DSL) which was causing API error.

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=EcsTaskDefinition' 2>~/tf.log
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=EcsTaskDefinition -timeout 90m
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (22.38s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (12.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	34.399s
```