### PR TITLE
provider/aws: Fixing panic in TestAccAWSBeanstalkEnv_basic.

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -493,7 +493,13 @@ func dropGeneratedSecurityGroup(settings *schema.Set, meta interface{}) {
 			continue
 		}
 
-		groups := strings.Split(setting["value"].(string), ",")
+		log.Printf("[DEBUG] Elastic Beanstalk setting: %v", setting)
+		settingValue, isString := setting["value"].(string)
+		if !isString {
+			continue
+		}
+
+		groups := strings.Split(settingValue, ",")
 
 		resp, err := conn.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 			GroupIds: aws.StringSlice(groups),


### PR DESCRIPTION
@catsby this is a minor addition to #4691 

When running the tests, Terraform panics with the message `panic: interface conversion: interface is nil, not string`. 
This occurs at https://github.com/hashicorp/terraform/blob/e775ae02ad42d91f4878897fabdf6351990f38dc/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go#L489

To fix this we throw out any option settings where the value is not a string. 