### PR TITLE
provider/aws: Fix issue with Route tables and VPC Peering

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -161,7 +161,6 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		m := make(map[string]interface{})
-
 		if r.DestinationCidrBlock != nil {
 			m["cidr_block"] = *r.DestinationCidrBlock
 		}
@@ -183,7 +182,10 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 
 		route.Add(m)
 	}
-	d.Set("route", route)
+
+	if err := d.Set("route", route); err != nil {
+		log.Printf("[ERR] Error setting routes for AWS Route Table (%s): %s", d.Id(), err)
+	}
 
 	// Tags
 	d.Set("tags", tagsToMap(rt.Tags))
@@ -303,9 +305,6 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 			if _, err := conn.CreateRoute(&opts); err != nil {
 				return err
 			}
-
-			routes.Add(route)
-			d.Set("route", routes)
 		}
 	}
 
@@ -389,27 +388,33 @@ func resourceAwsRouteTableHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	if v, ok := m["cidr_block"]; ok {
+	// Only has values if they are not empty
+	// On reading from config, these keys can have an empty value default
+	// On reading from AWS API, these keys will not be present, so a different
+	// hash can be calculated.
+	// See https://github.com/hashicorp/terraform/issues/4799 (and fix)
+
+	if v, ok := m["cidr_block"]; ok && v.(string) != "" {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
-	if v, ok := m["gateway_id"]; ok {
+	if v, ok := m["gateway_id"]; ok && v.(string) != "" {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
 	natGatewaySet := false
-	if v, ok := m["nat_gateway_id"]; ok {
-		natGatewaySet = v.(string) != ""
+	if v, ok := m["nat_gateway_id"]; ok && v.(string) != "" {
+		natGatewaySet = true
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
 	instanceSet := false
-	if v, ok := m["instance_id"]; ok {
-		instanceSet = v.(string) != ""
+	if v, ok := m["instance_id"]; ok && v.(string) != "" {
+		instanceSet = true
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
-	if v, ok := m["vpc_peering_connection_id"]; ok {
+	if v, ok := m["vpc_peering_connection_id"]; ok && v.(string) != "" {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -152,6 +152,24 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSRouteTable_Peers(t *testing.T) {
+	var route_table ec2.RouteTable
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRouteTableConfigPeers,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists("aws_route_table.monitor_public", &route_table),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRouteTableDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -383,6 +401,65 @@ resource "aws_route_table" "foo" {
 	tags {
 		foo = "bar"
 	}
+}
+`
+
+const testAccRouteTableConfigPeers = `
+resource "aws_vpc" "monitoring" {
+  cidr_block = "10.250.0.0/16"
+
+  tags {
+    Name = "monitoring"
+  }
+}
+
+resource "aws_internet_gateway" "monitoring" {
+  vpc_id = "${aws_vpc.monitoring.id}"
+}
+
+resource "aws_route_table" "monitor_public" {
+  vpc_id = "${aws_vpc.monitoring.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.monitoring.id}"
+  }
+
+  route {
+    cidr_block = "10.200.0.0/16"
+    gateway_id = "${aws_vpc_peering_connection.development.id}"
+  }
+
+  tags {
+    Name = "tf-peer-test"
+  }
+}
+
+resource "aws_vpc_peering_connection" "development" {
+  vpc_id        = "${aws_vpc.monitoring.id}"
+  peer_vpc_id   = "${aws_vpc.development.id}"
+  peer_owner_id = "470663696735"
+
+  tags {
+    foo = "bar"
+  }
+
+  auto_accept = true
+}
+
+
+#### 
+## dev
+resource "aws_vpc" "development" {
+  cidr_block = "10.200.0.0/16"
+
+  tags {
+    Name = "development"
+  }
+}
+
+resource "aws_internet_gateway" "monitoring_dev" {
+  vpc_id = "${aws_vpc.development.id}"
 }
 `
 


### PR DESCRIPTION
@ascendantlogic discovered that when adding routes in a `aws_route_table` to a `aws_vpc_peering_connection`, the route id hash can drift depending on if the attributes of the route were read from the config, or from the API. 

The resulting hash discrepancy in `resourceAwsRouteTableHash` in produces different strings respectively: `10.200.0.0/16----pcx-2ff32e46——` vs `10.200.0.0/16-pcx-2ff32e46——`

Reading from the config, keys like `gateway_id` were present, though empty (`""`), and were thus added to the hash string. 

Reading from the API, the same keys were not found, so not included in the map structure sent to `resourceAwsRouteTableHash`, thus not added to the hash string.

This PR fixes the issue by checking if the contained value in the map structure is empty. 

This should only affect route tables that are routing to VPC peering connections. 

Fixes https://github.com/hashicorp/terraform/issues/4799