### PR TITLE
provider/aws: fix for creating failover route53 records

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -417,7 +417,10 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 
 	if v, ok := d.GetOk("set_identifier"); ok {
 		rec.SetIdentifier = aws.String(v.(string))
-		rec.Weight = aws.Int64(int64(d.Get("weight").(int)))
+	}
+
+	if v, ok := d.GetOk("weight"); ok {
+		rec.Weight = aws.Int64(int64(v.(int)))
 	}
 
 	return rec, nil

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -122,6 +122,23 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Record_failover(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53FailoverCNAMERecord,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.www-primary"),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-secondary"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute53Record_weighted(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -381,6 +398,46 @@ resource "aws_route53_record" "default" {
 	type = "TXT"
 	ttl = "30"
 	records = ["lalalala"]
+}
+`
+
+const testAccRoute53FailoverCNAMERecord = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_health_check" "foo" {
+  fqdn = "dev.notexample.com"
+  port = 80
+  type = "HTTP"
+  resource_path = "/"
+  failure_threshold = "2"
+  request_interval = "30"
+
+  tags = {
+    Name = "tf-test-health-check"
+   }
+}
+
+resource "aws_route53_record" "www-primary" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "CNAME"
+  ttl = "5"
+  failover = "PRIMARY"
+  health_check_id = "${aws_route53_health_check.foo.id}"
+  set_identifier = "www-primary"
+  records = ["primary.notexample.com"]
+}
+
+resource "aws_route53_record" "www-secondary" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "www"
+  type = "CNAME"
+  ttl = "5"
+  failover = "SECONDARY"
+  set_identifier = "www-secondary"
+  records = ["secondary.notexample.com"]
 }
 `
 


### PR DESCRIPTION
I'm not sure when this was changed as this was working some time ago, but we haven't tried in the meantime.

Anyways, when creating a `aws_route53_record` with a failover strategy, we were always sending a `weight`, which AWS would reject with an obtuse `BadRequest`.

I changed the `aws_route53_record` to only send the weight when it's set and all is ok.

```
--- PASS: TestAccAWSRoute53Record_failover (98.90s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	98.912s
```

