### PR TITLE
providers/aws: Document and validate ELB ssl_cert and protocol require

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -44,7 +44,23 @@ func expandListeners(configured []interface{}) ([]*elb.Listener, error) {
 			l.SSLCertificateId = aws.String(v.(string))
 		}
 
-		listeners = append(listeners, l)
+                var valid bool
+                if l.SSLCertificateId != nil && *l.SSLCertificateId != "" {
+                        // validate the protocol is correct
+                        for _, p := range []string{"https", "ssl"} {
+                                if (*l.InstanceProtocol == p) || (*l.Protocol == p) {
+                                        valid = true
+                                }
+                        }
+                } else {
+                        valid = true
+                }
+
+                if valid {
+                        listeners = append(listeners, l)
+                } else {
+                        return nil, fmt.Errorf("[ERR] Invalid ssl_certificate_id / Protocol combination. Must be either HTTPS or SSL")
+                }
 	}
 
 	return listeners, nil

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -59,9 +59,9 @@ func expandListeners(configured []interface{}) ([]*elb.Listener, error) {
                 if valid {
                         listeners = append(listeners, l)
                 } else {
-                        return nil, fmt.Errorf("[ERR] Invalid ssl_certificate_id / Protocol combination. Must be either HTTPS or SSL")
+                        return nil, fmt.Errorf("[ERR] ELB Listener: ssl_certificate_id may be set only when protocol is 'https' or 'ssl'")
                 }
-	}
+        }
 
 	return listeners, nil
 }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -339,7 +339,7 @@ func TestExpandListeners_invalid(t *testing.T) {
         _, err := expandListeners(expanded)
         if err != nil {
                 // Check the error we got
-                if !strings.Contains(err.Error(), "Protocol combination") {
+                if !strings.Contains(err.Error(), "ssl_certificate_id may be set only when protocol") {
                         t.Fatalf("Got error in TestExpandListeners_invalid, but not what we expected: %s", err)
                 }
         }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"reflect"
+        "strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -314,7 +315,31 @@ func TestExpandListeners(t *testing.T) {
 			listeners[0],
 			expected)
 	}
+}
 
+// this test should produce an error from expandlisteners on an invalid
+// combination
+func TestExpandListeners_invalid(t *testing.T) {
+        expanded := []interface{}{
+                map[string]interface{}{
+                        "instance_port":      8000,
+                        "lb_port":            80,
+                        "instance_protocol":  "http",
+                        "lb_protocol":        "http",
+                        "ssl_certificate_id": "something",
+                },
+        }
+        _, err := expandListeners(expanded)
+        if err != nil {
+                // Check the error we got
+                if !strings.Contains(err.Error(), "Protocol combination") {
+                        t.Fatalf("Got error in TestExpandListeners_invalid, but not what we expected: %s", err)
+                }
+        }
+
+        if err == nil {
+                t.Fatalf("Expected TestExpandListeners_invalid to fail, but passed")
+        }
 }
 
 func TestFlattenHealthCheck(t *testing.T) {

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -296,6 +296,13 @@ func TestExpandListeners(t *testing.T) {
 			"instance_protocol": "http",
 			"lb_protocol":       "http",
 		},
+                map[string]interface{}{
+                        "instance_port":      8000,
+                        "lb_port":            80,
+                        "instance_protocol":  "https",
+                        "lb_protocol":        "https",
+                        "ssl_certificate_id": "something",
+                },
 	}
 	listeners, err := expandListeners(expanded)
 	if err != nil {

--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -33,7 +33,7 @@ resource "aws_elb" "bar" {
 
   listener {
     instance_port = 8000
-    instance_protocol = "http"
+    instance_protocol = "https"
     lb_port = 443
     lb_protocol = "https"
     ssl_certificate_id = "arn:aws:iam::123456789012:server-certificate/certName"
@@ -90,10 +90,14 @@ Access Logs support the following:
 Listeners support the following:
 
 * `instance_port` - (Required) The port on the instance to route to
-* `instance_protocol` - (Required) The protocol to use to the instance.
+* `instance_protocol` - (Required) The protocol to use to the instance. Valid
+  values are `HTTP`, `HTTPS`, `TCP`, or `SSL`
 * `lb_port` - (Required) The port to listen on for the load balancer
-* `lb_protocol` - (Required) The protocol to listen on.
-* `ssl_certificate_id` - (Optional) The id of an SSL certificate you have uploaded to AWS IAM.
+* `lb_protocol` - (Required) The protocol to listen on. Valid values are `HTTP`,
+  `HTTPS`, `TCP`, or `SSL`
+* `ssl_certificate_id` - (Optional) The id of an SSL certificate you have
+uploaded to AWS IAM. **Only valid when `instance_protocol` and
+  `lb_protocol` are either HTTPS or SSL**
 
 Health Check supports the following:
 


### PR DESCRIPTION
While not [explicitly documented][1], the `ssl_certificate_id` attribute of an ELB Listener is only valid if the protocols are either `SSL` or `HTTPS`. If you include `ssl_certificate_id` in a listener of any other protocol, AWS will not return an error, however, follow up `terraform plan` will reveal that the `Listener` returned will have had it's `ssl_certificate_id` omitted. 

For example:

```hcl
resource "aws_elb" "ourapp" {
  name = "terraform-asg-deployment-example"
  availability_zones = ["us-west-2a"]
  cross_zone_load_balancing = true

  listener {
    instance_port = 443
    instance_protocol = "tcp"
    lb_port = 443
    lb_protocol = "tcp"
    ssl_certificate_id = "<some cert arn>" # assume valid cert
  }
}
```

This will succeed, however, the state file will have an empty `ssl_certificate_id`:

```
listener.# = 1
  listener.610193557.instance_port = 443
  listener.610193557.instance_protocol = tcp
  listener.610193557.lb_port = 443
  listener.610193557.lb_protocol = tcp
  listener.610193557.ssl_certificate_id =
```

which gives us a `plan` loop:

```
~ aws_elb.ourapp
    listener.610193557.instance_port:      "443" => "0"
    listener.610193557.instance_protocol:  "tcp" => ""
    listener.610193557.lb_port:            "443" => "0"
    listener.610193557.lb_protocol:        "tcp" => ""
    listener.610193557.ssl_certificate_id: "" => ""
    listener.613970091.instance_port:      "" => "443"
    listener.613970091.instance_protocol:  "" => "tcp"
    listener.613970091.lb_port:            "" => "443"
    listener.613970091.lb_protocol:        "" => "tcp"
    listener.613970091.ssl_certificate_id: "" => "<some cert arn>"
```

With this PR, we get a validation error in Terraform:

```
1 error(s) occurred:

* aws_elb.ourapp: [ERR] Invalid ssl_certificate_id / Protocol combination. Must be either HTTPS or SSL
```

This PR is built off of #3863


[1]: http://docs.aws.amazon.com/fr_fr/ElasticLoadBalancing/latest/DeveloperGuide/elb-listener-config.html#https-ssl-listeners