### PR TITLE
Added support for http/https endpoints that auto confirms SNS topic subscription.

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/hashicorp/terraform/helper/resource"
 	"time"
 )
 
@@ -188,7 +188,7 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 	endpoint := d.Get("endpoint").(string)
 	topic_arn := d.Get("topic_arn").(string)
 	endpoint_auto_confirms := d.Get("endpoint_auto_confirms").(bool)
-	confirmation_timeout_in_minutes := time.Duration(d.Get("confirmation_timeout_in_minutes").(int))
+	confirmation_timeout_in_minutes := d.Get("confirmation_timeout_in_minutes").(int)
 
 	if strings.Contains(protocol, "http") && !endpoint_auto_confirms {
 		return nil, fmt.Errorf("Protocol http/https is only supported for endpoints which auto confirms!")
@@ -213,7 +213,7 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 
 		log.Printf("[DEBUG] SNS create topic subscription is pending so fetching the subscription list for topic : %s (%s) @ '%s'", endpoint, protocol, topic_arn)
 
-		err = resource.Retry(time.Minute*confirmation_timeout_in_minutes, func() error {
+		err = resource.Retry(time.Duration(int(time.Minute)*confirmation_timeout_in_minutes), func() error {
 
 			subscription, err := findSubscriptionByNonID(d, snsconn)
 

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -266,7 +266,7 @@ func findSubscriptionByNonID(d *schema.ResourceData, snsconn *sns.SNS) (*sns.Sub
 		}
 
 		for _, subscription := range res.Subscriptions {
-			if *subscription.Endpoint == endpoint && *subscription.Protocol == protocol && *subscription.TopicArn == topic_arn {
+			if *subscription.Endpoint == endpoint && *subscription.Protocol == protocol && *subscription.TopicArn == topic_arn && *subscription.SubscriptionArn != awsSNSPendingConfirmationMessage {
 				return subscription, nil
 			}
 		}

--- a/website/source/docs/providers/aws/r/sns_topic_subscription.html.markdown
+++ b/website/source/docs/providers/aws/r/sns_topic_subscription.html.markdown
@@ -51,9 +51,9 @@ The following arguments are supported:
 * `topic_arn` - (Required) The ARN of the SNS topic to subscribe to
 * `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`,  `lambda`, `application`. (`http` or `https` are partially supported, see below) (`email`, `sms`, are options but unsupported, see below).
 * `endpoint` - (Required) The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
-* `endpoint_auto_confirms` - (Optional) Boolean indicating whether the end point is capable of auto confirming subscription (default is false)
-* `max_fetch_retries` - (Optional) Integer indicating number of times the subscriptions list for a topic to be fetched to get the subscription arn for auto confirming end points.
-* `fetch_retry_delay` - (Optional) Integer indicating number of seconds to sleep before re-fetching the subscription list for the topic.
+* `endpoint_auto_confirms` - (Optional) Boolean indicating whether the end point is capable of [auto confirming subscription](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html#SendMessageToHttp.prepare) (default is false)
+* `max_fetch_retries` - (Optional) Integer indicating number of times the subscriptions list for a topic to be fetched to get the subscription arn for auto confirming end points (default is 3 times).
+* `fetch_retry_delay` - (Optional) Integer indicating number of seconds to sleep before re-fetching the subscription list for the topic (default is 1 second).
 * `raw_message_delivery` - (Optional) Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property).
 
 ### Protocols supported

--- a/website/source/docs/providers/aws/r/sns_topic_subscription.html.markdown
+++ b/website/source/docs/providers/aws/r/sns_topic_subscription.html.markdown
@@ -51,9 +51,8 @@ The following arguments are supported:
 * `topic_arn` - (Required) The ARN of the SNS topic to subscribe to
 * `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`,  `lambda`, `application`. (`http` or `https` are partially supported, see below) (`email`, `sms`, are options but unsupported, see below).
 * `endpoint` - (Required) The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
-* `endpoint_auto_confirms` - (Optional) Boolean indicating whether the end point is capable of [auto confirming subscription](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html#SendMessageToHttp.prepare) (default is false)
-* `max_fetch_retries` - (Optional) Integer indicating number of times the subscriptions list for a topic to be fetched to get the subscription arn for auto confirming end points (default is 3 times).
-* `fetch_retry_delay` - (Optional) Integer indicating number of seconds to sleep before re-fetching the subscription list for the topic (default is 1 second).
+* `endpoint_auto_confirms` - (Optional) Boolean indicating whether the end point is capable of [auto confirming subscription](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html#SendMessageToHttp.prepare) e.g., PagerDuty (default is false)
+* `confirmation_timeout_in_minutes` - (Optional) Integer indicating number of minutes to wait in retying mode for fetching subscription arn before marking it as failure. Only applicable for http and https protocols (default is 1 minute).
 * `raw_message_delivery` - (Optional) Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property).
 
 ### Protocols supported

--- a/website/source/docs/providers/aws/r/sns_topic_subscription.html.markdown
+++ b/website/source/docs/providers/aws/r/sns_topic_subscription.html.markdown
@@ -49,8 +49,11 @@ resource "aws_sns_topic_subscription" "user_updates_sqs_target" {
 The following arguments are supported:
 
 * `topic_arn` - (Required) The ARN of the SNS topic to subscribe to
-* `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`,  `lambda`,  or `application`. (`email`, `http`, `https`, `sms`, are options but unsupported, see below)
+* `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`,  `lambda`, `application`. (`http` or `https` are partially supported, see below) (`email`, `sms`, are options but unsupported, see below).
 * `endpoint` - (Required) The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
+* `endpoint_auto_confirms` - (Optional) Boolean indicating whether the end point is capable of auto confirming subscription (default is false)
+* `max_fetch_retries` - (Optional) Integer indicating number of times the subscriptions list for a topic to be fetched to get the subscription arn for auto confirming end points.
+* `fetch_retry_delay` - (Optional) Integer indicating number of seconds to sleep before re-fetching the subscription list for the topic.
 * `raw_message_delivery` - (Optional) Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property).
 
 ### Protocols supported
@@ -61,12 +64,15 @@ Supported SNS protocols include:
 * `sqs` -- delivery of JSON-encoded message to an Amazon SQS queue
 * `application` -- delivery of JSON-encoded message to an EndpointArn for a mobile app and device
 
+Partially supported SNS protocols include:
+
+* `http` -- delivery of JSON-encoded messages via HTTP. Supported only for the end points that auto confirms the subscription.
+* `https` -- delivery of JSON-encoded messages via HTTPS. Supported only for the end points that auto confirms the subscription.
+
 Unsupported protocols include the following:
 
 * `email` -- delivery of message via SMTP
 * `email-json` -- delivery of JSON-encoded message via SMTP
-* `http` -- delivery via HTTP
-* `http(s)` -- delivery via HTTPS
 * `sms` -- delivery text message
 
 These are unsupported because the endpoint needs to be authorized and does not 


### PR DESCRIPTION
Added support for http/https endpoints that auto confirms SNS topic subscription.

http and https SNS topic subscription endpoints require confirmation to set a valid arn otherwise
arn would be set to "pending confirmation". If the endpoints auto confirm then arn is set
asynchronously but if we try to create another subscription with same parameters then api returns
"pending subscription" as arn but does not create another a duplicate subscription. In order to
solve this we should be fetching the subscription list for the topic and identify the subscription
with same parameters i.e., protocol, topic_arn, endpoint and extract the subscription arn.

Following changes were made to support the http/https endpoints that auto confirms

1. Added 3 extra parameters i.e.,
   1. endpoint_auto_confirms -> boolean indicates if end points auto confirms
   2. max_fetch_retries -> number of times to fetch subscription list for the topic to get the subscription arn
   3. fetch_retry_delay -> delay b/w fetch subscription list call as the confirmation is done asynchronously.

  With these parameters help added support http and https protocol based endpoints that auto confirm.

2. Update website doc appropriately