### PR TITLE
Added support for the encryption flag on ebs_block_devices in launch configurations

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -185,6 +185,13 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
+
+						"encrypted": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
 					},
 				},
 				Set: func(v interface{}) int {
@@ -326,6 +333,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			bd := v.(map[string]interface{})
 			ebs := &autoscaling.Ebs{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
+				Encrypted:           aws.Bool(bd["encrypted"].(bool)),
 			}
 
 			if v, ok := bd["snapshot_id"].(string); ok && v != "" {
@@ -569,6 +577,9 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 		}
 		if bdm.Ebs != nil && bdm.Ebs.Iops != nil {
 			bd["iops"] = *bdm.Ebs.Iops
+		}
+		if bdm.Ebs != nil && bdm.Ebs.Encrypted != nil {
+			bd["encrypted"] = *bdm.Ebs.Encrypted
 		}
 		if bdm.DeviceName != nil && *bdm.DeviceName == *rootDeviceName {
 			blockDevices["root"] = bd

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -144,6 +144,7 @@ Each `ebs_block_device` supports the following:
   This must be set with a `volume_type` of `"io1"`.
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
+* `encryption` - (Optional) Whether the volume should be encrypted or not. Do not use this option if you are using `snapshot_id` as the encryption flag will be determined by the snapshot. (Default: `false`).
 
 Modifying any `ebs_block_device` currently requires resource replacement.
 


### PR DESCRIPTION
The aws-sdk supports setting an encrypted flag on ebs_block_devices in launch configurations. If no snapshot is specified, then the encryption flag can be turned on/off. Default is off. Tested this by creating launch configurations with this both on and off.