### PR TITLE
S3 bucket force_destroy error: MalformedXML

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -406,30 +406,46 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 				log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %+v", err)
 
 				bucket := d.Get("bucket").(string)
-				resp, err := s3conn.ListObjects(
-					&s3.ListObjectsInput{
+				resp, err := s3conn.ListObjectVersions(
+					&s3.ListObjectVersionsInput{
 						Bucket: aws.String(bucket),
 					},
 				)
 
 				if err != nil {
-					return fmt.Errorf("Error S3 Bucket list Objects err: %s", err)
+					return fmt.Errorf("Error S3 Bucket list Object Versions err: %s", err)
 				}
 
-				objectsToDelete := make([]*s3.ObjectIdentifier, len(resp.Contents))
-				for i, v := range resp.Contents {
-					objectsToDelete[i] = &s3.ObjectIdentifier{
-						Key: v.Key,
+				objectsToDelete := make([]*s3.ObjectIdentifier, 0)
+
+				if len(resp.DeleteMarkers) != 0 {
+
+					for _, v := range resp.DeleteMarkers {
+						objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
+							Key:       v.Key,
+							VersionId: v.VersionId,
+						})
 					}
 				}
-				_, err = s3conn.DeleteObjects(
-					&s3.DeleteObjectsInput{
-						Bucket: aws.String(bucket),
-						Delete: &s3.Delete{
-							Objects: objectsToDelete,
-						},
+
+				if len(resp.Versions) != 0 {
+					for _, v := range resp.Versions {
+						objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
+							Key:       v.Key,
+							VersionId: v.VersionId,
+						})
+					}
+				}
+
+				params := &s3.DeleteObjectsInput{
+					Bucket: aws.String(bucket),
+					Delete: &s3.Delete{
+						Objects: objectsToDelete,
 					},
-				)
+				}
+
+				_, err = s3conn.DeleteObjects(params)
+
 				if err != nil {
 					return fmt.Errorf("Error S3 Bucket force_destroy error deleting: %s", err)
 				}


### PR DESCRIPTION
While doing forced destroy and if versioning is enabled for a bucket, AWS provider is not checking whether DeleteMarkers and versions of objects are left resulting in following error:
```
$$: terraform destroy -force -var env=piotr -state ~/Downloads/bucket.tfstate.json -var force_destroy=true
aws_s3_bucket.terraform-state-s3: Refreshing state... (ID: piotr-state)
aws_s3_bucket.terraform-state-s3: Destroying...
Error applying plan:

1 error(s) occurred:

* aws_s3_bucket.terraform-state-s3: Error S3 Bucket force_destroy error deleting: MalformedXML: The XML you provided was not well-formed or did not validate against our published schema
        status code: 400, request id:
```

```s3conn.ListObjects``` is checking only wheter there are objects (not versions) in the bucket causing ```s3.DeleteObjects``` to send empty XML which results in 400 error and MalformedXML message.

In this PR I'm using ```ListObjectVersions``` to get Versions and DeleteMarkers slice and create ```objectsToDelete``` slice that is passed to ```s3conn.DeleteObjects```
After this change AWS provider is able to delete all versions and delete markers for versioned S3 bucket and finally properly delete versioned bucket.

