### PR TITLE
provider/aws: EBS optimised to force new resource

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -140,6 +140,7 @@ func resourceAwsInstance() *schema.Resource {
 			"ebs_optimized": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"disable_api_termination": &schema.Schema{


### PR DESCRIPTION
EBS optimised can't be changed without re-creating the instance. Apply forcenew.