### PR TITLE
Proposal: Refactoring AWS waiters (and examples for Lambda event source mapping and S3 bucket)

### DIFF
--- a/builtin/providers/aws/wait.go
+++ b/builtin/providers/aws/wait.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// Better waiter for AWS, extending the core waiter logic.
+//
+// Example:
+//     params := &awsservice.APICallInput { Name: value }
+//     out, err := retryWaiter(
+//       func() (interface{}, error) { return conn.APIFunction(params) },
+//       []string{"ListOfRetryableErrors"},
+//       1*time.Minute, // or other valid time representation
+//     )
+//
+//     if err != nil {
+//       // handle errors here
+//     }
+//
+//     apiCallOutput := out.(*service.APICallOutput)
+func retryWaiter(f func() (interface{}, error), codes []string, timeout time.Duration) (interface{}, error) {
+	var output interface{}
+
+	err := resource.Retry(timeout, func() error {
+		var err error
+		output, err = f()
+
+		if err != nil {
+			if awserr, ok := err.(awserr.Error); ok {
+				for _, code := range codes {
+					if code == awserr.Code() {
+						// Retryable
+						return awserr
+					}
+				}
+				// Didn't recognize the error, so shouldn't retry.
+				return resource.RetryError{Err: err}
+			}
+		}
+		// Successful
+		return nil
+	})
+	return output, err
+}


### PR DESCRIPTION
The following PR (and the `aws_waiters` branch) is the result of the work that I did on waiters today.

After several hours of diving into the waiters in the AWS Go SDK this morning, I found that Terraform already has a pretty competent retry waiter in `helper/resource/wait.go`, that is actually in use with several of the AWS provider resources already. However, it looked like there was a lot of code duplication, so I refactored the existing pattern into a new `aws.retryWaiter` function within the provider itself.

The method is contained and documented in `builtin/providers/aws/wait.go`. I have also re-factored the policy application function in `aws_s3_bucket` and the event source mapping creation in `aws_lambda_event_source_mapping` to use it. The latter addresses the issue that I mentioned in my last PR #4093. 

If this looks good and/or pending other comment I might go about checking out fixing #3557, if this is still an issue, and re-factoring the other instances of its use in the AWS provider. This can then be used easily to address other issues of the like should they come up.

Also not too sure if test coverage is going to be necessary or if just picking it up thru the consuming resources will be enough.

PS: This PR will probably have unrelated commits on it until #4093 is merged.
PPS: After looking at the AWS Go SDK's own waiter I actually think Terraform's is currently in better shape, as it offers a way to get return data and also has backoff baked in already.