### PR TITLE
config: Add base64sha256() function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -23,6 +23,7 @@ import (
 // Funcs is the mapping of built-in functions for configuration.
 func Funcs() map[string]ast.Function {
 	return map[string]ast.Function{
+		"base64sha256": interpolationFuncBase64Sha256(),
 		"cidrhost":     interpolationFuncCidrHost(),
 		"cidrnetmask":  interpolationFuncCidrNetmask(),
 		"cidrsubnet":   interpolationFuncCidrSubnet(),
@@ -605,6 +606,7 @@ func interpolationFuncSha1() ast.Function {
 	}
 }
 
+// hexadecimal representation of sha256 sum
 func interpolationFuncSha256() ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeString},
@@ -626,6 +628,21 @@ func interpolationFuncTrimSpace() ast.Function {
 		Callback: func(args []interface{}) (interface{}, error) {
 			trimSpace := args[0].(string)
 			return strings.TrimSpace(trimSpace), nil
+		},
+	}
+}
+
+func interpolationFuncBase64Sha256() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			h := sha256.New()
+			h.Write([]byte(s))
+			shaSum := h.Sum(nil)
+			encoded := base64.StdEncoding.EncodeToString(shaSum[:])
+			return encoded, nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -849,7 +849,7 @@ func TestInterpolateFuncSha1(t *testing.T) {
 func TestInterpolateFuncSha256(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
-			{
+			{ // hexadecimal representation of sha256 sum
 				`${sha256("test")}`,
 				"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 				false,
@@ -864,6 +864,23 @@ func TestInterpolateFuncTrimSpace(t *testing.T) {
 			{
 				`${trimspace(" test ")}`,
 				"test",
+				false,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncBase64Sha256(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${base64sha256("test")}`,
+				"n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=",
+				false,
+			},
+			{ // This will differ because we're base64-encoding hex represantiation, not raw bytes
+				`${base64encode(sha256("test"))}`,
+				"OWY4NmQwODE4ODRjN2Q2NTlhMmZlYWEwYzU1YWQwMTVhM2JmNGYxYjJiMGI4MjJjZDE1ZDZjMTViMGYwMGEwOA==",
 				false,
 			},
 		},

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -80,12 +80,17 @@ The supported built-in functions are:
   * `base64encode(string)` - Returns a base64-encoded representation of the
     given string.
 
-  * `sha1(string)` - Returns a SHA-1 hash representation of the
-    given string.
+  * `base64sha256(string)` - Returns a base64-encoded representation of raw
+    SHA-256 sum of the given string.
+    **This is not equivalent** of `base64encode(sha256(string))`
+    since `sha256()` returns hexadecimal representation.
+
+  * `sha1(string)` - Returns a (conventional) hexadecimal representation of the
+    SHA-1 hash of the given string.
     Example: `"${sha1(concat(aws_vpc.default.tags.customer, "-s3-bucket"))}"`
 
-  * `sha256(string)` - Returns a SHA-256 hash representation of the
-    given string.
+  * `sha256(string)` - Returns a (conventional) hexadecimal representation of the
+    SHA-256 hash of the given string.
     Example: `"${sha256(concat(aws_vpc.default.tags.customer, "-s3-bucket"))}"`
 
   * `cidrhost(iprange, hostnum)` - Takes an IP address range in CIDR notation


### PR DESCRIPTION
This will help finishing https://github.com/hashicorp/terraform/pull/3825 and solve the problem I described in https://github.com/hashicorp/terraform/pull/3825#issuecomment-176447881

I was thinking about the name, considering `base64encodedsha256()`, but it seemed a bit too long and unnecessary to keep "encoded" there. It is very unlikely we'll ever need something like `base64decodedsha256()`. That is why I chosen a simple name `base64sha256`.