### PR TITLE
provider/docker: locate container via ID not name

### DIFF
--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	dc "github.com/fsouza/go-dockerclient"
@@ -160,7 +159,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*dc.Client)
 
-	apiContainer, err := fetchDockerContainer(d.Get("name").(string), client)
+	apiContainer, err := fetchDockerContainer(d.Id(), client)
 	if err != nil {
 		return err
 	}
@@ -268,7 +267,7 @@ func mapTypeMapValsToString(typeMap map[string]interface{}) map[string]string {
 	return mapped
 }
 
-func fetchDockerContainer(name string, client *dc.Client) (*dc.APIContainers, error) {
+func fetchDockerContainer(ID string, client *dc.Client) (*dc.APIContainers, error) {
 	apiContainers, err := client.ListContainers(dc.ListContainersOptions{All: true})
 
 	if err != nil {
@@ -276,20 +275,8 @@ func fetchDockerContainer(name string, client *dc.Client) (*dc.APIContainers, er
 	}
 
 	for _, apiContainer := range apiContainers {
-		// Sometimes the Docker API prefixes container names with /
-		// like it does in these commands. But if there's no
-		// set name, it just uses the ID without a /...ugh.
-		switch len(apiContainer.Names) {
-		case 0:
-			if apiContainer.ID == name {
-				return &apiContainer, nil
-			}
-		default:
-			for _, containerName := range apiContainer.Names {
-				if strings.TrimLeft(containerName, "/") == name {
-					return &apiContainer, nil
-				}
-			}
+		if apiContainer.ID == ID {
+			return &apiContainer, nil
 		}
 	}
 


### PR DESCRIPTION
This reapplies the patch mentioned in #3364 - for an unknown reason the diff there was incorrect.

Acceptance test run after applying this:

```
$ make testacc TEST=./builtin/providers/docker 2>&1 | tee /tmp/testrun.log | grep -E 'PASS|FAIL'
--- PASS: TestProvider (0.00s)
--- PASS: TestProvider_impl (0.00s)
--- PASS: TestAccDockerContainer_basic (2.00s)
--- PASS: TestAccDockerContainer_customized (1.86s)
--- PASS: TestAccDockerImage_basic (1.67s)
--- PASS: TestAddDockerImage_private (10.86s)
PASS
```