### PR TITLE
config: test covering escaped quotes syntax error

### DIFF
--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -70,6 +70,26 @@ func TestLoadFileHeredoc(t *testing.T) {
 	}
 }
 
+func TestLoadFileEscapedQuotes(t *testing.T) {
+	c, err := LoadFile(filepath.Join(fixtureDir, "escapedquotes.tf"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	if c.Dir != "" {
+		t.Fatalf("bad: %#v", c.Dir)
+	}
+
+	actual := resourcesStr(c.Resources)
+	if actual != strings.TrimSpace(escapedquotesResourcesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestLoadFileBasic(t *testing.T) {
 	c, err := LoadFile(filepath.Join(fixtureDir, "basic.tf"))
 	if err != nil {
@@ -569,6 +589,13 @@ aws_iam_policy[policy] (x1)
   name
   path
   policy
+`
+
+const escapedquotesResourcesStr = `
+aws_instance[quotes] (x1)
+  ami
+  vars
+    user: var.ami
 `
 
 const basicOutputsStr = `

--- a/config/test-fixtures/escapedquotes.tf
+++ b/config/test-fixtures/escapedquotes.tf
@@ -1,0 +1,7 @@
+variable "ami" {
+  default = [ "ami", "abc123" ]
+}
+
+resource "aws_instance" "quotes" {
+  ami = "${join(\",\", var.ami)}"
+}


### PR DESCRIPTION
This was never intended to be valid syntax, but it worked in the old HCL
parser, and we've found a decent number of examples of it in the wild.

Fixed in https://github.com/hashicorp/hcl/pull/62 and we'll keep this
test in Terraform to cover the behavior.