### PR TITLE
Adding "named_port" support to Google's instance_group_manager.

### DIFF
--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -57,7 +57,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 						"google_compute_instance_group_manager.igm-update", &manager),
 					testAccCheckInstanceGroupManagerNamedPorts(
 						"google_compute_instance_group_manager.igm-update",
-						map[string]int64{"customHTTP": 8080},
+						map[string]int64{"customhttp": 8080},
 						&manager),
 				),
 			},
@@ -71,7 +71,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 						"google_compute_target_pool.igm-update", template2),
 					testAccCheckInstanceGroupManagerNamedPorts(
 						"google_compute_instance_group_manager.igm-update",
-						map[string]int64{"customHTTP": 8080, "customHTTPs": 8443},
+						map[string]int64{"customhttp": 8080, "customhttps": 8443},
 						&manager),
 				),
 			},
@@ -297,7 +297,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		zone = "us-central1-c"
 		target_size = 2
 		named_port {
-			name = "customHTTP"
+			name = "customhttp"
 			port = 8080
 		}
 	}`, template, target, igm)
@@ -371,11 +371,11 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		zone = "us-central1-c"
 		target_size = 3
 		named_port {
-			name = "customHTTP"
+			name = "customhttp"
 			port = 8080
 		}
 		named_port {
-			name = "customHTTPs"
+			name = "customhttps"
 			port = 8443
 		}
 	}`, template1, target, template2, igm)

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -252,6 +252,10 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		base_instance_name = "igm-update"
 		zone = "us-central1-c"
 		target_size = 2
+		named_port {
+			name = "customHTTP"
+			port = 8888
+		}
 	}`, template, target, igm)
 }
 
@@ -322,5 +326,13 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		base_instance_name = "igm-update"
 		zone = "us-central1-c"
 		target_size = 3
+		named_port {
+			name = "customHTTP"
+			port = 8888
+		}
+		named_port {
+			name = "customHTTPs"
+			port = 8889
+		}
 	}`, template1, target, template2, igm)
 }

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -55,6 +55,10 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-update", &manager),
+					testAccCheckInstanceGroupManagerNamedPorts(
+						"google_compute_instance_group_manager.igm-update",
+						map[string]int64{"customHTTP": 8080},
+						&manager),
 				),
 			},
 			resource.TestStep{
@@ -65,6 +69,10 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 					testAccCheckInstanceGroupManagerUpdated(
 						"google_compute_instance_group_manager.igm-update", 3,
 						"google_compute_target_pool.igm-update", template2),
+					testAccCheckInstanceGroupManagerNamedPorts(
+						"google_compute_instance_group_manager.igm-update",
+						map[string]int64{"customHTTP": 8080, "customHTTPs": 8443},
+						&manager),
 				),
 			},
 		},
@@ -151,6 +159,42 @@ func testAccCheckInstanceGroupManagerUpdated(n string, size int64, targetPool st
 
 		if instanceTemplate.Name != template {
 			return fmt.Errorf("instance template not updated")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckInstanceGroupManagerNamedPorts(n string, np map[string]int64, instanceGroupManager *compute.InstanceGroupManager) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		manager, err := config.clientCompute.InstanceGroupManagers.Get(
+			config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		var found bool
+		for _, namedPort := range manager.NamedPorts {
+			found = false
+			for name, port := range np {
+				if namedPort.Name == name && namedPort.Port == port {
+					found = true
+				}
+			}
+			if !found {
+				return fmt.Errorf("named port incorrect")
+			}
 		}
 
 		return nil
@@ -254,7 +298,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		target_size = 2
 		named_port {
 			name = "customHTTP"
-			port = 8888
+			port = 8080
 		}
 	}`, template, target, igm)
 }
@@ -328,11 +372,11 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		target_size = 3
 		named_port {
 			name = "customHTTP"
-			port = 8888
+			port = 8080
 		}
 		named_port {
 			name = "customHTTPs"
-			port = 8889
+			port = 8443
 		}
 	}`, template1, target, template2, igm)
 }

--- a/website/source/docs/providers/google/r/compute_instance_group_manager.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_group_manager.html.markdown
@@ -25,6 +25,12 @@ resource "google_compute_instance_group_manager" "foobar" {
 	base_instance_name = "foobar"
 	zone = "us-central1-a"
 	target_size = 2
+
+	named_port {
+		name = "customHTTP"
+		port = 8888
+	}
+
 }
 ```
 
@@ -62,6 +68,12 @@ instances in the group are added. Updating the target pools attribute does not
 affect existing instances.
 
 * `zone` - (Required) The zone that instances in this group should be created in.
+
+The `named_port` block supports: (Include a named_port block for each named-port required).
+
+* `name` - (Required) The name of the port.
+
+* `port` - (Required) The port number.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This allows HTTP and HTTPs load-balancers to direct traffic to ports other than tcp/80 and tcp/443.