### PR TITLE
provider/aws: Recurring plans with Elastic Beanstalk

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
@@ -109,6 +109,6 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
   name = "tf-test-template-config"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
 }
 `

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -356,7 +356,7 @@ func resourceAwsElasticBeanstalkEnvironmentSettingsRead(d *schema.ResourceData, 
 		return err
 	}
 
-	if err := d.Set("setting", updatedSettingsKeySet.List()); err != nil {
+	if err := d.Set("setting", updatedSettings.List()); err != nil {
 		return err
 	}
 
@@ -438,9 +438,7 @@ func optionSettingValueHash(v interface{}) int {
 	optionName := rd["name"].(string)
 	value, _ := rd["value"].(string)
 	hk := fmt.Sprintf("%s:%s=%s", namespace, optionName, sortValues(value))
-	if optionName == "Subnets" {
-		log.Printf("[DEBUG] Elastic Beanstalk optionSettingValueHash(%#v): hk=%s,hc=%d", v, hk, hashcode.String(hk))
-	}
+	log.Printf("[DEBUG] Elastic Beanstalk optionSettingValueHash(%#v): %s: hk=%s,hc=%d", v, optionName,hk, hashcode.String(hk))
 	return hashcode.String(hk)
 }
 
@@ -448,8 +446,9 @@ func optionSettingKeyHash(v interface{}) int {
 	rd := v.(map[string]interface{})
 	namespace := rd["namespace"].(string)
 	optionName := rd["name"].(string)
-	value, _ := rd["value"].(string)
-	return hashcode.String(fmt.Sprintf("%s:%s=%s", namespace, optionName, sortValues(value)))
+	hk := fmt.Sprintf("%s:%s", namespace, optionName)
+	log.Printf("[DEBUG] Elastic Beanstalk optionSettingKeyHash(%#v): %s: hk=%s,hc=%d", v, optionName,hk, hashcode.String(hk))
+	return hashcode.String(hk)
 }
 
 func sortValues(v string) string {

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"strings"
+	"sort"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -435,7 +437,7 @@ func optionSettingValueHash(v interface{}) int {
 	namespace := rd["namespace"].(string)
 	optionName := rd["name"].(string)
 	value, _ := rd["value"].(string)
-	hk := fmt.Sprintf("%s:%s=%s", namespace, optionName, value)
+	hk := fmt.Sprintf("%s:%s=%s", namespace, optionName, sortValues(value))
 	if optionName == "Subnets" {
 		log.Printf("[DEBUG] Elastic Beanstalk optionSettingValueHash(%#v): hk=%s,hc=%d", v, hk, hashcode.String(hk))
 	}
@@ -447,7 +449,13 @@ func optionSettingKeyHash(v interface{}) int {
 	namespace := rd["namespace"].(string)
 	optionName := rd["name"].(string)
 	value, _ := rd["value"].(string)
-	return hashcode.String(fmt.Sprintf("%s:%s=%s", namespace, optionName, value))
+	return hashcode.String(fmt.Sprintf("%s:%s=%s", namespace, optionName, sortValues(value)))
+}
+
+func sortValues(v string) string {
+	values := strings.Split(v, ",")
+	sort.Strings(values)
+	return strings.Join(values, ",")
 }
 
 func extractOptionSettings(s *schema.Set) []*elasticbeanstalk.ConfigurationOptionSetting {

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -105,7 +105,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name = "tf-test-name"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
   #solution_stack_name =
 }
 `


### PR DESCRIPTION
For some option setting values the Elastic Beanstalk api returns a list. This list may not be returned in the same order that the option was created with. We should sort the list so the Value and Key hashes are the same when creating and reading the option setting resource. Doing this prevents recurring plans where certain option values will always have a change detected.

This happens when values are interpolated from remote state or resources, but not if you are just defining a variable in a string like `"subnet-aaaaaaaa,subnet-bbbbbbbb"`.

Example document to create the issue:

