### PR TITLE
provisioner/file: Include content option

### DIFF
--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -2,12 +2,12 @@ package file
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"time"
 
 	"github.com/hashicorp/terraform/communicator"
-	"github.com/hashicorp/terraform/helper/config"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 )
@@ -26,18 +26,13 @@ func (p *ResourceProvisioner) Apply(
 		return err
 	}
 
-	// Get the source and destination
-	sRaw := c.Config["source"]
-	src, ok := sRaw.(string)
-	if !ok {
-		return fmt.Errorf("Unsupported 'source' type! Must be string.")
-	}
-
-	src, err = homedir.Expand(src)
+	// Get the source
+	src, err := p.getSrc(c)
 	if err != nil {
 		return err
 	}
 
+	// Get destination
 	dRaw := c.Config["destination"]
 	dst, ok := dRaw.(string)
 	if !ok {
@@ -48,13 +43,52 @@ func (p *ResourceProvisioner) Apply(
 
 // Validate checks if the required arguments are configured
 func (p *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string, es []error) {
-	v := &config.Validator{
-		Required: []string{
-			"source",
-			"destination",
-		},
+	numDst := 0
+	numSrc := 0
+	for name := range c.Raw {
+		switch name {
+		case "destination":
+			numDst++
+		case "source", "content":
+			numSrc++
+		default:
+			es = append(es, fmt.Errorf("Unknown configuration '%s'", name))
+		}
 	}
-	return v.Validate(c)
+	if numSrc != 1 || numDst != 1 {
+		es = append(es, fmt.Errorf("Must provide one  of 'content' or 'source' and 'destination' to file"))
+	}
+	return
+}
+
+// getSrc returns the file to use as source
+func (p *ResourceProvisioner) getSrc(c *terraform.ResourceConfig) (string, error) {
+	var src string
+
+	sRaw, ok := c.Config["source"]
+	if ok {
+		if src, ok = sRaw.(string); !ok {
+			return "", fmt.Errorf("Unsupported 'source' type! Must be string.")
+		}
+	}
+
+	content, ok := c.Config["content"]
+	if ok {
+		file, err := ioutil.TempFile("", "tf-file-content")
+		if err != nil {
+			return "", err
+		}
+		contentStr, ok := content.(string)
+		if !ok {
+			return "", fmt.Errorf("Unsupported 'content' type! Must be string.")
+		}
+		if _, err = file.WriteString(contentStr); err != nil {
+			return "", err
+		}
+		src = file.Name()
+	}
+
+	return homedir.Expand(src)
 }
 
 // copyFiles is used to copy the files from a source to a destination

--- a/builtin/provisioners/file/resource_provisioner_test.go
+++ b/builtin/provisioners/file/resource_provisioner_test.go
@@ -11,7 +11,7 @@ func TestResourceProvisioner_impl(t *testing.T) {
 	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
 }
 
-func TestResourceProvider_Validate_good(t *testing.T) {
+func TestResourceProvider_Validate_good_source(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source":      "/tmp/foo",
 		"destination": "/tmp/bar",
@@ -26,9 +26,40 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 	}
 }
 
-func TestResourceProvider_Validate_bad(t *testing.T) {
+func TestResourceProvider_Validate_good_content(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"content":     "value to copy",
+		"destination": "/tmp/bar",
+	})
+	p := new(ResourceProvisioner)
+	warn, errs := p.Validate(c)
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("Errors: %v", errs)
+	}
+}
+
+func TestResourceProvider_Validate_bad_not_destination(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source": "nope",
+	})
+	p := new(ResourceProvisioner)
+	warn, errs := p.Validate(c)
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) == 0 {
+		t.Fatalf("Should have errors")
+	}
+}
+
+func TestResourceProvider_Validate_bad_to_many_src(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"source":      "nope",
+		"content":     "value to copy",
+		"destination": "/tmp/bar",
 	})
 	p := new(ResourceProvisioner)
 	warn, errs := p.Validate(c)

--- a/website/source/docs/provisioners/file.html.markdown
+++ b/website/source/docs/provisioners/file.html.markdown
@@ -24,6 +24,12 @@ resource "aws_instance" "web" {
         destination = "/etc/myapp.conf"
     }
 
+    # Copies the string in content into /tmp/file.log
+    provisioner "file" {
+        content = "ami used: ${self.ami}"
+        destination = "/tmp/file.log"
+    }
+
     # Copies the configs.d folder to /etc/configs.d
     provisioner "file" {
         source = "conf/configs.d"
@@ -42,8 +48,14 @@ resource "aws_instance" "web" {
 
 The following arguments are supported:
 
-* `source` - (Required) This is the source file or folder. It can be specified as relative
-  to the current working directory or as an absolute path.
+* `source` - This is the source file or folder. It can be specified as relative
+  to the current working directory or as an absolute path. This cannot be provided with `content`.
+
+* `content` - This is the content to copy on the destination. If destination is a file,
+  the content will be written on that file, in case of a directory a file named
+  *tf-file-content* is created. It's recommended to use a file as destination. A
+  [`template_file`](/docs/providers/template/r/file.html) might be referenced in here, or
+  any interpolation syntax for that matter. This cannot be provided with `source`.
 
 * `destination` - (Required) This is the destination path. It must be specified as an
   absolute path.


### PR DESCRIPTION
- Include new option in file provisioner. Now content or source can be
  provided. Content will create a temp file and copy there the contents. Later that file will be used as source.
- Include test to check that changes are working correctly.

Made this to solve https://github.com/hashicorp/terraform/issues/2342