### PR TITLE
provider/google: Updated Read(..) behavior to handle deleted resources

### DIFF
--- a/builtin/providers/google/resource_compute_address.go
+++ b/builtin/providers/google/resource_compute_address.go
@@ -82,6 +82,7 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
+			log.Printf("[WARN] Removing Address %q because it's gone", d.Get("name").(string))
 			d.SetId("")
 
 			return nil

--- a/builtin/providers/google/resource_compute_autoscaler.go
+++ b/builtin/providers/google/resource_compute_autoscaler.go
@@ -240,6 +240,7 @@ func resourceComputeAutoscalerRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
+			log.Printf("[WARN] Removing Autoscalar %q because it's gone", d.Get("name").(string))
 			d.SetId("")
 
 			return nil

--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -186,6 +186,7 @@ func resourceComputeBackendServiceRead(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
+			log.Printf("[WARN] Removing Backend Service %q because it's gone", d.Get("name").(string))
 			d.SetId("")
 
 			return nil

--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -141,6 +141,7 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 		config.Project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Disk %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -3,6 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"sort"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -150,6 +151,7 @@ func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
+			log.Printf("[WARN] Removing Firewall %q because it's gone", d.Get("name").(string))
 			d.SetId("")
 
 			return nil

--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -139,6 +139,7 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 		config.Project, region, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Forwarding Rule %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_global_address.go
+++ b/builtin/providers/google/resource_compute_global_address.go
@@ -64,6 +64,7 @@ func resourceComputeGlobalAddressRead(d *schema.ResourceData, meta interface{}) 
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Global Address %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_global_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_global_forwarding_rule.go
@@ -131,6 +131,7 @@ func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interf
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Global Forwarding Rule %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -187,6 +187,7 @@ func resourceComputeHttpHealthCheckRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
+			log.Printf("[WARN] Removing HTTP Health Check %q because it's gone", d.Get("name").(string))
 			d.SetId("")
 
 			return nil

--- a/builtin/providers/google/resource_compute_https_health_check.go
+++ b/builtin/providers/google/resource_compute_https_health_check.go
@@ -186,6 +186,7 @@ func resourceComputeHttpsHealthCheckRead(d *schema.ResourceData, meta interface{
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing HTTPS Health Check %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -285,6 +285,7 @@ func getInstance(config *Config, d *schema.ResourceData) (*compute.Instance, err
 		config.Project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Instance %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			id := d.Id()
 			d.SetId("")

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -149,6 +149,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		config.Project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Instance Group Manager %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -466,6 +467,7 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Instance Template %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_network.go
+++ b/builtin/providers/google/resource_compute_network.go
@@ -74,6 +74,7 @@ func resourceComputeNetworkRead(d *schema.ResourceData, meta interface{}) error 
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Network %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_project_metadata.go
+++ b/builtin/providers/google/resource_compute_project_metadata.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"log"
 
-	//	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
-	//	"google.golang.org/api/googleapi"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeProjectMetadata() *schema.Resource {
@@ -85,6 +84,14 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Loading project service: %s", config.Project)
 	project, err := config.clientCompute.Projects.Get(config.Project).Do()
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Project Metadata because it's gone")
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
 		return fmt.Errorf("Error loading project '%s': %s", config.Project, err)
 	}
 

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -185,6 +185,7 @@ func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Route %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_ssl_certificate.go
+++ b/builtin/providers/google/resource_compute_ssl_certificate.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -91,6 +92,7 @@ func resourceComputeSslCertificateRead(d *schema.ResourceData, meta interface{})
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing SSL Certificate %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_target_http_proxy.go
+++ b/builtin/providers/google/resource_compute_target_http_proxy.go
@@ -111,6 +111,7 @@ func resourceComputeTargetHttpProxyRead(d *schema.ResourceData, meta interface{}
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Target HTTP Proxy %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_target_https_proxy.go
+++ b/builtin/providers/google/resource_compute_target_https_proxy.go
@@ -186,6 +186,7 @@ func resourceComputeTargetHttpsProxyRead(d *schema.ResourceData, meta interface{
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Target HTTPS Proxy %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -330,6 +330,7 @@ func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) err
 		config.Project, region, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Target Pool %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_compute_url_map.go
+++ b/builtin/providers/google/resource_compute_url_map.go
@@ -2,10 +2,12 @@ package google
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeUrlMap() *schema.Resource {
@@ -292,6 +294,14 @@ func resourceComputeUrlMapRead(d *schema.ResourceData, meta interface{}) error {
 	urlMap, err := config.clientCompute.UrlMaps.Get(config.Project, name).Do()
 
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing URL Map %q because it's gone", d.Get("name").(string))
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
 		return fmt.Errorf("Error, failed to get Url Map %s: %s", name, err)
 	}
 

--- a/builtin/providers/google/resource_compute_vpn_gateway.go
+++ b/builtin/providers/google/resource_compute_vpn_gateway.go
@@ -2,10 +2,12 @@ package google
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func resourceComputeVpnGateway() *schema.Resource {
@@ -88,6 +90,14 @@ func resourceComputeVpnGatewayRead(d *schema.ResourceData, meta interface{}) err
 	vpnGateway, err := vpnGatewaysService.Get(project, region, name).Do()
 
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing VPN Gateway %q because it's gone", d.Get("name").(string))
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
 		return fmt.Errorf("Error Reading VPN Gateway %s: %s", name, err)
 	}
 

--- a/builtin/providers/google/resource_dns_managed_zone.go
+++ b/builtin/providers/google/resource_dns_managed_zone.go
@@ -81,6 +81,7 @@ func resourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) error 
 		config.Project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing DNS Managed Zone %q because it's gone", d.Get("name").(string))
 			// The resource doesn't exist anymore
 			d.SetId("")
 

--- a/builtin/providers/google/resource_sql_database.go
+++ b/builtin/providers/google/resource_sql_database.go
@@ -2,9 +2,11 @@ package google
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/sqladmin/v1beta4"
 )
 
@@ -75,6 +77,14 @@ func resourceSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 		database_name).Do()
 
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing SQL Database %q because it's gone", d.Get("name").(string))
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
 		return fmt.Errorf("Error, failed to get"+
 			"database %s in instance %s: %s", database_name,
 			instance_name, err)

--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -2,9 +2,11 @@ package google
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/sqladmin/v1beta4"
 )
 
@@ -462,6 +464,14 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 		d.Get("name").(string)).Do()
 
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing SQL Database %q because it's gone", d.Get("name").(string))
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
 		return fmt.Errorf("Error retrieving instance %s: %s",
 			d.Get("name").(string), err)
 	}

