### PR TITLE
provider/azurerm: rename security group to be network security group

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -39,11 +39,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"azurerm_resource_group":        resourceArmResourceGroup(),
-			"azurerm_virtual_network":       resourceArmVirtualNetwork(),
-			"azurerm_local_network_gateway": resourceArmLocalNetworkGateway(),
-			"azurerm_availability_set":      resourceArmAvailabilitySet(),
-			"azurerm_security_group":        resourceArmSecurityGroup(),
+			"azurerm_resource_group":         resourceArmResourceGroup(),
+			"azurerm_virtual_network":        resourceArmVirtualNetwork(),
+			"azurerm_local_network_gateway":  resourceArmLocalNetworkGateway(),
+			"azurerm_availability_set":       resourceArmAvailabilitySet(),
+			"azurerm_network_security_group": resourceArmNetworkSecurityGroup(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/azurerm/resource_arm_network_security_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceAzureRMSecurityGroupProtocol_validation(t *testing.T) {
+func TestResourceAzureRMNetworkSecurityGroupProtocol_validation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -41,15 +41,15 @@ func TestResourceAzureRMSecurityGroupProtocol_validation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, errors := validateSecurityRuleProtocol(tc.Value, "azurerm_security_group")
+		_, errors := validateNetworkSecurityRuleProtocol(tc.Value, "azurerm_network_security_group")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Security Group protocol to trigger a validation error")
+			t.Fatalf("Expected the Azure RM Network Security Group protocol to trigger a validation error")
 		}
 	}
 }
 
-func TestResourceAzureRMSecurityGroupAccess_validation(t *testing.T) {
+func TestResourceAzureRMNetworkSecurityGroupAccess_validation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -77,15 +77,15 @@ func TestResourceAzureRMSecurityGroupAccess_validation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, errors := validateSecurityRuleAccess(tc.Value, "azurerm_security_group")
+		_, errors := validateNetworkSecurityRuleAccess(tc.Value, "azurerm_network_security_group")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Security Group access to trigger a validation error")
+			t.Fatalf("Expected the Azure RM Network Security Group access to trigger a validation error")
 		}
 	}
 }
 
-func TestResourceAzureRMSecurityGroupDirection_validation(t *testing.T) {
+func TestResourceAzureRMNetworkSecurityGroupDirection_validation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -113,60 +113,60 @@ func TestResourceAzureRMSecurityGroupDirection_validation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, errors := validateSecurityRuleDirection(tc.Value, "azurerm_security_group")
+		_, errors := validateNetworkSecurityRuleDirection(tc.Value, "azurerm_network_security_group")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Security Group direction to trigger a validation error")
+			t.Fatalf("Expected the Azure RM Network Security Group direction to trigger a validation error")
 		}
 	}
 }
 
-func TestAccAzureRMSecurityGroup_basic(t *testing.T) {
+func TestAccAzureRMNetworkSecurityGroup_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSecurityGroupDestroy,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMSecurityGroup_basic,
+				Config: testAccAzureRMNetworkSecurityGroup_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSecurityGroupExists("azurerm_security_group.test"),
+					testCheckAzureRMNetworkSecurityGroupExists("azurerm_network_security_group.test"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMSecurityGroup_addingExtraRules(t *testing.T) {
+func TestAccAzureRMNetworkSecurityGroup_addingExtraRules(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSecurityGroupDestroy,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMSecurityGroup_basic,
+				Config: testAccAzureRMNetworkSecurityGroup_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSecurityGroupExists("azurerm_security_group.test"),
+					testCheckAzureRMNetworkSecurityGroupExists("azurerm_network_security_group.test"),
 					resource.TestCheckResourceAttr(
-						"azurerm_security_group.test", "security_rule.#", "1"),
+						"azurerm_network_security_group.test", "security_rule.#", "1"),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMSecurityGroup_anotherRule,
+				Config: testAccAzureRMNetworkSecurityGroup_anotherRule,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSecurityGroupExists("azurerm_security_group.test"),
+					testCheckAzureRMNetworkSecurityGroupExists("azurerm_network_security_group.test"),
 					resource.TestCheckResourceAttr(
-						"azurerm_security_group.test", "security_rule.#", "2"),
+						"azurerm_network_security_group.test", "security_rule.#", "2"),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureRMSecurityGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkSecurityGroupExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, ok := s.RootModule().Resources[name]
@@ -177,7 +177,7 @@ func testCheckAzureRMSecurityGroupExists(name string) resource.TestCheckFunc {
 		sgName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for security group: %s", sgName)
+			return fmt.Errorf("Bad: no resource group found in state for network security group: %s", sgName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).secGroupClient
@@ -188,18 +188,18 @@ func testCheckAzureRMSecurityGroupExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Security Group %q (resource group: %q) does not exist", name, resourceGroup)
+			return fmt.Errorf("Bad: Network Security Group %q (resource group: %q) does not exist", name, resourceGroup)
 		}
 
 		return nil
 	}
 }
 
