### PR TITLE
provider/aws:  Add "enable_logging" to CloudTrail resource

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudtrail.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail.go
@@ -25,7 +25,7 @@ func resourceAwsCloudTrail() *schema.Resource {
 			"enable_logging": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 			"s3_bucket_name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_cloudtrail.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail.go
@@ -200,7 +200,7 @@ func cloudTrailGetLoggingStatus(conn *cloudtrail.CloudTrail, id *string) (bool, 
 	}
 	resp, err := conn.GetTrailStatus(GetTrailStatusOpts)
 	if err != nil {
-		return false, fmt.Errorf("Error retrieving logging status of CloudTrail (%s): %s", id, err)
+		return false, fmt.Errorf("Error retrieving logging status of CloudTrail (%s): %s", *id, err)
 	}
 
 	return *resp.IsLogging, err

--- a/builtin/providers/aws/resource_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail_test.go
@@ -39,6 +39,39 @@ func TestAccAWSCloudTrail_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudTrail_enable_logging(t *testing.T) {
+	var trail cloudtrail.Trail
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudTrailConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
+					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", false, &trail),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCloudTrailConfigModified,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
+					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", true, &trail),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCloudTrailConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
+					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", false, &trail),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudTrailExists(n string, trail *cloudtrail.Trail) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -58,6 +91,30 @@ func testAccCheckCloudTrailExists(n string, trail *cloudtrail.Trail) resource.Te
 			return fmt.Errorf("Trail not found")
 		}
 		*trail = *resp.TrailList[0]
+
+		return nil
+	}
+}
+
+func testAccCheckCloudTrailLoggingEnabled(n string, desired bool, trail *cloudtrail.Trail) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudtrailconn
+		params := cloudtrail.GetTrailStatusInput{
+			Name: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.GetTrailStatus(&params)
+
+		if err != nil {
+			return err
+		}
+		if *resp.IsLogging != desired {
+			return fmt.Errorf("Logging status is incorrect")
+		}
 
 		return nil
 	}
@@ -134,6 +191,7 @@ resource "aws_cloudtrail" "foobar" {
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     s3_key_prefix = "/prefix"
     include_global_service_events = false
+    enable_logging = true
 }
 
 resource "aws_s3_bucket" "foo" {

--- a/builtin/providers/aws/resource_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail_test.go
@@ -51,23 +51,23 @@ func TestAccAWSCloudTrail_enable_logging(t *testing.T) {
 				Config: testAccAWSCloudTrailConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
-					// This is a warning test.  AWS sets up new trails with logging disabled
-					// Should that change in the future, this test should fail.
-					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", false, &trail),
+					// AWS will create the trail with logging turned off.
+					// Test that "enable_logging" default works.
+					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", true, &trail),
 				),
 			},
 			resource.TestStep{
 				Config: testAccAWSCloudTrailConfigModified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
-					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", true, &trail),
+					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", false, &trail),
 				),
 			},
 			resource.TestStep{
 				Config: testAccAWSCloudTrailConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
-					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", false, &trail),
+					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", true, &trail),
 				),
 			},
 		},
@@ -193,7 +193,7 @@ resource "aws_cloudtrail" "foobar" {
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     s3_key_prefix = "/prefix"
     include_global_service_events = false
-    enable_logging = true
+    enable_logging = false
 }
 
 resource "aws_s3_bucket" "foo" {

--- a/builtin/providers/aws/resource_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail_test.go
@@ -115,7 +115,7 @@ func testAccCheckCloudTrailLoggingEnabled(n string, desired bool, trail *cloudtr
 			return err
 		}
 		if *resp.IsLogging != desired {
-			return fmt.Errorf("Logging status is incorrect")
+			return fmt.Errorf("Expected logging status %t, given %t", desired, *resp.IsLogging)
 		}
 
 		return nil

--- a/builtin/providers/aws/resource_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail_test.go
@@ -51,6 +51,8 @@ func TestAccAWSCloudTrail_enable_logging(t *testing.T) {
 				Config: testAccAWSCloudTrailConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
+					// This is a warning test.  AWS sets up new trails with logging disabled
+					// Should that change in the future, this test should fail.
 					testAccCheckCloudTrailLoggingEnabled("aws_cloudtrail.foobar", false, &trail),
 				),
 			},

--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -16,7 +16,6 @@ resource "aws_cloudtrail" "foobar" {
     name = "tf-trail-foobar"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     s3_key_prefix = "/prefix"
-    enable_logging = true
     include_global_service_events = false
 }
 

--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -64,7 +64,8 @@ The following arguments are supported:
     endpoint to assume to write to a user’s log group.
 * `cloud_watch_logs_group_arn` - (Optional) Specifies a log group name using an Amazon Resource Name (ARN),
     that represents the log group to which CloudTrail logs will be delivered.
-* `enable_logging` - (Optional) Enables logging for the trail.  Defaults to `false`.
+* `enable_logging` - (Optional) Enables logging for the trail. Defaults to `true`.
+    Setting this to `false` will pause logging.
 * `include_global_service_events` - (Optional) Specifies whether the trail is publishing events
     from global services such as IAM to the log files. Defaults to `true`.
 * `sns_topic_name` - (Optional) Specifies the name of the Amazon SNS topic

--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -16,6 +16,7 @@ resource "aws_cloudtrail" "foobar" {
     name = "tf-trail-foobar"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     s3_key_prefix = "/prefix"
+    enable_logging = true
     include_global_service_events = false
 }
 
@@ -63,6 +64,7 @@ The following arguments are supported:
     endpoint to assume to write to a user’s log group.
 * `cloud_watch_logs_group_arn` - (Optional) Specifies a log group name using an Amazon Resource Name (ARN),
     that represents the log group to which CloudTrail logs will be delivered.
+* `enable_logging` - (Optional) Enables logging for the trail.  Defaults to `false`.
 * `include_global_service_events` - (Optional) Specifies whether the trail is publishing events
     from global services such as IAM to the log files. Defaults to `true`.
 * `sns_topic_name` - (Optional) Specifies the name of the Amazon SNS topic


### PR DESCRIPTION
I was working with the CloudTrail resource (#3094, merged for release in 0.6.7) and discovered that AWS creates CloudTrail trails with logging disabled by default.  The user needs to click the button in the console, or send a `cloudtrail:StartLogging` API call to begin using the trail.

Terraform will create the trail, but had no ability to enable (or monitor the ongoing state of) logging on the trail resource.

I didn't want that to be managed or changed outside my TF config, so I wrote this PR to add an `enable_logging` parameter to the CloudTrail resource.  It requires extra API calls (`StartLogging` to enable or `StopLogging` to disable), so I wrapped those in helper functions inside `resource_aws_cloudtrail.go`.  The CRUD operations use these to try to do the right thing.

The default is still `false` to match existing AWS behavior.  I wrote some acceptance tests for enabling and disabling logging, and added the option to the documentation.

Please look through the implementation and let me know if there's something that looks off, I'm happy to fix it or rework it if necessary.  Big thanks to @radeksimko for writing the resource in the first place.


make testacc TEST=./builtin/providers/aws TESTARGS='-run=CloudTrail' 2>/dev/null
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=CloudTrail -timeout 90m
=== RUN   TestAccAWSCloudTrail_basic
--- PASS: TestAccAWSCloudTrail_basic (15.53s)
=== RUN   TestAccAWSCloudTrail_enable_logging
--- PASS: TestAccAWSCloudTrail_enable_logging (19.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	35.499s
