### PR TITLE
Update doc to use valid AMI and t2.micro instance types

### DIFF
--- a/website/source/docs/configuration/override.html.md
+++ b/website/source/docs/configuration/override.html.md
@@ -37,7 +37,7 @@ If you have a Terraform configuration `example.tf` with the contents:
 
 ```
 resource "aws_instance" "web" {
-    ami = "ami-1234567"
+    ami = "ami-d05e75b8"
 }
 ```
 

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -25,8 +25,8 @@ A resource configuration looks like the following:
 
 ```
 resource "aws_instance" "web" {
-    ami = "ami-123456"
-    instance_type = "m1.small"
+    ami = "ami-d05e75b8"
+    instance_type = "t2.micro"
 }
 ```
 

--- a/website/source/docs/modules/usage.html.markdown
+++ b/website/source/docs/modules/usage.html.markdown
@@ -87,9 +87,9 @@ For example:
 
 ```
 resource "aws_instance" "client" {
-	ami = "ami-123456"
-	instance_type = "m1.small"
-	availability_zone = "${module.consul.server_availability_zone}"
+  ami = "ami-d05e75b8"
+  instance_type = "t2.micro"  
+  availability_zone = "${module.consul.server_availability_zone}"
 }
 ```
 

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -14,11 +14,11 @@ and deleted. Instances also support [provisioning](/docs/provisioners/index.html
 ## Example Usage
 
 ```
-# Create a new instance of the ami-1234 on an m1.small node
-# with an AWS Tag naming it "HelloWorld"
+# Create a new instance of the `ami-d05e75b8` (Ubuntu 14.04) on an 
+# t2.micro node with an AWS Tag naming it "HelloWorld"
 resource "aws_instance" "web" {
-    ami = "ami-1234"
-    instance_type = "m1.small"
+    ami = "ami-d05e75b8"
+    instance_type = "t2.micro"
     tags {
         Name = "HelloWorld"
     }

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -15,8 +15,8 @@ Provides a resource to create a new launch configuration, used for autoscaling g
 ```
 resource "aws_launch_configuration" "as_conf" {
     name = "web_config"
-    image_id = "ami-1234"
-    instance_type = "m1.small"
+    ami = "ami-d05e75b8"
+    instance_type = "t2.micro"
 }
 ```
 
@@ -33,8 +33,8 @@ with `name_prefix`.  Example:
 ```
 resource "aws_launch_configuration" "as_conf" {
     name_prefix = "terraform-lc-example-"
-    image_id = "ami-1234"
-    instance_type = "m1.small"
+    ami = "ami-d05e75b8"
+    instance_type = "t2.micro"
 
     lifecycle {
       create_before_destroy = true
@@ -66,8 +66,8 @@ for more information or how to launch [Spot Instances][3] with Terraform.
 
 ```
 resource "aws_launch_configuration" "as_conf" {
-    image_id = "ami-1234"
-    instance_type = "m1.small"
+    ami = "ami-d05e75b8"
+    instance_type = "t2.micro"
     spot_price = "0.001"
     lifecycle {
       create_before_destroy = true

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -195,9 +195,9 @@
 								<p> </p>
 								<p>resource <span class="txt-spe">"aws_instance"</span> <span class="txt-str">"app"</span> {</p>
 								<p>    count = <span class="txt-int">5</span></p>
-								<p> </p>
-								<p>    ami = <span class="txt-str">"ami-043a5034"</span></p>
-								<p>    instance_type = <span class="txt-str">"m1.small"</span></p>
+                <p> </p>
+								<p>    ami = <span class="txt-str">"ami-d05e75b8"</span></p>
+								<p>    instance_type = <span class="txt-str">"t2.micro"</span></p>
 								<p>}</p>
 								</div>
 							</div>

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -195,7 +195,7 @@
 								<p> </p>
 								<p>resource <span class="txt-spe">"aws_instance"</span> <span class="txt-str">"app"</span> {</p>
 								<p>    count = <span class="txt-int">5</span></p>
-                <p> </p>
+								<p> </p>
 								<p>    ami = <span class="txt-str">"ami-d05e75b8"</span></p>
 								<p>    instance_type = <span class="txt-str">"t2.micro"</span></p>
 								<p>}</p>


### PR DESCRIPTION
Small doc update to make sure we have valid AMI and instance type remains in the free tier 