### PR TITLE
AWS SQS policy normalization

### DIFF
--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -64,8 +64,9 @@ func resourceAwsSqsQueue() *schema.Resource {
 				Computed: true,
 			},
 			"policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				StateFunc: normalizeJson,
 			},
 			"redrive_policy": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
Apply existing `normalizeJson` as `StateFunc` to SQS policy to prevent AWS from detecting policy changes when stripping whitespace characters. Labeled as bug in hashicorp/terraform#4273. Different resource, but appears to be a similar issue in hashicorp/terraform#4245 as well.