### PR TITLE
provider/google: remove conflicting names from acceptance tests

### DIFF
--- a/builtin/providers/google/resource_compute_address_test.go
+++ b/builtin/providers/google/resource_compute_address_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -75,7 +76,7 @@ func testAccCheckComputeAddressExists(n string, addr *compute.Address) resource.
 	}
 }
 
-const testAccComputeAddress_basic = `
+var testAccComputeAddress_basic = fmt.Sprintf(`
 resource "google_compute_address" "foobar" {
-	name = "terraform-test"
-}`
+	name = "address-test-%s"
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_autoscaler_test.go
+++ b/builtin/providers/google/resource_compute_autoscaler_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -130,9 +131,9 @@ func testAccCheckAutoscalerUpdated(n string, max int64) resource.TestCheckFunc {
 	}
 }
 
-const testAccAutoscaler_basic = `
+var testAccAutoscaler_basic = fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
-	name = "terraform-test-template-foobar"
+	name = "ascaler-test-%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
@@ -158,13 +159,13 @@ resource "google_compute_instance_template" "foobar" {
 
 resource "google_compute_target_pool" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test-tpool-foobar"
+	name = "ascaler-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
 	description = "Terraform test instance group manager"
-	name = "terraform-test-groupmanager"
+	name = "ascaler-test-%s"
 	instance_template = "${google_compute_instance_template.foobar.self_link}"
 	target_pools = ["${google_compute_target_pool.foobar.self_link}"]
 	base_instance_name = "foobar"
@@ -173,7 +174,7 @@ resource "google_compute_instance_group_manager" "foobar" {
 
 resource "google_compute_autoscaler" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test-ascaler"
+	name = "ascaler-test-%s"
 	zone = "us-central1-a"
 	target = "${google_compute_instance_group_manager.foobar.self_link}"
 	autoscaling_policy = {
@@ -185,11 +186,11 @@ resource "google_compute_autoscaler" "foobar" {
 		}
 	}
 
-}`
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccAutoscaler_update = `
+var testAccAutoscaler_update = fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
-	name = "terraform-test-template-foobar"
+	name = "ascaler-test-%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
@@ -215,13 +216,13 @@ resource "google_compute_instance_template" "foobar" {
 
 resource "google_compute_target_pool" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test-tpool-foobar"
+	name = "ascaler-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
 	description = "Terraform test instance group manager"
-	name = "terraform-test-groupmanager"
+	name = "ascaler-test-%s"
 	instance_template = "${google_compute_instance_template.foobar.self_link}"
 	target_pools = ["${google_compute_target_pool.foobar.self_link}"]
 	base_instance_name = "foobar"
@@ -230,7 +231,7 @@ resource "google_compute_instance_group_manager" "foobar" {
 
 resource "google_compute_autoscaler" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test-ascaler"
+	name = "ascaler-test-%s"
 	zone = "us-central1-a"
 	target = "${google_compute_instance_group_manager.foobar.self_link}"
 	autoscaling_policy = {
@@ -242,4 +243,4 @@ resource "google_compute_autoscaler" "foobar" {
 		}
 	}
 
-}`
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_firewall_test.go
+++ b/builtin/providers/google/resource_compute_firewall_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -118,14 +119,14 @@ func testAccCheckComputeFirewallPorts(
 	}
 }
 
-const testAccComputeFirewall_basic = `
+var testAccComputeFirewall_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-	name = "terraform-test"
+	name = "firewall-test-%s"
 	ipv4_range = "10.0.0.0/16"
 }
 
 resource "google_compute_firewall" "foobar" {
-	name = "terraform-test"
+	name = "firewall-test-%s"
 	description = "Resource created for Terraform acceptance testing"
 	network = "${google_compute_network.foobar.name}"
 	source_tags = ["foo"]
@@ -133,16 +134,16 @@ resource "google_compute_firewall" "foobar" {
 	allow {
 		protocol = "icmp"
 	}
-}`
+}`, acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeFirewall_update = `
+var testAccComputeFirewall_update = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-	name = "terraform-test"
+	name = "firewall-test-%s"
 	ipv4_range = "10.0.0.0/16"
 }
 
 resource "google_compute_firewall" "foobar" {
-	name = "terraform-test"
+	name = "firewall-test-%s"
 	description = "Resource created for Terraform acceptance testing"
 	network = "${google_compute_network.foobar.name}"
 	source_tags = ["foo"]
@@ -151,4 +152,4 @@ resource "google_compute_firewall" "foobar" {
 		protocol = "tcp"
 		ports = ["80-255"]
 	}
-}`
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_global_address_test.go
+++ b/builtin/providers/google/resource_compute_global_address_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -75,7 +76,7 @@ func testAccCheckComputeGlobalAddressExists(n string, addr *compute.Address) res
 	}
 }
 
