### PR TITLE
provider/aws: securitygroup name_prefix

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -28,11 +28,26 @@ func resourceAwsSecurityGroup() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
 					if len(value) > 255 {
 						errors = append(errors, fmt.Errorf(
 							"%q cannot be longer than 255 characters", k))
+					}
+					return
+				},
+			},
+
+			"name_prefix": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 100 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 100 characters, name is limited to 255", k))
 					}
 					return
 				},
@@ -178,6 +193,8 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 	var groupName string
 	if v, ok := d.GetOk("name"); ok {
 		groupName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		groupName = resource.PrefixedUniqueId(v.(string))
 	} else {
 		groupName = resource.UniqueId()
 	}

--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 
 * `name` - (Optional) The name of the security group. If omitted, Terraform will
 assign a random, unique name
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
 * `description` - (Optional) The security group description. Defaults to "Managed by Terraform". Cannot be "".
 * `ingress` - (Optional) Can be specified multiple times for each
    ingress rule. Each ingress block supports fields documented below.


### PR DESCRIPTION
Fixes #4152 

Adding the ability to generate a securitygroup name-prefix

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSSecurityGroup_' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSSecurityGroup_ -timeout 90m
=== RUN   TestAccAWSSecurityGroup_namePrefix
--- PASS: TestAccAWSSecurityGroup_namePrefix (2.22s)
```