### PR TITLE
provider/aws: StateFunc on db_subnet_group name to be lowercase

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -29,25 +29,10 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 			},
 
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^[ .0-9A-Za-z-_]+$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"only alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
-					}
-					if len(value) > 255 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 255 characters", k))
-					}
-					if regexp.MustCompile(`(?i)^default$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q is not allowed as %q", "Default", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateSubnetGroupName,
 			},
 
 			"description": &schema.Schema{
@@ -131,8 +116,8 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Unable to find DB Subnet Group: %#v", describeResp.DBSubnetGroups)
 	}
 
-	d.Set("name", d.Id())
-	d.Set("description", *subnetGroup.DBSubnetGroupDescription)
+	d.Set("name", subnetGroup.DBSubnetGroupName)
+	d.Set("description", subnetGroup.DBSubnetGroupDescription)
 
 	subnets := make([]string, 0, len(subnetGroup.Subnets))
 	for _, s := range subnetGroup.Subnets {
@@ -251,4 +236,21 @@ func buildRDSsubgrpARN(d *schema.ResourceData, meta interface{}) (string, error)
 	accountID := strings.Split(userARN, ":")[4]
 	arn := fmt.Sprintf("arn:aws:rds:%s:%s:subgrp:%s", region, accountID, d.Id())
 	return arn, nil
+}
+
+func validateSubnetGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[ .0-9a-z-_]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 255 characters", k))
+	}
+	if regexp.MustCompile(`(?i)^default$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q is not allowed as %q", "Default", k))
+	}
+	return
 }

--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -66,6 +66,38 @@ func TestAccAWSDBSubnetGroup_withUndocumentedCharacters(t *testing.T) {
 	})
 }
 
+func TestResourceAWSDBSubnetGroupNameValidation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing?",
+			ErrCount: 1,
+		},
+		{
+			Value:    "default",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(300),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateSubnetGroupName(tc.Value, "aws_db_subnet_group")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the DB Subnet Group name to trigger a validation error")
+		}
+	}
+}
+
 func testAccCheckDBSubnetGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
@@ -149,7 +181,7 @@ resource "aws_subnet" "bar" {
 }
 
 resource "aws_db_subnet_group" "foo" {
-	name = "FOO"
+	name = "foo"
 	description = "foo description"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 	tags {


### PR DESCRIPTION
Fixes: #4255 

We actually excluded uppercase chars on the DBSubnetName. This was causing a plan loop and would have been hidden by using a StateFunc to LowerCase

We actually throw a validate error now on any uppercase letters

```
TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSDBSubnetGroup' 2>~/tf.log
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSDBSubnetGroup -timeout 90m
=== RUN   TestAccAWSDBSubnetGroup_basic
--- PASS: TestAccAWSDBSubnetGroup_basic (27.01s)
=== RUN   TestAccAWSDBSubnetGroup_withUndocumentedCharacters
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (28.28s)
=== RUN   TestResourceAWSDBSubnetGroupNameValidation
--- PASS: TestResourceAWSDBSubnetGroupNameValidation (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	55.307s
```