### PR TITLE
provider/aws: IAM Instance Profile Waiter

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_instance_profile.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -139,6 +140,17 @@ func instanceProfileSetRoles(d *schema.ResourceData, iamconn *iam.IAM) error {
 	}
 
 	d.Partial(false)
+
+
+	name := d.Get("name").(string)
+	log.Printf("[DEBUG] Waiting for the IAM Instance Profile to Exist %s", name)
+	r := &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(name),
+	}
+	waitErr := iamconn.WaitUntilInstanceProfileExists(r)
+	if waitErr != nil {
+		return fmt.Errorf("Error Waiting for IAM instance profile to Exist %s: %s", name, waitErr)
+	}
 
 	return nil
 }


### PR DESCRIPTION
May fix #4230: Adding the aws-go-sdk Waiter for IAM Instance Profile

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSIAMInstanceProfile' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSIAMInstanceProfile -timeout 90m
=== RUN   TestAccAWSIAMInstanceProfile_basic
--- PASS: TestAccAWSIAMInstanceProfile_basic (4.87s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	4.885s
```