### PR TITLE
provider/aws: Guard against nil DB Parameter values

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -399,10 +399,16 @@ func flattenEcsContainerDefinitions(definitions []*ecs.ContainerDefinition) (str
 func flattenParameters(list []*rds.Parameter) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
-		result = append(result, map[string]interface{}{
-			"name":  strings.ToLower(*i.ParameterName),
-			"value": strings.ToLower(*i.ParameterValue),
-		})
+		if i.ParameterName != nil {
+			r := make(map[string]interface{})
+			r["name"] = strings.ToLower(*i.ParameterName)
+			// Default empty string, guard against nil parameter values
+			r["value"] = ""
+			if i.ParameterValue != nil {
+				r["value"] = strings.ToLower(*i.ParameterValue)
+			}
+			result = append(result, r)
+		}
 	}
 	return result
 }


### PR DESCRIPTION
This PR guards against a `nil` db parameter group value as shown in https://github.com/hashicorp/terraform/issues/4294 . Unfortunately, several attempts from multiple people have been unable to actually reproduce it, however, there are ~4 cited cases in that ticket across different version of TF, so I'll put this guard in here anyway. 