### PR TITLE
provider/aws Only inform statefile about users/groups/roles we've defined in tf

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_policy_attachment.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment.go
@@ -84,6 +84,9 @@ func resourceAwsIamPolicyAttachmentRead(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).iamconn
 	arn := d.Get("policy_arn").(string)
 	name := d.Get("name").(string)
+	users := expandStringList(d.Get("users").(*schema.Set).List())
+	roles := expandStringList(d.Get("roles").(*schema.Set).List())
+	groups := expandStringList(d.Get("groups").(*schema.Set).List())
 
 	_, err := conn.GetPolicy(&iam.GetPolicyInput{
 		PolicyArn: aws.String(arn),
@@ -112,16 +115,30 @@ func resourceAwsIamPolicyAttachmentRead(d *schema.ResourceData, meta interface{}
 	rl := make([]string, 0, len(policyEntities.PolicyRoles))
 	gl := make([]string, 0, len(policyEntities.PolicyGroups))
 
-	for _, u := range policyEntities.PolicyUsers {
-		ul = append(ul, *u.UserName)
+	// Only write state for users we specifically created and that were also returned
+
+	for _, ru := range policyEntities.PolicyUsers {
+		for _, ku := range users {
+			if *ru.UserName == *ku {
+				ul = append(ul, *ru.UserName)
+			}
+		}
 	}
 
-	for _, r := range policyEntities.PolicyRoles {
-		rl = append(rl, *r.RoleName)
+	for _, rr := range policyEntities.PolicyRoles {
+		for _, kr := range roles {
+			if *rr.RoleName == *kr {
+				rl = append(rl, *rr.RoleName)
+			}
+		}
 	}
 
-	for _, g := range policyEntities.PolicyGroups {
-		gl = append(gl, *g.GroupName)
+	for _, rg := range policyEntities.PolicyGroups {
+		for _, kg := range groups {
+			if *rg.GroupName == *kg {
+				gl = append(gl, *rg.GroupName)
+			}
+		}
 	}
 
 	userErr := d.Set("users", ul)


### PR DESCRIPTION
This should fix the ongoing comments about #2100 
I'm not sure how to handle for a situation like this:

```
resource "aws_iam_user" "u1" { name = "u1" }
resource "aws_iam_user" "u2" { name = "u2" }

resource "aws_iam_policy" "s3" {
  name = "ec2describe"
  path = "/"
  description = "ec2"
  policy = "${file("./ec2.json")}"
}
resource "aws_iam_policy_attachment" "a1" {
  name = "a1"
  users = [ "${aws_iam_user.u1.name}", "${aws_iam_user.u2.name}" ]
  policy_arn = "${aws_iam_policy.s3.arn}"
}
resource "aws_iam_policy_attachment" "a2" {
  name = "a2"
  users = [ "${aws_iam_user.u2.name}" ]
  policy_arn = "${aws_iam_policy.s3.arn}"
}
```

and the removal or updating of the a1 attachment.

If we remove u2 from the a1 attachment, it'll actually remove the a2's attachment since they refer to the same policy. It'll get picked up in a subsequent run and fixed, but there's a transient state that I don't know how to catch in a single run. 

It'll also throw a 404 from the API if we try to run a `terraform destroy` while the u2 user is in both groups because one of them removes the policy from the user, and the other then hits a 404 when trying to detach it again from the same policy.

@catsby please let me know if you have any advice.
