### PR TITLE
provider/aws: Normalization of SPF records to prevent reporting changes

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -82,6 +82,23 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53RecordConfigSPF,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_record.default", "records.2930149397", "include:notexample.com"),
+				),
+			},
+		},
+	})
+}
 func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -398,6 +415,19 @@ resource "aws_route53_record" "default" {
 	type = "TXT"
 	ttl = "30"
 	records = ["lalalala"]
+}
+`
+const testAccRoute53RecordConfigSPF = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_record" "default" {
+	zone_id = "${aws_route53_zone.main.zone_id}"
+	name = "test"
+	type = "SPF"
+	ttl = "30"
+	records = ["include:notexample.com"]
 }
 `
 

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -500,7 +500,7 @@ func expandResourceRecords(recs []interface{}, typeStr string) []*route53.Resour
 	for _, r := range recs {
 		s := r.(string)
 		switch typeStr {
-		case "TXT":
+		case "TXT", "SPF":
 			str := fmt.Sprintf("\"%s\"", s)
 			records = append(records, &route53.ResourceRecord{Value: aws.String(str)})
 		default:


### PR DESCRIPTION
Adding support for the normalizing of Route53 SPF records. Fixes #3230

```hcl
make testacc TEST=./builtin/providers/aws TESTARGS='-run=Route53Record_spfSupport' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=Route53Record_spfSupport -timeout 90m
=== RUN   TestAccAWSRoute53Record_spfSupport
--- PASS: TestAccAWSRoute53Record_spfSupport (79.17s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	79.185s
```