### PR TITLE
implements sha1 hash interpolation func

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -38,6 +40,7 @@ func init() {
 		"lower":        interpolationFuncLower(),
 		"replace":      interpolationFuncReplace(),
 		"split":        interpolationFuncSplit(),
+		"sha1":         interpolationFuncSha1(),
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64decode": interpolationFuncBase64Decode(),
 		"upper":        interpolationFuncUpper(),
@@ -583,6 +586,20 @@ func interpolationFuncUpper() ast.Function {
 		Callback: func(args []interface{}) (interface{}, error) {
 			toUpper := args[0].(string)
 			return strings.ToUpper(toUpper), nil
+		},
+	}
+}
+
+func interpolationFuncSha1() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			h := sha1.New()
+			h.Write([]byte(s))
+			hash := hex.EncodeToString(h.Sum(nil))
+			return hash, nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -834,6 +834,18 @@ func TestInterpolateFuncUpper(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncSha1(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${sha1("test")}`,
+				"a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+				false,
+			},
+		},
+	})
+}
+
 type testFunctionConfig struct {
 	Cases []testFunctionCase
 	Vars  map[string]ast.Variable

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -80,6 +80,10 @@ The supported built-in functions are:
   * `base64encode(string)` - Returns a base64-encoded representation of the
     given string.
 
+  * `sha1(string)` - Returns a sha1 hash representation of the
+    given string.
+    Example: `"${sha1(concat(aws_vpc.default.tags.customer, "-s3-bucket"))}"`
+
   * `cidrhost(iprange, hostnum)` - Takes an IP address range in CIDR notation
     and creates an IP address with the given host number. For example,
     ``cidrhost("10.0.0.0/8", 2)`` returns ``10.0.0.2``.
@@ -95,7 +99,7 @@ The supported built-in functions are:
     CIDR notation (like ``10.0.0.0/8``) and extends its prefix to include an
     additional subnet number. For example,
     ``cidrsubnet("10.0.0.0/8", 8, 2)`` returns ``10.2.0.0/16``.
-    
+
   * `coalesce(string1, string2, ...)` - Returns the first non-empty value from
     the given arguments. At least two arguments must be provided.
 


### PR DESCRIPTION
Adds functionality to convert a string to a sha1 hash.

Example: obfuscating the name used for the various terraform provider resources.

For instance:

    resource "aws_s3_bucket" "customer-bucket" {
        bucket = "${sha1(concat(aws_vpc.default.tags.cust-id, "-s3-bucket"))}"
        tags {
            Name = "${sha1(concat(aws_vpc.default.tags.cust-id, "-s3-bucket"))}"
            designation = "${var.designation}"
            env = "${var.env}"
            mgmt = "${var.mgmt}"
            product = "${var.product}"
            vpc-id = "${aws_vpc.default.id}"
        }
    }

Tested against master and works as intended.