### PR TITLE
core: use same logging setup for acctests

### DIFF
--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -1,7 +1,8 @@
-package main
+package logging
 
 import (
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -18,9 +19,9 @@ const (
 
 var validLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 
-// logOutput determines where we should send logs (if anywhere) and the log level.
-func logOutput() (logOutput io.Writer, err error) {
-	logOutput = nil
+// LogOutput determines where we should send logs (if anywhere) and the log level.
+func LogOutput() (logOutput io.Writer, err error) {
+	logOutput = ioutil.Discard
 	envLevel := os.Getenv(EnvLog)
 	if envLevel == "" {
 		return

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -102,6 +103,12 @@ func Test(t TestT, c TestCase) {
 			TestEnvVar))
 		return
 	}
+
+	logWriter, err := logging.LogOutput()
+	if err != nil {
+		t.Error(fmt.Errorf("error setting up logging: %s", err))
+	}
+	log.SetOutput(logWriter)
 
 	// We require verbose mode so that the user knows what is going on.
 	if !testTesting && !testing.Verbose() {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/panicwrap"
@@ -23,13 +24,10 @@ func realMain() int {
 
 	if !panicwrap.Wrapped(&wrapConfig) {
 		// Determine where logs should go in general (requested by the user)
-		logWriter, err := logOutput()
+		logWriter, err := logging.LogOutput()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't setup log output: %s", err)
 			return 1
-		}
-		if logWriter == nil {
-			logWriter = ioutil.Discard
 		}
 
 		// We always send logs to a temporary file that we use in case
@@ -41,10 +39,6 @@ func realMain() int {
 		}
 		defer os.Remove(logTempFile.Name())
 		defer logTempFile.Close()
-
-		// Tell the logger to log to this file
-		os.Setenv(EnvLog, "")
-		os.Setenv(EnvLogFile, "")
 
 		// Setup the prefixed readers that send data properly to
 		// stdout/stderr.


### PR DESCRIPTION
We weren't doing any log setup for acceptance tests, which made it
difficult to wrangle log output in CI.

This moves the log setup functions we use in `main` over into a helper
package so we can use them for acceptance tests as well.

This means that acceptance tests will by default be a _lot_ quieter,
only printing out actual test output. Setting `TF_LOG=trace` will
restore the full prior noise level.

Only minor behavior change is to make `ioutil.Discard` the default
return value rather than a `nil` that needs to be checked for.