### PR TITLE
config: add select function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -37,6 +37,7 @@ func init() {
 		"length":       interpolationFuncLength(),
 		"lower":        interpolationFuncLower(),
 		"replace":      interpolationFuncReplace(),
+		"select":       interpolationFuncSelect(),
 		"split":        interpolationFuncSplit(),
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64decode": interpolationFuncBase64Decode(),
@@ -377,6 +378,24 @@ func interpolationFuncReplace() ast.Function {
 			}
 
 			return strings.Replace(s, search, replace, -1), nil
+		},
+	}
+}
+
+// interpolationFuncSelect implements the "select" function that allows one to
+// choose between two values based on the equality of another two.
+func interpolationFuncSelect() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString, ast.TypeString, ast.TypeString, ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			value := args[0].(string)
+			compare_value := args[1].(string)
+			if value == compare_value {
+				return args[2].(string), nil
+			} else {
+				return args[3].(string), nil
+			}
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -477,6 +477,23 @@ func TestInterpolateFuncReplace(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncSelect(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${select("a", "b", "true", "false")}`,
+				"false",
+				false,
+			},
+			{
+				`${select("a", "a", "true", "false")}`,
+				"true",
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncLength(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -95,7 +95,7 @@ The supported built-in functions are:
     CIDR notation (like ``10.0.0.0/8``) and extends its prefix to include an
     additional subnet number. For example,
     ``cidrsubnet("10.0.0.0/8", 8, 2)`` returns ``10.2.0.0/16``.
-    
+
   * `coalesce(string1, string2, ...)` - Returns the first non-empty value from
     the given arguments. At least two arguments must be provided.
 
@@ -151,6 +151,11 @@ The supported built-in functions are:
       as `var.amis`.
 
   * `lower(string)` - returns a copy of the string with all Unicode letters mapped to their lower case.
+
+  * `select(value, compare, equal_value, other_value)` - Performs an equality
+      comparison between `value` and `compare`. If equal, the function returns
+      `equal_value`, otherwise `other_value` is returned. Example:
+      `select("a", "b", "bar", "foo")` = "foo".
 
   * `replace(string, search, replace)` - Does a search and replace on the
       given string. All instances of `search` are replaced with the value


### PR DESCRIPTION
There's a lot of activity in https://github.com/hashicorp/terraform/issues/1604, so conditional behaviour built into terraform core appears to be a much-desired request. In one of [my comments](https://github.com/hashicorp/terraform/issues/1604#issuecomment-141456800) in that thread I showed a way to evaluate a ternary – `if foo == "spam" then bar else baz` – using `replace`:
```
replace(replace(var.baz, replace(var.foo, "/^spam$/", "/^.*$/"), ""), "/^$/", var.bar)
```
Not a pretty beast, but we've been writing it. We were going to create a module to compute this for us, but feel that a module was too much, so I thought I'd propose this `select` function (note: feel free to propose a better name), as a way to avoid writing the nasty expression above. Some use cases for us:

1. We have a module to create a chef-managed `aws_instance`. If we decide to place it in a private subnet then we need to make sure the connection goes through a bastion and uses the private ip. We use a ternary to do this.
2. Setting the backup retention period of an RDS instance based on whether or not it's a read replica.
3. Dynamically creating reflexive security group rules (i.e., ports on which members of an SG can talk to each other on) based on whether or not a variable is empty.