### PR TITLE
provider/aws:Elasticache maintenance_window forces lowercase

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -71,6 +71,11 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				StateFunc: func(val interface{}) string {
+					// Elasticache always changes the maintenance
+					// to lowercase
+					return strings.ToLower(val.(string))
+				},
 			},
 			"subnet_group_name": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
Fixes #4014 

Changing the AWS ElastiCache cluster maintenance_window to enforce lowercase