### PR TITLE
provider/aws: DB Security Group Docs

### DIFF
--- a/website/source/docs/providers/aws/r/db_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_security_group.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DB security group.
 * `description` - (Required) The description of the DB security group.
-* `ingress` - (Optional) A list of ingress rules.
+* `ingress` - (Required) A list of ingress rules.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Ingress blocks support the following:


### PR DESCRIPTION
#4352 reports docs say ingress is optional whereas schema says it isn't. This doesn't fix the issue, just updates the docs to reflect the behaviour