### PR TITLE
docs/aws: Fix highlighting of ECR in sidebar

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -39,7 +39,7 @@
                         <li<%= sidebar_current("docs-aws-resource-cloudwatch-metric-alarm") %>>
                             <a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
                         </li>
- 
+
                     </ul>
                 </li>
 
@@ -465,7 +465,7 @@
                         <li<%= sidebar_current("docs-aws-resource-route53-zone-association") %>>
                             <a href="/docs/providers/aws/r/route53_zone_association.html">aws_route53_zone_association</a>
                         </li>
-                        
+
                     </ul>
                 </li>
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -177,7 +177,7 @@
                 </li>
 
 
-                <li<%= sidebar_current(/^docs-aws-resource-ecs/) %>>
+                <li<%= sidebar_current(/^docs-aws-resource-(ecs|ecr)/) %>>
                     <a href="#">ECS Resources</a>
                     <ul class="nav nav-visible">
 


### PR DESCRIPTION
ECR resources weren't highlighted in the sidebar when selected, this PR is fixing it.