### PR TITLE
aws_lambda_alias resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -224,6 +224,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kinesis_stream":                   resourceAwsKinesisStream(),
 			"aws_lambda_function":                  resourceAwsLambdaFunction(),
 			"aws_lambda_event_source_mapping":      resourceAwsLambdaEventSourceMapping(),
+			"aws_lambda_alias":                     resourceAwsLambdaAlias(),
 			"aws_launch_configuration":             resourceAwsLaunchConfiguration(),
 			"aws_lb_cookie_stickiness_policy":      resourceAwsLBCookieStickinessPolicy(),
 			"aws_main_route_table_association":     resourceAwsMainRouteTableAssociation(),

--- a/builtin/providers/aws/resource_aws_lambda_alias.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLambdaAlias() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLambdaAliasCreate,
+		Read:   resourceAwsLambdaAliasRead,
+		Update: resourceAwsLambdaAliasUpdate,
+		Delete: resourceAwsLambdaAliasDelete,
+
+		Schema: map[string]*schema.Schema{
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"function_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"function_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+// resourceAwsLambdaAliasCreate maps to:
+// CreateAlias in the API / SDK
+func resourceAwsLambdaAliasCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	functionName := d.Get("function_name").(string)
+	aliasName := d.Get("name").(string)
+
+	log.Printf("[DEBUG] Creating Lambda alias: alias %s for function %s", aliasName, functionName)
+
+	params := &lambda.CreateAliasInput{
+		Description:     aws.String(d.Get("description").(string)),
+		FunctionName:    aws.String(functionName),
+		FunctionVersion: aws.String(d.Get("function_version").(string)),
+		Name:            aws.String(aliasName),
+	}
+
+	aliasConfiguration, err := conn.CreateAlias(params)
+	if err != nil {
+		return fmt.Errorf("Error creating Lambda alias: %s", err)
+	}
+
+	d.SetId(*aliasConfiguration.AliasArn)
+
+	return resourceAwsLambdaAliasRead(d, meta)
+}
+
+// resourceAwsLambdaAliasRead maps to:
+// GetAlias in the API / SDK
+func resourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	log.Printf("[DEBUG] Fetching Lambda alias: %s:%s", d.Get("function_name"), d.Get("name"))
+
+	params := &lambda.GetAliasInput{
+		FunctionName: aws.String(d.Get("function_name").(string)),
+		Name:         aws.String(d.Get("name").(string)),
+	}
+
+	aliasConfiguration, err := conn.GetAlias(params)
+	if err != nil {
+		return err
+	}
+
+	d.Set("description", aliasConfiguration.Description)
+	d.Set("function_version", aliasConfiguration.FunctionVersion)
+	d.Set("name", aliasConfiguration.Name)
+
+	return nil
+}
+
+// resourceAwsLambdaAliasDelete maps to:
+// DeleteAlias in the API / SDK
+func resourceAwsLambdaAliasDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	log.Printf("[INFO] Deleting Lambda alias: %s:%s", d.Get("function_name"), d.Get("name"))
+
+	params := &lambda.DeleteAliasInput{
+		FunctionName: aws.String(d.Get("function_name").(string)),
+		Name:         aws.String(d.Get("name").(string)),
+	}
+
+	_, err := conn.DeleteAlias(params)
+	if err != nil {
+		return fmt.Errorf("Error deleting Lambda alias: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+// resourceAwsLambdaAliasUpdate maps to:
+// UpdateAlias in the API / SDK
+func resourceAwsLambdaAliasUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	log.Printf("[DEBUG] Updating Lambda alias: %s:%s", d.Get("function_name"), d.Get("name"))
+
+	params := &lambda.UpdateAliasInput{
+		Description:     aws.String(d.Get("description").(string)),
+		FunctionName:    aws.String(d.Get("function_name").(string)),
+		FunctionVersion: aws.String(d.Get("function_version").(string)),
+		Name:            aws.String(d.Get("name").(string)),
+	}
+
+	_, err := conn.UpdateAlias(params)
+	if err != nil {
+		return fmt.Errorf("Error updating Lambda alias: %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_lambda_alias_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias_test.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSLambdaAlias_basic(t *testing.T) {
+	var conf lambda.AliasConfiguration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsLambdaAliasDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsLambdaAliasConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaAliasExists("aws_lambda_alias.lambda_alias_test", &conf),
+					testAccCheckAwsLambdaAttributes(&conf),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsLambdaAliasDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).lambdaconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lambda_alias" {
+			continue
+		}
+
+		_, err := conn.GetAlias(&lambda.GetAliasInput{
+			FunctionName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			return fmt.Errorf("Lambda alias was not deleted")
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckAwsLambdaAliasExists(n string, mapping *lambda.AliasConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Lambda alias not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Lambda alias not set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
+
+		params := &lambda.GetAliasInput{
+			FunctionName: aws.String(rs.Primary.ID),
+			Name:         aws.String("testalias"),
+		}
+
+		getAliasConfiguration, err := conn.GetAlias(params)
+		if err != nil {
+			return err
+		}
+
+		*mapping = *getAliasConfiguration
+
+		return nil
+	}
+}
+
+func testAccCheckAwsLambdaAttributes(mapping *lambda.AliasConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		name := *mapping.Name
+		arn := *mapping.AliasArn
+		if arn == "" {
+			return fmt.Errorf("Could not read Lambda alias ARN")
+		}
+		if name == "" {
+			return fmt.Errorf("Could not read Lambda alias name")
+		}
+		return nil
+	}
+}
+
+const testAccAwsLambdaAliasConfig = `
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "iam_for_lambda"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_policy" "policy_for_role" {
+    name = "policy_for_role"
+    path = "/"
+    description = "IAM policy for for Lamda alias testing"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+            "lambda:*"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+resource "aws_iam_policy_attachment" "policy_attachment_for_role" {
+    name = "policy_attachment_for_role"
+    roles = ["${aws_iam_role.iam_for_lambda.name}"]
+    policy_arn = "${aws_iam_policy.policy_for_role.arn}"
+}
+resource "aws_lambda_function" "lambda_function_test_create" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "example_lambda_name_create"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+}
+resource "aws_lambda_alias" "lambda_alias_test" {
+		name = "testalias"
+		description = "a sample description"
+		function_name = "${aws_lambda_function.lambda_function_test_create.arn}"
+		function_version = "$LATEST"
+}
+`

--- a/website/source/docs/providers/aws/r/lambda_alias.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_alias.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lambda_alias"
+sidebar_current: "docs-aws-resource-aws-lambda-alias"
+description: |-
+  Creates a Lambda function alias.
+---
+
+# aws\_lambda\_alias
+
+Creates a Lambda function alias. Creates an alias that points to the specified Lambda function version.
+
+For information about Lambda and how to use it, see [What is AWS Lambda?][1]
+For information about function aliases, see [CreateAlias][2] in the API docs.
+
+## Example Usage
+
+```
+resource "aws_lambda_alias" "test_alias" {
+		name = "testalias"
+		description = "a sample description"
+		function_name = "${aws_lambda_function.lambda_function_test.arn}"
+		function_version = "$LATEST"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Name for the alias you are creating. Pattern: `(?!^[0-9]+$)([a-zA-Z0-9-_]+)`
+* `description` - (Optional) Description of the alias.
+* `function_name` - (Required) The function ARN of the Lambda function for which you want to create an alias.
+* `function_version` - (Required) Lambda function version for which you are creating the alias. Pattern: `(\$LATEST|[0-9]+)`.
+
+[1]: http://docs.aws.amazon.com/lambda/latest/dg/welcome.html
+[2]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html


### PR DESCRIPTION
This PR adds a new resource: `aws_lambda_alias`, allowing for the creation of Lambda function [aliases][1].

This satisfies https://github.com/hashicorp/terraform/issues/4123.

PR includes the resource, the test, and the doc page for the website.
[1]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html