### PR TITLE
provisioner/chef: gofmt error that keeps flagging on my machine

### DIFF
--- a/builtin/providers/chef/resource_data_bag_test.go
+++ b/builtin/providers/chef/resource_data_bag_test.go
@@ -19,7 +19,7 @@ func TestAccDataBag_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDataBagConfig_basic,
-				Check: testAccDataBagCheckExists("chef_data_bag.test", &dataBagName),
+				Check:  testAccDataBagCheckExists("chef_data_bag.test", &dataBagName),
 			},
 		},
 	})


### PR DESCRIPTION
Fixing a gofmt error with the chef provisioner that keeps popping up in my env