### PR TITLE
provider/aws: Autoscaling Group Code Refactor

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -229,11 +229,15 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) error {
-	g, err := getAwsAutoscalingGroup(d, meta)
+	conn := meta.(*AWSClient).autoscalingconn
+
+	g, err := getAwsAutoscalingGroup(d.Id(), conn)
 	if err != nil {
 		return err
 	}
 	if g == nil {
+		log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+		d.SetId("")
 		return nil
 	}
 
@@ -388,11 +392,13 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 	// Read the autoscaling group first. If it doesn't exist, we're done.
 	// We need the group in order to check if there are instances attached.
 	// If so, we need to remove those first.
-	g, err := getAwsAutoscalingGroup(d, meta)
+	g, err := getAwsAutoscalingGroup(d.Id(), conn)
 	if err != nil {
 		return err
 	}
 	if g == nil {
+		log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+		d.SetId("")
 		return nil
 	}
 	if len(g.Instances) > 0 || *g.DesiredCapacity > 0 {
@@ -433,7 +439,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	return resource.Retry(5*time.Minute, func() error {
-		if g, _ = getAwsAutoscalingGroup(d, meta); g != nil {
+		if g, _ = getAwsAutoscalingGroup(d.Id(), conn); g != nil {
 			return fmt.Errorf("Auto Scaling Group still exists")
 		}
 		return nil
@@ -441,12 +447,11 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 }
 
 func getAwsAutoscalingGroup(
-	d *schema.ResourceData,
-	meta interface{}) (*autoscaling.Group, error) {
-	conn := meta.(*AWSClient).autoscalingconn
+	asgName string,
+	conn *autoscaling.AutoScaling) (*autoscaling.Group, error) {
 
 	describeOpts := autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{aws.String(d.Id())},
+		AutoScalingGroupNames: []*string{aws.String(asgName)},
 	}
 
 	log.Printf("[DEBUG] AutoScaling Group describe configuration: %#v", describeOpts)
@@ -454,7 +459,6 @@ func getAwsAutoscalingGroup(
 	if err != nil {
 		autoscalingerr, ok := err.(awserr.Error)
 		if ok && autoscalingerr.Code() == "InvalidGroup.NotFound" {
-			d.SetId("")
 			return nil, nil
 		}
 
@@ -463,13 +467,11 @@ func getAwsAutoscalingGroup(
 
 	// Search for the autoscaling group
 	for idx, asc := range describeGroups.AutoScalingGroups {
-		if *asc.AutoScalingGroupName == d.Id() {
+		if *asc.AutoScalingGroupName == asgName {
 			return describeGroups.AutoScalingGroups[idx], nil
 		}
 	}
 
-	// ASG not found
-	d.SetId("")
 	return nil, nil
 }
 
@@ -496,11 +498,13 @@ func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) 
 	// Next, wait for the autoscale group to drain
 	log.Printf("[DEBUG] Waiting for group to have zero instances")
 	return resource.Retry(10*time.Minute, func() error {
-		g, err := getAwsAutoscalingGroup(d, meta)
+		g, err := getAwsAutoscalingGroup(d.Id(), conn)
 		if err != nil {
 			return resource.RetryError{Err: err}
 		}
 		if g == nil {
+			log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+			d.SetId("")
 			return nil
 		}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_waiting.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_waiting.go
@@ -33,11 +33,13 @@ func waitForASGCapacity(
 	log.Printf("[DEBUG] Waiting on %s for capacity...", d.Id())
 
 	return resource.Retry(wait, func() error {
-		g, err := getAwsAutoscalingGroup(d, meta)
+		g, err := getAwsAutoscalingGroup(d.Id(), meta.(*AWSClient).autoscalingconn)
 		if err != nil {
 			return resource.RetryError{Err: err}
 		}
 		if g == nil {
+			log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+			d.SetId("")
 			return nil
 		}
 		lbis, err := getLBInstanceStates(g, meta)


### PR DESCRIPTION
Refactoring the getAwsAutoscalingGroup func to accept only the arguments it needs rather than ResourceData and meta. This makes it more portable and reusable for other pieces of the autoscaling family