### PR TITLE
[WIP] JSON plan format

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,14 +26,14 @@ type Config struct {
 	// Dir is the path to the directory where this configuration was
 	// loaded from. If it is blank, this configuration wasn't loaded from
 	// any meaningful directory.
-	Dir string
+	Dir string `json:"dir"`
 
-	Atlas           *AtlasConfig
-	Modules         []*Module
-	ProviderConfigs []*ProviderConfig
-	Resources       []*Resource
-	Variables       []*Variable
-	Outputs         []*Output
+	Atlas           *AtlasConfig      `json:"atlas,omitempty"`
+	Modules         []*Module         `json:"modules,omitempty"`
+	ProviderConfigs []*ProviderConfig `json:"provider_configs,omitempty"`
+	Resources       []*Resource       `json:"resources,omitempty"`
+	Variables       []*Variable       `json:"variables,omitempty"`
+	Outputs         []*Output         `json:"outputs,omitempty"`
 
 	// The fields below can be filled in by loaders for validation
 	// purposes.
@@ -42,9 +42,9 @@ type Config struct {
 
 // AtlasConfig is the configuration for building in HashiCorp's Atlas.
 type AtlasConfig struct {
-	Name    string
-	Include []string
-	Exclude []string
+	Name    string   `json:"name"`
+	Include []string `json:"include"`
+	Exclude []string `json:"exclude"`
 }
 
 // Module is a module used within a configuration.
@@ -52,9 +52,9 @@ type AtlasConfig struct {
 // This does not represent a module itself, this represents a module
 // call-site within an existing configuration.
 type Module struct {
-	Name      string
-	Source    string
-	RawConfig *RawConfig
+	Name      string     `json:"name"`
+	Source    string     `json:"source"`
+	RawConfig *RawConfig `json:"raw_config"`
 }
 
 // ProviderConfig is the configuration for a resource provider.
@@ -62,52 +62,52 @@ type Module struct {
 // For example, Terraform needs to set the AWS access keys for the AWS
 // resource provider.
 type ProviderConfig struct {
-	Name      string
-	Alias     string
-	RawConfig *RawConfig
+	Name      string     `json:"name"`
+	Alias     string     `json:"source"`
+	RawConfig *RawConfig `json:"raw_config"`
 }
 
 // A resource represents a single Terraform resource in the configuration.
 // A Terraform resource is something that represents some component that
 // can be created and managed, and has some properties associated with it.
 type Resource struct {
-	Name         string
-	Type         string
-	RawCount     *RawConfig
-	RawConfig    *RawConfig
-	Provisioners []*Provisioner
-	Provider     string
-	DependsOn    []string
-	Lifecycle    ResourceLifecycle
+	Name         string            `json:"name"`
+	Type         string            `json:"type"`
+	RawCount     *RawConfig        `json:"raw_count"`
+	RawConfig    *RawConfig        `json:"raw_config"`
+	Provisioners []*Provisioner    `json:"provisioners,omitempty"`
+	Provider     string            `json:"provider,omitempty"`
+	DependsOn    []string          `json:"depends_on,omitempty"`
+	Lifecycle    ResourceLifecycle `json:"lifecycle"`
 }
 
 // ResourceLifecycle is used to store the lifecycle tuning parameters
 // to allow customized behavior
 type ResourceLifecycle struct {
-	CreateBeforeDestroy bool     `mapstructure:"create_before_destroy"`
-	PreventDestroy      bool     `mapstructure:"prevent_destroy"`
-	IgnoreChanges       []string `mapstructure:"ignore_changes"`
+	CreateBeforeDestroy bool     `mapstructure:"create_before_destroy" json:"create_before_destroy"`
+	PreventDestroy      bool     `mapstructure:"prevent_destroy" json:"prevent_destroy"`
+	IgnoreChanges       []string `mapstructure:"ignore_changes" json:"ignore_changes,omitempty"`
 }
 
 // Provisioner is a configured provisioner step on a resource.
 type Provisioner struct {
-	Type      string
-	RawConfig *RawConfig
-	ConnInfo  *RawConfig
+	Type      string     `json:"type"`
+	RawConfig *RawConfig `json:"raw_config"`
+	ConnInfo  *RawConfig `json:"conn_info"`
 }
 
 // Variable is a variable defined within the configuration.
 type Variable struct {
-	Name        string
-	Default     interface{}
-	Description string
+	Name        string      `json:"name"`
+	Default     interface{} `json:"default"`
+	Description string      `json:"description"`
 }
 
 // Output is an output defined within the configuration. An output is
 // resulting data that is highlighted by Terraform when finished.
 type Output struct {
-	Name      string
-	RawConfig *RawConfig
+	Name      string     `json:"name"`
+	RawConfig *RawConfig `json:"raw_config"`
 }
 
 // VariableType is the type of value a variable is holding, and returned

--- a/config/module/tree_json.go
+++ b/config/module/tree_json.go
@@ -1,0 +1,51 @@
+package module
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform/config"
+)
+
+func (t *Tree) UnmarshalJSON(bs []byte) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// Decode the gob data
+	var data treeJSON
+	dec := json.NewDecoder(bytes.NewReader(bs))
+	if err := dec.Decode(&data); err != nil {
+		return err
+	}
+
+	// Set the fields
+	t.name = data.Name
+	t.config = data.Config
+	t.children = data.Children
+	t.path = data.Path
+
+	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	data := &treeJSON{
+		Config:   t.config,
+		Children: t.children,
+		Name:     t.name,
+		Path:     t.path,
+	}
+
+	return json.Marshal(data)
+}
+
+// treeJSON is used as a structure to JSON encode a tree.
+//
+// This structure is private so it can't be referenced but the fields are
+// public, allowing us to properly encode this. When we decode this, we are
+// able to turn it into a Tree.
+type treeJSON struct {
+	Config   *config.Config   `json:"config"`
+	Children map[string]*Tree `json:"children"`
+	Name     string           `json:"name"`
+	Path     []string         `json:"path"`
+}

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -27,10 +27,10 @@ const UnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
 // RawConfig supports a query-like interface to request
 // information from deep within the structure.
 type RawConfig struct {
-	Key            string
-	Raw            map[string]interface{}
-	Interpolations []ast.Node
-	Variables      map[string]InterpolatedVariable
+	Key            string                          `json:"key"`
+	Raw            map[string]interface{}          `json:"raw"`
+	Interpolations []ast.Node                      `json:"interpolations,omitempty"`
+	Variables      map[string]InterpolatedVariable `json:"variables,omitempty"`
 
 	lock        sync.Mutex
 	config      map[string]interface{}

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -21,12 +21,13 @@ func init() {
 // Plan represents a single Terraform execution plan, which contains
 // all the information necessary to make an infrastructure change.
 type Plan struct {
-	Diff   *Diff
-	Module *module.Tree
-	State  *State
-	Vars   map[string]string
+	Diff    *Diff             `json:"diff"`
+	Module  *module.Tree      `json:"module"`
+	State   *State            `json:"state"`
+	Vars    map[string]string `json:"variables"`
+	Version string            `json:"version"`
 
-	once sync.Once
+	once sync.Once `json:"-"`
 }
 
 // Context returns a Context with the data encapsulated in this plan.

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -1,22 +1,15 @@
 package terraform
 
 import (
+	"bufio"
 	"bytes"
-	"encoding/gob"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
 
 	"github.com/hashicorp/terraform/config/module"
 )
-
-func init() {
-	gob.Register(make([]interface{}, 0))
-	gob.Register(make([]map[string]interface{}, 0))
-	gob.Register(make(map[string]interface{}))
-	gob.Register(make(map[string]string))
-}
 
 // Plan represents a single Terraform execution plan, which contains
 // all the information necessary to make an infrastructure change.
@@ -69,72 +62,85 @@ func (p *Plan) init() {
 	})
 }
 
-// The format byte is prefixed into the plan file format so that we have
-// the ability in the future to change the file format if we want for any
-// reason.
-const planFormatMagic = "tfplan"
-const planFormatVersion byte = 1
+// Our old binary format used a magic prefix to identify plan files.
+// We use this to recognize and reject old plan files with a helpful
+// error message.
+const planOldFormatMagic = "tfplan"
+
+func planFileVersion() string {
+	// Since plan files are short-lived and easy to recreate, we'll reject
+	// any plan file that was created by a different version of Terraform.
+	if VersionPrerelease == "" {
+		return Version
+	} else {
+		return fmt.Sprintf("%s-%s", Version, VersionPrerelease)
+	}
+}
 
 // ReadPlan reads a plan structure out of a reader in the format that
 // was written by WritePlan.
 func ReadPlan(src io.Reader) (*Plan, error) {
-	var result *Plan
-	var err error
-	n := 0
+	buf := bufio.NewReader(src)
 
-	// Verify the magic bytes
-	magic := make([]byte, len(planFormatMagic))
-	for n < len(magic) {
-		n, err = src.Read(magic[n:])
-		if err != nil {
-			return nil, fmt.Errorf("error while reading magic bytes: %s", err)
+	// Check if this is the legacy binary format
+	start, err := buf.Peek(len(planOldFormatMagic))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to check for magic bytes: %v", err)
+	}
+	if string(start) == stateFormatMagic {
+		return nil, fmt.Errorf(
+			"Plan was created with an earlier Terraform version; please create a new plan",
+		)
+	}
+
+	// Otherwise, assumed to be our JSON format
+	dec := json.NewDecoder(buf)
+	plan := &Plan{}
+	if err := dec.Decode(plan); err != nil {
+		return nil, fmt.Errorf("Decoding plan file failed: %v", err)
+	}
+
+	// Check the version, this to ensure we don't read a future
+	// version that we don't understand
+	if plan.Version > planFileVersion() {
+		return nil, fmt.Errorf(
+			"Plan was created with a different Terraform version; please create a new plan.",
+		)
+	}
+
+	if plan.State != nil {
+		if err := plan.State.prepareAfterRead(); err != nil {
+			return nil, fmt.Errorf("Error in state from plan: %s", err)
 		}
 	}
-	if string(magic) != planFormatMagic {
-		return nil, fmt.Errorf("not a valid plan file")
-	}
 
-	// Verify the version is something we can read
-	var formatByte [1]byte
-	n, err = src.Read(formatByte[:])
-	if err != nil {
-		return nil, err
-	}
-	if n != len(formatByte) {
-		return nil, errors.New("failed to read plan version byte")
-	}
-
-	if formatByte[0] != planFormatVersion {
-		return nil, fmt.Errorf("unknown plan file version: %d", formatByte[0])
-	}
-
-	dec := gob.NewDecoder(src)
-	if err := dec.Decode(&result); err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return plan, nil
 }
 
 // WritePlan writes a plan somewhere in a binary format.
 func WritePlan(d *Plan, dst io.Writer) error {
-	// Write the magic bytes so we can determine the file format later
-	n, err := dst.Write([]byte(planFormatMagic))
-	if err != nil {
-		return err
-	}
-	if n != len(planFormatMagic) {
-		return errors.New("failed to write plan format magic bytes")
+
+	// Note the version so we can reject incompatible versions
+	d.Version = planFileVersion()
+
+	// Normalize and prepare the state portion of the plan, in
+	// a manner compatible with the state file format.
+	if d.State != nil {
+		d.State.prepareForWrite()
 	}
 
-	// Write a version byte so we can iterate on version at some point
-	n, err = dst.Write([]byte{planFormatVersion})
+	data, err := json.MarshalIndent(d, "", "    ")
 	if err != nil {
-		return err
-	}
-	if n != 1 {
-		return errors.New("failed to write plan version byte")
+		return fmt.Errorf("Failed to encode plan: %s", err)
 	}
 
-	return gob.NewEncoder(dst).Encode(d)
+	// We append a newline to the data because MarshalIndent doesn't
+	data = append(data, '\n')
+
+	// Write the data out to the dst
+	if _, err := io.Copy(dst, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("Failed to write plan: %v", err)
+	}
+
+	return nil
 }

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1081,6 +1081,28 @@ func (e *EphemeralState) deepcopy() *EphemeralState {
 	return n
 }
 
+func (s *State) prepareForWrite() {
+	// Make sure it is sorted
+	s.sort()
+
+	// Ensure the version is set
+	s.Version = StateVersion
+}
+
+func (s *State) prepareAfterRead() error {
+	// Check the version, this to ensure we don't read a future
+	// version that we don't understand
+	if s.Version > StateVersion {
+		return fmt.Errorf("State version %d not supported, please update.",
+			s.Version)
+	}
+
+	// Sort it
+	s.sort()
+
+	return nil
+}
+
 // ReadState reads a state structure out of a reader in the format that
 // was written by WriteState.
 func ReadState(src io.Reader) (*State, error) {
@@ -1107,26 +1129,16 @@ func ReadState(src io.Reader) (*State, error) {
 		return nil, fmt.Errorf("Decoding state file failed: %v", err)
 	}
 
-	// Check the version, this to ensure we don't read a future
-	// version that we don't understand
-	if state.Version > StateVersion {
-		return nil, fmt.Errorf("State version %d not supported, please update.",
-			state.Version)
+	if err := state.prepareAfterRead(); err != nil {
+		return nil, err
 	}
-
-	// Sort it
-	state.sort()
 
 	return state, nil
 }
 
 // WriteState writes a state somewhere in a binary format.
 func WriteState(d *State, dst io.Writer) error {
-	// Make sure it is sorted
-	d.sort()
-
-	// Ensure the version is set
-	d.Version = StateVersion
+	d.prepareForWrite()
 
 	// Encode the data in a human-friendly way
 	data, err := json.MarshalIndent(d, "", "    ")


### PR DESCRIPTION
This change switches to a JSON serialization format for plans, rather than the `gob`-based binary serialization.

The motivation for this is to enable application-specific extra tools to do various sorts of checks or visualizations on the generated plan, to guide operators. For example:

* Automatically apply most changes to a QA/dev environment, but flag changes to certain resources for manual human review.
* Completely block certain changes that the application-specific logic knows must never happen, such as destroying a database.
* Perhaps just render the plan in a different medium than plain text, such as a web UI for Terraform that presents an HTML-formatted version of the plan.

Implementing this entails adding annotations to all of the structures included in a plan so that they can be JSON-serialized in a reasonable way. For just this change the diff feels rather disruptive, but it feels more reasonable if it's considered also a building block to enable machine readable progress output of various sorts as described in #2460: having a defined JSON serialization for Terraform's key structures makes Mitchell's suggestion there (having a new UI hook that produces JSON output) easier to achieve. 

My intent is that at first this wouldn't really be documented as a stable format; similar to the JSON state files, it's an implementation detail that happens to be human- and machine-readable to enable expert users to do certain things that wouldn't otherwise be possible, as long as they're willing to maintain those things as the format evolves.

Whereas JSON state files are long-lived and so deserve their own version numbering, I figured that plan files are very short-lived and so it's reasonable to refuse to apply plan files generated by different versions of Terraform. It seems pretty unlikely that someone would upgrade Terraform between making a plan and applying that plan, and even if they do it's a trivial matter to produce an updated plan with `terraform plan -refresh=false` to update the format.

This seems to basically work but I've not tested it extensively with various kinds of input and different sorts of plan. I intend to do some more thorough testing, but I figured I'd share this early to get feedback on the idea and in case others might want to try creating JSON plans against their own configurations and let me know if they run into any issues.

* [x] JSON tagging on relevant structs
* [x] JSON-serialized plan files
* [ ] Test against various configuration constructs
