### PR TITLE
Fix a bug whereby AWS elasticsearch domain access_policies will always appear changed

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -247,7 +247,7 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 
 	ds := out.DomainStatus
 
-	d.Set("access_policies", *ds.AccessPolicies)
+	d.Set("access_policies", normalizeJson(*ds.AccessPolicies))
 	err = d.Set("advanced_options", pointersMapToStringList(ds.AdvancedOptions))
 	if err != nil {
 		return err


### PR DESCRIPTION
Because of a missing normalizeJson().