### PR TITLE
Add signum interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -38,6 +38,7 @@ func Funcs() map[string]ast.Function {
 		"length":       interpolationFuncLength(),
 		"lower":        interpolationFuncLower(),
 		"replace":      interpolationFuncReplace(),
+		"signum":       interpolationFuncSignum(),
 		"split":        interpolationFuncSplit(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
@@ -399,6 +400,25 @@ func interpolationFuncLength() ast.Function {
 				length += StringList(arg.(string)).Length()
 			}
 			return length, nil
+		},
+	}
+}
+
+func interpolationFuncSignum() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeInt},
+		ReturnType: ast.TypeInt,
+		Variadic:   false,
+		Callback: func(args []interface{}) (interface{}, error) {
+			num := args[0].(int)
+			switch {
+			case num < 0:
+				return -1, nil
+			case num > 0:
+				return +1, nil
+			default:
+				return 0, nil
+			}
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -543,6 +543,42 @@ func TestInterpolateFuncLength(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncSignum(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${signum()}`,
+				nil,
+				true,
+			},
+
+			{
+				`${signum("")}`,
+				nil,
+				true,
+			},
+
+			{
+				`${signum(0)}`,
+				"0",
+				false,
+			},
+
+			{
+				`${signum(15)}`,
+				"1",
+				false,
+			},
+
+			{
+				`${signum(-29)}`,
+				"-1",
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncSplit(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -168,6 +168,11 @@ The supported built-in functions are:
       `n` is the index or name of the subcapture. If using a regular expression,
       the syntax conforms to the [re2 regular expression syntax](https://code.google.com/p/re2/wiki/Syntax).
 
+  * `signum(int)` - Returns -1 for negative numbers, 0 for 0 and 1 for positive numbers.
+      This function is useful when you need to set a value for the first resource and
+      a different value for the rest of the resources.
+      Example: `element(split(",", var.r53_failover_policy), signum(count.index))`
+
   * `split(delim, string)` - Splits the string previously created by `join`
       back into a list. This is useful for pushing lists through module
       outputs since they currently only support string values. Depending on the


### PR DESCRIPTION
This function returns -1 for negative numbers, 0 for 0 and 1 for positive numbers.

Useful when you need to set a value for the first resource and a different value for the rest of the resources.

Example: `${element(split(",", var.r53_failover_policy), signum(count.index))}`

This closes the issue #4853 reported previously by myself.