### PR TITLE
Add section on referencing security groups by name

### DIFF
--- a/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_secgroup_v2.html.markdown
@@ -99,3 +99,17 @@ rule {
 ```
 
 A list of ICMP types and codes can be found [here](https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol#Control_messages).
+
+### Referencing Security Groups
+
+When referencing a security group in a configuration (for example, a configuration creates a new security group and then needs to apply it to an instance being created in the same configuration), it is currently recommended to reference the security group by name and not by ID, like this:
+
+```
+resource "openstack_compute_instance_v2" "test-server" {
+  name = "tf-test"
+  image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id = "3"
+  key_pair = "my_key_pair_name"
+  security_groups = ["${openstack_compute_secgroup_v2.secgroup_1.name}"]
+}
+```


### PR DESCRIPTION
Added new section to end of Markdown file for OpenStack security groups, recommending that security groups are referenced by the name attribute instead of by the ID attribute.

Addresses documentation for #4319.