### PR TITLE
provider/openstack Add value_specs for routers

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -54,8 +54,57 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
+}
+
+// routerCreateOpts contains all the values needed to create a new router. There are
+// no required values.
+type RouterCreateOpts struct {
+	Name         string
+	AdminStateUp *bool
+	Distributed  *bool
+	TenantID     string
+	GatewayInfo  *routers.GatewayInfo
+	ValueSpecs   map[string]string
+}
+
+// ToRouterCreateMap casts a routerCreateOpts struct to a map.
+func (opts RouterCreateOpts) ToRouterCreateMap() (map[string]interface{}, error) {
+	r := make(map[string]interface{})
+
+	if gophercloud.MaybeString(opts.Name) != nil {
+		r["name"] = opts.Name
+	}
+
+	if opts.AdminStateUp != nil {
+		r["admin_state_up"] = opts.AdminStateUp
+	}
+
+	if opts.Distributed != nil {
+		r["distributed"] = opts.Distributed
+	}
+
+	if gophercloud.MaybeString(opts.TenantID) != nil {
+		r["tenant_id"] = opts.TenantID
+	}
+
+	if opts.GatewayInfo != nil {
+		r["external_gateway_info"] = opts.GatewayInfo
+	}
+
+	if opts.ValueSpecs != nil {
+		for k, v := range opts.ValueSpecs {
+			r[k] = v
+		}
+	}
+
+	return map[string]interface{}{"router": r}, nil
 }
 
 func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) error {
@@ -65,9 +114,10 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	createOpts := routers.CreateOpts{
-		Name:     d.Get("name").(string),
-		TenantID: d.Get("tenant_id").(string),
+	createOpts := RouterCreateOpts{
+		Name:       d.Get("name").(string),
+		TenantID:   d.Get("tenant_id").(string),
+		ValueSpecs: routerValueSpecs(d),
 	}
 
 	if asuRaw, ok := d.GetOk("admin_state_up"); ok {
@@ -238,4 +288,12 @@ func waitForRouterDelete(networkingClient *gophercloud.ServiceClient, routerId s
 		log.Printf("[DEBUG] OpenStack Router %s still active.\n", routerId)
 		return r, "ACTIVE", nil
 	}
+}
+
+func routerValueSpecs(d *schema.ResourceData) map[string]string {
+	m := make(map[string]string)
+	for key, val := range d.Get("value_specs").(map[string]interface{}) {
+		m[key] = val.(string)
+	}
+	return m
 }

--- a/website/source/docs/providers/openstack/r/networking_router_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_router_v2.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants
     to create a router for another tenant. Changing this creates a new router.
 
+* `value_specs` - (Optional) Map of additional driver-specific options.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -57,3 +59,4 @@ The following attributes are exported:
 * `admin_state_up` - See Argument Reference above.
 * `external_gateway` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
+* `value_specs` - See Argument Reference above.


### PR DESCRIPTION
There is a "hidden" parameter - router type. Either exclusive or shared (so exclusive will get a separate VM for sure, while shared will be shared with other routers on same tenants). The only actual reference (except testing it on live system) I could find is this blog post: https://blogs.vmware.com/openstack/openstack-networking-with-vmware-nsx-part-2/ It could be that this feature is VIO only.

Depends on https://github.com/rackspace/gophercloud/pull/526