### PR TITLE
provider/digitalocean: acctest improvements

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -293,43 +293,67 @@ func testAccCheckDigitalOceanDropletRecreated(t *testing.T,
 //
 //}
 
-const testAccCheckDigitalOceanDropletConfig_basic = `
-resource "digitalocean_droplet" "foobar" {
-    name = "foo"
-    size = "512mb"
-    image = "centos-5-8-x32"
-    region = "nyc3"
-    user_data  = "foobar"
+var testAccCheckDigitalOceanDropletConfig_basic = fmt.Sprintf(`
+resource "digitalocean_ssh_key" "foobar" {
+  name       = "foobar"
+  public_key = "%s"
 }
-`
 
-const testAccCheckDigitalOceanDropletConfig_userdata_update = `
 resource "digitalocean_droplet" "foobar" {
-    name = "foo"
-    size = "512mb"
-    image = "centos-5-8-x32"
-    region = "nyc3"
-    user_data  = "foobar foobar"
+  name      = "foo"
+  size      = "512mb"
+  image     = "centos-5-8-x32"
+  region    = "nyc3"
+  user_data = "foobar"
+  ssh_keys  = ["${digitalocean_ssh_key.foobar.id}"]
 }
-`
+`, testAccValidPublicKey)
 
-const testAccCheckDigitalOceanDropletConfig_RenameAndResize = `
-resource "digitalocean_droplet" "foobar" {
-    name = "baz"
-    size = "1gb"
-    image = "centos-5-8-x32"
-    region = "nyc3"
+var testAccCheckDigitalOceanDropletConfig_userdata_update = fmt.Sprintf(`
+resource "digitalocean_ssh_key" "foobar" {
+  name       = "foobar"
+  public_key = "%s"
 }
-`
+
+resource "digitalocean_droplet" "foobar" {
+  name      = "foo"
+  size      = "512mb"
+  image     = "centos-5-8-x32"
+  region    = "nyc3"
+  user_data = "foobar foobar"
+  ssh_keys  = ["${digitalocean_ssh_key.foobar.id}"]
+}
+`, testAccValidPublicKey)
+
+var testAccCheckDigitalOceanDropletConfig_RenameAndResize = fmt.Sprintf(`
+resource "digitalocean_ssh_key" "foobar" {
+  name       = "foobar"
+  public_key = "%s"
+}
+
+resource "digitalocean_droplet" "foobar" {
+  name     = "baz"
+  size     = "1gb"
+  image    = "centos-5-8-x32"
+  region   = "nyc3"
+  ssh_keys = ["${digitalocean_ssh_key.foobar.id}"]
+}
+`, testAccValidPublicKey)
 
 // IPV6 only in singapore
-const testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6 = `
-resource "digitalocean_droplet" "foobar" {
-    name = "baz"
-    size = "1gb"
-    image = "centos-5-8-x32"
-    region = "sgp1"
-    ipv6 = true
-    private_networking = true
+var testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6 = fmt.Sprintf(`
+resource "digitalocean_ssh_key" "foobar" {
+  name       = "foobar"
+  public_key = "%s"
 }
-`
+
+resource "digitalocean_droplet" "foobar" {
+  name               = "baz"
+  size               = "1gb"
+  image              = "centos-5-8-x32"
+  region             = "sgp1"
+  ipv6               = true
+  private_networking = true
+  ssh_keys           = ["${digitalocean_ssh_key.foobar.id}"]
+}
+`, testAccValidPublicKey)

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -101,21 +101,26 @@ func testAccCheckDigitalOceanFloatingIPExists(n string, floatingIP *godo.Floatin
 
 var testAccCheckDigitalOceanFloatingIPConfig_region = `
 resource "digitalocean_floating_ip" "foobar" {
-    region = "nyc3"
+  region = "nyc3"
 }`
 
-var testAccCheckDigitalOceanFloatingIPConfig_droplet = `
+var testAccCheckDigitalOceanFloatingIPConfig_droplet = fmt.Sprintf(`
+resource "digitalocean_ssh_key" "foobar" {
+  name       = "foobar"
+  public_key = "%s"
+}
 
 resource "digitalocean_droplet" "foobar" {
-    name = "baz"
-    size = "1gb"
-    image = "centos-5-8-x32"
-    region = "sgp1"
-    ipv6 = true
-    private_networking = true
+  name               = "baz"
+  size               = "1gb"
+  image              = "centos-5-8-x32"
+  region             = "sgp1"
+  ipv6               = true
+  private_networking = true
+  ssh_keys           = ["${digitalocean_ssh_key.foobar.id}"]
 }
 
 resource "digitalocean_floating_ip" "foobar" {
-    droplet_id = "${digitalocean_droplet.foobar.id}"
-    region = "${digitalocean_droplet.foobar.region}"
-}`
+  droplet_id = "${digitalocean_droplet.foobar.id}"
+  region     = "${digitalocean_droplet.foobar.region}"
+}`, testAccValidPublicKey)

