### PR TITLE
provider/aws: Make all fields in ecs_task_definition ForceNew

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_app_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_app_test.go
@@ -23,7 +23,7 @@ func TestAccAWSCodeDeployApp_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployAppModifier,
+				Config: testAccAWSCodeDeployAppModified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
 				),
@@ -72,7 +72,7 @@ resource "aws_codedeploy_app" "foo" {
 	name = "foo"
 }`
 
-var testAccAWSCodeDeployAppModifier = `
+var testAccAWSCodeDeployAppModified = `
 resource "aws_codedeploy_app" "foo" {
 	name = "bar"
 }`

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -23,7 +23,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroupModifier,
+				Config: testAccAWSCodeDeployDeploymentGroupModified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo"),
 				),
@@ -133,7 +133,7 @@ resource "aws_codedeploy_deployment_group" "foo" {
 	}
 }`
 
-var testAccAWSCodeDeployDeploymentGroupModifier = `
+var testAccAWSCodeDeployDeploymentGroupModified = `
 resource "aws_codedeploy_app" "foo_app" {
 	name = "foo_app"
 }

--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -17,7 +17,6 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsEcsTaskDefinitionCreate,
 		Read:   resourceAwsEcsTaskDefinitionRead,
-		Update: resourceAwsEcsTaskDefinitionUpdate,
 		Delete: resourceAwsEcsTaskDefinitionDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -40,6 +39,7 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			"container_definitions": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				StateFunc: func(v interface{}) string {
 					hash := sha1.Sum([]byte(v.(string)))
 					return hex.EncodeToString(hash[:])
@@ -49,6 +49,7 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			"volume": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -129,29 +130,6 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("volumes", flattenEcsVolumes(taskDefinition.Volumes))
 
 	return nil
-}
-
-func resourceAwsEcsTaskDefinitionUpdate(d *schema.ResourceData, meta interface{}) error {
-	oldArn := d.Get("arn").(string)
-
-	log.Printf("[DEBUG] Creating new revision of task definition %q", d.Id())
-	err := resourceAwsEcsTaskDefinitionCreate(d, meta)
-	if err != nil {
-		return err
-	}
-	log.Printf("[DEBUG] New revision of %q created: %q", d.Id(), d.Get("arn").(string))
-
-	log.Printf("[DEBUG] Deregistering old revision of task definition %q: %q", d.Id(), oldArn)
-	conn := meta.(*AWSClient).ecsconn
-	_, err = conn.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{
-		TaskDefinition: aws.String(oldArn),
-	})
-	if err != nil {
-		return err
-	}
-	log.Printf("[DEBUG] Old revision of task definition deregistered: %q", oldArn)
-
-	return resourceAwsEcsTaskDefinitionRead(d, meta)
 }
 
 func resourceAwsEcsTaskDefinitionDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
@@ -23,7 +23,7 @@ func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSEcsTaskDefinitionModifier,
+				Config: testAccAWSEcsTaskDefinitionModified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins"),
 				),
@@ -245,7 +245,7 @@ TASK_DEFINITION
 }
 `
 
-var testAccAWSEcsTaskDefinitionModifier = `
+var testAccAWSEcsTaskDefinitionModified = `
 resource "aws_ecs_task_definition" "jenkins" {
   family = "terraform-acc-test"
   container_definitions = <<TASK_DEFINITION


### PR DESCRIPTION
Fixes #2694 

You might be thinking this will cause troubles since we'd be deleting task definitions that are in use by existing ECS service, but due to the nature of TDs & deregistration it shouldn't be any problem:

http://docs.aws.amazon.com/AmazonECS/latest/developerguide/deregister-task-definition.html

> When you deregister a task definition, it is immediately marked as INACTIVE. Existing tasks and services that reference an INACTIVE task definition continue to run without disruption, and existing services that reference an INACTIVE task definition can still scale up or down by modifying the service's desired count.

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=EcsTaskDefinition' 2>~/tf.log
```
```
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=EcsTaskDefinition -timeout 90m
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (16.32s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (9.39s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (105.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	131.603s
```