### PR TITLE
Data-driven Terraform Configuration

### DIFF
--- a/config/append.go
+++ b/config/append.go
@@ -57,6 +57,14 @@ func Append(c1, c2 *Config) (*Config, error) {
 		c.ProviderConfigs = append(c.ProviderConfigs, c2.ProviderConfigs...)
 	}
 
+	if len(c1.DataSources) > 0 || len(c2.DataSources) > 0 {
+		c.DataSources = make(
+			[]*DataSource,
+			0, len(c1.DataSources)+len(c2.DataSources))
+		c.DataSources = append(c.DataSources, c1.DataSources...)
+		c.DataSources = append(c.DataSources, c2.DataSources...)
+	}
+
 	if len(c1.Resources) > 0 || len(c2.Resources) > 0 {
 		c.Resources = make(
 			[]*Resource,

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Atlas           *AtlasConfig
 	Modules         []*Module
 	ProviderConfigs []*ProviderConfig
+	DataSources     []*DataSource
 	Resources       []*Resource
 	Variables       []*Variable
 	Outputs         []*Output
@@ -65,6 +66,18 @@ type ProviderConfig struct {
 	Name      string
 	Alias     string
 	RawConfig *RawConfig
+}
+
+// DataSource is the configuration for a data source.
+// A data source represents retrieving some data from an external source for
+// use elsewhere in a Terraform configuration, or computing some data
+// internally within a logical provider.
+type DataSource struct {
+	Name      string
+	Type      string
+	RawConfig *RawConfig
+	Provider  string
+	DependsOn []string
 }
 
 // A resource represents a single Terraform resource in the configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -723,6 +723,21 @@ func (c *ProviderConfig) mergerMerge(m merger) merger {
 	return &result
 }
 
+func (r *DataSource) mergerName() string {
+	return fmt.Sprintf("%s.%s", r.Type, r.Name)
+}
+
+func (r *DataSource) mergerMerge(m merger) merger {
+	r2 := m.(*DataSource)
+
+	result := *r
+	result.Name = r2.Name
+	result.Type = r2.Type
+	result.RawConfig = result.RawConfig.merge(r2.RawConfig)
+
+	return &result
+}
+
 func (r *Resource) mergerName() string {
 	return fmt.Sprintf("%s.%s", r.Type, r.Name)
 }

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -19,6 +19,7 @@ type hclConfigurable struct {
 func (t *hclConfigurable) Config() (*Config, error) {
 	validKeys := map[string]struct{}{
 		"atlas":    struct{}{},
+		"data":     struct{}{},
 		"module":   struct{}{},
 		"output":   struct{}{},
 		"provider": struct{}{},
@@ -100,6 +101,15 @@ func (t *hclConfigurable) Config() (*Config, error) {
 	if providers := list.Filter("provider"); len(providers.Items) > 0 {
 		var err error
 		config.ProviderConfigs, err = loadProvidersHcl(providers)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Build the data sources
+	if dataSources := list.Filter("data"); len(dataSources.Items) > 0 {
+		var err error
+		config.DataSources, err = loadDataSourcesHcl(dataSources)
 		if err != nil {
 			return nil, err
 		}
@@ -381,6 +391,100 @@ func loadProvidersHcl(list *ast.ObjectList) ([]*ProviderConfig, error) {
 			Name:      n,
 			Alias:     alias,
 			RawConfig: rawConfig,
+		})
+	}
+
+	return result, nil
+}
+
+// Given a handle to a HCL object, this recurses into the structure
+// and pulls out a list of data sources.
+//
+// The resulting data sources may not be unique, but each one
+// represents exactly one data definition in the HCL configuration.
+// We leave it up to another pass to merge them together.
+func loadDataSourcesHcl(list *ast.ObjectList) ([]*DataSource, error) {
+	list = list.Children()
+	if len(list.Items) == 0 {
+		return nil, nil
+	}
+
+	// Where all the results will go
+	var result []*DataSource
+
+	// Now go over all the types and their children in order to get
+	// all of the actual resources.
+	for _, item := range list.Items {
+		if len(item.Keys) != 2 {
+			return nil, fmt.Errorf(
+				"position %s: 'data' must be followed by exactly two strings: a type and a name",
+				item.Pos())
+		}
+
+		t := item.Keys[0].Token.Value().(string)
+		k := item.Keys[1].Token.Value().(string)
+
+		var listVal *ast.ObjectList
+		if ot, ok := item.Val.(*ast.ObjectType); ok {
+			listVal = ot.List
+		} else {
+			return nil, fmt.Errorf("data sources %s[%s]: should be an object", t, k)
+		}
+
+		var config map[string]interface{}
+		if err := hcl.DecodeObject(&config, item.Val); err != nil {
+			return nil, fmt.Errorf(
+				"Error reading config for %s[%s]: %s",
+				t,
+				k,
+				err)
+		}
+
+		// Remove the fields we handle specially
+		delete(config, "depends_on")
+		delete(config, "provider")
+
+		rawConfig, err := NewRawConfig(config)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error reading config for %s[%s]: %s",
+				t,
+				k,
+				err)
+		}
+
+		// If we have depends fields, then add those in
+		var dependsOn []string
+		if o := listVal.Filter("depends_on"); len(o.Items) > 0 {
+			err := hcl.DecodeObject(&dependsOn, o.Items[0].Val)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Error reading depends_on for %s[%s]: %s",
+					t,
+					k,
+					err)
+			}
+		}
+
+		// If we have a provider, then parse it out
+		var provider string
+		if o := listVal.Filter("provider"); len(o.Items) > 0 {
+			err := hcl.DecodeObject(&provider, o.Items[0].Val)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Error reading provider for %s[%s]: %s",
+					t,
+					k,
+					err)
+			}
+		}
+
+		result = append(result, &DataSource{
+			Name:      k,
+			Type:      t,
+			RawConfig: rawConfig,
+			Provider:  provider,
+			DependsOn: dependsOn,
 		})
 	}
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -56,6 +56,17 @@ func TestLoadFile_resourceArityMistake(t *testing.T) {
 	}
 }
 
