### PR TITLE
config: detect provisioner-only resource in JSON and error [GH-4385]

### DIFF
--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -405,6 +405,15 @@ func loadResourcesHcl(list *ast.ObjectList) ([]*Resource, error) {
 	// Now go over all the types and their children in order to get
 	// all of the actual resources.
 	for _, item := range list.Items {
+		// GH-4385: We detect a pure provisioner resource and give the user
+		// an error about how to do it cleanly.
+		if len(item.Keys) == 4 && item.Keys[2].Token.Value().(string) == "provisioner" {
+			return nil, fmt.Errorf(
+				"position %s: provisioners in a resource should be wrapped in a list\n\n"+
+					"Example: \"provisioner\": [ { \"local-exec\": ... } ]",
+				item.Pos())
+		}
+
 		if len(item.Keys) != 2 {
 			return nil, fmt.Errorf(
 				"position %s: resource must be followed by exactly two strings, a type and a name",


### PR DESCRIPTION
Fixes #4385 

This detects when a very specific kind of JSON config is input to Terraform and shows an error. A potentially better fix would be to modify the HCL AST in Terraform and transform it to the correct one. This would be a lot of effort compared to this when there is a very easy workaround.

I didn't test this since the test case would have to test the error string itself which I don't like, and otherwise with without this fix you get an error, this just improves the error message.