### PR TITLE
provider/aws: Allow aws_instance to take ami_name as well as ami_id

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -29,7 +29,8 @@ resource "aws_instance" "web" {
 
 The following arguments are supported:
 
-* `ami` - (Required) The AMI to use for the instance.
+* `ami` - (Optional) The AMI to use for the instance.
+* `ami_name` - (Optional) The name of the AMI to use for the instance.
 * `availability_zone` - (Optional) The AZ to start the instance in.
 * `placement_group` - (Optional) The Placement Group to start the instance in.
 * `ebs_optimized` - (Optional) If true, the launched EC2 instance will be


### PR DESCRIPTION
Fixes #3923 

Changing the aws_instance to allow a user to pass an AMI name instead of an ID. This now makes use of the describe-images call to get an AMI by name

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSInstance_amiName' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSInstance_amiName -timeout 90m
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (127.67s)
=== RUN   TestAccAWSInstance_amiName
--- PASS: TestAccAWSInstance_amiName (207.51s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	335.18s
```
