### PR TITLE
Add Solaris builds of Terraform

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd}
+XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
 
 
 # Get dependencies unless running in quick mode


### PR DESCRIPTION
This PR adds support for Solaris builds as part of the release process following the work in #4470.

```
$ XC_OS=solaris make bin
==> Checking that code complies with gofmt requirements...
go generate ./...
==> Getting dependencies...
==> Removing old directory...
==> Building...
Number of parallel builds: 3

-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-atlas
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-dyn
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-azure
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provisioner-remote-exec
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-google
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-heroku
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-mailgun
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-mysql
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-null
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-openstack
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-packet
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-postgresql
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-rundeck
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-statuscake
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-template
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-terraform
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-tls
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-vcd
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-vsphere
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provisioner-chef
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provisioner-file
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provisioner-local-exec
-->   solaris/amd64: github.com/hashicorp/terraform
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-consul
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-azurerm
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-chef
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-cloudflare
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-cloudstack
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-dme
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-digitalocean
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-dnsimple
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-docker
-->   solaris/amd64: github.com/hashicorp/terraform/builtin/bins/provider-aws
find: `./pkg/darwin_amd64': No such file or directory
==> Packaging...
--> solaris_amd64
  adding: terraform (deflated 77%)
  adding: terraform-provider-atlas (deflated 73%)
  adding: terraform-provider-aws (deflated 80%)
  adding: terraform-provider-azure (deflated 73%)
  adding: terraform-provider-azurerm (deflated 76%)
  adding: terraform-provider-chef (deflated 73%)
  adding: terraform-provider-cloudflare (deflated 73%)
  adding: terraform-provider-cloudstack (deflated 77%)
  adding: terraform-provider-consul (deflated 73%)
  adding: terraform-provider-digitalocean (deflated 73%)
  adding: terraform-provider-dme (deflated 73%)
  adding: terraform-provider-dnsimple (deflated 73%)
  adding: terraform-provider-docker (deflated 73%)
  adding: terraform-provider-dyn (deflated 73%)
  adding: terraform-provider-google (deflated 76%)
  adding: terraform-provider-heroku (deflated 73%)
  adding: terraform-provider-mailgun (deflated 73%)
  adding: terraform-provider-mysql (deflated 73%)
  adding: terraform-provider-null (deflated 73%)
  adding: terraform-provider-openstack (deflated 74%)
  adding: terraform-provider-packet (deflated 73%)
  adding: terraform-provider-postgresql (deflated 72%)
  adding: terraform-provider-rundeck (deflated 73%)
  adding: terraform-provider-statuscake (deflated 73%)
  adding: terraform-provider-template (deflated 73%)
  adding: terraform-provider-terraform (deflated 77%)
  adding: terraform-provider-tls (deflated 73%)
  adding: terraform-provider-vcd (deflated 73%)
  adding: terraform-provider-vsphere (deflated 81%)
  adding: terraform-provisioner-chef (deflated 73%)
  adding: terraform-provisioner-file (deflated 73%)
  adding: terraform-provisioner-local-exec (deflated 73%)
  adding: terraform-provisioner-remote-exec (deflated 73%)

==> Results:
```