### PR TITLE
Fix for list of lists of unknown computed values [GH-3679]

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -496,7 +496,7 @@ func (i *Interpolater) computeResourceMultiVariable(
 		//
 		// For an input walk, computed values are okay to return because we're only
 		// looking for missing variables to prompt the user for.
-		if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkDestroy || i.Operation == walkInput {
+		if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkDestroy || i.Operation == walkInput || i.Operation == walkPlan {
 			return config.UnknownVariableValue, nil
 		}
 


### PR DESCRIPTION
This fixes GH-3679.

Not sure if this is correct, but it fixes an issue with using computed list of attributes that is not yet known during the first terraform apply or plan.

Really not sure what is the impact of this on other parts of terraform though, so feedback is welcome!