### PR TITLE
provider/openstack: Clean up some attributes in LBaaS VIP resource

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_vip_v1_test.go
+++ b/builtin/providers/openstack/resource_openstack_lb_vip_v1_test.go
@@ -116,6 +116,9 @@ var testAccLBV1VIP_basic = fmt.Sprintf(`
     protocol = "HTTP"
     port = 80
     pool_id = "${openstack_lb_pool_v1.pool_1.id}"
+    persistence {
+      type = "SOURCE_IP"
+    }
   }`,
 	OS_REGION_NAME, OS_REGION_NAME, OS_REGION_NAME)
 
@@ -148,5 +151,8 @@ var testAccLBV1VIP_update = fmt.Sprintf(`
     protocol = "HTTP"
     port = 80
     pool_id = "${openstack_lb_pool_v1.pool_1.id}"
+    persistence {
+      type = "SOURCE_IP"
+    }
   }`,
 	OS_REGION_NAME, OS_REGION_NAME, OS_REGION_NAME)


### PR DESCRIPTION
This commit makes a few attributes computed so the generated information
is accessible after creation.

It also fixes the "persistent" attribute, which previously had a typo.

Finally, it converts "admin_state_up" to a Boolean to match the majority
of other attributes of the same name.

Fixes #2908 