--- a/builtin/providers/google/resource_storage_bucket.go
+++ b/builtin/providers/google/resource_storage_bucket.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/storage/v1"
 )
 
@@ -174,8 +175,15 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 	res, err := config.clientStorage.Buckets.Get(bucket).Do()
 
 	if err != nil {
-		fmt.Printf("Error reading bucket %s: %v", bucket, err)
-		return err
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Bucket %q because it's gone", d.Get("name").(string))
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
+		return fmt.Errorf("Error reading bucket %s: %v", bucket, err)
 	}
 
 	log.Printf("[DEBUG] Read bucket %v at location %v\n\n", res.Name, res.SelfLink)

--- a/builtin/providers/google/resource_storage_bucket_acl.go
+++ b/builtin/providers/google/resource_storage_bucket_acl.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/storage/v1"
 )
 
@@ -166,6 +167,14 @@ func resourceStorageBucketAclRead(d *schema.ResourceData, meta interface{}) erro
 		res, err := config.clientStorage.BucketAccessControls.List(bucket).Do()
 
 		if err != nil {
+			if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+				log.Printf("[WARN] Removing Bucket ACL for bucket %q because it's gone", d.Get("bucket").(string))
+				// The resource doesn't exist anymore
+				d.SetId("")
+
+				return nil
+			}
+
 			return err
 		}
 

--- a/builtin/providers/google/resource_storage_object_acl.go
+++ b/builtin/providers/google/resource_storage_object_acl.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/storage/v1"
 )
 
@@ -134,6 +135,14 @@ func resourceStorageObjectAclRead(d *schema.ResourceData, meta interface{}) erro
 		res, err := config.clientStorage.ObjectAccessControls.List(bucket, object).Do()
 
 		if err != nil {
+			if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+				log.Printf("[WARN] Removing Storage Object ACL for Bucket %q because it's gone", d.Get("bucket").(string))
+				// The resource doesn't exist anymore
+				d.SetId("")
+
+				return nil
+			}
+
 			return err
 		}
 


### PR DESCRIPTION
When Terraform discovers that a resource has been deleted on a Read, it should update the statefile accordingly. This behavior was pointed out by @apparentlymart in #3742 as the standard, and with this PR all GCP resources follow this convention.

@sparkprime 