### PR TITLE
providers/aws: Fix issue with removing access_logs from ELB

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -239,24 +239,21 @@ func expandElastiCacheParameters(configured []interface{}) ([]*elasticache.Param
 }
 
 // Flattens an access log into something that flatmap.Flatten() can handle
-func flattenAccessLog(log *elb.AccessLog) []map[string]interface{} {
+func flattenAccessLog(l *elb.AccessLog) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
 
-	if log != nil {
+	if l != nil && *l.Enabled {
 		r := make(map[string]interface{})
-		// enabled is the only value we can rely on to not be nil
-		r["enabled"] = *log.Enabled
-
-		if log.S3BucketName != nil {
-			r["bucket"] = *log.S3BucketName
+		if l.S3BucketName != nil {
+			r["bucket"] = *l.S3BucketName
 		}
 
-		if log.S3BucketPrefix != nil {
-			r["bucket_prefix"] = *log.S3BucketPrefix
+		if l.S3BucketPrefix != nil {
+			r["bucket_prefix"] = *l.S3BucketPrefix
 		}
 
-		if log.EmitInterval != nil {
-			r["interval"] = *log.EmitInterval
+		if l.EmitInterval != nil {
+			r["interval"] = *l.EmitInterval
 		}
 
 		result = append(result, r)


### PR DESCRIPTION
This commit (https://github.com/hashicorp/terraform/commit/8c32536f3dbe1733e6685f9b908c6645ad186170) introduced a regression in the EBL AccessLog feature. Thankfully the acceptance test covered this, however, I mistakenly did not run it after making that _seemingly_ innocuous change. 

When _removing_ an `access_log` block from an ELB, we were attempting to set a slice of length 1, the only element of which was actually an empty element. `d.Set` did not like this, and threw an error. Now, if the access logs are disabled (`Enabled: false`) we do not create the element, and just return an empty slice, which `d.Set` is fine with, and we get the behavior we expect. 