### PR TITLE
core: demote evaltree loglevel from INFO -> TRACE

### DIFF
--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -96,7 +96,7 @@ func (w *ContextGraphWalker) EnterPath(path []string) EvalContext {
 }
 
 func (w *ContextGraphWalker) EnterEvalTree(v dag.Vertex, n EvalNode) EvalNode {
-	log.Printf("[INFO] Entering eval tree: %s", dag.VertexName(v))
+	log.Printf("[TRACE] Entering eval tree: %s", dag.VertexName(v))
 
 	// Acquire a lock on the semaphore
 	w.Context.parallelSem.Acquire()
@@ -108,7 +108,7 @@ func (w *ContextGraphWalker) EnterEvalTree(v dag.Vertex, n EvalNode) EvalNode {
 
 func (w *ContextGraphWalker) ExitEvalTree(
 	v dag.Vertex, output interface{}, err error) error {
-	log.Printf("[INFO] Exiting eval tree: %s", dag.VertexName(v))
+	log.Printf("[TRACE] Exiting eval tree: %s", dag.VertexName(v))
 
 	// Release the semaphore
 	w.Context.parallelSem.Release()


### PR DESCRIPTION
One small step in the long road to making our log levels actually
useful. :)