### PR TITLE
core: use !windows instead of a list of unixes

### DIFF
--- a/config_unix.go
+++ b/config_unix.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd linux netbsd openbsd
+// +build !windows
 
 package main
 


### PR DESCRIPTION
This allows building on a wider variety of unix-a-likes without needing to list them all explicitly - Windows is the special case here!