### PR TITLE
[WIP] helper/schema: implement ComputedWhen

### DIFF
--- a/builtin/providers/atlas/resource_artifact.go
+++ b/builtin/providers/atlas/resource_artifact.go
@@ -65,8 +65,9 @@ func resourceArtifact() *schema.Resource {
 			},
 
 			"metadata_full": &schema.Schema{
-				Type:     schema.TypeMap,
-				Computed: true,
+				Type:         schema.TypeMap,
+				Computed:     true,
+				ComputedWhen: []string{"name", "build", "version"},
 			},
 
 			"slug": &schema.Schema{

--- a/builtin/providers/consul/resource_consul_keys.go
+++ b/builtin/providers/consul/resource_consul_keys.go
@@ -68,8 +68,9 @@ func resourceConsulKeys() *schema.Resource {
 			},
 
 			"var": &schema.Schema{
-				Type:     schema.TypeMap,
-				Computed: true,
+				Type:         schema.TypeMap,
+				Computed:     true,
+				ComputedWhen: []string{"key"},
 			},
 		},
 	}


### PR DESCRIPTION
ComputedWhen is a long `TODO`d schema feature that allows any field to
be marked as computed when some target field changes.

Right now Terraform has no way of invalidating a field until it sees
_that_ field changes, but there are plenty of examples of scenarios
where one field changing implies that another field is going to be
assigned a new value.

I'd like to do a bit more testing and refactoring before this is fully ready. But I wanted to push what I had for now since it seems to be working for the cases I've tried it.

This should improve the experience of using consul_keys and atlas_artifacts (for scenarios where two plan/apply cycles would be required for a change to propagate), as well as any other resources where we find similar scenarios that we'd like to use `ComputedWhen`.
