### PR TITLE
updated referenced zone to use .zone_id vs .id

### DIFF
--- a/website/source/docs/providers/aws/r/route53_zone_association.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone_association.html.markdown
@@ -31,7 +31,7 @@ resource "aws_route53_zone" "example" {
 }
 
 resource "aws_route53_zone_association" "secondary" {
-  zone_id = "${aws_route53_zone.example.id}"
+  zone_id = "${aws_route53_zone.example.zone_id}"
   vpc_id = "${aws_vpc.secondary.id}"
 }
 ```


### PR DESCRIPTION
Documentation example for ```aws_route53_zone_association``` resource shows reference to associated zone using ```.id``` vs ```.zone_id```

```
zone_id = "${aws_route53_zone.example.id}"
```

This should be:
```
zone_id = "${aws_route53_zone.example.zone_id}"
```