### PR TITLE
Fix spelling mistake in aws saml example

### DIFF
--- a/website/source/docs/providers/aws/r/iam_saml_provider.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_saml_provider.html.markdown
@@ -13,7 +13,7 @@ Provides an IAM SAML provider.
 ## Example Usage
 
 ```
-resource "aws_saml_provider" "default" {
+resource "aws_iam_saml_provider" "default" {
     name = "myprovider"
     saml_metadata_document = "${file("saml-metadata.xml")}"
 }

--- a/website/source/docs/providers/aws/r/iam_saml_provider.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_saml_provider.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_saml_provider"
+page_title: "AWS: aws_iam_saml_provider"
 sidebar_current: "docs-aws-resource-iam-saml-provider"
 description: |-
   Provides an IAM SAML provider.


### PR DESCRIPTION
Example resource name is `aws_iam_saml_provider` instead of `aws_saml_provider`.