### PR TITLE
provider/azurerm: add subnet resource

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_network_security_group": resourceArmNetworkSecurityGroup(),
 			"azurerm_network_security_rule":  resourceArmNetworkSecurityRule(),
 			"azurerm_public_ip":              resourceArmPublicIp(),
+			"azurerm_subnet":                 resourceArmSubnet(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -1,0 +1,188 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmSubnet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmSubnetCreate,
+		Read:   resourceArmSubnetRead,
+		Update: resourceArmSubnetCreate,
+		Delete: resourceArmSubnetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"virtual_network_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"address_prefix": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"network_security_group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"route_table_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"ip_configurations": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceArmSubnetCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	subnetClient := client.subnetClient
+
+	log.Printf("[INFO] preparing arguments for Azure ARM Subnet creation.")
+
+	name := d.Get("name").(string)
+	vnetName := d.Get("virtual_network_name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	addressPrefix := d.Get("address_prefix").(string)
+
+	armMutexKV.Lock(vnetName)
+	defer armMutexKV.Unlock(vnetName)
+
+	properties := network.SubnetPropertiesFormat{
+		AddressPrefix: &addressPrefix,
+	}
+
+	if v, ok := d.GetOk("network_security_group_id"); ok {
+		nsgId := v.(string)
+		properties.NetworkSecurityGroup = &network.SecurityGroup{
+			ID: &nsgId,
+		}
+	}
+
+	if v, ok := d.GetOk("route_table_id"); ok {
+		rtId := v.(string)
+		properties.RouteTable = &network.RouteTable{
+			ID: &rtId,
+		}
+	}
+
+	subnet := network.Subnet{
+		Name:       &name,
+		Properties: &properties,
+	}
+
+	resp, err := subnetClient.CreateOrUpdate(resGroup, vnetName, name, subnet)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ID)
+
+	log.Printf("[DEBUG] Waiting for Subnet (%s) to become available", name)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  "Succeeded",
+		Refresh: subnetRuleStateRefreshFunc(client, resGroup, vnetName, name),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Subnet (%s) to become available: %s", name, err)
+	}
+
+	return resourceArmSubnetRead(d, meta)
+}
+
+func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
+	subnetClient := meta.(*ArmClient).subnetClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	vnetName := id.Path["virtualNetworks"]
+	name := id.Path["subnets"]
+
+	resp, err := subnetClient.Get(resGroup, vnetName, name, "")
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Subnet %s: %s", name, err)
+	}
+
+	if resp.Properties.IPConfigurations != nil && len(*resp.Properties.IPConfigurations) > 0 {
+		ips := make([]string, 0, len(*resp.Properties.IPConfigurations))
+		for _, ip := range *resp.Properties.IPConfigurations {
+			ips = append(ips, *ip.ID)
+		}
+
+		if err := d.Set("ip_configurations", ips); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceArmSubnetDelete(d *schema.ResourceData, meta interface{}) error {
+	subnetClient := meta.(*ArmClient).subnetClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["subnets"]
+	vnetName := id.Path["virtualNetworks"]
+
+	armMutexKV.Lock(vnetName)
+	defer armMutexKV.Unlock(vnetName)
+
+	_, err = subnetClient.Delete(resGroup, vnetName, name)
+
+	return err
+}
+
+func subnetRuleStateRefreshFunc(client *ArmClient, resourceGroupName string, virtualNetworkName string, subnetName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.subnetClient.Get(resourceGroupName, virtualNetworkName, subnetName, "")
+		if err != nil {
+			return nil, "", fmt.Errorf("Error issuing read request in subnetRuleStateRefreshFunc to Azure ARM for subnet '%s' (RG: '%s') (VNN: '%s'): %s", subnetName, resourceGroupName, virtualNetworkName, err)
+		}
+
+		return res, *res.Properties.ProvisioningState, nil
+	}
+}

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -1,0 +1,104 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMSubnet_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMSubnet_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		vnetName := rs.Primary.Attributes["virtual_network_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).subnetClient
+
+		resp, err := conn.Get(resourceGroup, vnetName, name, "")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on subnetClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMSubnetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).subnetClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_subnet" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		vnetName := rs.Primary.Attributes["virtual_network_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(resourceGroup, vnetName, name, "")
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Subnet still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMSubnet_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acceptanceTestVirtualNetwork1"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "testsubnet"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+`

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -42,7 +42,8 @@ func resourceArmVirtualNetwork() *schema.Resource {
 
 			"subnet": &schema.Schema{
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{

--- a/website/source/docs/providers/azurerm/r/subnet.html.markdown
+++ b/website/source/docs/providers/azurerm/r/subnet.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azure_subnet"
+sidebar_current: "docs-azurerm-resource-subnet"
+description: |-
+  Creates a new subnet. Subnets represent network segments within the IP space defined by the virtual network.
+---
+
+# azurerm\_subnet
+
+Creates a new subnet. Subnets represent network segments within the IP space defined by the virtual network.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acceptanceTestVirtualNetwork1"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "testsubnet"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.1.0/24"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the virtual network. Changing this forces a
+    new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the subnet.
+
+* `virtual_network_name` - (Required) The name of the virtual network to which to attach the subnet.
+
+* `address_prefix` - (Required) The address prefix to use for the subnet.
+
+* `network_security_group_id` - (Optional) The ID of the Network Security Group to associate with
+    the subnet.
+    
+* `route_table_id` - (Optional) The ID of the Route Table to associate with
+    the subnet.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The subnet ID.
+* `ip_configurations` - The collection of IP Configurations with IPs within this subnet.

--- a/website/source/docs/providers/azurerm/r/virtual_network.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_network.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `dns_servers` - (Optional) List of names of DNS servers previously registered
     on Azure.
 
-* `subnet` - (Required) Can be specified multiple times to define multiple
+* `subnet` - (Optional) Can be specified multiple times to define multiple
     subnets. Each `subnet` block supports fields documented below.
 
 The `subnet` block supports:

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -41,6 +41,10 @@
                           <a href="/docs/providers/azurerm/r/public_ip.html">azurerm_public_ip</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-azurerm-resource-subnet") %>>
+                          <a href="/docs/providers/azurerm/r/subnet.html">azurerm_subnet</a>
+                        </li>
+
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
@jen20 Scaffold the Azure RM Subnet resource

- [x] Schema
- [x] CRUD
- [x] Acceptance Tests
- [x] Documentation

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMSubnet' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMSubnet -timeout 120m
=== RUN   TestAccAzureRMSubnet_basic
--- PASS: TestAccAzureRMSubnet_basic (132.11s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	132.123s
```

the changes to the virtual_network resource is to mark subnets as Optional as they will compete with the use of azurerm_subnet

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMVirtualNetwork' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMVirtualNetwork -timeout 120m
=== RUN   TestAccAzureRMVirtualNetwork_basic
--- PASS: TestAccAzureRMVirtualNetwork_basic (125.13s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	125.140s
```