### PR TITLE
provider/aws: Refactor Route53 record to fix regression in deleting

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -345,9 +345,14 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	// Get the records
 	rec, err := findRecord(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] No matching record found for: %s, removing from state file", d.Id())
-		d.SetId("")
-		return err
+		switch err {
+		case r53NoHostedZoneFound, r53NoRecordsFound:
+			log.Printf("[DEBUG] %s for: %s, removing from state file", err, d.Id())
+			d.SetId("")
+			return nil
+		default:
+			return err
+		}
 	}
 
 	// Create the new records


### PR DESCRIPTION
Route 53 records created in Terraform versions pre-0.6.9 can not be deleted by versions post-0.6.9. This is because of the addition of the `weight` attribute and how we calculate our records for changes after introducing the sentinel value of `-1` for weights:

```
	w := d.Get("weight").(int)
	if w > -1 {
		rec.Weight = aws.Int64(int64(w))
	}
```

Records created pre-0.6.9 do not have the `weight` sentinel value of `-1`, which was added so that a value of zero could be used for the weight (prior to this it could not be). Because they do not have the `-1` value, a `d.Get("weight")` call returns `0`, which is greater than `-1`.  As a result, `delete` commands includes a `0` weight on records that don't have a weight, so the `delete` record set doesn't match. 

Since the actual record is not a thing we can query directly (it’s a property of the zone), we can’t just issue a DELETE to a specific record, we have to isolate it from the zone’s records and send an UPDATE / DELETE `ChangeBatch` call to the zone. Currently, we do this by _rebuilding_ the record set from the state. 

Additions to the state (via new attributes, et. al) in new versions of Terraform can cause this rebuild to be different than a previous run, if the state file was created in a previous version of Terraform.

In this PR we refactor out the code used in the `READ` method to range over a record set and find the matching record. We can then issue a delete call on that record, or update the local state file if we’re in the `READ` method. 

Fixes https://github.com/hashicorp/terraform/issues/4641