### PR TITLE
providers/aws: Update Security Group docs

### DIFF
--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -66,7 +66,8 @@ resource "aws_security_group" "allow_all" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the security group
+* `name` - (Optional) The name of the security group. If omitted, Terraform will
+assign a random, unique name
 * `description` - (Optional) The security group description. Defaults to "Managed by Terraform". Cannot be "".
 * `ingress` - (Optional) Can be specified multiple times for each
    ingress rule. Each ingress block supports fields documented below.


### PR DESCRIPTION
Small doc update: Security Group names are optional; Terraform will assign a unique id if omitted. 


![helping](https://cloud.githubusercontent.com/assets/61721/11536752/80d0beae-98df-11e5-9f19-565f50f5af24.gif)
