### PR TITLE
provider/aws: Allow changing of S3 Bucket ACL without forcing new bucket

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -71,6 +71,37 @@ func TestAccAWSS3Bucket_Policy(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3Bucket_UpdateAcl(t *testing.T) {
+
+	ri := genRandInt()
+	preConfig := fmt.Sprintf(testAccAWSS3BucketConfigWithAcl, ri)
+	postConfig := fmt.Sprintf(testAccAWSS3BucketConfigWithAclUpdate, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "acl", "public-read"),
+				),
+			},
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "acl", "private"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3Bucket_Website_Simple(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -521,3 +552,17 @@ resource "aws_s3_bucket" "bucket" {
 	}
 }
 `, randInt)
+
+var testAccAWSS3BucketConfigWithAcl = `
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+}
+`
+
+var testAccAWSS3BucketConfigWithAclUpdate = `
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+}
+`


### PR DESCRIPTION
Fixes #3135 
Changing the S3 Bucket resource to allow the update of ACL by using PutBucketAcl

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=S3Bucket_UpdateAcl' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=S3Bucket_UpdateAcl -timeout 90m
=== RUN   TestAccAWSS3Bucket_UpdateAcl
--- PASS: TestAccAWSS3Bucket_UpdateAcl (24.91s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	24.924s
```