### PR TITLE
Add character_set_name to aws_db_instance for use on Oracle instance creation.

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -65,6 +65,13 @@ func resourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"character_set_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"storage_encrypted": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -440,6 +447,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.MultiAZ = aws.Bool(attr.(bool))
 		}
 
+		if attr, ok := d.GetOk("character_set_name"); ok {
+			opts.CharacterSetName = aws.String(attr.(string))
+		}
+
 		if attr, ok := d.GetOk("maintenance_window"); ok {
 			opts.PreferredMaintenanceWindow = aws.String(attr.(string))
 		}
@@ -556,6 +567,10 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("multi_az", v.MultiAZ)
 	if v.DBSubnetGroup != nil {
 		d.Set("db_subnet_group_name", v.DBSubnetGroup.DBSubnetGroupName)
+	}
+
+	if v.CharacterSetName != nil {
+		d.Set("character_set_name", v.CharacterSetName)
 	}
 
 	if len(v.DBParameterGroups) > 0 {

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -99,6 +99,8 @@ database, and to use this value as the source database. This correlates to the
 * `license_model` - (Optional, but required for some DB engines, i.e. Oracle SE1) License model information for this DB instance.
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Defaults to true.
 * `allow_major_version_upgrade` - (Optional) Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.
+* `charater_set_name` - (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed.
+[Oracle Character Sets Supported in Amazon RDS](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully
@@ -126,6 +128,10 @@ The following attributes are exported:
 * `status` - The RDS instance status
 * `username` - The master username for the database
 * `storage_encrypted` - Specifies whether the DB instance is encrypted
+
+On Oracle instances the following is exported additionally:
+
+* `character_set_name` - The character set used on Oracle instances.
 
 [1]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html
 [2]: https://docs.aws.amazon.com/fr_fr/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -99,7 +99,7 @@ database, and to use this value as the source database. This correlates to the
 * `license_model` - (Optional, but required for some DB engines, i.e. Oracle SE1) License model information for this DB instance.
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Defaults to true.
 * `allow_major_version_upgrade` - (Optional) Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.
-* `charater_set_name` - (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed.
+* `character_set_name` - (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed.
 [Oracle Character Sets Supported in Amazon RDS](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS


### PR DESCRIPTION
On Oracle RDS DB instances you can't change the encoding of the database after creation. So we need to be able to set the CharacterSetName on creation.
This is an option and will automagically default to AL32UTF8.

The AWS SDK will give you an error message if you try to apply this setting to other engines. The patch will only report the character_set_name attribute, if CharacterSetName is set on the instance.

Signed-off-by: Lars Bahner <lars.bahner@gmail.com>