### PR TITLE
provider/aws: Treat INACTIVE ECS TDs as deleted in acc tests

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
@@ -82,17 +82,19 @@ func testAccCheckAWSEcsTaskDefinitionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		out, err := conn.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
-			TaskDefinition: aws.String(rs.Primary.ID),
-		})
-
-		if err == nil {
-			if out.TaskDefinition != nil {
-				return fmt.Errorf("ECS task definition still exists:\n%#v", *out.TaskDefinition)
-			}
+		input := ecs.DescribeTaskDefinitionInput{
+			TaskDefinition: aws.String(rs.Primary.Attributes["arn"]),
 		}
 
-		return err
+		out, err := conn.DescribeTaskDefinition(&input)
+
+		if err != nil {
+			return err
+		}
+
+		if out.TaskDefinition != nil && *out.TaskDefinition.Status != "INACTIVE" {
+			return fmt.Errorf("ECS task definition still exists:\n%#v", *out.TaskDefinition)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The fix was already implemented in https://github.com/hashicorp/terraform/pull/3924 but I forgot to do this for tests, hence these were failing.

This PR is also fixing the following failures by using ARN instead of ID (TD family):

```
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- FAIL: TestAccAWSEcsTaskDefinition_basic (13.57s)
	testing.go:165: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Check failed: ClientException: Unable to describe task definition.
			status code: 400, request id: abcd123f-a434-11e5-a12c-5d8de85cf2ff

		State: <no state>
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- FAIL: TestAccAWSEcsTaskDefinition_withScratchVolume (7.91s)
	testing.go:165: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Check failed: ClientException: Unable to describe task definition.
			status code: 400, request id: abcd123f-a434-a12c-abb1-eb4dd31a84df

		State: <no state>
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- FAIL: TestAccAWSEcsTaskDefinition_withEcsService (115.39s)
	testing.go:165: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Check failed: ClientException: Unable to describe task definition.
			status code: 400, request id: abcd123f-a435-11e5-a12c-55bc0aaa1ee9

		State: <no state>
```