### PR TITLE
provider/aws: Fix issue with LB Cookie Stickiness and empty expiration period

### DIFF
--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -51,11 +52,15 @@ func resourceAwsLBCookieStickinessPolicyCreate(d *schema.ResourceData, meta inte
 
 	// Provision the LBStickinessPolicy
 	lbspOpts := &elb.CreateLBCookieStickinessPolicyInput{
-		CookieExpirationPeriod: aws.Int64(int64(d.Get("cookie_expiration_period").(int))),
-		LoadBalancerName:       aws.String(d.Get("load_balancer").(string)),
-		PolicyName:             aws.String(d.Get("name").(string)),
+		LoadBalancerName: aws.String(d.Get("load_balancer").(string)),
+		PolicyName:       aws.String(d.Get("name").(string)),
 	}
 
+	if v := d.Get("cookie_expiration_period").(int); v > 0 {
+		lbspOpts.CookieExpirationPeriod = aws.Int64(int64(v))
+	}
+
+	log.Printf("[DEBUG] LB Cookie Stickiness Policy opts: %#v", lbspOpts)
 	if _, err := elbconn.CreateLBCookieStickinessPolicy(lbspOpts); err != nil {
 		return fmt.Errorf("Error creating LBCookieStickinessPolicy: %s", err)
 	}
@@ -66,6 +71,7 @@ func resourceAwsLBCookieStickinessPolicyCreate(d *schema.ResourceData, meta inte
 		PolicyNames:      []*string{aws.String(d.Get("name").(string))},
 	}
 
+	log.Printf("[DEBUG] LB Cookie Stickiness create configuration: %#v", setLoadBalancerOpts)
 	if _, err := elbconn.SetLoadBalancerPoliciesOfListener(setLoadBalancerOpts); err != nil {
 		return fmt.Errorf("Error setting LBCookieStickinessPolicy: %s", err)
 	}

--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -42,6 +42,14 @@ func resourceAwsLBCookieStickinessPolicy() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(int)
+					if value <= 0 {
+						es = append(es, fmt.Errorf(
+							"LB Cookie Expiration Period must be greater than zero if specified"))
+					}
+					return
+				},
 			},
 		},
 	}

--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -94,7 +94,6 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
 	name = "foo-policy"
 	load_balancer = "${aws_elb.lb.id}"
 	lb_port = 80
-	cookie_expiration_period = 600
 }
 `
 


### PR DESCRIPTION
`cookie_expiration_period` is optional for the `aws_lb_cookie_stickiness_policy` resource, however we were sending the default value (`0`) if nothing was in the configuration, which is invalid.

The change in `resource_aws_lb_cookie_stickiness_policy_test` confirms the bug/fix 

Fixes #3208 