### PR TITLE
Breaking change to Azure library failing the build

### DIFF
--- a/builtin/providers/azure/resource_azure_instance.go
+++ b/builtin/providers/azure/resource_azure_instance.go
@@ -682,7 +682,7 @@ func retrieveImageDetails(
 func retrieveVMImageDetails(
 	vmImageClient virtualmachineimage.Client,
 	label string) (func(*virtualmachine.Role) error, string, []string, error) {
-	imgs, err := vmImageClient.ListVirtualMachineImages()
+	imgs, err := vmImageClient.ListVirtualMachineImages(virtualmachineimage.ListParameters{})
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("Error retrieving image details: %s", err)
 	}


### PR DESCRIPTION
`vmImageClient.ListVirtualMachineImages` takes a parameter as of [68d50cb53a73edfeb7f17f5e86cdc8eb359a9528 in Azure/azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go/commit/68d50cb53a73edfeb7f17f5e86cdc8eb359a9528) .

Passing in a parameters object whose members are all empty strings seems to restore the previous behavior.