### PR TITLE
Remove recommendation to use create_before_destroy-hook in autoscaling group

### DIFF
--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -77,10 +77,6 @@ resource "aws_launch_configuration" "as_conf" {
 resource "aws_autoscaling_group" "bar" {
     name = "terraform-asg-example"
     launch_configuration = "${aws_launch_configuration.as_conf.name}"
-
-    lifecycle {
-      create_before_destroy = true
-    }
 }
 ```
 


### PR DESCRIPTION
Only use the create_before_destroy-hook in launch configurations. The autoscaling group must not use the create_before_destroy-hook, because it can be updated (and not destroyed + re-created). Using the create_before_destroy-hook in autoscaling group also leads to unwanted cyclic dependencies.