### PR TITLE
provider/aws: Update docs with t1 instance for accounts with EC2 Classic

### DIFF
--- a/website/source/docs/configuration/override.html.md
+++ b/website/source/docs/configuration/override.html.md
@@ -37,7 +37,7 @@ If you have a Terraform configuration `example.tf` with the contents:
 
 ```
 resource "aws_instance" "web" {
-    ami = "ami-d05e75b8"
+    ami = "ami-408c7f28"
 }
 ```
 

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -25,8 +25,8 @@ A resource configuration looks like the following:
 
 ```
 resource "aws_instance" "web" {
-    ami = "ami-d05e75b8"
-    instance_type = "t2.micro"
+    ami = "ami-408c7f28"
+    instance_type = "t1.micro"
 }
 ```
 

--- a/website/source/docs/modules/usage.html.markdown
+++ b/website/source/docs/modules/usage.html.markdown
@@ -87,8 +87,8 @@ For example:
 
 ```
 resource "aws_instance" "client" {
-  ami = "ami-d05e75b8"
-  instance_type = "t2.micro"  
+  ami = "ami-408c7f28"
+  instance_type = "t1.micro"  
   availability_zone = "${module.consul.server_availability_zone}"
 }
 ```

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -14,11 +14,15 @@ and deleted. Instances also support [provisioning](/docs/provisioners/index.html
 ## Example Usage
 
 ```
-# Create a new instance of the `ami-d05e75b8` (Ubuntu 14.04) on an 
-# t2.micro node with an AWS Tag naming it "HelloWorld"
+# Create a new instance of the `ami-408c7f28` (Ubuntu 14.04) on an 
+# t1.micro node with an AWS Tag naming it "HelloWorld"
+provider "aws" {
+    region = "us-east-1"
+}
+    
 resource "aws_instance" "web" {
-    ami = "ami-d05e75b8"
-    instance_type = "t2.micro"
+    ami = "ami-408c7f28"
+    instance_type = "t1.micro"
     tags {
         Name = "HelloWorld"
     }

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -15,8 +15,8 @@ Provides a resource to create a new launch configuration, used for autoscaling g
 ```
 resource "aws_launch_configuration" "as_conf" {
     name = "web_config"
-    ami = "ami-d05e75b8"
-    instance_type = "t2.micro"
+    ami = "ami-408c7f28"
+    instance_type = "t1.micro"
 }
 ```
 
@@ -33,8 +33,8 @@ with `name_prefix`.  Example:
 ```
 resource "aws_launch_configuration" "as_conf" {
     name_prefix = "terraform-lc-example-"
-    ami = "ami-d05e75b8"
-    instance_type = "t2.micro"
+    ami = "ami-408c7f28"
+    instance_type = "t1.micro"
 
     lifecycle {
       create_before_destroy = true
@@ -66,8 +66,8 @@ for more information or how to launch [Spot Instances][3] with Terraform.
 
 ```
 resource "aws_launch_configuration" "as_conf" {
-    ami = "ami-d05e75b8"
-    instance_type = "t2.micro"
+    ami = "ami-408c7f28"
+    instance_type = "t1.micro"
     spot_price = "0.001"
     lifecycle {
       create_before_destroy = true

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -196,8 +196,8 @@
 								<p>resource <span class="txt-spe">"aws_instance"</span> <span class="txt-str">"app"</span> {</p>
 								<p>    count = <span class="txt-int">5</span></p>
 								<p> </p>
-								<p>    ami = <span class="txt-str">"ami-d05e75b8"</span></p>
-								<p>    instance_type = <span class="txt-str">"t2.micro"</span></p>
+								<p>    ami = <span class="txt-str">"ami-408c7f28"</span></p>
+								<p>    instance_type = <span class="txt-str">"t1.micro"</span></p>
 								<p>}</p>
 								</div>
 							</div>

--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -59,8 +59,8 @@ provider "aws" {
 }
 
 resource "aws_instance" "example" {
-	ami = "ami-d05e75b8"
-	instance_type = "t2.micro"
+	ami = "ami-408c7f28"
+	instance_type = "t1.micro"
 }
 ```
 
@@ -111,9 +111,9 @@ $ terraform plan
 ...
 
 + aws_instance.example
-    ami:               "" => "ami-d05e75b8"
+    ami:               "" => "ami-408c7f28"
     availability_zone: "" => "<computed>"
-    instance_type:     "" => "t2.micro"
+    instance_type:     "" => "t1.micro"
     key_name:          "" => "<computed>"
     private_dns:       "" => "<computed>"
     private_ip:        "" => "<computed>"
@@ -148,8 +148,8 @@ since Terraform waits for the EC2 instance to become available.
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-d05e75b8"
-  instance_type: "" => "t2.micro"
+  ami:           "" => "ami-408c7f28"
+  instance_type: "" => "t1.micro"
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
@@ -172,9 +172,9 @@ You can inspect the state using `terraform show`:
 $ terraform show
 aws_instance.example:
   id = i-e60900cd
-  ami = ami-d05e75b8
+  ami = ami-408c7f28
   availability_zone = us-east-1c
-  instance_type = t2.micro
+  instance_type = t1.micro
   key_name =
   private_dns = domU-12-31-39-12-38-AB.compute-1.internal
   private_ip = 10.200.59.89

--- a/website/source/intro/getting-started/change.html.md
+++ b/website/source/intro/getting-started/change.html.md
@@ -28,8 +28,8 @@ resource in your configuration and change it to the following:
 
 ```
 resource "aws_instance" "example" {
-	ami = "ami-8eb061e6"
-	instance_type = "t2.micro"
+	ami = "ami-b8b061d0"
+	instance_type = "t1.micro"
 }
 ```
 
@@ -47,7 +47,7 @@ $ terraform plan
 ...
 
 -/+ aws_instance.example
-    ami:               "ami-d05e75b8" => "ami-8eb061e6" (forces new resource)
+    ami:               "ami-408c7f28" => "ami-b8b061d0" (forces new resource)
     availability_zone: "us-east-1c" => "<computed>"
     key_name:          "" => "<computed>"
     private_dns:       "domU-12-31-39-12-38-AB.compute-1.internal" => "<computed>"
@@ -79,7 +79,7 @@ the change.
 $ terraform apply
 aws_instance.example: Destroying...
 aws_instance.example: Modifying...
-  ami: "ami-d05e75b8" => "ami-8eb061e6"
+  ami: "ami-408c7f28" => "ami-b8b061d0"
 
 Apply complete! Resources: 0 added, 1 changed, 1 destroyed.
 


### PR DESCRIPTION
Documentation update for the getting started guide; updated to work with users with EC2 classic (no default VPC) as well as users who do have a VPC

Fixes https://github.com/hashicorp/terraform/issues/4367