### PR TITLE
Change wording of aws_route53_health_check

### DIFF
--- a/website/source/docs/providers/aws/r/route53_health_check.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_health_check.html.markdown
@@ -38,5 +38,5 @@ The following arguments are supported:
 * `search_string` - (Optional) String searched in respoonse body for check to considered healthy.
 * `tags` - (Optional) A mapping of tags to assign to the health check.
 
-Exactly one of `fqdn` or `ip_address` must be specified.
+At least one of either `fqdn` or `ip_address` must be specified.
 


### PR DESCRIPTION
Both may be specified, which enables health checking of an IP address
with the Host header specified.

Defined in the API documentation:
http://docs.aws.amazon.com/Route53/latest/APIReference/API_GetHealthCheck.html