### PR TITLE
Clear up `destroy --target` message

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -111,11 +111,27 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 	if !destroyForce && c.Destroy {
+		// Default destroy message
+		desc := "Terraform will delete all your managed infrastructure.\n" +
+			"There is no undo. Only 'yes' will be accepted to confirm."
+
+		// If targets are specified, list those to user
+		if c.Meta.targets != nil {
+			var descBuffer bytes.Buffer
+			descBuffer.WriteString("Terraform will delete the following infrastructure:\n")
+			for _, target := range c.Meta.targets {
+				descBuffer.WriteString("\t")
+				descBuffer.WriteString(target)
+				descBuffer.WriteString("\n")
+			}
+			descBuffer.WriteString("There is no undo. Only 'yes' will be accepted to confirm")
+			desc = descBuffer.String()
+		}
+
 		v, err := c.UIInput().Input(&terraform.InputOpts{
-			Id:    "destroy",
-			Query: "Do you really want to destroy?",
-			Description: "Terraform will delete all your managed infrastructure.\n" +
-				"There is no undo. Only 'yes' will be accepted to confirm.",
+			Id:          "destroy",
+			Query:       "Do you really want to destroy?",
+			Description: desc,
 		})
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error asking for confirmation: %s", err))


### PR DESCRIPTION
When destroying infrastructure with `--target`, print out which
infrastructure will be destroyed instead of saying `Terraform will
delete all your managed infrastructure`.

```
 terraform destroy --target aws_instance.test2 --target aws_instance.test1
Do you really want to destroy?
  Terraform will delete the following infrastructure:
        aws_instance.test2
        aws_instance.test1
  There is no undo. Only 'yes' will be accepted to confirm
```

Omitting `--target` arguments will use the default input description.

```
$ terraform destroy
Do you really want to destroy?
  Terraform will delete all your managed infrastructure.
  There is no undo. Only 'yes' will be accepted to confirm.
```

Fixes #3585 