### PR TITLE
provider/aws: Fix missing AMI issue with Launch Configurations

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -386,6 +386,11 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			}
 
 			if dn, err := fetchRootDeviceName(d.Get("image_id").(string), ec2conn); err == nil {
+				if dn == nil {
+					return fmt.Errorf(
+						"Expected to find a Root Device name for AMI (%s), but got none",
+						d.Get("image_id").(string))
+				}
 				blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 					DeviceName: dn,
 					Ebs:        ebs,


### PR DESCRIPTION
If a launch configuration references an AMI that does not exist, it will fail to find the `DeviceName` for the AMI when it's building up it's Block Device Mappings.

Unlike [other][1] [invocations][2] of the `fetchRootDeviceName` method, Launch Configurations was not checking for a `nil` device name. 

The resulting Block Mappings end up something like this:

```
BlockDeviceMappings: [{
       Ebs: {
         DeleteOnTermination: true,
         VolumeSize: 1024,
         VolumeType: "gp2"
       }
     }],
``` 

(no device name, required for EBS) 

And then get an error on apply similar to this:

```
* aws_launch_configuration.lc: Error creating launch configuration: InvalidParameter: 1 validation errors:
- missing required parameter: BlockDeviceMappings[0].DeviceName
```

This PR errors if a `nil` device name is returned. 


[1]: https://github.com/hashicorp/terraform/blob/b-aws-lc-guard/builtin/providers/aws/resource_aws_instance.go#L889
[2]: https://github.com/hashicorp/terraform/blob/b-aws-lc-guard/builtin/providers/aws/resource_aws_launch_configuration.go#L550