### PR TITLE
Split long comment to two lines

### DIFF
--- a/website/source/docs/providers/do/index.html.markdown
+++ b/website/source/docs/providers/do/index.html.markdown
@@ -17,7 +17,8 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```
-# Set the variable value in *.tfvars file or using -var="do_token=..." CLI option
+# Set the variable value in *.tfvars file
+# or using -var="do_token=..." CLI option
 variable "do_token" {}
 
 # Configure the DigitalOcean Provider


### PR DESCRIPTION
The comment on first line of the code example is 82 characters long
and is cut on the 80-th character when viewed online. The second line
contains only two letters "on" without # in front.

The comment is displayed on two lines anyway, it is better if it is split to
two lines of less than 80 characters.