### PR TITLE
core: write planfile even on empty plans

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -102,15 +102,6 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	if plan.Diff.Empty() {
-		c.Ui.Output(
-			"No changes. Infrastructure is up-to-date. This means that Terraform\n" +
-				"could not detect any differences between your configuration and\n" +
-				"the real physical resources that exist. As a result, Terraform\n" +
-				"doesn't need to do anything.")
-		return 0
-	}
-
 	if outPath != "" {
 		log.Printf("[INFO] Writing plan output to: %s", outPath)
 		f, err := os.Create(outPath)
@@ -122,6 +113,15 @@ func (c *PlanCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Error writing plan file: %s", err))
 			return 1
 		}
+	}
+
+	if plan.Diff.Empty() {
+		c.Ui.Output(
+			"No changes. Infrastructure is up-to-date. This means that Terraform\n" +
+				"could not detect any differences between your configuration and\n" +
+				"the real physical resources that exist. As a result, Terraform\n" +
+				"doesn't need to do anything.")
+		return 0
 	}
 
 	if outPath == "" {

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -177,6 +177,55 @@ func TestPlan_outPath(t *testing.T) {
 	}
 }
 
+func TestPlan_outPathNoChange(t *testing.T) {
+	originalState := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo": &terraform.ResourceState{
+						Type: "test_instance",
+						Primary: &terraform.InstanceState{
+							ID: "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	statePath := testStateFile(t, originalState)
+
+	tf, err := ioutil.TempFile("", "tf")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	outPath := tf.Name()
+	os.Remove(tf.Name())
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &PlanCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-out", outPath,
+		"-state", statePath,
+		testFixturePath("plan"),
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	plan := testReadPlan(t, outPath)
+	if !plan.Diff.Empty() {
+		t.Fatalf("Expected empty plan to be written to plan file, got: %s", plan)
+	}
+}
+
 func TestPlan_refresh(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)


### PR DESCRIPTION
This makes the planfile workflow more consistent. If a plan yields a
noop, the apply of that planfile will noop.

Fixes #1783