### PR TITLE
[WIP] provider/vsphere: Add resource_pool support in host cluster

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -768,9 +768,16 @@ func (vm *virtualMachine) createVirtualMachine(c *govmomi.Client) error {
 			}
 		}
 	} else {
-		resourcePool, err = finder.ResourcePool(context.TODO(), vm.resourcePool)
-		if err != nil {
-			return err
+		if vm.cluster == "" {
+			resourcePool, err = finder.ResourcePool(context.TODO(), vm.resourcePool)
+			if err != nil {
+				return err
+			}
+		} else {
+			resourcePool, err = finder.ResourcePool(context.TODO(), "*"+vm.cluster+"/Resources/"+vm.resourcePool)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	log.Printf("[DEBUG] resource pool: %#v", resourcePool)
@@ -907,9 +914,16 @@ func (vm *virtualMachine) deployVirtualMachine(c *govmomi.Client) error {
 			}
 		}
 	} else {
-		resourcePool, err = finder.ResourcePool(context.TODO(), vm.resourcePool)
-		if err != nil {
-			return err
+		if vm.cluster == "" {
+			resourcePool, err = finder.ResourcePool(context.TODO(), vm.resourcePool)
+			if err != nil {
+				return err
+			}
+		} else {
+			resourcePool, err = finder.ResourcePool(context.TODO(), "*"+vm.cluster+"/Resources/"+vm.resourcePool)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	log.Printf("[DEBUG] resource pool: %#v", resourcePool)


### PR DESCRIPTION
In a case of using resource pool in a host cluster, an error occurs like "resource pool 'XXX' not found". This PR adds the possibility to use `resource_pool` argument in the host cluster.

The example DC structure is the following:

```
DC1 (Data Center)
..|
..+---> CL1 (host cluster)
........ |
........ +-----> PRINCIPAL (resource pool)
........ |
........ +-----> UNO (resource pool)
```

- Ref: https://github.com/rakutentech/terraform-provider-vsphere/issues/45.