### PR TITLE
Build using `make test` on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ go:
 install: make updatedeps
 
 script:
-  - go test ./...
-  - make vet
-  #- go test -race ./...
+  - make test
 
 branches:
   only:


### PR DESCRIPTION
This leaves us with fewer moving parts, since `make test` now runs vet anyway.