### PR TITLE
provider/aws: Update VPC Endpoint to correctly set route table ids, a…

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_endpoint.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint.go
@@ -103,7 +103,9 @@ func resourceAwsVPCEndpointRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("vpc_id", vpce.VpcId)
 	d.Set("policy", normalizeJson(*vpce.PolicyDocument))
 	d.Set("service_name", vpce.ServiceName)
-	d.Set("route_table_ids", vpce.RouteTableIds)
+	if err := d.Set("route_table_ids", aws.StringValueSlice(vpce.RouteTableIds)); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -142,7 +144,7 @@ func resourceAwsVPCEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 	log.Printf("[DEBUG] VPC Endpoint %q updated", input.VpcEndpointId)
 
-	return nil
+	return resourceAwsVPCEndpointRead(d, meta)
 }
 
 func resourceAwsVPCEndpointDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
…nd read after update

https://github.com/hashicorp/terraform/pull/4264 revealed we weren't updating correctly. Fixing that revealed we weren't storing in state correctly, nor re-reading after the updated.

This PR fixes those two