### PR TITLE
provider/vsphere: restore vcenter_server as deprecated field

### DIFF
--- a/builtin/providers/vsphere/provider.go
+++ b/builtin/providers/vsphere/provider.go
@@ -1,6 +1,8 @@
 package vsphere
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -25,21 +27,26 @@ func Provider() terraform.ResourceProvider {
 
 			"vsphere_server": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_SERVER", nil),
 				Description: "The vSphere Server name for vSphere API operations.",
 			},
-
 			"allow_unverified_ssl": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_ALLOW_UNVERIFIED_SSL", false),
 				Description: "If set, VMware vSphere client will permit unverifiable SSL certificates.",
 			},
+			"vcenter_server": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_VCENTER", nil),
+				Deprecated:  "This field has been renamed to vsphere_server.",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"vsphere_folder": resourceVSphereFolder(),
+			"vsphere_folder":          resourceVSphereFolder(),
 			"vsphere_virtual_machine": resourceVSphereVirtualMachine(),
 		},
 
@@ -48,11 +55,25 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	// Handle backcompat support for vcenter_server; once that is removed,
+	// vsphere_server can just become a Required field that is referenced inline
+	// in Config below.
+	server := d.Get("vsphere_server").(string)
+
+	if server == "" {
+		server = d.Get("vcenter_server").(string)
+	}
+
+	if server == "" {
+		return nil, fmt.Errorf(
+			"One of vsphere_server or [deprecated] vcenter_server must be provided.")
+	}
+
 	config := Config{
 		User:          d.Get("user").(string),
 		Password:      d.Get("password").(string),
-		VSphereServer: d.Get("vsphere_server").(string),
 		InsecureFlag:  d.Get("allow_unverified_ssl").(bool),
+		VSphereServer: server,
 	}
 
 	return config.Client()


### PR DESCRIPTION
As promised in my comment in #3718, this preserves backwards
compatibility while warning users of the new proper name for the field.