### PR TITLE
provider/aws: Fix issue with detecting drift in AWS Security Groups rules

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -277,15 +277,21 @@ func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 	sg := sgRaw.(*ec2.SecurityGroup)
 
-	ingressRules := resourceAwsSecurityGroupIPPermGather(d, sg.IpPermissions)
-	egressRules := resourceAwsSecurityGroupIPPermGather(d, sg.IpPermissionsEgress)
+	ingressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), sg.IpPermissions)
+	egressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), sg.IpPermissionsEgress)
 
 	d.Set("description", sg.Description)
 	d.Set("name", sg.GroupName)
 	d.Set("vpc_id", sg.VpcId)
 	d.Set("owner_id", sg.OwnerId)
-	d.Set("ingress", ingressRules)
-	d.Set("egress", egressRules)
+	if err := d.Set("ingress", ingressRules); err != nil {
+		log.Printf("[WARN] Error setting Ingress rule set for (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("egress", egressRules); err != nil {
+		log.Printf("[WARN] Error setting Egress rule set for (%s): %s", d.Id(), err)
+	}
+
 	d.Set("tags", tagsToMap(sg.Tags))
 	return nil
 }
@@ -394,7 +400,7 @@ func resourceAwsSecurityGroupRuleHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func resourceAwsSecurityGroupIPPermGather(d *schema.ResourceData, permissions []*ec2.IpPermission) []map[string]interface{} {
+func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpPermission) []map[string]interface{} {
 	ruleMap := make(map[string]map[string]interface{})
 	for _, perm := range permissions {
 		var fromPort, toPort int64
@@ -435,7 +441,7 @@ func resourceAwsSecurityGroupIPPermGather(d *schema.ResourceData, permissions []
 			groups = flattenSecurityGroups(perm.UserIdGroupPairs)
 		}
 		for i, id := range groups {
-			if id == d.Id() {
+			if id == groupId {
 				groups[i], groups = groups[len(groups)-1], groups[:len(groups)-1]
 				m["self"] = true
 			}
@@ -444,11 +450,14 @@ func resourceAwsSecurityGroupIPPermGather(d *schema.ResourceData, permissions []
 		if len(groups) > 0 {
 			raw, ok := m["security_groups"]
 			if !ok {
-				raw = make([]string, 0, len(groups))
+				raw = schema.NewSet(schema.HashString, nil)
 			}
-			list := raw.([]string)
+			list := raw.(*schema.Set)
 
-			list = append(list, groups...)
+			for _, g := range groups {
+				list.Add(g)
+			}
+
 			m["security_groups"] = list
 		}
 	}
@@ -456,6 +465,7 @@ func resourceAwsSecurityGroupIPPermGather(d *schema.ResourceData, permissions []
 	for _, m := range ruleMap {
 		rules = append(rules, m)
 	}
+
 	return rules
 }
 


### PR DESCRIPTION
This PR updates the `resourceAwsSecurityGroupIPPermGather` method to correctly create the Ingress/Egress TypeSet need to store the data locally. https://github.com/hashicorp/terraform/issues/4741 revealed that ingress/egress rules were not actually being stored on `Read` of a Security Group. There was an error with `d.Set("ingress")` (and egress) that was being ignored, and as a result whatever was in the configuration file remained unchanged since the first initial set on create.

This prevented drift from being detected, e.g. an additional rule being added on the AWS Console. 

The crux of it was that `resourceAwsSecurityGroupIPPermGather` would return a slice of security group Ids, which was not compatible with the `TypeSet` that it was supposed to be.

This PR fixes that by correctly formatting the `[]map[string]interface{}` returned from the method to include the Set of security groups, instead of a slice of strings. 

Fixes #4741 