### PR TITLE
provider/aws: Fix template_url/template_body conflict

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack.go
@@ -269,11 +269,11 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 	}
 
 	// Either TemplateBody or TemplateURL are required for each change
-	if v, ok := d.GetOk("template_body"); ok {
-		input.TemplateBody = aws.String(normalizeJson(v.(string)))
-	}
 	if v, ok := d.GetOk("template_url"); ok {
 		input.TemplateURL = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("template_body"); ok && input.TemplateURL == nil {
+		input.TemplateBody = aws.String(normalizeJson(v.(string)))
 	}
 
 	if d.HasChange("capabilities") {

--- a/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -83,6 +85,31 @@ func TestAccAWSCloudFormation_withParams(t *testing.T) {
 				Config: testAccAWSCloudFormationConfig_withParams_modified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
+				),
+			},
+		},
+	})
+}
+
+// Regression for https://github.com/hashicorp/terraform/issues/4534
+func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
+	var stack cloudformation.Stack
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudFormationConfig_templateUrl_withParams,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCloudFormationConfig_templateUrl_withParams_modified,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
 			},
 		},
@@ -293,3 +320,57 @@ var testAccAWSCloudFormationConfig_withParams = fmt.Sprintf(
 var testAccAWSCloudFormationConfig_withParams_modified = fmt.Sprintf(
 	tpl_testAccAWSCloudFormationConfig_withParams,
 	"12.0.0.0/16")
+
+var tpl_testAccAWSCloudFormationConfig_templateUrl_withParams = `
+resource "aws_s3_bucket" "b" {
+  bucket = "%s"
+  acl = "public-read"
+  policy = <<POLICY
+{
+  "Version":"2008-10-17",
+  "Statement": [
+    {
+      "Sid":"AllowPublicRead",
+      "Effect":"Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::%s/*"
+    }
+  ]
+}
+POLICY
+
+  website {
+      index_document = "index.html"
+      error_document = "error.html"
+  }
+}
+
+resource "aws_s3_bucket_object" "object" {
+  bucket = "${aws_s3_bucket.b.id}"
+  key = "tf-cf-stack.json"
+  source = "test-fixtures/cloudformation-template.json"
+}
+
+resource "aws_cloudformation_stack" "with-url-and-params" {
+  name = "tf-stack-template-url-with-params"
+  parameters {
+    VpcCIDR = "%s"
+  }
+  template_url = "https://${aws_s3_bucket.b.id}.s3-us-west-2.amazonaws.com/${aws_s3_bucket_object.object.key}"
+  on_failure = "DELETE"
+  timeout_in_minutes = 1
+}
+`
+
+var cfRandInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+var cfBucketName = "tf-stack-with-url-and-params-" + fmt.Sprintf("%d", cfRandInt)
+
+var testAccAWSCloudFormationConfig_templateUrl_withParams = fmt.Sprintf(
+	tpl_testAccAWSCloudFormationConfig_templateUrl_withParams,
+	cfBucketName, cfBucketName, "11.0.0.0/16")
+var testAccAWSCloudFormationConfig_templateUrl_withParams_modified = fmt.Sprintf(
+	tpl_testAccAWSCloudFormationConfig_templateUrl_withParams,
+	cfBucketName, cfBucketName, "13.0.0.0/16")

--- a/builtin/providers/aws/test-fixtures/cloudformation-template.json
+++ b/builtin/providers/aws/test-fixtures/cloudformation-template.json
@@ -1,0 +1,19 @@
+{
+  "Parameters" : {
+    "VpcCIDR" : {
+      "Description" : "CIDR to be used for the VPC",
+      "Type" : "String"
+    }
+  },
+  "Resources" : {
+    "MyVPC": {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : {"Ref": "VpcCIDR"},
+        "Tags" : [
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This bug occurs because `v, ok := GetOk("template_body"); ok` is always true as we always download it back from the API in `Read()` function.

Here I'm ignoring `template_body` completely if the user has provided `template_url`, since that means the `template_body` comes from the API, not from the user.

Fixes https://github.com/hashicorp/terraform/issues/4534