### PR TITLE
provider/aws: Supporting New AWS Route53 HealthCheck additions (supersedes #3741)

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToUpper(val.(string))
+				},
 			},
 			"failure_threshold": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -22,6 +22,8 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
 					resource.TestCheckResourceAttr(
 						"aws_route53_health_check.foo", "measure_latency", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_health_check.foo", "invert_healthcheck", "true"),
 				),
 			},
 			resource.TestStep{
@@ -30,6 +32,8 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
 					resource.TestCheckResourceAttr(
 						"aws_route53_health_check.foo", "failure_threshold", "5"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_health_check.foo", "invert_healthcheck", "false"),
 				),
 			},
 		},
@@ -127,6 +131,7 @@ resource "aws_route53_health_check" "foo" {
   failure_threshold = "2"
   request_interval = "30"
   measure_latency = true
+  invert_healthcheck = true
 
   tags = {
     Name = "tf-test-health-check"
@@ -142,6 +147,8 @@ resource "aws_route53_health_check" "foo" {
   resource_path = "/"
   failure_threshold = "5"
   request_interval = "30"
+  measure_latency = true
+  invert_healthcheck = false
 
   tags = {
     Name = "tf-test-health-check"

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -41,19 +41,19 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
-        resource.Test(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
-                Steps: []resource.TestStep{
-                        resource.TestStep{
-                                Config: testAccRoute53HealthCheckConfig_withChildHealthChecks,
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53HealthCheckConfig_withChildHealthChecks,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {

--- a/builtin/providers/aws/resource_aws_route53_health_check_test.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check_test.go
@@ -40,6 +40,22 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccRoute53HealthCheckConfig_withChildHealthChecks,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
+                                ),
+                        },
+                },
+        })
+}
+
 func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -167,6 +183,27 @@ resource "aws_route53_health_check" "bar" {
 
   tags = {
     Name = "tf-test-health-check"
+   }
+}
+`
+
+const testAccRoute53HealthCheckConfig_withChildHealthChecks = `
+resource "aws_route53_health_check" "child1" {
+  fqdn = "child1.notexample.com"
+  port = 80
+  type = "HTTP"
+  resource_path = "/"
+  failure_threshold = "2"
+  request_interval = "30"
+}
+
+resource "aws_route53_health_check" "foo" {
+  type = "CALCULATED"
+  child_health_threshold = 1
+  child_healthchecks = ["${aws_route53_health_check.child1.id}"]
+
+  tags = {
+    Name = "tf-test-calculated-health-check"
    }
 }
 `

--- a/website/source/docs/providers/aws/r/route53_health_check.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_health_check.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
 * `request_interval` - (Required) The number of seconds between the time that Amazon Route 53 gets a response from your endpoint and the time that it sends the next health-check request.
 * `resource_path` - (Optional) The path that you want Amazon Route 53 to request when performing health checks.
 * `search_string` - (Optional) String searched in respoonse body for check to considered healthy.
+* `measure_latency` - (Optional) A Boolean value that indicates whether you want Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint and to display CloudWatch latency graphs in the Route 53 console.
+* `invert_healthcheck` - (Optional) A boolean value that indicates whether the status of health check should be inverted. For example, if a health check is healthy but Inverted is True , then Route 53 considers the health check to be unhealthy.
 * `tags` - (Optional) A mapping of tags to assign to the health check.
 
 At least one of either `fqdn` or `ip_address` must be specified.

--- a/website/source/docs/providers/aws/r/route53_health_check.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_health_check.html.markdown
@@ -12,7 +12,7 @@ Provides a Route53 health check.
 ## Example Usage
 
 ```
-resource "aws_route53_health_check" "foo" {
+resource "aws_route53_health_check" "child1" {
   fqdn = "foobar.terraform.com"
   port = 80
   type = "HTTP"
@@ -22,6 +22,16 @@ resource "aws_route53_health_check" "foo" {
 
   tags = {
     Name = "tf-test-health-check"
+   }
+}
+
+resource "aws_route53_health_check" "foo" {
+  type = "CALCULATED"
+  child_health_threshold = 1
+  child_healthchecks = ["${aws_route53_health_check.child1.id}"]
+
+  tags = {
+    Name = "tf-test-calculated-health-check"
    }
 }
 ```
@@ -38,6 +48,8 @@ The following arguments are supported:
 * `search_string` - (Optional) String searched in respoonse body for check to considered healthy.
 * `measure_latency` - (Optional) A Boolean value that indicates whether you want Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint and to display CloudWatch latency graphs in the Route 53 console.
 * `invert_healthcheck` - (Optional) A boolean value that indicates whether the status of health check should be inverted. For example, if a health check is healthy but Inverted is True , then Route 53 considers the health check to be unhealthy.
+* `child_healthchecks` - (Optional) For a specified parent health check, a list of HealthCheckId values for the associated child health checks.
+* `child_health_threshold` - (Optional) The minimum number of child health checks that must be healthy for Route 53 to consider the parent health check to be healthy. Valid values are integers between 0 and 256, inclusive
 * `tags` - (Optional) A mapping of tags to assign to the health check.
 
 At least one of either `fqdn` or `ip_address` must be specified.


### PR DESCRIPTION
Hey @stack72 – I merged https://github.com/hashicorp/terraform/pull/3688 then found your #3741, so I then pulled your branch down and rebased, doing my best to clean up conflicts. The result is this PR, could you give it a pass and let me know if it's good? The acceptance test passes, but there was some difference in how the two pr's defined `measure_latency` 

Closes #3741

Fixes #3273