### PR TITLE
ECS stability improvements

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_cluster.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster.go
@@ -77,6 +77,39 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Deleting ECS cluster %s", d.Id())
 
+	clusterName := d.Get("name").(string)
+
+	servicesOut, servicesErr := conn.ListServices(&ecs.ListServicesInput{
+		Cluster: aws.String(clusterName),
+	})
+	if servicesErr != nil {
+		return servicesErr
+	}
+
+	for _, serviceArn := range servicesOut.ServiceArns {
+		updateInput := ecs.UpdateServiceInput{
+			Service:      aws.String(*serviceArn),
+			Cluster:      aws.String(clusterName),
+			DesiredCount: aws.Int64(int64(0)),
+		}
+		_, updateErr := conn.UpdateService(&updateInput)
+		if updateErr != nil {
+			return updateErr
+		}
+		log.Printf("[DEBUG] Set DesiredCount to 0 for service %s", *serviceArn)
+
+		deleteInput := ecs.DeleteServiceInput{
+			Service: aws.String(*serviceArn),
+			Cluster: aws.String(clusterName),
+		}
+
+		_, deleteErr := conn.DeleteService(&deleteInput)
+		if deleteErr != nil {
+			return deleteErr
+		}
+		log.Printf("[DEBUG] Delete found service %s", *serviceArn)
+	}
+
 	return resource.Retry(10*time.Minute, func() error {
 		out, err := conn.DeleteCluster(&ecs.DeleteClusterInput{
 			Cluster: aws.String(d.Id()),


### PR DESCRIPTION
We've experienced issues with deleting ECS cluster services and ECS clusters. It's mostly due to peculiarities within AWS:

1) It's possible to look up a service using DescribeServices(servicename, clustername) and get a "DRAINING" response even if the cluster is already deleted. Fix seems to be using ListServices(clustername) and then check if the service is gone or not before calling DescribeServices.

2) For the servies, we've also seen the wait condition go from DRAINING to MISSING -- and the wait condition in Terraform has the target INACTIVE before it exits. Which made the deletion of the service hang - even when the service was already gone

3) We've seen issues with deleting a cluster that has running services or services that have DesiredCount > 0 (for instance: if services has been started in the cluster from outside Terraform). I acknowledge that this might be controversial - and a corner case regarding the philosophy of "not deleting anything that isn't started by Terraform itself".

