### PR TITLE
website: add `` to format documentation env vars

### DIFF
--- a/website/source/docs/internals/debugging.html.md
+++ b/website/source/docs/internals/debugging.html.md
@@ -12,6 +12,6 @@ Terraform has detailed logs which can be enabled by setting the `TF_LOG` environ
 
 You can set `TF_LOG` to one of the log levels `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR` to change the verbosity of the logs. `TRACE` is the most verbose and it is the default if `TF_LOG` is set to something other than a log level name.
 
-To persist logged output you can set TF_LOG_PATH in order to force the log to always go to a specific file when logging is enabled. Note that even when TF_LOG_PATH is set, TF_LOG must be set in order for any logging to be enabled.
+To persist logged output you can set `TF_LOG_PATH` in order to force the log to always go to a specific file when logging is enabled. Note that even when `TF_LOG_PATH` is set, `TF_LOG` must be set in order for any logging to be enabled.
 
 If you find a bug with Terraform, please include the detailed log by using a service such as gist.


### PR DESCRIPTION
this consistently formats the `TF_*` variables referenced in
documentation and also improves readability.