### PR TITLE
providers/aws: Fix issue with VPC Classic Link and regions that don't support it

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -264,6 +264,10 @@ resource "aws_vpc" "bar" {
 `
 
 const testAccVpcConfig_BothDnsOptions = `
+provider "aws" {
+	region = "eu-central-1"
+}
+
 resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
 

--- a/website/source/docs/providers/aws/r/vpc.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc.html.markdown
@@ -41,7 +41,9 @@ The following arguments are supported:
 * `instance_tenancy` - (Optional) A tenancy option for instances launched into the VPC
 * `enable_dns_support` - (Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true.
 * `enable_dns_hostnames` - (Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false.
-* `enable_classiclink` - (Optional) A boolean flag to enable/disable ClassicLink for the VPC. Defaults false.
+* `enable_classiclink` - (Optional) A boolean flag to enable/disable ClassicLink 
+  for the VPC. Only valid in regions and accounts that support EC2 Classic.
+  See the [ClassicLink documentation][1] for more information. Defaults false.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
@@ -59,3 +61,6 @@ The following attributes are exported:
      [`aws_main_route_table_association`](/docs/providers/aws/r/main_route_table_assoc.html).
 * `default_network_acl_id` - The ID of the network ACL created by default on VPC creation
 * `default_security_group_id` - The ID of the security group created by default on VPC creation
+
+
+[1]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/UserGuide/vpc-classiclink.html


### PR DESCRIPTION
Fixes regression introduced into https://github.com/hashicorp/terraform/pull/3994 (reported in https://github.com/hashicorp/terraform/issues/4874) by only reading/storing the classic value for regions that support it