### PR TITLE
provider/aws: Adding Tag support for DB Param Groups

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
@@ -24,6 +25,10 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 		Update: resourceAwsDbParameterGroupUpdate,
 		Delete: resourceAwsDbParameterGroupDelete,
 		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
 				ForceNew:     true,
@@ -71,17 +76,21 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 				},
 				Set: resourceAwsDbParameterHash,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
 
 func resourceAwsDbParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
+	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
 	createOpts := rds.CreateDBParameterGroupInput{
 		DBParameterGroupName:   aws.String(d.Get("name").(string)),
 		DBParameterGroupFamily: aws.String(d.Get("family").(string)),
 		Description:            aws.String(d.Get("description").(string)),
+		Tags:                   tags,
 	}
 
 	log.Printf("[DEBUG] Create DB Parameter Group: %#v", createOpts)
@@ -136,6 +145,31 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
 
+	paramGroup := describeResp.DBParameterGroups[0]
+	arn, err := buildRDSPGARN(d, meta)
+	if err != nil {
+		name := "<empty>"
+		if paramGroup.DBParameterGroupName != nil && *paramGroup.DBParameterGroupName != "" {
+			name = *paramGroup.DBParameterGroupName
+		}
+		log.Printf("[DEBUG] Error building ARN for DB Parameter Group, not setting Tags for Param Group %s", name)
+	} else {
+		d.Set("arn", arn)
+		resp, err := rdsconn.ListTagsForResource(&rds.ListTagsForResourceInput{
+			ResourceName: aws.String(arn),
+		})
+
+		if err != nil {
+			log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+		}
+
+		var dt []*rds.Tag
+		if len(resp.TagList) > 0 {
+			dt = resp.TagList
+		}
+		d.Set("tags", tagsToMapRDS(dt))
+	}
+
 	return nil
 }
 
@@ -175,6 +209,14 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 		d.SetPartial("parameter")
+	}
+
+	if arn, err := buildRDSPGARN(d, meta); err == nil {
+		if err := setTagsRDS(rdsconn, d, arn); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
 	}
 
 	d.Partial(false)
@@ -228,6 +270,20 @@ func resourceAwsDbParameterHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["value"].(string))))
 
 	return hashcode.String(buf.String())
+}
+
+func buildRDSPGARN(d *schema.ResourceData, meta interface{}) (string, error) {
+	iamconn := meta.(*AWSClient).iamconn
+	region := meta.(*AWSClient).region
+	// An zero value GetUserInput{} defers to the currently logged in user
+	resp, err := iamconn.GetUser(&iam.GetUserInput{})
+	if err != nil {
+		return "", err
+	}
+	userARN := *resp.User.Arn
+	accountID := strings.Split(userARN, ":")[4]
+	arn := fmt.Sprintf("arn:aws:rds:%s:%s:pg:%s", region, accountID, d.Id())
+	return arn, nil
 }
 
 func validateDbParamGroupName(v interface{}, k string) (ws []string, errors []error) {

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -44,6 +44,8 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 						"aws_db_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "tags.#", "1"),
 				),
 			},
 			resource.TestStep{
@@ -77,6 +79,8 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 						"aws_db_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "tags.#", "2"),
 				),
 			},
 		},
@@ -174,7 +178,7 @@ func testAccCheckAWSDBParameterGroupDestroy(s *terraform.State) error {
 		if !ok {
 			return err
 		}
-		if newerr.Code() != "InvalidDBParameterGroup.NotFound" {
+		if newerr.Code() != "DBParameterGroupNotFound" {
 			return err
 		}
 	}
@@ -262,6 +266,9 @@ resource "aws_db_parameter_group" "bar" {
 	  name = "character_set_results"
 	  value = "utf8"
 	}
+	tags {
+		foo = "bar"
+	}
 }
 `
 
@@ -289,6 +296,10 @@ resource "aws_db_parameter_group" "bar" {
 	parameter {
 	  name = "collation_connection"
 	  value = "utf8_unicode_ci"
+	}
+	tags {
+		foo = "bar"
+		baz = "foo"
 	}
 }
 `

--- a/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `family` - (Required) The family of the DB parameter group.
 * `description` - (Required) The description of the DB parameter group.
 * `parameter` - (Optional) A list of DB parameters to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Parameter blocks support the following:
 
@@ -50,3 +51,4 @@ Parameter blocks support the following:
 The following attributes are exported:
 
 * `id` - The db parameter group name.
+* `arn` - The ARN of the db parameter group.


### PR DESCRIPTION
Fixes: #4246 - Adding support to DB Parameter Group for Tags

```
TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSDBParameterGroup' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSDBParameterGroup -timeout 90m
=== RUN   TestAccAWSDBParameterGroup_basic
--- PASS: TestAccAWSDBParameterGroup_basic (17.65s)
=== RUN   TestAccAWSDBParameterGroupOnly
--- PASS: TestAccAWSDBParameterGroupOnly (10.08s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	27.755s
```