### PR TITLE
provider/azurerm: Register needed Azure providers

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -36,6 +36,7 @@ type ArmClient struct {
 	vnetGatewayClient            network.VirtualNetworkGatewaysClient
 	vnetClient                   network.VirtualNetworksClient
 
+	providers           resources.ProvidersClient
 	resourceGroupClient resources.GroupsClient
 	tagsClient          resources.TagsClient
 
@@ -159,6 +160,11 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	rgc.Authorizer = spt
 	rgc.Sender = autorest.CreateSender(withRequestLogging())
 	client.resourceGroupClient = rgc
+
+	pc := resources.NewProvidersClient(c.SubscriptionID)
+	pc.Authorizer = spt
+	pc.Sender = autorest.CreateSender(withRequestLogging())
+	client.providers = pc
 
 	tc := resources.NewTagsClient(c.SubscriptionID)
 	tc.Authorizer = spt


### PR DESCRIPTION
It is necessary to register Azure Resource Manager providers to a given subscription in order to use them. This PR hooks into the provider configuration function in order to register all of the providers which the Terraform provider may use. It was confirmed by Microsoft that this is a valid approach.

When implementing new resources, the list of (Azure) provider namespaces in `provider.go` may need updating - @aznashwan this is likely to be of interest to you!