### PR TITLE
provider/docker: Refer to a tag instead of latest

### DIFF
--- a/builtin/providers/docker/resource_docker_image_test.go
+++ b/builtin/providers/docker/resource_docker_image_test.go
@@ -17,7 +17,7 @@ func TestAccDockerImage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"docker_image.foo",
 						"latest",
-						"d52aff8195301dba95e8e3d14f0c3738a874237afd54233d250a2fc4489bfa83"),
+						"8dd8107abd2e22bfd3b45b05733f3d2677d4078b09b5edce56ee3d8677d3c648"),
 				),
 			},
 		},
@@ -44,8 +44,8 @@ func TestAddDockerImage_private(t *testing.T) {
 
 const testAccDockerImageConfig = `
 resource "docker_image" "foo" {
-	name = "ubuntu:trusty-20150320"
-	keep_updated = true
+	name = "alpine:3.1"
+	keep_updated = false
 }
 `
 


### PR DESCRIPTION
This should make tests more stable going forward. Also switch out the image used from Ubuntu to Alpine Linux to reduce required download size during test runs.

When applied, all Docker acceptance tests pass:

```
$ make testacc TEST=./builtin/providers/docker 2>&1 | tee /tmp/testrun.log | grep -E 'PASS|FAIL'
--- PASS: TestProvider (0.00s)
--- PASS: TestProvider_impl (0.00s)
--- PASS: TestAccDockerContainer_basic (23.70s)
--- PASS: TestAccDockerContainer_customized (2.09s)
--- PASS: TestAccDockerImage_basic (1.74s)
--- PASS: TestAddDockerImage_private (20.03s)
PASS
```