### PR TITLE
core/remote_state: add the option to specify a custom (AWS compatible) S3 endpoint

### DIFF
--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -29,6 +29,11 @@ func s3Factory(conf map[string]string) (Client, error) {
 		return nil, fmt.Errorf("missing 'key' configuration")
 	}
 
+	endpoint, ok := conf["endpoint"]
+	if !ok {
+		endpoint = os.Getenv("AWS_S3_ENDPOINT")
+	}
+
 	regionName, ok := conf["region"]
 	if !ok {
 		regionName = os.Getenv("AWS_DEFAULT_REGION")
@@ -77,6 +82,7 @@ func s3Factory(conf map[string]string) (Client, error) {
 
 	awsConfig := &aws.Config{
 		Credentials: credentialsProvider,
+		Endpoint:    aws.String(endpoint),
 		Region:      aws.String(regionName),
 		HTTPClient:  cleanhttp.DefaultClient(),
 	}

--- a/website/source/docs/commands/remote-config.html.markdown
+++ b/website/source/docs/commands/remote-config.html.markdown
@@ -69,11 +69,11 @@ The following backends are supported:
 
 * S3 - Stores the state as a given key in a given bucket on Amazon S3.
   Requires the `bucket` and `key` variables. Supports and honors the standard
-  AWS environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
-  and `AWS_DEFAULT_REGION`. These can optionally be provided as parameters
-  in the `access_key`, `secret_key` and `region` variables
-  respectively, but passing credentials this way is not recommended since they
-  will be included in cleartext inside the persisted state.
+  AWS environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+  `AWS_S3_ENDPOINT` and `AWS_DEFAULT_REGION`. These can optionally be provided
+  as parameters in the `access_key`, `secret_key`, `endpoint` and `region`
+  variables respectively, but passing credentials this way is not recommended
+  since they will be included in cleartext inside the persisted state.
   Other supported parameters include:
   * `bucket` - the name of the S3 bucket
   * `key` - path where to place/look for state file inside the bucket


### PR DESCRIPTION
Same fix/option as I added in Vault not too long ago:
https://github.com/hashicorp/vault/pull/750