### PR TITLE
provider/digitalocean: FloatingIP Read Func for Region

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
@@ -82,11 +82,10 @@ func resourceDigitalOceanFloatingIpRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error retrieving FloatingIP: %s", err)
 	}
 
-	if _, ok := d.GetOk("droplet_id"); ok {
-		if floatingIp.Droplet != nil {
-			log.Printf("[INFO] The region of the Droplet is %s", floatingIp.Droplet.Region)
-			d.Set("region", floatingIp.Droplet.Region.Slug)
-		}
+	if floatingIp.Droplet != nil {
+		log.Printf("[INFO] A droplet was detected on the FloatingIP so setting the Region based on the Droplet")
+		log.Printf("[INFO] The region of the Droplet is %s", floatingIp.Droplet.Region.Slug)
+		d.Set("region", floatingIp.Droplet.Region.Slug)
 	} else {
 		d.Set("region", floatingIp.Region.Slug)
 	}


### PR DESCRIPTION
This makes the FloatingIP Read func safer when trying to set the Region. We now check for Droplet having a Region and then fallback to FloatingIP Region

```
make testacc TEST=./builtin/providers/digitalocean TESTARGS='-run=FloatingIP' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=FloatingIP -timeout 90m
=== RUN   TestAccDigitalOceanFloatingIP_Region
--- PASS: TestAccDigitalOceanFloatingIP_Region (4.08s)
=== RUN   TestAccDigitalOceanFloatingIP_Droplet
--- PASS: TestAccDigitalOceanFloatingIP_Droplet (89.79s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/digitalocean	93.885s
```