### PR TITLE
provider/azure: Fixes for #3568 and #3428

### DIFF
--- a/builtin/providers/azure/resource_azure_data_disk.go
+++ b/builtin/providers/azure/resource_azure_data_disk.go
@@ -92,6 +92,7 @@ func resourceAzureDataDisk() *schema.Resource {
 func resourceAzureDataDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	mc := meta.(*Client).mgmtClient
 	vmDiskClient := meta.(*Client).vmDiskClient
+	vmClient := meta.(*Client).vmClient
 
 	if err := verifyDataDiskParameters(d); err != nil {
 		return err
@@ -125,7 +126,14 @@ func resourceAzureDataDiskCreate(d *schema.ResourceData, meta interface{}) error
 
 	deploymentName := d.Get("deployment_name").(string)
 	if deploymentName == "" {
-		deploymentName = vm
+		deptName, err := vmClient.GetDeploymentName(cloudServiceName)
+		if err != nil {
+			return fmt.Errorf("Error creating data disk %d for instance %s while getting deployment name from cloud service %s: %s", lun, vm, cloudServiceName, err)
+		}
+		deploymentName = deptName
+	}
+	if deploymentName == "" {
+		return fmt.Errorf("Error creating data disk %d for instance %s while getting deployment name from cloud service %s: Deployment Name is blank", lun, vm, cloudServiceName)
 	}
 
 	log.Printf("[DEBUG] Adding data disk %d to instance: %s", lun, vm)
@@ -153,6 +161,7 @@ func resourceAzureDataDiskCreate(d *schema.ResourceData, meta interface{}) error
 
 func resourceAzureDataDiskRead(d *schema.ResourceData, meta interface{}) error {
 	vmDiskClient := meta.(*Client).vmDiskClient
+	vmClient := meta.(*Client).vmClient
 
 	lun := d.Get("lun").(int)
 	vm := d.Get("virtual_machine").(string)
@@ -163,7 +172,14 @@ func resourceAzureDataDiskRead(d *schema.ResourceData, meta interface{}) error {
 
 	deploymentName := d.Get("deployment_name").(string)
 	if deploymentName == "" {
-		deploymentName = vm
+		deptName, err := vmClient.GetDeploymentName(cloudServiceName)
+		if err != nil {
+			return fmt.Errorf("Error reading data disk %d for instance %s while getting deployment name from cloud service %s: %s", lun, vm, cloudServiceName, err)
+		}
+		deploymentName = deptName
+	}
+	if deploymentName == "" {
+		return fmt.Errorf("Error reading data disk %d for instance %s while getting deployment name from cloud service %s: Deployment Name is blank", lun, vm, cloudServiceName)
 	}
 
 	log.Printf("[DEBUG] Retrieving data disk: %s", d.Id())
@@ -199,6 +215,7 @@ func resourceAzureDataDiskRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAzureDataDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	mc := meta.(*Client).mgmtClient
 	vmDiskClient := meta.(*Client).vmDiskClient
+	vmClient := meta.(*Client).vmClient
 
 	lun := d.Get("lun").(int)
 	vm := d.Get("virtual_machine").(string)
@@ -210,7 +227,14 @@ func resourceAzureDataDiskUpdate(d *schema.ResourceData, meta interface{}) error
 
 	deploymentName := d.Get("deployment_name").(string)
 	if deploymentName == "" {
-		deploymentName = vm
+		deptName, err := vmClient.GetDeploymentName(cloudServiceName)
+		if err != nil {
+			return fmt.Errorf("Error updating data disk %d for instance %s while getting deployment name from cloud service %s: %s", lun, vm, cloudServiceName, err)
+		}
+		deploymentName = deptName
+	}
+	if deploymentName == "" {
+		return fmt.Errorf("Error updating data disk %d for instance %s while getting deployment name from cloud service %s: Deployment Name is blank", lun, vm, cloudServiceName)
 	}
 
 	if d.HasChange("lun") || d.HasChange("size") || d.HasChange("virtual_machine") {
@@ -222,7 +246,14 @@ func resourceAzureDataDiskUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 		odeploymentName, _ := d.GetChange("deployment_name")
 		if odeploymentName == "" {
-			odeploymentName = ovm
+			odeptName, err := vmClient.GetDeploymentName(ocloudServiceName.(string))
+			if err != nil {
+				return fmt.Errorf("Error updating data disk %d for instance %s while getting deployment name from cloud service %s: %s", lun, ovm, ocloudServiceName, err)
+			}
+			odeploymentName = odeptName
+		}
+		if odeploymentName == "" {
+			return fmt.Errorf("Error updating data disk %d for instance %s while getting deployment name from cloud service %s: Deployment Name is blank", lun, ovm, ocloudServiceName)
 		}
 
 		log.Printf("[DEBUG] Detaching data disk: %s", d.Id())
@@ -325,6 +356,7 @@ func resourceAzureDataDiskUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceAzureDataDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	mc := meta.(*Client).mgmtClient
 	vmDiskClient := meta.(*Client).vmDiskClient
+	vmClient := meta.(*Client).vmClient
 
 	lun := d.Get("lun").(int)
 	vm := d.Get("virtual_machine").(string)
@@ -336,7 +368,14 @@ func resourceAzureDataDiskDelete(d *schema.ResourceData, meta interface{}) error
 
 	deploymentName := d.Get("deployment_name").(string)
 	if deploymentName == "" {
-		deploymentName = vm
+		deptName, err := vmClient.GetDeploymentName(cloudServiceName)
+		if err != nil {
+			return fmt.Errorf("Error deleting data disk %d for instance %s while getting deployment name from cloud service %s: %s", lun, vm, cloudServiceName, err)
+		}
+		deploymentName = deptName
+	}
+	if deploymentName == "" {
+		return fmt.Errorf("Error deleting data disk %d for instance %s while getting deployment name from cloud service %s: Deployment Name is blank", lun, vm, cloudServiceName)
 	}
 
 	// If a name was not supplied, it means we created a new emtpy disk and we now want to

--- a/builtin/providers/azure/resource_azure_data_disk.go
+++ b/builtin/providers/azure/resource_azure_data_disk.go
@@ -73,6 +73,18 @@ func resourceAzureDataDisk() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			"cloud_service_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"deployment_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -105,9 +117,19 @@ func resourceAzureDataDiskCreate(d *schema.ResourceData, meta interface{}) error
 	if name, ok := d.GetOk("name"); ok {
 		p.DiskName = name.(string)
 	}
+	
+	cloudServiceName := d.Get("cloud_service_name").(string)
+	if cloudServiceName == "" {
+		cloudServiceName = vm
+	}
+
+	deploymentName := d.Get("deployment_name").(string)
+	if deploymentName == "" {
+		deploymentName = vm
+	}
 
 	log.Printf("[DEBUG] Adding data disk %d to instance: %s", lun, vm)
-	req, err := vmDiskClient.AddDataDisk(vm, vm, vm, p)
+	req, err := vmDiskClient.AddDataDisk(cloudServiceName, deploymentName, vm, p)
 	if err != nil {
 		return fmt.Errorf("Error adding data disk %d to instance %s: %s", lun, vm, err)
 	}
@@ -119,7 +141,7 @@ func resourceAzureDataDiskCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Retrieving data disk %d from instance %s", lun, vm)
-	disk, err := vmDiskClient.GetDataDisk(vm, vm, vm, lun)
+	disk, err := vmDiskClient.GetDataDisk(cloudServiceName, deploymentName, vm, lun)
 	if err != nil {
 		return fmt.Errorf("Error retrieving data disk %d from instance %s: %s", lun, vm, err)
 	}
@@ -134,9 +156,18 @@ func resourceAzureDataDiskRead(d *schema.ResourceData, meta interface{}) error {
 
 	lun := d.Get("lun").(int)
 	vm := d.Get("virtual_machine").(string)
+	cloudServiceName := d.Get("cloud_service_name").(string)
+	if cloudServiceName == "" {
+		cloudServiceName = vm
+	}
+
+	deploymentName := d.Get("deployment_name").(string)
+	if deploymentName == "" {
+		deploymentName = vm
+	}
 
 	log.Printf("[DEBUG] Retrieving data disk: %s", d.Id())
-	datadisk, err := vmDiskClient.GetDataDisk(vm, vm, vm, lun)
+	datadisk, err := vmDiskClient.GetDataDisk(cloudServiceName, deploymentName, vm, lun)
 	if err != nil {
 		if management.IsResourceNotFoundError(err) {
 			d.SetId("")
@@ -159,6 +190,8 @@ func resourceAzureDataDiskRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("virtual_machine", disk.AttachedTo.RoleName)
+	d.Set("deployment_name", disk.AttachedTo.DeploymentName)
+	d.Set("cloud_service_name", disk.AttachedTo.HostedServiceName)
 
 	return nil
 }
@@ -170,13 +203,31 @@ func resourceAzureDataDiskUpdate(d *schema.ResourceData, meta interface{}) error
 	lun := d.Get("lun").(int)
 	vm := d.Get("virtual_machine").(string)
 
+	cloudServiceName := d.Get("cloud_service_name").(string)
+	if cloudServiceName == "" {
+		cloudServiceName = vm
+	}
+
+	deploymentName := d.Get("deployment_name").(string)
+	if deploymentName == "" {
+		deploymentName = vm
+	}
+
 	if d.HasChange("lun") || d.HasChange("size") || d.HasChange("virtual_machine") {
 		olun, _ := d.GetChange("lun")
 		ovm, _ := d.GetChange("virtual_machine")
+		ocloudServiceName, _ := d.GetChange("cloud_service_name")
+		if ocloudServiceName == "" {
+			ocloudServiceName = ovm
+		}
+		odeploymentName, _ := d.GetChange("deployment_name")
+		if odeploymentName == "" {
+			odeploymentName = ovm
+		}
 
 		log.Printf("[DEBUG] Detaching data disk: %s", d.Id())
 		req, err := vmDiskClient.
-			DeleteDataDisk(ovm.(string), ovm.(string), ovm.(string), olun.(int), false)
+			DeleteDataDisk(ocloudServiceName.(string), odeploymentName.(string), ovm.(string), olun.(int), false)
 		if err != nil {
 			return fmt.Errorf("Error detaching data disk %s: %s", d.Id(), err)
 		}
@@ -231,7 +282,7 @@ func resourceAzureDataDiskUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		log.Printf("[DEBUG] Attaching data disk: %s", d.Id())
-		req, err = vmDiskClient.AddDataDisk(vm, vm, vm, p)
+		req, err = vmDiskClient.AddDataDisk(cloudServiceName, deploymentName, vm, p)
 		if err != nil {
 			return fmt.Errorf("Error attaching data disk %s to instance %s: %s", d.Id(), vm, err)
 		}
@@ -256,7 +307,7 @@ func resourceAzureDataDiskUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		log.Printf("[DEBUG] Updating data disk: %s", d.Id())
-		req, err := vmDiskClient.UpdateDataDisk(vm, vm, vm, lun, p)
+		req, err := vmDiskClient.UpdateDataDisk(cloudServiceName, deploymentName, vm, lun, p)
 		if err != nil {
 			return fmt.Errorf("Error updating data disk %s: %s", d.Id(), err)
 		}
@@ -277,13 +328,23 @@ func resourceAzureDataDiskDelete(d *schema.ResourceData, meta interface{}) error
 
 	lun := d.Get("lun").(int)
 	vm := d.Get("virtual_machine").(string)
+	
+	cloudServiceName := d.Get("cloud_service_name").(string)
+	if cloudServiceName == "" {
+		cloudServiceName = vm
+	}
+
+	deploymentName := d.Get("deployment_name").(string)
+	if deploymentName == "" {
+		deploymentName = vm
+	}
 
 	// If a name was not supplied, it means we created a new emtpy disk and we now want to
 	// delete that disk again. Otherwise we only want to detach the disk and keep the blob.
 	_, removeBlob := d.GetOk("name")
 
 	log.Printf("[DEBUG] Detaching data disk %s with removeBlob = %t", d.Id(), removeBlob)
-	req, err := vmDiskClient.DeleteDataDisk(vm, vm, vm, lun, removeBlob)
+	req, err := vmDiskClient.DeleteDataDisk(cloudServiceName, deploymentName, vm, lun, removeBlob)
 	if err != nil {
 		return fmt.Errorf(
 			"Error detaching data disk %s with removeBlob = %t: %s", d.Id(), removeBlob, err)

--- a/builtin/providers/azure/resource_azure_instance.go
+++ b/builtin/providers/azure/resource_azure_instance.go
@@ -740,7 +740,7 @@ func resourceAzureInstanceDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	err = resource.Retry(5*time.Minute, func() error {
+	err = resource.Retry(20*time.Minute, func() error {
 		exists, err := blobClient.BlobExists(
 			storageContainterName, fmt.Sprintf(osDiskBlobNameFormat, name),
 		)


### PR DESCRIPTION
Hi Terraform Developers,

These two bugs in Terraform Azure provider severely limits its usage with Azure, because they prevent the deployment of any practical multi-VM environment sitting behind a cloud service, and also using VM-s with additional data disks in such a scenario, both of them pretty basic needs: 
1. https://github.com/hashicorp/terraform/issues/3568
2. https://github.com/hashicorp/terraform/issues/3428

I have fixed these two bugs and thoroughly tested them. They needed a couple of changes in the underlying azure-sdk-for-go. These changes have now been accepted and merged, the latest pull request to get merged to the azure-sdk-for-go repo being this: https://github.com/Azure/azure-sdk-for-go/pull/238

Therefore, the master on azure-sdk-for-go is now ready for these fixes. I request you to take a look at them, review thoroughly, and let me know if they look good. If they do, please accept and merge.

The fixes do not touch a lot of files. They also respect the previous changes put in for "has_dedicated_service". I have tested these scenarios. Thanks!
