### PR TITLE
Literals with escaped interpolations work

### DIFF
--- a/config/interpolate_walk.go
+++ b/config/interpolate_walk.go
@@ -118,9 +118,15 @@ func (w *interpolationWalker) Primitive(v reflect.Value) error {
 		return err
 	}
 
-	// If the AST we got is just a literal string value, then we ignore it
-	if _, ok := astRoot.(*ast.LiteralNode); ok {
-		return nil
+	// If the AST we got is just a literal string value with the same
+	// value then we ignore it. We have to check if its the same value
+	// because it is possible to input a string, get out a string, and
+	// have it be different. For example: "foo-$${bar}" turns into
+	// "foo-${bar}"
+	if n, ok := astRoot.(*ast.LiteralNode); ok {
+		if s, ok := n.Value.(string); ok && s == v.String() {
+			return nil
+		}
 	}
 
 	if w.ContextF != nil {

--- a/config/interpolate_walk_test.go
+++ b/config/interpolate_walk_test.go
@@ -18,7 +18,9 @@ func TestInterpolationWalker_detect(t *testing.T) {
 			Input: map[string]interface{}{
 				"foo": "$${var.foo}",
 			},
-			Result: nil,
+			Result: []string{
+				"Literal(TypeString, ${var.foo})",
+			},
 		},
 
 		{
@@ -114,7 +116,7 @@ func TestInterpolationWalker_replace(t *testing.T) {
 				"foo": "$${var.foo}",
 			},
 			Output: map[string]interface{}{
-				"foo": "$${var.foo}",
+				"foo": "bar",
 			},
 			Value: "bar",
 		},

--- a/config/lang/eval_test.go
+++ b/config/lang/eval_test.go
@@ -25,6 +25,14 @@ func TestEval(t *testing.T) {
 		},
 
 		{
+			"foo $${bar}",
+			nil,
+			false,
+			"foo ${bar}",
+			ast.TypeString,
+		},
+
+		{
 			"foo ${bar}",
 			&ast.BasicScope{
 				VarMap: map[string]ast.Variable{

--- a/config/raw_config_test.go
+++ b/config/raw_config_test.go
@@ -114,6 +114,38 @@ func TestRawConfig_double(t *testing.T) {
 	}
 }
 
+func TestRawConfigInterpolate_escaped(t *testing.T) {
+	raw := map[string]interface{}{
+		"foo": "bar-$${baz}",
+	}
+
+	rc, err := NewRawConfig(raw)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Before interpolate, Config() should be the raw
+	if !reflect.DeepEqual(rc.Config(), raw) {
+		t.Fatalf("bad: %#v", rc.Config())
+	}
+
+	if err := rc.Interpolate(nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := rc.Config()
+	expected := map[string]interface{}{
+		"foo": "bar-${baz}",
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+	if len(rc.UnknownKeys()) != 0 {
+		t.Fatalf("bad: %#v", rc.UnknownKeys())
+	}
+}
+
 func TestRawConfig_merge(t *testing.T) {
 	raw1 := map[string]interface{}{
 		"foo": "${var.foo}",

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -104,6 +104,29 @@ func TestContext2Plan_emptyDiff(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_escapedVar(t *testing.T) {
+	m := testModule(t, "plan-escaped-var")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(testTerraformPlanEscapedVarStr)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestContext2Plan_minimal(t *testing.T) {
 	m := testModule(t, "plan-empty")
 	p := testProvider("aws")

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -983,6 +983,18 @@ STATE:
 <no state>
 `
 
+const testTerraformPlanEscapedVarStr = `
+DIFF:
+
+CREATE: aws_instance.foo
+  foo:  "" => "bar-${baz}"
+  type: "" => "aws_instance"
+
+STATE:
+
+<no state>
+`
+
 const testTerraformPlanModulesStr = `
 DIFF:
 

--- a/terraform/test-fixtures/plan-escaped-var/main.tf
+++ b/terraform/test-fixtures/plan-escaped-var/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  foo = "bar-$${baz}"
+}


### PR DESCRIPTION
Fixes #2909 

If you had a literal with an escaped interpolation such as `foo-$${bar}` it was not properly turning into `foo-${bar}`. This fixes that. 

The fix is simple: we had an optimization where if after we parsed the string for interpolations we found only a literal we assumed there was nothing and skipped it. We now check to make sure the result is also the same string and if not, we still evaluate the string.