--- a/builtin/providers/digitalocean/resource_digitalocean_record_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDigitalOceanRecord_Basic(t *testing.T) {
 	var record godo.DomainRecord
+	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,14 +21,14 @@ func TestAccDigitalOceanRecord_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckDigitalOceanRecordConfig_basic,
+				Config: fmt.Sprintf(testAccCheckDigitalOceanRecordConfig_basic, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
 					testAccCheckDigitalOceanRecordAttributes(&record),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "name", "terraform"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+						"digitalocean_record.foobar", "domain", domain),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "value", "192.168.0.10"),
 				),
@@ -37,6 +39,7 @@ func TestAccDigitalOceanRecord_Basic(t *testing.T) {
 
 func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 	var record godo.DomainRecord
+	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,14 +47,14 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckDigitalOceanRecordConfig_basic,
+				Config: fmt.Sprintf(testAccCheckDigitalOceanRecordConfig_basic, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
 					testAccCheckDigitalOceanRecordAttributes(&record),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "name", "terraform"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+						"digitalocean_record.foobar", "domain", domain),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "value", "192.168.0.10"),
 					resource.TestCheckResourceAttr(
@@ -59,14 +62,15 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckDigitalOceanRecordConfig_new_value,
+				Config: fmt.Sprintf(
+					testAccCheckDigitalOceanRecordConfig_new_value, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
 					testAccCheckDigitalOceanRecordAttributesUpdated(&record),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "name", "terraform"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+						"digitalocean_record.foobar", "domain", domain),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "value", "192.168.0.11"),
 					resource.TestCheckResourceAttr(
@@ -79,6 +83,7 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 
 func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
 	var record godo.DomainRecord
+	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -86,14 +91,15 @@ func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckDigitalOceanRecordConfig_cname,
+				Config: fmt.Sprintf(
+					testAccCheckDigitalOceanRecordConfig_cname, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
-					testAccCheckDigitalOceanRecordAttributesHostname("a", &record),
+					testAccCheckDigitalOceanRecordAttributesHostname("a.foobar-test-terraform.com", &record),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "name", "terraform"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+						"digitalocean_record.foobar", "domain", domain),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "value", "a.foobar-test-terraform.com."),
 					resource.TestCheckResourceAttr(
@@ -106,6 +112,7 @@ func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
 
 func TestAccDigitalOceanRecord_ExternalHostnameValue(t *testing.T) {
 	var record godo.DomainRecord
+	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,14 +120,15 @@ func TestAccDigitalOceanRecord_ExternalHostnameValue(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckDigitalOceanRecordConfig_external_cname,
+				Config: fmt.Sprintf(
+					testAccCheckDigitalOceanRecordConfig_external_cname, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
 					testAccCheckDigitalOceanRecordAttributesHostname("a.foobar-test-terraform.net", &record),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "name", "terraform"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_record.foobar", "domain", "foobar-test-terraform.com"),
+						"digitalocean_record.foobar", "domain", domain),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "value", "a.foobar-test-terraform.net."),
 					resource.TestCheckResourceAttr(
@@ -225,70 +233,56 @@ func testAccCheckDigitalOceanRecordAttributesHostname(data string, record *godo.
 
 const testAccCheckDigitalOceanRecordConfig_basic = `
 resource "digitalocean_domain" "foobar" {
-    name = "foobar-test-terraform.com"
-    ip_address = "192.168.0.10"
+  name       = "%s"
+  ip_address = "192.168.0.10"
 }
 
 resource "digitalocean_record" "foobar" {
-    domain = "${digitalocean_domain.foobar.name}"
+  domain = "${digitalocean_domain.foobar.name}"
 
-    name = "terraform"
-    value = "192.168.0.10"
-    type = "A"
+  name  = "terraform"
+  value = "192.168.0.10"
+  type  = "A"
 }`
 
 const testAccCheckDigitalOceanRecordConfig_new_value = `
 resource "digitalocean_domain" "foobar" {
-    name = "foobar-test-terraform.com"
-    ip_address = "192.168.0.10"
+  name       = "%s"
+  ip_address = "192.168.0.10"
 }
 
 resource "digitalocean_record" "foobar" {
-    domain = "${digitalocean_domain.foobar.name}"
+  domain = "${digitalocean_domain.foobar.name}"
 
-    name = "terraform"
-    value = "192.168.0.11"
-    type = "A"
+  name  = "terraform"
+  value = "192.168.0.11"
+  type  = "A"
 }`
 
 const testAccCheckDigitalOceanRecordConfig_cname = `
 resource "digitalocean_domain" "foobar" {
-    name = "foobar-test-terraform.com"
-    ip_address = "192.168.0.10"
+  name       = "%s"
+  ip_address = "192.168.0.10"
 }
 
 resource "digitalocean_record" "foobar" {
-    domain = "${digitalocean_domain.foobar.name}"
+  domain = "${digitalocean_domain.foobar.name}"
 
-    name = "terraform"
-    value = "a.foobar-test-terraform.com."
-    type = "CNAME"
-}`
-
-const testAccCheckDigitalOceanRecordConfig_relative_cname = `
-resource "digitalocean_domain" "foobar" {
-    name = "foobar-test-terraform.com"
-    ip_address = "192.168.0.10"
-}
-
-resource "digitalocean_record" "foobar" {
-    domain = "${digitalocean_domain.foobar.name}"
-
-    name = "terraform"
-    value = "a.b"
-    type = "CNAME"
+  name  = "terraform"
+  value = "a.foobar-test-terraform.com."
+  type  = "CNAME"
 }`
 
 const testAccCheckDigitalOceanRecordConfig_external_cname = `
 resource "digitalocean_domain" "foobar" {
-    name = "foobar-test-terraform.com"
-    ip_address = "192.168.0.10"
+  name       = "%s"
+  ip_address = "192.168.0.10"
 }
 
 resource "digitalocean_record" "foobar" {
-    domain = "${digitalocean_domain.foobar.name}"
+  domain = "${digitalocean_domain.foobar.name}"
 
-    name = "terraform"
-    value = "a.foobar-test-terraform.net."
-    type = "CNAME"
+  name  = "terraform"
+  value = "a.foobar-test-terraform.net."
+  type  = "CNAME"
 }`

--- a/helper/acctest/acctest.go
+++ b/helper/acctest/acctest.go
@@ -1,0 +1,2 @@
+// Package acctest contains for Terraform Acceptance Tests
+package acctest

--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -1,0 +1,35 @@
+package acctest
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Helpers for generating random tidbits for use in identifiers to prevent
+// collisions in acceptance tests.
+
+// RandString generates a random alphanumeric string of the length specified
+func RandString(strlen int) string {
+	return RandStringFromCharSet(strlen, CharSetAlphaNum)
+}
+
+// RandStringFromCharSet generates a random string by selecting characters from
+// the charset provided
+func RandStringFromCharSet(strlen int, charSet string) string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = charSet[rand.Intn(len(charSet))]
+	}
+	return string(result)
+}
+
+const (
+	// CharSetAlphaNum is the alphanumeric character set for use with
+	// RandStringFromCharSet
+	CharSetAlphaNum = "abcdefghijklmnopqrstuvwxyz012346789"
+
+	// CharSetAlpha is the alphabetical character set for use with
+	// RandStringFromCharSet
+	CharSetAlpha = "abcdefghijklmnopqrstuvwxyz"
+)


### PR DESCRIPTION
 * Add SSH Keys to all droplets in tests, this prevents acctests from
   spamming account owner email with root password details
 * Add a new helper/acctest package to be a home for random string / int
   implementations used in tests.
 * Insert some random details into record tests to prevent collisions