### PR TITLE
travis: remove go tip builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: go
 
 go:
   - 1.5
-  - tip
 
 install: make updatedeps
 


### PR DESCRIPTION
I don't really see a good reason for running a build against Go tip.
This probably made more sense in the earlier days of Golang, but now
IMHO it's just wasting cycles for not much benefit.

/cc @jen20 @mitchellh