### PR TITLE
Fix typo in error checking for IAM Policy Attachments

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_policy_attachment.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -90,7 +91,8 @@ func resourceAwsIamPolicyAttachmentRead(d *schema.ResourceData, meta interface{}
 
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NoSuchIdentity" {
+			if awsErr.Code() == "NoSuchEntity" {
+				log.Printf("[WARN] No such entity found for Policy Attachment (%s)", d.Id())
 				d.SetId("")
 				return nil
 			}


### PR DESCRIPTION
Fix an issue where a user could get stuck if an IAM Policy is no longer available, by trapping the `NoSuchEntity` error, and logging the event. 