### PR TITLE
provider/aws: db_parameter_groups with no parameters defined cause panic

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -143,7 +143,9 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
+	if describeParametersResp.Parameters != nil {
+		d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
+	}
 
 	paramGroup := describeResp.DBParameterGroups[0]
 	arn, err := buildRDSPGARN(d, meta)


### PR DESCRIPTION
Fixes #4294

Adding a guard clause to make sure there are DB Parameters in the parameter_group before trying to flatten them. This is causing a panic

I actually didn't think this was an issue as there is a test for it in the codebase. But the referenced issues shows that it actually is for some reason. Therefore, adding a guard clause to be extra careful

```
TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSDBParameterGroup' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSDBParameterGroup -timeout 90m
=== RUN   TestAccAWSDBParameterGroup_basic
--- PASS: TestAccAWSDBParameterGroup_basic (18.82s)
=== RUN   TestAccAWSDBParameterGroupOnly
--- PASS: TestAccAWSDBParameterGroupOnly (10.41s)
=== RUN   TestResourceAWSDBParameterGroupName_validation
--- PASS: TestResourceAWSDBParameterGroupName_validation (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	29.254s
```