### PR TITLE
Properly detect terminated environments in Elastic Beanstalk

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -267,6 +267,13 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 
 	env := resp.Environments[0]
 
+	if *env.Status == "Terminated" {
+		log.Printf("[DEBUG] Elastic Beanstalk environment %s was terminated", d.Id())
+
+		d.SetId("")
+		return nil
+	}
+
 	if err := d.Set("description", env.Description); err != nil {
 		return err
 	}


### PR DESCRIPTION
@catsby @dharrisio terminated environments linger for about 1.5 hours, but are functionally deleted. The one caveat is that you can't overwrite them afaik, so you have to change the name of your environment if you want to keep going right away. I ran into this one when I applied with invalid settings, and the environment transitioned straight away to `Terminated`.

Adds to https://github.com/hashicorp/terraform/pull/3157