### PR TITLE
provider/aws: ecr resources

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -67,6 +68,7 @@ type AWSClient struct {
 	dsconn             *directoryservice.DirectoryService
 	dynamodbconn       *dynamodb.DynamoDB
 	ec2conn            *ec2.EC2
+	ecrconn            *ecr.ECR
 	ecsconn            *ecs.ECS
 	efsconn            *efs.EFS
 	elbconn            *elb.ELB
@@ -188,6 +190,9 @@ func (c *Config) Client() (interface{}, error) {
 
 		log.Println("[INFO] Initializing EC2 Connection")
 		client.ec2conn = ec2.New(sess)
+
+		log.Println("[INFO] Initializing ECR Connection")
+		client.ecrconn = ecr.New(sess)
 
 		log.Println("[INFO] Initializing ECS Connection")
 		client.ecsconn = ecs.New(sess)

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -114,6 +114,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_directory_service_directory":      resourceAwsDirectoryServiceDirectory(),
 			"aws_dynamodb_table":                   resourceAwsDynamoDbTable(),
 			"aws_ebs_volume":                       resourceAwsEbsVolume(),
+			"aws_ecr_repository":                   resourceAwsEcrRepository(),
+			"aws_ecr_repository_policy":            resourceAwsEcrRepositoryPolicy(),
 			"aws_ecs_cluster":                      resourceAwsEcsCluster(),
 			"aws_ecs_service":                      resourceAwsEcsService(),
 			"aws_ecs_task_definition":              resourceAwsEcsTaskDefinition(),

--- a/builtin/providers/aws/resource_aws_ecr_repository.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository.go
@@ -1,0 +1,106 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsEcrRepository() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEcrRepositoryCreate,
+		Read:   resourceAwsEcrRepositoryRead,
+		Delete: resourceAwsEcrRepositoryDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"registry_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	input := ecr.CreateRepositoryInput{
+		RepositoryName: aws.String(d.Get("name").(string)),
+	}
+
+	log.Printf("[DEBUG] Creating ECR resository: %s", input)
+	out, err := conn.CreateRepository(&input)
+	if err != nil {
+		return err
+	}
+
+	repository := *out.Repository
+
+	log.Printf("[DEBUG] ECR repository created: %q", *repository.RepositoryArn)
+
+	d.SetId(*repository.RepositoryName)
+	d.Set("arn", *repository.RepositoryArn)
+	d.Set("registry_id", *repository.RegistryId)
+
+	return resourceAwsEcrRepositoryRead(d, meta)
+}
+
+func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	log.Printf("[DEBUG] Reading repository %s", d.Id())
+	out, err := conn.DescribeRepositories(&ecr.DescribeRepositoriesInput{
+		RegistryId:      aws.String(d.Get("registry_id").(string)),
+		RepositoryNames: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	repository := out.Repositories[0]
+
+	log.Printf("[DEBUG] Received repository %s", out)
+
+	d.SetId(*repository.RepositoryName)
+	d.Set("arn", *repository.RepositoryArn)
+	d.Set("registry_id", *repository.RegistryId)
+
+	return nil
+}
+
+func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	_, err := conn.DeleteRepository(&ecr.DeleteRepositoryInput{
+		RepositoryName: aws.String(d.Id()),
+		RegistryId:     aws.String(d.Get("registry_id").(string)),
+		Force:          aws.Bool(true),
+	})
+	if err != nil {
+		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	log.Printf("[DEBUG] repository %q deleted.", d.Get("arn").(string))
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_ecr_repository_policy.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_policy.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsEcrRepositoryPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEcrRepositoryPolicyCreate,
+		Read:   resourceAwsEcrRepositoryPolicyRead,
+		Update: resourceAwsEcrRepositoryPolicyUpdate,
+		Delete: resourceAwsEcrRepositoryPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"repository": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"registry_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	input := ecr.SetRepositoryPolicyInput{
+		RepositoryName: aws.String(d.Get("repository").(string)),
+		PolicyText:     aws.String(d.Get("policy").(string)),
+	}
+
+	log.Printf("[DEBUG] Creating ECR resository policy: %s", input)
+	out, err := conn.SetRepositoryPolicy(&input)
+	if err != nil {
+		return err
+	}
+
+	repositoryPolicy := *out
+
+	log.Printf("[DEBUG] ECR repository policy created: %s", *repositoryPolicy.RepositoryName)
+
+	d.SetId(*repositoryPolicy.RepositoryName)
+	d.Set("registry_id", *repositoryPolicy.RegistryId)
+
+	return resourceAwsEcrRepositoryPolicyRead(d, meta)
+}
+
+func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	log.Printf("[DEBUG] Reading repository policy %s", d.Id())
+	out, err := conn.GetRepositoryPolicy(&ecr.GetRepositoryPolicyInput{
+		RegistryId:     aws.String(d.Get("registry_id").(string)),
+		RepositoryName: aws.String(d.Id()),
+	})
+	if err != nil {
+		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryPolicyNotFoundException" {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	log.Printf("[DEBUG] Received repository policy %s", out)
+
+	repositoryPolicy := out
+
+	d.SetId(*repositoryPolicy.RepositoryName)
+	d.Set("registry_id", *repositoryPolicy.RegistryId)
+
+	return nil
+}
+
+func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	if !d.HasChange("policy") {
+		return nil
+	}
+
+	input := ecr.SetRepositoryPolicyInput{
+		RepositoryName: aws.String(d.Get("repository").(string)),
+		RegistryId:     aws.String(d.Get("registry_id").(string)),
+		PolicyText:     aws.String(d.Get("policy").(string)),
+	}
+
+	out, err := conn.SetRepositoryPolicy(&input)
+	if err != nil {
+		return err
+	}
+
+	repositoryPolicy := *out
+
+	d.SetId(*repositoryPolicy.RepositoryName)
+	d.Set("registry_id", *repositoryPolicy.RegistryId)
+
+	return nil
+}
+
+func resourceAwsEcrRepositoryPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	_, err := conn.DeleteRepositoryPolicy(&ecr.DeleteRepositoryPolicyInput{
+		RepositoryName: aws.String(d.Id()),
+		RegistryId:     aws.String(d.Get("registry_id").(string)),
+	})
+	if err != nil {
+		if ecrerr, ok := err.(awserr.Error); ok {
+			if ecrerr.Code() == "RepositoryPolicyNotFoundException" || ecrerr.Code() == "RepositoryNotFoundException" {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	log.Printf("[DEBUG] repository policy %s deleted.", d.Id())
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_ecr_repository_policy.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_policy.go
@@ -67,9 +67,14 @@ func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}
 		RepositoryName: aws.String(d.Id()),
 	})
 	if err != nil {
-		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryPolicyNotFoundException" {
-			d.SetId("")
-			return nil
+		if ecrerr, ok := err.(awserr.Error); ok {
+			switch ecrerr.Code() {
+			case "RepositoryNotFoundException", "RepositoryPolicyNotFoundException":
+				d.SetId("")
+				return nil
+			default:
+				return err
+			}
 		}
 		return err
 	}
