### PR TITLE
provider/aws: Check for nil on some spot instance attributes

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -194,8 +194,13 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("[ERR] Error reading Spot Instance Data: %s", err)
 		}
 	}
-	d.Set("spot_request_state", *request.State)
-	d.Set("block_duration_minutes", *request.BlockDurationMinutes)
+
+	if request.State != nil {
+		d.Set("spot_request_state", *request.State)
+	}
+	if request.BlockDurationMinutes != nil {
+		d.Set("block_duration_minutes", *request.BlockDurationMinutes)
+	}
 	d.Set("tags", tagsToMap(request.Tags))
 
 	return nil


### PR DESCRIPTION
Acceptance test `TestAccAWSSpotInstanceRequest_basic` was panicking due to a nil reference. `*request.BlockDurationMinutes` was nil :frowning: 