### PR TITLE
resource.StateChangeConf.Target is now of type []string

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -137,7 +137,7 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"Launching", "Updating"},
-		Target:     "Ready",
+		Target:     []string{"Ready"},
 		Refresh:    environmentStateRefreshFunc(conn, d.Id()),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
@@ -390,7 +390,7 @@ func resourceAwsElasticBeanstalkEnvironmentDelete(d *schema.ResourceData, meta i
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"Terminating"},
-		Target:     "Terminated",
+		Target:     []string{"Terminated"},
 		Refresh:    environmentStateRefreshFunc(conn, d.Id()),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,


### PR DESCRIPTION
@catsby this should take care of the test failure I think. Change was made in https://github.com/hashicorp/terraform/commit/47ac10d