### PR TITLE
Do not error out if cloudwatch log_group already exists

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,7 +47,13 @@ func resourceAwsCloudWatchLogGroupCreate(d *schema.ResourceData, meta interface{
 		LogGroupName: aws.String(d.Get("name").(string)),
 	})
 	if err != nil {
-		return fmt.Errorf("Creating CloudWatch Log Group failed: %s", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() != "ResourceAlreadyExistsException" {
+				return fmt.Errorf("Creating CloudWatch Log Group failed: %s", err)
+			}
+		} else {
+			return fmt.Errorf("Creating CloudWatch Log Group failed: %s", err)
+		}
 	}
 
 	d.SetId(d.Get("name").(string))


### PR DESCRIPTION
The `aws_cloudwatch_log_group` resource uses the name as ID - when trying to create a log group and a log group by that name already exists the run should just succeed.