-const testAccComputeGlobalAddress_basic = `
+var testAccComputeGlobalAddress_basic = fmt.Sprintf(`
 resource "google_compute_global_address" "foobar" {
-	name = "terraform-test"
-}`
+	name = "address-test-%s"
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_global_forwarding_rule_test.go
+++ b/builtin/providers/google/resource_compute_global_forwarding_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -95,41 +96,41 @@ func testAccCheckComputeGlobalForwardingRuleExists(n string) resource.TestCheckF
 	}
 }
 
-const testAccComputeGlobalForwardingRule_basic1 = `
+var testAccComputeGlobalForwardingRule_basic1 = fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	ip_protocol = "TCP"
-	name = "terraform-test"
+	name = "gforward-test-%s"
 	port_range = "80"
 	target = "${google_compute_target_http_proxy.foobar1.self_link}"
 }
 
 resource "google_compute_target_http_proxy" "foobar1" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test1"
+	name = "gforward-test-%s"
 	url_map = "${google_compute_url_map.foobar.self_link}"
 }
 
 resource "google_compute_target_http_proxy" "foobar2" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test2"
+	name = "gforward-test-%s"
 	url_map = "${google_compute_url_map.foobar.self_link}"
 }
 
 resource "google_compute_backend_service" "foobar" {
-	name = "service"
+	name = "gforward-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-	name = "tf-test-zero"
+	name = "gforward-test-%s"
 	request_path = "/"
 	check_interval_sec = 1
 	timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+	name = "gforward-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -149,43 +150,44 @@ resource "google_compute_url_map" "foobar" {
 		service = "${google_compute_backend_service.foobar.self_link}"
 	}
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeGlobalForwardingRule_basic2 = `
+var testAccComputeGlobalForwardingRule_basic2 = fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	ip_protocol = "TCP"
-	name = "terraform-test"
+	name = "gforward-test-%s"
 	port_range = "80"
 	target = "${google_compute_target_http_proxy.foobar2.self_link}"
 }
 
 resource "google_compute_target_http_proxy" "foobar1" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test1"
+	name = "gforward-test-%s"
 	url_map = "${google_compute_url_map.foobar.self_link}"
 }
 
 resource "google_compute_target_http_proxy" "foobar2" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test2"
+	name = "gforward-test-%s"
 	url_map = "${google_compute_url_map.foobar.self_link}"
 }
 
 resource "google_compute_backend_service" "foobar" {
-	name = "service"
+	name = "gforward-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-	name = "tf-test-zero"
+	name = "gforward-test-%s"
 	request_path = "/"
 	check_interval_sec = 1
 	timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+	name = "gforward-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -205,4 +207,5 @@ resource "google_compute_url_map" "foobar" {
 		service = "${google_compute_backend_service.foobar.self_link}"
 	}
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_http_health_check_test.go
+++ b/builtin/providers/google/resource_compute_http_health_check_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -137,35 +138,35 @@ func testAccCheckComputeHttpHealthCheckThresholds(healthy, unhealthy int64, heal
 	}
 }
 
-const testAccComputeHttpHealthCheck_basic = `
+var testAccComputeHttpHealthCheck_basic = fmt.Sprintf(`
 resource "google_compute_http_health_check" "foobar" {
 	check_interval_sec = 3
 	description = "Resource created for Terraform acceptance testing"
 	healthy_threshold = 3
 	host = "foobar"
-	name = "terraform-test"
+	name = "httphealth-test-%s"
 	port = "80"
 	request_path = "/health_check"
 	timeout_sec = 2
 	unhealthy_threshold = 3
 }
-`
+`, acctest.RandString(10))
 
-const testAccComputeHttpHealthCheck_update1 = `
+var testAccComputeHttpHealthCheck_update1 = fmt.Sprintf(`
 resource "google_compute_http_health_check" "foobar" {
-	name = "terraform-test"
+	name = "httphealth-test-%s"
 	description = "Resource created for Terraform acceptance testing"
 	request_path = "/not_default"
 }
-`
+`, acctest.RandString(10))
 
 /* Change description, restore request_path to default, and change
 * thresholds from defaults */
-const testAccComputeHttpHealthCheck_update2 = `
+var testAccComputeHttpHealthCheck_update2 = fmt.Sprintf(`
 resource "google_compute_http_health_check" "foobar" {
-	name = "terraform-test"
+	name = "httphealth-test-%s"
 	description = "Resource updated for Terraform acceptance testing"
 	healthy_threshold = 10
 	unhealthy_threshold = 10
 }
-`
+`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_https_health_check_test.go
+++ b/builtin/providers/google/resource_compute_https_health_check_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -137,35 +138,35 @@ func testAccCheckComputeHttpsHealthCheckThresholds(healthy, unhealthy int64, hea
 	}
 }
 
-const testAccComputeHttpsHealthCheck_basic = `
+var testAccComputeHttpsHealthCheck_basic = fmt.Sprintf(`
 resource "google_compute_https_health_check" "foobar" {
 	check_interval_sec = 3
 	description = "Resource created for Terraform acceptance testing"
 	healthy_threshold = 3
 	host = "foobar"
-	name = "terraform-test"
+	name = "httpshealth-test-%s"
 	port = "80"
 	request_path = "/health_check"
 	timeout_sec = 2
 	unhealthy_threshold = 3
 }
-`
+`, acctest.RandString(10))
 
-const testAccComputeHttpsHealthCheck_update1 = `
+var testAccComputeHttpsHealthCheck_update1 = fmt.Sprintf(`
 resource "google_compute_https_health_check" "foobar" {
-	name = "terraform-test"
+	name = "httpshealth-test-%s"
 	description = "Resource created for Terraform acceptance testing"
 	request_path = "/not_default"
 }
-`
+`, acctest.RandString(10))
 
 /* Change description, restore request_path to default, and change
 * thresholds from defaults */
-const testAccComputeHttpsHealthCheck_update2 = `
+var testAccComputeHttpsHealthCheck_update2 = fmt.Sprintf(`
 resource "google_compute_https_health_check" "foobar" {
-	name = "terraform-test"
+	name = "httpshealth-test-%s"
 	description = "Resource updated for Terraform acceptance testing"
 	healthy_threshold = 10
 	unhealthy_threshold = 10
 }
-`
+`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -6,6 +6,7 @@ import (
 
 	"google.golang.org/api/compute/v1"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -146,9 +147,9 @@ func testAccCheckInstanceGroupManagerUpdated(n string, size int64, targetPool st
 	}
 }
 
-const testAccInstanceGroupManager_basic = `
+var testAccInstanceGroupManager_basic = fmt.Sprintf(`
 resource "google_compute_instance_template" "igm-basic" {
-	name = "terraform-test-igm-basic"
+	name = "igm-test-%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
@@ -174,13 +175,13 @@ resource "google_compute_instance_template" "igm-basic" {
 
 resource "google_compute_target_pool" "igm-basic" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test-igm-basic"
+	name = "igm-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
 }
 
 resource "google_compute_instance_group_manager" "igm-basic" {
 	description = "Terraform test instance group manager"
-	name = "terraform-test-igm-basic"
+	name = "igm-test-%s"
 	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
 	target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 	base_instance_name = "igm-basic"
@@ -190,17 +191,17 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 
 resource "google_compute_instance_group_manager" "igm-no-tp" {
 	description = "Terraform test instance group manager"
-	name = "terraform-test-igm-no-tp"
+	name = "igm-test-%s"
 	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
 	base_instance_name = "igm-no-tp"
 	zone = "us-central1-c"
 	target_size = 2
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccInstanceGroupManager_update = `
+var testAccInstanceGroupManager_update = fmt.Sprintf(`
 resource "google_compute_instance_template" "igm-update" {
-	name = "terraform-test-igm-update"
+	name = "igm-test-%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
@@ -226,24 +227,24 @@ resource "google_compute_instance_template" "igm-update" {
 
 resource "google_compute_target_pool" "igm-update" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test-igm-update"
+	name = "igm-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
 }
 
 resource "google_compute_instance_group_manager" "igm-update" {
 	description = "Terraform test instance group manager"
-	name = "terraform-test-igm-update"
+	name = "igm-test-%s"
 	instance_template = "${google_compute_instance_template.igm-update.self_link}"
 	target_pools = ["${google_compute_target_pool.igm-update.self_link}"]
 	base_instance_name = "igm-update"
 	zone = "us-central1-c"
 	target_size = 2
-}`
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
 // Change IGM's instance template and target size
-const testAccInstanceGroupManager_update2 = `
+var testAccInstanceGroupManager_update2 = fmt.Sprintf(`
 resource "google_compute_instance_template" "igm-update" {
-	name = "terraform-test-igm-update"
+	name = "igm-test-%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
@@ -269,12 +270,12 @@ resource "google_compute_instance_template" "igm-update" {
 
 resource "google_compute_target_pool" "igm-update" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test-igm-update"
+	name = "igm-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
 }
 
 resource "google_compute_instance_template" "igm-update2" {
-	name = "terraform-test-igm-update2"
+	name = "igm-test-%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
@@ -300,10 +301,10 @@ resource "google_compute_instance_template" "igm-update2" {
 
 resource "google_compute_instance_group_manager" "igm-update" {
 	description = "Terraform test instance group manager"
-	name = "terraform-test-igm-update"
+	name = "igm-test-%s"
 	instance_template = "${google_compute_instance_template.igm-update2.self_link}"
 	target_pools = ["${google_compute_target_pool.igm-update.self_link}"]
 	base_instance_name = "igm-update"
 	zone = "us-central1-c"
 	target_size = 3
-}`
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -201,9 +202,9 @@ func testAccCheckComputeInstanceTemplateTag(instanceTemplate *compute.InstanceTe
 	}
 }
 
-const testAccComputeInstanceTemplate_basic = `
+var testAccComputeInstanceTemplate_basic = fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
-	name = "terraform-test"
+	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
@@ -230,15 +231,15 @@ resource "google_compute_instance_template" "foobar" {
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstanceTemplate_ip = `
+var testAccComputeInstanceTemplate_ip = fmt.Sprintf(`
 resource "google_compute_address" "foo" {
-	name = "foo"
+	name = "instancet-test-%s"
 }
 
 resource "google_compute_instance_template" "foobar" {
-	name = "terraform-test"
+	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
@@ -256,11 +257,11 @@ resource "google_compute_instance_template" "foobar" {
 	metadata {
 		foo = "bar"
 	}
-}`
+}`, acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeInstanceTemplate_disks = `
+var testAccComputeInstanceTemplate_disks = fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
-	name = "terraform-test-foobar"
+	name = "instancet-test-%s"
 	image = "debian-7-wheezy-v20140814"
 	size = 10
 	type = "pd-ssd"
@@ -268,7 +269,7 @@ resource "google_compute_disk" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-	name = "terraform-test"
+	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 
 	disk {
@@ -291,4 +292,4 @@ resource "google_compute_instance_template" "foobar" {
 	metadata {
 		foo = "bar"
 	}
-}`
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -436,9 +437,9 @@ func testAccCheckComputeInstanceServiceAccount(instance *compute.Instance, scope
 	}
 }
 
-const testAccComputeInstance_basic_deprecated_network = `
+var testAccComputeInstance_basic_deprecated_network = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	can_ip_forward = false
@@ -455,11 +456,11 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		foo = "bar"
 	}
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstance_update_deprecated_network = `
+var testAccComputeInstance_update_deprecated_network = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	tags = ["baz"]
@@ -475,11 +476,11 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		bar = "baz"
 	}
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstance_basic = `
+var testAccComputeInstance_basic = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	can_ip_forward = false
@@ -499,11 +500,11 @@ resource "google_compute_instance" "foobar" {
 	}
 
 	metadata_startup_script = "echo Hello"
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstance_basic2 = `
+var testAccComputeInstance_basic2 = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	can_ip_forward = false
@@ -521,11 +522,11 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		foo = "bar"
 	}
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstance_basic3 = `
+var testAccComputeInstance_basic3 = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	can_ip_forward = false
@@ -542,13 +543,13 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		foo = "bar"
 	}
-}`
+}`, acctest.RandString(10))
 
 // Update zone to ForceNew, and change metadata k/v entirely
 // Generates diff mismatch
-const testAccComputeInstance_forceNewAndChangeMetadata = `
+var testAccComputeInstance_forceNewAndChangeMetadata = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	zone = "us-central1-b"
@@ -566,12 +567,12 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		qux = "true"
 	}
-}`
+}`, acctest.RandString(10))
 
 // Update metadata, tags, and network_interface
-const testAccComputeInstance_update = `
+var testAccComputeInstance_update = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	tags = ["baz"]
@@ -588,15 +589,15 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		bar = "baz"
 	}
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstance_ip = `
+var testAccComputeInstance_ip = fmt.Sprintf(`
 resource "google_compute_address" "foo" {
-	name = "foo"
+	name = "instance-test-%s"
 }
 
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 	tags = ["foo", "bar"]
@@ -615,18 +616,18 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		foo = "bar"
 	}
-}`
+}`, acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeInstance_disks = `
+var testAccComputeInstance_disks = fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
-	name = "terraform-test-disk"
+	name = "instance-test-%s"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
 }
 
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 
@@ -646,11 +647,11 @@ resource "google_compute_instance" "foobar" {
 	metadata {
 		foo = "bar"
 	}
-}`
+}`, acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeInstance_local_ssd = `
+var testAccComputeInstance_local_ssd = fmt.Sprintf(`
 resource "google_compute_instance" "local-ssd" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 
@@ -667,11 +668,11 @@ resource "google_compute_instance" "local-ssd" {
 		network = "default"
 	}
 
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstance_service_account = `
+var testAccComputeInstance_service_account = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 
@@ -690,11 +691,11 @@ resource "google_compute_instance" "foobar" {
 			"storage-ro",
 		]
 	}
-}`
+}`, acctest.RandString(10))
 
-const testAccComputeInstance_scheduling = `
+var testAccComputeInstance_scheduling = fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
-	name = "terraform-test"
+	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 
@@ -708,4 +709,4 @@ resource "google_compute_instance" "foobar" {
 
 	scheduling {
 	}
-}`
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_network_test.go
+++ b/builtin/providers/google/resource_compute_network_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -75,8 +76,8 @@ func testAccCheckComputeNetworkExists(n string, network *compute.Network) resour
 	}
 }
 
-const testAccComputeNetwork_basic = `
+var testAccComputeNetwork_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-	name = "terraform-test"
+	name = "network-test-%s"
 	ipv4_range = "10.0.0.0/16"
-}`
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_route_test.go
+++ b/builtin/providers/google/resource_compute_route_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -75,16 +76,16 @@ func testAccCheckComputeRouteExists(n string, route *compute.Route) resource.Tes
 	}
 }
 
-const testAccComputeRoute_basic = `
+var testAccComputeRoute_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-	name = "terraform-test"
+	name = "route-test-%s"
 	ipv4_range = "10.0.0.0/16"
 }
 
 resource "google_compute_route" "foobar" {
-	name = "terraform-test"
+	name = "route-test-%s"
 	dest_range = "15.0.0.0/24"
 	network = "${google_compute_network.foobar.name}"
 	next_hop_ip = "10.0.1.5"
 	priority = 100
-}`
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_ssl_certificate_test.go
+++ b/builtin/providers/google/resource_compute_ssl_certificate_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -70,11 +71,11 @@ func testAccCheckComputeSslCertificateExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccComputeSslCertificate_basic = `
+var testAccComputeSslCertificate_basic = fmt.Sprintf(`
 resource "google_compute_ssl_certificate" "foobar" {
-	name = "terraform-test"
+	name = "sslcert-test-%s"
 	description = "very descriptive"
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
-`
+`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_target_http_proxy_test.go
+++ b/builtin/providers/google/resource_compute_target_http_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -97,27 +98,27 @@ func testAccCheckComputeTargetHttpProxyExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccComputeTargetHttpProxy_basic1 = `
+var testAccComputeTargetHttpProxy_basic1 = fmt.Sprintf(`
 resource "google_compute_target_http_proxy" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test"
+	name = "httpproxy-test-%s"
 	url_map = "${google_compute_url_map.foobar1.self_link}"
 }
 
 resource "google_compute_backend_service" "foobar" {
-	name = "service"
+	name = "httpproxy-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-	name = "tf-test-zero"
+	name = "httpproxy-test-%s"
 	request_path = "/"
 	check_interval_sec = 1
 	timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar1" {
-	name = "myurlmap1"
+	name = "httpproxy-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -139,7 +140,7 @@ resource "google_compute_url_map" "foobar1" {
 }
 
 resource "google_compute_url_map" "foobar2" {
-	name = "myurlmap2"
+	name = "httpproxy-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -159,29 +160,29 @@ resource "google_compute_url_map" "foobar2" {
 		service = "${google_compute_backend_service.foobar.self_link}"
 	}
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeTargetHttpProxy_basic2 = `
+var testAccComputeTargetHttpProxy_basic2 = fmt.Sprintf(`
 resource "google_compute_target_http_proxy" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test"
+	name = "httpproxy-test-%s"
 	url_map = "${google_compute_url_map.foobar2.self_link}"
 }
 
 resource "google_compute_backend_service" "foobar" {
-	name = "service"
+	name = "httpproxy-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-	name = "tf-test-zero"
+	name = "httpproxy-test-%s"
 	request_path = "/"
 	check_interval_sec = 1
 	timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar1" {
-	name = "myurlmap1"
+	name = "httpproxy-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -203,7 +204,7 @@ resource "google_compute_url_map" "foobar1" {
 }
 
 resource "google_compute_url_map" "foobar2" {
-	name = "myurlmap2"
+	name = "httpproxy-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -223,4 +224,4 @@ resource "google_compute_url_map" "foobar2" {
 		service = "${google_compute_backend_service.foobar.self_link}"
 	}
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_target_https_proxy_test.go
+++ b/builtin/providers/google/resource_compute_target_https_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -97,28 +98,28 @@ func testAccCheckComputeTargetHttpsProxyExists(n string) resource.TestCheckFunc 
 	}
 }
 
-const testAccComputeTargetHttpsProxy_basic1 = `
+var testAccComputeTargetHttpsProxy_basic1 = fmt.Sprintf(`
 resource "google_compute_target_https_proxy" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test"
+	name = "httpsproxy-test-%s"
 	url_map = "${google_compute_url_map.foobar.self_link}"
 	ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
 }
 
 resource "google_compute_backend_service" "foobar" {
-	name = "service"
+	name = "httpsproxy-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-	name = "tf-test-zero"
+	name = "httpsproxy-test-%s"
 	request_path = "/"
 	check_interval_sec = 1
 	timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+	name = "httpsproxy-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -140,42 +141,43 @@ resource "google_compute_url_map" "foobar" {
 }
 
 resource "google_compute_ssl_certificate" "foobar1" {
-	name = "terraform-test1"
+	name = "httpsproxy-test-%s"
 	description = "very descriptive"
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
 
 resource "google_compute_ssl_certificate" "foobar2" {
-	name = "terraform-test2"
+	name = "httpsproxy-test-%s"
 	description = "very descriptive"
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeTargetHttpsProxy_basic2 = `
+var testAccComputeTargetHttpsProxy_basic2 = fmt.Sprintf(`
 resource "google_compute_target_https_proxy" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	name = "terraform-test"
+	name = "httpsproxy-test-%s"
 	url_map = "${google_compute_url_map.foobar.self_link}"
 	ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
 }
 
 resource "google_compute_backend_service" "foobar" {
-	name = "service"
+	name = "httpsproxy-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-	name = "tf-test-zero"
+	name = "httpsproxy-test-%s"
 	request_path = "/"
 	check_interval_sec = 1
 	timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+	name = "httpsproxy-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 	host_rule {
 		hosts = ["mysite.com", "myothersite.com"]
@@ -197,16 +199,17 @@ resource "google_compute_url_map" "foobar" {
 }
 
 resource "google_compute_ssl_certificate" "foobar1" {
-	name = "terraform-test1"
+	name = "httpsproxy-test-%s"
 	description = "very descriptive"
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
 
 resource "google_compute_ssl_certificate" "foobar2" {
-	name = "terraform-test2"
+	name = "httpsproxy-test-%s"
 	description = "very descriptive"
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_target_pool_test.go
+++ b/builtin/providers/google/resource_compute_target_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -71,10 +72,10 @@ func testAccCheckComputeTargetPoolExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccComputeTargetPool_basic = `
+var testAccComputeTargetPool_basic = fmt.Sprintf(`
 resource "google_compute_target_pool" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	instances = ["us-central1-a/foo", "us-central1-b/bar"]
-	name = "terraform-test"
+	name = "tpool-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
-}`
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_url_map_test.go
+++ b/builtin/providers/google/resource_compute_url_map_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -119,21 +120,21 @@ func testAccCheckComputeUrlMapExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccComputeUrlMap_basic1 = `
+var testAccComputeUrlMap_basic1 = fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
-    name = "service"
+    name = "urlmap-test-%s"
     health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-    name = "tf-test-zero"
+    name = "urlmap-test-%s"
     request_path = "/"
     check_interval_sec = 1
     timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+    name = "urlmap-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 
     host_rule {
@@ -156,23 +157,23 @@ resource "google_compute_url_map" "foobar" {
 		service = "${google_compute_backend_service.foobar.self_link}"
 	}
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeUrlMap_basic2 = `
+var testAccComputeUrlMap_basic2 = fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
-    name = "service"
+    name = "urlmap-test-%s"
     health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-    name = "tf-test-zero"
+    name = "urlmap-test-%s"
     request_path = "/"
     check_interval_sec = 1
     timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+    name = "urlmap-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 
     host_rule {
@@ -195,23 +196,23 @@ resource "google_compute_url_map" "foobar" {
 		service = "${google_compute_backend_service.foobar.self_link}"
 	}
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeUrlMap_advanced1 = `
+var testAccComputeUrlMap_advanced1 = fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
-    name = "service"
+    name = "urlmap-test-%s"
     health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-    name = "tf-test-zero"
+    name = "urlmap-test-%s"
     request_path = "/"
     check_interval_sec = 1
     timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+    name = "urlmap-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 
     host_rule {
@@ -242,23 +243,23 @@ resource "google_compute_url_map" "foobar" {
         }
     }
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
-const testAccComputeUrlMap_advanced2 = `
+var testAccComputeUrlMap_advanced2 = fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
-    name = "service"
+    name = "urlmap-test-%s"
     health_checks = ["${google_compute_http_health_check.zero.self_link}"]
 }
 
 resource "google_compute_http_health_check" "zero" {
-    name = "tf-test-zero"
+    name = "urlmap-test-%s"
     request_path = "/"
     check_interval_sec = 1
     timeout_sec = 1
 }
 
 resource "google_compute_url_map" "foobar" {
-	name = "myurlmap"
+    name = "urlmap-test-%s"
 	default_service = "${google_compute_backend_service.foobar.self_link}"
 
     host_rule {
@@ -308,4 +309,4 @@ resource "google_compute_url_map" "foobar" {
         }
     }
 }
-`
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_vpn_gateway_test.go
+++ b/builtin/providers/google/resource_compute_vpn_gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -79,13 +80,13 @@ func testAccCheckComputeVpnGatewayExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccComputeVpnGateway_basic = `
+var testAccComputeVpnGateway_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-	name = "tf-test-network"
+	name = "gateway-test-%s"
 	ipv4_range = "10.0.0.0/16"
 }
 resource "google_compute_vpn_gateway" "foobar" {
-	name = "tf-test-vpn-gateway"
+	name = "gateway-test-%s"
 	network = "${google_compute_network.foobar.self_link}"
 	region = "us-central1"
-} `
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_vpn_tunnel_test.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -79,29 +80,29 @@ func testAccCheckComputeVpnTunnelExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccComputeVpnTunnel_basic = `
+var testAccComputeVpnTunnel_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-	name = "tf-test-network"
+	name = "tunnel-test-%s"
 	ipv4_range = "10.0.0.0/16"
 }
 resource "google_compute_address" "foobar" {
-	name = "tf-test-static-ip"
+	name = "tunnel-test-%s"
 	region = "us-central1"
 }
 resource "google_compute_vpn_gateway" "foobar" {
-	name = "tf-test-vpn-gateway"
+	name = "tunnel-test-%s"
 	network = "${google_compute_network.foobar.self_link}"
 	region = "${google_compute_address.foobar.region}"
 }
 resource "google_compute_forwarding_rule" "foobar_esp" {
-	name = "tf-test-fr-esp"
+	name = "tunnel-test-%s"
 	region = "${google_compute_vpn_gateway.foobar.region}"
 	ip_protocol = "ESP"
 	ip_address = "${google_compute_address.foobar.address}"
 	target = "${google_compute_vpn_gateway.foobar.self_link}"
 }
 resource "google_compute_forwarding_rule" "foobar_udp500" {
-	name = "tf-test-fr-udp500"
+	name = "tunnel-test-%s"
 	region = "${google_compute_forwarding_rule.foobar_esp.region}"
 	ip_protocol = "UDP"
 	port_range = "500"
@@ -109,7 +110,7 @@ resource "google_compute_forwarding_rule" "foobar_udp500" {
 	target = "${google_compute_vpn_gateway.foobar.self_link}"
 }
 resource "google_compute_forwarding_rule" "foobar_udp4500" {
-	name = "tf-test-fr-udp4500"
+	name = "tunnel-test-%s"
 	region = "${google_compute_forwarding_rule.foobar_udp500.region}"
 	ip_protocol = "UDP"
 	port_range = "4500"
@@ -117,9 +118,11 @@ resource "google_compute_forwarding_rule" "foobar_udp4500" {
 	target = "${google_compute_vpn_gateway.foobar.self_link}"
 }
 resource "google_compute_vpn_tunnel" "foobar" {
-	name = "tf-test-vpn-tunnel"
+	name = "tunnel-test-%s"
 	region = "${google_compute_forwarding_rule.foobar_udp4500.region}"
 	target_vpn_gateway = "${google_compute_vpn_gateway.foobar.self_link}"
 	shared_secret = "unguessable"
 	peer_ip = "0.0.0.0"
-}`
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+	acctest.RandString(10))

--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -89,9 +90,9 @@ func testAccCheckContainerClusterExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccContainerCluster_basic = `
+var testAccContainerCluster_basic = fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-	name = "terraform-foo-bar-test"
+	name = "cluster-test-%s"
 	zone = "us-central1-a"
 	initial_node_count = 3
 
@@ -99,11 +100,11 @@ resource "google_container_cluster" "primary" {
 		username = "mr.yoda"
 		password = "adoy.rm"
 	}
-}`
+}`, acctest.RandString(10))
 
-const testAccContainerCluster_withNodeConfig = `
+var testAccContainerCluster_withNodeConfig = fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config" {
-	name = "terraform-foo-bar-with-nodeconfig"
+	name = "cluster-test-%s"
 	zone = "us-central1-f"
 	initial_node_count = 1
 
@@ -122,4 +123,4 @@ resource "google_container_cluster" "with_node_config" {
 			"https://www.googleapis.com/auth/monitoring"
 		]
 	}
-}`
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_dns_managed_zone_test.go
+++ b/builtin/providers/google/resource_dns_managed_zone_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/dns/v1"
@@ -75,9 +76,9 @@ func testAccCheckDnsManagedZoneExists(n string, zone *dns.ManagedZone) resource.
 	}
 }
 
-const testAccDnsManagedZone_basic = `
+var testAccDnsManagedZone_basic = fmt.Sprintf(`
 resource "google_dns_managed_zone" "foobar" {
-	name = "terraform-test"
+	name = "mzone-test-%s"
 	dns_name = "terraform.test."
 	description = "Test Description"
-}`
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_dns_record_set_test.go
+++ b/builtin/providers/google/resource_dns_record_set_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -76,9 +77,9 @@ func testAccCheckDnsRecordSetExists(name string) resource.TestCheckFunc {
 	}
 }
 
-const testAccDnsRecordSet_basic = `
+var testAccDnsRecordSet_basic = fmt.Sprintf(`
 resource "google_dns_managed_zone" "parent-zone" {
-	name = "terraform-test-zone"
+	name = "dnsrecord-test-%s"
 	dns_name = "terraform.test."
 	description = "Test Description"
 }
@@ -89,4 +90,4 @@ resource "google_dns_record_set" "foobar" {
 	rrdatas = ["127.0.0.1", "127.0.0.10"]
 	ttl = 600
 }
-`
+`, acctest.RandString(10))

--- a/builtin/providers/google/resource_pubsub_subscription_test.go
+++ b/builtin/providers/google/resource_pubsub_subscription_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -62,12 +63,12 @@ func testAccPubsubSubscriptionExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccPubsubSubscription = `
+var testAccPubsubSubscription = fmt.Sprintf(`
 resource "google_pubsub_topic" "foobar_sub" {
-	name = "foobar_sub"
+	name = "pssub-test-%s"
 }
 
 resource "google_pubsub_subscription" "foobar_sub" {
-	name = "foobar_sub"
+	name = "pssub-test-%s"
 	topic = "${google_pubsub_topic.foobar_sub.name}"
-}`
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_pubsub_topic_test.go
+++ b/builtin/providers/google/resource_pubsub_topic_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -62,7 +63,7 @@ func testAccPubsubTopicExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccPubsubTopic = `
+var testAccPubsubTopic = fmt.Sprintf(`
 resource "google_pubsub_topic" "foobar" {
-	name = "foobar"
-}`
+	name = "pstopic-test-%s"
+}`, acctest.RandString(10))

--- a/builtin/providers/google/resource_sql_database_test.go
+++ b/builtin/providers/google/resource_sql_database_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -100,7 +101,7 @@ func testAccGoogleSqlDatabaseDestroy(s *terraform.State) error {
 
 var testGoogleSqlDatabase_basic = fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
-	name = "tf-lw-%d"
+	name = "sqldatabase-test-%s"
 	region = "us-central"
 	settings {
 		tier = "D0"
@@ -108,7 +109,7 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "database" {
-	name = "database1"
+	name = "sqldatabase-test-%s"
 	instance = "${google_sql_database_instance.instance.name}"
 }
-`, genRandInt())
+`, acctest.RandString(10), acctest.RandString(10))


### PR DESCRIPTION
@phinze, for the sake of completeness I made sure all test resources have randomly generated names. Addresses #4514 