### PR TITLE
helper: Add ContinuousTargetOccurence to work around inconsistency

### DIFF
--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -29,6 +29,9 @@ type StateChangeConf struct {
 	Timeout        time.Duration    // The amount of time to wait before timeout
 	MinTimeout     time.Duration    // Smallest time to wait before refreshes
 	NotFoundChecks int              // Number of times to allow not found
+
+	// This is to work around inconsistent APIs
+	ContinuousTargetOccurence int // Number of times the Target state has to occur continuously
 }
 
 // WaitForState watches an object and waits for it to achieve the state
@@ -49,10 +52,15 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 	log.Printf("[DEBUG] Waiting for state to become: %s", conf.Target)
 
 	notfoundTick := 0
+	targetOccurence := 0
 
 	// Set a default for times to check for not found
 	if conf.NotFoundChecks == 0 {
 		conf.NotFoundChecks = 20
+	}
+
+	if conf.ContinuousTargetOccurence == 0 {
+		conf.ContinuousTargetOccurence = 1
 	}
 
 	var result interface{}
@@ -88,7 +96,12 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 
 			// If we're waiting for the absence of a thing, then return
 			if result == nil && len(conf.Target) == 0 {
-				return
+				targetOccurence += 1
+				if conf.ContinuousTargetOccurence == targetOccurence {
+					return
+				} else {
+					continue
+				}
 			}
 
 			if result == nil {
@@ -102,17 +115,24 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 			} else {
 				// Reset the counter for when a resource isn't found
 				notfoundTick = 0
+				found := false
 
 				for _, allowed := range conf.Target {
 					if currentState == allowed {
-						return
+						found = true
+						targetOccurence += 1
+						if conf.ContinuousTargetOccurence == targetOccurence {
+							return
+						} else {
+							continue
+						}
 					}
 				}
 
-				found := false
 				for _, allowed := range conf.Pending {
 					if currentState == allowed {
 						found = true
+						targetOccurence = 0
 						break
 					}
 				}


### PR DESCRIPTION
This is to work around the known issue with inconsistent APIs, like IAM or KMS, namely https://github.com/hashicorp/terraform/issues/4375 https://github.com/hashicorp/terraform/issues/4306 https://github.com/hashicorp/terraform/issues/2869 https://github.com/hashicorp/terraform/issues/2499 https://github.com/hashicorp/terraform/issues/2136

Very similar issue has been raised recently in Vault too: https://github.com/hashicorp/vault/issues/687
cc @jefferai

As you may expect such issues are difficult to reproduce unless you have a full copy of AWS environment.

### Current solution(s)/work-around(s)

#### Just simply wait for the 1st "successful" state
The problem here is that 1st success != replication done, see below a snippet from my KMS testing:

```sh
KEY_ID=$(aws kms create-key --description "aws-eventually-consistent-kms-3" | jq -r .KeyMetadata.KeyId)
echo "Disabling $KEY_ID"
aws kms disable-key --key-id $KEY_ID
echo "$KEY_ID should be now disabled"
aws kms describe-key --key-id $KEY_ID | jq .KeyMetadata.Enabled
aws kms describe-key --key-id $KEY_ID | jq .KeyMetadata.Enabled
aws kms describe-key --key-id $KEY_ID | jq .KeyMetadata.Enabled
aws kms describe-key --key-id $KEY_ID | jq .KeyMetadata.Enabled
aws kms describe-key --key-id $KEY_ID | jq .KeyMetadata.Enabled
aws kms describe-key --key-id $KEY_ID | jq .KeyMetadata.Enabled
```
```
Disabling 128169fc-a5ac-481f-99f5-730c6980d924
128169fc-a5ac-481f-99f5-730c6980d924 should be now disabled
false
true
false
false
true
true
```

#### Retry dependent API calls

This for example means retrying `ec2:StartInstance` if the IAM Instance Profile has a policy which has not been replicated yet or retrying `ecs:CreateService` if the IAM Role has a policy which has not been replicated yet.

It seemed to be a pretty good solution, until I realised this approach fails exactly the same way as the approach above - see https://github.com/hashicorp/terraform/issues/4375#issuecomment-166612411 where `ecs:CreateService` succeeded and subsequent `ecs:UpdateService` failed.