### PR TITLE
Align IAM version number to the current version (2012-10-17)

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_service_test.go
@@ -319,7 +319,7 @@ resource "aws_iam_role" "ecs_service" {
     name = "EcsService"
     assume_role_policy = <<EOF
 {
-    "Version": "2008-10-17",
+    "Version": "2012-10-17",
     "Statement": [
         {
             "Action": "sts:AssumeRole",

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -430,7 +430,7 @@ func testAccCheckAWSS3BucketCors(n string, corsRules []*s3.CORSRule) resource.Te
 // within AWS
 var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 var testAccWebsiteEndpoint = fmt.Sprintf("tf-test-bucket-%d.s3-website-us-west-2.amazonaws.com", randInt)
-var testAccAWSS3BucketPolicy = fmt.Sprintf(`{ "Version": "2008-10-17", "Statement": [ { "Sid": "", "Effect": "Allow", "Principal": { "AWS": "*" }, "Action": "s3:GetObject", "Resource": "arn:aws:s3:::tf-test-bucket-%d/*" } ] }`, randInt)
+var testAccAWSS3BucketPolicy = fmt.Sprintf(`{ "Version": "2012-10-17", "Statement": [ { "Sid": "", "Effect": "Allow", "Principal": { "AWS": "*" }, "Action": "s3:GetObject", "Resource": "arn:aws:s3:::tf-test-bucket-%d/*" } ] }`, randInt)
 
 var testAccAWSS3BucketConfig = fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {

--- a/builtin/providers/aws/resource_aws_sns_topic_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_test.go
@@ -128,7 +128,7 @@ resource "aws_sns_topic" "test_topic" {
   name = "example"
   policy = <<EOF
 {
-  "Version": "2008-10-17",
+  "Version": "2012-10-17",
   "Id": "Policy1445931846145",
   "Statement": [
     {

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
@@ -136,7 +136,7 @@ resource "aws_vpc_endpoint" "second-private-s3" {
     route_table_ids = ["${aws_route_table.default.id}"]
     policy = <<POLICY
 {
-	"Version": "2008-10-17",
+	"Version": "2012-10-17",
 	"Statement": [
 		{
 			"Sid":"AllowAll",
@@ -176,7 +176,7 @@ resource "aws_vpc_endpoint" "second-private-s3" {
     route_table_ids = ["${aws_route_table.default.id}"]
     policy = <<POLICY
 {
-	"Version": "2008-10-17",
+	"Version": "2012-10-17",
 	"Statement": [
 		{
 			"Sid":"AllowAll",

--- a/examples/aws-s3-cross-account-access/main.tf
+++ b/examples/aws-s3-cross-account-access/main.tf
@@ -13,7 +13,7 @@ resource "aws_s3_bucket" "prod" {
   acl = "private"
   policy = <<POLICY
 {
-  "Version": "2008-10-17",
+  "Version": "2012-10-17",
   "Statement": [
     {
       "Sid": "AllowTest",

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -23,7 +23,7 @@ resource "aws_iam_role" "role" {
     path = "/"
     assume_role_policy = <<EOF
 {
-    "Version": "2008-10-17",
+    "Version": "2012-10-17",
     "Statement": [
         {
             "Action": "sts:AssumeRole",


### PR DESCRIPTION
As per AWS [docs](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Version),

>The `Version` element specifies the policy language version. The only allowed values are these:
>
>* `2012-10-17`. This is the current version of the policy language, and you should use this version number for all policies.
>* `2008-10-17`. This was an earlier version of the policy language. You might see this version on existing policies. Do not use this version for any new policies or any existing policies that you are updating.
