### PR TITLE
core: fix diff mismatch when RequiresNew field and list both change

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -466,6 +466,13 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 				ok = true
 			}
 
+			// Similarly, in a RequiresNew scenario, a list that shows up in the plan
+			// diff can disappear from the apply diff, which is calculated from an
+			// empty state.
+			if d.RequiresNew() && strings.HasSuffix(k, ".#") {
+				ok = true
+			}
+
 			if !ok {
 				return false, fmt.Sprintf("attribute mismatch: %s", k)
 			}

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -553,6 +553,43 @@ func TestInstanceDiffSame(t *testing.T) {
 			true,
 			"",
 		},
+
+		// Another thing that can occur in DESTROY/CREATE scenarios is that list
+		// values that are going to zero have diffs that show up at plan time but
+		// are gone at apply time. The NewRemoved handling catches the fields and
+		// treats them as OK, but it also needs to treat the .# field itself as
+		// okay to be present in the old diff but not in the new one.
+		{
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"reqnew": &ResourceAttrDiff{
+						Old:         "old",
+						New:         "new",
+						RequiresNew: true,
+					},
+					"somemap.#": &ResourceAttrDiff{
+						Old: "1",
+						New: "0",
+					},
+					"somemap.oldkey": &ResourceAttrDiff{
+						Old:        "long ago",
+						New:        "",
+						NewRemoved: true,
+					},
+				},
+			},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"reqnew": &ResourceAttrDiff{
+						Old:         "",
+						New:         "new",
+						RequiresNew: true,
+					},
+				},
+			},
+			true,
+			"",
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
fixes #1752

Includes AccTest reproducing example from the issue as well as a bunch
of explanatory comments in the tests and impls.