### PR TITLE
core: treat refs to unknown set resource attrs as unknown

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -519,6 +519,16 @@ func (i *Interpolater) interpolateListAttribute(
 	log.Printf("[DEBUG] Interpolating computed list attribute %s (%s)",
 		resourceID, attr)
 
+	// In Terraform's internal dotted representation of list-like attributes, the
+	// ".#" count field is marked as unknown to indicate "this whole list is
+	// unknown". We must honor that meaning here so computed references can be
+	// treated properly during the plan phase.
+	if attr == config.UnknownVariableValue {
+		return attr, nil
+	}
+
+	// Otherwise we gather the values from the list-like attribute and return
+	// them.
 	var members []string
 	numberedListMember := regexp.MustCompile("^" + resourceID + "\\.[0-9]+$")
 	for id, value := range attributes {


### PR DESCRIPTION
References to computed list-ish attributes (set, list, map) were being
improperly resolved as an empty list `[]` during the plan phase (when
the value of the reference is not yet known) instead of as an
UnknownValue.

A "diffs didn't match" failure in an AWS DirectoryServices test led to
this discovery (and this commit fixes the failing test):

https://travis-ci.org/hashicorp/terraform/jobs/104812951

Refs #2157 which has the original work to support computed list
attributes at all. This is just a simple tweak to that work.

/cc @radeksimko