### PR TITLE
provider/openstack: extend documentation of Neutron::FloatingIP

### DIFF
--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -35,6 +35,9 @@ The following arguments are supported:
 * `pool` - (Required) The name of the pool from which to obtain the floating
     IP. Changing this creates a new floating IP.
 
+* `port_id` - ID of an existing port with at least one IP address to associate with
+this floating IP.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -42,3 +45,4 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `pool` - See Argument Reference above.
 * `address` - The actual floating IP address itself.
+* `port_id` - ID of associated port.


### PR DESCRIPTION
https://github.com/hashicorp/terraform/pull/1788 added ability to attach floating IP to the port. But there was no documentation added thus people like me were unaware about this feature.

This PR fixes this small issue.