### PR TITLE
providers/aws: Validate IOPs for EBS Volumes

### DIFF
--- a/builtin/providers/aws/resource_aws_ebs_volume.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume.go
@@ -37,14 +37,6 @@ func resourceAwsEbsVolume() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(int)
-					if value < 100 {
-						es = append(es, fmt.Errorf(
-							"%q must be an integer, minimum value 100", k))
-					}
-					return
-				},
 			},
 			"kms_key_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_ebs_volume_test.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume_test.go
@@ -26,14 +26,14 @@ func TestAccAWSEBSVolume_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEBSVolume_Iops(t *testing.T) {
+func TestAccAWSEBSVolume_NoIops(t *testing.T) {
 	var v ec2.Volume
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAwsEbsVolumeConfigWithIops,
+				Config: testAccAwsEbsVolumeConfigWithNoIops,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists("aws_ebs_volume.iops_test", &v),
 				),
@@ -103,7 +103,7 @@ resource "aws_ebs_volume" "tags_test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithIops = `
+const testAccAwsEbsVolumeConfigWithNoIops = `
 resource "aws_ebs_volume" "iops_test" {
 	availability_zone = "us-west-2a"
 	size = 10

--- a/builtin/providers/aws/resource_aws_ebs_volume_test.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume_test.go
@@ -26,6 +26,22 @@ func TestAccAWSEBSVolume_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSEBSVolume_Iops(t *testing.T) {
+	var v ec2.Volume
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsEbsVolumeConfigWithIops,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.iops_test", &v),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSEBSVolume_withTags(t *testing.T) {
 	var v ec2.Volume
 	resource.Test(t, resource.TestCase{
@@ -81,6 +97,18 @@ const testAccAwsEbsVolumeConfigWithTags = `
 resource "aws_ebs_volume" "tags_test" {
 	availability_zone = "us-west-2a"
 	size = 1
+	tags {
+		Name = "TerraformTest"
+	}
+}
+`
+
+const testAccAwsEbsVolumeConfigWithIops = `
+resource "aws_ebs_volume" "iops_test" {
+	availability_zone = "us-west-2a"
+	size = 10
+  type = "gp2"
+	iops = 0
 	tags {
 		Name = "TerraformTest"
 	}

--- a/website/source/docs/providers/aws/r/ebs_volume.html.md
+++ b/website/source/docs/providers/aws/r/ebs_volume.html.md
@@ -14,7 +14,7 @@ Manages a single EBS volume.
 
 ```
 resource "aws_ebs_volume" "example" {
-    availability_zone = "us-west-1a"
+    availability_zone = "us-west-2a"
     size = 40
     tags {
         Name = "HelloWorld"


### PR DESCRIPTION
IOPs must be an integer. 
The range varies by instance size (docs [here][1])pl, so we simply validate that it's an integer. 
IOPs is also not valid for any type that is not `io1`. Unfortunately I don't believe we can check for that in the `plan` phase, but we validate that in the `apply` phase here

Also, a minor fix to the docs: `us-west-1a` does not exist 


![helping](https://cloud.githubusercontent.com/assets/61721/11544612/7044142c-9908-11e5-96a0-aa57e387e066.gif)

[1]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_CreateVolume.html