### PR TITLE
helper/schema: Allow identification of a new resource in update func

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -142,6 +142,7 @@ func (r *Resource) Apply(
 	err = nil
 	if data.Id() == "" {
 		// We're creating, it is a new resource.
+		data.MarkNewResource()
 		err = r.Create(data, meta)
 	} else {
 		if r.Update == nil {

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -30,6 +30,7 @@ type ResourceData struct {
 	partial     bool
 	partialMap  map[string]struct{}
 	once        sync.Once
+	isNew       bool
 }
 
 // getResult is the internal structure that is generated when a Get
@@ -169,6 +170,14 @@ func (d *ResourceData) SetPartial(k string) {
 	if d.partial {
 		d.partialMap[k] = struct{}{}
 	}
+}
+
+func (d *ResourceData) MarkNewResource() {
+	d.isNew = true
+}
+
+func (d *ResourceData) IsNewResource() bool {
+	return d.isNew
 }
 
 // Id returns the ID of the resource.


### PR DESCRIPTION
### TL;DR
This is to avoid situations where we call Update function right from the `Create` function and the `Update` function has in some situations no way to differentiate between a new resource and resource that's being updated.

e.g. in [KMS](https://github.com/hashicorp/terraform/pull/3928) I'm enabling/disabling keys in the `Update` function, but I don't want to call the enable/disable key API at all if I know that the key is enabled by default once created.

### Why not ____

#### `d.HasChange` ?

You could say that `d.HasChange()` may cover such situations, but if we have
```go
			"is_enabled": &schema.Schema{
				Type:     schema.TypeBool,
				Optional: true,
				Default:  true,
			},
```
and `is_enabled` not present in the HCL template then
```go
d.HasChange("is_enabled")
```
is always true when creating a new resource. `d.GetChange` reports `false` => `true` which makes it impossible to differentiate between creation & real update from `is_enabled=false` to `is_enabled=true`.

#### Strict separation between Create & Update?

Also you could say that we just may not call `Update` from `Create` and make these strictly separated, but that may (in some cases) involve a lot of duplication purely because some attributes can only be set from Update APIs. This approach would therefore make the code much more verbose.

#### Just always call update?

Because more API calls cost more time - in case like KMS, where we need to confirm the state has been properly propagated it makes a huge difference - even **minutes**. Each API call also counts toward the limit and we should make Terraform efficient enough to not throttle any APIs.