### PR TITLE
provider/aws: Add profile to provider config

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -29,6 +29,20 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["secret_key"],
 			},
 
+			"profile": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["profile"],
+			},
+
+			"shared_credentials_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["shared_credentials_file"],
+			},
+
 			"token": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -222,6 +236,12 @@ func init() {
 		"secret_key": "The secret key for API operations. You can retrieve this\n" +
 			"from the 'Security & Credentials' section of the AWS console.",
 
+		"profile": "The profile for API operations. If not set, the default profile\n" +
+			"created with `aws configure` will be used.",
+
+		"shared_credentials_file": "The path to the shared credentials file. If not set\n" +
+			"this defaults to ~/.aws/credentials.",
+
 		"token": "session token. A session token is only required if you are\n" +
 			"using temporary security credentials.",
 
@@ -241,6 +261,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		AccessKey:        d.Get("access_key").(string),
 		SecretKey:        d.Get("secret_key").(string),
+		Profile:          d.Get("profile").(string),
+		CredsFilename:    d.Get("shared_credentials_file").(string),
 		Token:            d.Get("token").(string),
 		Region:           d.Get("region").(string),
 		MaxRetries:       d.Get("max_retries").(int),

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -34,14 +34,26 @@ resource "aws_instance" "web" {
 
 The following arguments are supported in the `provider` block:
 
-* `access_key` - (Required) This is the AWS access key. It must be provided, but
-  it can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable.
+* `access_key` - (Optional) This is the AWS access key. It must be provided, but
+  it can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, or via
+  a shared credentials file if `profile` is specified.
 
-* `secret_key` - (Required) This is the AWS secret key. It must be provided, but
-  it can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable.
+* `secret_key` - (Optional) This is the AWS secret key. It must be provided, but
+  it can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, or
+  via a shared credentials file if `profile` is specified.
 
 * `region` - (Required) This is the AWS region. It must be provided, but
-  it can also be sourced from the `AWS_DEFAULT_REGION` environment variables.
+  it can also be sourced from the `AWS_DEFAULT_REGION` environment variables, or
+  via a shared credentials file if `profile` is specified.
+
+* `profile` - (Optional) This is the AWS profile name as set in the shared credentials
+  file.
+
+* `shared_credentials_file` = (Optional) This is the path to the shared credentials file.
+  If this is not set and a profile is specified, ~/.aws/credentials will be used.
+
+* `token` - (Optional) Use this to set an MFA token. It can also be sourced
+  from the `AWS_SECURITY_TOKEN` environment variable.
 
 * `max_retries` - (Optional) This is the maximum number of times an API call is
   being retried in case requests are being throttled or experience transient failures.
@@ -55,8 +67,10 @@ The following arguments are supported in the `provider` block:
   to prevent you mistakenly using a wrong one (and end up destroying live environment).
   Conflicts with `allowed_account_ids`.
 
-* `dynamodb_endpoint` - (Optional) Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to dynamodb-local.
+* `dynamodb_endpoint` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  dynamodb-local.
 
-* `kinesis_endpoint` - (Optional) Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to kinesalite.
+* `kinesis_endpoint` - (Optional) Use this to override the default endpoint URL
+  constructed from the `region`. It's typically used to connect to kinesalite.
 
-* `token` - (Optional) Use this to set an MFA token. It can also be sourced from the `AWS_SECURITY_TOKEN` environment variable.


### PR DESCRIPTION
This allows specification of the profile for the shared credentials
provider for AWS to be specified in Terraform configuration. This is
useful if defining providers with aliases, or if you don't want to set
environment variables. Example:

$ aws configure --profile this_is_dog
... enter keys

$ cat main.tf
provider "aws" {
    profile = "this_is_dog"
}

This is equivalent to specifying AWS_PROFILE in the environment. Tests
have been made to pass but do not yet excercise the new functionality.

TODO: Write tests.