### PR TITLE
Add "lowercase" to error message

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -242,7 +242,7 @@ func validateSubnetGroupName(v interface{}, k string) (ws []string, errors []err
 	value := v.(string)
 	if !regexp.MustCompile(`^[ .0-9a-z-_]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
+			"only lowercase alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
 	}
 	if len(value) > 255 {
 		errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
Spent a little time running down this error message as it wasn't specific about what was wrong with my alphanumerics.