### PR TITLE
provider/aws: DB Subnet group arn output

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -23,6 +23,11 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 		Delete: resourceAwsDbSubnetGroupDelete,
 
 		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -142,6 +147,7 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		log.Printf("[DEBUG] Error building ARN for DB Subnet Group, not setting Tags for group %s", *subnetGroup.DBSubnetGroupName)
 	} else {
+		d.Set("arn", arn)
 		resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
 			ResourceName: aws.String(arn),
 		})

--- a/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
@@ -37,4 +37,5 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The db subnet group name.
+* `arn` - The ARN of the db subnet group.
 


### PR DESCRIPTION
Adding the ARN as an output of the DB Subnet Group

```
TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSDBSubnetGroup' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSDBSubnetGroup -timeout 90m
=== RUN   TestAccAWSDBSubnetGroup_basic
--- PASS: TestAccAWSDBSubnetGroup_basic (19.87s)
=== RUN   TestAccAWSDBSubnetGroup_withUndocumentedCharacters
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (20.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	40.836s
```