### PR TITLE
provider/aws: Fix error format in Kinesis Firehose

### DIFF
--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -192,7 +192,7 @@ func resourceAwsKinesisFirehoseDeliveryStreamUpdate(d *schema.ResourceData, meta
 	_, err := conn.UpdateDestination(destOpts)
 	if err != nil {
 		return fmt.Errorf(
-			"Error Updating Kinesis Firehose Delivery Stream: %s",
+			"Error Updating Kinesis Firehose Delivery Stream: \"%s\"\n%s",
 			sn, err)
 	}
 


### PR DESCRIPTION
Fixes a `go vet` warning introduced by #3849 .