+func TestLoadFile_dataSourceArityMistake(t *testing.T) {
+	_, err := LoadFile(filepath.Join(fixtureDir, "data-source-arity-mistake.tf"))
+	if err == nil {
+		t.Fatal("should have error")
+	}
+	expected := "Error loading test-fixtures/data-source-arity-mistake.tf: position 2:6: 'data' must be followed by exactly two strings: a type and a name"
+	if err.Error() != expected {
+		t.Fatalf("expected:\n%s\ngot:\n%s", expected, err)
+	}
+}
+
 func TestLoadFileWindowsLineEndings(t *testing.T) {
 	testFile := filepath.Join(fixtureDir, "windows-line-endings.tf")
 
@@ -160,6 +171,11 @@ func TestLoadFileBasic(t *testing.T) {
 		t.Fatalf("bad:\n%s", actual)
 	}
 
+	actual = dataSourcesStr(c.DataSources)
+	if actual != strings.TrimSpace(basicDataSourcesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
 	actual = resourcesStr(c.Resources)
 	if actual != strings.TrimSpace(basicResourcesStr) {
 		t.Fatalf("bad:\n%s", actual)
@@ -240,6 +256,11 @@ func TestLoadFileBasic_json(t *testing.T) {
 		t.Fatalf("bad:\n%s", actual)
 	}
 
+	actual = dataSourcesStr(c.DataSources)
+	if actual != strings.TrimSpace(basicDataSourcesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
 	actual = resourcesStr(c.Resources)
 	if actual != strings.TrimSpace(basicResourcesStr) {
 		t.Fatalf("bad:\n%s", actual)
@@ -305,6 +326,11 @@ func TestLoadJSONBasic(t *testing.T) {
 		t.Fatalf("bad:\n%s", actual)
 	}
 
+	actual = dataSourcesStr(c.DataSources)
+	if actual != strings.TrimSpace(basicDataSourcesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
 	actual = resourcesStr(c.Resources)
 	if actual != strings.TrimSpace(basicResourcesStr) {
 		t.Fatalf("bad:\n%s", actual)
@@ -361,6 +387,11 @@ func TestLoadDir_basic(t *testing.T) {
 
 	actual = providerConfigsStr(c.ProviderConfigs)
 	if actual != strings.TrimSpace(dirBasicProvidersStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
+	actual = dataSourcesStr(c.DataSources)
+	if actual != strings.TrimSpace(dirBasicDataSourcesStr) {
 		t.Fatalf("bad:\n%s", actual)
 	}
 
@@ -421,6 +452,11 @@ func TestLoadDir_override(t *testing.T) {
 
 	actual = providerConfigsStr(c.ProviderConfigs)
 	if actual != strings.TrimSpace(dirOverrideProvidersStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
+	actual = dataSourcesStr(c.DataSources)
+	if actual != strings.TrimSpace(dirOverrideDataSourcesStr) {
 		t.Fatalf("bad:\n%s", actual)
 	}
 
@@ -766,6 +802,14 @@ do
     user: var.foo
 `
 
+const basicDataSourcesStr = `
+do[depends]
+  dependsOn
+    data.do.simple
+do[simple]
+  foo
+`
+
 const basicResourcesStr = `
 aws_instance[db] (x1)
   VPC
@@ -814,6 +858,14 @@ do
     user: var.foo
 `
 
+const dirBasicDataSourcesStr = `
+do[depends]
+  dependsOn
+    data.do.simple
+do[simple]
+  foo
+`
+
 const dirBasicResourcesStr = `
 aws_instance[db] (x1)
   security_groups
@@ -849,6 +901,15 @@ do
   api_key
   vars
     user: var.foo
+`
+
+const dirOverrideDataSourcesStr = `
+do[depends]
+  hello
+  dependsOn
+    data.do.simple
+do[simple]
+  foo
 `
 
 const dirOverrideResourcesStr = `

--- a/config/merge.go
+++ b/config/merge.go
@@ -93,6 +93,23 @@ func Merge(c1, c2 *Config) (*Config, error) {
 		}
 	}
 
+	// Data Sources
+	m1 = make([]merger, 0, len(c1.DataSources))
+	m2 = make([]merger, 0, len(c2.DataSources))
+	for _, v := range c1.DataSources {
+		m1 = append(m1, v)
+	}
+	for _, v := range c2.DataSources {
+		m2 = append(m2, v)
+	}
+	mresult = mergeSlice(m1, m2)
+	if len(mresult) > 0 {
+		c.DataSources = make([]*DataSource, len(mresult))
+		for i, v := range mresult {
+			c.DataSources[i] = v.(*DataSource)
+		}
+	}
+
 	// Resources
 	m1 = make([]merger, 0, len(c1.Resources))
 	m2 = make([]merger, 0, len(c2.Resources))

--- a/config/test-fixtures/basic.tf
+++ b/config/test-fixtures/basic.tf
@@ -12,6 +12,14 @@ provider "do" {
   api_key = "${var.foo}"
 }
 
+data "do" "simple" {
+    foo = "baz"
+}
+
+data "do" "depends" {
+    depends_on = ["data.do.simple"]
+}
+
 resource "aws_security_group" "firewall" {
     count = 5
 }

--- a/config/test-fixtures/basic.tf.json
+++ b/config/test-fixtures/basic.tf.json
@@ -17,6 +17,17 @@
         }
     },
 
+    "data": {
+        "do": {
+            "simple": {
+                "foo": "baz"
+            },
+            "depends": {
+                "depends_on": ["data.do.simple"]
+            }
+        }
+    },
+
     "resource": {
         "aws_instance": {
             "db": {

--- a/config/test-fixtures/data-source-arity-mistake.tf
+++ b/config/test-fixtures/data-source-arity-mistake.tf
@@ -1,0 +1,3 @@
+# I forgot the data source name!
+data "null" {
+}

--- a/config/test-fixtures/dir-basic/one.tf
+++ b/config/test-fixtures/dir-basic/one.tf
@@ -8,6 +8,10 @@ provider "aws" {
   secret_key = "bar"
 }
 
+data "do" "simple" {
+  foo = "baz"
+}
+
 resource "aws_instance" "db" {
     security_groups = "${aws_security_group.firewall.*.id}"
 }

--- a/config/test-fixtures/dir-basic/two.tf
+++ b/config/test-fixtures/dir-basic/two.tf
@@ -2,6 +2,10 @@ provider "do" {
   api_key = "${var.foo}"
 }
 
+data "do" "depends" {
+  depends_on = ["data.do.simple"]
+}
+
 resource "aws_security_group" "firewall" {
     count = 5
 }

--- a/config/test-fixtures/dir-override/foo_override.tf.json
+++ b/config/test-fixtures/dir-override/foo_override.tf.json
@@ -1,4 +1,11 @@
 {
+    "data": {
+        "do": {
+            "depends": {
+                "hello": "world"
+            }
+        }
+    },
     "resource": {
         "aws_instance": {
             "web": {

--- a/config/test-fixtures/dir-override/one.tf
+++ b/config/test-fixtures/dir-override/one.tf
@@ -8,6 +8,11 @@ provider "aws" {
   secret_key = "bar"
 }
 
+
+data "do" "simple" {
+  foo = "baz"
+}
+
 resource "aws_instance" "db" {
     security_groups = "${aws_security_group.firewall.*.id}"
 }

--- a/config/test-fixtures/dir-override/two.tf
+++ b/config/test-fixtures/dir-override/two.tf
@@ -2,6 +2,10 @@ provider "do" {
   api_key = "${var.foo}"
 }
 
+data "do" "depends" {
+  depends_on = ["data.do.simple"]
+}
+
 resource "aws_security_group" "firewall" {
     count = 5
 }


### PR DESCRIPTION
This is where I'm working on the implementation of the proposal from #4169.

* [x] `DataSource` type in the config module
* [x] Loading of `data` blocks from configuration files
* [ ] Validation of `data` blocks
* [ ] Introduction of data sources in the main `terraform` module
* [ ] New `RefreshData` method on the `ResourceProvider` interface
* [ ] `RefreshData` support in `helper/schema`
* Graph node and eval implementations for data sources:
 * [ ] Refresh
 * [ ] Plan
 * [ ] Apply
