### PR TITLE
Add coalesce interpolation func

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -25,6 +25,7 @@ func init() {
 		"cidrhost":     interpolationFuncCidrHost(),
 		"cidrnetmask":  interpolationFuncCidrNetmask(),
 		"cidrsubnet":   interpolationFuncCidrSubnet(),
+		"coalesce":     interpolationFuncCoalesce(),
 		"compact":      interpolationFuncCompact(),
 		"concat":       interpolationFuncConcat(),
 		"element":      interpolationFuncElement(),
@@ -141,6 +142,30 @@ func interpolationFuncCidrSubnet() ast.Function {
 			}
 
 			return newNetwork.String(), nil
+		},
+	}
+}
+
+// interpolationFuncCoalesce implements the "coalesce" function that
+// returns the first non null / empty string from the provided input
+func interpolationFuncCoalesce() ast.Function {
+	return ast.Function{
+		ArgTypes:     []ast.Type{ast.TypeString},
+		ReturnType:   ast.TypeString,
+		Variadic:     true,
+		VariadicType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			if len(args) < 2 {
+				return nil, fmt.Errorf("must provide at least two arguments")
+			}
+			for _, arg := range args {
+				argument := arg.(string)
+
+				if argument != "" {
+					return argument, nil
+				}
+			}
+			return "", nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -147,6 +147,33 @@ func TestInterpolateFuncCidrSubnet(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncCoalesce(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${coalesce("first", "second", "third")}`,
+				"first",
+				false,
+			},
+			{
+				`${coalesce("", "second", "third")}`,
+				"second",
+				false,
+			},
+			{
+				`${coalesce("", "", "")}`,
+				"",
+				false,
+			},
+			{
+				`${coalesce("foo")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncDeprecatedConcat(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -95,6 +95,9 @@ The supported built-in functions are:
     CIDR notation (like ``10.0.0.0/8``) and extends its prefix to include an
     additional subnet number. For example,
     ``cidrsubnet("10.0.0.0/8", 8, 2)`` returns ``10.2.0.0/16``.
+    
+  * `coalesce(string1, string2, ...)` - Returns the first non-empty value from
+    the given arguments. At least two arguments must be provided.
 
   * `compact(list)` - Removes empty string elements from a list. This can be
      useful in some cases, for example when passing joined lists as module


### PR DESCRIPTION
We are using terraform for multi user / multi environment solution. 
We'd like the ability to store some global default variables in consul, but be able to override them per user / per environment as needed.
The coalesce func allows us to achieve this.

Example config:
```
resource "google_compute_instance" "instance" {
  zone = "${coalesce(var.gce_zone, consul_keys.user.var.gce_zone, consul_keys.globals.var.gce_zone)}"
  ....
}
```
