### PR TITLE
provider/vsphere: Change ip_address parameter for ipv6 support

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -198,8 +198,8 @@ resource "vsphere_virtual_machine" "foo" {
     gateway = "%s"
     network_interface {
         label = "%s"
-        ip_address = "%s"
-        subnet_mask = "255.255.255.0"
+        ipv4_address = "%s"
+        ipv4_prefix_length = 24
     }
     disk {
 %s

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -49,21 +49,37 @@ The following arguments are supported:
 * `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for details
 * `boot_delay` - (Optional) Time in seconds to wait for machine network to be ready.
 
-<a id="network-interfaces"></a>
-## Network Interfaces
-
-Network interfaces support the following attributes:
+The `network_interface` block supports:
 
 * `label` - (Required) Label to assign to this network interface
-* `ip_address` - (Optional) Static IP to assign to this network interface. Interface will use DHCP if this is left blank. Currently only IPv4 IP addresses are supported.
-* `subnet_mask` - (Optional) Subnet mask to use when statically assigning an IP.
+* `ipv4_address` - (Optional) Static IP to assign to this network interface. Interface will use DHCP if this is left blank. Currently only IPv4 IP addresses are supported.
+* `ipv4_prefix_length` - (Optional) prefix length to use when statically assigning an IP.
 
-<a id="disks"></a>
-## Disks
+The following arguments are maintained for backwards compatibility and may be
+removed in a future version:
 
-Disks support the following attributes:
+* `ip_address` - __Deprecated, please use `ipv4_address` instead_.
+* `subnet_mask` - __Deprecated, please use `ipv4_prefix_length` instead_.
+
+
+The `disk` block supports:
 
 * `template` - (Required if size not provided) Template for this disk.
 * `datastore` - (Optional) Datastore for this disk
 * `size` - (Required if template not provided) Size of this disk (in GB).
 * `iops` - (Optional) Number of virtual iops to allocate for this disk.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The instance ID.
+* `name` - See Argument Reference above.
+* `vcpu` - See Argument Reference above.
+* `memory` - See Argument Reference above.
+* `datacenter` - See Argument Reference above.
+* `network_interface/label` - See Argument Reference above.
+* `network_interface/ipv4_address` - See Argument Reference above.
+* `network_interface/ipv4_prefix_length` - See Argument Reference above.
+* `network_interface/ipv6_address` - Assigned static IPv6 address.
+* `network_interface/ipv6_prefix_length` - Prefix length of assigned static IPv6 address.


### PR DESCRIPTION
This is a proposal PR to fix #3957.

I'd like to split `ip_address` parameter to `ipv4_address` and `ipv6_address` to support IPv6 address. (But, current version can not configure IPv6 address, just only read IPv6 address.)
And I'm thinking about changing `subnet_mask` parameter to `ipv4_prefix_length` and `ipv6_prefix_length` to simplify a configuration file and the code.

Before:

```
resource "vsphere_virtual_machine" "foo" {
    name = "sample"
    datacenter = "foo-dc"
    cluster = "foo-cluster"
    vcpu = 2
    memory = 4096
    gateway = "10.71.128.254"
    network_interface {
        label = "foo-label"
        ip_address = "10.71.128.1"
        subnet_mask = "255.255.255.0"
    }
    disk {
        datastore = "foo-datastore"
        template = "foo-template"
    }
}
```

After:

```
resource "vsphere_virtual_machine" "foo" {
    name = "sample"
    datacenter = "foo-dc"
    cluster = "foo-cluster"
    vcpu = 2
    memory = 4096
    gateway = "10.71.128.254"
    network_interface {
        label = "foo-label"
        ipv4_address = "10.71.128.1"
        ipv4_prefix_length = 24
    }
    disk {
        datastore = "foo-datastore"
        template = "foo-template"
    }
}
```

Thanks!