### PR TITLE
provider/openstack: Make Networking Port attributes more intuitive

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_network_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2_test.go
@@ -148,8 +148,8 @@ func TestAccNetworkingV2Network_fullstack(t *testing.T) {
 			name = "port_1"
 			network_id = "${openstack_networking_network_v2.foo.id}"
 			admin_state_up = "true"
-			security_groups = ["${openstack_compute_secgroup_v2.foo.id}"]
-			fixed_ips {
+			security_group_ids = ["${openstack_compute_secgroup_v2.foo.id}"]
+			fixed_ip {
 				"subnet_id" =  "${openstack_networking_subnet_v2.foo.id}"
 				"ip_address" =  "192.168.199.23"
 			}

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
@@ -40,7 +40,7 @@ func TestAccNetworkingV2Port_basic(t *testing.T) {
 			name = "port_1"
 			network_id = "${openstack_networking_network_v2.foo.id}"
 			admin_state_up = "true"
-			fixed_ips {
+			fixed_ip {
 				subnet_id =  "${openstack_networking_subnet_v2.foo.id}"
 				ip_address = "192.168.199.23"
 			}

--- a/builtin/providers/openstack/resource_openstack_networking_router_interface_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_interface_v2_test.go
@@ -160,7 +160,7 @@ var testAccNetworkingV2RouterInterface_basic_port = fmt.Sprintf(`
 		name = "port_1"
 		network_id = "${openstack_networking_network_v2.network_1.id}"
 		admin_state_up = "true"
-		fixed_ips {
+		fixed_ip {
 			subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 			ip_address = "192.168.199.1"
 		}

--- a/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
@@ -53,17 +53,18 @@ The following arguments are supported:
 * `device_owner` - (Optional) The device owner of the Port. Changing this creates
     a new port.
 
-* `security_groups` - (Optional) A list of security groups to apply to the port.
-    The security groups must be specified by ID and not name (as opposed to how
-    they are configured with the Compute Instance).
+* `security_group_ids` - (Optional) A list of security group IDs to apply to the
+    port. The security groups must be specified by ID and not name (as opposed
+    to how they are configured with the Compute Instance).
 
 * `device_id` - (Optional) The ID of the device attached to the port. Changing this
     creates a new port.
 
-* `fixed_ips` - (Optional) An array of desired IPs for this port. 
+* `fixed_ip` - (Optional) An array of desired IPs for this port. The structure is
+    described below.
 
 
-The `fixed_ips` block supports:
+The `fixed_ip` block supports:
 
 * `subnet_id` - (Required) Subnet in which to allocate IP address for
 this port.


### PR DESCRIPTION
This commit makes some quick updates to the port attributes to make them
more intuitive:

* `security_groups` to `security_group_ids`: since the port is expecting
IDs and not security group names like in other areas of OpenStack.

* `admin_state_up`: change to Boolean to match this same attribute on
other resources.

* `fixed_ips` to `fixed_ip`: while multiple `fixed_ip` blocks can be
specified, only one fixed IP can be specified in each block.