### PR TITLE
Adds an acceptance test to the ARM Availability Set to show that tagging and updating of tags work as expected

### DIFF
--- a/builtin/providers/azurerm/resource_arm_availability_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set_test.go
@@ -32,6 +32,40 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVAvailabilitySet_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMVAvailabilitySet_withUpdatedTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -118,6 +152,39 @@ resource "azurerm_availability_set" "test" {
     name = "acceptanceTestAvailabilitySet1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`
+
+var testAccAzureRMVAvailabilitySet_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_availability_set" "test" {
+    name = "acceptanceTestAvailabilitySet1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMVAvailabilitySet_withUpdatedTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_availability_set" "test" {
+    name = "acceptanceTestAvailabilitySet1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    tags {
+	environment = "staging"
+    }
 }
 `
 

--- a/website/source/docs/providers/azurerm/r/availability_set.html.markdown
+++ b/website/source/docs/providers/azurerm/r/availability_set.html.markdown
@@ -22,6 +22,10 @@ resource "azurerm_availability_set" "test" {
     name = "acceptanceTestAvailabilitySet1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
+    
+    tags {
+        environment = "Production"
+    }
 }
 ```
 
@@ -40,6 +44,7 @@ The following arguments are supported:
 * `platform_update_domain_count` - (Optional) Specifies the number of update domains that are used. Defaults to 5.
 
 * `platform_fault_domain_count` - (Optional) Specifies the number of fault domains that are used. Defaults to 3.
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
Also updated the documentation for azure rm availability set to
demonstrate this

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMAvailabilitySet' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMAvailabilitySet -timeout 120m
=== RUN   TestAccAzureRMAvailabilitySet_basic
--- PASS: TestAccAzureRMAvailabilitySet_basic (119.59s)
=== RUN   TestAccAzureRMAvailabilitySet_withTags
--- PASS: TestAccAzureRMAvailabilitySet_withTags (171.14s)
=== RUN   TestAccAzureRMAvailabilitySet_withDomainCounts
--- PASS: TestAccAzureRMAvailabilitySet_withDomainCounts (119.99s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	410.736s
```