### PR TITLE
[WIP] Tracking Remote State Lineage to Reduce Mistakes

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 
+	"code.google.com/p/go-uuid/uuid"
+
 	"github.com/hashicorp/terraform/config"
 )
 
@@ -33,6 +35,12 @@ type State struct {
 	// the State file. It is used to detect potentially conflicting
 	// updates.
 	Serial int64 `json:"serial"`
+
+	// Lineage is set when a new, blank state is created and then never
+	// updated. This is used to identify whether another state is a
+	// later or earlier version of the same state lineage, or whether it
+	// is is of different lineage.
+	Lineage string `json:"lineage,omitempty"`
 
 	// Remote is used to track the metadata required to
 	// pull and push state files from a remote storage endpoint.
@@ -264,6 +272,20 @@ func (s *State) IncrementSerialMaybe(other *State) {
 	}
 }
 
+// CompatibleLineage returns true if the other state is of compatible
+// lineage to this state. Lineage is compatible if either it's set to
+// the same value or, for backward compatibility, if one of the states
+// has an empty lineage.
+func (s *State) CompatibleLineage(other *State) bool {
+	if s.Lineage == "" || other.Lineage == "" {
+		// One of the states predates the concept of state lineage,
+		// so we'll just assume that the states are compatible.
+		return true
+	}
+
+	return s.Lineage == other.Lineage
+}
+
 func (s *State) init() {
 	if s.Version == 0 {
 		s.Version = StateVersion
@@ -274,6 +296,9 @@ func (s *State) init() {
 		}
 		root.init()
 		s.Modules = []*ModuleState{root}
+	}
+	if s.Lineage == "" {
+		s.Lineage = uuid.New()
 	}
 }
 

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -254,6 +254,36 @@ func TestStateEqual(t *testing.T) {
 	}
 }
 
+func TestStateLineage(t *testing.T) {
+	state := NewState()
+
+	if state.Lineage == "" {
+		t.Fatalf("New state gets lineage")
+	}
+
+	newState := &State{
+		Serial:  state.Serial + 1,
+		Lineage: state.Lineage,
+	}
+
+	if !state.CompatibleLineage(newState) {
+		t.Fatalf("New state should have compatible lineage")
+	}
+
+	oldState := &State{
+		Serial:  state.Serial,
+		Lineage: "",
+	}
+	if !state.CompatibleLineage(oldState) {
+		t.Fatalf("Old state should have compatible lineage")
+	}
+
+	unrelatedState := NewState()
+	if state.CompatibleLineage(unrelatedState) {
+		t.Fatalf("Unrelated state should have incompatible lineage")
+	}
+}
+
 func TestStateIncrementSerialMaybe(t *testing.T) {
 	cases := map[string]struct {
 		S1, S2 *State


### PR DESCRIPTION
Each new state will have a uuid as its "lineage" value, and that value will never be changed when updating the state in future. This allows Terraform to detect whether two different states are different points in time along a particular line of states, or if they are unrelated.

In the situation where a state is already present locally (either in `terraform.tfstate` or `.terraform/terraform.tfstate`, depending on whether remote state is enabled), one can run `terraform remote config` to change the remote state configuration.

When this is run, Terraform writes the current local state to the newly-selected remote state storage backend, unconditionally overwriting whatever was there before. This can prove troublesome if, due to user error, the given new configuration points at a location where an unrelated state is already stored: the state is then overwritten, and if that backend doesn't provide any sort of versioning capability (e.g. for Consul) then the state is completely lost.

This implements the feature request in #4389

* [x] Add "lineage" to the state file
* [ ] Check lineage during `terraform remote config`
