### PR TITLE
provider/azure: Track upstream library changes

### DIFF
--- a/builtin/providers/azure/resource_azure_instance.go
+++ b/builtin/providers/azure/resource_azure_instance.go
@@ -695,7 +695,7 @@ func retrieveVMImageDetails(
 			}
 
 			configureForImage := func(role *virtualmachine.Role) error {
-				return vmutils.ConfigureDeploymentFromVMImage(
+				return vmutils.ConfigureDeploymentFromPublishedVMImage(
 					role,
 					img.Name,
 					"",


### PR DESCRIPTION
`vmutils.ConfigureDeploymentFromVMImage` has been changed to `vmutils.ConfigureDeploymentFromPublishedVMImage` in the upstream library - this allows us to build.