### PR TITLE
provider/azurerm: Add storage container and blob

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -310,3 +310,17 @@ func (armClient *ArmClient) getBlobStorageClientForStorageAccount(resourceGroupN
 	blobClient := storageClient.GetBlobService()
 	return &blobClient, nil
 }
+func (armClient *ArmClient) getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName string) (*mainStorage.QueueServiceClient, error) {
+	key, err := armClient.getKeyForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return nil, err
+	}
+
+	storageClient, err := mainStorage.NewBasicClient(storageAccountName, key)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating storage client for storage account %q: %s", storageAccountName, err)
+	}
+
+	queueClient := storageClient.GetQueueService()
+	return &queueClient, nil
+}

--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/Azure/azure-sdk-for-go/arm/scheduler"
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
+	mainStorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -280,4 +281,32 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	client.cdnEndpointsClient = cec
 
 	return &client, nil
+}
+
+func (armClient *ArmClient) getKeyForStorageAccount(resourceGroupName, storageAccountName string) (string, error) {
+	keys, err := armClient.storageServiceClient.ListKeys(resourceGroupName, storageAccountName)
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving keys for storage account %q: %s", storageAccountName, err)
+	}
+
+	if keys.Key1 == nil {
+		return "", fmt.Errorf("Nil key returned for storage account %q", storageAccountName)
+	}
+
+	return *keys.Key1, nil
+}
+
+func (armClient *ArmClient) getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName string) (*mainStorage.BlobStorageClient, error) {
+	key, err := armClient.getKeyForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return nil, err
+	}
+
+	storageClient, err := mainStorage.NewBasicClient(storageAccountName, key)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating storage client for storage account %q: %s", storageAccountName, err)
+	}
+
+	blobClient := storageClient.GetBlobService()
+	return &blobClient, nil
 }

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_storage_account":        resourceArmStorageAccount(),
 			"azurerm_storage_container":      resourceArmStorageContainer(),
 			"azurerm_storage_blob":           resourceArmStorageBlob(),
+			"azurerm_storage_queue":          resourceArmStorageQueue(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -56,6 +56,8 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_cdn_profile":            resourceArmCdnProfile(),
 			"azurerm_cdn_endpoint":           resourceArmCdnEndpoint(),
 			"azurerm_storage_account":        resourceArmStorageAccount(),
+			"azurerm_storage_container":      resourceArmStorageContainer(),
+			"azurerm_storage_blob":           resourceArmStorageBlob(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/resource_arm_storage_blob.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob.go
@@ -43,10 +43,11 @@ func resourceArmStorageBlob() *schema.Resource {
 				ValidateFunc: validateArmStorageBlobType,
 			},
 			"size": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  0,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      0,
+				ValidateFunc: validateArmStorageBlobSize,
 			},
 			"url": &schema.Schema{
 				Type:     schema.TypeString,
@@ -54,6 +55,16 @@ func resourceArmStorageBlob() *schema.Resource {
 			},
 		},
 	}
