### PR TITLE
provider/aws: Fix issue destroy Route 53 zone/record if it no longer …

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -245,6 +245,11 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	// get expanded name
 	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone)})
 	if err != nil {
+		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
+			log.Printf("[DEBUG] No matching Route 53 Record found for: %s, removing from state file", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	en := expandRecordName(d.Get("name").(string), *zoneRecord.HostedZone.Name)
@@ -312,6 +317,11 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	var err error
 	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone)})
 	if err != nil {
+		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
+			log.Printf("[DEBUG] No matching Route 53 Record found for: %s, removing from state file", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	// Get the records

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -213,6 +213,11 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 		d.Get("name").(string), d.Id())
 	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{Id: aws.String(d.Id())})
 	if err != nil {
+		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
+			log.Printf("[DEBUG] No matching Route 53 Zone found for: %s, removing from state file", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
…exists

Fixes https://github.com/hashicorp/terraform/issues/4185 by removing the offending record(s) from the state file if it's no longer found. 