### PR TITLE
Add ENV['no_proxy'] to chef provisioner if no_proxy is detected

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -328,4 +328,6 @@ ENV['https_proxy'] = "https://proxy.local"
 ENV['HTTPS_PROXY'] = "https://proxy.local"
 
 
-no_proxy "http://local.local,https://local.local"`
+
+no_proxy          "http://local.local,https://local.local"
+ENV['no_proxy'] = "http://local.local,https://local.local"`

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -60,7 +60,11 @@ ENV['https_proxy'] = "{{ .HTTPSProxy }}"
 ENV['HTTPS_PROXY'] = "{{ .HTTPSProxy }}"
 {{ end }}
 
-{{ if .NOProxy }}no_proxy "{{ join .NOProxy "," }}"{{ end }}
+{{ if .NOProxy }}
+no_proxy          "{{ join .NOProxy "," }}"
+ENV['no_proxy'] = "{{ join .NOProxy "," }}"
+{{ end }}
+
 {{ if .SSLVerifyMode }}ssl_verify_mode {{ .SSLVerifyMode }}{{ end }}
 
 {{ if .DisableReporting }}enable_reporting false{{ end }}

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -355,4 +355,6 @@ ENV['https_proxy'] = "https://proxy.local"
 ENV['HTTPS_PROXY'] = "https://proxy.local"
 
 
-no_proxy "http://local.local,https://local.local"`
+
+no_proxy          "http://local.local,https://local.local"
+ENV['no_proxy'] = "http://local.local,https://local.local"`


### PR DESCRIPTION
This adds the no_proxy environment variable to the chef provisioner. For some reason <code>ENV['http_proxy']</code> and <code>ENV['https_proxy']</code> were added, but <code>ENV['no_proxy']</code> was not added.