### PR TITLE
Fix to Google CloudSQL instance documentation

### DIFF
--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -41,12 +41,6 @@ The following arguments are supported:
 * `database_version` - (Optional, Default: `MYSQL_5_5`) The MySQL version to
   use. Can be either `MYSQL_5_5` or `MYSQL_5_6`.
 
-* `pricing_plan` - (Optional) Pricing plan for this instance, can be one of
-  `PER_USE` or `PACKAGE`.
-
-* `replication_type` - (Optional) Replication type for this instance, can be one of
-  `ASYNCHRONOUS` or `SYNCHRONOUS`.
-
 The required `settings` block supports:
 
 * `tier` - (Required) The machine tier to use. See
@@ -61,6 +55,12 @@ The required `settings` block supports:
 
 * `crash_safe_replication` - (Optional) Specific to read instances, indicates
   when crash-safe replication flags are enabled.
+
+* `pricing_plan` - (Optional) Pricing plan for this instance, can be one of
+  `PER_USE` or `PACKAGE`.
+
+* `replication_type` - (Optional) Replication type for this instance, can be one of
+  `ASYNCHRONOUS` or `SYNCHRONOUS`.
 
 The optional `settings.database_flags` sublist supports:
 


### PR DESCRIPTION
The `pricing_plan` and `replication_type` config options are listed in the wrong section in the website documentation, which caused Terraform crashes until I looked through the code to see where they should actually go.  This is just a super minor change to put the options in the `settings` section of the documentation.