### PR TITLE
provider/aws: allow ap-northeast-2 in region validation

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -250,9 +250,9 @@ func (c *Config) Client() (interface{}, error) {
 // ValidateRegion returns an error if the configured region is not a
 // valid aws region and nil otherwise.
 func (c *Config) ValidateRegion() error {
-	var regions = [11]string{"us-east-1", "us-west-2", "us-west-1", "eu-west-1",
+	var regions = []string{"us-east-1", "us-west-2", "us-west-1", "eu-west-1",
 		"eu-central-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1",
-		"sa-east-1", "cn-north-1", "us-gov-west-1"}
+		"ap-northeast-2", "sa-east-1", "cn-north-1", "us-gov-west-1"}
 
 	for _, valid := range regions {
 		if c.Region == valid {


### PR DESCRIPTION
Fixes #4635