### PR TITLE
provider/google: Fix instance group manager instance restart policy

### DIFF
--- a/builtin/providers/google/compute_operation.go
+++ b/builtin/providers/google/compute_operation.go
@@ -134,6 +134,10 @@ func computeOperationWaitRegion(config *Config, op *compute.Operation, region, a
 }
 
 func computeOperationWaitZone(config *Config, op *compute.Operation, zone, activity string) error {
+	return computeOperationWaitZoneTime(config, op, zone, 4, activity)
+}
+
+func computeOperationWaitZoneTime(config *Config, op *compute.Operation, zone string, minutes int, activity string) error {
 	w := &ComputeOperationWaiter{
 		Service: config.clientCompute,
 		Op:      op,
@@ -143,7 +147,7 @@ func computeOperationWaitZone(config *Config, op *compute.Operation, zone, activ
 	}
 	state := w.Conf()
 	state.Delay = 10 * time.Second
-	state.Timeout = 4 * time.Minute
+	state.Timeout = time.Duration(minutes) * time.Minute
 	state.MinTimeout = 2 * time.Second
 	opRaw, err := state.WaitForState()
 	if err != nil {

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -53,6 +53,12 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Required: true,
 			},
 
+			"update_strategy": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "RESTART",
+			},
+
 			"target_pools": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -110,6 +116,11 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 			s = append(s, v.(string))
 		}
 		manager.TargetPools = s
+	}
+
+	updateStrategy := d.Get("update_strategy").(string)
+	if !(updateStrategy == "NONE" || updateStrategy == "RESTART") {
+		return fmt.Errorf("Update strategy must be \"NONE\" or \"RESTART\"")
 	}
 
 	log.Printf("[DEBUG] InstanceGroupManager insert request: %#v", manager)
@@ -207,6 +218,35 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Updating InstanceGroupManager")
 		if err != nil {
 			return err
+		}
+
+		if d.Get("update_strategy").(string) == "RESTART" {
+			managedInstances, err := config.clientCompute.InstanceGroupManagers.ListManagedInstances(
+				config.Project, d.Get("zone").(string), d.Id()).Do()
+
+			managedInstanceCount := len(managedInstances.ManagedInstances)
+			instances := make([]string, managedInstanceCount)
+			for i, v := range managedInstances.ManagedInstances {
+				instances[i] = v.Instance
+			}
+
+			recreateInstances := &compute.InstanceGroupManagersRecreateInstancesRequest{
+				Instances: instances,
+			}
+
+			op, err = config.clientCompute.InstanceGroupManagers.RecreateInstances(
+				config.Project, d.Get("zone").(string), d.Id(), recreateInstances).Do()
+
+			if err != nil {
+				return fmt.Errorf("Error restarting instance group managers instances: %s", err)
+			}
+
+			// Wait for the operation to complete
+			err = computeOperationWaitZoneTime(config, op, d.Get("zone").(string),
+				managedInstanceCount * 4, "Restarting InstanceGroupManagers instances")
+			if err != nil {
+				return err
+			}
 		}
 
 		d.SetPartial("instance_template")

--- a/website/source/docs/providers/google/r/compute_instance_group_manager.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_group_manager.html.markdown
@@ -20,6 +20,7 @@ resource "google_compute_instance_group_manager" "foobar" {
 	description = "Terraform test instance group manager"
 	name = "terraform-test"
 	instance_template = "${google_compute_instance_template.foobar.self_link}"
+	update_strategy= "NONE"
 	target_pools = ["${google_compute_target_pool.foobar.self_link}"]
 	base_instance_name = "foobar"
 	zone = "us-central1-a"
@@ -41,7 +42,13 @@ instance name.
 group manager.
 
 * `instance_template` - (Required) The full URL to an instance template from
-which all new instances will be created.
+which all new instances will be created. 
+
+* `update_strategy` - (Optional, Default `"RESTART"`) If the `instance_template` resource is
+modified, a value of `"NONE"` will prevent any of the managed instances from
+being restarted by Terraform. A value of `"RESTART"` will restart all of the 
+instances at once. In the future, as the GCE API matures we will support
+`"ROLLING_UPDATE"` as well.
 
 * `name` - (Required) The name of the instance group manager. Must be 1-63
 characters long and comply with [RFC1035](https://www.ietf.org/rfc/rfc1035.txt).


### PR DESCRIPTION
As pointed out in #3875, `instance_group_manager` does not restart instances on an `instance_template` change. Since some people might not want this behavior, I added a `update_strategy` field to allow `instance_template` changes to avoid restarting instances (see the options [here](https://github.com/lwander/terraform/blob/7be90215bcf00b05d7b7d14ebcee60cc39bfeeee/website/source/docs/providers/google/r/compute_instance_group_manager.html.markdown)). @jen20 @sparkprime @premist