### PR TITLE
[WIP] provider/azurerm: tagging of resources

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -139,6 +139,8 @@ func resourceArmNetworkInterface() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -152,6 +154,7 @@ func resourceArmNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
+	tags := d.Get("tags").(map[string]interface{})
 
 	properties := network.InterfacePropertiesFormat{}
 
@@ -198,6 +201,7 @@ func resourceArmNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 		Name:       &name,
 		Location:   &location,
 		Properties: &properties,
+		Tags:       expandTags(tags),
 	}
 
 	resp, err := ifaceClient.CreateOrUpdate(resGroup, name, iface)
@@ -270,6 +274,8 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 			d.Set("internal_fqdn", iface.DNSSettings.InternalFqdn)
 		}
 	}
+
+	flattenAndSetTags(d, resp.Tags)
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
@@ -26,6 +26,40 @@ func TestAccAzureRMNetworkInterface_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterface_withTags(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_interface.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_interface.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_interface.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_withTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_interface.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_interface.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
 ///TODO: Re-enable this test when https://github.com/Azure/azure-sdk-for-go/issues/259 is fixed
 //func TestAccAzureRMNetworkInterface_addingIpConfigurations(t *testing.T) {
 //
@@ -138,6 +172,81 @@ resource "azurerm_network_interface" "test" {
     	name = "testconfiguration1"
     	subnet_id = "${azurerm_subnet.test.id}"
     	private_ip_address_allocation = "dynamic"
+    }
+}
+`
+
+var testAccAzureRMNetworkInterface_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acceptanceTestVirtualNetwork1"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "testsubnet"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acceptanceTestNetworkInterface1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMNetworkInterface_withTagsUpdate = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acceptanceTestVirtualNetwork1"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "testsubnet"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acceptanceTestNetworkInterface1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+
+    tags {
+	environment = "staging"
     }
 }
 `