```
variable "cidr" {
  default = "10.10.0.0/16"
}

variable "cidrs" {
  default = "10.10.0.0/24,10.10.1.0/24"
}

variable "azs" {
  default = "us-east-1a,us-east-1b"
}

variable "region" {
  default = "us-east-1"
}

variable "name" {
  default = "recurring_plan_test"
}

provider "aws" {
  region = "us-east-1"
}

resource "aws_vpc" "default" {
  cidr_block           = "${var.cidr}"
  enable_dns_support   = true
  enable_dns_hostnames = true
}

resource "aws_internet_gateway" "public" {
  vpc_id = "${aws_vpc.default.id}"

  tags { Name = "${var.name}" }
}

resource "aws_subnet" "public" {
  vpc_id            = "${aws_vpc.default.id}"
  cidr_block        = "${element(split(",", var.cidrs), count.index)}"
  availability_zone = "${element(split(",", var.azs), count.index)}"
  count             = "${length(split(",", var.cidrs))}"

  map_public_ip_on_launch = true

  tags {
    Name = "${var.name}.${element(split(",", var.azs), count.index)}"
  }
}

resource "aws_route_table" "public" {
  vpc_id = "${aws_vpc.default.id}"

  route {
    cidr_block = "0.0.0.0/0"
    gateway_id = "${aws_internet_gateway.public.id}"
  }

  tags {
    Name = "${var.name}.${element(split(",", var.azs), count.index)}"
  }
}

resource "aws_route_table_association" "public" {
  count          = "${length(split(",", var.cidrs))}"
  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
  route_table_id = "${aws_route_table.public.id}"
}

resource "aws_elastic_beanstalk_application" "default" {
  name        = "tf-test-name"
  description = "tf-test-desc"
}

resource "aws_elastic_beanstalk_environment" "default" {
  name                = "tf-test-name"
  application         = "${aws_elastic_beanstalk_application.default.name}"
  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"

  setting {
    namespace = "aws:autoscaling:asg"
    name      = "MinSize"
    value     = "1"
  }

  setting {
    namespace = "aws:autoscaling:asg"
    name      = "MaxSize"
    value     = "2"
  }

  setting {
    namespace = "aws:ec2:vpc"
    name      = "VPCId"
    value     = "${aws_vpc.default.id}"
  }

  setting {
    namespace = "aws:ec2:vpc"
    name      = "ELBSubnets"
    value     = "${join(",", aws_subnet.public.*.id)}"
  }

  setting {
    namespace = "aws:ec2:vpc"
    name      = "Subnets"
    value     = "${join(",", aws_subnet.public.*.id)}"
  }
}
```

Expected Results:

```
$ terraform apply
aws_elastic_beanstalk_application.default: Creating...
  description: "" => "tf-test-desc"
  name:        "" => "tf-test-name"
aws_vpc.default: Creating...
  cidr_block:                "" => "10.10.0.0/16"
  default_network_acl_id:    "" => "<computed>"
  default_security_group_id: "" => "<computed>"
  dhcp_options_id:           "" => "<computed>"
  enable_dns_hostnames:      "" => "1"
  enable_dns_support:        "" => "1"
  main_route_table_id:       "" => "<computed>"
aws_elastic_beanstalk_application.default: Creation complete
aws_vpc.default: Creation complete
aws_internet_gateway.public: Creating...
  tags.#:    "0" => "1"
  tags.Name: "" => "recurring_plan_test"
  vpc_id:    "" => "vpc-xxxxxxxx"
aws_subnet.public.1: Creating...
  availability_zone:       "" => "us-east-1b"
  cidr_block:              "" => "10.10.1.0/24"
  map_public_ip_on_launch: "" => "1"
  tags.#:                  "" => "1"
  tags.Name:               "" => "recurring_plan_test.us-east-1b"
  vpc_id:                  "" => "vpc-xxxxxxxx"
aws_subnet.public.0: Creating...
  availability_zone:       "" => "us-east-1a"
  cidr_block:              "" => "10.10.0.0/24"
  map_public_ip_on_launch: "" => "1"
  tags.#:                  "" => "1"
  tags.Name:               "" => "recurring_plan_test.us-east-1a"
  vpc_id:                  "" => "vpc-xxxxxxxx"
aws_internet_gateway.public: Creation complete
aws_route_table.public: Creating...
  route.#:                                   "" => "1"
  route.277943721.cidr_block:                "" => "0.0.0.0/0"
  route.277943721.gateway_id:                "" => "igw-xxxxxxxx"
  route.277943721.instance_id:               "" => ""
  route.277943721.network_interface_id:      "" => ""
  route.277943721.vpc_peering_connection_id: "" => ""
  tags.#:                                    "" => "1"
  tags.Name:                                 "" => "recurring_plan_test.us-east-1a"
  vpc_id:                                    "" => "vpc-xxxxxxxx"
aws_subnet.public.1: Creation complete
aws_subnet.public.0: Creation complete
aws_elastic_beanstalk_environment.default: Creating...
  all_settings.#:               "" => "<computed>"
  application:                  "" => "tf-test-name"
  cname:                        "" => "<computed>"
  name:                         "" => "tf-test-name"
  setting.#:                    "" => "5"
  setting.2054203407.name:      "" => "VPCId"
  setting.2054203407.namespace: "" => "aws:ec2:vpc"
  setting.2054203407.value:     "" => "vpc-xxxxxxxx"
  setting.2396587397.name:      "" => "MinSize"
  setting.2396587397.namespace: "" => "aws:autoscaling:asg"
  setting.2396587397.value:     "" => "1"
  setting.3194658499.name:      "" => "ELBSubnets"
  setting.3194658499.namespace: "" => "aws:ec2:vpc"
  setting.3194658499.value:     "" => "subnet-aaaaaaaa,subnet-bbbbbbbb"
  setting.3225151102.name:      "" => "MaxSize"
  setting.3225151102.namespace: "" => "aws:autoscaling:asg"
  setting.3225151102.value:     "" => "2"
  setting.581185794.name:       "" => "Subnets"
  setting.581185794.namespace:  "" => "aws:ec2:vpc"
  setting.581185794.value:      "" => "subnet-aaaaaaaa,subnet-bbbbbbbb"
  solution_stack_name:          "" => "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
aws_route_table.public: Creation complete
aws_route_table_association.public.1: Creating...
  route_table_id: "" => "rtb-xxxxxxxx"
  subnet_id:      "" => "subnet-bbbbbbbb"
aws_route_table_association.public.0: Creating...
  route_table_id: "" => "rtb-xxxxxxxx"
  subnet_id:      "" => "subnet-aaaaaaaa"
aws_route_table_association.public.1: Creation complete
aws_route_table_association.public.0: Creation complete
aws_elastic_beanstalk_environment.default: Creation complete

Apply complete! Resources: 9 added, 0 changed, 0 destroyed.


$ terraform plan 
Refreshing Terraform state prior to plan...

aws_vpc.default: Refreshing state... (ID: vpc-xxxxxxxx)
aws_elastic_beanstalk_application.default: Refreshing state... (ID: tf-test-name)
aws_internet_gateway.public: Refreshing state... (ID: igw-xxxxxxxx)
aws_subnet.public.0: Refreshing state... (ID: subnet-aaaaaaaa)
aws_subnet.public.1: Refreshing state... (ID: subnet-bbbbbbbb)
aws_route_table.public: Refreshing state... (ID: rtb-xxxxxxxx)
aws_elastic_beanstalk_environment.default: Refreshing state... (ID: e-w3jrxnsib3)
aws_route_table_association.public.1: Refreshing state... (ID: rtbassoc-xxxxxxxx)
aws_route_table_association.public.0: Refreshing state... (ID: rtbassoc-xxxxxxxy)

No changes. Infrastructure is up-to-date. This means that Terraform
could not detect any differences between your configuration and
the real physical resources that exist. As a result, Terraform
doesn't need to do anything. 
```

