### PR TITLE
provider/aws: Treat CF stacks in DELETE_COMPLETE state as deleted

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack.go
@@ -190,7 +190,17 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 
 	stacks := resp.Stacks
 	if len(stacks) < 1 {
+		log.Printf("[DEBUG] Removing CloudFormation stack %s as it's already gone", d.Id())
+		d.SetId("")
 		return nil
+	}
+	for _, s := range stacks {
+		if *s.StackId == d.Id() && *s.StackStatus == "DELETE_COMPLETE" {
+			log.Printf("[DEBUG] Removing CloudFormation stack %s"+
+				" as it has been already deleted", d.Id())
+			d.SetId("")
+			return nil
+		}
 	}
 
 	tInput := cloudformation.GetTemplateInput{

--- a/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
@@ -101,9 +101,12 @@ func testAccCheckAWSCloudFormationDestroy(s *terraform.State) error {
 
 		resp, err := conn.DescribeStacks(&params)
 
-		if err == nil {
-			if len(resp.Stacks) != 0 &&
-				*resp.Stacks[0].StackId == rs.Primary.ID {
+		if err != nil {
+			return err
+		}
+
+		for _, s := range resp.Stacks {
+			if *s.StackId == rs.Primary.ID && *s.StackStatus != "DELETE_COMPLETE" {
 				return fmt.Errorf("CloudFormation stack still exists: %q", rs.Primary.ID)
 			}
 		}


### PR DESCRIPTION
Similar to https://github.com/hashicorp/terraform/pull/4364 , as @phinze mentioned:

> we recently found that the DestroyCheck portion of the AccTest suite has not been called correctly for some time
