### PR TITLE
docs/remote-state/s3: Fix typo

### DIFF
--- a/website/source/docs/state/remote/s3.html.md
+++ b/website/source/docs/state/remote/s3.html.md
@@ -51,4 +51,4 @@ The following configuration options / environment variables are supported:
     to be applied to the state file.
  * `access_key` / `AWS_ACCESS_KEY_ID` - (Optional) AWS access key
  * `secret_key` / `AWS_SECRET_ACCESS_KEY` - (Optional) AWS secret key
- * `kms_key_id` - (Optional) Set to to the ARN of a KMS Key to use that key to encrypt the state.
+ * `kms_key_id` - (Optional) The ARN of a KMS Key to use for encrypting the state.


### PR DESCRIPTION
The description should now make a bit more sense.