### PR TITLE
provider/openstack: Per-network Floating IPs

### DIFF
--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -50,7 +50,8 @@ The following arguments are supported:
     desired flavor for the server. Changing this resizes the existing server.
 
 * `floating_ip` - (Optional) A *Compute* Floating IP that will be associated
-    with the Instance. The Floating IP must be provisioned already.
+    with the Instance. The Floating IP must be provisioned already. See *Notes*
+    for more information about Floating IPs.
 
 * `user_data` - (Optional) The user data to provide when launching the instance.
     Changing this creates a new server.
@@ -105,6 +106,13 @@ The `network` block supports:
 
 * `fixed_ip_v4` - (Optional) Specifies a fixed IPv4 address to be used on this
     network.
+
+* `floating_ip` - (Optional) Specifies a floating IP address to be associated
+    with this network. Cannot be combined with a top-level floating IP. See
+    *Notes* for more information about Floating IPs.
+
+* `access_network` - (Optional) Specifies if this network should be used for
+    provisioning access. Accepts true or false. Defaults to false.
 
 The `block_device` block supports:
 
@@ -173,11 +181,21 @@ The following attributes are exported:
     network.
 * `network/fixed_ip_v6` - The Fixed IPv6 address of the Instance on that
     network.
+* `network/floating_ip` - The Floating IP address of the Instance on that
+    network.
 * `network/mac` - The MAC address of the NIC on that network.
 
 ## Notes
 
-If you configure the instance to have multiple networks, be aware that only
-the first network can be associated with a Floating IP. So the first network
-in the instance resource _must_ be the network that you have configured to
-communicate with your floating IP / public network via a Neutron Router.
+Floating IPs can be associated in one of two ways:
+
+* You can specify a Floating IP address by using the top-level `floating_ip`
+attribute. This floating IP will be associated with either the network defined
+in the first `network` block or the default network if no `network` blocks are
+defined.
+
+* You can specify a Floating IP address by using the `floating_ip` attribute
+defined in the `network` block. Each `network` block can have its own floating
+IP address.
+
+Only one of the above methods can be used.


### PR DESCRIPTION
This commit adds the ability to associate a Floating IP to a specific network.
Previously, there only existed a top-level floating IP attribute which was
automatically associated with either the first defined network or the default
network (when no network block was used).

Now floating IPs can be associated with networks beyond the first defined
network as well as each network being able to have their own floating IP.

Specifying the floating IP by using the top-level floating_ip attribute and
the per-network floating IP attribute is not possible.

Additionally, an `access_network` attribute has been added in order to easily
specify which network should be used for provisioning.

Fixes #4677 