### PR TITLE
provider/azurerm: add CDN Endpoint resource

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -41,7 +41,8 @@ type ArmClient struct {
 	routeTablesClient            network.RouteTablesClient
 	routesClient                 network.RoutesClient
 
-	cdnProfilesClient cdn.ProfilesClient
+	cdnProfilesClient  cdn.ProfilesClient
+	cdnEndpointsClient cdn.EndpointsClient
 
 	providers           resources.ProvidersClient
 	resourceGroupClient resources.GroupsClient
@@ -254,6 +255,12 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	cpc.Authorizer = spt
 	cpc.Sender = autorest.CreateSender(withRequestLogging())
 	client.cdnProfilesClient = cpc
+
+	cec := cdn.NewEndpointsClient(c.SubscriptionID)
+	setUserAgent(&cec.Client)
+	cec.Authorizer = spt
+	cec.Sender = autorest.CreateSender(withRequestLogging())
+	client.cdnEndpointsClient = cec
 
 	return &client, nil
 }

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -54,6 +54,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_route_table":            resourceArmRouteTable(),
 			"azurerm_route":                  resourceArmRoute(),
 			"azurerm_cdn_profile":            resourceArmCdnProfile(),
+			"azurerm_cdn_endpoint":           resourceArmCdnEndpoint(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
@@ -1,0 +1,451 @@
+package azurerm
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/cdn"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmCdnEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmCdnEndpointCreate,
+		Read:   resourceArmCdnEndpointRead,
+		Update: resourceArmCdnEndpointUpdate,
+		Delete: resourceArmCdnEndpointDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"profile_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"origin_host_header": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"is_http_allowed": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"is_https_allowed": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"origin": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"host_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"http_port": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+
+						"https_port": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+				Set: resourceArmCdnEndpointOriginHash,
+			},
+
+			"origin_path": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"querystring_caching_behaviour": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "IgnoreQueryString",
+				ValidateFunc: validateCdnEndpointQuerystringCachingBehaviour,
+			},
+
+			"content_types_to_compress": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"is_compression_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"host_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	cdnEndpointsClient := client.cdnEndpointsClient
+
+	log.Printf("[INFO] preparing arguments for Azure ARM CDN EndPoint creation.")
+
+	name := d.Get("name").(string)
+	location := d.Get("location").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	profileName := d.Get("profile_name").(string)
+	http_allowed := d.Get("is_http_allowed").(bool)
+	https_allowed := d.Get("is_https_allowed").(bool)
+	compression_enabled := d.Get("is_compression_enabled").(bool)
+	caching_behaviour := d.Get("querystring_caching_behaviour").(string)
+	tags := d.Get("tags").(map[string]interface{})
+
+	properties := cdn.EndpointPropertiesCreateUpdateParameters{
+		IsHTTPAllowed:              &http_allowed,
+		IsHTTPSAllowed:             &https_allowed,
+		IsCompressionEnabled:       &compression_enabled,
+		QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(caching_behaviour),
+	}
+
+	origins, originsErr := expandAzureRmCdnEndpointOrigins(d)
+	if originsErr != nil {
+		return fmt.Errorf("Error Building list of CDN Endpoint Origins: %s", originsErr)
+	}
+	if len(origins) > 0 {
+		properties.Origins = &origins
+	}
+
+	if v, ok := d.GetOk("origin_host_header"); ok {
+		host_header := v.(string)
+		properties.OriginHostHeader = &host_header
+	}
+
+	if v, ok := d.GetOk("origin_path"); ok {
+		origin_path := v.(string)
+		properties.OriginPath = &origin_path
+	}
+
+	if v, ok := d.GetOk("content_types_to_compress"); ok {
+		var content_types []string
+		ctypes := v.(*schema.Set).List()
+		for _, ct := range ctypes {
+			str := ct.(string)
+			content_types = append(content_types, str)
+		}
+
+		properties.ContentTypesToCompress = &content_types
+	}
+
+	cdnEndpoint := cdn.EndpointCreateParameters{
+		Location:   &location,
+		Properties: &properties,
+		Tags:       expandTags(tags),
+	}
+
+	resp, err := cdnEndpointsClient.Create(name, cdnEndpoint, profileName, resGroup)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ID)
+
+	log.Printf("[DEBUG] Waiting for CDN Endpoint (%s) to become available", name)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating", "Creating"},
+		Target:  "Succeeded",
+		Refresh: cdnEndpointStateRefreshFunc(client, resGroup, profileName, name),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for CDN Endpoint (%s) to become available: %s", name, err)
+	}
+
+	return resourceArmCdnEndpointRead(d, meta)
+}
+
+func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	cdnEndpointsClient := meta.(*ArmClient).cdnEndpointsClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["endpoints"]
+	profileName := id.Path["profiles"]
+	if profileName == "" {
+		profileName = id.Path["Profiles"]
+	}
+	log.Printf("[INFO] Trying to find the AzureRM CDN Endpoint %s (Profile: %s, RG: %s)", name, profileName, resGroup)
+	resp, err := cdnEndpointsClient.Get(name, profileName, resGroup)
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure CDN Endpoint %s: %s", name, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("host_name", resp.Properties.HostName)
+	d.Set("is_compression_enabled", resp.Properties.IsCompressionEnabled)
+	d.Set("is_http_allowed", resp.Properties.IsHTTPAllowed)
+	d.Set("is_https_allowed", resp.Properties.IsHTTPSAllowed)
+	d.Set("querystring_caching_behaviour", resp.Properties.QueryStringCachingBehavior)
+	if resp.Properties.OriginHostHeader != nil && *resp.Properties.OriginHostHeader != "" {
+		d.Set("origin_host_header", resp.Properties.OriginHostHeader)
+	}
+	if resp.Properties.OriginPath != nil && *resp.Properties.OriginPath != "" {
+		d.Set("origin_path", resp.Properties.OriginPath)
+	}
+	if resp.Properties.ContentTypesToCompress != nil && len(*resp.Properties.ContentTypesToCompress) > 0 {
+		d.Set("content_types_to_compress", flattenAzureRMCdnEndpointContentTypes(resp.Properties.ContentTypesToCompress))
+	}
+	d.Set("origin", flattenAzureRMCdnEndpointOrigin(resp.Properties.Origins))
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}
+
+func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+	cdnEndpointsClient := meta.(*ArmClient).cdnEndpointsClient
+
+	if !d.HasChange("tags") {
+		return nil
+	}
+
+	name := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	profileName := d.Get("profile_name").(string)
+	http_allowed := d.Get("is_http_allowed").(bool)
+	https_allowed := d.Get("is_https_allowed").(bool)
+	compression_enabled := d.Get("is_compression_enabled").(bool)
+	caching_behaviour := d.Get("querystring_caching_behaviour").(string)
+	newTags := d.Get("tags").(map[string]interface{})
+
+	properties := cdn.EndpointPropertiesCreateUpdateParameters{
+		IsHTTPAllowed:              &http_allowed,
+		IsHTTPSAllowed:             &https_allowed,
+		IsCompressionEnabled:       &compression_enabled,
+		QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(caching_behaviour),
+	}
+
+	if d.HasChange("origin") {
+		origins, originsErr := expandAzureRmCdnEndpointOrigins(d)
+		if originsErr != nil {
+			return fmt.Errorf("Error Building list of CDN Endpoint Origins: %s", originsErr)
+		}
+		if len(origins) > 0 {
+			properties.Origins = &origins
+		}
+	}
+
+	if d.HasChange("origin_host_header") {
+		host_header := d.Get("origin_host_header").(string)
+		properties.OriginHostHeader = &host_header
+	}
+
+	if d.HasChange("origin_path") {
+		origin_path := d.Get("origin_path").(string)
+		properties.OriginPath = &origin_path
+	}
+
+	if d.HasChange("content_types_to_compress") {
+		var content_types []string
+		ctypes := d.Get("content_types_to_compress").(*schema.Set).List()
+		for _, ct := range ctypes {
+			str := ct.(string)
+			content_types = append(content_types, str)
+		}
+
+		properties.ContentTypesToCompress = &content_types
+	}
+
+	updateProps := cdn.EndpointUpdateParameters{
+		Tags:       expandTags(newTags),
+		Properties: &properties,
+	}
+
+	_, err := cdnEndpointsClient.Update(name, updateProps, profileName, resGroup)
+	if err != nil {
+		return fmt.Errorf("Error issuing Azure ARM update request to update CDN Endpoint %q: %s", name, err)
+	}
+
+	return resourceArmCdnEndpointRead(d, meta)
+}
+
+func resourceArmCdnEndpointDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).cdnEndpointsClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	profileName := id.Path["profiles"]
+	if profileName == "" {
+		profileName = id.Path["Profiles"]
+	}
+	name := id.Path["endpoints"]
+
+	accResp, err := client.DeleteIfExists(name, profileName, resGroup)
+	if err != nil {
+		if accResp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("Error issuing AzureRM delete request for CDN Endpoint %q: %s", name, err)
+	}
+	_, err = pollIndefinitelyAsNeeded(client.Client, accResp.Response, http.StatusNotFound)
+	if err != nil {
+		return fmt.Errorf("Error polling for AzureRM delete request for CDN Endpoint %q: %s", name, err)
+	}
+
+	return err
+}
+
+func cdnEndpointStateRefreshFunc(client *ArmClient, resourceGroupName string, profileName string, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.cdnEndpointsClient.Get(name, profileName, resourceGroupName)
+		if err != nil {
+			return nil, "", fmt.Errorf("Error issuing read request in cdnEndpointStateRefreshFunc to Azure ARM for CDN Endpoint '%s' (RG: '%s'): %s", name, resourceGroupName, err)
+		}
+		return res, string(res.Properties.ProvisioningState), nil
+	}
+}
+
+func validateCdnEndpointQuerystringCachingBehaviour(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	cachingTypes := map[string]bool{
+		"ignorequerystring": true,
+		"bypasscaching":     true,
+		"usequerystring":    true,
+	}
+
+	if !cachingTypes[value] {
+		errors = append(errors, fmt.Errorf("CDN Endpoint querystringCachingBehaviours can only be IgnoreQueryString, BypassCaching or UseQueryString"))
+	}
+	return
+}
+
+func resourceArmCdnEndpointOriginHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["host_name"].(string)))
+
+	return hashcode.String(buf.String())
+}
+
+func expandAzureRmCdnEndpointOrigins(d *schema.ResourceData) ([]cdn.DeepCreatedOrigin, error) {
+	configs := d.Get("origin").(*schema.Set).List()
+	origins := make([]cdn.DeepCreatedOrigin, 0, len(configs))
+
+	for _, configRaw := range configs {
+		data := configRaw.(map[string]interface{})
+
+		host_name := data["host_name"].(string)
+
+		properties := cdn.DeepCreatedOriginProperties{
+			HostName: &host_name,
+		}
+
+		if v, ok := data["https_port"]; ok {
+			https_port := v.(int)
+			properties.HTTPSPort = &https_port
+
+		}
+
+		if v, ok := data["http_port"]; ok {
+			http_port := v.(int)
+			properties.HTTPPort = &http_port
+		}
+
+		name := data["name"].(string)
+
+		origin := cdn.DeepCreatedOrigin{
+			Name:       &name,
+			Properties: &properties,
+		}
+
+		origins = append(origins, origin)
+	}
+
+	return origins, nil
+}
+
+func flattenAzureRMCdnEndpointOrigin(list *[]cdn.DeepCreatedOrigin) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(*list))
+	for _, i := range *list {
+		l := map[string]interface{}{
+			"name":      *i.Name,
+			"host_name": *i.Properties.HostName,
+		}
+
+		if i.Properties.HTTPPort != nil {
+			l["http_port"] = *i.Properties.HTTPPort
+		}
+		if i.Properties.HTTPSPort != nil {
+			l["https_port"] = *i.Properties.HTTPSPort
+		}
+		result = append(result, l)
+	}
+	return result
+}
+
+func flattenAzureRMCdnEndpointContentTypes(list *[]string) []interface{} {
+	vs := make([]interface{}, 0, len(*list))
+	for _, v := range *list {
+		vs = append(vs, v)
+	}
+	return vs
+}

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
@@ -1,0 +1,201 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMCdnEndpoint_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMCdnEndpoints_withTags(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMCdnEndpoint_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_cdn_endpoint.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_cdn_endpoint.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_cdn_endpoint.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAzureRMCdnEndpoint_withTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_cdn_endpoint.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_cdn_endpoint.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMCdnEndpointExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		profileName := rs.Primary.Attributes["profile_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient
+
+		resp, err := conn.Get(name, profileName, resourceGroup)
+		if err != nil {
+			return fmt.Errorf("Bad: Get on cdnEndpointsClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: CDN Endpoint %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMCdnEndpointDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_cdn_endpoint" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		profileName := rs.Primary.Attributes["profile_name"]
+
+		resp, err := conn.Get(name, profileName, resourceGroup)
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("CDN Endpoint still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMCdnEndpoint_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_cdn_profile" "test" {
+    name = "acceptanceTestCdnProfile1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "Standard"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+    name = "acceptanceTestCdnEndpoint1"
+    profile_name = "${azurerm_cdn_profile.test.name}"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    origin {
+	name = "acceptanceTestCdnOrigin1"
+	host_name = "www.example.com"
+    }
+}
+`
+
+var testAccAzureRMCdnEndpoint_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup2"
+    location = "West US"
+}
+resource "azurerm_cdn_profile" "test" {
+    name = "acceptanceTestCdnProfile2"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "Standard"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+    name = "acceptanceTestCdnEndpoint2"
+    profile_name = "${azurerm_cdn_profile.test.name}"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    origin {
+	name = "acceptanceTestCdnOrigin2"
+	host_name = "www.example.com"
+    }
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMCdnEndpoint_withTagsUpdate = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup2"
+    location = "West US"
+}
+resource "azurerm_cdn_profile" "test" {
+    name = "acceptanceTestCdnProfile2"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "Standard"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+    name = "acceptanceTestCdnEndpoint2"
+    profile_name = "${azurerm_cdn_profile.test.name}"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    origin {
+	name = "acceptanceTestCdnOrigin2"
+	host_name = "www.example.com"
+    }
+
+    tags {
+	environment = "staging"
+    }
+}
+`

--- a/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
@@ -107,7 +107,7 @@ func testCheckAzureRMCdnProfileExists(name string) resource.TestCheckFunc {
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for availability set: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for cdn profile: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnProfilesClient

--- a/website/source/docs/providers/azurerm/r/cdn_endpoint.html.markdown
+++ b/website/source/docs/providers/azurerm/r/cdn_endpoint.html.markdown
@@ -1,0 +1,87 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cdn_endpoint"
+sidebar_current: "docs-azurerm-resource-cdn-endpoint"
+description: |-
+  Create a CDN Endpoint entity.
+---
+
+# azurerm\_cdn\_endpoint
+
+A CDN Endpoint is the entity within a CDN Profile containing configuration information regarding caching behaviors and origins. The CDN Endpoint is exposed using the URL format <endpointname>.azureedge.net by default, but custom domains can also be created.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+resource "azurerm_cdn_profile" "test" {
+    name = "acceptanceTestCdnProfile1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "Standard"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+    name = "acceptanceTestCdnEndpoint1"
+    profile_name = "${azurerm_cdn_profile.test.name}"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    origin {
+	    name = "acceptanceTestCdnOrigin1"
+	    host_name = "www.example.com"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the CDN Endpoint. Changing this forces a
+    new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the CDN Endpoint.
+    
+* `profile_name` - (Required) The CDN Profile to which to attach the CDN Endpoint.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
+
+* `is_http_allowed` - (Optional) Defaults to `true`.
+
+* `is_https_allowed` - (Optional) Defaults to `true`.
+
+* `origin` - (Optional) The set of origins of the CDN endpoint. When multiple origins exist, the first origin will be used as primary and rest will be used as failover options. 
+Each `origin` block supports fields documented below.
+
+* `origin_path` - (Optional) The path used at for origin requests.
+
+* `querystring_caching_behaviour` - (Optional) Sets query string caching behavior. Allowed values are `IgnoreQueryString`, `BypassCaching` and `UseQueryString`. Defaults to `IgnoreQueryString`.
+
+* `content_types_to_compress` - (Optional) An array of strings that indicates a content types on which compression will be applied. The value for the elements should be MIME types.
+
+* `is_compression_enabled` - (Optional) Indicates whether compression is to be enabled. Defaults to false.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
+
+The `origin` block supports:
+
+* `name` - (Required) The name of the origin. This is an arbitrary value. However, this value needs to be unique under endpoint.
+
+* `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string could be a domain name, IPv4 address or IPv6 address.
+
+* `http_port` - (Optional) The HTTP port of the origin. Defaults to null. When null, 80 will be used for HTTP.
+
+* `https_port` - (Optional) The HTTPS port of the origin. Defaults to null. When null, 443 will be used for HTTPS.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The CDN Endpoint ID.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -23,6 +23,10 @@
                   <a href="/docs/providers/azurerm/r/cdn_profile.html">azurerm_cdn_profile</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-cdn-endpoint") %>>
+                  <a href="/docs/providers/azurerm/r/cdn_endpoint.html">azurerm_cdn_endpoint</a>
+                </li>
+
               </ul>
             </li>
 


### PR DESCRIPTION
Scaffold the AzureRM [CDN Endpoint](https://msdn.microsoft.com/en-us/library/mt634457.aspx) resource 

- [x] schema
- [x] CRUD
- [x] Acceptance Tests
- [x] Documentation

Test Results:

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMCdnEndpoint' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate ./...
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=AzureRMCdnEndpoint -timeout 120m
=== RUN   TestAccAzureRMCdnEndpoint_basic
--- PASS: TestAccAzureRMCdnEndpoint_basic (359.38s)
=== RUN   TestAccAzureRMCdnEndpoints_withTags
--- PASS: TestAccAzureRMCdnEndpoints_withTags (414.45s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	773.843s
```