### PR TITLE
command/init: put remote state config at proper path [GH-2927]

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-getter"
@@ -51,6 +52,11 @@ func (c *InitCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Error getting pwd: %s", err))
 		}
 	}
+
+	// Set the state out path to be the path requested for the module
+	// to be copied. This ensures any remote states gets setup in the
+	// proper directory.
+	c.Meta.dataDir = filepath.Join(path, DefaultDataDirectory)
 
 	source := args[0]
 

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -179,6 +179,42 @@ func TestInit_remoteState(t *testing.T) {
 	}
 }
 
+func TestInit_remoteStateSubdir(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+	subdir := filepath.Join(tmp, "subdir")
+
+	s := terraform.NewState()
+	conf, srv := testRemoteState(t, s, 200)
+	defer srv.Close()
+
+	ui := new(cli.MockUi)
+	c := &InitCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-backend", "http",
+		"-backend-config", "address=" + conf.Config["address"],
+		testFixturePath("init"),
+		subdir,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(subdir, "hello.tf")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(subdir, DefaultDataDir, DefaultStateFilename)); err != nil {
+		t.Fatalf("missing state: %s", err)
+	}
+}
+
 func TestInit_remoteStateWithLocal(t *testing.T) {
 	tmp, cwd := testCwd(t)
 	defer testFixCwd(t, tmp, cwd)


### PR DESCRIPTION
Fixes #2927 

Fairly straightforward based on the issue described in #2927.