### PR TITLE
core: fix the provisioner graphing

### DIFF
--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -136,9 +136,6 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 
 		// Make sure all the connections that are proxies are connected through
 		&ProxyTransformer{},
-
-		// Make sure we have a single root
-		&RootTransformer{},
 	}
 
 	// If we're on the root path, then we do a bunch of other stuff.
@@ -170,16 +167,14 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 			&CloseProviderTransformer{},
 			&CloseProvisionerTransformer{},
 
-			// Make sure we have a single root after the above changes.
-			// This is the 2nd root transformer. In practice this shouldn't
-			// actually matter as the RootTransformer is idempotent.
-			&RootTransformer{},
-
 			// Perform the transitive reduction to make our graph a bit
 			// more sane if possible (it usually is possible).
 			&TransitiveReductionTransformer{},
 		)
 	}
+
+	// Make sure we have a single root
+	steps = append(steps, &RootTransformer{})
 
 	// Remove nils
 	for i, s := range steps {

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -146,11 +146,9 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 			// their dependencies.
 			&TargetsTransformer{Targets: b.Targets, Destroy: b.Destroy},
 
-			// Prune the providers and provisioners. This must happen
-			// only once because flattened modules might depend on empty
-			// providers.
+			// Prune the providers. This must happen only once because flattened
+			// modules might depend on empty providers.
 			&PruneProviderTransformer{},
-			&PruneProvisionerTransformer{},
 
 			// Create the destruction nodes
 			&DestroyTransformer{FullDestroy: b.Destroy},

--- a/terraform/graph_builder_test.go
+++ b/terraform/graph_builder_test.go
@@ -265,6 +265,7 @@ provider.aws (close)
 const testBuiltinGraphBuilderMultiLevelStr = `
 module.foo.module.bar.output.value
   module.foo.module.bar.var.bar
+  module.foo.var.foo
 module.foo.module.bar.plan-destroy
 module.foo.module.bar.var.bar
   module.foo.var.foo
@@ -273,7 +274,9 @@ module.foo.var.foo
 root
   module.foo.module.bar.output.value
   module.foo.module.bar.plan-destroy
+  module.foo.module.bar.var.bar
   module.foo.plan-destroy
+  module.foo.var.foo
 `
 
 const testBuiltinGraphBuilderOrphanDepsStr = `

--- a/terraform/transform_provisioner_test.go
+++ b/terraform/transform_provisioner_test.go
@@ -19,14 +19,14 @@ func TestMissingProvisionerTransformer(t *testing.T) {
 	}
 
 	{
-		transform := &MissingProvisionerTransformer{Provisioners: []string{"foo"}}
+		transform := &MissingProvisionerTransformer{Provisioners: []string{"shell"}}
 		if err := transform.Transform(&g); err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
-		transform := &CloseProvisionerTransformer{}
+		transform := &ProvisionerTransformer{}
 		if err := transform.Transform(&g); err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -39,8 +39,8 @@ func TestMissingProvisionerTransformer(t *testing.T) {
 	}
 }
 
-func TestPruneProvisionerTransformer(t *testing.T) {
-	mod := testModule(t, "transform-provisioner-prune")
+func TestCloseProvisionerTransformer(t *testing.T) {
+	mod := testModule(t, "transform-provisioner-basic")
 
 	g := Graph{Path: RootModulePath}
 	{
@@ -51,8 +51,7 @@ func TestPruneProvisionerTransformer(t *testing.T) {
 	}
 
 	{
-		transform := &MissingProvisionerTransformer{
-			Provisioners: []string{"foo", "bar"}}
+		transform := &MissingProvisionerTransformer{Provisioners: []string{"shell"}}
 		if err := transform.Transform(&g); err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -72,28 +71,20 @@ func TestPruneProvisionerTransformer(t *testing.T) {
 		}
 	}
 
-	{
-		transform := &PruneProvisionerTransformer{}
-		if err := transform.Transform(&g); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-	}
-
 	actual := strings.TrimSpace(g.String())
-	expected := strings.TrimSpace(testTransformPruneProvisionerBasicStr)
+	expected := strings.TrimSpace(testTransformCloseProvisionerBasicStr)
 	if actual != expected {
 		t.Fatalf("bad:\n\n%s", actual)
 	}
 }
-
-func TestGraphNodeMissingProvisioner_impl(t *testing.T) {
-	var _ dag.Vertex = new(graphNodeMissingProvisioner)
-	var _ dag.NamedVertex = new(graphNodeMissingProvisioner)
-	var _ GraphNodeProvisioner = new(graphNodeMissingProvisioner)
+func TestGraphNodeProvisioner_impl(t *testing.T) {
+	var _ dag.Vertex = new(graphNodeProvisioner)
+	var _ dag.NamedVertex = new(graphNodeProvisioner)
+	var _ GraphNodeProvisioner = new(graphNodeProvisioner)
 }
 
-func TestGraphNodeMissingProvisioner_ProvisionerName(t *testing.T) {
-	n := &graphNodeMissingProvisioner{ProvisionerNameValue: "foo"}
+func TestGraphNodeProvisioner_ProvisionerName(t *testing.T) {
+	n := &graphNodeProvisioner{ProvisionerNameValue: "foo"}
 	if v := n.ProvisionerName(); v != "foo" {
 		t.Fatalf("bad: %#v", v)
 	}
@@ -101,14 +92,14 @@ func TestGraphNodeMissingProvisioner_ProvisionerName(t *testing.T) {
 
 const testTransformMissingProvisionerBasicStr = `
 aws_instance.web
-provisioner.shell (close)
-  aws_instance.web
+  provisioner.shell
+provisioner.shell
 `
 
-const testTransformPruneProvisionerBasicStr = `
+const testTransformCloseProvisionerBasicStr = `
 aws_instance.web
-  provisioner.foo
-provisioner.foo
-provisioner.foo (close)
+  provisioner.shell
+provisioner.shell
+provisioner.shell (close)
   aws_instance.web
 `

--- a/terraform/transform_provisioner_test.go
+++ b/terraform/transform_provisioner_test.go
@@ -101,7 +101,6 @@ func TestGraphNodeMissingProvisioner_ProvisionerName(t *testing.T) {
 
 const testTransformMissingProvisionerBasicStr = `
 aws_instance.web
-provisioner.foo
 provisioner.shell (close)
   aws_instance.web
 `


### PR DESCRIPTION
Without this change, all provisioners are added to the graph by default and they are never pruned from the graph if their not needed.

I must admit I'm not a 100% sure if this is the correct solution, but there are a few (weird) things that we should discuss and/or have a look at in order to determine the correct solution.

1. I wonder if it makes any sense at all to have a `MissingProvisionerTransformer`? It makes sense to have a `MissingProviderTransformer` because you could have used a resource without specifying the needed `provider` for that resource. But that isn't possible for a `provisioner` as that is a single entity which you either specify in your config, or you don't. So how can you ever have a missing `provisioner` in your config?

2. I think we could ask ourselves the exact same question for the `PruneProvisionerTransformer`. What could this transformer ever prune (if we don't add all available `provisioners` or selves that is, see point 3 :wink:).

3. If we still do want the `MissingProvisionerTransformer`, then I suppose we only want to add the `provisioners` that we actually need. Currently we just add all known `provisioners` and try to prune them in a later stage (which currently doesn't work, see point 4). The code in the PR changes the logic by only adding the `provisioners` that are needed by the supplied config in the same way as this is done for `providers`.

4. We should have a closer look at `PruneProviderTransformer` and `PruneProvisionerTransformer`. They currently both check if there are any `UpEdges`, and only if there none the `provider` or `provisioner` is removed from the graph. But when the `RootTransformer` is executed before one of the prune transformers, they will have at least 1 `UpEdge`, being the `graphNodeRoot` added by the `RootTransformer`. And since the current graph builder [ordering](https://github.com/hashicorp/terraform/blob/master/terraform/graph_builder.go#L103) places the `RootTransformer` before the prune transformers, it means the prune transformers are effectively broken at this moment.

The code in this PR fixes the problem described in point 4 by reordering the transformers, but that doesn't feel like a robust solution. Another (possibly better) fix would be to change [this code](https://github.com/hashicorp/terraform/blob/master/terraform/transform_provisioner.go#L126-L129) to something like:

```go
s := g.UpEdges(v)
if s.Len() == 0 {
  g.Remove(v)
}
if s.Len() == 1 {
  if _, ok := s.List()[0].(graphNodeRoot); ok {
    g.Remove(v)
  }
}
```

This would make the ordering of the graph transformations less critical, but I'm not sure if this is a 100% fix and if this also works when your using modules and/or already have a root, not being a `graphNodeRoot` (not sure that is even possible?). So I need some input to be sure this would indeed be a solid fix for the current prune transformers problem in all use cases...

I labeled this as a bug, because the current code allocates resources (mainly a goroutine with a yamux stream) for each `provisioner` for every action (e.g. `refresh`, `plan`, `apply`) which is never released. If your running Terraform as a long running daemon (API) you can see this will kill your service at a certain point in time :grin:  