### PR TITLE
provider/vcd: Add flags for unverified SSL/TLS

### DIFF
--- a/builtin/providers/vcd/config.go
+++ b/builtin/providers/vcd/config.go
@@ -14,11 +14,13 @@ type Config struct {
 	Href            string
 	VDC             string
 	MaxRetryTimeout int
+	InsecureFlag    bool
 }
 
 type VCDClient struct {
 	*govcd.VCDClient
 	MaxRetryTimeout int
+	InsecureFlag    bool
 }
 
 func (c *Config) Client() (*VCDClient, error) {
@@ -28,8 +30,8 @@ func (c *Config) Client() (*VCDClient, error) {
 	}
 
 	vcdclient := &VCDClient{
-		govcd.NewVCDClient(*u),
-		c.MaxRetryTimeout}
+		govcd.NewVCDClient(*u, c.InsecureFlag),
+		c.MaxRetryTimeout, c.InsecureFlag}
 	org, vcd, err := vcdclient.Authenticate(c.User, c.Password, c.Org, c.VDC)
 	if err != nil {
 		return nil, fmt.Errorf("Something went wrong: %s", err)

--- a/builtin/providers/vcd/provider.go
+++ b/builtin/providers/vcd/provider.go
@@ -50,6 +50,13 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("VCD_MAX_RETRY_TIMEOUT", 60),
 				Description: "Max num seconds to wait for successful response when operating on resources within vCloud (defaults to 60)",
 			},
+
+			"allow_unverified_ssl": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VCD_ALLOW_UNVERIFIED_SSL", false),
+				Description: "If set, VCDClient will permit unverifiable SSL certificates.",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -72,6 +79,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Href:            d.Get("url").(string),
 		VDC:             d.Get("vdc").(string),
 		MaxRetryTimeout: d.Get("maxRetryTimeout").(int),
+		InsecureFlag:    d.Get("allow_unverified_ssl").(bool),
 	}
 
 	return config.Client()

--- a/website/source/docs/providers/vcd/index.html.markdown
+++ b/website/source/docs/providers/vcd/index.html.markdown
@@ -19,12 +19,13 @@ Use the navigation to the left to read about the available resources.
 ```
 # Configure the VMware vCloud Director Provider
 provider "vcd" {
-	user            = "${var.vcd_user}"
-	password        = "${var.vcd_pass}"
-	org             = "${var.vcd_org}"
-	url             = "${var.vcd_url}"
-	vdc             = "${var.vcd_vdc}"
-	maxRetryTimeout = "${var.vcd_maxRetryTimeout}"	
+	user                 = "${var.vcd_user}"
+	password             = "${var.vcd_pass}"
+	org                  = "${var.vcd_org}"
+	url                  = "${var.vcd_url}"
+	vdc                  = "${var.vcd_vdc}"
+	maxRetryTimeout      = "${var.vcd_maxRetryTimeout}"	
+       allow_unverified_ssl = "${var.vcd_allow_unverified_ssl}"
 }
 
 # Create a new network
@@ -55,4 +56,9 @@ The following arguments are used to configure the VMware vCloud Director Provide
   by vCloud Director to be successful. If a resource action fails, the action will be retried
   (as long as it is still within the `maxRetryTimeout` value) to try and ensure success. 
   Defaults to 60 seconds if not set.
-  Can also be specified with the `VCD_MAX_RETRY_TIMEOUT` environment variable.  
+  Can also be specified with the `VCD_MAX_RETRY_TIMEOUT` environment variable.
+* `allow_unverified_ssl` - (Optional) Boolean that can be set to true to 
+  disable SSL certificate verification. This should be used with care as it
+  could allow an attacker to intercept your auth token. If omitted, default
+  value is false. Can also be specified with the 
+  `VCD_ALLOW_UNVERIFIED_SSL` environment variable.


### PR DESCRIPTION
Ability to configure to allow insecure SSL/TLS certificates. Useful for test environments that don't have a proper certificate (chain) or some appliances don't have proper certificates anyway. This should be identical behaviour as the configuration for the vSphere provider.

Before this can be merged, we have to wait for https://github.com/hmrc/vmware-govcd/pull/4 to be merged. This then should be used in a new release.

This PR fixes #4620 