### PR TITLE
mailgun: poll until domain destroy takes effect

### DIFF
--- a/builtin/providers/mailgun/resource_mailgun_domain_test.go
+++ b/builtin/providers/mailgun/resource_mailgun_domain_test.go
@@ -48,10 +48,10 @@ func testAccCheckMailgunDomainDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.RetrieveDomain(rs.Primary.ID)
+		resp, err := client.RetrieveDomain(rs.Primary.ID)
 
 		if err == nil {
-			return fmt.Errorf("Domain still exists")
+			return fmt.Errorf("Domain still exists: %s", resp)
 		}
 	}
 


### PR DESCRIPTION
Test failures indicate that this operation doesn't always take effect
immediately:

https://travis-ci.org/hashicorp/terraform/builds/103764466

Add a simple poll to retry a few times until it does.

```
--- PASS: TestAccMailgunDomain_Basic (1.51s)
```

Verified that this does the trick by looping the test and watching the
logs for the retry behavior to kick in.