### PR TITLE
Organises the AzureRM layout to Network and Virtual Machine resources

### DIFF
--- a/website/source/docs/providers/azurerm/r/availability_set.html.markdown
+++ b/website/source/docs/providers/azurerm/r/availability_set.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_availability_set"
-sidebar_current: "docs-azurerm-resource-availability-set"
+sidebar_current: "docs-azurerm-resource-virtualmachine-availability-set"
 description: |-
   Create an availability set for virtual machines.
 ---

--- a/website/source/docs/providers/azurerm/r/public_ip.html.markdown
+++ b/website/source/docs/providers/azurerm/r/public_ip.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ip"
-sidebar_current: "docs-azurerm-resource-public-ip"
+sidebar_current: "docs-azurerm-resource-network-public-ip"
 description: |-
   Create a Public IP Address.
 ---

--- a/website/source/docs/providers/azurerm/r/subnet.html.markdown
+++ b/website/source/docs/providers/azurerm/r/subnet.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azure_subnet"
-sidebar_current: "docs-azurerm-resource-subnet"
+sidebar_current: "docs-azurerm-resource-network-subnet"
 description: |-
   Creates a new subnet. Subnets represent network segments within the IP space defined by the virtual network.
 ---

--- a/website/source/docs/providers/azurerm/r/virtual_network.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_network.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azure_virtual_network"
-sidebar_current: "docs-azurerm-resource-virtual-network"
+sidebar_current: "docs-azurerm-resource-network-virtual-network"
 description: |-
   Creates a new virtual network including any configured subnets. Each subnet can optionally be configured with a security group to be associated with the subnet.
 ---

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -10,43 +10,52 @@
                     <a href="/docs/providers/azurerm/index.html">Azure Resource Manager Provider</a>
                 </li>
 
-                <li<%= sidebar_current(/^docs-azurerm-resource/) %>>
-                    <a href="#">Resources</a>
-                    <ul class="nav nav-visible">
-                        <li<%= sidebar_current("docs-azurerm-resource-resource-group") %>>
-                            <a href="/docs/providers/azurerm/r/resource_group.html">azurerm_resource_group</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-azurerm-resource-virtual-network") %>>
-                            <a href="/docs/providers/azurerm/r/virtual_network.html">azurerm_virtual_network</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-azurerm-resource-local-network-gateway") %>>
-                            <a href="/docs/providers/azurerm/r/local_network_gateway.html">azurerm_local_network_gateway</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-azurerm-resource-availability-set") %>>
-                          <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-azurerm-resource-network-security-group") %>>
-                          <a href="/docs/providers/azurerm/r/network_security_group.html">azurerm_network_security_group</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-azurerm-resource-network-security-rule") %>>
-                          <a href="/docs/providers/azurerm/r/network_security_rule.html">azurerm_network_security_rule</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-azurerm-resource-public-ip") %>>
-                          <a href="/docs/providers/azurerm/r/public_ip.html">azurerm_public_ip</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-azurerm-resource-subnet") %>>
-                          <a href="/docs/providers/azurerm/r/subnet.html">azurerm_subnet</a>
-                        </li>
-
-                    </ul>
+                <li<%= sidebar_current("docs-azurerm-resource-resource-group") %>>
+                  <a href="/docs/providers/azurerm/r/resource_group.html">azurerm_resource_group</a>
                 </li>
+
+                <li<%= sidebar_current(/^docs-azurerm-resource-network/) %>>
+                  <a href="#">Network Resources</a>
+                  <ul class="nav nav-visible">
+
+                    <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network") %>>
+                      <a href="/docs/providers/azurerm/r/virtual_network.html">azurerm_virtual_network</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-azurerm-resource-network-security-group") %>>
+                      <a href="/docs/providers/azurerm/r/network_security_group.html">azurerm_network_security_group</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-azurerm-resource-network-security-rule") %>>
+                      <a href="/docs/providers/azurerm/r/network_security_rule.html">azurerm_network_security_rule</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-azurerm-resource-network-public-ip") %>>
+                      <a href="/docs/providers/azurerm/r/public_ip.html">azurerm_public_ip</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-azurerm-resource-network-subnet") %>>
+                      <a href="/docs/providers/azurerm/r/subnet.html">azurerm_subnet</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-azurerm-resource-local-network-gateway") %>>
+                      <a href="/docs/providers/azurerm/r/local_network_gateway.html">azurerm_local_network_gateway</a>
+                    </li>
+
+                  </ul>
+                </li>
+
+                <li<%= sidebar_current(/^docs-azurerm-resource-virtualmachine/) %>>
+                  <a href="#">Virtual Machine Resources</a>
+                  <ul class="nav nav-visible">
+
+                    <li<%= sidebar_current("docs-azurerm-resource-virtualmachine-availability-set") %>>
+                      <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
+                    </li>
+
+                  </ul>
+                </li>
+              
             </ul>
         </div>
     <% end %>


### PR DESCRIPTION
Makes the docs layout look as follows:

<img width="336" alt="screen shot 2016-01-10 at 01 09 33" src="https://cloud.githubusercontent.com/assets/227823/12219330/ec23d6f8-b736-11e5-801a-f9ea667c38c3.png">
