### PR TITLE
provider/aws: aws autoscale schedule 0 values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ IMPROVEMENTS:
   * provider/aws: Add support for creating Managed Microsoft Active Directory 
     and Directory Connectors [GH-4388]
   * provider/aws: Mark some `aws_db_instance` fields as optional [GH-3139]
+  * provider/docker: Add support for adding host entries on `docker_container` resources [GH-3463]
+  * provider/google: Add content field to bucket object [GH-3893]
   * provider/openstack: Add "personality" support to instance resource [GH-4623]
   * provider/packet: Handle external state changes for Packet resources gracefully [GH-4676]
-  * provider/google: Add content field to bucket object [GH-3893]
 
 BUG FIXES:
 

--- a/builtin/providers/aws/resource_aws_autoscaling_schedule_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_schedule_test.go
@@ -47,6 +47,24 @@ func TestAccAWSAutoscalingSchedule_recurrence(t *testing.T) {
 	})
 }
 
+func TestAccAWSAutoscalingSchedule_zeroValues(t *testing.T) {
+	var schedule autoscaling.ScheduledUpdateGroupAction
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoscalingScheduleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAutoscalingScheduleConfig_zeroValues,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckScalingScheduleExists(n string, policy *autoscaling.ScheduledUpdateGroupAction) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -165,6 +183,41 @@ resource "aws_autoscaling_schedule" "foobar" {
     max_size = 1
     desired_capacity = 0
     recurrence = "0 8 * * *"
+    autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+}
+`)
+
+var testAccAWSAutoscalingScheduleConfig_zeroValues = fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+    name = "terraform-test-foobar5"
+    image_id = "ami-21f78e11"
+    instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "foobar" {
+    availability_zones = ["us-west-2a"]
+    name = "terraform-test-foobar5"
+    max_size = 1
+    min_size = 1
+    health_check_grace_period = 300
+    health_check_type = "ELB"
+    force_delete = true
+    termination_policies = ["OldestInstance"]
+    launch_configuration = "${aws_launch_configuration.foobar.name}"
+    tag {
+        key = "Foo"
+        value = "foo-bar"
+        propagate_at_launch = true
+    }
+}
+
+resource "aws_autoscaling_schedule" "foobar" {
+    scheduled_action_name = "foobar"
+    max_size = 0
+    min_size = 0
+    desired_capacity = 0
+    start_time = "2016-01-16T07:00:00Z"
+    end_time = "2016-01-16T13:00:00Z"
     autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
 }
 `)


### PR DESCRIPTION
As per #4690 

Added a test to prove that 0 values cannot be specified for the Autoscale Group Schedule resource for min_size, max_size or desirect_capacity even though they are valid values

This shouldn't really be merged until a fix is added for this