### PR TITLE
Add test attempting to reproduce #2598

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2851,6 +2851,55 @@ func TestContext2Apply_outputInvalid(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_outputAdd(t *testing.T) {
+	m1 := testModule(t, "apply-output-add-before")
+	p1 := testProvider("aws")
+	p1.ApplyFn = testApplyFn
+	p1.DiffFn = testDiffFn
+	ctx1 := testContext2(t, &ContextOpts{
+		Module: m1,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p1),
+		},
+	})
+
+	if _, err := ctx1.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state1, err := ctx1.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	m2 := testModule(t, "apply-output-add-after")
+	p2 := testProvider("aws")
+	p2.ApplyFn = testApplyFn
+	p2.DiffFn = testDiffFn
+	ctx2 := testContext2(t, &ContextOpts{
+		Module: m2,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p2),
+		},
+		State: state1,
+	})
+
+	if _, err := ctx2.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state2, err := ctx2.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(state2.String())
+	expected := strings.TrimSpace(testTerraformApplyOutputAddStr)
+	if actual != expected {
+		t.Fatalf("bad: \n%s", actual)
+	}
+}
+
 func TestContext2Apply_outputList(t *testing.T) {
 	m := testModule(t, "apply-output-list")
 	p := testProvider("aws")

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -575,6 +575,22 @@ Outputs:
 foo_num = 2
 `
 
+const testTerraformApplyOutputAddStr = `
+aws_instance.test.0:
+  ID = foo
+  foo = foo0
+  type = aws_instance
+aws_instance.test.1:
+  ID = foo
+  foo = foo1
+  type = aws_instance
+
+Outputs:
+
+firstOutput = foo0
+secondOutput = foo1
+`
+
 const testTerraformApplyOutputListStr = `
 aws_instance.bar.0:
   ID = foo

--- a/terraform/test-fixtures/apply-output-add-after/main.tf
+++ b/terraform/test-fixtures/apply-output-add-after/main.tf
@@ -1,0 +1,6 @@
+provider "aws" {}
+
+resource "aws_instance" "test" {
+		foo = "${format("foo%d", count.index)}"
+		count = 2
+}

--- a/terraform/test-fixtures/apply-output-add-after/outputs.tf.json
+++ b/terraform/test-fixtures/apply-output-add-after/outputs.tf.json
@@ -1,0 +1,10 @@
+{
+		"output": {
+				"firstOutput": {
+						"value": "${aws_instance.test.0.foo}"
+				},
+				"secondOutput": {
+						"value": "${aws_instance.test.1.foo}"
+				}
+		}
+}

--- a/terraform/test-fixtures/apply-output-add-before/main.tf
+++ b/terraform/test-fixtures/apply-output-add-before/main.tf
@@ -1,0 +1,6 @@
+provider "aws" {}
+
+resource "aws_instance" "test" {
+		foo = "${format("foo%d", count.index)}"
+		count = 2
+}

--- a/terraform/test-fixtures/apply-output-add-before/outputs.tf.json
+++ b/terraform/test-fixtures/apply-output-add-before/outputs.tf.json
@@ -1,0 +1,7 @@
+{
+		"output": {
+				"firstOutput": {
+						"value": "${aws_instance.test.0.foo}"
+				}
+		}
+}


### PR DESCRIPTION
This test attempts to reproduce the issue described in #2598 whereby outputs added after an apply are not reflected in the output. As per the issue the outputs are described using the JSON syntax.

The test does not reproduce the issue, leading me to believe the observed effects are likely due to something deeper inside state handling.