### PR TITLE
provider/vsphere: Linked cloning support.

### DIFF
--- a/builtin/providers/vsphere/provider_test.go
+++ b/builtin/providers/vsphere/provider_test.go
@@ -2,6 +2,7 @@ package vsphere
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -39,5 +40,23 @@ func testAccPreCheck(t *testing.T) {
 
 	if v := os.Getenv("VSPHERE_SERVER"); v == "" {
 		t.Fatal("VSPHERE_SERVER must be set for acceptance tests")
+	}
+}
+
+// validateEnvArgs is a helper function to verify that required test related environment variables are set.
+func validateEnvArgs(t *testing.T, requiredVars ...string) {
+	realEnvVars := os.Environ()
+	for _, requiredVar := range requiredVars {
+		for _, v := range realEnvVars {
+			if requiredVar == strings.Split(v, "=")[0] {
+				// Remove the variable from the list of required variables if the required variable is defined in the real environment.
+				// This way of removing the required variable from the slice preserves the order of the slice (not really needed in this case though).
+				requiredVars = requiredVars[:len(requiredVars)-1]
+			}
+		}
+	}
+
+	if len(requiredVars) > 0 {
+		t.Fatalf("Some required environment variables are missing: %s\n", requiredVars)
 	}
 }

--- a/website/source/docs/providers/vsphere/index.html.markdown
+++ b/website/source/docs/providers/vsphere/index.html.markdown
@@ -54,7 +54,9 @@ resource "vsphere_virtual_machine" "web" {
   }
 
   disk {
-    template = "centos-7"
+    template {
+      label = "centos-7"
+    }
   }
 }
 ```
@@ -152,7 +154,8 @@ set to valid values for your VMware vSphere environment:
  * VSPHERE\_IPV6\_ADDRESS
  * VSPHERE\_NETWORK\_LABEL
  * VSPHERE\_NETWORK\_LABEL\_DHCP
- * VSPHERE\_TEMPLATE
+ * VSPHERE\_CLONE\_SOURCE
+ * VSPHERE\_SNAPSHOT
 
 The following environment variables depend on your vSphere environment:
 

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -24,7 +24,9 @@ resource "vsphere_virtual_machine" "web" {
   }
 
   disk {
-    template = "centos-7"
+    template {
+      label = "centos-7"
+    }
   }
 }
 ```
@@ -78,11 +80,12 @@ The following arguments are supported:
 * `cdrom` - (Optional) Configures a CDROM device and mounts an image as its media; see [CDROM](#cdrom) below for more details.
 * `boot_delay` - (Optional) Time in seconds to wait for machine network to be ready.
 * `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
-* `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
+* `linked_clone` - __Deprecated, please use `disk.clone.linked` instead__.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
 * `skip_customization` - (Optional) skip virtual machine customization (useful if OS is not in the guest OS support matrix of VMware like "other3xLinux64Guest").
 
-The `network_interface` block supports:
+<a id="network-interfaces"></a>
+## Network interfaces
 
 * `label` - (Required) Label to assign to this network interface
 * `ipv4_address` - (Optional) Static IPv4 to assign to this network interface. Interface will use DHCP if this is left blank.
@@ -111,7 +114,7 @@ The `windows_opt_config` block supports:
 
 The `disk` block supports:
 
-* `template` - (Required if size and bootable_vmdk_path not provided) Template for this disk.
+* `clone` - (Required if `size` is not provided) Cloning source for this disk; see [Clones](#clones) below for details.
 * `datastore` - (Optional) Datastore for this disk
 * `size` - (Required if template and bootable_vmdks_path not provided) Size of this disk (in GB).
 * `iops` - (Optional) Number of virtual iops to allocate for this disk.
@@ -126,6 +129,15 @@ The `cdrom` block supports:
 
 * `datastore` - (Required) The name of the datastore where the disk image is stored.
 * `path` - (Required) The absolute path to the image within the datastore.
+
+<a id="clones"></a>
+## Clones
+
+The `clone` block supports:
+
+* `label` - (Required) The template label (label of the virtual machine/template to clone from).
+* `linked` - (Optional) Set to true if this should be a linked clone. Linked cloning requires the source virtual machine/template to have at least one existing snapshot which can be cloned from. Defaults to false.
+* `snapshot` - (Optional) This is silently ignored if `linked` is false. Linked clones are, by default, cloned from the latest snapshot. However, here you can specify the label of the snapshot you want to clone from.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The disk -> clone property introduced.

The disk -> template is automatically translated to disk.clone.label for
backwards compatibility (deprecated warning is shown).

The linked_clone property is automatically translated to
disk.clone.linked if disk.clone is configured for backwards
compatibility (deprecated warning is shown).

Linked cloning requires a snapshot to clone from. We support the ability to provide
a named snapshot. However, we try to use the current snapshot if no named snapshot is provided.

We error out if no snapshot name is provided and there is no current snapshot to clone from (error out if there is no snapshot available).
We error out if the requested snapshot name is not found.

Note: Breaking change when running tests!
The VSPHERE_TEMPLATE variable has been renamed to VSPHERE_CLONE_SOURCE -
since vms can be cloned from both templates and other vms.