### PR TITLE
docs: add locally_signed_cert to tls sidenav

### DIFF
--- a/website/source/layouts/tls.erb
+++ b/website/source/layouts/tls.erb
@@ -19,6 +19,9 @@
 						<li<%= sidebar_current("docs-tls-resourse-self-signed-cert") %>>
 							<a href="/docs/providers/tls/r/self_signed_cert.html">tls_self_signed_cert</a>
 						</li>
+						<li<%= sidebar_current("docs-tls-resourse-locally-signed-cert") %>>
+							<a href="/docs/providers/tls/r/locally_signed_cert.html">tls_locally_signed_cert</a>
+						</li>
 						<li<%= sidebar_current("docs-tls-resourse-cert-request") %>>
 							<a href="/docs/providers/tls/r/cert_request.html">tls_cert_request</a>
 						</li>


### PR DESCRIPTION
This adds `locally_signed_cert` to the `tls` sidenav and is applicable to the current release.