### PR TITLE
helper/schema: skip StateFunc when value is nil

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -919,7 +919,7 @@ func (m schemaMap) diffString(
 	var originalN interface{}
 	var os, ns string
 	o, n, _, _ := d.diffChange(k)
-	if schema.StateFunc != nil {
+	if schema.StateFunc != nil && n != nil {
 		originalN = n
 		n = schema.StateFunc(n)
 	}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -321,7 +321,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		"#7 String with StateFunc": {
+		"String with StateFunc": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -345,6 +345,36 @@ func TestSchemaMap_Diff(t *testing.T) {
 						Old:      "",
 						New:      "foo!",
 						NewExtra: "foo",
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		"StateFunc not called with nil value": {
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+					StateFunc: func(a interface{}) string {
+						t.Fatalf("should not get here!")
+						return ""
+					},
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"availability_zone": &terraform.ResourceAttrDiff{
+						Old:         "",
+						New:         "",
+						NewComputed: true,
 					},
 				},
 			},


### PR DESCRIPTION
This takes the nil checking burden off of StateFunc.

fixes #3586, see that issue for further discussion