### PR TITLE
Correct 'aws-two-tier' example README.md and add missing variable

### DIFF
--- a/examples/aws-two-tier/README.md
+++ b/examples/aws-two-tier/README.md
@@ -10,6 +10,10 @@ getting your application onto the servers. However, you could do so either via
 management tool, or by pre-baking configured AMIs with
 [Packer](http://www.packer.io).
 
+This example will also create a new EC2 Key Pair in the specified AWS Region. 
+The key name and path to the public key must be specified via the  
+terraform command vars.
+
 After you run `terraform apply` on this configuration, it will
 automatically output the DNS address of the ELB. After your instance
 registers, this should respond with the default nginx web page.
@@ -22,11 +26,11 @@ Run with a command like this:
 
 ```
 terraform apply -var 'key_name={your_aws_key_name}' \
-   -var 'key_path={location_of_your_key_in_your_local_machine}'` 
+   -var 'public_key_path={location_of_your_key_in_your_local_machine}'` 
 ```
 
 For example:
 
 ```
-terraform apply -var 'key_name=terraform' -var 'key_path=/Users/jsmith/.ssh/terraform.pem'
+terraform apply -var 'key_name=terraform' -var 'public_key_path=/Users/jsmith/.ssh/terraform.pub'
 ```

--- a/examples/aws-two-tier/main.tf
+++ b/examples/aws-two-tier/main.tf
@@ -100,7 +100,7 @@ resource "aws_elb" "web" {
 }
 
 resource "aws_key_pair" "auth" {
-  key_name   = "tf-aws-two-tier-example"
+  key_name   = "${var.key_name}"
   public_key = "${file(var.public_key_path)}"
 }
 

--- a/examples/aws-two-tier/variables.tf
+++ b/examples/aws-two-tier/variables.tf
@@ -4,8 +4,12 @@ Path to the SSH public key to be used for authentication.
 Ensure this keypair is added to your local SSH agent so provisioners can
 connect.
 
-Example: ~/.ssh/id_rsa.pub
+Example: ~/.ssh/terraform.pub
 DESCRIPTION
+}
+
+variable "key_name" {
+  description = "Desired name of AWS key pair"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
Hi,

I couldn't initially get the aws-two-tier example working, and I believe this is because the 'key_path' var (as mentioned in the README.md instructions) variable should actually be 'public_key_path'.

The 'key_name' variable was also not used in the 'aws_key_pair' resource, which I have corrected.

I hope all of this makes sense, but please feel free to get in touch if you would like any more information.

Daniel