### PR TITLE
Lambda S3 object version defaults to $LATEST if unspecified

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -128,13 +128,15 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		s3Bucket, bucketOk := d.GetOk("s3_bucket")
 		s3Key, keyOk := d.GetOk("s3_key")
 		s3ObjectVersion, versionOk := d.GetOk("s3_object_version")
-		if !bucketOk || !keyOk || !versionOk {
-			return errors.New("s3_bucket, s3_key and s3_object_version must all be set while using S3 code source")
+		if !bucketOk || !keyOk {
+			return errors.New("s3_bucket and s3_key must all be set while using S3 code source")
 		}
 		functionCode = &lambda.FunctionCode{
-			S3Bucket:        aws.String(s3Bucket.(string)),
-			S3Key:           aws.String(s3Key.(string)),
-			S3ObjectVersion: aws.String(s3ObjectVersion.(string)),
+			S3Bucket: aws.String(s3Bucket.(string)),
+			S3Key:    aws.String(s3Key.(string)),
+		}
+		if versionOk {
+			functionCode.S3ObjectVersion = aws.String(s3ObjectVersion.(string))
 		}
 	}
 
@@ -155,6 +157,8 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 	err := resource.Retry(1*time.Minute, func() error {
 		_, err := conn.CreateFunction(params)
 		if err != nil {
+			log.Printf("[DEBUG] Error creating Lambda Function: %s", err)
+
 			if awserr, ok := err.(awserr.Error); ok {
 				if awserr.Code() == "InvalidParameterValueException" {
 					// Retryable

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -2,7 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"math/rand"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -21,8 +24,15 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSLambdaConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", &conf),
-					testAccCheckAWSLambdaAttributes(&conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", "example_lambda_name", &conf),
+					testAccCheckAWSLambdaAttributes("example_lambda_name", &conf),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSLambdaConfigS3,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3test", "example_lambda_name_s3", &conf),
+					testAccCheckAWSLambdaAttributes("example_lambda_name_s3", &conf),
 				),
 			},
 		},
@@ -51,12 +61,12 @@ func testAccCheckLambdaFunctionDestroy(s *terraform.State) error {
 
 }
 
-func testAccCheckAwsLambdaFunctionExists(n string, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
+func testAccCheckAwsLambdaFunctionExists(res, fname string, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
 	// Wait for IAM role
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
+		rs, ok := s.RootModule().Resources[res]
 		if !ok {
-			return fmt.Errorf("Lambda function not found: %s", n)
+			return fmt.Errorf("Lambda function not found: %s", res)
 		}
 
 		if rs.Primary.ID == "" {
@@ -66,7 +76,7 @@ func testAccCheckAwsLambdaFunctionExists(n string, function *lambda.GetFunctionO
 		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
 
 		params := &lambda.GetFunctionInput{
-			FunctionName: aws.String("example_lambda_name"),
+			FunctionName: aws.String(fname),
 		}
 
 		getFunction, err := conn.GetFunction(params)
@@ -80,16 +90,19 @@ func testAccCheckAwsLambdaFunctionExists(n string, function *lambda.GetFunctionO
 	}
 }
 
-func testAccCheckAWSLambdaAttributes(function *lambda.GetFunctionOutput) resource.TestCheckFunc {
+func testAccCheckAWSLambdaAttributes(fname string, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		c := function.Configuration
-		const expectedName = "example_lambda_name"
-		if *c.FunctionName != expectedName {
-			return fmt.Errorf("Expected function name %s, got %s", expectedName, *c.FunctionName)
+		if *c.FunctionName != fname {
+			return fmt.Errorf("Expected function name %s, got %s", fname, *c.FunctionName)
 		}
 
 		if *c.FunctionArn == "" {
 			return fmt.Errorf("Could not read Lambda Function's ARN")
+		}
+
+		if strings.HasSuffix(fname, "s3") && *c.Version != "$LATEST" {
+			return fmt.Errorf("Expected version $LATEST, got %s", *c.Version)
 		}
 
 		return nil
@@ -123,3 +136,42 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
 }
 `
+
+var testAccAWSLambdaConfigS3 = fmt.Sprintf(`
+resource "aws_s3_bucket" "lambda_bucket" {
+  bucket = "tf-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "lambda_code" {
+  bucket = "${aws_s3_bucket.lambda_bucket.id}"
+  key = "lambdatest.zip"
+  source = "test-fixtures/lambdatest.zip"
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "iam_for_lambda"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "lambda_function_s3test" {
+    s3_bucket = "${aws_s3_bucket.lambda_bucket.id}"
+    s3_key = "${aws_s3_bucket_object.lambda_code.id}"
+    function_name = "example_lambda_name_s3"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+}
+`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())


### PR DESCRIPTION
Turns out `S3ObjectVersion` is not required by the S3 API. Since there's no way to get an object's version in terraform (afaik), it's useful to be able to leave it out.