### PR TITLE
Revert "Update Build documentation to use t2.micro"

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -60,7 +60,7 @@ provider "aws" {
 
 resource "aws_instance" "example" {
 	ami = "ami-408c7f28"
-	instance_type = "t2.micro"
+	instance_type = "t1.micro"
 }
 ```
 
@@ -113,7 +113,7 @@ $ terraform plan
 + aws_instance.example
     ami:               "" => "ami-408c7f28"
     availability_zone: "" => "<computed>"
-    instance_type:     "" => "t2.micro"
+    instance_type:     "" => "t1.micro"
     key_name:          "" => "<computed>"
     private_dns:       "" => "<computed>"
     private_ip:        "" => "<computed>"
@@ -149,7 +149,7 @@ since Terraform waits for the EC2 instance to become available.
 $ terraform apply
 aws_instance.example: Creating...
   ami:           "" => "ami-408c7f28"
-  instance_type: "" => "t2.micro"
+  instance_type: "" => "t1.micro"
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
@@ -174,7 +174,7 @@ aws_instance.example:
   id = i-e60900cd
   ami = ami-408c7f28
   availability_zone = us-east-1c
-  instance_type = t2.micro
+  instance_type = t1.micro
   key_name =
   private_dns = domU-12-31-39-12-38-AB.compute-1.internal
   private_ip = 10.200.59.89


### PR DESCRIPTION
Reverts hashicorp/terraform#4458

`t2.micro` instances are not available in EC2 Classic, which sadly a number of accounts still use. In order to provide a quick start guide for all account types, we'll revert this back to `t1.micro` which should work across Classic and VPC.