### PR TITLE
Add queued as a pending state for Packet provider.

### DIFF
--- a/builtin/providers/packet/resource_packet_device.go
+++ b/builtin/providers/packet/resource_packet_device.go
@@ -158,7 +158,7 @@ func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[INFO] Device ID: %s", d.Id())
 
-	_, err = WaitForDeviceAttribute(d, "active", []string{"provisioning"}, "state", meta)
+	_, err = WaitForDeviceAttribute(d, "active", []string{"queued", "provisioning"}, "state", meta)
 	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for device (%s) to become ready: %s", d.Id(), err)


### PR DESCRIPTION
When provisioning a bunch of Packet devices at once, some of them may be seen in a state called `queued`, which is totally normal and shouldn't cause an error.