### PR TITLE
splitting an IAM ARN into a Name should return the last element

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1082,5 +1082,6 @@ func iamInstanceProfileArnToName(ip *ec2.IamInstanceProfile) string {
 	if ip == nil || ip.Arn == nil {
 		return ""
 	}
-	return strings.Split(*ip.Arn, "/")[1]
+	s := strings.Split(*ip.Arn, "/")
+	return s[len(s)-1]
 }


### PR DESCRIPTION
My `aws_iam_instance_profile` had a path of `/apps/<service>/` and a name of `<Service>Profile`.  When I build new instances, the tfstate file saved the value incorrectly.

```
"iam_instance_profile": "apps",
```

When running `terraform plan` I continued to get this.
```
iam_instance_profile:              "apps" => "<Service>Profile" (forces new resource)
```