### PR TITLE
provider/google: Fix project metadata sshkeys from showing up

### DIFF
--- a/builtin/providers/google/metadata.go
+++ b/builtin/providers/google/metadata.go
@@ -60,11 +60,13 @@ func MetadataUpdate(oldMDMap map[string]interface{}, newMDMap map[string]interfa
 }
 
 // Format metadata from the server data format -> schema data format
-func MetadataFormatSchema(md *compute.Metadata) map[string]interface{} {
+func MetadataFormatSchema(curMDMap map[string]interface{}, md *compute.Metadata) map[string]interface{} {
 	newMD := make(map[string]interface{})
 
 	for _, kv := range md.Items {
-		newMD[kv.Key] = *kv.Value
+		if _, ok := curMDMap[kv.Key]; ok {
+			newMD[kv.Key] = *kv.Value
+		}
 	}
 
 	return newMD

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -562,7 +562,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	// Synch metadata
 	md := instance.Metadata
 
-	_md := MetadataFormatSchema(md)
+	_md := MetadataFormatSchema(d.Get("metadata").(map[string]interface{}), md)
 	delete(_md, "startup-script")
 
 	if script, scriptExists := d.GetOk("metadata_startup_script"); scriptExists {

--- a/builtin/providers/google/resource_compute_project_metadata.go
+++ b/builtin/providers/google/resource_compute_project_metadata.go
@@ -90,7 +90,7 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 
 	md := project.CommonInstanceMetadata
 
-	if err = d.Set("metadata", MetadataFormatSchema(md)); err != nil {
+	if err = d.Set("metadata", MetadataFormatSchema(d.Get("metadata").(map[string]interface{}), md)); err != nil {
 		return fmt.Errorf("Error setting metadata: %s", err)
 	}
 

--- a/builtin/providers/google/resource_compute_project_metadata_test.go
+++ b/builtin/providers/google/resource_compute_project_metadata_test.go
@@ -13,8 +13,6 @@ import (
 func TestAccComputeProjectMetadata_basic(t *testing.T) {
 	var project compute.Project
 
-	t.Skip("See https://github.com/hashicorp/terraform/issues/4504")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -37,8 +35,6 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 // Add three key value pairs, then replace one and modify a second
 func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 	var project compute.Project
-
-	t.Skip("See https://github.com/hashicorp/terraform/issues/4504")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -75,8 +71,6 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 // Add two key value pairs, and replace both
 func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
 	var project compute.Project
-
-	t.Skip("See https://github.com/hashicorp/terraform/issues/4504")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
Addressing #4504

The fix I made is to ignore any project metadata pairs that do not show up in the users config. `sshKeys`, `gke-cluster-<id>-cidr`, and `stackdriver-key` are a few examples of keys that are generated by GCP depending on a users existing infrastructure that would be overwritten by Terraform if not ignored during `Read`. 

@phinze 