### PR TITLE
provider/google: enchance storage acctests to avoid collisions

### DIFF
--- a/builtin/providers/google/resource_storage_bucket_acl_test.go
+++ b/builtin/providers/google/resource_storage_bucket_acl_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -18,19 +19,22 @@ var roleEntityBasic3_owner = "OWNER:user-yetanotheremail@gmail.com"
 
 var roleEntityBasic3_reader = "READER:user-yetanotheremail@gmail.com"
 
-var testAclBucketName = fmt.Sprintf("%s-%d", "tf-test-acl-bucket", genRandInt())
+func testAclBucketName() string {
+	return fmt.Sprintf("%s-%d", "tf-test-acl-bucket", acctest.RandInt())
+}
 
 func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
+	bucketName := testAclBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclBasic1,
+				Config: testGoogleStorageBucketsAclBasic1(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic1),
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic2),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic1),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic2),
 				),
 			},
 		},
@@ -38,33 +42,34 @@ func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
+	bucketName := testAclBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclBasic1,
+				Config: testGoogleStorageBucketsAclBasic1(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic1),
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic2),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic1),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic2),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclBasic2,
+				Config: testGoogleStorageBucketsAclBasic2(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic2),
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic3_owner),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic2),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic3_owner),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclBasicDelete,
+				Config: testGoogleStorageBucketsAclBasicDelete(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageBucketAclDelete(testAclBucketName, roleEntityBasic1),
-					testAccCheckGoogleStorageBucketAclDelete(testAclBucketName, roleEntityBasic2),
-					testAccCheckGoogleStorageBucketAclDelete(testAclBucketName, roleEntityBasic3_owner),
+					testAccCheckGoogleStorageBucketAclDelete(bucketName, roleEntityBasic1),
+					testAccCheckGoogleStorageBucketAclDelete(bucketName, roleEntityBasic2),
+					testAccCheckGoogleStorageBucketAclDelete(bucketName, roleEntityBasic3_owner),
 				),
 			},
 		},
@@ -72,33 +77,34 @@ func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
+	bucketName := testAclBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclBasic2,
+				Config: testGoogleStorageBucketsAclBasic2(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic2),
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic3_owner),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic2),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic3_owner),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclBasic3,
+				Config: testGoogleStorageBucketsAclBasic3(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic2),
-					testAccCheckGoogleStorageBucketAcl(testAclBucketName, roleEntityBasic3_reader),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic2),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic3_reader),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclBasicDelete,
+				Config: testGoogleStorageBucketsAclBasicDelete(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageBucketAclDelete(testAclBucketName, roleEntityBasic1),
-					testAccCheckGoogleStorageBucketAclDelete(testAclBucketName, roleEntityBasic2),
-					testAccCheckGoogleStorageBucketAclDelete(testAclBucketName, roleEntityBasic3_owner),
+					testAccCheckGoogleStorageBucketAclDelete(bucketName, roleEntityBasic1),
+					testAccCheckGoogleStorageBucketAclDelete(bucketName, roleEntityBasic2),
+					testAccCheckGoogleStorageBucketAclDelete(bucketName, roleEntityBasic3_owner),
 				),
 			},
 		},
@@ -112,7 +118,7 @@ func TestAccGoogleStorageBucketAcl_predefined(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsAclPredefined,
+				Config: testGoogleStorageBucketsAclPredefined(bucketName),
 			},
 		},
 	})
@@ -172,7 +178,8 @@ func testAccGoogleStorageBucketAclDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testGoogleStorageBucketsAclBasic1 = fmt.Sprintf(`
+func testGoogleStorageBucketsAclBasic1(bucketName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -181,9 +188,11 @@ resource "google_storage_bucket_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = ["%s", "%s"]
 }
-`, testAclBucketName, roleEntityBasic1, roleEntityBasic2)
+`, bucketName, roleEntityBasic1, roleEntityBasic2)
+}
 
-var testGoogleStorageBucketsAclBasic2 = fmt.Sprintf(`
+func testGoogleStorageBucketsAclBasic2(bucketName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -192,9 +201,11 @@ resource "google_storage_bucket_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = ["%s", "%s"]
 }
-`, testAclBucketName, roleEntityBasic2, roleEntityBasic3_owner)
+`, bucketName, roleEntityBasic2, roleEntityBasic3_owner)
+}
 
-var testGoogleStorageBucketsAclBasicDelete = fmt.Sprintf(`
+func testGoogleStorageBucketsAclBasicDelete(bucketName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -203,9 +214,11 @@ resource "google_storage_bucket_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = []
 }
-`, testAclBucketName)
+`, bucketName)
+}
 
-var testGoogleStorageBucketsAclBasic3 = fmt.Sprintf(`
+func testGoogleStorageBucketsAclBasic3(bucketName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -214,9 +227,11 @@ resource "google_storage_bucket_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = ["%s", "%s"]
 }
