### PR TITLE
provider/template: Clouding provider headers

### DIFF
--- a/builtin/providers/template/resource_cloudinit_config.go
+++ b/builtin/providers/template/resource_cloudinit_config.go
@@ -6,12 +6,13 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/textproto"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/sthulb/mime/multipart"
 )
 
 func resourceCloudinitConfig() *schema.Resource {

--- a/builtin/providers/template/resource_cloudinit_config.go
+++ b/builtin/providers/template/resource_cloudinit_config.go
@@ -170,6 +170,7 @@ func renderPartsToWriter(parts cloudInitParts, writer io.Writer) error {
 	}
 
 	writer.Write([]byte(fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\n", mimeWriter.Boundary())))
+	writer.Write([]byte("MIME-Version: 1.0\r\n"))
 
 	for _, part := range parts {
 		header := textproto.MIMEHeader{}
@@ -178,6 +179,9 @@ func renderPartsToWriter(parts cloudInitParts, writer io.Writer) error {
 		} else {
 			header.Set("Content-Type", part.ContentType)
 		}
+
+		header.Set("MIME-Version", "1.0")
+		header.Set("Content-Transfer-Encoding", "7bit")
 
 		if part.Filename != "" {
 			header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, part.Filename))

--- a/builtin/providers/template/resource_cloudinit_config_test.go
+++ b/builtin/providers/template/resource_cloudinit_config_test.go
@@ -21,7 +21,7 @@ func TestRender(t *testing.T) {
 					content = "baz"
 				}
 			}`,
-			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDRY\"\n--MIMEBOUNDRY\r\nContent-Type: text/x-shellscript\r\n\r\nbaz\r\n--MIMEBOUNDRY--\r\n",
+			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDRY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDRY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDRY--\r\n",
 		},
 		{
 			`resource "template_cloudinit_config" "foo" {
@@ -34,7 +34,7 @@ func TestRender(t *testing.T) {
 					filename = "foobar.sh"
 				}
 			}`,
-			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDRY\"\n--MIMEBOUNDRY\r\nContent-Type: text/x-shellscript\r\nContent-Disposition: attachment; filename=\"foobar.sh\"\r\n\r\nbaz\r\n--MIMEBOUNDRY--\r\n",
+			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDRY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDRY\r\nContent-Disposition: attachment; filename=\"foobar.sh\"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDRY--\r\n",
 		},
 		{
 			`resource "template_cloudinit_config" "foo" {
@@ -50,7 +50,7 @@ func TestRender(t *testing.T) {
 					content = "ffbaz"
 				}
 			}`,
-			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDRY\"\n--MIMEBOUNDRY\r\nContent-Type: text/x-shellscript\r\n\r\nbaz\r\n--MIMEBOUNDRY\r\nContent-Type: text/x-shellscript\r\n\r\nffbaz\r\n--MIMEBOUNDRY--\r\n",
+			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDRY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDRY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDRY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDRY--\r\n",
 		},
 		{
 			`resource "template_cloudinit_config" "foo" {
@@ -67,7 +67,7 @@ func TestRender(t *testing.T) {
 					content = "ffbaz"
 				}
 			}`,
-			"\x1f\x8b\b\x00\x00\tn\x88\x00\xff\x94\x8d\xbd\n\xc2@\x10\x84\xfb\x83{\x87\xe3\xfa%}B\x1a\x8d\x85E\x14D\v\xcbM\xb2!\v\xf7Gn\x03\x89O\xaf\x9d\x8a\x95\xe5\f3߷\x8fA(\b\\\xb7D\xa5\xf1\x8b\x13N8K\xe1y\xa5\xa12]\\\u0080\xf3V\xdb\xf6\xd8\x1ev\xe7۩\xb9ܭ\x02\xf8\x88Z}C\x84V)V\xc8\x139\x97\xfb\x99\x93\xbc\x17\r\xe7\x143\v\xc7P\x1a\x14\xc1~\xf2\xaf\xbe2#;\n詶8Y\xad\xb4\xea\xf0\xa1\xff\xf7h5\x8e\xbfO\x00\xad\x9e\x01\x00\x00\xff\xff\xecM\xd3\x1e\xe9\x00\x00\x00",
+			"\x1f\x8b\b\x00\x00\tn\x88\x00\xff\xac\xce\xc1J\x031\x10\xc6\xf1{`\xdf!\xe4>VO\u0096^\xb4=xX\x05\xa9\x82\xc7\xd9݉;\x90LB2\x85\xadOo-\x88\x8b\xe2\xadǄ\x1f\xf3\xfd\xef\x93(\x89\xc2\xfe\x98\xa9\xb5\xf1\x10\x943\x16]E\x9ei\\\xdb>\x1dd\xc4rܸ\xee\xa1\xdb\xdd=\xbd<n\x9fߜ\xf9z\xc0+\x95\xcaIZ{su\xdd\x18\x80\x85h\xcc\xf7\xdd-ל*\xeb\x19\xa2*\x0eS<\xfd\xaf\xad\xe7@\x82\x916\x0e'\xf7\xe3\xf7\x05\xa5z*\xb0\x93!\x8d,ﭽ\xedY\x17\xe0\x1c\xaa4\xebj\x86:Q\bu(\x9cO\xa2\xe3H\xbf\xa2\x1a\xd3\xe3ǿm\x97\xde\xf2\xfe\xef\x1a@c>\x03\x00\x00\xff\xffmB\x8c\xeed\x01\x00\x00",
 		},
 	}
 


### PR DESCRIPTION
Adds headers to the parts and `MIME-Version` to the overall document.

So, it appears that mime/multipart has some issues: https://golang.org/src/mime/multipart/writer.go#L97

Because it doesn't sort headers before writing them, they could end up out of order, this would mean the diff could change.