### PR TITLE
vSphere: Support mounting ISO images to virtual cdrom drives.

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -388,6 +388,71 @@ func TestAccVSphereVirtualMachine_createWithFolder(t *testing.T) {
 	})
 }
 
+func TestAccVSphereVirtualMachine_createWithCdrom(t *testing.T) {
+	var vm virtualMachine
+	var locationOpt string
+	var datastoreOpt string
+
+	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
+		locationOpt += fmt.Sprintf("    datacenter = \"%s\"\n", v)
+	}
+	if v := os.Getenv("VSPHERE_CLUSTER"); v != "" {
+		locationOpt += fmt.Sprintf("    cluster = \"%s\"\n", v)
+	}
+	if v := os.Getenv("VSPHERE_RESOURCE_POOL"); v != "" {
+		locationOpt += fmt.Sprintf("    resource_pool = \"%s\"\n", v)
+	}
+	if v := os.Getenv("VSPHERE_DATASTORE"); v != "" {
+		datastoreOpt = fmt.Sprintf("        datastore = \"%s\"\n", v)
+	}
+	template := os.Getenv("VSPHERE_TEMPLATE")
+	label := os.Getenv("VSPHERE_NETWORK_LABEL_DHCP")
+	cdromDatastore := os.Getenv("VSPHERE_CDROM_DATASTORE")
+	cdromPath := os.Getenv("VSPHERE_CDROM_PATH")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testAccCheckVsphereVirtualMachineConfig_cdrom,
+					locationOpt,
+					label,
+					datastoreOpt,
+					template,
+					cdromDatastore,
+					cdromPath,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVSphereVirtualMachineExists("vsphere_virtual_machine.with_cdrom", &vm),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "name", "terraform-test-with-cdrom"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "vcpu", "2"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "memory", "4096"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "disk.#", "1"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "disk.0.template", template),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "cdrom.#", "1"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "cdrom.0.datastore", cdromDatastore),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "cdrom.0.path", cdromPath),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "network_interface.#", "1"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.with_cdrom", "network_interface.0.label", label),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVSphereVirtualMachineDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*govmomi.Client)
 	finder := find.NewFinder(client.Client, true)
@@ -664,7 +729,7 @@ resource "vsphere_virtual_machine" "folder" {
 
 const testAccCheckVSphereVirtualMachineConfig_createWithFolder = `
 resource "vsphere_folder" "with_folder" {
-	path = "%s"	
+	path = "%s"
 %s
 }
 resource "vsphere_virtual_machine" "with_folder" {
@@ -679,6 +744,27 @@ resource "vsphere_virtual_machine" "with_folder" {
     disk {
 %s
         template = "%s"
+    }
+}
+`
+
+const testAccCheckVsphereVirtualMachineConfig_cdrom = `
+resource "vsphere_virtual_machine" "with_cdrom" {
+    name = "terraform-test-with-cdrom"
+%s
+    vcpu = 2
+    memory = 4096
+    network_interface {
+        label = "%s"
+    }
+    disk {
+%s
+        template = "%s"
+    }
+
+    cdrom {
+        datastore = "%s"
+        path = "%s"
     }
 }
 `

--- a/website/source/docs/providers/vsphere/index.html.markdown
+++ b/website/source/docs/providers/vsphere/index.html.markdown
@@ -89,6 +89,11 @@ The following environment variables depend on your vSphere environment:
  * VSPHERE\_RESOURCE\_POOL
  * VSPHERE\_DATASTORE
 
+The following additional environment variables are needed for running the "Mount ISO as CDROM media" acceptance tests.
+
+ * VSPHERE\_CDROM\_DATASTORE
+ * VSPHERE\_CDROM\_PATH
+
 
 These are used to set and verify attributes on the `vsphere_virtual_machine`
 resource in tests.

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `dns_servers` - (Optional) List of DNS servers for the virtual network adapter; defaults to 8.8.8.8, 8.8.4.4
 * `network_interface` - (Required) Configures virtual network interfaces; see [Network Interfaces](#network-interfaces) below for details.
 * `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for details
+* `cdrom` - (Optional) Configures a CDROM device and mounts an image as its media; see [CDROM](#cdrom) below for more details.
 * `boot_delay` - (Optional) Time in seconds to wait for machine network to be ready.
 * `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
 * `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
@@ -71,6 +72,9 @@ The `windows_opt_config` block supports:
 * `domain_user` - (Optional) User that is a member of the specified domain.
 * `domain_user_password` - (Optional) Password for domain user, in plain text.
 
+<a id="disks"></a>
+## Disks
+
 The `disk` block supports:
 
 * `template` - (Required if size not provided) Template for this disk.
@@ -78,6 +82,14 @@ The `disk` block supports:
 * `size` - (Required if template not provided) Size of this disk (in GB).
 * `iops` - (Optional) Number of virtual iops to allocate for this disk.
 * `type` - (Optional) 'eager_zeroed' (the default), or 'thin' are supported options.
+
+<a id="cdrom"></a>
+## CDROM
+
+The `cdrom` block supports:
+
+* `datastore` - (Required) The name of the datastore where the disk image is stored.
+* `path` - (Required) The absolute path to the image within the datastore.
 
 ## Attributes Reference
 


### PR DESCRIPTION
It can come in handy to be able to mount ISOs programmatically.
For instance if you're developing a custom appliance (that automatically installs itself on the hard drive volume)
that you want to automatically test on every successful build (given the ISO is uploaded to the vmware datastore).

There are probably lots of other reasons for using this functionality.