### PR TITLE
provider/openstack: Revert Security Group Rule Fix

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
@@ -131,10 +131,10 @@ func resourceComputeSecGroupV2Read(d *schema.ResourceData, meta interface{}) err
 	d.Set("description", sg.Description)
 	rtm := rulesToMap(sg.Rules)
 	for _, v := range rtm {
-		if v["from_group_id"] == d.Get("name") {
-			v["self"] = true
+		if v["group"] == d.Get("name") {
+			v["self"] = "1"
 		} else {
-			v["self"] = false
+			v["self"] = "0"
 		}
 	}
 	log.Printf("[DEBUG] rulesToMap(sg.Rules): %+v", rtm)
@@ -283,12 +283,12 @@ func rulesToMap(sgrs []secgroups.Rule) []map[string]interface{} {
 	sgrMap := make([]map[string]interface{}, len(sgrs))
 	for i, sgr := range sgrs {
 		sgrMap[i] = map[string]interface{}{
-			"id":            sgr.ID,
-			"from_port":     sgr.FromPort,
-			"to_port":       sgr.ToPort,
-			"ip_protocol":   sgr.IPProtocol,
-			"cidr":          sgr.IPRange.CIDR,
-			"from_group_id": sgr.Group.Name,
+			"id":          sgr.ID,
+			"from_port":   sgr.FromPort,
+			"to_port":     sgr.ToPort,
+			"ip_protocol": sgr.IPProtocol,
+			"cidr":        sgr.IPRange.CIDR,
+			"group":       sgr.Group.Name,
 		}
 	}
 	return sgrMap


### PR DESCRIPTION
This commit reverts the patch from #3796.

It has been discovered that multiple rules are being reported out
of order when the configuration is applied multiple times. I feel
this is a larger issue than the bug this patch originally fixed,
so until I can resolve it, I am reverting the patch.