-`, testAclBucketName, roleEntityBasic2, roleEntityBasic3_reader)
+`, bucketName, roleEntityBasic2, roleEntityBasic3_reader)
+}
 
-var testGoogleStorageBucketsAclPredefined = fmt.Sprintf(`
+func testGoogleStorageBucketsAclPredefined(bucketName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -226,4 +241,5 @@ resource "google_storage_bucket_acl" "acl" {
 	predefined_acl = "projectPrivate"
 	default_acl = "projectPrivate"
 }
-`, testAclBucketName)
+`, bucketName)
+}

--- a/builtin/providers/google/resource_storage_object_acl_test.go
+++ b/builtin/providers/google/resource_storage_object_acl_test.go
@@ -14,10 +14,15 @@ import (
 )
 
 var tfObjectAcl, errObjectAcl = ioutil.TempFile("", "tf-gce-test")
-var testAclObjectName = fmt.Sprintf("%s-%d", "tf-test-acl-object",
-	rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+
+func testAclObjectName() string {
+	return fmt.Sprintf("%s-%d", "tf-test-acl-object",
+		rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+}
 
 func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
+	bucketName := testAclBucketName()
+	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
 	resource.Test(t, resource.TestCase{
@@ -31,12 +36,12 @@ func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclBasic1,
+				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic1),
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic2),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic1),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic2),
 				),
 			},
 		},
@@ -44,6 +49,8 @@ func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
+	bucketName := testAclBucketName()
+	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
 	resource.Test(t, resource.TestCase{
@@ -57,34 +64,34 @@ func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclBasic1,
+				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic1),
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic2),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic1),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic2),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclBasic2,
+				Config: testGoogleStorageObjectsAclBasic2(bucketName, objectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic2),
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic3_owner),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic2),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic3_owner),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclBasicDelete,
+				Config: testGoogleStorageObjectsAclBasicDelete(bucketName, objectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageObjectAclDelete(testAclBucketName,
-						testAclObjectName, roleEntityBasic1),
-					testAccCheckGoogleStorageObjectAclDelete(testAclBucketName,
-						testAclObjectName, roleEntityBasic2),
-					testAccCheckGoogleStorageObjectAclDelete(testAclBucketName,
-						testAclObjectName, roleEntityBasic3_reader),
+					testAccCheckGoogleStorageObjectAclDelete(bucketName,
+						objectName, roleEntityBasic1),
+					testAccCheckGoogleStorageObjectAclDelete(bucketName,
+						objectName, roleEntityBasic2),
+					testAccCheckGoogleStorageObjectAclDelete(bucketName,
+						objectName, roleEntityBasic3_reader),
 				),
 			},
 		},
@@ -92,6 +99,8 @@ func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
+	bucketName := testAclBucketName()
+	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
 	resource.Test(t, resource.TestCase{
@@ -105,34 +114,34 @@ func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclBasic2,
+				Config: testGoogleStorageObjectsAclBasic2(bucketName, objectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic2),
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic3_owner),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic2),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic3_owner),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclBasic3,
+				Config: testGoogleStorageObjectsAclBasic3(bucketName, objectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic2),
-					testAccCheckGoogleStorageObjectAcl(testAclBucketName,
-						testAclObjectName, roleEntityBasic3_reader),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic2),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic3_reader),
 				),
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclBasicDelete,
+				Config: testGoogleStorageObjectsAclBasicDelete(bucketName, objectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageObjectAclDelete(testAclBucketName,
-						testAclObjectName, roleEntityBasic1),
-					testAccCheckGoogleStorageObjectAclDelete(testAclBucketName,
-						testAclObjectName, roleEntityBasic2),
-					testAccCheckGoogleStorageObjectAclDelete(testAclBucketName,
-						testAclObjectName, roleEntityBasic3_reader),
+					testAccCheckGoogleStorageObjectAclDelete(bucketName,
+						objectName, roleEntityBasic1),
+					testAccCheckGoogleStorageObjectAclDelete(bucketName,
+						objectName, roleEntityBasic2),
+					testAccCheckGoogleStorageObjectAclDelete(bucketName,
+						objectName, roleEntityBasic3_reader),
 				),
 			},
 		},
@@ -140,6 +149,8 @@ func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_predefined(t *testing.T) {
+	bucketName := testAclBucketName()
+	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
 	resource.Test(t, resource.TestCase{
@@ -153,7 +164,7 @@ func TestAccGoogleStorageObjectAcl_predefined(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageObjectsAclPredefined,
+				Config: testGoogleStorageObjectsAclPredefined(bucketName, objectName),
 			},
 		},
 	})
@@ -216,7 +227,8 @@ func testAccGoogleStorageObjectAclDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testGoogleStorageObjectsAclBasicDelete = fmt.Sprintf(`
+func testGoogleStorageObjectsAclBasicDelete(bucketName string, objectName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -232,9 +244,11 @@ resource "google_storage_object_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = []
 }
