### PR TITLE
provider/aws: Enable account ID check for AWS with assumed roles

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -291,11 +291,11 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 		}
 
 		out, err := iamconn.ListRoles(&iam.ListRolesInput{
-			MaxItems: 1,
+			MaxItems: aws.Int64(int64(1)),
 		})
 		if err != nil {
 			return fmt.Errorf("Failed getting account ID from IAM: %s", err)
-		} else if len(resp.Roles) < 1 {
+		} else if len(out.Roles) < 1 {
 			return fmt.Errorf("Failed getting account ID from IAM: Couldn't determine current user or role")
 		}
 

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -281,8 +281,10 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 
 	out, err := iamconn.GetUser(nil)
 
+	var account_id string
+
 	if err == nil {
-		account_id := strings.Split(*out.User.Arn, ":")[4]
+		account_id = strings.Split(*out.User.Arn, ":")[4]
 	} else {
 		awsErr, _ := err.(awserr.Error)
 
@@ -299,7 +301,7 @@ func (c *Config) ValidateAccountId(iamconn *iam.IAM) error {
 			return fmt.Errorf("Failed getting account ID from IAM: Couldn't determine current user or role")
 		}
 
-		account_id := strings.Split(*out.Roles[0].Arn, ":")[4]
+		account_id = strings.Split(*out.Roles[0].Arn, ":")[4]
 	}
 
 	if c.ForbiddenAccountIds != nil {


### PR DESCRIPTION
Currently we're assuming that if there is no current user (`iamconn.GetUser(nil)` fails), we're in an IAM instance profile therefore the check is superfluous.

This isn't quite true, in the case where we're in an assumed role (cross account assumed role, SAML assumed role, etc.) it's still important to check whether we're applying the changes on the correct AWS account.

Given that we're in an assumed role, it's safe to make the assumption that at least one role will be available (and that the role will be readable).

This PR uses this assumption to check the AWS account ID we're currently on even if we're not logged in through a user.