### PR TITLE
provider/azure: Fix up acctest destroy checks

### DIFF
--- a/builtin/providers/azure/resource_azure_dns_server_test.go
+++ b/builtin/providers/azure/resource_azure_dns_server_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/management"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -98,6 +99,10 @@ func testAccCheckAzureDnsServerDestroy(s *terraform.State) error {
 
 		netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 		if err != nil {
+			// This is desirable - if there is no network config there can't be any DNS Servers
+			if management.IsResourceNotFoundError(err) {
+				continue
+			}
 			return fmt.Errorf("Error retrieving networking configuration from Azure: %s", err)
 		}
 

--- a/builtin/providers/azure/resource_azure_local_network_test.go
+++ b/builtin/providers/azure/resource_azure_local_network_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/management"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -109,6 +110,10 @@ func testAccAzureLocalNetworkConnectionDestroyed(s *terraform.State) error {
 
 		netConf, err := vnetClient.GetVirtualNetworkConfiguration()
 		if err != nil {
+			// This is desirable - if there is no network config there can be no gateways
+			if management.IsResourceNotFoundError(err) {
+				continue
+			}
 			return err
 		}
 

--- a/builtin/providers/azure/resource_azure_virtual_network_test.go
+++ b/builtin/providers/azure/resource_azure_virtual_network_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/management"
 	"github.com/Azure/azure-sdk-for-go/management/virtualnetwork"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -185,6 +186,10 @@ func testAccCheckAzureVirtualNetworkDestroy(s *terraform.State) error {
 
 		nc, err := vnetClient.GetVirtualNetworkConfiguration()
 		if err != nil {
+			if management.IsResourceNotFoundError(err) {
+				// This is desirable - no configuration = no networks
+				continue
+			}
 			return fmt.Errorf("Error retrieving Virtual Network Configuration: %s", err)
 		}
 


### PR DESCRIPTION
Some resources can only be queried via the network configuration - if the network configuration does not exist we were failing, however that is a desirable state since without a network configuration for the subscription the resources in question cannot exist.