### PR TITLE
provider/aws: removed build-blocking unused variable.

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -96,7 +96,7 @@ func resourceAwsIamGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("name") || d.HasChange("path") {
 		iamconn := meta.(*AWSClient).iamconn
 		on, nn := d.GetChange("name")
-		op, np := d.GetChange("path")
+		_, np := d.GetChange("path")
 
 		request := &iam.UpdateGroupInput{
 			GroupName:    aws.String(on.(string)),


### PR DESCRIPTION
The go toolchain can be fussier than "My sweet 16" protagonists sometimes...