### PR TITLE
provider/aws: Fix check destroy method for s3 tests

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -265,6 +266,9 @@ func testAccCheckAWSS3BucketDestroy(s *terraform.State) error {
 			Bucket: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoSuchBucket" {
+				return nil
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
The check destroy method was erring with "Bucket not found", which is actually what we want 

Fixes #4328