### PR TITLE
provider/aws: Restructure OpsWorks test files

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
@@ -16,7 +16,7 @@ import (
 // and `aws-opsworks-service-role`.
 
 func TestAccAWSOpsworksCustomLayer(t *testing.T) {
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
+	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -26,7 +26,7 @@ func TestAccAWSOpsworksCustomLayer(t *testing.T) {
 				Config: testAccAwsOpsworksCustomLayerConfigCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "name", "tf-ops-acc-custom-layer",
+						"aws_opsworks_custom_layer.tf-acc", "name", stackName,
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_custom_layer.tf-acc", "auto_assign_elastic_ips", "false",
@@ -73,7 +73,7 @@ func TestAccAWSOpsworksCustomLayer(t *testing.T) {
 				Config: testAccAwsOpsworksCustomLayerConfigUpdate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "name", "tf-ops-acc-custom-layer",
+						"aws_opsworks_custom_layer.tf-acc", "name", stackName,
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_custom_layer.tf-acc", "drain_elb_on_shutdown", "false",

--- a/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
@@ -181,7 +181,7 @@ resource "aws_security_group" "tf-ops-acc-layer2" {
     protocol = "icmp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-}`, name)
+}`, name, name)
 }
 
 func testAccAwsOpsworksCustomLayerConfigCreate(name string) string {
@@ -192,7 +192,7 @@ provider "aws" {
 
 resource "aws_opsworks_custom_layer" "tf-acc" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
-  name = "tf-ops-acc-custom-layer"
+  name = "%s"
   short_name = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = true
   custom_security_group_ids = [
@@ -238,7 +238,7 @@ resource "aws_security_group" "tf-ops-acc-layer3" {
 }
 resource "aws_opsworks_custom_layer" "tf-acc" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
-  name = "tf-ops-acc-custom-layer"
+  name = "%s"
   short_name = "tf-ops-acc-custom-layer"
   auto_assign_public_ips = true
   custom_security_group_ids = [


### PR DESCRIPTION
- use random stack names
- duplicate things instead of concatenating them

This should _reduce_ if not eliminate the floppiness of the acceptance test runs in Travis