### PR TITLE
tests: allow opt-out of remote tests via env var

### DIFF
--- a/helper/acctest/remotetests.go
+++ b/helper/acctest/remotetests.go
@@ -1,0 +1,27 @@
+package acctest
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+// SkipRemoteTestsEnvVar is an environment variable that can be set by a user
+// running the tests in an environment with limited network connectivity. By
+// default, tests requiring internet connectivity make an effort to skip if no
+// internet is available, but in some cases the smoke test will pass even
+// though the test should still be skipped.
+const SkipRemoteTestsEnvVar = "TF_SKIP_REMOTE_TESTS"
+
+// RemoteTestPrecheck is meant to be run by any unit test that requires
+// outbound internet connectivity. The test will be skipped if it's
+// unavailable.
+func RemoteTestPrecheck(t *testing.T) {
+	if os.Getenv(SkipRemoteTestsEnvVar) != "" {
+		t.Skipf("skipping test, %s was set", SkipRemoteTestsEnvVar)
+	}
+
+	if _, err := http.Get("http://google.com"); err != nil {
+		t.Skipf("skipping, internet seems to not be available: %s", err)
+	}
+}

--- a/state/remote/atlas_test.go
+++ b/state/remote/atlas_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -17,9 +18,7 @@ func TestAtlasClient_impl(t *testing.T) {
 }
 
 func TestAtlasClient(t *testing.T) {
-	if _, err := http.Get("http://google.com"); err != nil {
-		t.Skipf("skipping, internet seems to not be available: %s", err)
-	}
+	acctest.RemoteTestPrecheck(t)
 
 	token := os.Getenv("ATLAS_TOKEN")
 	if token == "" {

--- a/state/remote/consul_test.go
+++ b/state/remote/consul_test.go
@@ -2,9 +2,10 @@ package remote
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
 )
 
 func TestConsulClient_impl(t *testing.T) {
@@ -12,9 +13,7 @@ func TestConsulClient_impl(t *testing.T) {
 }
 
 func TestConsulClient(t *testing.T) {
-	if _, err := http.Get("http://google.com"); err != nil {
-		t.Skipf("skipping, internet seems to not be available: %s", err)
-	}
+	acctest.RemoteTestPrecheck(t)
 
 	client, err := consulFactory(map[string]string{
 		"address": "demo.consul.io:80",

--- a/website/source/docs/configuration/environment-variables.html.md
+++ b/website/source/docs/configuration/environment-variables.html.md
@@ -62,3 +62,15 @@ export TF_VAR_ami=ami-049d8641
 ```
 
 For more on how to use `TF_VAR_name` in context, check out the section on [Variable Configuration](/docs/configuration/variables.html).
+
+## TF_SKIP_REMOTE_TESTS
+
+This can be set prior to running the unit tests to opt-out of any tests
+requiring remote network connectivity. The unit tests make an attempt to
+automatically detect when connectivity is unavailable and skip the relevant
+tests, but by setting this variable you can force these tests to be skipped.
+
+```
+export TF_SKIP_REMOTE_TESTS=1
+make test
+```


### PR DESCRIPTION
Adds the `TF_SKIP_REMOTE_TESTS` env var to be used in cases where the
`http.Get()` smoke test passes but the network is not able to service
the needs of the tests.

Fixes #4421