@@ -119,9 +124,12 @@ func resourceAwsEcrRepositoryPolicyDelete(d *schema.ResourceData, meta interface
 	})
 	if err != nil {
 		if ecrerr, ok := err.(awserr.Error); ok {
-			if ecrerr.Code() == "RepositoryPolicyNotFoundException" || ecrerr.Code() == "RepositoryNotFoundException" {
+			switch ecrerr.Code() {
+			case "RepositoryNotFoundException", "RepositoryPolicyNotFoundException":
 				d.SetId("")
 				return nil
+			default:
+				return err
 			}
 		}
 		return err

--- a/builtin/providers/aws/resource_aws_ecr_repository_policy_test.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_policy_test.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSEcrRepositoryPolicy_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcrRepositoryPolicy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryPolicyExists("aws_ecr_repository_policy.default"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEcrRepositoryPolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ecrconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ecr_repository_policy" {
+			continue
+		}
+
+		_, err := conn.GetRepositoryPolicy(&ecr.GetRepositoryPolicyInput{
+			RegistryId:     aws.String(rs.Primary.Attributes["registry_id"]),
+			RepositoryName: aws.String(rs.Primary.Attributes["repository"]),
+		})
+		if err != nil {
+			if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSEcrRepositoryPolicyExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+var testAccAWSEcrRepositoryPolicy = `
+resource "aws_ecr_repository" "foo" {
+	name = "bar"
+}
+
+resource "aws_ecr_repository_policy" "default" {
+	repository = "${aws_ecr_repository.foo.name}"
+	policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "testpolicy",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "ecr:ListImages"
+            ]
+        }
+    ]
+}
+EOF
+}
+`

--- a/builtin/providers/aws/resource_aws_ecr_repository_test.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_test.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSEcrRepository_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcrRepository,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists("aws_ecr_repository.default"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEcrRepositoryDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ecrconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ecr_repository" {
+			continue
+		}
+
+		input := ecr.DescribeRepositoriesInput{
+			RegistryId:      aws.String(rs.Primary.Attributes["registry_id"]),
+			RepositoryNames: []*string{aws.String(rs.Primary.Attributes["name"])},
+		}
+
+		out, err := conn.DescribeRepositories(&input)
+
+		if err != nil {
+			if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+				return nil
+			}
+			return err
+		}
+
+		for _, repository := range out.Repositories {
+			if repository.RepositoryName == aws.String(rs.Primary.Attributes["name"]) {
+				return fmt.Errorf("ECR repository still exists:\n%#v", repository)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSEcrRepositoryExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+var testAccAWSEcrRepository = `
+resource "aws_ecr_repository" "default" {
+	name = "foo-repository-terraform"
+}
+`

--- a/website/source/docs/providers/aws/r/ecr_repository.html.markdown
+++ b/website/source/docs/providers/aws/r/ecr_repository.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ecr_repository"
+sidebar_current: "docs-aws-resource-ecr-repository"
+description: |-
+  Provides an ECR Repository.
+---
+
+# aws\_ecr\_repository
+
+Provides an ECR repository.
+
+## Example Usage
+
+```
+resource "aws_ecr_repository" "foo" {
+  name = "bar"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the repository.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - Full ARN of the repository.
+* `name` - The name of the repository.
+* `registry_id` - The registry ID where the repository was created.

--- a/website/source/docs/providers/aws/r/ecr_repository_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/ecr_repository_policy.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ecr_repository_policy"
+sidebar_current: "docs-aws-resource-ecr-repository-policy"
+description: |-
+  Provides an ECR Repository Policy.
+---
+
+# aws\_ecr\_repository\_policy
+
+Provides an ECR repository policy.
+
+Note that currently only one policy may be applied to a repository.
+
+## Example Usage
+
+```
+resource "aws_ecr_repository" "foo" {
+  repository = "bar"
+}
+
+resource "aws_ecr_repository_policy" "foopolicy" {
+  repository = "${aws_ecr_repository.foo.name}"
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "new policy",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeRepositories",
+                "ecr:GetRepositoryPolicy",
+                "ecr:ListImages",
+                "ecr:DeleteRepository",
+                "ecr:BatchDeleteImage",
+                "ecr:SetRepositoryPolicy",
+                "ecr:DeleteRepositoryPolicy"
+            ]
+        }
+    ]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository` - (Required) Name of the repository to apply the policy.
+* `policy` - (Required) The policy document. This is a JSON formatted string.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `repository` - The name of the repository.
+* `registry_id` - The registry ID where the repository was created.


### PR DESCRIPTION
Adds ECR `aws_ecr_repository` and `aws_ecr_repository_policy` resources to the AWS provider. Currently, there is a one to one mapping between repository policies and the repository itself. I may have missed the way to work around this browsing the AWS ECR SDK.