### PR TITLE
Add acceptance tests and docs update to allow the tagging of AzureRM …

### DIFF
--- a/builtin/providers/azurerm/resource_arm_resource_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_resource_group_test.go
@@ -25,6 +25,39 @@ func TestAccAzureRMResourceGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMResourceGroup_withTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMResourceGroup_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMResourceGroupExists("azurerm_resource_group.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_resource_group.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_resource_group.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_resource_group.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMResourceGroup_withTagsUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMResourceGroupExists("azurerm_resource_group.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_resource_group.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_resource_group.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMResourceGroupExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -78,5 +111,28 @@ var testAccAzureRMResourceGroup_basic = `
 resource "azurerm_resource_group" "test" {
     name = "acceptanceTestResourceGroup1_basic"
     location = "West US"
+}
+`
+
+var testAccAzureRMResourceGroup_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1_basic"
+    location = "West US"
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMResourceGroup_withTagsUpdated = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1_basic"
+    location = "West US"
+
+    tags {
+	environment = "staging"
+    }
 }
 `

--- a/builtin/providers/azurerm/resource_arm_virtual_network_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network_test.go
@@ -25,6 +25,39 @@ func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVirtualNetwork_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkExists("azurerm_virtual_network.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_virtual_network.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_virtual_network.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_virtual_network.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMVirtualNetwork_withTagsUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkExists("azurerm_virtual_network.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_virtual_network.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_virtual_network.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMVirtualNetworkExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -95,6 +128,53 @@ resource "azurerm_virtual_network" "test" {
     subnet {
         name = "subnet1"
         address_prefix = "10.0.1.0/24"
+    }
+}
+`
+
+var testAccAzureRMVirtualNetwork_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acceptanceTestVirtualNetwork1"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    subnet {
+        name = "subnet1"
+        address_prefix = "10.0.1.0/24"
+    }
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMVirtualNetwork_withTagsUpdated = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acceptanceTestVirtualNetwork1"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    subnet {
+        name = "subnet1"
+        address_prefix = "10.0.1.0/24"
+    }
+
+    tags {
+	environment = "staging"
     }
 }
 `

--- a/website/source/docs/providers/azurerm/r/resource_group.html.markdown
+++ b/website/source/docs/providers/azurerm/r/resource_group.html.markdown
@@ -16,6 +16,10 @@ Creates a new resource group on Azure.
 resource "azurerm_resource_group" "test" {
   name     = "testResourceGroup1"
   location = "West US"
+  
+  tags {
+    environment = "Production"
+  }
 }
 ```
 
@@ -28,6 +32,8 @@ The following arguments are supported:
 
 * `location` - (Required) The location where the resource group should be created.
     For a list of all Azure locations, please consult [this link](http://azure.microsoft.com/en-us/regions/).
+    
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/azurerm/r/virtual_network.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_network.html.markdown
@@ -34,6 +34,10 @@ resource "azurerm_virtual_network" "test" {
     name           = "subnet3"
     address_prefix = "10.0.3.0/24"
   }
+  
+  tags {
+    environment = "Production"
+  }
 }
 ```
 
@@ -59,6 +63,8 @@ The following arguments are supported:
 
 * `subnet` - (Optional) Can be specified multiple times to define multiple
     subnets. Each `subnet` block supports fields documented below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 The `subnet` block supports:
 


### PR DESCRIPTION
…resource  &

@jen20 

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMResourceGroup' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMResourceGroup -timeout 120m
=== RUN   TestAccAzureRMResourceGroup_basic
--- PASS: TestAccAzureRMResourceGroup_basic (116.65s)
=== RUN   TestAccAzureRMResourceGroup_withTags
--- PASS: TestAccAzureRMResourceGroup_withTags (151.96s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	268.637s
```

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMVirtualNetwork' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMVirtualNetwork -timeout 120m
=== RUN   TestAccAzureRMVirtualNetwork_basic
--- PASS: TestAccAzureRMVirtualNetwork_basic (122.23s)
=== RUN   TestAccAzureRMVirtualNetwork_withTags
--- PASS: TestAccAzureRMVirtualNetwork_withTags (164.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	286.617s
```