### PR TITLE
provider/aws: Adding support for Tags to DB SecurityGroup

### DIFF
--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -19,9 +21,15 @@ func resourceAwsDbSecurityGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsDbSecurityGroupCreate,
 		Read:   resourceAwsDbSecurityGroupRead,
+		Update: resourceAwsDbSecurityGroupUpdate,
 		Delete: resourceAwsDbSecurityGroupDelete,
 
 		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -66,12 +74,15 @@ func resourceAwsDbSecurityGroup() *schema.Resource {
 				},
 				Set: resourceAwsDbSecurityGroupIngressHash,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
 
 func resourceAwsDbSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
+	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
 	var err error
 	var errs []error
@@ -79,6 +90,7 @@ func resourceAwsDbSecurityGroupCreate(d *schema.ResourceData, meta interface{}) 
 	opts := rds.CreateDBSecurityGroupInput{
 		DBSecurityGroupName:        aws.String(d.Get("name").(string)),
 		DBSecurityGroupDescription: aws.String(d.Get("description").(string)),
+		Tags: tags,
 	}
 
 	log.Printf("[DEBUG] DB Security Group create configuration: %#v", opts)
@@ -157,7 +169,48 @@ func resourceAwsDbSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("ingress", rules)
 
+	conn := meta.(*AWSClient).rdsconn
+	arn, err := buildRDSSecurityGroupARN(d, meta)
+	if err != nil {
+		name := "<empty>"
+		if sg.DBSecurityGroupName != nil && *sg.DBSecurityGroupName != "" {
+			name = *sg.DBSecurityGroupName
+		}
+		log.Printf("[DEBUG] Error building ARN for DB Security Group, not setting Tags for DB Security Group %s", name)
+	} else {
+		d.Set("arn", arn)
+		resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
+			ResourceName: aws.String(arn),
+		})
+
+		if err != nil {
+			log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+		}
+
+		var dt []*rds.Tag
+		if len(resp.TagList) > 0 {
+			dt = resp.TagList
+		}
+		d.Set("tags", tagsToMapRDS(dt))
+	}
+
 	return nil
+}
+
+func resourceAwsDbSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	d.Partial(true)
+	if arn, err := buildRDSSecurityGroupARN(d, meta); err == nil {
+		if err := setTagsRDS(conn, d, arn); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
+	}
+	d.Partial(false)
+
+	return resourceAwsDbSecurityGroupRead(d, meta)
 }
 
 func resourceAwsDbSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
@@ -289,4 +342,18 @@ func resourceAwsDbSecurityGroupStateRefreshFunc(
 
 		return v, "authorized", nil
 	}
+}
+
+func buildRDSSecurityGroupARN(d *schema.ResourceData, meta interface{}) (string, error) {
+	iamconn := meta.(*AWSClient).iamconn
+	region := meta.(*AWSClient).region
+	// An zero value GetUserInput{} defers to the currently logged in user
+	resp, err := iamconn.GetUser(&iam.GetUserInput{})
+	if err != nil {
+		return "", err
+	}
+	userARN := *resp.User.Arn
+	accountID := strings.Split(userARN, ":")[4]
+	arn := fmt.Sprintf("arn:aws:rds:%s:%s:secgrp:%s", region, accountID, d.Id())
+	return arn, nil
 }

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -32,6 +32,8 @@ func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 						"aws_db_security_group.bar", "ingress.3363517775.cidr", "10.0.0.1/24"),
 					resource.TestCheckResourceAttr(
 						"aws_db_security_group.bar", "ingress.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_db_security_group.bar", "tags.#", "1"),
 				),
 			},
 		},
@@ -64,7 +66,7 @@ func testAccCheckAWSDBSecurityGroupDestroy(s *terraform.State) error {
 		if !ok {
 			return err
 		}
-		if newerr.Code() != "InvalidDBSecurityGroup.NotFound" {
+		if newerr.Code() != "DBSecurityGroupNotFound" {
 			return err
 		}
 	}
@@ -148,6 +150,10 @@ resource "aws_db_security_group" "bar" {
 
     ingress {
         cidr = "10.0.0.1/24"
+    }
+
+    tags {
+		foo = "bar"
     }
 }
 `

--- a/website/source/docs/providers/aws/r/db_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_security_group.html.markdown
@@ -33,6 +33,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the DB security group.
 * `description` - (Required) The description of the DB security group.
 * `ingress` - (Optional) A list of ingress rules.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Ingress blocks support the following:
 
@@ -47,4 +48,5 @@ Ingress blocks support the following:
 The following attributes are exported:
 
 * `id` - The db security group ID.
+* `arn` - The arn of the DB security group.
 


### PR DESCRIPTION
Adding support for Tags to the DB Security Group

```
TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSDBSecurityGroup' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSDBSecurityGroup -timeout 90m
=== RUN   TestAccAWSDBSecurityGroup_basic
--- PASS: TestAccAWSDBSecurityGroup_basic (9.94s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	9.961s
```