### PR TITLE
[WIP]: provider/azurerm: Add storage account custom domains

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_account_custom_domain.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account_custom_domain.go
@@ -1,0 +1,136 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/arm/storage"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmStorageAccountCustomDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmStorageAccountCustomDomainCreate,
+		Read:   resourceArmStorageAccountCustomDomainRead,
+		Update: resourceArmStorageAccountCustomDomainCreate,
+		Delete: resourceArmStorageAccountCustomDomainDelete,
+
+		Schema: map[string]*schema.Schema{
+			"storage_account_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"custom_domain_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"use_subdomain": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceArmStorageAccountCustomDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).storageServiceClient
+
+	storageAccountId := d.Get("storage_account_id").(string)
+	thisResourceId := fmt.Sprintf("%s::custom_domain", storageAccountId)
+	customDomainName := d.Get("custom_domain_name").(string)
+	useSubdomain := d.Get("use_subdomain").(bool)
+
+	id, err := parseAzureResourceID(storageAccountId)
+	if err != nil {
+		return err
+	}
+	storageAccountName := id.Path["storageAccounts"]
+	storageAccountResourceGroup := id.ResourceGroup
+
+	opts := storage.AccountUpdateParameters{
+		Properties: &storage.AccountPropertiesUpdateParameters{
+			CustomDomain: &storage.CustomDomain{
+				Name:         &customDomainName,
+				UseSubDomain: &useSubdomain,
+			},
+		},
+	}
+
+	accResp, err := client.Update(storageAccountResourceGroup, storageAccountName, opts)
+	if err != nil {
+		return fmt.Errorf("Error updating Azure Storage Account custom domain %q: %s", storageAccountName, err)
+	}
+	_, err = pollIndefinitelyAsNeeded(client.Client, accResp.Response.Response, http.StatusOK)
+	if err != nil {
+		return fmt.Errorf("Error updating Azure Storage Account custom domain %q: %s", storageAccountName, err)
+	}
+
+	d.SetId(thisResourceId)
+
+	return resourceArmStorageAccountRead(d, meta)
+}
+
+func resourceArmStorageAccountCustomDomainRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).storageServiceClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	name := id.Path["storageAccounts"]
+	resGroup := id.ResourceGroup
+
+	resp, err := client.GetProperties(resGroup, name)
+	if err != nil {
+		if resp.StatusCode == http.StatusNoContent {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error reading the state of AzureRM Storage Account Custom Domain %q: %s", name, err)
+	}
+
+	if resp.Properties.CustomDomain == nil {
+		d.SetId("")
+	} else {
+		d.Set("custom_domain_name", resp.Properties.CustomDomain.Name)
+		d.Set("use_subdomain", resp.Properties.CustomDomain.UseSubDomain)
+	}
+
+	return nil
+}
+
+func resourceArmStorageAccountCustomDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).storageServiceClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	storageAccountName := id.Path["storageAccounts"]
+	storageAccountResourceGroup := id.ResourceGroup
+
+	empty := ""
+	opts := storage.AccountUpdateParameters{
+		Properties: &storage.AccountPropertiesUpdateParameters{
+			CustomDomain: &storage.CustomDomain{
+				Name: &empty,
+			},
+		},
+	}
+
+	accResp, err := client.Update(storageAccountResourceGroup, storageAccountName, opts)
+	if err != nil {
+		return fmt.Errorf("Error updating Azure Storage Account custom domain %q: %s", storageAccountName, err)
+	}
+	_, err = pollIndefinitelyAsNeeded(client.Client, accResp.Response.Response, http.StatusOK)
+	if err != nil {
+		return fmt.Errorf("Error updating Azure Storage Account custom domain %q: %s", storageAccountName, err)
+	}
+
+	d.SetId("")
+
+	return nil
+}


### PR DESCRIPTION
The "obvious" implementation of putting custom domains on the `azurerm_storage_account` resource is sadly not very practical for usage or testing because of the global nature of storage account names. It was suggested by Microsoft that storage account names be considered more of an "output" than an "input".

The impact of this is that the following workflow is needed to add a custom domain to a storage account:

1. Create storage account
2. Create DNS records for the storage account
3. Add the custom domain

Consequently this is implemented as a separate resource.

TODO
----

- [ ] Add acceptance tests for local run only which use a subdomain of `hashicorptest.com`
- [ ] Investigate whether this is practical to run as part of the nightly build on Travis
- [ ] Add resource documentation