### PR TITLE
provider/aws: lambda function runtime documentation link

### DIFF
--- a/website/source/docs/providers/aws/r/lambda_function.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_function.html.markdown
@@ -53,7 +53,7 @@ resource "aws_lambda_function" "test_lambda" {
 * `role` - (Required) IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See [Lambda Permission Model][4] for more details.
 * `description` - (Optional) Description of what your Lambda Function does.
 * `memory_size` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
-* `runtime` - (Optional) Defaults to `nodejs`.
+* `runtime` - (Optional) Defaults to `nodejs`. See [Runtimes][6] for valid values.
 * `timeout` - (Optional) The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
 
 ## Attributes Reference
@@ -67,3 +67,4 @@ resource "aws_lambda_function" "test_lambda" {
 [3]: http://docs.aws.amazon.com/lambda/latest/dg/walkthrough-custom-events-create-test-function.html
 [4]: http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html
 [5]: http://docs.aws.amazon.com/lambda/latest/dg/limits.html
+[6]: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#API_CreateFunction_RequestBody


### PR DESCRIPTION
Fixes #4445 and helps out with #4314

Adding a link to the runtime options for the AWS Lambda functions. We don't currently validate the lambda runtime values so we should link to the accepted values