### PR TITLE
provider/aws: Treat INACTIVE ECS cluster as deleted

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_cluster.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -61,6 +62,13 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	for _, c := range out.Clusters {
 		if *c.ClusterName == clusterName {
+			// Status==INACTIVE means deleted cluster
+			if *c.Status == "INACTIVE" {
+				log.Printf("[DEBUG] Removing ECS cluster %q because it's INACTIVE", *c.ClusterArn)
+				d.SetId("")
+				return nil
+			}
+
 			d.SetId(*c.ClusterArn)
 			d.Set("name", c.ClusterName)
 			return nil
@@ -77,7 +85,7 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Deleting ECS cluster %s", d.Id())
 
-	return resource.Retry(10*time.Minute, func() error {
+	err := resource.Retry(10*time.Minute, func() error {
 		out, err := conn.DeleteCluster(&ecs.DeleteClusterInput{
 			Cluster: aws.String(d.Id()),
 		})
@@ -104,4 +112,37 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 
 		return resource.RetryError{Err: err}
 	})
+	if err != nil {
+		return err
+	}
+
+	clusterName := d.Get("name").(string)
+	err = resource.Retry(5*time.Minute, func() error {
+		log.Printf("[DEBUG] Checking if ECS Cluster %q is INACTIVE", d.Id())
+		out, err := conn.DescribeClusters(&ecs.DescribeClustersInput{
+			Clusters: []*string{aws.String(clusterName)},
+		})
+
+		for _, c := range out.Clusters {
+			if *c.ClusterName == clusterName {
+				if *c.Status == "INACTIVE" {
+					return nil
+				}
+
+				return fmt.Errorf("ECS Cluster %q is still %q", clusterName, *c.Status)
+			}
+		}
+
+		if err != nil {
+			return resource.RetryError{Err: err}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] ECS cluster %q deleted", d.Id())
+	return nil
 }

--- a/builtin/providers/aws/resource_aws_ecs_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster_test.go
@@ -38,13 +38,15 @@ func testAccCheckAWSEcsClusterDestroy(s *terraform.State) error {
 			Clusters: []*string{aws.String(rs.Primary.ID)},
 		})
 
-		if err == nil {
-			if len(out.Clusters) != 0 {
-				return fmt.Errorf("ECS cluster still exists:\n%#v", out.Clusters)
-			}
+		if err != nil {
+			return err
 		}
 
-		return err
+		for _, c := range out.Clusters {
+			if *c.ClusterArn == rs.Primary.ID && *c.Status != "INACTIVE" {
+				return fmt.Errorf("ECS cluster still exists:\n%s", c)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Either Amazon has changed this behaviour/timeouts or this just slipped through for some reason.

The PR is fixing the following acceptance test failure:

```
=== RUN   TestAccAWSEcsCluster_basic
--- FAIL: TestAccAWSEcsCluster_basic (8.43s)
	testing.go:165: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Check failed: ECS cluster still exists:
		[]*ecs.Cluster{{
		  ActiveServicesCount: 0,
		  ClusterArn: "arn:aws:ecs:us-west-2:212346748836:cluster/red-grapes",
		  ClusterName: "red-grapes",
		  PendingTasksCount: 0,
		  RegisteredContainerInstancesCount: 0,
		  RunningTasksCount: 0,
		  Status: "INACTIVE"
		}}

		State: <no state>
```