+}
+
+func validateArmStorageBlobSize(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(int)
+
+	if value%512 != 0 {
+		errors = append(errors, fmt.Errorf("Blob Size %q is invalid, must be a multiple of 512", value))
+	}
+
+	return
 }
 
 func validateArmStorageBlobType(v interface{}, k string) (ws []string, errors []error) {

--- a/builtin/providers/azurerm/resource_arm_storage_blob.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob.go
@@ -1,0 +1,185 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmStorageBlob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmStorageBlobCreate,
+		Read:   resourceArmStorageBlobRead,
+		Exists: resourceArmStorageBlobExists,
+		Delete: resourceArmStorageBlobDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"storage_account_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"storage_container_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArmStorageBlobType,
+			},
+			"size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  0,
+			},
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func validateArmStorageBlobType(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	validTypes := map[string]struct{}{
+		"blob": struct{}{},
+		"page": struct{}{},
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf("Blob type %q is invalid, must be %q or %q", value, "blob", "page"))
+	}
+	return
+}
+
+func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+	blobType := d.Get("type").(string)
+	cont := d.Get("storage_container_name").(string)
+
+	log.Printf("[INFO] Creating blob %q in storage account %q", name, storageAccountName)
+	switch strings.ToLower(blobType) {
+	case "block":
+		err = blobClient.CreateBlockBlob(cont, name)
+	case "page":
+		size := int64(d.Get("size").(int))
+		err = blobClient.PutPageBlob(cont, name, size, map[string]string{})
+	}
+	if err != nil {
+		return fmt.Errorf("Error creating storage blob on Azure: %s", err)
+	}
+
+	d.SetId(name)
+	return resourceArmStorageBlobRead(d, meta)
+}
+
+func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	exists, err := resourceArmStorageBlobExists(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		// Exists already removed this from state
+		return nil
+	}
+
+	name := d.Get("name").(string)
+	storageContainerName := d.Get("storage_container_name").(string)
+
+	url := blobClient.GetBlobURL(storageContainerName, name)
+	if url == "" {
+		log.Printf("[INFO] URL for %q is empty", name)
+	}
+	d.Set("url", url)
+
+	return nil
+}
+
+func resourceArmStorageBlobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return false, err
+	}
+
+	name := d.Get("name").(string)
+	storageContainerName := d.Get("storage_container_name").(string)
+
+	log.Printf("[INFO] Checking for existence of storage blob %q.", name)
+	exists, err := blobClient.BlobExists(storageContainerName, name)
+	if err != nil {
+		return false, fmt.Errorf("error testing existence of storage blob %q: %s", name, err)
+	}
+
+	if !exists {
+		log.Printf("[INFO] Storage blob %q no longer exists, removing from state...", name)
+		d.SetId("")
+	}
+
+	return exists, nil
+}
+
+func resourceArmStorageBlobDelete(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+	storageContainerName := d.Get("storage_container_name").(string)
+
+	log.Printf("[INFO] Deleting storage blob %q", name)
+	if _, err = blobClient.DeleteBlobIfExists(storageContainerName, name); err != nil {
+		return fmt.Errorf("Error deleting storage blob %q: %s", name, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_storage_blob_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob_test.go
@@ -1,0 +1,208 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceAzureRMStorageBlobType_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "unknown",
+			ErrCount: 1,
+		},
+		{
+			Value:    "page",
+			ErrCount: 0,
+		},
+		{
+			Value:    "blob",
+			ErrCount: 0,
+		},
+		{
+			Value:    "BLOB",
+			ErrCount: 0,
+		},
+		{
+			Value:    "Blob",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateArmStorageBlobType(tc.Value, "azurerm_storage_blob")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Azure RM Storage Blob type to trigger a validation error")
+		}
+	}
+}
+
+func TestResourceAzureRMStorageBlobSize_validation(t *testing.T) {
+	cases := []struct {
+		Value    int
+		ErrCount int
+	}{
+		{
+			Value:    511,
+			ErrCount: 1,
+		},
+		{
+			Value:    512,
+			ErrCount: 0,
+		},
+		{
+			Value:    1024,
+			ErrCount: 0,
+		},
+		{
+			Value:    2048,
+			ErrCount: 0,
+		},
+		{
+			Value:    5120,
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateArmStorageBlobSize(tc.Value, "azurerm_storage_blob")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Azure RM Storage Blob size to trigger a validation error")
+		}
+	}
+}
+
+func TestAccAzureRMStorageBlob_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageBlob_basic, ri, rs)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageBlobExists("azurerm_storage_blob.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMStorageBlobExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		storageContainerName := rs.Primary.Attributes["storage_container_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return err
+		}
+
+		exists, err := blobClient.BlobExists(storageContainerName, name)
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			return fmt.Errorf("Bad: Storage Blob %q (storage container: %q) does not exist", name, storageContainerName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMStorageBlobDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_storage_blob" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		storageContainerName := rs.Primary.Attributes["storage_container_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return nil
+		}
+
+		exists, err := blobClient.BlobExists(storageContainerName, name)
+		if err != nil {
+			return nil
+		}
+
+		if exists {
+			return fmt.Errorf("Bad: Storage Blob %q (storage container: %q) still exists", name, storageContainerName)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMStorageBlob_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_storage_blob" "test" {
+    name = "herpderp1.vhd"
+
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    storage_container_name = "${azurerm_storage_container.test.name}"
+
+    type = "page"
+    size = 5120
+}
+`

--- a/builtin/providers/azurerm/resource_arm_storage_container.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container.go
@@ -1,0 +1,188 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmStorageContainer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmStorageContainerCreate,
+		Read:   resourceArmStorageContainerRead,
+		Exists: resourceArmStorageContainerExists,
+		Delete: resourceArmStorageContainerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"storage_account_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"container_access_type": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "private",
+				ValidateFunc: validateArmStorageContainerAccessType,
+			},
+			"properties": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func validateArmStorageContainerAccessType(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	validTypes := map[string]struct{}{
+		"private":   struct{}{},
+		"blob":      struct{}{},
+		"container": struct{}{},
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf("Storage container access type %q is invalid, must be %q, %q or %q", value, "private", "blob", "page"))
+	}
+	return
+}
+
+func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+
+	var accessType storage.ContainerAccessType
+	if d.Get("container_access_type").(string) == "private" {
+		accessType = storage.ContainerAccessType("")
+	} else {
+		accessType = storage.ContainerAccessType(d.Get("container_access_type").(string))
+	}
+
+	log.Printf("[INFO] Creating container %q in storage account %q.", name, storageAccountName)
+	_, err = blobClient.CreateContainerIfNotExists(name, accessType)
+	if err != nil {
+		return fmt.Errorf("Error creating container %q in storage account %q: %s", name, storageAccountName, err)
+	}
+
+	d.SetId(name)
+	return resourceArmStorageContainerRead(d, meta)
+}
+
+// resourceAzureStorageContainerRead does all the necessary API calls to
+// read the status of the storage container off Azure.
+func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+	containers, err := blobClient.ListContainers(storage.ListContainersParameters{
+		Prefix:  name,
+		Timeout: 90,
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve storage containers in account %q: %s", name, err)
+	}
+
+	var found bool
+	for _, cont := range containers.Containers {
+		if cont.Name == name {
+			found = true
+
+			props := make(map[string]interface{})
+			props["last_modified"] = cont.Properties.LastModified
+			props["lease_status"] = cont.Properties.LeaseStatus
+			props["lease_state"] = cont.Properties.LeaseState
+			props["lease_duration"] = cont.Properties.LeaseDuration
+
+			d.Set("properties", props)
+		}
+	}
+
+	if !found {
+		log.Printf("[INFO] Storage container %q does not exist in account %q, removing from state...", name, storageAccountName)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceArmStorageContainerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return false, err
+	}
+
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Checking existence of storage container %q in storage account %q", name, storageAccountName)
+	exists, err := blobClient.ContainerExists(name)
+	if err != nil {
+		return false, fmt.Errorf("Error querying existence of storage container %q in storage account %q: %s", name, storageAccountName, err)
+	}
+
+	if !exists {
+		log.Printf("[INFO] Storage container %q does not exist in account %q, removing from state...", name, storageAccountName)
+		d.SetId("")
+	}
+
+	return exists, nil
+}
+
+// resourceAzureStorageContainerDelete does all the necessary API calls to
+// delete a storage container off Azure.
+func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Deleting storage container %q in account %q", name, storageAccountName)
+	if _, err := blobClient.DeleteContainerIfExists(name); err != nil {
+		return fmt.Errorf("Error deleting storage container %q from storage account %q: %s", name, storageAccountName, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_storage_container_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container_test.go
@@ -1,0 +1,146 @@
+package azurerm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMStorageContainer_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageContainer_basic, ri, rs)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageContainerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageContainerExists("azurerm_storage_container.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMStorageContainerExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage container: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return err
+		}
+
+		containers, err := blobClient.ListContainers(storage.ListContainersParameters{
+			Prefix:  name,
+			Timeout: 90,
+		})
+
+		if len(containers.Containers) == 0 {
+			return fmt.Errorf("Bad: Storage Container %q (storage account: %q) does not exist", name, storageAccountName)
+		}
+
+		var found bool
+		for _, container := range containers.Containers {
+			if container.Name == name {
+				found = true
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Bad: Storage Container %q (storage account: %q) does not exist", name, storageAccountName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMStorageContainerDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_storage_container" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage container: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			//If we can't get keys then the blob can't exist
+			return nil
+		}
+
+		containers, err := blobClient.ListContainers(storage.ListContainersParameters{
+			Prefix:  name,
+			Timeout: 90,
+		})
+
+		if err != nil {
+			return nil
+		}
+
+		var found bool
+		for _, container := range containers.Containers {
+			if container.Name == name {
+				found = true
+			}
+		}
+
+		if found {
+			return fmt.Errorf("Bad: Storage Container %q (storage account: %q) still exist", name, storageAccountName)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMStorageContainer_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+`

