### PR TITLE
Remove mime type validation

### DIFF
--- a/builtin/providers/template/resource_cloudinit_config.go
+++ b/builtin/providers/template/resource_cloudinit_config.go
@@ -32,15 +32,6 @@ func resourceCloudinitConfig() *schema.Resource {
 						"content_type": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-
-								if _, supported := supportedContentTypes[value]; !supported {
-									errors = append(errors, fmt.Errorf("Part has an unsupported content type: %s", v))
-								}
-
-								return
-							},
 						},
 						"content": &schema.Schema{
 							Type:     schema.TypeString,
@@ -166,7 +157,7 @@ func renderPartsToWriter(parts cloudInitParts, writer io.Writer) error {
 
 	// we need to set the boundary explictly, otherwise the boundary is random
 	// and this causes terraform to complain about the resource being different
-	if err := mimeWriter.SetBoundary("MIMEBOUNDRY"); err != nil {
+	if err := mimeWriter.SetBoundary("MIMEBOUNDARY"); err != nil {
 		return err
 	}
 
@@ -214,15 +205,3 @@ type cloudInitPart struct {
 }
 
 type cloudInitParts []cloudInitPart
-
-// Support content types as specified by http://cloudinit.readthedocs.org/en/latest/topics/format.html
-var supportedContentTypes = map[string]bool{
-	"text/x-include-once-url":   true,
-	"text/x-include-url":        true,
-	"text/cloud-config-archive": true,
-	"text/upstart-job":          true,
-	"text/cloud-config":         true,
-	"text/part-handler":         true,
-	"text/x-shellscript":        true,
-	"text/cloud-boothook":       true,
-}

--- a/builtin/providers/template/resource_cloudinit_config_test.go
+++ b/builtin/providers/template/resource_cloudinit_config_test.go
@@ -130,4 +130,4 @@ resource "template_cloudinit_config" "config" {
   }
 }`
 
-var testCloudInitConfig_update_expected = `Content-Type: multipart/mixed; boundary=\"MIMEBOUNDRY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDRY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDRY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDRY--\r\n`
+var testCloudInitConfig_update_expected = `Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDARY--\r\n`


### PR DESCRIPTION
Remove the mime type validation since the part handler type allows for
custom types.

http://cloudinit.readthedocs.org/en/latest/topics/format.html#part-handler

The docs specify that if a part handler type is specified, one could use
custom mime types.