### PR TITLE
Add support for multiple final states on the WaitForState resource

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack.go
@@ -142,7 +142,7 @@ func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface
 
 	wait := resource.StateChangeConf{
 		Pending:    []string{"CREATE_IN_PROGRESS", "ROLLBACK_IN_PROGRESS", "ROLLBACK_COMPLETE"},
-		Target:     "CREATE_COMPLETE",
+		Target:     []string{"CREATE_COMPLETE"},
 		Timeout:    30 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -311,7 +311,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 			"UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
 			"UPDATE_ROLLBACK_COMPLETE",
 		},
-		Target:     "UPDATE_COMPLETE",
+		Target:     []string{"UPDATE_COMPLETE"},
 		Timeout:    15 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -370,7 +370,7 @@ func resourceAwsCloudFormationStackDelete(d *schema.ResourceData, meta interface
 
 	wait := resource.StateChangeConf{
 		Pending:    []string{"DELETE_IN_PROGRESS", "ROLLBACK_IN_PROGRESS"},
-		Target:     "DELETE_COMPLETE",
+		Target:     []string{"DELETE_COMPLETE"},
 		Timeout:    30 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (interface{}, string, error) {

--- a/builtin/providers/aws/resource_aws_customer_gateway.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway.go
@@ -68,7 +68,7 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	// Wait for the CustomerGateway to be available.
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    customerGatewayRefreshFunc(conn, *customerGateway.CustomerGatewayId),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -388,7 +388,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			stateConf := &resource.StateChangeConf{
 				Pending: []string{"creating", "backing-up", "modifying", "resetting-master-credentials",
 					"maintenance", "renaming", "rebooting", "upgrading"},
-				Target:     "available",
+				Target:     []string{"available"},
 				Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 				Timeout:    40 * time.Minute,
 				MinTimeout: 10 * time.Second,
@@ -512,7 +512,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"creating", "backing-up", "modifying", "resetting-master-credentials",
 			"maintenance", "renaming", "rebooting", "upgrading"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 		Timeout:    40 * time.Minute,
 		MinTimeout: 10 * time.Second,
@@ -663,7 +663,7 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"creating", "backing-up",
 			"modifying", "deleting", "available"},
-		Target:     "",
+		Target:     []string{},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 		Timeout:    40 * time.Minute,
 		MinTimeout: 10 * time.Second,

--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -226,7 +226,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 func resourceAwsDbParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsDbParameterGroupDeleteRefreshFunc(d, meta),
 		Timeout:    3 * time.Minute,
 		MinTimeout: 1 * time.Second,

--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -125,7 +125,7 @@ func resourceAwsDbSecurityGroupCreate(d *schema.ResourceData, meta interface{}) 
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"authorizing"},
-		Target:  "authorized",
+		Target:  []string{"authorized"},
 		Refresh: resourceAwsDbSecurityGroupStateRefreshFunc(d, meta),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -189,7 +189,7 @@ func resourceAwsDbSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsDbSubnetGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsDbSubnetGroupDeleteRefreshFunc(d, meta),
 		Timeout:    3 * time.Minute,
 		MinTimeout: 1 * time.Second,

--- a/builtin/providers/aws/resource_aws_directory_service_directory.go
+++ b/builtin/providers/aws/resource_aws_directory_service_directory.go
@@ -321,7 +321,7 @@ func resourceAwsDirectoryServiceDirectoryCreate(d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Waiting for DS (%q) to become available", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Requested", "Creating", "Created"},
-		Target:  "Active",
+		Target:  []string{"Active"},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := dsconn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
 				DirectoryIds: []*string{aws.String(d.Id())},
@@ -449,7 +449,7 @@ func resourceAwsDirectoryServiceDirectoryDelete(d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Waiting for DS (%q) to be deleted", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Deleting"},
-		Target:  "Deleted",
+		Target:  []string{"Deleted"},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := dsconn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
 				DirectoryIds: []*string{aws.String(d.Id())},

--- a/builtin/providers/aws/resource_aws_ebs_volume.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume.go
@@ -117,7 +117,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    volumeStateRefreshFunc(conn, *result.VolumeId),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -313,7 +313,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 	// Wait until it's deleted
 	wait := resource.StateChangeConf{
 		Pending:    []string{"DRAINING"},
-		Target:     "INACTIVE",
+		Target:     []string{"INACTIVE"},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {

--- a/builtin/providers/aws/resource_aws_efs_file_system.go
+++ b/builtin/providers/aws/resource_aws_efs_file_system.go
@@ -51,7 +51,7 @@ func resourceAwsEfsFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"creating"},
-		Target:  "available",
+		Target:  []string{"available"},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeFileSystems(&efs.DescribeFileSystemsInput{
 				FileSystemId: aws.String(d.Id()),
@@ -127,7 +127,7 @@ func resourceAwsEfsFileSystemDelete(d *schema.ResourceData, meta interface{}) er
 	})
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"available", "deleting"},
-		Target:  "",
+		Target:  []string{},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeFileSystems(&efs.DescribeFileSystemsInput{
 				FileSystemId: aws.String(d.Id()),

--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -81,7 +81,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"creating"},
-		Target:  "available",
+		Target:  []string{"available"},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeMountTargets(&efs.DescribeMountTargetsInput{
 				MountTargetId: aws.String(d.Id()),
@@ -179,7 +179,7 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"available", "deleting", "deleted"},
-		Target:  "",
+		Target:  []string{},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeMountTargets(&efs.DescribeMountTargetsInput{
 				MountTargetId: aws.String(d.Id()),

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -290,7 +290,7 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 	pending := []string{"creating"}
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    cacheClusterStateRefreshFunc(conn, d.Id(), "available", pending),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
@@ -466,7 +466,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		pending := []string{"modifying", "rebooting cache cluster nodes", "snapshotting"}
 		stateConf := &resource.StateChangeConf{
 			Pending:    pending,
-			Target:     "available",
+			Target:     []string{"available"},
 			Refresh:    cacheClusterStateRefreshFunc(conn, d.Id(), "available", pending),
 			Timeout:    5 * time.Minute,
 			Delay:      5 * time.Second,
@@ -537,7 +537,7 @@ func resourceAwsElasticacheClusterDelete(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Waiting for deletion: %v", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "available", "deleting", "incompatible-parameters", "incompatible-network", "restore-failed"},
-		Target:     "",
+		Target:     []string{},
 		Refresh:    cacheClusterStateRefreshFunc(conn, d.Id(), "", []string{}),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
@@ -169,7 +169,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 func resourceAwsElasticacheParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsElasticacheParameterGroupDeleteRefreshFunc(d, meta),
 		Timeout:    3 * time.Minute,
 		MinTimeout: 1 * time.Second,

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -401,7 +401,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "running",
+		Target:     []string{"running"},
 		Refresh:    InstanceStateRefreshFunc(conn, *instance.InstanceId),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
@@ -1082,7 +1082,7 @@ func awsTerminateInstance(conn *ec2.EC2, id string) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending", "running", "shutting-down", "stopped", "stopping"},
-		Target:     "terminated",
+		Target:     []string{"terminated"},
 		Refresh:    InstanceStateRefreshFunc(conn, id),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -170,7 +170,7 @@ func resourceAwsInternetGatewayAttach(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Waiting for internet gateway (%s) to attach", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"detached", "attaching"},
-		Target:  "available",
+		Target:  []string{"available"},
 		Refresh: IGAttachStateRefreshFunc(conn, d.Id(), "available"),
 		Timeout: 1 * time.Minute,
 	}
@@ -205,7 +205,7 @@ func resourceAwsInternetGatewayDetach(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Waiting for internet gateway (%s) to detach", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"detaching"},
-		Target:  "detached",
+		Target:  []string{"detached"},
 		Refresh: detachIGStateRefreshFunc(conn, d.Id(), vpcID.(string)),
 		Timeout: 5 * time.Minute,
 		Delay:   10 * time.Second,

--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -141,7 +141,7 @@ func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"CREATING"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    firehoseStreamStateRefreshFunc(conn, sn),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
@@ -256,7 +256,7 @@ func resourceAwsKinesisFirehoseDeliveryStreamDelete(d *schema.ResourceData, meta
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"DELETING"},
-		Target:     "DESTROYED",
+		Target:     []string{"DESTROYED"},
 		Refresh:    firehoseStreamStateRefreshFunc(conn, sn),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_kinesis_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_stream.go
@@ -60,7 +60,7 @@ func resourceAwsKinesisStreamCreate(d *schema.ResourceData, meta interface{}) er
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"CREATING"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    streamStateRefreshFunc(conn, sn),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
@@ -142,7 +142,7 @@ func resourceAwsKinesisStreamDelete(d *schema.ResourceData, meta interface{}) er
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"DELETING"},
-		Target:     "DESTROYED",
+		Target:     []string{"DESTROYED"},
 		Refresh:    streamStateRefreshFunc(conn, sn),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_nat_gateway.go
+++ b/builtin/providers/aws/resource_aws_nat_gateway.go
@@ -77,7 +77,7 @@ func resourceAwsNatGatewayCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Waiting for NAT Gateway (%s) to become available", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  "available",
+		Target:  []string{"available"},
 		Refresh: NGStateRefreshFunc(conn, d.Id()),
 		Timeout: 10 * time.Minute,
 	}
@@ -137,7 +137,7 @@ func resourceAwsNatGatewayDelete(d *schema.ResourceData, meta interface{}) error
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting"},
-		Target:     "deleted",
+		Target:     []string{"deleted"},
 		Refresh:    NGStateRefreshFunc(conn, d.Id()),
 		Timeout:    30 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -186,7 +186,7 @@ func resourceAwsNetworkInterfaceDetach(oa *schema.Set, meta interface{}, eniId s
 		log.Printf("[DEBUG] Waiting for ENI (%s) to become dettached", eniId)
 		stateConf := &resource.StateChangeConf{
 			Pending: []string{"true"},
-			Target:  "false",
+			Target:  []string{"false"},
 			Refresh: networkInterfaceAttachmentRefreshFunc(conn, eniId),
 			Timeout: 10 * time.Minute,
 		}

--- a/builtin/providers/aws/resource_aws_placement_group.go
+++ b/builtin/providers/aws/resource_aws_placement_group.go
@@ -49,7 +49,7 @@ func resourceAwsPlacementGroupCreate(d *schema.ResourceData, meta interface{}) e
 
 	wait := resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -114,7 +114,7 @@ func resourceAwsPlacementGroupDelete(d *schema.ResourceData, meta interface{}) e
 
 	wait := resource.StateChangeConf{
 		Pending:    []string{"deleting"},
-		Target:     "deleted",
+		Target:     []string{"deleted"},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -212,7 +212,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 	d.SetId(*resp.DBCluster.DBClusterIdentifier)
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "backing-up", "modifying"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
 		Timeout:    5 * time.Minute,
 		MinTimeout: 3 * time.Second,
@@ -352,7 +352,7 @@ func resourceAwsRDSClusterDelete(d *schema.ResourceData, meta interface{}) error
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting", "backing-up", "modifying"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
 		Timeout:    5 * time.Minute,
 		MinTimeout: 3 * time.Second,

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -105,7 +105,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 	// reuse db_instance refresh func
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "backing-up", "modifying"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 		Timeout:    40 * time.Minute,
 		MinTimeout: 10 * time.Second,
@@ -205,7 +205,7 @@ func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{
 	log.Println("[INFO] Waiting for RDS Cluster Instance to be destroyed")
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"modifying", "deleting"},
-		Target:     "",
+		Target:     []string{},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 		Timeout:    40 * time.Minute,
 		MinTimeout: 10 * time.Second,

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -261,7 +261,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "backing-up", "modifying"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    resourceAwsRedshiftClusterStateRefreshFunc(d, meta),
 		Timeout:    5 * time.Minute,
 		MinTimeout: 3 * time.Second,
@@ -402,7 +402,7 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "deleting", "rebooting", "resizing", "renaming"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    resourceAwsRedshiftClusterStateRefreshFunc(d, meta),
 		Timeout:    10 * time.Minute,
 		MinTimeout: 5 * time.Second,
@@ -444,7 +444,7 @@ func resourceAwsRedshiftClusterDelete(d *schema.ResourceData, meta interface{}) 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"available", "creating", "deleting", "rebooting", "resizing", "renaming"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsRedshiftClusterStateRefreshFunc(d, meta),
 		Timeout:    40 * time.Minute,
 		MinTimeout: 5 * time.Second,

--- a/builtin/providers/aws/resource_aws_redshift_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_parameter_group.go
@@ -167,7 +167,7 @@ func resourceAwsRedshiftParameterGroupUpdate(d *schema.ResourceData, meta interf
 func resourceAwsRedshiftParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsRedshiftParameterGroupDeleteRefreshFunc(d, meta),
 		Timeout:    3 * time.Minute,
 		MinTimeout: 1 * time.Second,

--- a/builtin/providers/aws/resource_aws_redshift_security_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_security_group.go
@@ -107,7 +107,7 @@ func resourceAwsRedshiftSecurityGroupCreate(d *schema.ResourceData, meta interfa
 	log.Println("[INFO] Waiting for Redshift Security Group Ingress Authorizations to be authorized")
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"authorizing"},
-		Target:  "authorized",
+		Target:  []string{"authorized"},
 		Refresh: resourceAwsRedshiftSecurityGroupStateRefreshFunc(d, meta),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_redshift_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group.go
@@ -127,7 +127,7 @@ func resourceAwsRedshiftSubnetGroupUpdate(d *schema.ResourceData, meta interface
 func resourceAwsRedshiftSubnetGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsRedshiftSubnetGroupDeleteRefreshFunc(d, meta),
 		Timeout:    3 * time.Minute,
 		MinTimeout: 1 * time.Second,

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -180,7 +180,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 
 	wait := resource.StateChangeConf{
 		Pending:    []string{"rejected"},
-		Target:     "accepted",
+		Target:     []string{"accepted"},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -223,7 +223,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 	wait = resource.StateChangeConf{
 		Delay:      30 * time.Second,
 		Pending:    []string{"PENDING"},
-		Target:     "INSYNC",
+		Target:     []string{"INSYNC"},
 		Timeout:    30 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {
@@ -357,7 +357,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 
 	wait := resource.StateChangeConf{
 		Pending:    []string{"rejected"},
-		Target:     "accepted",
+		Target:     []string{"accepted"},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -109,7 +109,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	wait := resource.StateChangeConf{
 		Delay:      30 * time.Second,
 		Pending:    []string{"PENDING"},
-		Target:     "INSYNC",
+		Target:     []string{"INSYNC"},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 2 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {

--- a/builtin/providers/aws/resource_aws_route53_zone_association.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association.go
@@ -71,7 +71,7 @@ func resourceAwsRoute53ZoneAssociationCreate(d *schema.ResourceData, meta interf
 	wait := resource.StateChangeConf{
 		Delay:      30 * time.Second,
 		Pending:    []string{"PENDING"},
-		Target:     "INSYNC",
+		Target:     []string{"INSYNC"},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 2 * time.Second,
 		Refresh: func() (result interface{}, state string, err error) {

--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -107,7 +107,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 		d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  "ready",
+		Target:  []string{"ready"},
 		Refresh: resourceAwsRouteTableStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}
@@ -372,7 +372,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"ready"},
-		Target:  "",
+		Target:  []string{},
 		Refresh: resourceAwsRouteTableStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -218,7 +218,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{""},
-		Target:  "exists",
+		Target:  []string{"exists"},
 		Refresh: SGStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -119,7 +119,7 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 					log.Printf("[DEBUG] Updating SNS Topic (%s) attributes request: %s", d.Id(), req)
 					stateConf := &resource.StateChangeConf{
 						Pending:    []string{"retrying"},
-						Target:     "success",
+						Target:     []string{"success"},
 						Refresh:    resourceAwsSNSUpdateRefreshFunc(meta, req),
 						Timeout:    1 * time.Minute,
 						MinTimeout: 3 * time.Second,

--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -132,7 +132,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 		spotStateConf := &resource.StateChangeConf{
 			// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html
 			Pending:    []string{"start", "pending-evaluation", "pending-fulfillment"},
-			Target:     "fulfilled",
+			Target:     []string{"fulfilled"},
 			Refresh:    SpotInstanceStateRefreshFunc(conn, sir),
 			Timeout:    10 * time.Minute,
 			Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -75,7 +75,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for subnet (%s) to become available", *subnet.SubnetId)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  "available",
+		Target:  []string{"available"},
 		Refresh: SubnetStateRefreshFunc(conn, *subnet.SubnetId),
 		Timeout: 10 * time.Minute,
 	}
@@ -166,7 +166,7 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	wait := resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "destroyed",
+		Target:     []string{"destroyed"},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {

--- a/builtin/providers/aws/resource_aws_volume_attachment.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment.go
@@ -72,7 +72,7 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"attaching"},
-		Target:     "attached",
+		Target:     []string{"attached"},
 		Refresh:    volumeAttachmentStateRefreshFunc(conn, vID, iID),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
@@ -163,7 +163,7 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 	_, err := conn.DetachVolume(opts)
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"detaching"},
-		Target:     "detached",
+		Target:     []string{"detached"},
 		Refresh:    volumeAttachmentStateRefreshFunc(conn, vID, iID),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -118,7 +118,7 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 		d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  "available",
+		Target:  []string{"available"},
 		Refresh: VPCStateRefreshFunc(conn, d.Id()),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
@@ -121,7 +121,7 @@ func resourceAwsVpcDhcpOptionsCreate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Waiting for DHCP Options (%s) to become available", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  "",
+		Target:  []string{},
 		Refresh: DHCPOptionsStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -75,7 +75,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 		d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  "pending-acceptance",
+		Target:  []string{"pending-acceptance"},
 		Refresh: resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -171,7 +171,7 @@ func resourceAwsVpnConnectionCreate(d *schema.ResourceData, meta interface{}) er
 	// more frequently than every ten seconds.
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    vpnConnectionRefreshFunc(conn, *vpnConnection.VpnConnectionId),
 		Timeout:    30 * time.Minute,
 		Delay:      10 * time.Second,
@@ -303,7 +303,7 @@ func resourceAwsVpnConnectionDelete(d *schema.ResourceData, meta interface{}) er
 	// VPC stack can safely run.
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting"},
-		Target:     "deleted",
+		Target:     []string{"deleted"},
 		Refresh:    vpnConnectionRefreshFunc(conn, d.Id()),
 		Timeout:    30 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -195,7 +195,7 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Waiting for VPN gateway (%s) to attach", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"detached", "attaching"},
-		Target:  "attached",
+		Target:  []string{"attached"},
 		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "available"),
 		Timeout: 1 * time.Minute,
 	}
@@ -256,7 +256,7 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Waiting for VPN gateway (%s) to detach", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"attached", "detaching", "available"},
-		Target:  "detached",
+		Target:  []string{"detached"},
 		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "detached"),
 		Timeout: 1 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
@@ -201,7 +201,7 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Waiting for CDN Endpoint (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating", "Creating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: cdnEndpointStateRefreshFunc(client, resGroup, profileName, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_cdn_profile.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile.go
@@ -85,7 +85,7 @@ func resourceArmCdnProfileCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Waiting for CDN Profile (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating", "Creating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: cdnProfileStateRefreshFunc(client, resGroup, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -214,7 +214,7 @@ func resourceArmNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Waiting for Network Interface (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: networkInterfaceStateRefreshFunc(client, resGroup, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_network_security_group.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group.go
@@ -157,7 +157,7 @@ func resourceArmNetworkSecurityGroupCreate(d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Waiting for Network Security Group (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: securityGroupStateRefreshFunc(client, resGroup, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_network_security_rule.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_rule.go
@@ -153,7 +153,7 @@ func resourceArmNetworkSecurityRuleCreate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Waiting for Network Security Rule (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: securityRuleStateRefreshFunc(client, resGroup, nsgName, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_public_ip.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip.go
@@ -142,7 +142,7 @@ func resourceArmPublicIpCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for Public IP (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: publicIPStateRefreshFunc(client, resGroup, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_resource_group.go
+++ b/builtin/providers/azurerm/resource_arm_resource_group.go
@@ -103,7 +103,7 @@ func resourceArmResourceGroupCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Waiting for Resource Group (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: resourceGroupStateRefreshFunc(client, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_route.go
+++ b/builtin/providers/azurerm/resource_arm_route.go
@@ -95,7 +95,7 @@ func resourceArmRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for Route (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: routeStateRefreshFunc(client, resGroup, rtName, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_route_table.go
+++ b/builtin/providers/azurerm/resource_arm_route_table.go
@@ -125,7 +125,7 @@ func resourceArmRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Waiting for Route Table (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: routeTableStateRefreshFunc(client, resGroup, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -112,7 +112,7 @@ func resourceArmSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for Subnet (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: subnetRuleStateRefreshFunc(client, resGroup, vnetName, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -109,7 +109,7 @@ func resourceArmVirtualNetworkCreate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Waiting for Virtual Network (%s) to become available", name)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Accepted", "Updating"},
-		Target:  "Succeeded",
+		Target:  []string{"Succeeded"},
 		Refresh: virtualNetworkStateRefreshFunc(client, resGroup, name),
 		Timeout: 10 * time.Minute,
 	}

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -418,7 +418,7 @@ func WaitForDropletAttribute(
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
-		Target:     target,
+		Target:     []string{target},
 		Refresh:    newDropletStateRefreshFunc(d, attribute, meta),
 		Timeout:    60 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
@@ -131,7 +131,7 @@ func waitForFloatingIPReady(
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
-		Target:     target,
+		Target:     []string{target},
 		Refresh:    newFloatingIPStateRefreshFunc(d, attribute, meta, actionId),
 		Timeout:    60 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/google/compute_operation.go
+++ b/builtin/providers/google/compute_operation.go
@@ -63,7 +63,7 @@ func (w *ComputeOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
 func (w *ComputeOperationWaiter) Conf() *resource.StateChangeConf {
 	return &resource.StateChangeConf{
 		Pending: []string{"PENDING", "RUNNING"},
-		Target:  "DONE",
+		Target:  []string{"DONE"},
 		Refresh: w.RefreshFunc(),
 	}
 }

--- a/builtin/providers/google/dns_change.go
+++ b/builtin/providers/google/dns_change.go
@@ -32,7 +32,7 @@ func (w *DnsChangeWaiter) RefreshFunc() resource.StateRefreshFunc {
 func (w *DnsChangeWaiter) Conf() *resource.StateChangeConf {
 	return &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  "done",
+		Target:  []string{"done"},
 		Refresh: w.RefreshFunc(),
 	}
 }

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -281,7 +281,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	// Wait until it's created
 	wait := resource.StateChangeConf{
 		Pending:    []string{"PENDING", "RUNNING"},
-		Target:     "DONE",
+		Target:     []string{"DONE"},
 		Timeout:    30 * time.Minute,
 		MinTimeout: 3 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -373,7 +373,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	// Wait until it's updated
 	wait := resource.StateChangeConf{
 		Pending:    []string{"PENDING", "RUNNING"},
-		Target:     "DONE",
+		Target:     []string{"DONE"},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 2 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -413,7 +413,7 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 	// Wait until it's deleted
 	wait := resource.StateChangeConf{
 		Pending:    []string{"PENDING", "RUNNING"},
-		Target:     "DONE",
+		Target:     []string{"DONE"},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 3 * time.Second,
 		Refresh: func() (interface{}, string, error) {

--- a/builtin/providers/google/sqladmin_operation.go
+++ b/builtin/providers/google/sqladmin_operation.go
@@ -37,7 +37,7 @@ func (w *SqlAdminOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
 func (w *SqlAdminOperationWaiter) Conf() *resource.StateChangeConf {
 	return &resource.StateChangeConf{
 		Pending: []string{"PENDING", "RUNNING"},
-		Target:  "DONE",
+		Target:  []string{"DONE"},
 		Refresh: w.RefreshFunc(),
 	}
 }

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -137,7 +137,7 @@ func resourceBlockStorageVolumeV1Create(d *schema.ResourceData, meta interface{}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"downloading", "creating"},
-		Target:     "available",
+		Target:     []string{"available"},
 		Refresh:    VolumeV1StateRefreshFunc(blockStorageClient, v.ID),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
@@ -243,7 +243,7 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 
 			stateConf := &resource.StateChangeConf{
 				Pending:    []string{"in-use", "attaching"},
-				Target:     "available",
+				Target:     []string{"available"},
 				Refresh:    VolumeV1StateRefreshFunc(blockStorageClient, d.Id()),
 				Timeout:    10 * time.Minute,
 				Delay:      10 * time.Second,
@@ -273,7 +273,7 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting", "downloading", "available"},
-		Target:     "deleted",
+		Target:     []string{"deleted"},
 		Refresh:    VolumeV1StateRefreshFunc(blockStorageClient, d.Id()),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -411,7 +411,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"BUILD"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    ServerV2StateRefreshFunc(computeClient, server.ID),
 		Timeout:    30 * time.Minute,
 		Delay:      10 * time.Second,
@@ -744,7 +744,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"RESIZE"},
-			Target:     "VERIFY_RESIZE",
+			Target:     []string{"VERIFY_RESIZE"},
 			Refresh:    ServerV2StateRefreshFunc(computeClient, d.Id()),
 			Timeout:    3 * time.Minute,
 			Delay:      10 * time.Second,
@@ -765,7 +765,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 
 		stateConf = &resource.StateChangeConf{
 			Pending:    []string{"VERIFY_RESIZE"},
-			Target:     "ACTIVE",
+			Target:     []string{"ACTIVE"},
 			Refresh:    ServerV2StateRefreshFunc(computeClient, d.Id()),
 			Timeout:    3 * time.Minute,
 			Delay:      10 * time.Second,
@@ -798,7 +798,7 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    ServerV2StateRefreshFunc(computeClient, d.Id()),
 		Timeout:    30 * time.Minute,
 		Delay:      10 * time.Second,
@@ -1158,7 +1158,7 @@ func attachVolumesToInstance(computeClient *gophercloud.ServiceClient, blockClie
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"attaching", "available"},
-			Target:     "in-use",
+			Target:     []string{"in-use"},
 			Refresh:    VolumeV1StateRefreshFunc(blockClient, va["volume_id"].(string)),
 			Timeout:    30 * time.Minute,
 			Delay:      5 * time.Second,
@@ -1185,7 +1185,7 @@ func detachVolumesFromInstance(computeClient *gophercloud.ServiceClient, blockCl
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"detaching", "in-use"},
-			Target:     "available",
+			Target:     []string{"available"},
 			Refresh:    VolumeV1StateRefreshFunc(blockClient, va["volume_id"].(string)),
 			Timeout:    30 * time.Minute,
 			Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
@@ -217,7 +217,7 @@ func resourceComputeSecGroupV2Delete(d *schema.ResourceData, meta interface{}) e
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    SecGroupV2StateRefreshFunc(computeClient, d),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
@@ -81,7 +81,7 @@ func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForFirewallActive(networkingClient, firewall.ID),
 		Timeout:    30 * time.Second,
 		Delay:      0,
@@ -150,7 +150,7 @@ func resourceFWFirewallV1Update(d *schema.ResourceData, meta interface{}) error 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForFirewallActive(networkingClient, d.Id()),
 		Timeout:    30 * time.Second,
 		Delay:      0,
@@ -178,7 +178,7 @@ func resourceFWFirewallV1Delete(d *schema.ResourceData, meta interface{}) error 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForFirewallActive(networkingClient, d.Id()),
 		Timeout:    30 * time.Second,
 		Delay:      0,
@@ -195,7 +195,7 @@ func resourceFWFirewallV1Delete(d *schema.ResourceData, meta interface{}) error 
 
 	stateConf = &resource.StateChangeConf{
 		Pending:    []string{"DELETING"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForFirewallDeletion(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      0,

--- a/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
@@ -116,7 +116,7 @@ func resourceLBMonitorV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForLBMonitorActive(networkingClient, m.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -206,7 +206,7 @@ func resourceLBMonitorV1Delete(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE", "PENDING"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForLBMonitorDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
@@ -130,7 +130,7 @@ func resourceLBPoolV1Create(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for OpenStack LB pool (%s) to become available.", p.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForLBPoolActive(networkingClient, p.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -294,7 +294,7 @@ func resourceLBPoolV1Delete(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForLBPoolDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
@@ -134,7 +134,7 @@ func resourceLBVipV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForLBVIPActive(networkingClient, p.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -265,7 +265,7 @@ func resourceLBVipV1Delete(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForLBVIPDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -74,7 +74,7 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Waiting for OpenStack Neutron Floating IP (%s) to become available.", floatingIP.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForFloatingIPActive(networkingClient, floatingIP.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -143,7 +143,7 @@ func resourceNetworkFloatingIPV2Delete(d *schema.ResourceData, meta interface{})
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForFloatingIPDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_networking_network_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2.go
@@ -95,7 +95,7 @@ func resourceNetworkingNetworkV2Create(d *schema.ResourceData, meta interface{})
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"BUILD"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForNetworkActive(networkingClient, n.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -182,7 +182,7 @@ func resourceNetworkingNetworkV2Delete(d *schema.ResourceData, meta interface{})
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForNetworkDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -127,7 +127,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Waiting for OpenStack Neutron Port (%s) to become available.", p.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForNetworkPortActive(networkingClient, p.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -220,7 +220,7 @@ func resourceNetworkingPortV2Delete(d *schema.ResourceData, meta interface{}) er
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForNetworkPortDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
@@ -68,7 +68,7 @@ func resourceNetworkingRouterInterfaceV2Create(d *schema.ResourceData, meta inte
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"BUILD", "PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForRouterInterfaceActive(networkingClient, n.PortID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -117,7 +117,7 @@ func resourceNetworkingRouterInterfaceV2Delete(d *schema.ResourceData, meta inte
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForRouterInterfaceDelete(networkingClient, d),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -87,7 +87,7 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Waiting for OpenStack Neutron Router (%s) to become available", n.ID)
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"BUILD", "PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForRouterActive(networkingClient, n.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -167,7 +167,7 @@ func resourceNetworkingRouterV2Delete(d *schema.ResourceData, meta interface{}) 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForRouterDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
@@ -146,7 +146,7 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[DEBUG] Waiting for Subnet (%s) to become available", s.ID)
 	stateConf := &resource.StateChangeConf{
-		Target:     "ACTIVE",
+		Target:     []string{"ACTIVE"},
 		Refresh:    waitForSubnetActive(networkingClient, s.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -237,7 +237,7 @@ func resourceNetworkingSubnetV2Delete(d *schema.ResourceData, meta interface{}) 
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
-		Target:     "DELETED",
+		Target:     []string{"DELETED"},
 		Refresh:    waitForSubnetDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/packet/resource_packet_device.go
+++ b/builtin/providers/packet/resource_packet_device.go
@@ -261,7 +261,7 @@ func resourcePacketDeviceDelete(d *schema.ResourceData, meta interface{}) error 
 func waitForDeviceAttribute(d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}) (interface{}, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
-		Target:     target,
+		Target:     []string{target},
 		Refresh:    newDeviceStateRefreshFunc(d, attribute, meta),
 		Timeout:    60 * time.Minute,
 		Delay:      10 * time.Second,

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -406,7 +406,7 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		if v, ok := d.GetOk("boot_delay"); ok {
 			stateConf := &resource.StateChangeConf{
 				Pending:    []string{"pending"},
-				Target:     "active",
+				Target:     []string{"active"},
 				Refresh:    waitForNetworkingActive(client, vm.datacenter, vm.Path()),
 				Timeout:    600 * time.Second,
 				Delay:      time.Duration(v.(int)) * time.Second,

--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -25,7 +25,7 @@ type StateChangeConf struct {
 	Delay          time.Duration    // Wait this time before starting checks
 	Pending        []string         // States that are "allowed" and will continue trying
 	Refresh        StateRefreshFunc // Refreshes the current state
-	Target         string           // Target state
+	Target         []string         // Target state
 	Timeout        time.Duration    // The amount of time to wait before timeout
 	MinTimeout     time.Duration    // Smallest time to wait before refreshes
 	NotFoundChecks int              // Number of times to allow not found
@@ -87,7 +87,7 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 			}
 
 			// If we're waiting for the absence of a thing, then return
-			if result == nil && conf.Target == "" {
+			if result == nil && len(conf.Target) == 0 {
 				return
 			}
 
@@ -103,8 +103,10 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 				// Reset the counter for when a resource isn't found
 				notfoundTick = 0
 
-				if currentState == conf.Target {
-					return
+				for _, allowed := range conf.Target {
+					if currentState == allowed {
+						return
+					}
 				}
 
 				found := false

--- a/helper/resource/state_test.go
+++ b/helper/resource/state_test.go
@@ -28,7 +28,7 @@ func SuccessfulStateRefreshFunc() StateRefreshFunc {
 func TestWaitForState_timeout(t *testing.T) {
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
-		Target:  "running",
+		Target:  []string{"running"},
 		Refresh: TimeoutStateRefreshFunc(),
 		Timeout: 1 * time.Millisecond,
 	}
@@ -48,7 +48,7 @@ func TestWaitForState_timeout(t *testing.T) {
 func TestWaitForState_success(t *testing.T) {
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
-		Target:  "running",
+		Target:  []string{"running"},
 		Refresh: SuccessfulStateRefreshFunc(),
 		Timeout: 200 * time.Second,
 	}
@@ -65,7 +65,7 @@ func TestWaitForState_success(t *testing.T) {
 func TestWaitForState_successEmpty(t *testing.T) {
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
-		Target:  "",
+		Target:  []string{},
 		Refresh: func() (interface{}, string, error) {
 			return nil, "", nil
 		},
@@ -84,7 +84,7 @@ func TestWaitForState_successEmpty(t *testing.T) {
 func TestWaitForState_failure(t *testing.T) {
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
-		Target:  "running",
+		Target:  []string{"running"},
 		Refresh: FailedStateRefreshFunc(),
 		Timeout: 200 * time.Second,
 	}

--- a/helper/resource/wait.go
+++ b/helper/resource/wait.go
@@ -12,7 +12,7 @@ type RetryFunc func() error
 func Retry(timeout time.Duration, f RetryFunc) error {
 	c := &StateChangeConf{
 		Pending:    []string{"error"},
-		Target:     "success",
+		Target:     []string{"success"},
 		Timeout:    timeout,
 		MinTimeout: 500 * time.Millisecond,
 		Refresh: func() (interface{}, string, error) {


### PR DESCRIPTION
The WaitForState resource only accepts a single string as a final state.

In our experience this failed. We are using openstack with soft delete enabled on a destroy the status is set to soft_deleted rather than deleted.

This PR updates the WaitForState configuration to accept an array of possible final states, updates anywhere that calls it and fixes the above described openstack issue.