--- a/builtin/providers/azurerm/resource_arm_storage_queue.go
+++ b/builtin/providers/azurerm/resource_arm_storage_queue.go
@@ -1,0 +1,153 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmStorageQueue() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmStorageQueueCreate,
+		Read:   resourceArmStorageQueueRead,
+		Exists: resourceArmStorageQueueExists,
+		Delete: resourceArmStorageQueueDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArmStorageQueueName,
+			},
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"storage_account_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func validateArmStorageQueueName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if !regexp.MustCompile(`^[a-z0-9-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+
+	if regexp.MustCompile(`^-`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q cannot start with a hyphen", k))
+	}
+
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q cannot end with a hyphen", k))
+	}
+
+	if len(value) > 63 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 63 characters", k))
+	}
+
+	if len(value) < 3 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be at least 3 characters", k))
+	}
+
+	return
+}
+
+func resourceArmStorageQueueCreate(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Creating queue %q in storage account %q", name, storageAccountName)
+	err = queueClient.CreateQueue(name)
+	if err != nil {
+		return fmt.Errorf("Error creating storage queue on Azure: %s", err)
+	}
+
+	d.SetId(name)
+	return resourceArmStorageQueueRead(d, meta)
+}
+
+func resourceArmStorageQueueRead(d *schema.ResourceData, meta interface{}) error {
+
+	exists, err := resourceArmStorageQueueExists(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		// Exists already removed this from state
+		return nil
+	}
+
+	return nil
+}
+
+func resourceArmStorageQueueExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return false, err
+	}
+
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Checking for existence of storage queue %q.", name)
+	exists, err := queueClient.QueueExists(name)
+	if err != nil {
+		return false, fmt.Errorf("error testing existence of storage queue %q: %s", name, err)
+	}
+
+	if !exists {
+		log.Printf("[INFO] Storage queue %q no longer exists, removing from state...", name)
+		d.SetId("")
+	}
+
+	return exists, nil
+}
+
+func resourceArmStorageQueueDelete(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Deleting storage queue %q", name)
+	if err = queueClient.DeleteQueue(name); err != nil {
+		return fmt.Errorf("Error deleting storage queue %q: %s", name, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_storage_queue_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_queue_test.go
@@ -1,0 +1,162 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceAzureRMStorageQueueName_Validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "testing_123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123-",
+			ErrCount: 1,
+		},
+		{
+			Value:    "-testing123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "TestingSG",
+			ErrCount: 1,
+		},
+		{
+			Value:    acctest.RandString(256),
+			ErrCount: 1,
+		},
+		{
+			Value:    acctest.RandString(1),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateArmStorageQueueName(tc.Value, "azurerm_storage_queue")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the ARM Storage Queue Name to trigger a validation error")
+		}
+	}
+}
+
+func TestAccAzureRMStorageQueue_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageQueue_basic, ri, rs, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageQueueDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageQueueExists("azurerm_storage_queue.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMStorageQueueExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage queue: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return err
+		}
+
+		exists, err := queueClient.QueueExists(name)
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			return fmt.Errorf("Bad: Storage Queue %q (storage account: %q) does not exist", name, storageAccountName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMStorageQueueDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_storage_queue" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage queue: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return nil
+		}
+
+		exists, err := queueClient.QueueExists(name)
+		if err != nil {
+			return nil
+		}
+
+		if exists {
+			return fmt.Errorf("Bad: Storage Queue %q (storage account: %q) still exists", name, storageAccountName)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMStorageQueue_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_queue" "test" {
+    name = "mysamplequeue-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+}
+`

--- a/website/source/docs/providers/azurerm/r/storage_blob.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_blob.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_blob"
+sidebar_current: "docs-azurerm-resource-storage-blob"
+description: |-
+  Create a Azure Storage Blob.
+---
+
+# azurerm\_storage\_blob
+
+Create an Azure Storage Blob.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_storage_blob" "testsb" {
+    name = "sample.vhd"
+
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    storage_container_name = "${azurerm_storage_container.test.name}"
+
+    type = "page"
+    size = 5120
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the storage blob. Must be unique within the storage container the blob is located.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the storage container. Changing this forces a new resource to be created.
+
+* `storage_account_name` - (Required) Specifies the storage account in which to create the storage container.
+ Changing this forces a new resource to be created.
+
+* `storage_container_name` - (Required) The name of the storage container in which this blob should be created.
+
+* `type` - (Required) The type of the storage blob to be created. One of either `block` or `page`.
+
+* `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0. 
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The storage blob Resource ID.
+* `url` - The URL of the blob

--- a/website/source/docs/providers/azurerm/r/storage_container.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_container.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_container"
+sidebar_current: "docs-azurerm-resource-storage-container"
+description: |-
+  Create a Azure Storage Container.
+---
+
+# azurerm\_storage\_container
+
+Create an Azure Storage Container.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accteststorageaccount"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the storage container. Must be unique within the storage service the container is located.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the storage container. Changing this forces a new resource to be created.
+
+* `storage_account_name` - (Required) Specifies the storage account in which to create the storage container.
+ Changing this forces a new resource to be created.
+
+* `container_access_type` - (Required) The 'interface' for access the container provides. Can be either `blob`, `container` or `private`.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The storage container Resource ID.
+* `properties` - Key-value definition of additional properties associated to the storage container

--- a/website/source/docs/providers/azurerm/r/storage_queue.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_queue.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_queue"
+sidebar_current: "docs-azurerm-resource-storage-queue"
+description: |-
+  Create a Azure Storage Queue.
+---
+
+# azurerm\_storage\_queue
+
+Create an Azure Storage Queue.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+}
+
+resource "azurerm_storage_queue" "test" {
+    name = "mysamplequeue"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the storage queue. Must be unique within the storage account the queue is located. 
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the storage queue. Changing this forces a new resource to be created.
+
+* `storage_account_name` - (Required) Specifies the storage account in which to create the storage queue.
+ Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The storage queue Resource ID.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -81,6 +81,14 @@
                   <a href="/docs/providers/azurerm/r/storage_account.html">azurerm_storage_account</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-storage-container") %>>
+                  <a href="/docs/providers/azurerm/r/storage_container.html">azurerm_storage_container</a>
+                </li>
+
+                <li<%= sidebar_current("docs-azurerm-resource-storage-blob") %>>
+                  <a href="/docs/providers/azurerm/r/storage_blob.html">azurerm_storage_blob</a>
+                </li>
+
               </ul>
             </li>
 

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -89,6 +89,10 @@
                   <a href="/docs/providers/azurerm/r/storage_blob.html">azurerm_storage_blob</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-storage-queue") %>>
+                  <a href="/docs/providers/azurerm/r/storage_queue.html">azurerm_storage_queue</a>
+                </li>
+
               </ul>
             </li>
 


### PR DESCRIPTION
These resources use ARM to get keys for the storage API, but then use the storage REST API as per the ASM provider. The code is significantly reworked with better logging and error handling. The key functions can be reused for queues and file storage resources when they get added.

TODO
----

- [x] Tests for `azurerm_storage_container`
- [x] Tests for `azurerm_storage_blob`
- [x] Investigate validation of page blob sizes
- [ ] Investigate parsing the ID storage accounts to remove the need for specifying the resource group everywhere. Potentially add this as a second option such that non-Terraform-managed storage accounts can also be used with these resources.