### PR TITLE
provider/azurerm: add public ip resource

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_local_network_gateway":  resourceArmLocalNetworkGateway(),
 			"azurerm_availability_set":       resourceArmAvailabilitySet(),
 			"azurerm_network_security_group": resourceArmNetworkSecurityGroup(),
+			"azurerm_public_ip":              resourceArmPublicIp(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/azurerm/resource_arm_public_ip.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip.go
@@ -1,0 +1,245 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmPublicIp() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmPublicIpCreate,
+		Read:   resourceArmPublicIpRead,
+		Update: resourceArmPublicIpCreate,
+		Delete: resourceArmPublicIpDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"public_ip_address_allocation": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validatePublicIpAllocation,
+			},
+
+			"idle_timeout_in_minutes": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(int)
+					if value < 4 || value > 30 {
+						errors = append(errors, fmt.Errorf(
+							"The idle timeout must be between 4 and 30 minutes"))
+					}
+					return
+				},
+			},
+
+			"domain_name_label": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validatePublicIpDomainNameLabel,
+			},
+
+			"reverse_fqdn": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"fqdn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmPublicIpCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	publicIPClient := client.publicIPClient
+
+	log.Printf("[INFO] preparing arguments for Azure ARM Public IP creation.")
+
+	name := d.Get("name").(string)
+	location := d.Get("location").(string)
+	resGroup := d.Get("resource_group_name").(string)
+
+	properties := network.PublicIPAddressPropertiesFormat{
+		PublicIPAllocationMethod: network.IPAllocationMethod(d.Get("public_ip_address_allocation").(string)),
+	}
+
+	dnl, hasDnl := d.GetOk("domain_name_label")
+	rfqdn, hasRfqdn := d.GetOk("reverse_fqdn")
+
+	if hasDnl || hasRfqdn {
+		dnsSettings := network.PublicIPAddressDNSSettings{}
+
+		if hasRfqdn {
+			reverse_fqdn := rfqdn.(string)
+			dnsSettings.ReverseFqdn = &reverse_fqdn
+		}
+
+		if hasDnl {
+			domain_name_label := dnl.(string)
+			dnsSettings.DomainNameLabel = &domain_name_label
+
+		}
+
+		properties.DNSSettings = &dnsSettings
+	}
+
+	if v, ok := d.GetOk("idle_timeout_in_minutes"); ok {
+		idle_timeout := v.(int)
+		properties.IdleTimeoutInMinutes = &idle_timeout
+	}
+
+	publicIp := network.PublicIPAddress{
+		Name:       &name,
+		Location:   &location,
+		Properties: &properties,
+	}
+
+	resp, err := publicIPClient.CreateOrUpdate(resGroup, name, publicIp)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ID)
+
+	log.Printf("[DEBUG] Waiting for Public IP (%s) to become available", name)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  "Succeeded",
+		Refresh: publicIPStateRefreshFunc(client, resGroup, name),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Public IP (%s) to become available: %s", name, err)
+	}
+
+	return resourceArmPublicIpRead(d, meta)
+}
+
+func resourceArmPublicIpRead(d *schema.ResourceData, meta interface{}) error {
+	publicIPClient := meta.(*ArmClient).publicIPClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["publicIPAddresses"]
+
+	resp, err := publicIPClient.Get(resGroup, name)
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure public ip %s: %s", name, err)
+	}
+
+	if resp.Properties.DNSSettings != nil && resp.Properties.DNSSettings.Fqdn != nil && *resp.Properties.DNSSettings.Fqdn != "" {
+		d.Set("fqdn", resp.Properties.DNSSettings.Fqdn)
+	}
+
+	if resp.Properties.IPAddress != nil && *resp.Properties.IPAddress != "" {
+		d.Set("ip_address", resp.Properties.IPAddress)
+	}
+
+	return nil
+}
+
+func resourceArmPublicIpDelete(d *schema.ResourceData, meta interface{}) error {
+	publicIPClient := meta.(*ArmClient).publicIPClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["publicIPAddresses"]
+
+	_, err = publicIPClient.Delete(resGroup, name)
+
+	return err
+}
+
+func publicIPStateRefreshFunc(client *ArmClient, resourceGroupName string, publicIpName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.publicIPClient.Get(resourceGroupName, publicIpName)
+		if err != nil {
+			return nil, "", fmt.Errorf("Error issuing read request in publicIPStateRefreshFunc to Azure ARM for public ip '%s' (RG: '%s'): %s", publicIpName, resourceGroupName, err)
+		}
+
+		return res, *res.Properties.ProvisioningState, nil
+	}
+}
+
+func validatePublicIpAllocation(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	allocations := map[string]bool{
+		"static":  true,
+		"dynamic": true,
+	}
+
+	if !allocations[value] {
+		errors = append(errors, fmt.Errorf("Public IP Allocation can only be Static of Dynamic"))
+	}
+	return
+}
+
+func validatePublicIpDomainNameLabel(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-z0-9-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q: %q",
+			k, value))
+	}
+
+	if len(value) > 61 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 61 characters: %q", k, value))
+	}
+
+	if len(value) == 0 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be an empty string: %q", k, value))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen: %q", k, value))
+	}
+
+	return
+
+}

