### PR TITLE
Wrap string in double quotes

### DIFF
--- a/website/source/docs/provisioners/null_resource.html.markdown
+++ b/website/source/docs/provisioners/null_resource.html.markdown
@@ -32,7 +32,7 @@ resource "aws_instance" "cluster" {
 resource "null_resource" "cluster" {
   # Changes to any instance of the cluster requires re-provisioning
   triggers {
-    cluster_instance_ids = "${join(",", aws_instance.cluster.*.id)}"
+    cluster_instance_ids = "${join(",", "aws_instance.cluster.*.id")}"
   }
 
   # Bootstrap script can run on any instance of the cluster
@@ -44,7 +44,7 @@ resource "null_resource" "cluster" {
   provisioner "remote-exec" {
     # Bootstrap script called with private_ip of each node in the clutser
     inline = [
-      "bootstrap-cluster.sh ${join(" ", aws_instance.cluster.*.private_ip}"
+      "bootstrap-cluster.sh ${join(" ", "aws_instance.cluster.*.private_ip"}"
     ]
   }
 }


### PR DESCRIPTION
Without the double quotes terraform produces an error like: `resource variables must be three parts: type.name.attr in (...)`

Maybe the call to `element(...)` also needs double quotes! 