### PR TITLE
provider/aws: aws_spot_instance block_duration_minutes

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -58,6 +58,11 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			}
+			s["block_duration_minutes"] = &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			}
 
 			return s
 		}(),
@@ -95,6 +100,10 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 			SubnetId:            instanceOpts.SubnetID,
 			UserData:            instanceOpts.UserData64,
 		},
+	}
+
+	if v, ok := d.GetOk("block_duration_minutes"); ok {
+		spotOpts.BlockDurationMinutes = aws.Int64(int64(v.(int)))
 	}
 
 	// If the instance is configured with a Network Interface (a subnet, has
@@ -186,6 +195,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 		}
 	}
 	d.Set("spot_request_state", *request.State)
+	d.Set("block_duration_minutes", *request.BlockDurationMinutes)
 	d.Set("tags", tagsToMap(request.Tags))
 
 	return nil

--- a/builtin/providers/aws/resource_aws_spot_instance_request_test.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request_test.go
@@ -36,6 +36,33 @@ func TestAccAWSSpotInstanceRequest_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSpotInstanceRequest_withBlockDuration(t *testing.T) {
+	var sir ec2.SpotInstanceRequest
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSpotInstanceRequestConfig_withBlockDuration,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSpotInstanceRequestExists(
+						"aws_spot_instance_request.foo", &sir),
+					testAccCheckAWSSpotInstanceRequestAttributes(&sir),
+					testCheckKeyPair("tmp-key", &sir),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "block_duration_minutes", "60"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSpotInstanceRequest_vpc(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
 
@@ -264,6 +291,33 @@ resource "aws_spot_instance_request" "foo" {
 	// we wait for fulfillment because we want to inspect the launched instance
 	// and verify termination behavior
 	wait_for_fulfillment = true
+
+	tags {
+		Name = "terraform-test"
+	}
+}
+`
+
+const testAccAWSSpotInstanceRequestConfig_withBlockDuration = `
+resource "aws_key_pair" "debugging" {
+	key_name = "tmp-key"
+	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+
+resource "aws_spot_instance_request" "foo" {
+	ami = "ami-4fccb37f"
+	instance_type = "m1.small"
+	key_name = "${aws_key_pair.debugging.key_name}"
+
+	// base price is $0.044 hourly, so bidding above that should theoretically
+	// always fulfill
+	spot_price = "0.05"
+
+	// we wait for fulfillment because we want to inspect the launched instance
+	// and verify termination behavior
+	wait_for_fulfillment = true
+
+	block_duration_minutes = 60
 
 	tags {
 		Name = "terraform-test"

--- a/website/source/docs/providers/aws/r/spot_instance_request.html.markdown
+++ b/website/source/docs/providers/aws/r/spot_instance_request.html.markdown
@@ -54,6 +54,9 @@ Spot Instance Requests support all the same arguments as
 * `spot_type` - (Optional; Default: "persistent") If set to "one-time", after
   the instance is terminated, the spot request will be closed. Also, Terraform
   can't manage one-time spot requests, just launch them.
+* `block_duration_minutes` - (Optional) The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+  The duration period starts as soon as your Spot instance receives its instance ID. At the end of the duration period, Amazon EC2 marks the Spot instance for termination and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates.
+  Note that you can't specify an Availability Zone group or a launch group if you specify a duration.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adding support for Block_Durations to AWS Spot instance. Fixes #3969 

As Per Their Docs: http://docs.aws.amazon.com/cli/latest/reference/ec2/request-spot-instances.html 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSSpotInstanceRequest_withBlock' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSSpotInstanceRequest_withBlock -timeout 90m
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (104.97s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	104.985s
```