-`, testAclBucketName, testAclObjectName, tfObjectAcl.Name())
+`, bucketName, objectName, tfObjectAcl.Name())
+}
 
-var testGoogleStorageObjectsAclBasic1 = fmt.Sprintf(`
+func testGoogleStorageObjectsAclBasic1(bucketName string, objectName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -250,10 +264,12 @@ resource "google_storage_object_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = ["%s", "%s"]
 }
-`, testAclBucketName, testAclObjectName, tfObjectAcl.Name(),
-	roleEntityBasic1, roleEntityBasic2)
+`, bucketName, objectName, tfObjectAcl.Name(),
+		roleEntityBasic1, roleEntityBasic2)
+}
 
-var testGoogleStorageObjectsAclBasic2 = fmt.Sprintf(`
+func testGoogleStorageObjectsAclBasic2(bucketName string, objectName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -269,10 +285,12 @@ resource "google_storage_object_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = ["%s", "%s"]
 }
-`, testAclBucketName, testAclObjectName, tfObjectAcl.Name(),
-	roleEntityBasic2, roleEntityBasic3_owner)
+`, bucketName, objectName, tfObjectAcl.Name(),
+		roleEntityBasic2, roleEntityBasic3_owner)
+}
 
-var testGoogleStorageObjectsAclBasic3 = fmt.Sprintf(`
+func testGoogleStorageObjectsAclBasic3(bucketName string, objectName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -288,10 +306,12 @@ resource "google_storage_object_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = ["%s", "%s"]
 }
-`, testAclBucketName, testAclObjectName, tfObjectAcl.Name(),
-	roleEntityBasic2, roleEntityBasic3_reader)
+`, bucketName, objectName, tfObjectAcl.Name(),
+		roleEntityBasic2, roleEntityBasic3_reader)
+}
 
-var testGoogleStorageObjectsAclPredefined = fmt.Sprintf(`
+func testGoogleStorageObjectsAclPredefined(bucketName string, objectName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -307,4 +327,5 @@ resource "google_storage_object_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	predefined_acl = "projectPrivate"
 }
-`, testAclBucketName, testAclObjectName, tfObjectAcl.Name())
+`, bucketName, objectName, tfObjectAcl.Name())
+}

--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -8,6 +8,12 @@ import (
 // Helpers for generating random tidbits for use in identifiers to prevent
 // collisions in acceptance tests.
 
+// RandInt generates a random integer
+func RandInt() int {
+	reseed()
+	return rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+}
+
 // RandString generates a random alphanumeric string of the length specified
 func RandString(strlen int) string {
 	return RandStringFromCharSet(strlen, CharSetAlphaNum)
@@ -16,12 +22,17 @@ func RandString(strlen int) string {
 // RandStringFromCharSet generates a random string by selecting characters from
 // the charset provided
 func RandStringFromCharSet(strlen int, charSet string) string {
-	rand.Seed(time.Now().UTC().UnixNano())
+	reseed()
 	result := make([]byte, strlen)
 	for i := 0; i < strlen; i++ {
 		result[i] = charSet[rand.Intn(len(charSet))]
 	}
 	return string(result)
+}
+
+// Seeds random with current timestamp
+func reseed() {
+	rand.Seed(time.Now().UTC().UnixNano())
 }
 
 const (


### PR DESCRIPTION
Generate bucket names and object names per test instead of once at the
top level. Should help avoid failures like this one:

https://travis-ci.org/hashicorp/terraform/jobs/100254008

All storage tests checked on this commit:

```
TF_ACC=1 go test -v ./builtin/providers/google -run TestAccGoogleStorage
=== RUN   TestAccGoogleStorageBucketAcl_basic
--- PASS: TestAccGoogleStorageBucketAcl_basic (8.90s)
=== RUN   TestAccGoogleStorageBucketAcl_upgrade
--- PASS: TestAccGoogleStorageBucketAcl_upgrade (14.18s)
=== RUN   TestAccGoogleStorageBucketAcl_downgrade
--- PASS: TestAccGoogleStorageBucketAcl_downgrade (12.83s)
=== RUN   TestAccGoogleStorageBucketAcl_predefined
--- PASS: TestAccGoogleStorageBucketAcl_predefined (4.51s)
=== RUN   TestAccGoogleStorageObject_basic
--- PASS: TestAccGoogleStorageObject_basic (3.77s)
=== RUN   TestAccGoogleStorageObjectAcl_basic
--- PASS: TestAccGoogleStorageObjectAcl_basic (4.85s)
=== RUN   TestAccGoogleStorageObjectAcl_upgrade
--- PASS: TestAccGoogleStorageObjectAcl_upgrade (7.68s)
=== RUN   TestAccGoogleStorageObjectAcl_downgrade
--- PASS: TestAccGoogleStorageObjectAcl_downgrade (7.37s)
=== RUN   TestAccGoogleStorageObjectAcl_predefined
--- PASS: TestAccGoogleStorageObjectAcl_predefined (4.16s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/google 68.275s
```