### PR TITLE
provider/azurerm: add availability set

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -42,6 +42,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_resource_group":        resourceArmResourceGroup(),
 			"azurerm_virtual_network":       resourceArmVirtualNetwork(),
 			"azurerm_local_network_gateway": resourceArmLocalNetworkGateway(),
+			"azurerm_availability_set":      resourceArmAvailabilitySet(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -87,7 +88,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 func registerAzureResourceProvidersWithSubscription(config *Config, client *ArmClient) error {
 	providerClient := client.providers
 
-	providers := []string{"Microsoft.Network"}
+	providers := []string{"Microsoft.Network", "Microsoft.Compute"}
 
 	for _, v := range providers {
 		res, err := providerClient.Register(v)

--- a/builtin/providers/azurerm/resource_arm_availability_set.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set.go
@@ -1,0 +1,140 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmAvailabilitySet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAvailabilitySetCreate,
+		Read:   resourceArmAvailabilitySetRead,
+		Update: resourceArmAvailabilitySetCreate,
+		Delete: resourceArmAvailabilitySetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"platform_update_domain_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  5,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(int)
+					if value > 20 {
+						errors = append(errors, fmt.Errorf(
+							"Maximum value for `platform_update_domain_count` is 20"))
+					}
+					return
+				},
+			},
+
+			"platform_fault_domain_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  3,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(int)
+					if value > 3 {
+						errors = append(errors, fmt.Errorf(
+							"Maximum value for `platform_fault_domain_count` is 3", k))
+					}
+					return
+				},
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceArmAvailabilitySetCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	availSetClient := client.availSetClient
+
+	log.Printf("[INFO] preparing arguments for Azure ARM Availability Set creation.")
+
+	name := d.Get("name").(string)
+	location := d.Get("location").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	updateDomainCount := d.Get("platform_update_domain_count").(int)
+	faultDomainCount := d.Get("platform_fault_domain_count").(int)
+
+	availSet := compute.AvailabilitySet{
+		Name:     &name,
+		Location: &location,
+		Properties: &compute.AvailabilitySetProperties{
+			PlatformFaultDomainCount:  &faultDomainCount,
+			PlatformUpdateDomainCount: &updateDomainCount,
+		},
+	}
+
+	resp, err := availSetClient.CreateOrUpdate(resGroup, name, availSet)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmAvailabilitySetRead(d, meta)
+}
+
+func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) error {
+	availSetClient := meta.(*ArmClient).availSetClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["availabilitySets"]
+
+	resp, err := availSetClient.Get(resGroup, name)
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Availability Set %s: %s", name, err)
+	}
+
+	availSet := *resp.Properties
+	d.Set("platform_update_domain_count", availSet.PlatformUpdateDomainCount)
+	d.Set("platform_fault_domain_count", availSet.PlatformFaultDomainCount)
+
+	return nil
+}
+
+func resourceArmAvailabilitySetDelete(d *schema.ResourceData, meta interface{}) error {
+	availSetClient := meta.(*ArmClient).availSetClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["availabilitySets"]
+
+	_, err = availSetClient.Delete(resGroup, name)
+
+	return err
+}

--- a/builtin/providers/azurerm/resource_arm_availability_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set_test.go
@@ -1,0 +1,136 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVAvailabilitySet_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "name", "acceptanceTestAvailabilitySet1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "platform_update_domain_count", "5"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "platform_fault_domain_count", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVAvailabilitySet_withDomainCounts,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "name", "acceptanceTestAvailabilitySet1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "platform_update_domain_count", "10"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "platform_fault_domain_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMAvailabilitySetExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		availSetName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for availability set: %s", availSetName)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).availSetClient
+
+		resp, err := conn.Get(resourceGroup, availSetName)
+		if err != nil {
+			return fmt.Errorf("Bad: Get on availSetClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Availability Set %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMAvailabilitySetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).vnetClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_availability_set" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(resourceGroup, name)
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Availability Set still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMVAvailabilitySet_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_availability_set" "test" {
+    name = "acceptanceTestAvailabilitySet1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`
+
+var testAccAzureRMVAvailabilitySet_withDomainCounts = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_availability_set" "test" {
+    name = "acceptanceTestAvailabilitySet1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    platform_update_domain_count = 10
+    platform_fault_domain_count = 1
+}
+`

--- a/website/source/docs/providers/azurerm/r/availability_set.html.markdown
+++ b/website/source/docs/providers/azurerm/r/availability_set.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_availability_set"
+sidebar_current: "docs-azurerm-resource-availability-set"
+description: |-
+  Create an availability set for virtual machines.
+---
+
+# azurerm\_availability\_set
+
+Create an availability set for virtual machines.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "resourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_availability_set" "test" {
+    name = "acceptanceTestAvailabilitySet1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the availability set. Changing this forces a
+    new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the availability set.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `platform_update_domain_count` - (Optional) Specifies the number of update domains that are used. Defaults to 5.
+
+* `platform_fault_domain_count` - (Optional) Specifies the number of fault domains that are used. Defaults to 3.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The virtual AvailabilitySet ID.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -25,6 +25,10 @@
                             <a href="/docs/providers/azurerm/r/local_network_gateway.html">azurerm_local_network_gateway</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-azurerm-resource-availability-set") %>>
+                          <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
+                        </li>
+
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
@jen20: Adds [Availablity Set](https://msdn.microsoft.com/en-us/library/azure/mt163607.aspx)

- [x] Schema
- [x] CRUD
- [x] Acceptance Tests
- [x] Documentation

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMAvailabilitySet' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMAvailabilitySet -timeout 90m
=== RUN   TestAccAzureRMAvailabilitySet_basic
--- PASS: TestAccAzureRMAvailabilitySet_basic (119.76s)
=== RUN   TestAccAzureRMAvailabilitySet_withDomainCounts
--- PASS: TestAccAzureRMAvailabilitySet_withDomainCounts (134.37s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	254.142s
```