### PR TITLE
Add gzip and base64 default values to cloudinit template docs

### DIFF
--- a/website/source/docs/providers/template/r/cloudinit_config.html.markdown
+++ b/website/source/docs/providers/template/r/cloudinit_config.html.markdown
@@ -58,9 +58,9 @@ resource "aws_instance" "web" {
 
 The following arguments are supported:
 
-* `gzip` - (Optional) Specify whether or not to gzip the rendered output.
+* `gzip` - (Optional) Specify whether or not to gzip the rendered output. Default to `true`
 
-* `base64_encode` - (Optional) Base64 encoding of the rendered output.
+* `base64_encode` - (Optional) Base64 encoding of the rendered output. Default to `true`
 
 * `part` - (Required) One may specify this many times, this creates a fragment of the rendered cloud-init config file. The order of the parts is maintained in the configuration is maintained in the rendered template.
 


### PR DESCRIPTION
The default behavior of both gzipping and base64 encoding was surprising to me so I think it is worth mentioning the defaults in the docs as in many other places.

Relevant Terraform version: 0.6.9