### PR TITLE
provider/aws: support custom endpoints for AWS EC2 ELB and IAM

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -45,6 +45,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"net/http"
+	"crypto/tls"
 )
 
 type Config struct {
@@ -61,6 +63,10 @@ type Config struct {
 
 	DynamoDBEndpoint string
 	KinesisEndpoint  string
+	Ec2Endpoint string
+	IamEndpoint string
+	ElbEndpoint string
+	Insecure bool
 }
 
 type AWSClient struct {
@@ -136,9 +142,21 @@ func (c *Config) Client() (interface{}, error) {
 			HTTPClient:  cleanhttp.DefaultClient(),
 		}
 
+		if c.Insecure {
+			transport := awsConfig.HTTPClient.Transport.(*http.Transport)
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify:true,
+			}
+		}
+
 		log.Println("[INFO] Initializing IAM Connection")
 		sess := session.New(awsConfig)
-		client.iamconn = iam.New(sess)
+
+		awsIamConfig := *awsConfig
+		awsIamConfig.Endpoint = aws.String(c.IamEndpoint)
+
+		awsIamSess := session.New(&awsIamConfig)
+		client.iamconn = iam.New(awsIamSess)
 
 		err = c.ValidateCredentials(client.iamconn)
 		if err != nil {
@@ -166,7 +184,12 @@ func (c *Config) Client() (interface{}, error) {
 		client.dynamodbconn = dynamodb.New(dynamoSess)
 
 		log.Println("[INFO] Initializing ELB connection")
-		client.elbconn = elb.New(sess)
+		awsElbConfig := *awsConfig
+		awsElbConfig.Endpoint = aws.String(c.ElbEndpoint)
+
+		awsElbSess := session.New(&awsElbConfig)
+
+		client.elbconn = elb.New(awsElbSess)
 
 		log.Println("[INFO] Initializing S3 connection")
 		client.s3conn = s3.New(sess)
@@ -199,7 +222,12 @@ func (c *Config) Client() (interface{}, error) {
 		client.autoscalingconn = autoscaling.New(sess)
 
 		log.Println("[INFO] Initializing EC2 Connection")
-		client.ec2conn = ec2.New(sess)
+
+		awsEc2Config := *awsConfig
+		awsEc2Config.Endpoint = aws.String(c.Ec2Endpoint)
+
+		awsEc2Sess := session.New(&awsEc2Config)
+		client.ec2conn = ec2.New(awsEc2Sess)
 
 		log.Println("[INFO] Initializing ECR Connection")
 		client.ecrconn = ecr.New(sess)

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-multierror"
 
+	"crypto/tls"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	awsCredentials "github.com/aws/aws-sdk-go/aws/credentials"
@@ -45,8 +46,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"net/http"
-	"crypto/tls"
 )
 
 type Config struct {
@@ -63,10 +62,10 @@ type Config struct {
 
 	DynamoDBEndpoint string
 	KinesisEndpoint  string
-	Ec2Endpoint string
-	IamEndpoint string
-	ElbEndpoint string
-	Insecure bool
+	Ec2Endpoint      string
+	IamEndpoint      string
+	ElbEndpoint      string
+	Insecure         bool
 }
 
 type AWSClient struct {
@@ -145,7 +144,7 @@ func (c *Config) Client() (interface{}, error) {
 		if c.Insecure {
 			transport := awsConfig.HTTPClient.Transport.(*http.Transport)
 			transport.TLSClientConfig = &tls.Config{
-				InsecureSkipVerify:true,
+				InsecureSkipVerify: true,
 			}
 		}
 

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"bytes"
+	"fmt"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -101,25 +103,8 @@ func Provider() terraform.ResourceProvider {
 				Default:     "",
 				Description: descriptions["kinesis_endpoint"],
 			},
-			"iam_endpoint": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["iam_endpoint"],
-			},
+			"endpoints": endpointsSchema(),
 
-			"ec2_endpoint": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["ec2_endpoint"],
-			},
-			"elb_endpoint": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["elb_endpoint"],
-			},
 			"insecure": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -286,7 +271,7 @@ func init() {
 
 		"elb_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
 
-		"insecure" : "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
+		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
 			"default value is `false`",
 	}
 }
@@ -302,10 +287,16 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		MaxRetries:       d.Get("max_retries").(int),
 		DynamoDBEndpoint: d.Get("dynamodb_endpoint").(string),
 		KinesisEndpoint:  d.Get("kinesis_endpoint").(string),
-		IamEndpoint:	  d.Get("iam_endpoint").(string),
-		Ec2Endpoint:	  d.Get("ec2_endpoint").(string),
-		ElbEndpoint:	  d.Get("elb_endpoint").(string),
-		Insecure:		  d.Get("insecure").(bool),
+		Insecure:         d.Get("insecure").(bool),
+	}
+
+	endpointsSet := d.Get("endpoints").(*schema.Set)
+
+	for _, endpointsSetI := range endpointsSet.List() {
+		endpoints := endpointsSetI.(map[string]interface{})
+		config.IamEndpoint = endpoints["iam"].(string)
+		config.Ec2Endpoint = endpoints["ec2"].(string)
+		config.ElbEndpoint = endpoints["elb"].(string)
 	}
 
 	if v, ok := d.GetOk("allowed_account_ids"); ok {
@@ -321,3 +312,45 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 // This is a global MutexKV for use within this plugin.
 var awsMutexKV = mutexkv.NewMutexKV()
+
+func endpointsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"iam": &schema.Schema{
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: descriptions["iam_endpoint"],
+				},
+
+				"ec2": &schema.Schema{
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: descriptions["ec2_endpoint"],
+				},
+
+				"elb": &schema.Schema{
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: descriptions["elb_endpoint"],
+				},
+			},
+		},
+		Set: endpointsToHash,
+	}
+}
+
+func endpointsToHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["iam"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["ec2"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["elb"].(string)))
+
+	return hashcode.String(buf.String())
+}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -101,6 +101,31 @@ func Provider() terraform.ResourceProvider {
 				Default:     "",
 				Description: descriptions["kinesis_endpoint"],
 			},
