### PR TITLE
provider/aws: Skip SG ID determination logic for Classic ELBs

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -350,12 +350,12 @@ func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 		var elbVpc string
 		if lb.VPCId != nil {
 			elbVpc = *lb.VPCId
-		}
-		sgId, err := sourceSGIdByName(meta, *lb.SourceSecurityGroup.GroupName, elbVpc)
-		if err != nil {
-			return fmt.Errorf("[WARN] Error looking up ELB Security Group ID: %s", err)
-		} else {
-			d.Set("source_security_group_id", sgId)
+			sgId, err := sourceSGIdByName(meta, *lb.SourceSecurityGroup.GroupName, elbVpc)
+			if err != nil {
+				return fmt.Errorf("[WARN] Error looking up ELB Security Group ID: %s", err)
+			} else {
+				d.Set("source_security_group_id", sgId)
+			}
 		}
 	}
 	d.Set("subnets", lb.Subnets)


### PR DESCRIPTION
Should fix https://github.com/hashicorp/terraform/issues/4073. Tested locally and `terraform plan` does not now throw an error.