### PR TITLE
helper/schema: name test cases w/ strings

### DIFF
--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -124,7 +124,7 @@ func TestValueType_Zero(t *testing.T) {
 }
 
 func TestSchemaMap_Diff(t *testing.T) {
-	cases := []struct {
+	cases := map[string]struct {
 		Schema          map[string]*Schema
 		State           *terraform.InstanceState
 		Config          map[string]interface{}
@@ -132,12 +132,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		Diff            *terraform.InstanceDiff
 		Err             bool
 	}{
-		/*
-		 * String decode
-		 */
-
-		// #0
-		{
+		"#0": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -166,8 +161,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #1
-		{
+		"#1": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -194,8 +188,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #2
-		{
+		"#2": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -216,8 +209,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #3 Computed, but set in config
-		{
+		"#3 Computed, but set in config": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -248,8 +240,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #4 Default
-		{
+		"#4 Default": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -274,8 +265,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #5 DefaultFunc, value
-		{
+		"#5 DefaultFunc, value": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -302,8 +292,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #6 DefaultFunc, configuration set
-		{
+		"#6 DefaultFunc, configuration set": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -332,8 +321,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #7 String with StateFunc
-		{
+		"#7 String with StateFunc": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -364,8 +352,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #8 Variable (just checking)
-		{
+		"#8 Variable (just checking)": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -395,8 +382,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #9 Variable computed
-		{
+		"#9 Variable computed": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -426,12 +412,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * Int decode
-		 */
-
-		// #10
-		{
+		"#10 Int decode": {
 			Schema: map[string]*Schema{
 				"port": &Schema{
 					Type:     TypeInt,
@@ -460,12 +441,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * Bool decode
-		 */
-
-		// #11
-		{
+		"#11 bool decode": {
 			Schema: map[string]*Schema{
 				"port": &Schema{
 					Type:     TypeBool,
@@ -494,12 +470,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * Bool
-		 */
-
-		// #12
-		{
+		"#12 Bool": {
 			Schema: map[string]*Schema{
 				"delete": &Schema{
 					Type:     TypeBool,
@@ -521,12 +492,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * List decode
-		 */
-
-		// #13
-		{
+		"#13 List decode": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -565,8 +531,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #14
-		{
+		"#14": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -609,8 +574,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #15
-		{
+		"#15": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -643,8 +607,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #16
-		{
+		"#16": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -671,8 +634,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #17
-		{
+		"#17": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -709,8 +671,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #18
-		{
+		"#18": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -754,8 +715,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #19
-		{
+		"#19": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -781,12 +741,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * Set
-		 */
-
-		// #20
-		{
+		"#20 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -828,8 +783,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #21
-		{
+		"#21 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -855,8 +809,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #22
-		{
+		"#22 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -885,8 +838,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #23
-		{
+		"#23 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -932,8 +884,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #24
-		{
+		"#24 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -969,8 +920,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #25
-		{
+		"#25 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -1018,8 +968,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #26
-		{
+		"#26 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -1063,8 +1012,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #27
-		{
+		"#27 Set": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -1092,8 +1040,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #28
-		{
+		"#28 Set": {
 			Schema: map[string]*Schema{
 				"ingress": &Schema{
 					Type:     TypeSet,
@@ -1145,12 +1092,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * List of structure decode
-		 */
-
-		// #29
-		{
+		"#29 List of structure decode": {
 			Schema: map[string]*Schema{
 				"ingress": &Schema{
 					Type:     TypeList,
@@ -1192,12 +1134,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * ComputedWhen
-		 */
-
-		// #30
-		{
+		"#30 ComputedWhen": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:         TypeString,
@@ -1227,8 +1164,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #31
-		{
+		"#31": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:         TypeString,
@@ -1306,12 +1242,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 		*/
 
-		/*
-		 * Maps
-		 */
-
-		// #32
-		{
+		"#32 Maps": {
 			Schema: map[string]*Schema{
 				"config_vars": &Schema{
 					Type: TypeMap,
@@ -1345,8 +1276,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #33
-		{
+		"#33 Maps": {
 			Schema: map[string]*Schema{
 				"config_vars": &Schema{
 					Type: TypeMap,
@@ -1383,8 +1313,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #34
-		{
+		"#34 Maps": {
 			Schema: map[string]*Schema{
 				"vars": &Schema{
 					Type:     TypeMap,
@@ -1424,8 +1353,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #35
-		{
+		"#35 Maps": {
 			Schema: map[string]*Schema{
 				"vars": &Schema{
 					Type:     TypeMap,
@@ -1446,8 +1374,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #36
-		{
+		"#36 Maps": {
 			Schema: map[string]*Schema{
 				"config_vars": &Schema{
 					Type: TypeList,
@@ -1486,8 +1413,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #37
-		{
+		"#37 Maps": {
 			Schema: map[string]*Schema{
 				"config_vars": &Schema{
 					Type: TypeList,
@@ -1529,12 +1455,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-		 * ForceNews
-		 */
-
-		// #38
-		{
+		"#38 ForceNews": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -1579,8 +1500,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #39 Set
-		{
+		"#39 Set": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -1630,8 +1550,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #40 Set
-		{
+		"#40 Set": {
 			Schema: map[string]*Schema{
 				"instances": &Schema{
 					Type:     TypeSet,
@@ -1669,8 +1588,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #41 Set
-		{
+		"#41 Set": {
 			Schema: map[string]*Schema{
 				"route": &Schema{
 					Type:     TypeSet,
@@ -1730,8 +1648,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #42 Set
-		{
+		"#42 Set": {
 			Schema: map[string]*Schema{
 				"route": &Schema{
 					Type:     TypeSet,
@@ -1796,8 +1713,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #43 - Computed maps
-		{
+		"#43 - Computed maps": {
 			Schema: map[string]*Schema{
 				"vars": &Schema{
 					Type:     TypeMap,
@@ -1821,8 +1737,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #44 - Computed maps
-		{
+		"#44 - Computed maps": {
 			Schema: map[string]*Schema{
 				"vars": &Schema{
 					Type:     TypeMap,
@@ -1858,8 +1773,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #45 - Empty
-		{
+		"#45 - Empty": {
 			Schema: map[string]*Schema{},
 
 			State: &terraform.InstanceState{},
@@ -1871,8 +1785,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #46 - Float
-		{
+		"#46 - Float": {
 			Schema: map[string]*Schema{
 				"some_threshold": &Schema{
 					Type: TypeFloat,
@@ -1901,8 +1814,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #47 - https://github.com/hashicorp/terraform/issues/824
-		{
+		"#47 - https://github.com/hashicorp/terraform/issues/824": {
 			Schema: map[string]*Schema{
 				"block_device": &Schema{
 					Type:     TypeSet,
@@ -1955,8 +1867,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err:  false,
 		},
 
-		// #48 - Zero value in state shouldn't result in diff
-		{
+		"#48 - Zero value in state shouldn't result in diff": {
 			Schema: map[string]*Schema{
 				"port": &Schema{
 					Type:     TypeBool,
@@ -1978,8 +1889,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #49 Set - Same as #48 but for sets
-		{
+		"#49 Set - Same as #48 but for sets": {
 			Schema: map[string]*Schema{
 				"route": &Schema{
 					Type:     TypeSet,
@@ -2021,8 +1931,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #50 - A set computed element shouldn't cause a diff
-		{
+		"#50 - A set computed element shouldn't cause a diff": {
 			Schema: map[string]*Schema{
 				"active": &Schema{
 					Type:     TypeBool,
@@ -2044,8 +1953,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #51 - An empty set should show up in the diff
-		{
+		"#51 - An empty set should show up in the diff": {
 			Schema: map[string]*Schema{
 				"instances": &Schema{
 					Type:     TypeSet,
@@ -2085,8 +1993,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #52 - Map with empty value
-		{
+		"#52 - Map with empty value": {
 			Schema: map[string]*Schema{
 				"vars": &Schema{
 					Type: TypeMap,
@@ -2117,8 +2024,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #53 - Unset bool, not in state
-		{
+		"#53 - Unset bool, not in state": {
 			Schema: map[string]*Schema{
 				"force": &Schema{
 					Type:     TypeBool,
@@ -2136,8 +2042,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #54 - Unset set, not in state
-		{
+		"#54 - Unset set, not in state": {
 			Schema: map[string]*Schema{
 				"metadata_keys": &Schema{
 					Type:     TypeSet,
@@ -2157,8 +2062,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #55 - Unset list in state, should not show up computed
-		{
+		"#55 - Unset list in state, should not show up computed": {
 			Schema: map[string]*Schema{
 				"metadata_keys": &Schema{
 					Type:     TypeList,
@@ -2182,8 +2086,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #56 - Set element computed substring
-		{
+		"#56 - Set element computed substring": {
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -2218,9 +2121,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #57 - Computed map without config that's known to be empty does not
-		//       generate diff
-		{
+		"#57 Computed map without config that's known to be empty does not generate diff": {
 			Schema: map[string]*Schema{
 				"tags": &Schema{
 					Type:     TypeMap,
@@ -2241,8 +2142,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #58 Set with hyphen keys
-		{
+		"#58 Set with hyphen keys": {
 			Schema: map[string]*Schema{
 				"route": &Schema{
 					Type:     TypeSet,
@@ -2298,8 +2198,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #59: StateFunc in nested set (#1759)
-		{
+		"#59: StateFunc in nested set (#1759)": {
 			Schema: map[string]*Schema{
 				"service_account": &Schema{
 					Type:     TypeList,
@@ -2364,8 +2263,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		// #60 - Removing set elements
-		{
+		"#60 - Removing set elements": {
 			Schema: map[string]*Schema{
 				"instances": &Schema{
 					Type:     TypeSet,
@@ -2418,10 +2316,10 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 	}
 
-	for i, tc := range cases {
+	for tn, tc := range cases {
 		c, err := config.NewRawConfig(tc.Config)
 		if err != nil {
-			t.Fatalf("#%d err: %s", i, err)
+			t.Fatalf("#%q err: %s", tn, err)
 		}
 
 		if len(tc.ConfigVariables) > 0 {
@@ -2431,18 +2329,18 @@ func TestSchemaMap_Diff(t *testing.T) {
 			}
 
 			if err := c.Interpolate(vars); err != nil {
-				t.Fatalf("#%d err: %s", i, err)
+				t.Fatalf("#%q err: %s", tn, err)
 			}
 		}
 
 		d, err := schemaMap(tc.Schema).Diff(
 			tc.State, terraform.NewResourceConfig(c))
 		if err != nil != tc.Err {
-			t.Fatalf("#%d err: %s", i, err)
+			t.Fatalf("#%q err: %s", tn, err)
 		}
 
 		if !reflect.DeepEqual(tc.Diff, d) {
-			t.Fatalf("#%d:\n\nexpected: %#v\n\ngot:\n\n%#v", i, tc.Diff, d)
+			t.Fatalf("#%q:\n\nexpected: %#v\n\ngot:\n\n%#v", tn, tc.Diff, d)
 		}
 	}
 }
@@ -2640,17 +2538,16 @@ func TestSchemaMap_InputDefault(t *testing.T) {
 }
 
 func TestSchemaMap_InternalValidate(t *testing.T) {
-	cases := []struct {
+	cases := map[string]struct {
 		In  map[string]*Schema
 		Err bool
 	}{
-		{
+		"nothing": {
 			nil,
 			false,
 		},
 
-		// No optional and no required
-		{
+		"Both optional and required": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeInt,
@@ -2661,8 +2558,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// No optional and no required
-		{
+		"No optional and no required": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type: TypeInt,
@@ -2671,8 +2567,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Missing Type
-		{
+		"Missing Type": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Required: true,
@@ -2681,8 +2576,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Required but computed
-		{
+		"Required but computed": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeInt,
@@ -2693,8 +2587,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Looks good
-		{
+		"Looks good": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeString,
@@ -2704,8 +2597,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			false,
 		},
 
-		// Computed but has default
-		{
+		"Computed but has default": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeInt,
@@ -2717,8 +2609,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Required but has default
-		{
+		"Required but has default": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeInt,
@@ -2730,8 +2621,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// List element not set
-		{
+		"List element not set": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type: TypeList,
@@ -2740,8 +2630,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// List default
-		{
+		"List default": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:    TypeList,
@@ -2752,8 +2641,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// List element computed
-		{
+		"List element computed": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeList,
@@ -2767,8 +2655,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// List element with Set set
-		{
+		"List element with Set set": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeList,
@@ -2780,8 +2667,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Set element with no Set set
-		{
+		"Set element with no Set set": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeSet,
@@ -2792,8 +2678,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			false,
 		},
 
-		// Required but computed
-		{
+		"Required but computedWhen": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:         TypeInt,
@@ -2804,8 +2689,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Conflicting attributes cannot be required
-		{
+		"Conflicting attributes cannot be required": {
 			map[string]*Schema{
 				"blacklist": &Schema{
 					Type:     TypeBool,
@@ -2820,8 +2704,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Attribute with conflicts cannot be required
-		{
+		"Attribute with conflicts cannot be required": {
 			map[string]*Schema{
 				"whitelist": &Schema{
 					Type:          TypeBool,
@@ -2832,8 +2715,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// ConflictsWith cannot be used w/ Computed
-		{
+		"ConflictsWith cannot be used w/ Computed": {
 			map[string]*Schema{
 				"blacklist": &Schema{
 					Type:     TypeBool,
@@ -2848,8 +2730,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// ConflictsWith cannot be used w/ ComputedWhen
-		{
+		"ConflictsWith cannot be used w/ ComputedWhen": {
 			map[string]*Schema{
 				"blacklist": &Schema{
 					Type:         TypeBool,
@@ -2864,8 +2745,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Sub-resource invalid
-		{
+		"Sub-resource invalid": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeList,
@@ -2880,8 +2760,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		// Sub-resource valid
-		{
+		"Sub-resource valid": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeList,
@@ -2899,8 +2778,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			false,
 		},
 
-		// ValidateFunc on non-primitive
-		{
+		"ValidateFunc on non-primitive": {
 			map[string]*Schema{
 				"foo": &Schema{
 					Type:     TypeSet,
@@ -2914,13 +2792,13 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 		},
 	}
 
-	for i, tc := range cases {
+	for tn, tc := range cases {
 		err := schemaMap(tc.In).InternalValidate(schemaMap{})
 		if err != nil != tc.Err {
 			if tc.Err {
-				t.Fatalf("%d: Expected error did not occur:\n\n%#v", i, tc.In)
+				t.Fatalf("%q: Expected error did not occur:\n\n%#v", tn, tc.In)
 			}
-			t.Fatalf("%d: Unexpected error occurred:\n\n%#v", i, tc.In)
+			t.Fatalf("%q: Unexpected error occurred:\n\n%#v", tn, tc.In)
 		}
 	}
 


### PR DESCRIPTION
I promised myself that next time I jumped in this file I'd fix this up.
Now we don't have to manually index the file with comments, we can just
add descriptive names to the test cases!