### PR TITLE
Remove locale identifier from links to the AWS document.

### DIFF
--- a/website/source/docs/providers/aws/r/eip.html.markdown
+++ b/website/source/docs/providers/aws/r/eip.html.markdown
@@ -42,4 +42,4 @@ The following attributes are exported:
 * `network_interface` - Contains the ID of the attached network interface.
 
 
-[1]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_AssociateAddress.html
+[1]: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateAddress.html

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -90,4 +90,4 @@ this instance is a read replica
 [3]: /docs/providers/aws/r/rds_cluster.html
 [4]: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html
 [5]: /docs/configuration/resources.html#count
-[6]: http://docs.aws.amazon.com/fr_fr/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
+[6]: http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html


### PR DESCRIPTION
Remove locale identifier, fr_fr, from links to the AWS document.