--- a/builtin/providers/azurerm/resource_arm_network_security_group.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group.go
@@ -118,6 +118,8 @@ func resourceArmNetworkSecurityGroup() *schema.Resource {
 				},
 				Set: resourceArmNetworkSecurityGroupRuleHash,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -129,6 +131,7 @@ func resourceArmNetworkSecurityGroupCreate(d *schema.ResourceData, meta interfac
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
+	tags := d.Get("tags").(map[string]interface{})
 
 	sgRules, sgErr := expandAzureRmSecurityRules(d)
 	if sgErr != nil {
@@ -141,6 +144,7 @@ func resourceArmNetworkSecurityGroupCreate(d *schema.ResourceData, meta interfac
 		Properties: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &sgRules,
 		},
+		Tags: expandTags(tags),
 	}
 
 	resp, err := secClient.CreateOrUpdate(resGroup, name, sg)
@@ -186,6 +190,8 @@ func resourceArmNetworkSecurityGroupRead(d *schema.ResourceData, meta interface{
 	if resp.Properties.SecurityRules != nil {
 		d.Set("security_rule", flattenNetworkSecurityRules(resp.Properties.SecurityRules))
 	}
+
+	flattenAndSetTags(d, resp.Tags)
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_network_security_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group_test.go
@@ -26,6 +26,40 @@ func TestAccAzureRMNetworkSecurityGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkSecurityGroup_withTags(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkSecurityGroup_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkSecurityGroupExists("azurerm_network_security_group.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_security_group.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_security_group.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_security_group.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMNetworkSecurityGroup_withTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkSecurityGroupExists("azurerm_network_security_group.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_security_group.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_security_group.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkSecurityGroup_addingExtraRules(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -166,6 +200,66 @@ resource "azurerm_network_security_group" "test" {
     	destination_port_range = "*"
     	source_address_prefix = "*"
     	destination_address_prefix = "*"
+    }
+}
+`
+
+var testAccAzureRMNetworkSecurityGroup_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_network_security_group" "test" {
+    name = "acceptanceTestSecurityGroup1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    security_rule {
+    	name = "test123"
+    	priority = 100
+    	direction = "Inbound"
+    	access = "Allow"
+    	protocol = "Tcp"
+    	source_port_range = "*"
+    	destination_port_range = "*"
+    	source_address_prefix = "*"
+    	destination_address_prefix = "*"
+    }
+
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMNetworkSecurityGroup_withTagsUpdate = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_network_security_group" "test" {
+    name = "acceptanceTestSecurityGroup1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    security_rule {
+    	name = "test123"
+    	priority = 100
+    	direction = "Inbound"
+    	access = "Allow"
+    	protocol = "Tcp"
+    	source_port_range = "*"
+    	destination_port_range = "*"
+    	source_address_prefix = "*"
+    	destination_address_prefix = "*"
+    }
+
+    tags {
+	environment = "staging"
     }
 }
 `

--- a/builtin/providers/azurerm/resource_arm_public_ip.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip.go
@@ -79,6 +79,8 @@ func resourceArmPublicIp() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -92,6 +94,7 @@ func resourceArmPublicIpCreate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
+	tags := d.Get("tags").(map[string]interface{})
 
 	properties := network.PublicIPAddressPropertiesFormat{
 		PublicIPAllocationMethod: network.IPAllocationMethod(d.Get("public_ip_address_allocation").(string)),
@@ -126,6 +129,7 @@ func resourceArmPublicIpCreate(d *schema.ResourceData, meta interface{}) error {
 		Name:       &name,
 		Location:   &location,
 		Properties: &properties,
+		Tags:       expandTags(tags),
 	}
 
 	resp, err := publicIPClient.CreateOrUpdate(resGroup, name, publicIp)
@@ -175,6 +179,8 @@ func resourceArmPublicIpRead(d *schema.ResourceData, meta interface{}) error {
 	if resp.Properties.IPAddress != nil && *resp.Properties.IPAddress != "" {
 		d.Set("ip_address", resp.Properties.IPAddress)
 	}
+
+	flattenAndSetTags(d, resp.Tags)
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_public_ip_test.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip_test.go
@@ -96,6 +96,40 @@ func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPublicIpStatic_withTags(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMVPublicIpStatic_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_public_ip.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_public_ip.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_public_ip.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMVPublicIpStatic_withTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_public_ip.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_public_ip.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMPublicIpStatic_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -240,5 +274,40 @@ resource "azurerm_public_ip" "test" {
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "dynamic"
+}
+`
+
+var testAccAzureRMVPublicIpStatic_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_public_ip" "test" {
+    name = "acceptanceTestPublicIp1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMVPublicIpStatic_withTagsUpdate = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_public_ip" "test" {
+    name = "acceptanceTestPublicIp1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+
+    tags {
+	environment = "staging"
+    }
 }
 `

--- a/builtin/providers/azurerm/resource_arm_route_table.go
+++ b/builtin/providers/azurerm/resource_arm_route_table.go
@@ -80,6 +80,8 @@ func resourceArmRouteTable() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -93,10 +95,12 @@ func resourceArmRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
+	tags := d.Get("tags").(map[string]interface{})
 
 	routeSet := network.RouteTable{
 		Name:     &name,
 		Location: &location,
+		Tags:     expandTags(tags),
 	}
 
 	if _, ok := d.GetOk("route"); ok {
@@ -164,6 +168,8 @@ func resourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
+
+	flattenAndSetTags(d, resp.Tags)
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_route_table_test.go
+++ b/builtin/providers/azurerm/resource_arm_route_table_test.go
@@ -74,6 +74,40 @@ func TestAccAzureRMRouteTable_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMRouteTable_withTags(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMRouteTable_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_route_table.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_route_table.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_route_table.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMRouteTable_withTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_route_table.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_route_table.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMRouteTable_multipleRoutes(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -196,6 +230,53 @@ resource "azurerm_route_table" "test" {
     	name = "route2"
     	address_prefix = "*"
     	next_hop_type = "virtualappliance"
+    }
+}
+`
+
+var testAccAzureRMRouteTable_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_route_table" "test" {
+    name = "acceptanceTestSecurityGroup1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    route {
+    	name = "route1"
+    	address_prefix = "*"
+    	next_hop_type = "internet"
+    }
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMRouteTable_withTagsUpdate = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_route_table" "test" {
+    name = "acceptanceTestSecurityGroup1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    route {
+    	name = "route1"
+    	address_prefix = "*"
+    	next_hop_type = "internet"
+    }
+
+    tags {
+	environment = "staging"
     }
 }
 `

--- a/website/source/docs/providers/azurerm/r/network_interface.html.markdown
+++ b/website/source/docs/providers/azurerm/r/network_interface.html.markdown
@@ -34,6 +34,10 @@ resource "azurerm_virtual_network" "test" {
     name           = "subnet3"
     address_prefix = "10.0.3.0/24"
   }
+  
+  tags {
+    environment = "Production"
+  }
 }
 ```
 
@@ -58,6 +62,8 @@ The following arguments are supported:
 * `dns_servers` - (Optional) List of DNS servers IP addresses to use for this NIC, overrides the VNet-level server list
 
 * `ip_configuration` - (Optional) Collection of ipConfigurations associated with this NIC. Each `ip_configuration` block supports fields documented below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 The `ip_configuration` block supports:
 

--- a/website/source/docs/providers/azurerm/r/network_security_group.html.markdown
+++ b/website/source/docs/providers/azurerm/r/network_security_group.html.markdown
@@ -34,7 +34,12 @@ resource "azurerm_network_security_group" "test" {
     	source_address_prefix = "*"
     	destination_address_prefix = "*"
     }
+    
+    tags {
+        environment = "Production"
+    }
 }
+
 ```
 
 ## Argument Reference
@@ -51,6 +56,8 @@ The following arguments are supported:
 
 * `security_rule` - (Optional) Can be specified multiple times to define multiple
                                    security rules. Each `security_rule` block supports fields documented below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 
 The `security_rule` block supports:

--- a/website/source/docs/providers/azurerm/r/public_ip.html.markdown
+++ b/website/source/docs/providers/azurerm/r/public_ip.html.markdown
@@ -23,6 +23,10 @@ resource "azurerm_public_ip" "test" {
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
+    
+    tags {
+        environment = "Production"
+    }
 }
 ```
 
@@ -45,6 +49,8 @@ The following arguments are supported:
 * `domain_name_label` - (Optional) Label for the Domain Name. Will be used to make up the FQDN.  If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
 
 * `reverse_fqdn` - (Optional) A fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/azurerm/r/route_table.html.markdown
+++ b/website/source/docs/providers/azurerm/r/route_table.html.markdown
@@ -28,6 +28,10 @@ resource "azurerm_route_table" "test" {
     	address_prefix = "*"
     	next_hop_type = "internet"
     }
+    
+    tags {
+        environment = "Production"
+    }
 }
 ```
 
@@ -45,6 +49,8 @@ The following arguments are supported:
 
 * `route` - (Optional) Can be specified multiple times to define multiple
                                    routes. Each `route` block supports fields documented below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 The `route` block supports:
 


### PR DESCRIPTION
Adds the ability to tag to the Azure RM resources:

- [x] Network Security Group
- [x] Network Interface Card
- [x] Public IP
- [x] Route Table

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMNetworkInterface' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMNetworkInterface -timeout 120m
=== RUN   TestAccAzureRMNetworkInterface_basic
--- PASS: TestAccAzureRMNetworkInterface_basic (151.08s)
=== RUN   TestAccAzureRMNetworkInterface_withTags
--- PASS: TestAccAzureRMNetworkInterface_withTags (211.20s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	362.290s
```

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMNetworkSecurityGroup' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMNetworkSecurityGroup -timeout 120m
=== RUN   TestAccAzureRMNetworkSecurityGroup_basic
--- PASS: TestAccAzureRMNetworkSecurityGroup_basic (135.98s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_withTags
--- PASS: TestAccAzureRMNetworkSecurityGroup_withTags (183.24s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_addingExtraRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_addingExtraRules (164.85s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	484.081s
```

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMPublicIp' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMPublicIp -timeout 120m
=== RUN   TestResourceAzureRMPublicIpAllocation_validation
--- PASS: TestResourceAzureRMPublicIpAllocation_validation (0.00s)
=== RUN   TestResourceAzureRMPublicIpDomainNameLabel_validation
--- PASS: TestResourceAzureRMPublicIpDomainNameLabel_validation (0.00s)
=== RUN   TestAccAzureRMPublicIpStatic_basic
--- PASS: TestAccAzureRMPublicIpStatic_basic (135.58s)
=== RUN   TestAccAzureRMPublicIpStatic_withTags
--- PASS: TestAccAzureRMPublicIpStatic_withTags (180.36s)
=== RUN   TestAccAzureRMPublicIpStatic_update
--- PASS: TestAccAzureRMPublicIpStatic_update (179.63s)
=== RUN   TestAccAzureRMPublicIpDynamic_basic
--- PASS: TestAccAzureRMPublicIpDynamic_basic (135.36s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm
```

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMRouteTable' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMRouteTable -timeout 120m
=== RUN   TestResourceAzureRMRouteTableNextHopType_validation
--- PASS: TestResourceAzureRMRouteTableNextHopType_validation (0.00s)
=== RUN   TestAccAzureRMRouteTable_basic
--- PASS: TestAccAzureRMRouteTable_basic (120.87s)
=== RUN   TestAccAzureRMRouteTable_withTags
--- PASS: TestAccAzureRMRouteTable_withTags (169.16s)
=== RUN   TestAccAzureRMRouteTable_multipleRoutes
--- PASS: TestAccAzureRMRouteTable_multipleRoutes (161.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	451.424s
```