### PR TITLE
Populate the provisioner connection info for packet.net devices with …

### DIFF
--- a/builtin/providers/packet/resource_packet_device.go
+++ b/builtin/providers/packet/resource_packet_device.go
@@ -184,13 +184,15 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("billing_cycle", device.BillingCycle)
 	d.Set("locked", device.Locked)
 	d.Set("created", device.Created)
-	d.Set("udpated", device.Updated)
+	d.Set("updated", device.Updated)
 
 	tags := make([]string, 0)
 	for _, tag := range device.Tags {
 		tags = append(tags, tag)
 	}
 	d.Set("tags", tags)
+
+	provisionerAddress := ""
 
 	networks := make([]map[string]interface{}, 0, 1)
 	for _, ip := range device.Network {
@@ -201,8 +203,20 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 		network["cidr"] = ip.Cidr
 		network["public"] = ip.Public
 		networks = append(networks, network)
+		if ip.Family == 4 && ip.Public == true {
+			provisionerAddress = ip.Address
+		}
 	}
 	d.Set("network", networks)
+
+	log.Printf("[DEBUG] Provisioner Address set to %v", provisionerAddress)
+
+	if provisionerAddress != "" {
+		d.SetConnInfo(map[string]string{
+			"type": "ssh",
+			"host": provisionerAddress,
+		})
+	}
 
 	return nil
 }


### PR DESCRIPTION
…the ipv4 public address

Debug line confirmed correct address and tested by provisioning a box with a remote exec.