### PR TITLE
update docs to reflect that the allocation ID is exported as the attribute 'id'

### DIFF
--- a/website/source/docs/providers/aws/r/eip.html.markdown
+++ b/website/source/docs/providers/aws/r/eip.html.markdown
@@ -36,6 +36,7 @@ more information.
 
 The following attributes are exported:
 
+* `id` - Contains the EIP allocation ID.
 * `private_ip` - Contains the private IP address (if in VPC).
 * `public_ip` - Contains the public IP address.
 * `instance` - Contains the ID of the attached instance.


### PR DESCRIPTION
came up in a discussion on IRC that you need the EIP's allocation ID for the new NAT gateway resource.