### PR TITLE
Documentation: fix typo in snapshot_retention_limit

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -77,7 +77,7 @@ Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
 * `snapshot_window` - (Optional) The daily time range (in UTC) during which ElastiCache will 
 begin taking a daily snapshot of your cache cluster. Can only be used for the Redis engine. Example: 05:00-09:00
 
-* `snapshow_retention_limit` - (Optional) The number of days for which ElastiCache will 
+* `snapshot_retention_limit` - (Optional) The number of days for which ElastiCache will 
 retain automatic cache cluster snapshots before deleting them. For example, if you set 
 SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days 
 before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. 


### PR DESCRIPTION
`snapshow_retention_limit` should be `snapshot_retention_limit`.