Actual Results:

```
$ terraform apply
aws_vpc.default: Creating...
  cidr_block:                "" => "10.10.0.0/16"
  default_network_acl_id:    "" => "<computed>"
  default_security_group_id: "" => "<computed>"
  dhcp_options_id:           "" => "<computed>"
  enable_dns_hostnames:      "" => "1"
  enable_dns_support:        "" => "1"
  main_route_table_id:       "" => "<computed>"
aws_elastic_beanstalk_application.default: Creating...
  description: "" => "tf-test-desc"
  name:        "" => "tf-test-name"
aws_elastic_beanstalk_application.default: Creation complete
aws_vpc.default: Creation complete
aws_internet_gateway.public: Creating...
  tags.#:    "0" => "1"
  tags.Name: "" => "recurring_plan_test"
  vpc_id:    "" => "vpc-xxxxxxxx"
aws_subnet.public.0: Creating...
  availability_zone:       "" => "us-east-1a"
  cidr_block:              "" => "10.10.0.0/24"
  map_public_ip_on_launch: "" => "1"
  tags.#:                  "" => "1"
  tags.Name:               "" => "recurring_plan_test.us-east-1a"
  vpc_id:                  "" => "vpc-xxxxxxxx"
aws_subnet.public.1: Creating...
  availability_zone:       "" => "us-east-1b"
  cidr_block:              "" => "10.10.1.0/24"
  map_public_ip_on_launch: "" => "1"
  tags.#:                  "" => "1"
  tags.Name:               "" => "recurring_plan_test.us-east-1b"
  vpc_id:                  "" => "vpc-xxxxxxxx"
aws_internet_gateway.public: Creation complete
aws_route_table.public: Creating...
  route.#:                                    "" => "1"
  route.1040895054.cidr_block:                "" => "0.0.0.0/0"
  route.1040895054.gateway_id:                "" => "igw-xxxxxxxx"
  route.1040895054.instance_id:               "" => ""
  route.1040895054.network_interface_id:      "" => ""
  route.1040895054.vpc_peering_connection_id: "" => ""
  tags.#:                                     "" => "1"
  tags.Name:                                  "" => "recurring_plan_test.us-east-1a"
  vpc_id:                                     "" => "vpc-xxxxxxxx"
aws_subnet.public.1: Creation complete
aws_subnet.public.0: Creation complete
aws_elastic_beanstalk_environment.default: Creating...
  all_settings.#:               "" => "<computed>"
  application:                  "" => "tf-test-name"
  cname:                        "" => "<computed>"
  name:                         "" => "tf-test-name"
  setting.#:                    "" => "5"
  setting.1636676030.name:      "" => "Subnets"
  setting.1636676030.namespace: "" => "aws:ec2:vpc"
  setting.1636676030.value:     "" => "subnet-aaaaaaaa,subnet-bbbbbbbb"
  setting.2396587397.name:      "" => "MinSize"
  setting.2396587397.namespace: "" => "aws:autoscaling:asg"
  setting.2396587397.value:     "" => "1"
  setting.3225151102.name:      "" => "MaxSize"
  setting.3225151102.namespace: "" => "aws:autoscaling:asg"
  setting.3225151102.value:     "" => "2"
  setting.4127213107.name:      "" => "VPCId"
  setting.4127213107.namespace: "" => "aws:ec2:vpc"
  setting.4127213107.value:     "" => "vpc-xxxxxxxx"
  setting.4249034367.name:      "" => "ELBSubnets"
  setting.4249034367.namespace: "" => "aws:ec2:vpc"
  setting.4249034367.value:     "" => "subnet-aaaaaaaa,subnet-bbbbbbbb"
  solution_stack_name:          "" => "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
aws_route_table.public: Creation complete
aws_route_table_association.public.1: Creating...
  route_table_id: "" => "rtb-xxxxxxxx5"
  subnet_id:      "" => "subnet-bbbbbbbb"
aws_route_table_association.public.0: Creating...
  route_table_id: "" => "rtb-xxxxxxxx5"
  subnet_id:      "" => "subnet-aaaaaaaa"
aws_route_table_association.public.1: Creation complete
aws_route_table_association.public.0: Creation complete
aws_elastic_beanstalk_environment.default: Creation complete

Apply complete! Resources: 9 added, 0 changed, 0 destroyed.


$ terraform plan 
Refreshing Terraform state prior to plan...

aws_vpc.default: Refreshing state... (ID: vpc-xxxxxxxx)
aws_elastic_beanstalk_application.default: Refreshing state... (ID: tf-test-name)
aws_internet_gateway.public: Refreshing state... (ID: igw-xxxxxxxx)
aws_subnet.public.1: Refreshing state... (ID: subnet-bbbbbbbb)
aws_subnet.public.0: Refreshing state... (ID: subnet-aaaaaaaa)
aws_route_table.public: Refreshing state... (ID: rtb-xxxxxxxx5)
aws_route_table_association.public.1: Refreshing state... (ID: rtbassoc-xxxxxxxx)
aws_route_table_association.public.0: Refreshing state... (ID: rtbassoc-xxxxxxxy)
aws_elastic_beanstalk_environment.default: Refreshing state... (ID: e-8yimid4k2j)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

~ aws_elastic_beanstalk_environment.default
    setting.#:                    "3" => "5"
    setting.1636676030.name:      "" => "Subnets"
    setting.1636676030.namespace: "" => "aws:ec2:vpc"
    setting.1636676030.value:     "" => "subnet-aaaaaaaa,subnet-bbbbbbbb"
    setting.2396587397.name:      "MinSize" => "MinSize"
    setting.2396587397.namespace: "aws:autoscaling:asg" => "aws:autoscaling:asg"
    setting.2396587397.value:     "1" => "1"
    setting.3225151102.name:      "MaxSize" => "MaxSize"
    setting.3225151102.namespace: "aws:autoscaling:asg" => "aws:autoscaling:asg"
    setting.3225151102.value:     "2" => "2"
    setting.4127213107.name:      "VPCId" => "VPCId"
    setting.4127213107.namespace: "aws:ec2:vpc" => "aws:ec2:vpc"
    setting.4127213107.value:     "vpc-xxxxxxxx" => "vpc-xxxxxxxx"
    setting.4249034367.name:      "" => "ELBSubnets"
    setting.4249034367.namespace: "" => "aws:ec2:vpc"
    setting.4249034367.value:     "" => "subnet-aaaaaaaa,subnet-bbbbbbbb"


Plan: 0 to add, 1 to change, 0 to destroy.
```