-func testCheckAzureRMSecurityGroupDestroy(s *terraform.State) error {
+func testCheckAzureRMNetworkSecurityGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).secGroupClient
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "azurerm_security_group" {
+		if rs.Type != "azurerm_network_security_group" {
 			continue
 		}
 
@@ -213,20 +213,20 @@ func testCheckAzureRMSecurityGroupDestroy(s *terraform.State) error {
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("Security Group still exists:\n%#v", resp.Properties)
+			return fmt.Errorf("Network Security Group still exists:\n%#v", resp.Properties)
 		}
 	}
 
 	return nil
 }
 
-var testAccAzureRMSecurityGroup_basic = `
+var testAccAzureRMNetworkSecurityGroup_basic = `
 resource "azurerm_resource_group" "test" {
     name = "acceptanceTestResourceGroup1"
     location = "West US"
 }
 
-resource "azurerm_security_group" "test" {
+resource "azurerm_network_security_group" "test" {
     name = "acceptanceTestSecurityGroup1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -245,13 +245,13 @@ resource "azurerm_security_group" "test" {
 }
 `
 
-var testAccAzureRMSecurityGroup_anotherRule = `
+var testAccAzureRMNetworkSecurityGroup_anotherRule = `
 resource "azurerm_resource_group" "test" {
     name = "acceptanceTestResourceGroup1"
     location = "West US"
 }
 
-resource "azurerm_security_group" "test" {
+resource "azurerm_network_security_group" "test" {
     name = "acceptanceTestSecurityGroup1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"

--- a/website/source/docs/providers/azurerm/r/network_security_group.html.markdown
+++ b/website/source/docs/providers/azurerm/r/network_security_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_security_group"
-sidebar_current: "docs-azurerm-resource-security-group"
+page_title: "Azure Resource Manager: azurerm_network_security_group"
+sidebar_current: "docs-azurerm-resource-network-security-group"
 description: |-
   Create a network security group that contains a list of network security rules. Network security groups enable inbound or outbound traffic to be enabled or denied.
 ---
@@ -18,7 +18,7 @@ resource "azurerm_resource_group" "test" {
     location = "West US"
 }
 
-resource "azurerm_security_group" "test" {
+resource "azurerm_network_security_group" "test" {
     name = "acceptanceTestSecurityGroup1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -29,8 +29,8 @@
                           <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-azurerm-resource-security-group") %>>
-                          <a href="/docs/providers/azurerm/r/security_group.html">azurerm_security_group</a>
+                        <li<%= sidebar_current("docs-azurerm-resource-network-security-group") %>>
+                          <a href="/docs/providers/azurerm/r/network_security_group.html">azurerm_network_security_group</a>
                         </li>
 
                     </ul>


### PR DESCRIPTION
Rename the AzureRM Security Group to AzureRM Network Security Group

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMNetworkSecurityGroup' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMNetworkSecurityGroup -timeout 120m
=== RUN   TestResourceAzureRMNetworkSecurityGroupProtocol_validation
--- PASS: TestResourceAzureRMNetworkSecurityGroupProtocol_validation (0.00s)
=== RUN   TestResourceAzureRMNetworkSecurityGroupAccess_validation
--- PASS: TestResourceAzureRMNetworkSecurityGroupAccess_validation (0.00s)
=== RUN   TestResourceAzureRMNetworkSecurityGroupDirection_validation
--- PASS: TestResourceAzureRMNetworkSecurityGroupDirection_validation (0.00s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_basic
--- PASS: TestAccAzureRMNetworkSecurityGroup_basic (121.68s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_addingExtraRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_addingExtraRules (163.24s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	284.936s
```