### PR TITLE
provider/google: Clarify SQL database name cannot be reused

### DIFF
--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"google.golang.org/api/googleapi"
@@ -20,7 +21,8 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"master_instance_name": &schema.Schema{
@@ -233,7 +235,6 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	name := d.Get("name").(string)
 	region := d.Get("region").(string)
 	databaseVersion := d.Get("database_version").(string)
 
@@ -378,10 +379,16 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	instance := &sqladmin.DatabaseInstance{
-		Name:            name,
 		Region:          region,
 		Settings:        settings,
 		DatabaseVersion: databaseVersion,
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		instance.Name = v.(string)
+	} else {
+		instance.Name = resource.UniqueId()
+		d.Set("name", instance.Name)
 	}
 
 	if v, ok := d.GetOk("replica_configuration"); ok {
@@ -446,7 +453,11 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	op, err := config.clientSqlAdmin.Instances.Insert(config.Project, instance).Do()
 	if err != nil {
-		return fmt.Errorf("Error, failed to create instance %s: %s", name, err)
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 409 {
+			return fmt.Errorf("Error, the name %s is unavailable because it was used recently", instance.Name)
+		} else {
+			return fmt.Errorf("Error, failed to create instance %s: %s", instance.Name, err)
+		}
 	}
 
 	err = sqladminOperationWait(config, op, "Create Instance")

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -41,6 +41,27 @@ func TestAccGoogleSqlDatabaseInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccGoogleSqlDatabaseInstance_basic2(t *testing.T) {
+	var instance sqladmin.DatabaseInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleSqlDatabaseInstance_basic2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleSqlDatabaseInstanceExists(
+						"google_sql_database_instance.instance", &instance),
+					testAccCheckGoogleSqlDatabaseInstanceEquals(
+						"google_sql_database_instance.instance", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGoogleSqlDatabaseInstance_settings_basic(t *testing.T) {
 	var instance sqladmin.DatabaseInstance
 	databaseID := genRandInt()
@@ -332,6 +353,16 @@ func testAccGoogleSqlDatabaseInstanceDestroy(s *terraform.State) error {
 var testGoogleSqlDatabaseInstance_basic = `
 resource "google_sql_database_instance" "instance" {
 	name = "tf-lw-%d"
+	region = "us-central"
+	settings {
+		tier = "D0"
+		crash_safe_replication = false
+	}
+}
+`
+
+var testGoogleSqlDatabaseInstance_basic2 = `
+resource "google_sql_database_instance" "instance" {
 	region = "us-central"
 	settings {
 		tier = "D0"

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -28,7 +28,10 @@ resource "google_sql_database_instance" "master" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the instance.
+* `name` - (Optional, Computed) The name of the instance. If the name is left
+  blank, Terraform will randomly generate one when the instance is first
+  created. This is done because after a name is used, it cannot be reused 
+  for up to [two months](https://cloud.google.com/sql/docs/delete-instance).
 
 * `region` - (Required) The region the instance will sit in. Note, this does
   not line up with the Google Compute Engine (GCE) regions - your options are


### PR DESCRIPTION
Fixes issue found by @gtaylor in #4557.