--- a/builtin/providers/azurerm/resource_arm_public_ip_test.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip_test.go
@@ -1,0 +1,244 @@
+package azurerm
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceAzureRMPublicIpAllocation_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "Random",
+			ErrCount: 1,
+		},
+		{
+			Value:    "Static",
+			ErrCount: 0,
+		},
+		{
+			Value:    "Dynamic",
+			ErrCount: 0,
+		},
+		{
+			Value:    "STATIC",
+			ErrCount: 0,
+		},
+		{
+			Value:    "static",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validatePublicIpAllocation(tc.Value, "azurerm_public_ip")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Azure RM Public IP allocation to trigger a validation error")
+		}
+	}
+}
+
+func TestResourceAzureRMPublicIpDomainNameLabel_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123-",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(80),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validatePublicIpDomainNameLabel(tc.Value, "azurerm_public_ip")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Azure RM Public IP Domain Name Label to trigger a validation error")
+		}
+	}
+}
+
+func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVPublicIpStatic_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMPublicIpStatic_update(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVPublicIpStatic_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMVPublicIpStatic_update,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_public_ip.test", "domain_name_label", "mylabel01"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMPublicIpDynamic_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVPublicIpDynamic_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMPublicIpExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		availSetName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for public ip: %s", availSetName)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).publicIPClient
+
+		resp, err := conn.Get(resourceGroup, availSetName)
+		if err != nil {
+			return fmt.Errorf("Bad: Get on publicIPClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Public IP %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMPublicIpDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).publicIPClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_public_ip" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(resourceGroup, name)
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Public IP still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+func randomString(strlen int) string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789-"
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(result)
+}
+
+var testAccAzureRMVPublicIpStatic_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_public_ip" "test" {
+    name = "acceptanceTestPublicIp1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+`
+
+var testAccAzureRMVPublicIpStatic_update = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_public_ip" "test" {
+    name = "acceptanceTestPublicIp1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+    domain_name_label = "mylabel01"
+}
+`
+
+var testAccAzureRMVPublicIpDynamic_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup2"
+    location = "West US"
+}
+resource "azurerm_public_ip" "test" {
+    name = "acceptanceTestPublicIp2"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "dynamic"
+}
+`

--- a/website/source/docs/providers/azurerm/r/network_security_group.html.markdown
+++ b/website/source/docs/providers/azurerm/r/network_security_group.html.markdown
@@ -80,4 +80,4 @@ The `security_rule` block supports:
 
 The following attributes are exported:
 
-* `id` - The virtual AvailabilitySet ID.
+* `id` - The Network Security Group ID.

--- a/website/source/docs/providers/azurerm/r/public_ip.html.markdown
+++ b/website/source/docs/providers/azurerm/r/public_ip.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_public_ip"
+sidebar_current: "docs-azurerm-resource-public-ip"
+description: |-
+  Create a Public IP Address.
+---
+
+# azurerm\_public\_ip
+
+Create a Public IP Address.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "resourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "acceptanceTestPublicIp1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the availability set. Changing this forces a
+    new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the availability set.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `public_ip_address_allocation` - (Required) Defines whether the IP address is stable or dynamic. Options are Static or Dynamic.
+
+* `idle_timeout_in_minutes` - (Optional) Specifies the timeout for the TCP idle connection. The value can be set between 4 and 30 minutes.
+
+* `domain_name_label` - (Optional) Label for the Domain Name. Will be used to make up the FQDN.  If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
+
+* `reverse_fqdn` - (Optional) A fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Public IP ID.
+* `ip_address` - The IP address value that was allocated.
+* `fqdn` - Fully qualified domain name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -33,6 +33,10 @@
                           <a href="/docs/providers/azurerm/r/network_security_group.html">azurerm_network_security_group</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-azurerm-resource-public-ip") %>>
+                          <a href="/docs/providers/azurerm/r/public_ip.html">azurerm_public_ip</a>
+                        </li>
+
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
@jen20 Scaffolds the AzureRM Public IP resource

- [x] Schema
- [x] CRUD
- [x] Acceptance Tests
- [x] Documentation

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMPublicIp' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMPublicIp -timeout 120m
=== RUN   TestResourceAzureRMPublicIpAllocation_validation
--- PASS: TestResourceAzureRMPublicIpAllocation_validation (0.00s)
=== RUN   TestResourceAzureRMPublicIpDomainNameLabel_validation
--- PASS: TestResourceAzureRMPublicIpDomainNameLabel_validation (0.00s)
=== RUN   TestAccAzureRMPublicIpStatic_basic
--- PASS: TestAccAzureRMPublicIpStatic_basic (128.95s)
=== RUN   TestAccAzureRMPublicIpStatic_update
--- PASS: TestAccAzureRMPublicIpStatic_update (181.03s)
=== RUN   TestAccAzureRMPublicIpDynamic_basic
--- PASS: TestAccAzureRMPublicIpDynamic_basic (122.72s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	432.718s
```