### PR TITLE
provider/aws: Updates for ElastiCache, ElastiSearch tests

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -152,6 +153,10 @@ func testAccCheckAWSElasticacheClusterDestroy(s *terraform.State) error {
 			CacheClusterId: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
+			// Verify the error is what we want
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "CacheClusterNotFound" {
+				continue
+			}
 			return err
 		}
 		if len(res.CacheClusters) > 0 {

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group_test.go
@@ -112,7 +112,7 @@ func testAccCheckAWSElasticacheParameterGroupDestroy(s *terraform.State) error {
 		if !ok {
 			return err
 		}
-		if newerr.Code() != "InvalidCacheParameterGroup.NotFound" {
+		if newerr.Code() != "CacheParameterGroupNotFound" {
 			return err
 		}
 	}

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -71,6 +72,10 @@ func testAccCheckAWSElasticacheSubnetGroupDestroy(s *terraform.State) error {
 			CacheSubnetGroupName: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
+			// Verify the error is what we want
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "CacheSubnetGroupNotFoundFault" {
+				continue
+			}
 			return err
 		}
 		if len(res.CacheSubnetGroups) > 0 {

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -247,7 +247,9 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 
 	ds := out.DomainStatus
 
-	d.Set("access_policies", normalizeJson(*ds.AccessPolicies))
+	if ds.AccessPolicies != nil && *ds.AccessPolicies != "" {
+		d.Set("access_policies", normalizeJson(*ds.AccessPolicies))
+	}
 	err = d.Set("advanced_options", pointersMapToStringList(ds.AdvancedOptions))
 	if err != nil {
 		return err

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -85,8 +86,12 @@ func testAccCheckESDomainDestroy(s *terraform.State) error {
 		}
 
 		_, err := conn.DescribeElasticsearchDomain(opts)
+		// Verify the error is what we want
 		if err != nil {
-			return fmt.Errorf("Error describing ES domains: %q", err.Error())
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+				continue
+			}
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Mostly updates for the tests after the destroy step was fixed, but also an update to `access_policies` in the latter to end the perpetual plan diff