### PR TITLE
provider/azurerm: Parse "resourcegroups" in IDs

### DIFF
--- a/builtin/providers/azurerm/resourceid.go
+++ b/builtin/providers/azurerm/resourceid.go
@@ -69,7 +69,15 @@ func parseAzureResourceID(id string) (*ResourceID, error) {
 		idObj.ResourceGroup = resourceGroup
 		delete(componentMap, "resourceGroups")
 	} else {
-		return nil, fmt.Errorf("No resource group name found in: %q", path)
+		// Some Azure APIs are weird and provide things in lower case...
+		// However it's not clear whether the casing of other elements in the URI
+		// matter, so we explicitly look for that case here.
+		if resourceGroup, ok := componentMap["resourcegroups"]; ok {
+			idObj.ResourceGroup = resourceGroup
+			delete(componentMap, "resourcegroups")
+		} else {
+			return nil, fmt.Errorf("No resource group name found in: %q", path)
+		}
 	}
 
 	// It is OK not to have a provider in the case of a resource group

--- a/builtin/providers/azurerm/resourceid_test.go
+++ b/builtin/providers/azurerm/resourceid_test.go
@@ -89,6 +89,18 @@ func TestParseAzureResourceID(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourcegroups/acceptanceTestResourceGroup1/providers/Microsoft.Cdn/profiles/acceptanceTestCdnProfile1",
+			&ResourceID{
+				SubscriptionID: "34ca515c-4629-458e-bf7c-738d77e0d0ea",
+				ResourceGroup:  "acceptanceTestResourceGroup1",
+				Provider:       "Microsoft.Cdn",
+				Path: map[string]string{
+					"profiles": "acceptanceTestCdnProfile1",
+				},
+			},
+			false,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
When parsing resource IDs (probably incorrectly since they are URIs and should therefore be opaque), we need to look for "resourcegroups" in addition to "resourceGroups" because the Azure CDN resources return that in their URIs.

Unfortunately the casing semantics of the rest of the string are not clear, so downcasing the entire URI is probably best avoided. This is a fix for a single case. If it comes up again we may need to re-examine this.