### PR TITLE
provider/aws: Allow ap-northeast-2 (Seoul) as valid region

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -250,9 +250,9 @@ func (c *Config) Client() (interface{}, error) {
 // ValidateRegion returns an error if the configured region is not a
 // valid aws region and nil otherwise.
 func (c *Config) ValidateRegion() error {
-	var regions = [11]string{"us-east-1", "us-west-2", "us-west-1", "eu-west-1",
+	var regions = [12]string{"us-east-1", "us-west-2", "us-west-1", "eu-west-1",
 		"eu-central-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1",
-		"sa-east-1", "cn-north-1", "us-gov-west-1"}
+		"ap-northeast-2", "sa-east-1", "cn-north-1", "us-gov-west-1"}
 
 	for _, valid := range regions {
 		if c.Region == valid {

--- a/builtin/providers/aws/hosted_zones.go
+++ b/builtin/providers/aws/hosted_zones.go
@@ -12,6 +12,7 @@ var hostedZoneIDsMap = map[string]string{
 	"ap-southeast-1": "Z3O0J2DXBE1FTB",
 	"ap-southeast-2": "Z1WCIGYICN2BYD",
 	"ap-northeast-1": "Z2M4EHUR26P7ZW",
+	"ap-northeast-2": "Z3W03O7B5YMIYP",
 	"sa-east-1":      "Z7KQH4QJS55SO",
 	"us-gov-west-1":  "Z31GFT0UA1I2HV",
 }

--- a/builtin/providers/aws/website_endpoint_url_test.go
+++ b/builtin/providers/aws/website_endpoint_url_test.go
@@ -15,6 +15,7 @@ var websiteEndpoints = []struct {
 	{"ap-southeast-1", "bucket-name.s3-website-ap-southeast-1.amazonaws.com"},
 	{"ap-northeast-1", "bucket-name.s3-website-ap-northeast-1.amazonaws.com"},
 	{"ap-southeast-2", "bucket-name.s3-website-ap-southeast-2.amazonaws.com"},
+	{"ap-northeast-2", "bucket-name.s3-website-ap-northeast-2.amazonaws.com"},
 	{"sa-east-1", "bucket-name.s3-website-sa-east-1.amazonaws.com"},
 }
 


### PR DESCRIPTION
Adds the region, updates the S3 hosted zones and website endpoint test