### PR TITLE
Bug fixes for aws_autoscaling_schedule resource

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_schedule.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_schedule.go
@@ -93,7 +93,7 @@ func resourceAwsAutoscalingScheduleCreate(d *schema.ResourceData, meta interface
 		params.EndTime = aws.Time(t)
 	}
 
-	if attr, ok := d.GetOk("recurrance"); ok {
+	if attr, ok := d.GetOk("recurrence"); ok {
 		params.Recurrence = aws.String(attr.(string))
 	}
 
@@ -131,9 +131,15 @@ func resourceAwsAutoscalingScheduleRead(d *schema.ResourceData, meta interface{}
 	d.Set("desired_capacity", sa.DesiredCapacity)
 	d.Set("min_size", sa.MinSize)
 	d.Set("max_size", sa.MaxSize)
-	d.Set("recurrance", sa.Recurrence)
-	d.Set("start_time", sa.StartTime.Format(awsAutoscalingScheduleTimeLayout))
-	d.Set("end_time", sa.EndTime.Format(awsAutoscalingScheduleTimeLayout))
+	d.Set("recurrence", sa.Recurrence)
+
+	if sa.StartTime != nil {
+		d.Set("start_time", sa.StartTime.Format(awsAutoscalingScheduleTimeLayout))
+	}
+
+	if sa.EndTime != nil {
+		d.Set("end_time", sa.EndTime.Format(awsAutoscalingScheduleTimeLayout))
+	}
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_autoscaling_schedule_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_schedule_test.go
@@ -28,6 +28,25 @@ func TestAccAWSAutoscalingSchedule_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAutoscalingSchedule_recurrence(t *testing.T) {
+	var schedule autoscaling.ScheduledUpdateGroupAction
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoscalingScheduleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAutoscalingScheduleConfig_recurrence,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
+					resource.TestCheckResourceAttr("aws_autoscaling_schedule.foobar", "recurrence", "0 8 * * *"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckScalingScheduleExists(n string, policy *autoscaling.ScheduledUpdateGroupAction) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -112,6 +131,40 @@ resource "aws_autoscaling_schedule" "foobar" {
     desired_capacity = 0
     start_time = "2016-12-11T18:00:00Z"
     end_time = "2016-12-12T06:00:00Z"
+    autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+}
+`)
+
+var testAccAWSAutoscalingScheduleConfig_recurrence = fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+    name = "terraform-test-foobar5"
+    image_id = "ami-21f78e11"
+    instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "foobar" {
+    availability_zones = ["us-west-2a"]
+    name = "terraform-test-foobar5"
+    max_size = 1
+    min_size = 1
+    health_check_grace_period = 300
+    health_check_type = "ELB"
+    force_delete = true
+    termination_policies = ["OldestInstance"]
+    launch_configuration = "${aws_launch_configuration.foobar.name}"
+    tag {
+        key = "Foo"
+        value = "foo-bar"
+        propagate_at_launch = true
+    }
+}
+
+resource "aws_autoscaling_schedule" "foobar" {
+    scheduled_action_name = "foobar"
+    min_size = 0
+    max_size = 1
+    desired_capacity = 0
+    recurrence = "0 8 * * *"
     autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
 }
 `)


### PR DESCRIPTION
- Fix typo s/recurrance/recurrence
- Fix missing nil check on EndTime that was crashing
- Added an acceptance test

(this was originally https://github.com/hashicorp/terraform/issues/4628 but i forked that, added a test and then opened a PR to get this through faster)

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSAutoscalingSchedule' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSAutoscalingSchedule -timeout 120m
=== RUN   TestAccAWSAutoscalingSchedule_basic
--- PASS: TestAccAWSAutoscalingSchedule_basic (163.69s)
=== RUN   TestAccAWSAutoscalingSchedule_recurrence
--- PASS: TestAccAWSAutoscalingSchedule_recurrence (165.66s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	329.421s
```