### PR TITLE
Fix issue creating AWS RDS replicas across regions

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -271,6 +271,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			CopyTagsToSnapshot:         aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBInstanceClass:            aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:       aws.String(d.Get("identifier").(string)),
+			DBSubnetGroupName:          aws.String(d.Get("db_subnet_group_name").(string)),
 			Tags:                       tags,
 		}
 		if attr, ok := d.GetOk("iops"); ok {
@@ -287,6 +288,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("publicly_accessible"); ok {
 			opts.PubliclyAccessible = aws.Bool(attr.(bool))
+		}
+
+		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+			opts.DBSubnetGroupName = aws.String(attr.(string))
 		}
 		_, err := conn.CreateDBInstanceReadReplica(&opts)
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -276,7 +276,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			CopyTagsToSnapshot:         aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBInstanceClass:            aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:       aws.String(d.Get("identifier").(string)),
-			DBSubnetGroupName:          aws.String(d.Get("db_subnet_group_name").(string)),
 			Tags:                       tags,
 		}
 		if attr, ok := d.GetOk("iops"); ok {

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -31,6 +31,11 @@ func resourceAwsDbInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"username": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -553,6 +558,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		log.Printf("[DEBUG] Error building ARN for DB Instance, not setting Tags for DB %s", name)
 	} else {
+		d.Set("arn", arn)
 		resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
 			ResourceName: aws.String(arn),
 		})

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -93,6 +93,7 @@ The following attributes are exported:
 
 * `id` - The RDS instance ID.
 * `address` - The address of the RDS instance.
+* `arn` - The ARN of the RDS instance.
 * `allocated_storage` - The amount of allocated storage
 * `availability_zone` - The availability zone of the instance
 * `backup_retention_period` - The backup retention period


### PR DESCRIPTION
Supersedes #4207, fixed #4192 

#4207 was the core of it, we just needed to export the database instance ARN for reference in the replica