### PR TITLE
ssh: accept private key contents instead of path

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -93,7 +93,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 				"  SSH Agent: %t",
 			c.connInfo.Host, c.connInfo.User,
 			c.connInfo.Password != "",
-			c.connInfo.KeyFile != "",
+			c.connInfo.PrivateKey != "",
 			c.connInfo.Agent,
 		))
 
@@ -107,7 +107,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 					"  SSH Agent: %t",
 				c.connInfo.BastionHost, c.connInfo.BastionUser,
 				c.connInfo.BastionPassword != "",
-				c.connInfo.BastionKeyFile != "",
+				c.connInfo.BastionPrivateKey != "",
 				c.connInfo.Agent,
 			))
 		}

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -10,13 +10,13 @@ func TestProvisioner_connInfo(t *testing.T) {
 	r := &terraform.InstanceState{
 		Ephemeral: terraform.EphemeralState{
 			ConnInfo: map[string]string{
-				"type":     "ssh",
-				"user":     "root",
-				"password": "supersecret",
-				"key_file": "/my/key/file.pem",
-				"host":     "127.0.0.1",
-				"port":     "22",
-				"timeout":  "30s",
+				"type":        "ssh",
+				"user":        "root",
+				"password":    "supersecret",
+				"private_key": "someprivatekeycontents",
+				"host":        "127.0.0.1",
+				"port":        "22",
+				"timeout":     "30s",
 
 				"bastion_host": "127.0.1.1",
 			},
@@ -34,7 +34,7 @@ func TestProvisioner_connInfo(t *testing.T) {
 	if conf.Password != "supersecret" {
 		t.Fatalf("bad: %v", conf)
 	}
-	if conf.KeyFile != "/my/key/file.pem" {
+	if conf.PrivateKey != "someprivatekeycontents" {
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.Host != "127.0.0.1" {
@@ -61,7 +61,31 @@ func TestProvisioner_connInfo(t *testing.T) {
 	if conf.BastionPassword != "supersecret" {
 		t.Fatalf("bad: %v", conf)
 	}
-	if conf.BastionKeyFile != "/my/key/file.pem" {
+	if conf.BastionPrivateKey != "someprivatekeycontents" {
+		t.Fatalf("bad: %v", conf)
+	}
+}
+
+func TestProvisioner_connInfoLegacy(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":         "ssh",
+				"key_file":     "/my/key/file.pem",
+				"bastion_host": "127.0.1.1",
+			},
+		},
+	}
+
+	conf, err := parseConnectionInfo(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if conf.PrivateKey != "/my/key/file.pem" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPrivateKey != "/my/key/file.pem" {
 		t.Fatalf("bad: %v", conf)
 	}
 }

--- a/helper/pathorcontents/read.go
+++ b/helper/pathorcontents/read.go
@@ -1,0 +1,40 @@
+// Helpers for dealing with file paths and their contents
+package pathorcontents
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// If the argument is a path, Read loads it and returns the contents,
+// otherwise the argument is assumed to be the desired contents and is simply
+// returned.
+//
+// The boolean second return value can be called `wasPath` - it indicates if a
+// path was detected and a file loaded.
+func Read(poc string) (string, bool, error) {
+	if len(poc) == 0 {
+		return poc, false, nil
+	}
+
+	path := poc
+	if path[0] == '~' {
+		var err error
+		path, err = homedir.Expand(path)
+		if err != nil {
+			return path, true, err
+		}
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return string(contents), true, err
+		}
+		return string(contents), true, nil
+	}
+
+	return poc, false, nil
+}

--- a/helper/pathorcontents/read_test.go
+++ b/helper/pathorcontents/read_test.go
@@ -1,0 +1,140 @@
+package pathorcontents
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+func TestRead_Path(t *testing.T) {
+	isPath := true
+	f, cleanup := testTempFile(t)
+	defer cleanup()
+
+	if _, err := io.WriteString(f, "foobar"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	f.Close()
+
+	contents, wasPath, err := Read(f.Name())
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if wasPath != isPath {
+		t.Fatalf("expected wasPath: %t, got %t", isPath, wasPath)
+	}
+	if contents != "foobar" {
+		t.Fatalf("expected contents %s, got %s", "foobar", contents)
+	}
+}
+
+func TestRead_TildePath(t *testing.T) {
+	isPath := true
+	home, err := homedir.Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	f, cleanup := testTempFile(t, home)
+	defer cleanup()
+
+	if _, err := io.WriteString(f, "foobar"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	f.Close()
+
+	r := strings.NewReplacer(home, "~")
+	homePath := r.Replace(f.Name())
+	contents, wasPath, err := Read(homePath)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if wasPath != isPath {
+		t.Fatalf("expected wasPath: %t, got %t", isPath, wasPath)
+	}
+	if contents != "foobar" {
+		t.Fatalf("expected contents %s, got %s", "foobar", contents)
+	}
+}
+
+func TestRead_PathNoPermission(t *testing.T) {
+	isPath := true
+	f, cleanup := testTempFile(t)
+	defer cleanup()
+
+	if _, err := io.WriteString(f, "foobar"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	f.Close()
+
+	if err := os.Chmod(f.Name(), 0); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	contents, wasPath, err := Read(f.Name())
+
+	if err == nil {
+		t.Fatal("Expected error, got none!")
+	}
+	if wasPath != isPath {
+		t.Fatalf("expected wasPath: %t, got %t", isPath, wasPath)
+	}
+	if contents != "" {
+		t.Fatalf("expected contents %s, got %s", "", contents)
+	}
+}
+
+func TestRead_Contents(t *testing.T) {
+	isPath := false
+	input := "hello"
+
+	contents, wasPath, err := Read(input)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if wasPath != isPath {
+		t.Fatalf("expected wasPath: %t, got %t", isPath, wasPath)
+	}
+	if contents != input {
+		t.Fatalf("expected contents %s, got %s", input, contents)
+	}
+}
+
+func TestRead_TildeContents(t *testing.T) {
+	isPath := false
+	input := "~/hello/notafile"
+
+	contents, wasPath, err := Read(input)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if wasPath != isPath {
+		t.Fatalf("expected wasPath: %t, got %t", isPath, wasPath)
+	}
+	if contents != input {
+		t.Fatalf("expected contents %s, got %s", input, contents)
+	}
+}
+
+// Returns an open tempfile based at baseDir and a function to clean it up.
+func testTempFile(t *testing.T, baseDir ...string) (*os.File, func()) {
+	base := ""
+	if len(baseDir) == 1 {
+		base = baseDir[0]
+	}
+	f, err := ioutil.TempFile(base, "tf")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return f, func() {
+		os.Remove(f.Name())
+	}
+}

--- a/website/source/docs/provisioners/connection.html.markdown
+++ b/website/source/docs/provisioners/connection.html.markdown
@@ -68,8 +68,10 @@ provisioner "file" {
 
 **Additional arguments only supported by the "ssh" connection type:**
 
-* `key_file` - The SSH key to use for the connection. This takes preference over the
-  password if provided.
+* `private_key` - The contents of an SSH key to use for the connection. These can
+  be loaded from a file on disk using the [`file()` interpolation
+  function](/docs/configuration/interpolation.html#file_path_). This takes
+  preference over the password if provided.
 
 * `agent` - Set to false to disable using ssh-agent to authenticate.
 
@@ -99,5 +101,22 @@ The `ssh` connection additionally supports the following fields to facilitate a
 * `bastion_password` - The password we should use for the bastion host.
   Defaults to the value of `password`.
 
-* `bastion_key_file` - The SSH key to use for the bastion host. Defaults to the
-  value of `key_file`.
+* `bastion_private_key` - The contents of an SSH key file to use for the bastion
+  host. These can be loaded from a file on disk using the [`file()`
+  interpolation function](/docs/configuration/interpolation.html#file_path_).
+  Defaults to the value of `private_key`.
+
+## Deprecations
+
+These are supported for backwards compatibility and may be removed in a
+future version:
+
+* `key_file` - A path to or the contents of an SSH key to use for the
+  connection. These can be loaded from a file on disk using the [`file()`
+  interpolation function](/docs/configuration/interpolation.html#file_path_).
+  This takes preference over the password if provided.
+
+* `bastion_key_file` - The contents of an SSH key file to use for the bastion
+  host. These can be loaded from a file on disk using the [`file()`
+  interpolation function](/docs/configuration/interpolation.html#file_path_).
+  Defaults to the value of `key_file`.


### PR DESCRIPTION
We've been moving in the direction of pushing away from config fields
expecting file paths that Terraform will load, instead prefering fields
that expect file contents, leaning on `file()` to do loading from a
path.

This helps with consistency and also flexibility - since this makes it
easier to shift sensitive files into environment variables.

Here we add a little helper package to manage the transitional period
for these fields where we support both behaviors.

These fields already had this behavior, just got to move to a shared
implementation:

 * provider/azure: settings_file
 * provider/google: account_file

These fields move to the new contents-preferrred
path-supported-but-deprecated behavior:

 * provisioner/chef: validation_key and secret_key
 * connection/ssh: key_file