### PR TITLE
Orphan addressing / targeting

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -1647,6 +1647,12 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 								ID: "i-789xyz",
 							},
 						},
+						"aws_instance.nottargeted": &ResourceState{
+							Type: "aws_instance",
+							Primary: &InstanceState{
+								ID: "i-abc123",
+							},
+						},
 					},
 				},
 			},
@@ -1667,8 +1673,150 @@ DESTROY: aws_instance.orphan
 
 STATE:
 
+aws_instance.nottargeted:
+  ID = i-abc123
 aws_instance.orphan:
-  ID = i-789xyz`)
+  ID = i-789xyz
+`)
+	if actual != expected {
+		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
+	}
+}
+
+// https://github.com/hashicorp/terraform/issues/2538
+func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
+	m := testModule(t, "plan-targeted-module-orphan")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: &State{
+			Modules: []*ModuleState{
+				&ModuleState{
+					Path: []string{"root", "child"},
+					Resources: map[string]*ResourceState{
+						"aws_instance.orphan": &ResourceState{
+							Type: "aws_instance",
+							Primary: &InstanceState{
+								ID: "i-789xyz",
+							},
+						},
+						"aws_instance.nottargeted": &ResourceState{
+							Type: "aws_instance",
+							Primary: &InstanceState{
+								ID: "i-abc123",
+							},
+						},
+					},
+				},
+			},
+		},
+		Destroy: true,
+		Targets: []string{"module.child.aws_instance.orphan"},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(`DIFF:
+
+module.child:
+  DESTROY: aws_instance.orphan
+
+STATE:
+
+module.child:
+  aws_instance.nottargeted:
+    ID = i-abc123
+  aws_instance.orphan:
+    ID = i-789xyz
+`)
+	if actual != expected {
+		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
+	}
+}
+
+// https://github.com/hashicorp/terraform/issues/4515
+func TestContext2Plan_targetedOverTen(t *testing.T) {
+	m := testModule(t, "plan-targeted-over-ten")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+
+	resources := make(map[string]*ResourceState)
+	var expectedState []string
+	for i := 0; i < 13; i++ {
+		key := fmt.Sprintf("aws_instance.foo.%d", i)
+		id := fmt.Sprintf("i-abc%d", i)
+		resources[key] = &ResourceState{
+			Type:    "aws_instance",
+			Primary: &InstanceState{ID: id},
+		}
+		expectedState = append(expectedState,
+			fmt.Sprintf("%s:\n  ID = %s\n", key, id))
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: &State{
+			Modules: []*ModuleState{
+				&ModuleState{
+					Path:      rootModulePath,
+					Resources: resources,
+				},
+			},
+		},
+		Targets: []string{"aws_instance.foo[1]"},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	sort.Strings(expectedState)
+	expected := strings.TrimSpace(`
+DIFF:
+
+
+
+STATE:
+
+aws_instance.foo.0:
+  ID = i-abc0
+aws_instance.foo.1:
+  ID = i-abc1
+aws_instance.foo.10:
+  ID = i-abc10
+aws_instance.foo.11:
+  ID = i-abc11
+aws_instance.foo.12:
+  ID = i-abc12
+aws_instance.foo.2:
+  ID = i-abc2
+aws_instance.foo.3:
+  ID = i-abc3
+aws_instance.foo.4:
+  ID = i-abc4
+aws_instance.foo.5:
+  ID = i-abc5
+aws_instance.foo.6:
+  ID = i-abc6
+aws_instance.foo.7:
+  ID = i-abc7
+aws_instance.foo.8:
+  ID = i-abc8
+aws_instance.foo.9:
+  ID = i-abc9
+	`)
 	if actual != expected {
 		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
 	}

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -163,9 +163,8 @@ func (n *GraphNodeConfigResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 		// expand orphans, which have all the same semantics in a destroy
 		// as a primary.
 		steps = append(steps, &OrphanTransformer{
-			State:   state,
-			View:    n.Resource.Id(),
-			Targets: n.Targets,
+			State: state,
+			View:  n.Resource.Id(),
 		})
 
 		steps = append(steps, &DeposedTransformer{
@@ -180,6 +179,12 @@ func (n *GraphNodeConfigResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 			View:  n.Resource.Id(),
 		})
 	}
+
+	// We always want to apply targeting
+	steps = append(steps, &TargetsTransformer{
+		ParsedTargets: n.Targets,
+		Destroy:       n.DestroyMode != DestroyNone,
+	})
 
 	// Always end with the root being added
 	steps = append(steps, &RootTransformer{})

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -28,6 +28,15 @@ func TestParseResourceAddress(t *testing.T) {
 				Index:        2,
 			},
 		},
+		"implicit primary, explicit index over ten": {
+			Input: "aws_instance.foo[12]",
+			Expected: &ResourceAddress{
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        12,
+			},
+		},
 		"explicit primary, explicit index": {
 			Input: "aws_instance.foo.primary[2]",
 			Expected: &ResourceAddress{
@@ -183,6 +192,21 @@ func TestResourceAddressEquals(t *testing.T) {
 				Index:        -1,
 			},
 			Expect: true,
+		},
+		"index over ten": {
+			Address: &ResourceAddress{
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        1,
+			},
+			Other: &ResourceAddress{
+				Type:         "aws_instance",
+				Name:         "foo",
+				InstanceType: TypePrimary,
+				Index:        13,
+			},
+			Expect: false,
 		},
 		"different type": {
 			Address: &ResourceAddress{

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -895,3 +895,57 @@ func TestUpgradeV1State(t *testing.T) {
 		t.Fatalf("bad: %#v", bt)
 	}
 }
+
+func TestParseResourceStateKey(t *testing.T) {
+	cases := []struct {
+		Input       string
+		Expected    *ResourceStateKey
+		ExpectedErr bool
+	}{
+		{
+			Input: "aws_instance.foo.3",
+			Expected: &ResourceStateKey{
+				Type:  "aws_instance",
+				Name:  "foo",
+				Index: 3,
+			},
+		},
+		{
+			Input: "aws_instance.foo.0",
+			Expected: &ResourceStateKey{
+				Type:  "aws_instance",
+				Name:  "foo",
+				Index: 0,
+			},
+		},
+		{
+			Input: "aws_instance.foo",
+			Expected: &ResourceStateKey{
+				Type:  "aws_instance",
+				Name:  "foo",
+				Index: -1,
+			},
+		},
+		{
+			Input:       "aws_instance.foo.malformed",
+			ExpectedErr: true,
+		},
+		{
+			Input:       "aws_instance.foo.malformedwithnumber.123",
+			ExpectedErr: true,
+		},
+		{
+			Input:       "malformed",
+			ExpectedErr: true,
+		},
+	}
+	for _, tc := range cases {
+		rsk, err := ParseResourceStateKey(tc.Input)
+		if rsk != nil && tc.Expected != nil && !rsk.Equal(tc.Expected) {
+			t.Fatalf("%s: expected %s, got %s", tc.Input, tc.Expected, rsk)
+		}
+		if (err != nil) != tc.ExpectedErr {
+			t.Fatalf("%s: expected err: %t, got %s", tc.Input, tc.ExpectedErr, err)
+		}
+	}
+}

--- a/terraform/test-fixtures/plan-targeted-module-orphan/main.tf
+++ b/terraform/test-fixtures/plan-targeted-module-orphan/main.tf
@@ -1,0 +1,6 @@
+# Once opon a time, there was a child module here
+/*
+module "child" {
+  source = "./child"
+}
+*/

--- a/terraform/test-fixtures/plan-targeted-over-ten/main.tf
+++ b/terraform/test-fixtures/plan-targeted-over-ten/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  count    = 13
+}

--- a/terraform/transform_orphan_test.go
+++ b/terraform/transform_orphan_test.go
@@ -333,17 +333,18 @@ func TestGraphNodeOrphanResource_impl(t *testing.T) {
 	var _ dag.Vertex = new(graphNodeOrphanResource)
 	var _ dag.NamedVertex = new(graphNodeOrphanResource)
 	var _ GraphNodeProviderConsumer = new(graphNodeOrphanResource)
+	var _ GraphNodeAddressable = new(graphNodeOrphanResource)
 }
 
 func TestGraphNodeOrphanResource_ProvidedBy(t *testing.T) {
-	n := &graphNodeOrphanResource{ResourceName: "aws_instance.foo"}
+	n := &graphNodeOrphanResource{ResourceKey: &ResourceStateKey{Type: "aws_instance"}}
 	if v := n.ProvidedBy(); v[0] != "aws" {
 		t.Fatalf("bad: %#v", v)
 	}
 }
 
 func TestGraphNodeOrphanResource_ProvidedBy_alias(t *testing.T) {
-	n := &graphNodeOrphanResource{ResourceName: "aws_instance.foo", Provider: "aws.bar"}
+	n := &graphNodeOrphanResource{ResourceKey: &ResourceStateKey{Type: "aws_instance"}, Provider: "aws.bar"}
 	if v := n.ProvidedBy(); v[0] != "aws.bar" {
 		t.Fatalf("bad: %#v", v)
 	}

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -13,20 +13,25 @@ type TargetsTransformer struct {
 	// List of targeted resource names specified by the user
 	Targets []string
 
+	// List of parsed targets, provided by callers like ResourceCountTransform
+	// that already have the targets parsed
+	ParsedTargets []ResourceAddress
+
 	// Set to true when we're in a `terraform destroy` or a
 	// `terraform plan -destroy`
 	Destroy bool
 }
 
 func (t *TargetsTransformer) Transform(g *Graph) error {
-	if len(t.Targets) > 0 {
-		// TODO: duplicated in OrphanTransformer; pull up parsing earlier
+	if len(t.Targets) > 0 && len(t.ParsedTargets) == 0 {
 		addrs, err := t.parseTargetAddresses()
 		if err != nil {
 			return err
 		}
-
-		targetedNodes, err := t.selectTargetedNodes(g, addrs)
+		t.ParsedTargets = addrs
+	}
+	if len(t.ParsedTargets) > 0 {
+		targetedNodes, err := t.selectTargetedNodes(g, t.ParsedTargets)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Instead of trying to skip non-targeted orphans as they are added to
the graph in OrphanTransformer, remove knowledge of targeting from
OrphanTransformer and instead make the orphan resource nodes properly
addressable.

That allows us to use existing logic in TargetTransformer to filter out
the nodes appropriately. This does require adding TargetTransformer to the
list of transforms that run during DynamicExpand so that targeting can
be applied to nodes with expanded counts.

Fixes #4515
Fixes #2538
Fixes #4462