### PR TITLE
add example of redrive_policy #2711

### DIFF
--- a/website/source/docs/providers/aws/r/sqs_queue.html.markdown
+++ b/website/source/docs/providers/aws/r/sqs_queue.html.markdown
@@ -17,6 +17,7 @@ resource "aws_sqs_queue" "terraform_queue" {
   max_message_size = 2048
   message_retention_seconds = 86400
   receive_wait_time_seconds = 10
+  redrive_policy = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.terraform_queue_deadletter.arn}\",\"maxReceiveCount\":4}"
 }
 ```
 


### PR DESCRIPTION
took a painful amount of webhunting/trial/error for me to get the escaping/quoting just right for redrive_policy.  I think an example in the docs would save others some time.