### PR TITLE
provider/openstack Changing the port resource to mark the ip_address as optional

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -89,7 +89,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 						},
 						"ip_address": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 					},
 				},

--- a/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
@@ -69,8 +69,9 @@ The `fixed_ip` block supports:
 * `subnet_id` - (Required) Subnet in which to allocate IP address for
 this port.
 
-* `ip_address` - (Required) IP address desired in the subnet for this
-port.
+* `ip_address` - (Optional) IP address desired in the subnet for this
+port. If you don't specify `ip_address`, OpenStack will be allocated an available
+IP address to this port.
 
 ## Attributes Reference
 


### PR DESCRIPTION
According to API reference of openstack, ip_address attribute of port resource is optional.
http://developer.openstack.org/api-ref-networking-v2.html#createPort