### PR TITLE
Enable specifying aws s3 redirect protocol

### DIFF
--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -106,7 +106,7 @@ The `website` object supports the following:
 
 * `index_document` - (Required, unless using `redirect_all_requests_to`) Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
 * `error_document` - (Optional) An absolute path to the document to return in case of a 4XX error.
-* `redirect_all_requests_to` - (Optional) A hostname to redirect all website requests for this bucket to.
+* `redirect_all_requests_to` - (Optional) A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
 
 The `CORS` object supports the following:
 


### PR DESCRIPTION
S3 website redirect configurations allows specifying a protocol for redirects (http or https). 

This PR adds support for that using the same `redirect_all_requests_to` field by specifying a protocol there e.g: `redirect_all_requests_to = https://hashicorp.com` will result in `{ HostName: hashicorp.com, Protocol: https }` being sent to AWS. When no protocol is specified behaviour remains the same as before.

Still need to update docs and tests. Please let me know if this is a feature you'd want to merge.