### PR TITLE
provider/aws: Add support for S3 logging.

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -255,6 +255,24 @@ func TestAccAWSS3Bucket_Cors(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3Bucket_Logging(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithLogging,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketLogging(
+						"aws_s3_bucket.bucket", "aws_s3_bucket.log_bucket", "log/"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSS3BucketDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).s3conn
 
@@ -461,6 +479,45 @@ func testAccCheckAWSS3BucketCors(n string, corsRules []*s3.CORSRule) resource.Te
 	}
 }
 
+func testAccCheckAWSS3BucketLogging(n, b, p string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[n]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		out, err := conn.GetBucketLogging(&s3.GetBucketLoggingInput{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("GetBucketLogging error: %v", err)
+		}
+
+		tb, _ := s.RootModule().Resources[b]
+
+		if v := out.LoggingEnabled.TargetBucket; v == nil {
+			if tb.Primary.ID != "" {
+				return fmt.Errorf("bad target bucket, found nil, expected: %s", tb.Primary.ID)
+			}
+		} else {
+			if *v != tb.Primary.ID {
+				return fmt.Errorf("bad target bucket, expected: %s, got %s", tb.Primary.ID, *v)
+			}
+		}
+
+		if v := out.LoggingEnabled.TargetPrefix; v == nil {
+			if p != "" {
+				return fmt.Errorf("bad target prefix, found nil, expected: %s", p)
+			}
+		} else {
+			if *v != p {
+				return fmt.Errorf("bad target prefix, expected: %s, got %s", p, *v)
+			}
+		}
+
+		return nil
+	}
+}
+
 // These need a bit of randomness as the name can only be used once globally
 // within AWS
 var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -570,3 +627,18 @@ resource "aws_s3_bucket" "bucket" {
 	acl = "private"
 }
 `
+
+var testAccAWSS3BucketConfigWithLogging = fmt.Sprintf(`
+resource "aws_s3_bucket" "log_bucket" {
+	bucket = "tf-test-log-bucket-%d"
+	acl = "log-delivery-write"
+}
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+	logging {
+		target_bucket = "${aws_s3_bucket.log_bucket.id}"
+		target_prefix = "log/"
+	}
+}
+`, randInt, randInt)

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -70,6 +70,23 @@ resource "aws_s3_bucket" "b" {
 }
 ```
 
+### Enable Logging
+
+```
+resource "aws_s3_bucket" "log_bucket" {
+   bucket = "my_tf_log_bucket"
+   acl = "log-delivery-write"
+}
+resource "aws_s3_bucket" "b" {
+   bucket = "my_tf_test_bucket"
+   acl = "private"
+   logging {
+	   target_bucket = "${aws_s3_bucket.log_bucket.id}"
+	   target_prefix = "log/"
+   }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -83,6 +100,7 @@ The following arguments are supported:
 * `website` - (Optional) A website object (documented below).
 * `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 * `versioning` - (Optional) A state of [versioning](http://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+* `logging` - (Optional) A settings of [bucket logging](http://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 
 The website object supports the following:
 
@@ -101,6 +119,11 @@ The CORS supports the following:
 The versioning supports the following:
 
 * `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.
+
+The logging supports the following:
+
+* `target_bucket` - (Required) The name of the bucket that will receive the log objects.
+* `target_prefix` - (Optional) To specify a key prefix for log objects.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This commit is allows to logging configuration to S3 bucket resource.

* Test
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3Bucket_Logging' 2> /dev/null
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3Bucket_Logging -timeout 90m
=== RUN   TestAccAWSS3Bucket_Logging
--- PASS: TestAccAWSS3Bucket_Logging (13.55s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    13.559s
```

* Example

```
resource "aws_s3_bucket" "log_bucket" {
   bucket = "my_tf_log_bucket"
   acl = "log-delivery-write"
}
resource "aws_s3_bucket" "b" {
   bucket = "my_tf_test_bucket"
   acl = "private"
   logging {
	   target_bucket = "${aws_s3_bucket.log_bucket.id}"
	   target_prefix = "log/"
   }
}
```