### PR TITLE
provider/aws: DynamoDB Table StreamSpecifications

### DIFF
--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -172,6 +172,7 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 					value := v.(string)
 					return strings.ToUpper(value)
 				},
+				ValidateFunc: validateStreamViewType,
 			},
 		},
 	}
@@ -799,4 +800,19 @@ func waitForTableToBeActive(tableName string, meta interface{}) error {
 
 	return nil
 
+}
+
+func validateStreamViewType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	viewTypes := map[string]bool {
+		"KEYS_ONLY": true,
+		"NEW_IMAGE": true,
+		"OLD_IMAGE": true,
+		"NEW_AND_OLD_IMAGES": true,
+	}
+
+	if !viewTypes[value] {
+		errors = append(errors, fmt.Errorf("%q be a valid DynamoDB StreamViewType", k))
+	}
+	return
 }

--- a/builtin/providers/aws/resource_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table_test.go
@@ -53,6 +53,46 @@ func TestAccAWSDynamoDbTable_streamSpecification(t *testing.T) {
 	})
 }
 
+func TestResourceAWSDynamoDbTableStreamViewType_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "KEYS-ONLY",
+			ErrCount: 1,
+		},
+		{
+			Value:    "RANDOM-STRING",
+			ErrCount: 1,
+		},
+		{
+			Value:    "KEYS_ONLY",
+			ErrCount: 0,
+		},
+		{
+			Value:    "NEW_AND_OLD_IMAGES",
+			ErrCount: 0,
+		},
+		{
+			Value:    "NEW_IMAGE",
+			ErrCount: 0,
+		},
+		{
+			Value:    "OLD_IMAGE",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateStreamViewType(tc.Value, "aws_dynamodb_table_stream_view_type")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the DynamoDB stream_view_type to trigger a validation error")
+		}
+	}
+}
+
 func testAccCheckAWSDynamoDbTableDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
 

--- a/website/source/docs/providers/aws/r/dynamodb_table.html.markdown
+++ b/website/source/docs/providers/aws/r/dynamodb_table.html.markdown
@@ -84,6 +84,8 @@ parameter.
 * `non_key_attributes` - (Optional) Only required with *INCLUDE* as a
   projection type; a list of attributes to project into the index. These
 do not need to be defined as attributes on the table.
+* `stream_enabled` - (Optional) Indicates whether Streams is to be enabled (true) or disabled (false).
+* `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES.
 
 For `global_secondary_index` objects only, you need to specify
 `write_capacity` and `read_capacity` in the same way you would for the


### PR DESCRIPTION
Adding support for AWS DynamoDB Table for StreamSpecifications as per #4188 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSDynamoDbTable' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSDynamoDbTable -timeout 90m
=== RUN   TestAccAWSDynamoDbTable
-- PASS: TestAccAWSDynamoDbTable (290.82s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (10.02s)
PASS
```