### PR TITLE
Check HTTP status codes on responses from the DigitalOcean API instead of doing string compares

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_domain.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_domain.go
@@ -3,7 +3,6 @@ package digitalocean
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -56,11 +55,11 @@ func resourceDigitalOceanDomainCreate(d *schema.ResourceData, meta interface{}) 
 func resourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*godo.Client)
 
-	domain, _, err := client.Domains.Get(d.Id())
+	domain, resp, err := client.Domains.Get(d.Id())
 	if err != nil {
 		// If the domain is somehow already destroyed, mark as
 		// successfully gone
-		if strings.Contains(err.Error(), "404 Not Found") {
+		if resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/digitalocean/resource_digitalocean_record.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record.go
@@ -115,11 +115,11 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("invalid record ID: %v", err)
 	}
 
-	rec, _, err := client.Domains.Record(domain, id)
+	rec, resp, err := client.Domains.Record(domain, id)
 	if err != nil {
 		// If the record is somehow already destroyed, mark as
 		// successfully gone
-		if strings.Contains(err.Error(), "404 Not Found") {
+		if resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -183,15 +183,15 @@ func resourceDigitalOceanRecordDelete(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[INFO] Deleting record: %s, %d", domain, id)
 
-	_, err = client.Domains.DeleteRecord(domain, id)
-	if err != nil {
+  resp, delErr := client.Domains.DeleteRecord(domain, id)
+	if delErr != nil {
 		// If the record is somehow already destroyed, mark as
 		// successfully gone
-		if strings.Contains(err.Error(), "404 Not Found") {
+		if resp.StatusCode == 404 {
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting record: %s", err)
+		return fmt.Errorf("Error deleting record: %s", delErr)
 	}
 
 	return nil

--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -71,11 +70,11 @@ func resourceDigitalOceanSSHKeyRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("invalid SSH key id: %v", err)
 	}
 
-	key, _, err := client.Keys.GetByID(id)
+	key, resp, err := client.Keys.GetByID(id)
 	if err != nil {
 		// If the key is somehow already destroyed, mark as
 		// successfully gone
-		if strings.Contains(err.Error(), "404 Not Found") {
+		if resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Analogous to #3768 -- just for DNS and keys.

The error string for 404s on DNS domains has (apparently)
changed, causing things to be a little sad when you modify
DNS domains from the DO console instead of terraform. This
is just the same fix as was applied to droplets around this
time last month.

While I was at it I just fixed this everywhere I saw it in the
DO provider source tree.

NB. I didn't run the acceptance tests on this (it's late where
I am, and I wanted to open this while it was still on my mind).
I did however confirm that for my project I was able to
reprovision DNS entries where I'd previously crashed out.