### PR TITLE
Changes (inconsistently used) t2.micro back to t1.micro - t2.micro is…

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -95,7 +95,7 @@ Within the resource block itself is configuration for that
 resource. This is dependent on each resource provider and
 is fully documented within our
 [providers reference](/docs/providers/index.html). For our EC2 instance, we specify
-an AMI for Ubuntu, and request a "t2.micro" instance so we
+an AMI for Ubuntu, and request a "t1.micro" instance so we
 qualify under the free tier.
 
 ## Execution Plan

--- a/website/source/intro/getting-started/dependencies.html.md
+++ b/website/source/intro/getting-started/dependencies.html.md
@@ -69,7 +69,7 @@ $ terraform plan
 + aws_instance.example
     ami:               "" => "ami-8eb061e6"
     availability_zone: "" => "<computed>"
-    instance_type:     "" => "t2.micro"
+    instance_type:     "" => "t1.micro"
     key_name:          "" => "<computed>"
     private_dns:       "" => "<computed>"
     private_ip:        "" => "<computed>"
@@ -91,7 +91,7 @@ following:
 ```
 aws_instance.example: Creating...
   ami:           "" => "ami-8eb061e6"
-  instance_type: "" => "t2.micro"
+  instance_type: "" => "t1.micro"
 aws_eip.ip: Creating...
   instance: "" => "i-0e737b25"
 
@@ -145,7 +145,7 @@ created in parallel to everything else.
 ```
 resource "aws_instance" "another" {
 	ami = "ami-8eb061e6"
-	instance_type = "t2.micro"
+	instance_type = "t1.micro"
 }
 ```
 

--- a/website/source/intro/getting-started/provision.html.md
+++ b/website/source/intro/getting-started/provision.html.md
@@ -26,7 +26,7 @@ To define a provisioner, modify the resource block defining the
 ```
 resource "aws_instance" "example" {
 	ami = "ami-8eb061e6"
-	instance_type = "t2.micro"
+	instance_type = "t1.micro"
 
 	provisioner "local-exec" {
 		command = "echo ${aws_instance.example.public_ip} > file.txt"
@@ -62,7 +62,7 @@ then run `apply`:
 $ terraform apply
 aws_instance.example: Creating...
   ami:           "" => "ami-8eb061e6"
-  instance_type: "" => "t2.micro"
+  instance_type: "" => "t1.micro"
 aws_eip.ip: Creating...
   instance: "" => "i-213f350a"
 

--- a/website/source/intro/getting-started/variables.html.md
+++ b/website/source/intro/getting-started/variables.html.md
@@ -137,7 +137,7 @@ Then, replace the "aws\_instance" with the following:
 ```
 resource "aws_instance" "example" {
 	ami = "${lookup(var.amis, var.region)}"
-	instance_type = "t2.micro"
+	instance_type = "t1.micro"
 }
 ```
 


### PR DESCRIPTION
… VPC only and thus will cause problems for users with a default VPC (e.g. people who signed up for AWS a few years ago)