### PR TITLE
provider/template: fix race causing panic in template_file

### DIFF
--- a/builtin/providers/template/resource_template_file.go
+++ b/builtin/providers/template/resource_template_file.go
@@ -155,7 +155,7 @@ func execute(s string, vars map[string]interface{}) (string, error) {
 	cfg := lang.EvalConfig{
 		GlobalScope: &ast.BasicScope{
 			VarMap:  varmap,
-			FuncMap: config.Funcs,
+			FuncMap: config.Funcs(),
 		},
 	}
 

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -20,10 +20,8 @@ import (
 )
 
 // Funcs is the mapping of built-in functions for configuration.
-var Funcs map[string]ast.Function
-
-func init() {
-	Funcs = map[string]ast.Function{
+func Funcs() map[string]ast.Function {
+	return map[string]ast.Function{
 		"cidrhost":     interpolationFuncCidrHost(),
 		"cidrnetmask":  interpolationFuncCidrNetmask(),
 		"cidrsubnet":   interpolationFuncCidrSubnet(),

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -300,7 +300,7 @@ type gobRawConfig struct {
 // langEvalConfig returns the evaluation configuration we use to execute.
 func langEvalConfig(vs map[string]ast.Variable) *lang.EvalConfig {
 	funcMap := make(map[string]ast.Function)
-	for k, v := range Funcs {
+	for k, v := range Funcs() {
 		funcMap[k] = v
 	}
 	funcMap["lookup"] = interpolationFuncLookup(vs)


### PR DESCRIPTION
The render code path in `template_file` was doing unsynchronized access
to a shared mapping of functions in `config.Func`.

This caused a race condition that was most often triggered when a
`template_file` had a `count` of more than one, and expressed itself as
a panic in the plugin followed by a cascade of "unexpected EOF" errors
through the plugin system.

Here, we simply turn the FuncMap from shared state into a generated
value, which avoids the race. We do more re-initialization of the data
structure, but the performance implications are minimal, and we can
always revisit with a perf pass later now that the race is fixed.