### PR TITLE
provider/aws: Fix issue with Route53 and zero weighted records

### DIFF
--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -103,7 +103,7 @@ record from one another. Required for each weighted record.
 default in Terraform. This allows Terraform to distinquish between a `0` value
 and an empty value in the configuration (none specified). As a result, a 
 `weight` of `-1` will be present in the statefile if `weight` is omitted in the 
-configuraiton.
+configuration.
 
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 

--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -99,6 +99,12 @@ record from one another. Required for each weighted record.
 * `alias` - (Optional) An alias block. Conflicts with `ttl` & `records`.
   Alias record documented below.
 
+~> **Note:** The `weight` attribute uses a special sentinel value of `-1` for a
+default in Terraform. This allows Terraform to distinquish between a `0` value
+and an empty value in the configuration (none specified). As a result, a 
+`weight` of `-1` will be present in the statefile if `weight` is omitted in the 
+configuraiton.
+
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 
 Alias records support the following:


### PR DESCRIPTION
Route 53 allows weighted records, with a weight of `0` [meaning various things depending on the context][1].

Terraform's internal can sometimes confuse `0` for "not specified", which is incorrect in this case. As a result, a `0` weight was not possible... UNTIL NOW!

Here we default the weight to `-1` as a sentinel value*. A record uses this default when the user does not specify `weight` in the record. A weight of `-1` is ignored.

[1]: http://docs.aws.amazon.com/fr_fr/Route53/latest/APIReference/API_ChangeResourceRecordSets_Examples.html


--- 
_*probably not a true sentinel value_