### PR TITLE
core: Validate context after input of vars on refresh

### DIFF
--- a/command/refresh.go
+++ b/command/refresh.go
@@ -87,11 +87,13 @@ func (c *RefreshCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-	if !validateContext(ctx, c.Ui) {
-		return 1
-	}
+
 	if err := ctx.Input(c.InputMode()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
+		return 1
+	}
+
+	if !validateContext(ctx, c.Ui) {
 		return 1
 	}
 

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"bytes"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 )
@@ -410,6 +411,34 @@ func TestRefresh_varFileDefault(t *testing.T) {
 	}
 	if p.ConfigureConfig.Config["value"].(string) != "bar" {
 		t.Fatalf("bad: %#v", p.ConfigureConfig.Config)
+	}
+}
+
+func TestRefresh_varsUnset(t *testing.T) {
+	// Disable test mode so input would be asked
+	test = false
+	defer func() { test = true }()
+
+	defaultInputReader = bytes.NewBufferString("bar\n")
+
+	state := testState()
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &RefreshCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		testFixturePath("refresh-unset-var"),
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 }
 

--- a/command/test-fixtures/refresh-unset-var/main.tf
+++ b/command/test-fixtures/refresh-unset-var/main.tf
@@ -1,0 +1,7 @@
+variable "should_ask" {}
+
+provider "test" {}
+
+resource "test_instance" "foo" {
+  ami = "${var.should_ask}"
+}


### PR DESCRIPTION
See #4013 for context.