### PR TITLE
Always deploy from stable website branch

### DIFF
--- a/scripts/website_push.sh
+++ b/scripts/website_push.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Switch to the stable-website branch
+git checkout stable-website
+
 # Set the tmpdir
 if [ -z "$TMPDIR" ]; then
   TMPDIR="/tmp"


### PR DESCRIPTION
Change site deploy script to always deploy from the [stable-website][1] branch.

At time of opening, the [stable-website][1] branch is based off of [release/v0.6.6][2] branch


[1]: https://github.com/hashicorp/terraform/tree/stable-website
[2]: https://github.com/hashicorp/terraform/tree/release/v0.6.6