### PR TITLE
Only refresh project name if Rundeck server provides it

### DIFF
--- a/builtin/providers/rundeck/resource_job.go
+++ b/builtin/providers/rundeck/resource_job.go
@@ -463,7 +463,14 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 	d.Set("id", job.ID)
 	d.Set("name", job.Name)
 	d.Set("group_name", job.GroupName)
-	d.Set("project_name", job.ProjectName)
+
+	// The project name is not consistently returned in all rundeck versions,
+	// so we'll only update it if it's set. Jobs can't move between projects
+	// anyway, so this is harmless.
+	if job.ProjectName != "" {
+		d.Set("project_name", job.ProjectName)
+	}
+
 	d.Set("description", job.Description)
 	d.Set("log_level", job.LogLevel)
 	d.Set("allow_concurrent_executions", job.AllowConcurrentExecutions)


### PR DESCRIPTION
It seems that not all Rundeck servers consistently return the project name when retrieving a job. Not yet sure in what situations it is or isn't returned, but since jobs are not allowed to move between projects anyway it doesn't hurt to just skip refreshing it if the server provides no value.

Without this, the project name can get refreshed as the empty string, which then causes Terraform to treat it as a diff. This means that Terraform constantly wants to delete and re-create the job, since project is a `ForceNew` attribute.
