### PR TITLE
provider/azure: read publish_settings as contents instead of path

### DIFF
--- a/builtin/providers/azure/provider_test.go
+++ b/builtin/providers/azure/provider_test.go
@@ -51,12 +51,12 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("AZURE_SETTINGS_FILE"); v == "" {
+	if v := os.Getenv("AZURE_PUBLISH_SETTINGS"); v == "" {
 		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
 		certificate := os.Getenv("AZURE_CERTIFICATE")
 
 		if subscriptionID == "" || certificate == "" {
-			t.Fatal("either AZURE_SETTINGS_FILE, or AZURE_SUBSCRIPTION_ID " +
+			t.Fatal("either AZURE_PUBLISH_SETTINGS, or AZURE_SUBSCRIPTION_ID " +
 				"and AZURE_CERTIFICATE must be set for acceptance tests")
 		}
 	}
@@ -78,6 +78,11 @@ func TestAzure_validateSettingsFile(t *testing.T) {
 		t.Fatalf("Error creating temporary file with XML in TestAzure_validateSettingsFile: %s", err)
 	}
 	defer os.Remove(fx.Name())
+	_, err = io.WriteString(fx, "<PublishData></PublishData>")
+	if err != nil {
+		t.Fatalf("Error writing XML File: %s", err)
+	}
+	fx.Close()
 
 	home, err := homedir.Dir()
 	if err != nil {
@@ -88,12 +93,11 @@ func TestAzure_validateSettingsFile(t *testing.T) {
 		t.Fatalf("Error creating homedir-based temporary file: %s", err)
 	}
 	defer os.Remove(fh.Name())
-
-	_, err = io.WriteString(fx, "<PublishData></PublishData>")
+	_, err = io.WriteString(fh, "<PublishData></PublishData>")
 	if err != nil {
 		t.Fatalf("Error writing XML File: %s", err)
 	}
-	fx.Close()
+	fh.Close()
 
 	r := strings.NewReplacer(home, "~")
 	homePath := r.Replace(fh.Name())
@@ -103,8 +107,8 @@ func TestAzure_validateSettingsFile(t *testing.T) {
 		W     int    // expected count of warnings
 		E     int    // expected count of errors
 	}{
-		{"test", 1, 1},
-		{f.Name(), 1, 0},
+		{"test", 0, 1},
+		{f.Name(), 1, 1},
 		{fx.Name(), 1, 0},
 		{homePath, 1, 0},
 		{"<PublishData></PublishData>", 0, 0},
@@ -114,10 +118,10 @@ func TestAzure_validateSettingsFile(t *testing.T) {
 		w, e := validateSettingsFile(tc.Input, "")
 
 		if len(w) != tc.W {
-			t.Errorf("Error in TestAzureValidateSettingsFile: input: %s , warnings: %#v, errors: %#v", tc.Input, w, e)
+			t.Errorf("Error in TestAzureValidateSettingsFile: input: %s , warnings: %v, errors: %v", tc.Input, w, e)
 		}
 		if len(e) != tc.E {
-			t.Errorf("Error in TestAzureValidateSettingsFile: input: %s , warnings: %#v, errors: %#v", tc.Input, w, e)
+			t.Errorf("Error in TestAzureValidateSettingsFile: input: %s , warnings: %v, errors: %v", tc.Input, w, e)
 		}
 	}
 }
@@ -164,33 +168,8 @@ func TestAzure_providerConfigure(t *testing.T) {
 		err = rp.Configure(terraform.NewResourceConfig(rawConfig))
 		meta := rp.(*schema.Provider).Meta()
 		if (meta == nil) != tc.NilMeta {
-			t.Fatalf("expected NilMeta: %t, got meta: %#v", tc.NilMeta, meta)
-		}
-	}
-}
-
-func TestAzure_isFile(t *testing.T) {
-	f, err := ioutil.TempFile("", "tf-test-file")
-	if err != nil {
-		t.Fatalf("Error creating temporary file with XML in TestAzure_isFile: %s", err)
-	}
-	cases := []struct {
-		Input string // String path to file
-		B     bool   // expected true/false
-		E     bool   // expect error
-	}{
-		{"test", false, true},
-		{f.Name(), true, false},
-	}
-
-	for _, tc := range cases {
-		x, y := isFile(tc.Input)
-		if tc.B != x {
-			t.Errorf("Error in TestAzure_isFile: input: %s , returned: %#v, expected: %#v", tc.Input, x, tc.B)
-		}
-
-		if tc.E != (y != nil) {
-			t.Errorf("Error in TestAzure_isFile: input: %s , returned: %#v, expected: %#v", tc.Input, y, tc.E)
+			t.Fatalf("expected NilMeta: %t, got meta: %#v, settings_file: %q",
+				tc.NilMeta, meta, tc.SettingsFile)
 		}
 	}
 }

--- a/website/source/docs/providers/azure/index.html.markdown
+++ b/website/source/docs/providers/azure/index.html.markdown
@@ -33,11 +33,11 @@ resource "azure_instance" "web" {
 
 The following arguments are supported:
 
-* `settings_file` - (Optional) Contents of a valid `publishsettings` file, used to
-  authenticate with the Azure API. You can download the settings file here:
-  https://manage.windowsazure.com/publishsettings. You must either provide
-  (or source from the `AZURE_SETTINGS_FILE` environment variable) a settings
-  file or both a `subscription_id` and `certificate`.
+* `publish_settings` - (Optional) Contents of a valid `publishsettings` file,
+  used to authenticate with the Azure API. You can download the settings file
+  here: https://manage.windowsazure.com/publishsettings. You must either
+  provide publish settings or both a `subscription_id` and `certificate`. It
+  can also be sourced from the `AZURE_PUBLISH_SETTINGS` environment variable.
 
 * `subscription_id` - (Optional) The subscription ID to use. If a
   `settings_file` is not provided `subscription_id` is required. It can also
@@ -46,6 +46,16 @@ The following arguments are supported:
 * `certificate` - (Optional) The certificate used to authenticate with the
   Azure API. If a `settings_file` is not provided `certificate` is required.
   It can also be sourced from the `AZURE_CERTIFICATE` environment variable.
+
+These arguments are supported for backwards compatibility, and may be removed
+in a future version:
+
+* `settings_file` - __Deprecated: please use `publish_settings` instead.__
+  Path to or contents of a valid `publishsettings` file, used to
+  authenticate with the Azure API. You can download the settings file here:
+  https://manage.windowsazure.com/publishsettings. You must either provide
+  (or source from the `AZURE_SETTINGS_FILE` environment variable) a settings
+  file or both a `subscription_id` and `certificate`.
 
 ## Testing:
 


### PR DESCRIPTION
Building on the work in #3846, shifting the Azure provider's
configuration option from `settings_file` to `publish_settings`.