### PR TITLE
provider/aws: Workaround API issue with RDS Cluster DatabaseName

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -262,7 +262,15 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving AvailabilityZones to state for RDS Cluster (%s): %s", d.Id(), err)
 	}
-	d.Set("database_name", dbc.DatabaseName)
+
+	// Only set the DatabaseName if it is not nil. There is a known API bug where
+	// RDS accepts a DatabaseName but does not return it, causing a perpetual
+	// diff.
+	//	See https://github.com/hashicorp/terraform/issues/4671 for backstory
+	if dbc.DatabaseName != nil {
+		d.Set("database_name", dbc.DatabaseName)
+	}
+
 	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
 	d.Set("endpoint", dbc.Endpoint)
 	d.Set("engine", dbc.Engine)

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -99,7 +99,7 @@ func testAccCheckAWSClusterDestroy(s *terraform.State) error {
 
 		// Return nil if the cluster is already destroyed
 		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "DBClusterNotFound" {
+			if awsErr.Code() == "DBClusterNotFoundFault" {
 				return nil
 			}
 		}


### PR DESCRIPTION
Workaround for known RDS API bug, where the API does not return the `DatabaseName`. 

Fixes https://github.com/hashicorp/terraform/issues/4671

Looking into if this affects db instances, as mentioned in https://github.com/hashicorp/terraform/issues/4671#issuecomment-174641859