### PR TITLE
provider/azurerm: Acceptance Test Name Randomising

### DIFF
--- a/builtin/providers/azurerm/resource_arm_availability_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set_test.go
@@ -5,11 +5,15 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,11 +21,9 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVAvailabilitySet_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "name", "acceptanceTestAvailabilitySet1"),
 					resource.TestCheckResourceAttr(
 						"azurerm_availability_set.test", "platform_update_domain_count", "5"),
 					resource.TestCheckResourceAttr(
@@ -34,13 +36,17 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 
 func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withTags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withUpdatedTags, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVAvailabilitySet_withTags,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
 					resource.TestCheckResourceAttr(
@@ -53,7 +59,7 @@ func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMVAvailabilitySet_withUpdatedTags,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
 					resource.TestCheckResourceAttr(
@@ -68,17 +74,18 @@ func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
 
 func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
 
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withDomainCounts, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVAvailabilitySet_withDomainCounts,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "name", "acceptanceTestAvailabilitySet1"),
 					resource.TestCheckResourceAttr(
 						"azurerm_availability_set.test", "platform_update_domain_count", "10"),
 					resource.TestCheckResourceAttr(
@@ -145,11 +152,11 @@ func testCheckAzureRMAvailabilitySetDestroy(s *terraform.State) error {
 
 var testAccAzureRMVAvailabilitySet_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_availability_set" "test" {
-    name = "acceptanceTestAvailabilitySet1"
+    name = "acctestavset-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
@@ -157,11 +164,11 @@ resource "azurerm_availability_set" "test" {
 
 var testAccAzureRMVAvailabilitySet_withTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_availability_set" "test" {
-    name = "acceptanceTestAvailabilitySet1"
+    name = "acctestavset-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -174,11 +181,11 @@ resource "azurerm_availability_set" "test" {
 
 var testAccAzureRMVAvailabilitySet_withUpdatedTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_availability_set" "test" {
-    name = "acceptanceTestAvailabilitySet1"
+    name = "acctestavset-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -190,11 +197,11 @@ resource "azurerm_availability_set" "test" {
 
 var testAccAzureRMVAvailabilitySet_withDomainCounts = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_availability_set" "test" {
-    name = "acceptanceTestAvailabilitySet1"
+    name = "acctestavset-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     platform_update_domain_count = 10

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
@@ -5,11 +5,15 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +21,7 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMCdnEndpoint_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
 				),
@@ -28,13 +32,17 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 
 func TestAccAzureRMCdnEndpoints_withTags(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTags, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTagsUpdate, ri, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMCdnEndpoint_withTags,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
 					resource.TestCheckResourceAttr(
@@ -47,7 +55,7 @@ func TestAccAzureRMCdnEndpoints_withTags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMCdnEndpoint_withTagsUpdate,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
 					resource.TestCheckResourceAttr(
@@ -118,18 +126,18 @@ func testCheckAzureRMCdnEndpointDestroy(s *terraform.State) error {
 
 var testAccAzureRMCdnEndpoint_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_cdn_profile" "test" {
-    name = "acceptanceTestCdnProfile1"
+    name = "acctestcdnprof%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Standard"
 }
 
 resource "azurerm_cdn_endpoint" "test" {
-    name = "acceptanceTestCdnEndpoint1"
+    name = "acctestcdnend%d"
     profile_name = "${azurerm_cdn_profile.test.name}"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -143,18 +151,18 @@ resource "azurerm_cdn_endpoint" "test" {
 
 var testAccAzureRMCdnEndpoint_withTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup2"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_cdn_profile" "test" {
-    name = "acceptanceTestCdnProfile2"
+    name = "acctestcdnprof%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Standard"
 }
 
 resource "azurerm_cdn_endpoint" "test" {
-    name = "acceptanceTestCdnEndpoint2"
+    name = "acctestcdnend%d"
     profile_name = "${azurerm_cdn_profile.test.name}"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -173,18 +181,18 @@ resource "azurerm_cdn_endpoint" "test" {
 
 var testAccAzureRMCdnEndpoint_withTagsUpdate = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup2"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_cdn_profile" "test" {
-    name = "acceptanceTestCdnProfile2"
+    name = "acctestcdnprof%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Standard"
 }
 
 resource "azurerm_cdn_endpoint" "test" {
-    name = "acceptanceTestCdnEndpoint2"
+    name = "acctestcdnend%d"
     profile_name = "${azurerm_cdn_profile.test.name}"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"

--- a/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -47,13 +48,16 @@ func TestResourceAzureRMCdnProfileSKU_validation(t *testing.T) {
 
 func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMCdnProfile_basic, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMCdnProfile_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnProfileExists("azurerm_cdn_profile.test"),
 				),
@@ -64,13 +68,17 @@ func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 
 func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMCdnProfile_withTags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMCdnProfile_withTagsUpdate, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMCdnProfile_withTags,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnProfileExists("azurerm_cdn_profile.test"),
 					resource.TestCheckResourceAttr(
@@ -83,7 +91,7 @@ func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMCdnProfile_withTagsUpdate,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnProfileExists("azurerm_cdn_profile.test"),
 					resource.TestCheckResourceAttr(
@@ -152,11 +160,11 @@ func testCheckAzureRMCdnProfileDestroy(s *terraform.State) error {
 
 var testAccAzureRMCdnProfile_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_cdn_profile" "test" {
-    name = "acceptanceTestCdnProfile1"
+    name = "acctestcdnprof%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Standard"
@@ -165,11 +173,11 @@ resource "azurerm_cdn_profile" "test" {
 
 var testAccAzureRMCdnProfile_withTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_cdn_profile" "test" {
-    name = "acceptanceTestCdnProfile1"
+    name = "acctestcdnprof%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Standard"
@@ -183,11 +191,11 @@ resource "azurerm_cdn_profile" "test" {
 
 var testAccAzureRMCdnProfile_withTagsUpdate = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_cdn_profile" "test" {
-    name = "acceptanceTestCdnProfile1"
+    name = "acctestcdnprof%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Standard"

--- a/builtin/providers/azurerm/resource_arm_public_ip_test.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip_test.go
@@ -80,13 +80,16 @@ func TestResourceAzureRMPublicIpDomainNameLabel_validation(t *testing.T) {
 
 func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVPublicIpStatic_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
 				),
@@ -97,13 +100,17 @@ func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 
 func TestAccAzureRMPublicIpStatic_withTags(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_withTags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_withTagsUpdate, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVPublicIpStatic_withTags,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
 					resource.TestCheckResourceAttr(
@@ -116,7 +123,7 @@ func TestAccAzureRMPublicIpStatic_withTags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMVPublicIpStatic_withTagsUpdate,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
 					resource.TestCheckResourceAttr(
@@ -131,20 +138,24 @@ func TestAccAzureRMPublicIpStatic_withTags(t *testing.T) {
 
 func TestAccAzureRMPublicIpStatic_update(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_update, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVPublicIpStatic_basic,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMVPublicIpStatic_update,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
 					resource.TestCheckResourceAttr(
@@ -157,13 +168,16 @@ func TestAccAzureRMPublicIpStatic_update(t *testing.T) {
 
 func TestAccAzureRMPublicIpDynamic_basic(t *testing.T) {
 
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVPublicIpDynamic_basic, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVPublicIpDynamic_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
 				),
@@ -228,11 +242,11 @@ func testCheckAzureRMPublicIpDestroy(s *terraform.State) error {
 
 var testAccAzureRMVPublicIpStatic_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_public_ip" "test" {
-    name = "acceptanceTestPublicIp1"
+    name = "acctestpublicip-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
@@ -241,11 +255,11 @@ resource "azurerm_public_ip" "test" {
 
 var testAccAzureRMVPublicIpStatic_update = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_public_ip" "test" {
-    name = "acceptanceTestPublicIp1"
+    name = "acctestpublicip-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
@@ -255,11 +269,11 @@ resource "azurerm_public_ip" "test" {
 
 var testAccAzureRMVPublicIpDynamic_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup2"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_public_ip" "test" {
-    name = "acceptanceTestPublicIp2"
+    name = "acctestpublicip-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "dynamic"
@@ -268,11 +282,11 @@ resource "azurerm_public_ip" "test" {
 
 var testAccAzureRMVPublicIpStatic_withTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_public_ip" "test" {
-    name = "acceptanceTestPublicIp1"
+    name = "acctestpublicip-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
@@ -286,11 +300,11 @@ resource "azurerm_public_ip" "test" {
 
 var testAccAzureRMVPublicIpStatic_withTagsUpdate = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 resource "azurerm_public_ip" "test" {
-    name = "acceptanceTestPublicIp1"
+    name = "acctestpublicip-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"

--- a/builtin/providers/azurerm/resource_arm_resource_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_resource_group_test.go
@@ -5,18 +5,22 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/core/http"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAzureRMResourceGroup_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMResourceGroup_basic, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMResourceGroup_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMResourceGroupExists("azurerm_resource_group.test"),
 				),
@@ -26,13 +30,17 @@ func TestAccAzureRMResourceGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMResourceGroup_withTags(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMResourceGroup_withTags, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMResourceGroup_withTagsUpdated, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMResourceGroup_withTags,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMResourceGroupExists("azurerm_resource_group.test"),
 					resource.TestCheckResourceAttr(
@@ -45,7 +53,7 @@ func TestAccAzureRMResourceGroup_withTags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMResourceGroup_withTagsUpdated,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMResourceGroupExists("azurerm_resource_group.test"),
 					resource.TestCheckResourceAttr(
@@ -109,14 +117,14 @@ func testCheckAzureRMResourceGroupDestroy(s *terraform.State) error {
 
 var testAccAzureRMResourceGroup_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1_basic"
+    name = "acctestrg-%d"
     location = "West US"
 }
 `
 
 var testAccAzureRMResourceGroup_withTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1_basic"
+    name = "acctestrg-%d"
     location = "West US"
 
     tags {
@@ -128,7 +136,7 @@ resource "azurerm_resource_group" "test" {
 
 var testAccAzureRMResourceGroup_withTagsUpdated = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1_basic"
+    name = "acctestrg-%d"
     location = "West US"
 
     tags {

--- a/builtin/providers/azurerm/resource_arm_route_table_test.go
+++ b/builtin/providers/azurerm/resource_arm_route_table_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -59,13 +60,16 @@ func TestResourceAzureRMRouteTableNextHopType_validation(t *testing.T) {
 
 func TestAccAzureRMRouteTable_basic(t *testing.T) {
 
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMRouteTable_basic, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMRouteTable_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
 				),
@@ -76,13 +80,17 @@ func TestAccAzureRMRouteTable_basic(t *testing.T) {
 
 func TestAccAzureRMRouteTable_withTags(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMRouteTable_withTags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMRouteTable_withTagsUpdate, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMRouteTable_withTags,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
 					resource.TestCheckResourceAttr(
@@ -95,7 +103,7 @@ func TestAccAzureRMRouteTable_withTags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMRouteTable_withTagsUpdate,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
 					resource.TestCheckResourceAttr(
@@ -110,13 +118,17 @@ func TestAccAzureRMRouteTable_withTags(t *testing.T) {
 
 func TestAccAzureRMRouteTable_multipleRoutes(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMRouteTable_basic, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMRouteTable_multipleRoutes, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMRouteTable_basic,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
 					resource.TestCheckResourceAttr(
@@ -125,7 +137,7 @@ func TestAccAzureRMRouteTable_multipleRoutes(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMRouteTable_multipleRoutes,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
 					resource.TestCheckResourceAttr(
@@ -192,12 +204,12 @@ func testCheckAzureRMRouteTableDestroy(s *terraform.State) error {
 
 var testAccAzureRMRouteTable_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_route_table" "test" {
-    name = "acceptanceTestSecurityGroup1"
+    name = "acctestrt%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -211,12 +223,12 @@ resource "azurerm_route_table" "test" {
 
 var testAccAzureRMRouteTable_multipleRoutes = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_route_table" "test" {
-    name = "acceptanceTestSecurityGroup1"
+    name = "acctestrt%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -236,12 +248,12 @@ resource "azurerm_route_table" "test" {
 
 var testAccAzureRMRouteTable_withTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_route_table" "test" {
-    name = "acceptanceTestSecurityGroup1"
+    name = "acctestrt%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -260,12 +272,12 @@ resource "azurerm_route_table" "test" {
 
 var testAccAzureRMRouteTable_withTagsUpdate = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_route_table" "test" {
-    name = "acceptanceTestSecurityGroup1"
+    name = "acctestrt%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 

--- a/builtin/providers/azurerm/resource_arm_route_test.go
+++ b/builtin/providers/azurerm/resource_arm_route_test.go
@@ -5,11 +5,15 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAzureRMRoute_basic(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMRoute_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +21,7 @@ func TestAccAzureRMRoute_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMRouteDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMRoute_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteExists("azurerm_route.test"),
 				),
@@ -28,20 +32,24 @@ func TestAccAzureRMRoute_basic(t *testing.T) {
 
 func TestAccAzureRMRoute_multipleRoutes(t *testing.T) {
 
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMRoute_basic, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMRoute_multipleRoutes, ri, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMRouteDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMRoute_basic,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteExists("azurerm_route.test"),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMRoute_multipleRoutes,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteExists("azurerm_route.test1"),
 				),
@@ -108,18 +116,18 @@ func testCheckAzureRMRouteDestroy(s *terraform.State) error {
 
 var testAccAzureRMRoute_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_route_table" "test" {
-    name = "acceptanceTestRouteTable1"
+    name = "acctestrt%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_route" "test" {
-    name = "acceptanceTestRoute1"
+    name = "acctestroute%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     route_table_name = "${azurerm_route_table.test.name}"
 
@@ -130,18 +138,18 @@ resource "azurerm_route" "test" {
 
 var testAccAzureRMRoute_multipleRoutes = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_route_table" "test" {
-    name = "acceptanceTestRouteTable1"
+    name = "acctestrt%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_route" "test1" {
-    name = "acceptanceTestRoute2"
+    name = "acctestroute%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     route_table_name = "${azurerm_route_table.test.name}"
 

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -5,11 +5,15 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAzureRMSubnet_basic(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +21,7 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMSubnetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMSubnet_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
 				),
@@ -84,19 +88,19 @@ func testCheckAzureRMSubnetDestroy(s *terraform.State) error {
 
 var testAccAzureRMSubnet_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acceptanceTestVirtualNetwork1"
+    name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name = "testsubnet"
+    name = "acctestsubnet%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     virtual_network_name = "${azurerm_virtual_network.test.name}"
     address_prefix = "10.0.2.0/24"

--- a/builtin/providers/azurerm/resource_arm_virtual_network_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network_test.go
@@ -5,18 +5,23 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/core/http"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualNetwork_basic, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVirtualNetwork_basic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists("azurerm_virtual_network.test"),
 				),
@@ -26,13 +31,18 @@ func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
+
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMVirtualNetwork_withTags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMVirtualNetwork_withTagsUpdated, ri, ri)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMVirtualNetwork_withTags,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists("azurerm_virtual_network.test"),
 					resource.TestCheckResourceAttr(
@@ -45,7 +55,7 @@ func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMVirtualNetwork_withTagsUpdated,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists("azurerm_virtual_network.test"),
 					resource.TestCheckResourceAttr(
@@ -115,12 +125,12 @@ func testCheckAzureRMVirtualNetworkDestroy(s *terraform.State) error {
 
 var testAccAzureRMVirtualNetwork_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acceptanceTestVirtualNetwork1"
+    name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -134,12 +144,12 @@ resource "azurerm_virtual_network" "test" {
 
 var testAccAzureRMVirtualNetwork_withTags = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acceptanceTestVirtualNetwork1"
+    name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -158,12 +168,12 @@ resource "azurerm_virtual_network" "test" {
 
 var testAccAzureRMVirtualNetwork_withTagsUpdated = `
 resource "azurerm_resource_group" "test" {
-    name = "acceptanceTestResourceGroup1"
+    name = "acctestrg-%d"
     location = "West US"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acceptanceTestVirtualNetwork1"
+    name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"


### PR DESCRIPTION
Randomising the resource names in AzureRM acceptance tests. There is a potential issue that reusing names will cause the tests to be slower while we wait for old resources to go through GC