### PR TITLE
Fix AWS RDS cross-region read replica always being placed in default VPC

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -271,6 +271,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			CopyTagsToSnapshot:         aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBInstanceClass:            aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:       aws.String(d.Get("identifier").(string)),
+			DBSubnetGroupName:          aws.String(d.Get("db_subnet_group_name").(string)),
 			Tags:                       tags,
 		}
 		if attr, ok := d.GetOk("iops"); ok {
@@ -287,6 +288,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("publicly_accessible"); ok {
 			opts.PubliclyAccessible = aws.Bool(attr.(bool))
+		}
+
+		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+			opts.DBSubnetGroupName = aws.String(attr.(string))
 		}
 		_, err := conn.CreateDBInstanceReadReplica(&opts)
 		if err != nil {


### PR DESCRIPTION
Fixes #4192 by honouring the `db_subnet_group_name` parameter when creating a cross-region read replica.

:exclamation: These are my very first (baby-)steps in Go so I might missed something obvious. :grin: Maybe @catsby can take a look, thanks for pointing me into the right direction!

I tested this locally with my patched version, is that "good enough"? Looking forward to some feedback.

Btw your documentation & provided dev environment via Vagrant is outstanding, appreciate the effort. Working on terraform, even as go newbie, is a breeze!