### PR TITLE
provider/aws: Clean up OpsWorks tests

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -131,11 +134,30 @@ func TestAccAWSOpsworksCustomLayer(t *testing.T) {
 }
 
 func testAccCheckAwsOpsworksCustomLayerDestroy(s *terraform.State) error {
-	if len(s.RootModule().Resources) > 0 {
-		return fmt.Errorf("Expected all resources to be gone, but found: %#v", s.RootModule().Resources)
+	opsworksconn := testAccProvider.Meta().(*AWSClient).opsworksconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_opsworks_custom_layer" {
+			continue
+		}
+		req := &opsworks.DescribeLayersInput{
+			LayerIds: []*string{
+				aws.String(rs.Primary.ID),
+			},
+		}
+
+		_, err := opsworksconn.DescribeLayers(req)
+		if err != nil {
+			if awserr, ok := err.(awserr.Error); ok {
+				if awserr.Code() == "ResourceNotFoundException" {
+					// not found, good to go
+					return nil
+				}
+			}
+			return err
+		}
 	}
 
-	return nil
+	return fmt.Errorf("Fall through error on OpsWorks custom layer test")
 }
 
 var testAccAwsOpsworksCustomLayerSecurityGroups = `
@@ -160,6 +182,10 @@ resource "aws_security_group" "tf-ops-acc-layer2" {
 `
 
 var testAccAwsOpsworksCustomLayerConfigCreate = testAccAwsOpsworksStackConfigNoVpcCreate + testAccAwsOpsworksCustomLayerSecurityGroups + `
+provider "aws" {
+	region = "us-east-1"
+}
+
 resource "aws_opsworks_custom_layer" "tf-acc" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
   name = "tf-ops-acc-custom-layer"

--- a/builtin/providers/aws/resource_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack_test.go
@@ -91,10 +91,10 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
 var testAccAwsOpsworksStackConfigNoVpcCreate = testAccAwsOpsworksStackIamConfig + `
 resource "aws_opsworks_stack" "tf-acc" {
   name = "tf-opsworks-acc"
-  region = "us-west-2"
+  region = "us-east-1"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
-  default_availability_zone = "us-west-2a"
+  default_availability_zone = "us-east-1c"
   default_os = "Amazon Linux 2014.09"
   default_root_device_type = "ebs"
   custom_json = "{\"key\": \"value\"}"
@@ -105,10 +105,10 @@ resource "aws_opsworks_stack" "tf-acc" {
 var testAccAWSOpsworksStackConfigNoVpcUpdate = testAccAwsOpsworksStackIamConfig + `
 resource "aws_opsworks_stack" "tf-acc" {
   name = "tf-opsworks-acc"
-  region = "us-west-2"
+  region = "us-east-1"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
-  default_availability_zone = "us-west-2a"
+  default_availability_zone = "us-east-1c"
   default_os = "Amazon Linux 2014.09"
   default_root_device_type = "ebs"
   custom_json = "{\"key\": \"value\"}"
@@ -153,11 +153,11 @@ resource "aws_vpc" "tf-acc" {
 resource "aws_subnet" "tf-acc" {
   vpc_id = "${aws_vpc.tf-acc.id}"
   cidr_block = "${aws_vpc.tf-acc.cidr_block}"
-  availability_zone = "us-west-2a"
+  availability_zone = "us-east-1c"
 }
 resource "aws_opsworks_stack" "tf-acc" {
   name = "tf-opsworks-acc"
-  region = "us-west-2"
+  region = "us-east-1"
   vpc_id = "${aws_vpc.tf-acc.id}"
   default_subnet_id = "${aws_subnet.tf-acc.id}"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
@@ -177,11 +177,11 @@ resource "aws_vpc" "tf-acc" {
 resource "aws_subnet" "tf-acc" {
   vpc_id = "${aws_vpc.tf-acc.id}"
   cidr_block = "${aws_vpc.tf-acc.cidr_block}"
-  availability_zone = "us-west-2a"
+  availability_zone = "us-east-1c"
 }
 resource "aws_opsworks_stack" "tf-acc" {
   name = "tf-opsworks-acc"
-  region = "us-west-2"
+  region = "us-east-1"
   vpc_id = "${aws_vpc.tf-acc.id}"
   default_subnet_id = "${aws_subnet.tf-acc.id}"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
@@ -235,7 +235,7 @@ var testAccAwsOpsworksStackCheckResourceAttrsCreate = resource.ComposeTestCheckF
 	resource.TestCheckResourceAttr(
 		"aws_opsworks_stack.tf-acc",
 		"default_availability_zone",
-		"us-west-2a",
+		"us-east-1c",
 	),
 	resource.TestCheckResourceAttr(
 		"aws_opsworks_stack.tf-acc",
@@ -273,7 +273,7 @@ var testAccAwsOpsworksStackCheckResourceAttrsUpdate = resource.ComposeTestCheckF
 	resource.TestCheckResourceAttr(
 		"aws_opsworks_stack.tf-acc",
 		"default_availability_zone",
-		"us-west-2a",
+		"us-east-1c",
 	),
 	resource.TestCheckResourceAttr(
 		"aws_opsworks_stack.tf-acc",


### PR DESCRIPTION
Clean up OpsWorks tests to use us-east, validate destroy of custom layer

- `TestAccAWSOpsworksStackNoVpc` should pass now
- `TestAccAWSOpsworksCustomLayer` should pass now