### PR TITLE
Ignore .test files generated by some editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ website/node_modules
 *~
 .*.swp
 .idea
+*.test


### PR DESCRIPTION
Seems like Emacs is generating .test files when saving _test.go files -
we don't need these in the repo.