### PR TITLE
Make the OpsWorks cookbooks SSH key write only

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -231,9 +231,6 @@ func resourceAwsOpsworksSetStackCustomCookbooksSource(d *schema.ResourceData, v 
 		if v.Revision != nil {
 			m["revision"] = *v.Revision
 		}
-		if v.SshKey != nil {
-			m["ssh_key"] = *v.SshKey
-		}
 		nv = append(nv, m)
 	}
 


### PR DESCRIPTION
Fixes #3635

This follows the suggestion of @apparentlymart in
https://github.com/hashicorp/terraform/issues/3635#issuecomment-151000068
to fix the issue of OpsWorks stacks always complaining about the custom
cookbooks SSH key needing to be changed.

Functional tests:

* Created a new stack and gave it an SSH key. The key was written to
  OpsWorks properly.
* Ran "plan" again and terraform indicated it needed to change the SSH
  key, which is expected since terraform cannot read what the existing
  SSH is.
* Removed the key from my resource and this time, "plan" did not have
  any changes. The `tfstate` file indicated the SSH key was "" (empty
  string).
* Changed an unrelated property of the stack. Previously this was not
  working for me due to terraform attempting to change the SSH key.