### PR TITLE
Added ability to show specified types of resources

### DIFF
--- a/command/format_state.go
+++ b/command/format_state.go
@@ -21,6 +21,9 @@ type FormatStateOpts struct {
 	// ModuleDepth is the depth of the modules to expand. By default this
 	// is zero which will not expand modules at all.
 	ModuleDepth int
+
+	// Types of resources to show, by default will show all resources.
+	ShowResourceTypes map[string]bool
 }
 
 // FormatState takes a state and returns a string
@@ -85,6 +88,10 @@ func formatStateModuleExpand(
 
 	// Go through each resource and begin building up the output.
 	for _, k := range names {
+		resourceType := strings.Split(k, ".")[0]
+		if opts.ShowResourceTypes != nil && !opts.ShowResourceTypes[resourceType] {
+			continue
+		}
 		name := k
 		if moduleName != "" {
 			name = moduleName + "." + name


### PR DESCRIPTION
New argument `-resource-types` for `show` command allows to specify list
of resource types, i.e. "aws_instance,aws_db_instance" to limit output
for these types.

This is useful for ad-hoc queries regarding Terraform state -- getting
list of particular attributes, like ip addresses or tags, etc.

Since output of `terraform show` is not json, where tools like `jshon`
can be applied to filter, it's useful to have smth like proposed changes.
