### PR TITLE
provider/aws: Make VPC ID required on subnets

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -22,9 +22,8 @@ func resourceAwsSubnet() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"vpc_id": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
-				Computed: true,
 			},
 
 			"cidr_block": &schema.Schema{


### PR DESCRIPTION
This fixes an issue observed earlier today whereby not specifying a subnet ID fails with an API error (at least in some regions). This now matches the documentation which marks VPC ID as required.