### PR TITLE
Add AWS Classiclink for AWS VPC resource

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -206,6 +206,23 @@ func TestAccAWSVpc_bothDnsOptionsSet(t *testing.T) {
 	})
 }
 
+func TestAccAWSVpc_classiclinkOptionSet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcConfig_ClassiclinkOption,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_vpc.bar", "enable_classiclink", "true"),
+				),
+			},
+		},
+	})
+}
+
 const testAccVpcConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
@@ -252,5 +269,13 @@ resource "aws_vpc" "bar" {
 
 	enable_dns_hostnames = true
 	enable_dns_support = true
+}
+`
+
+const testAccVpcConfig_ClassiclinkOption = `
+resource "aws_vpc" "bar" {
+	cidr_block = "172.2.0.0/16"
+
+	enable_classiclink = true
 }
 `

--- a/website/source/docs/providers/aws/r/vpc.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `instance_tenancy` - (Optional) A tenancy option for instances launched into the VPC
 * `enable_dns_support` - (Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true.
 * `enable_dns_hostnames` - (Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false.
+* `enable_classiclink` - (Optional) A boolean flag to enable/disable ClassicLink for the VPC. Defaults false.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
@@ -52,6 +53,7 @@ The following attributes are exported:
 * `instance_tenancy` - Tenancy of instances spin up within VPC.
 * `enable_dns_support` - Whether or not the VPC has DNS support
 * `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support
+* `enable_classiclink` - Whether or not the VPC has Classiclink enabled
 * `main_route_table_id` - The ID of the main route table associated with
      this VPC. Note that you can change a VPC's main route table by using an
      [`aws_main_route_table_association`](/docs/providers/aws/r/main_route_table_assoc.html).


### PR DESCRIPTION
This PR add the possibility to enable/disable AWS Classiclink (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html) for VPC.

See issue : https://github.com/hashicorp/terraform/issues/2985

I just saw there is another PR (#3971) about this issue but I decided to push anyway since the first PR handle only the activation during the VPC creation.