### PR TITLE
Use underscore in virtual machine attribute

### DIFF
--- a/website/source/docs/providers/cloudstack/r/disk.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/disk.html.markdown
@@ -19,7 +19,7 @@ resource "cloudstack_disk" "default" {
   attach = "true"
   disk_offering = "custom"
   size = 50
-  virtual-machine = "server-1"
+  virtual_machine = "server-1"
   zone = "zone-1"
 }
 ```


### PR DESCRIPTION
Without this PR a terraform plan using the disk resource as it is in the docs, would throw the error
```
Errors:

  * cloudstack_disk.master_disk1: : invalid or unknown key: virtual-machine
```
because the docs specify the key with an hyphen instead of a underscore.