### PR TITLE
Principal * gets rejected by AWS, use cloudtrail.amazonaws.com instead.

### DIFF
--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -29,14 +29,18 @@ resource "aws_s3_bucket" "foo" {
         {
             "Sid": "AWSCloudTrailAclCheck",
             "Effect": "Allow",
-            "Principal": "*",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
             "Action": "s3:GetBucketAcl",
             "Resource": "arn:aws:s3:::tf-test-trail"
         },
         {
             "Sid": "AWSCloudTrailWrite",
             "Effect": "Allow",
-            "Principal": "*",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
             "Action": "s3:PutObject",
             "Resource": "arn:aws:s3:::tf-test-trail/*",
             "Condition": {


### PR DESCRIPTION
Using Principal * causes following error:

This policy contains the following error: Has prohibited field Principal For more information about the IAM policy grammar, see AWS IAM Policies.

Changing Principal to cloudtrail.amazonaws.com fixes it as per http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-set-bucket-policy-for-multiple-accounts.html