### PR TITLE
Add more instructions for the AWS OpsWorks acctests

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack_test.go
@@ -14,6 +14,14 @@ import (
 
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
 // and `aws-opsworks-service-role`.
+//
+// If you've never used Opsworks in your AWS account before, you can get these
+// default roles by going to the AWS OpsWorks console and adding a stack.
+// While adding your first stack, the "IAM role" and "Default IAM instance
+// profile" fields can be set to "New IAM role" and "New IAM instance profile"
+// respectively, which will then cause OpsWorks to create the IAM objects
+// these tests expect. It may take a few minutes after creating the stack for
+// these IAM objects to propagate fully.
 
 ///////////////////////////////
 //// Tests for the No-VPC case


### PR DESCRIPTION
While doing pre-release testing, @catsby found that the tests added in #2162 won't work out of the box unless you've already used OpsWorks via the AWS console and have some default objects that the console creates.

As a short-term workaround this PR adds some instructions on how to get those default objects so that the tests will work.

In the long run we should rewrite these tests to create the necessary roles and instances profiles automatically, which will be a bunch more work and tackled separately so it doesn't block the current release.
