### PR TITLE
Add iam_server_certificate nuances to docs.

### DIFF
--- a/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
@@ -91,6 +91,8 @@ The following arguments are supported:
     AWS CloudFront, the path must be in format `/cloudfront/your_path_here`.
     See [IAM Identifiers][1] for more details on IAM Paths.
 
+~> **NOTE:** AWS performs behind-the-scenes modifications to some certificate files if they do not adhere to a specific format. These modifications will result in terraform forever believing that it needs to update the resources since the local and AWS file contents will not match after theses modifications occur. In order to prevent this from happening you must ensure that all your PEM-encoded files use UNIX line-breaks and that `certificate_body` contains only one certificate. All other certificates should go in `certificate_chain`. It is common for some Certificate Authorities to issue certificate files that have DOS line-breaks and that are actually multiple certificates concatenated together in order to form a full certificate chain.
+
 ## Attributes Reference
 
 * `id` - The unique Server Certificate name


### PR DESCRIPTION
AWS does some funky stuff to handle all the variations in certificates that CA's like to hand out to users. This commit adds a note about this and details how to avoid issues. See #3837 for more information.