### PR TITLE
provider/docker: Add network_mode support to docker

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -238,6 +238,12 @@ func resourceDockerContainer() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"network_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -137,7 +137,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if v, ok := d.GetOk("network_mode"); ok {
-		hostConfig.NetworkMode = v
+		hostConfig.NetworkMode = v.(string)
 	}
 
 	createOpts.HostConfig = hostConfig

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -136,6 +136,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		hostConfig.LogConfig.Config = mapTypeMapValsToString(v.(map[string]interface{}))
 	}
 
+	if v, ok := d.GetOk("network_mode"); ok {
+		hostConfig.NetworkMode = v
+	}
+
 	createOpts.HostConfig = hostConfig
 
 	var retContainer *dc.Container

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -155,5 +155,6 @@ resource "docker_container" "foo" {
     max-size = "10m"
     max-file = 20
 	}
+	network_mode = "bridge"
 }
 `

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -68,6 +68,7 @@ The following arguments are supported:
   Defaults to "json-file".
 * `log_opts` - (Optional) Key/value pairs to use as options for the logging
   driver.
+* `network_mode` - (Optional) Network mode of the container.
 
 <a id="ports"></a>
 ## Ports


### PR DESCRIPTION
Fixes #2929

Add the possibility to customise the NetworkMode:
https://docs.docker.com/engine/reference/run/#network-settings
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-container
https://github.com/fsouza/go-dockerclient/blob/master/container.go