### PR TITLE
provider/aws: fixes for Network ACL Rules

### DIFF
--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -50,7 +50,7 @@ func resourceAwsNetworkAcl() *schema.Resource {
 				Type:     schema.TypeSet,
 				Required: false,
 				Optional: true,
-				Computed: false,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": &schema.Schema{
@@ -93,7 +93,7 @@ func resourceAwsNetworkAcl() *schema.Resource {
 				Type:     schema.TypeSet,
 				Required: false,
 				Optional: true,
-				Computed: false,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": &schema.Schema{


### PR DESCRIPTION
 * Fixup Exists and CheckDestroy assertions
 * Make ingress/egress computed on network_acl, otherwise you could
   never use network_acl_rule with a managed network_acl without a
   perpetual diff.