+			"iam_endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["iam_endpoint"],
+			},
+
+			"ec2_endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["ec2_endpoint"],
+			},
+			"elb_endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["elb_endpoint"],
+			},
+			"insecure": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["insecure"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -254,6 +279,15 @@ func init() {
 
 		"kinesis_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n" +
 			"It's typically used to connect to kinesalite.",
+
+		"iam_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
+
+		"ec2_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
+
+		"elb_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
+
+		"insecure" : "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
+			"default value is `false`",
 	}
 }
 
@@ -268,6 +302,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		MaxRetries:       d.Get("max_retries").(int),
 		DynamoDBEndpoint: d.Get("dynamodb_endpoint").(string),
 		KinesisEndpoint:  d.Get("kinesis_endpoint").(string),
+		IamEndpoint:	  d.Get("iam_endpoint").(string),
+		Ec2Endpoint:	  d.Get("ec2_endpoint").(string),
+		ElbEndpoint:	  d.Get("elb_endpoint").(string),
+		Insecure:		  d.Get("insecure").(bool),
 	}
 
 	if v, ok := d.GetOk("allowed_account_ids"); ok {

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -137,5 +137,24 @@ The following arguments are supported in the `provider` block:
   URL constructed from the `region`. It's typically used to connect to
   dynamodb-local.
 
-* `kinesis_endpoint` - (Optional) Use this to override the default endpoint URL
-  constructed from the `region`. It's typically used to connect to kinesalite.
+* `kinesis_endpoint` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  kinesalite.
+
+* `iam_endpoint` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  custom iam endpoints.
+
+* `ec2_endpoint` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  custom ec2 endpoints.
+
+* `elb_endpoint` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  custom elb endpoints.
+
+* `token` - (Optional) Use this to set an MFA token. It can also be
+  sourced from the `AWS_SECURITY_TOKEN` environment variable.
+
+* `insecure` - (Optional) Optional) Explicitly allow the provider to
+  perform "insecure" SSL requests. If omitted, default value is `false`

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -149,9 +149,6 @@ The following arguments are supported in the `provider` block:
   URL constructed from the `region`. It's typically used to connect to
   custom ec2 endpoints.
 
-* `elb_endpoint` - (Optional) Use this to override the default endpoint
-  URL constructed from the `region`. It's typically used to connect to
-  custom elb endpoints.
 
 * `token` - (Optional) Use this to set an MFA token. It can also be
   sourced from the `AWS_SECURITY_TOKEN` environment variable.

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -132,7 +132,10 @@ The following arguments are supported in the `provider` block:
 * `forbidden_account_ids` - (Optional) List of forbidden AWS account IDs (blacklist)
   to prevent you mistakenly using a wrong one (and end up destroying live environment).
   Conflicts with `allowed_account_ids`.
-
+  
+* `insecure` - (Optional) Optional) Explicitly allow the provider to
+  perform "insecure" SSL requests. If omitted, default value is `false`
+    
 * `dynamodb_endpoint` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
   dynamodb-local.
@@ -141,17 +144,16 @@ The following arguments are supported in the `provider` block:
   URL constructed from the `region`. It's typically used to connect to
   kinesalite.
 
-* `iam_endpoint` - (Optional) Use this to override the default endpoint
+Nested `endpoints` block supports the followings:
+
+* `iam` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
   custom iam endpoints.
 
-* `ec2_endpoint` - (Optional) Use this to override the default endpoint
+* `ec2` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
   custom ec2 endpoints.
 
-
-* `token` - (Optional) Use this to set an MFA token. It can also be
-  sourced from the `AWS_SECURITY_TOKEN` environment variable.
-
-* `insecure` - (Optional) Optional) Explicitly allow the provider to
-  perform "insecure" SSL requests. If omitted, default value is `false`
+* `elb` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  custom elb endpoints.


### PR DESCRIPTION
Allows to specify AWS Endpoints for EC2, IAM and ELB directly from .tf file like: 

```
provider "aws" {
    access_key = "xxx"
    secret_key = "xxx"
    ec2_endpoint = "<ec2_endpoint_url>"
    elb_endpoint = "<elb_endpoint_url>"
    iam_endpoint = "<iam_endpoint_url>"
    insecure = "true"
    region = "us-east-1"
}
```
It also allows to disable HTTPS certificate check which is necessary for corporate solutions.

Solves https://github.com/hashicorp/terraform/issues/416 and https://github.com/hashicorp/terraform/issues/3974