### PR TITLE
provider/openstack: Add port id to router interface

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
@@ -33,7 +33,12 @@ func resourceNetworkingRouterInterfaceV2() *schema.Resource {
 			},
 			"subnet_id": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				ForceNew: true,
+			},
+			"port_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 				ForceNew: true,
 			},
 		},
@@ -49,6 +54,7 @@ func resourceNetworkingRouterInterfaceV2Create(d *schema.ResourceData, meta inte
 
 	createOpts := routers.InterfaceOpts{
 		SubnetID: d.Get("subnet_id").(string),
+		PortID:   d.Get("port_id").(string),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -148,6 +154,7 @@ func waitForRouterInterfaceDelete(networkingClient *gophercloud.ServiceClient, d
 
 		removeOpts := routers.InterfaceOpts{
 			SubnetID: d.Get("subnet_id").(string),
+			PortID:   d.Get("port_id").(string),
 		}
 
 		r, err := ports.Get(networkingClient, routerInterfaceId).Extract()

--- a/website/source/docs/providers/openstack/r/networking_router_interface_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_router_interface_v2.html.markdown
@@ -49,7 +49,10 @@ The following arguments are supported:
 * `router_id` - (Required) ID of the router this interface belongs to. Changing
     this creates a new router interface.
 
-* `subnet_id` - (Required) ID of the subnet this interface connects to. Changing
+* `subnet_id` - ID of the subnet this interface connects to. Changing
+    this creates a new router interface.
+
+* `port_id` - ID of the port this interface connects to. Changing
     this creates a new router interface.
 
 ## Attributes Reference
@@ -59,3 +62,4 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `router_id` - See Argument Reference above.
 * `subnet_id` - See Argument Reference above.
+* `port_id` - See Argument Reference above.


### PR DESCRIPTION
This PR adds the ability to specify a router interface with a `port_id`. Tests also included.

Thanks to @Fodoj for this. :smile: 