### PR TITLE
Trivial change for AWS upgraded T2 instance type and AMI ami-5189a661

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -59,8 +59,8 @@ provider "aws" {
 }
 
 resource "aws_instance" "example" {
-	ami = "ami-408c7f28"
-	instance_type = "t1.micro"
+	ami = "ami-5189a661"
+	instance_type = "t2.micro"
 }
 ```
 
@@ -95,7 +95,7 @@ Within the resource block itself is configuration for that
 resource. This is dependent on each resource provider and
 is fully documented within our
 [providers reference](/docs/providers/index.html). For our EC2 instance, we specify
-an AMI for Ubuntu, and request a "t1.micro" instance so we
+an AMI for Ubuntu, and request a "t2.micro" instance so we
 qualify under the free tier.
 
 ## Execution Plan
@@ -111,9 +111,9 @@ $ terraform plan
 ...
 
 + aws_instance.example
-    ami:               "" => "ami-408c7f28"
+    ami:               "" => "ami-5189a661"
     availability_zone: "" => "<computed>"
-    instance_type:     "" => "t1.micro"
+    instance_type:     "" => "t2.micro"
     key_name:          "" => "<computed>"
     private_dns:       "" => "<computed>"
     private_ip:        "" => "<computed>"
@@ -148,8 +148,8 @@ since Terraform waits for the EC2 instance to become available.
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-408c7f28"
-  instance_type: "" => "t1.micro"
+  ami:           "" => "ami-5189a661"
+  instance_type: "" => "t2.micro"
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
@@ -172,9 +172,9 @@ You can inspect the state using `terraform show`:
 $ terraform show
 aws_instance.example:
   id = i-e60900cd
-  ami = ami-408c7f28
+  ami = ami-5189a661
   availability_zone = us-east-1c
-  instance_type = t1.micro
+  instance_type = t2.micro
   key_name =
   private_dns = domU-12-31-39-12-38-AB.compute-1.internal
   private_ip = 10.200.59.89


### PR DESCRIPTION
Guides' original AMI ami-408c7f28 not found on AWS (us-west-2)