### PR TITLE
provider/aws: Prevent crashing when deleting ecs_service which is gone

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -156,6 +156,8 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if len(out.Services) < 1 {
+		log.Printf("[DEBUG] Removing ECS service %q because it's gone", service.ServiceArn)
+		d.SetId("")
 		return nil
 	}
 

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -247,6 +247,12 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return err
 	}
+
+	if len(resp.Services) == 0 {
+		log.Printf("[DEBUG] ECS Service %q is already gone", d.Id())
+		return nil
+	}
+
 	log.Printf("[DEBUG] ECS service %s is currently %s", d.Id(), *resp.Services[0].Status)
 
 	if *resp.Services[0].Status == "INACTIVE" {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform/issues/3868 and also addresses https://github.com/hashicorp/terraform/pull/3829#issuecomment-155350232