### PR TITLE
Add tests for JSON configuration parsing

### DIFF
--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -557,6 +557,102 @@ func TestLoad_temporary_files(t *testing.T) {
 	}
 }
 
+func TestLoad_hclAttributes(t *testing.T) {
+	c, err := LoadFile(filepath.Join(fixtureDir, "attributes.tf"))
+	if err != nil {
+		t.Fatalf("Bad: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	actual := resourcesStr(c.Resources)
+	print(actual)
+	if actual != strings.TrimSpace(jsonAttributeStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
+	r := c.Resources[0]
+	if r.Name != "test" && r.Type != "cloudstack_firewall" {
+		t.Fatalf("Bad: %#v", r)
+	}
+
+	raw := r.RawConfig
+	if raw.Raw["ipaddress"] != "192.168.0.1" {
+		t.Fatalf("Bad: %s", raw.Raw["ipAddress"])
+	}
+
+	rule := raw.Raw["rule"].([]map[string]interface{})[0]
+	if rule["protocol"] != "tcp" {
+		t.Fatalf("Bad: %s", rule["protocol"])
+	}
+
+	if rule["source_cidr"] != "10.0.0.0/8" {
+		t.Fatalf("Bad: %s", rule["source_cidr"])
+	}
+
+	ports := rule["ports"].([]interface{})
+
+	if ports[0] != "80" {
+		t.Fatalf("Bad ports: %s", ports[0])
+	}
+	if ports[1] != "1000-2000" {
+		t.Fatalf("Bad ports: %s", ports[1])
+	}
+}
+
+func TestLoad_jsonAttributes(t *testing.T) {
+	c, err := LoadFile(filepath.Join(fixtureDir, "attributes.tf.json"))
+	if err != nil {
+		t.Fatalf("Bad: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	actual := resourcesStr(c.Resources)
+	print(actual)
+	if actual != strings.TrimSpace(jsonAttributeStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
+	r := c.Resources[0]
+	if r.Name != "test" && r.Type != "cloudstack_firewall" {
+		t.Fatalf("Bad: %#v", r)
+	}
+
+	raw := r.RawConfig
+	if raw.Raw["ipaddress"] != "192.168.0.1" {
+		t.Fatalf("Bad: %s", raw.Raw["ipAddress"])
+	}
+
+	rule := raw.Raw["rule"].([]map[string]interface{})[0]
+	if rule["protocol"] != "tcp" {
+		t.Fatalf("Bad: %s", rule["protocol"])
+	}
+
+	if rule["source_cidr"] != "10.0.0.0/8" {
+		t.Fatalf("Bad: %s", rule["source_cidr"])
+	}
+
+	ports := rule["ports"].([]interface{})
+
+	if ports[0] != "80" {
+		t.Fatalf("Bad ports: %s", ports[0])
+	}
+	if ports[1] != "1000-2000" {
+		t.Fatalf("Bad ports: %s", ports[1])
+	}
+}
+
+const jsonAttributeStr = `
+cloudstack_firewall[test] (x1)
+  ipaddress
+  rule
+`
+
 const heredocProvidersStr = `
 aws
   access_key

--- a/config/test-fixtures/attributes.tf
+++ b/config/test-fixtures/attributes.tf
@@ -1,0 +1,15 @@
+provider "cloudstack" {
+  api_url = "bla"
+  api_key = "bla"
+  secret_key = "bla"
+}
+
+resource "cloudstack_firewall" "test" {
+  ipaddress = "192.168.0.1"
+
+  rule {
+    source_cidr = "10.0.0.0/8"
+    protocol = "tcp"
+    ports = ["80", "1000-2000"]
+  }
+}

--- a/config/test-fixtures/attributes.tf.json
+++ b/config/test-fixtures/attributes.tf.json
@@ -1,0 +1,27 @@
+{
+    "provider": {
+        "cloudstack": {
+            "api_url": "bla",
+            "api_key": "bla",
+            "secret_key": "bla"
+        }
+    },
+    "resource": {
+        "cloudstack_firewall": {
+            "test": {
+                "ipaddress": "192.168.0.1",
+                "rule": [
+                    {
+                        "source_cidr": "10.0.0.0/8",
+                        "protocol": "tcp",
+                        "ports": [
+                            "80",
+                            "1000-2000"
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Reproduces the issue reported by @svanharmelen in #3964 (subsequently fixed).