### PR TITLE
#3595 azure provider search vm image by name not label; strict

### DIFF
--- a/builtin/providers/azure/resource_azure_instance_test.go
+++ b/builtin/providers/azure/resource_azure_instance_test.go
@@ -446,7 +446,7 @@ resource "azure_security_group_rule" "foo" {
 
 resource "azure_instance" "foo" {
     name = "terraform-test1"
-    image = "Windows Server 2012 R2 Datacenter, September 2015"
+    image = "a699494373c04fc0bc8f2bb1389d6106__Windows-Server-2012-R2-20150916-en.us-127GB.vhd"
     size = "Basic_A1"
     storage_service_name = "%s"
     location = "West US"
@@ -520,7 +520,7 @@ resource "azure_security_group_rule" "bar" {
 
 resource "azure_instance" "foo" {
     name = "terraform-test1"
-    image = "Windows Server 2012 R2 Datacenter, September 2015"
+    image = "a699494373c04fc0bc8f2bb1389d6106__Windows-Server-2012-R2-20150916-en.us-127GB.vhd"
     size = "Basic_A2"
     storage_service_name = "%s"
     location = "West US"


### PR DESCRIPTION
This is a breaking change I'm not that confident of how would reviewer/commit handle it. I tried to gather some opinions over #3595 before making this a PR. So far no objection. :)

As I might already mentioned there I could do a "better" change so it can be backward compatible, but I insist here again: searching on image label is WRONG, simply because Label is not unique, that leads to undefined consequences.
