### PR TITLE
provider/aws: SNS Topic State Refreshing correctly

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -163,6 +163,12 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFound" {
+			log.Printf("[WARN] SNS Topic (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Fixes #4888

Provider/aws - SNS Topics deleted from the UI were causing Terraform to throw an error:

* aws_sns_topic_subscription.checker: NotFound: Subscription does not
* exist
    status code: 404, request id: b8ca0c27-1a62-57b3-8b96-43038a0ead86

Terraform wasn't refreshing the state when the topic gave a 404