### PR TITLE
Remove redundant -build-toolchain for gox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ plugin-dev: generate
 	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
 
 release: updatedeps
-	gox -build-toolchain
+	gox
 	@$(MAKE) bin
 
 # test runs the unit tests and vets the code


### PR DESCRIPTION
Running `make release` on the provided Vagrant machine errors with an error.

Removing the `-build-toolchain` fixes it. Maybe someone can verify this as it's not covered by CI.