### PR TITLE
Add the trimspace() interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -41,6 +41,7 @@ func Funcs() map[string]ast.Function {
 		"split":        interpolationFuncSplit(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
+		"strip":        interpolationFuncStrip(),
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64decode": interpolationFuncBase64Decode(),
 		"upper":        interpolationFuncUpper(),
@@ -614,6 +615,17 @@ func interpolationFuncSha256() ast.Function {
 			h.Write([]byte(s))
 			hash := hex.EncodeToString(h.Sum(nil))
 			return hash, nil
+		},
+	}
+}
+
+func interpolationFuncTrim() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			trim := args[0].(string)
+			return strings.TrimSpace(trim), nil
 		},
 	}
 }

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -41,7 +41,7 @@ func Funcs() map[string]ast.Function {
 		"split":        interpolationFuncSplit(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
-		"trim":         interpolationFuncTrim(),
+		"trimspace":    interpolationFuncTrimSpace(),
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64decode": interpolationFuncBase64Decode(),
 		"upper":        interpolationFuncUpper(),
@@ -619,13 +619,13 @@ func interpolationFuncSha256() ast.Function {
 	}
 }
 
-func interpolationFuncTrim() ast.Function {
+func interpolationFuncTrimSpace() ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeString},
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
-			trim := args[0].(string)
-			return strings.TrimSpace(trim), nil
+			trimSpace := args[0].(string)
+			return strings.TrimSpace(trimSpace), nil
 		},
 	}
 }

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -41,7 +41,7 @@ func Funcs() map[string]ast.Function {
 		"split":        interpolationFuncSplit(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
-		"strip":        interpolationFuncStrip(),
+		"trim":         interpolationFuncTrim(),
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64decode": interpolationFuncBase64Decode(),
 		"upper":        interpolationFuncUpper(),

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -858,6 +858,18 @@ func TestInterpolateFuncSha256(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncTrim(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${trim(" test ")}`,
+				"test",
+				false,
+			},
+		},
+	})
+}
+
 type testFunctionConfig struct {
 	Cases []testFunctionCase
 	Vars  map[string]ast.Variable

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -858,11 +858,11 @@ func TestInterpolateFuncSha256(t *testing.T) {
 	})
 }
 
-func TestInterpolateFuncTrim(t *testing.T) {
+func TestInterpolateFuncTrimSpace(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
 			{
-				`${trim(" test ")}`,
+				`${trimspace(" test ")}`,
 				"test",
 				false,
 			},

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -176,6 +176,8 @@ The supported built-in functions are:
       `a_resource_param = ["${split(",", var.CSV_STRING)}"]`.
       Example: `split(",", module.amod.server_ids)`
 
+  * `trim(string)` - Returns a copy of the string with all leading and trailing white spaces removed.
+
   * `upper(string)` - Returns a copy of the string with all Unicode letters mapped to their upper case.
 
 ## Templates

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -176,7 +176,7 @@ The supported built-in functions are:
       `a_resource_param = ["${split(",", var.CSV_STRING)}"]`.
       Example: `split(",", module.amod.server_ids)`
 
-  * `trim(string)` - Returns a copy of the string with all leading and trailing white spaces removed.
+  * `trimspace(string)` - Returns a copy of the string with all leading and trailing white spaces removed.
 
   * `upper(string)` - Returns a copy of the string with all Unicode letters mapped to their upper case.
 


### PR DESCRIPTION
This function helps when interpolating string from UNIX files.

For example

```
resource "docker_container" "test" {
  name         = "test"
  image        = "${docker_image.ubuntu.latest}"
  env          = [
    "PASSWORD=${trimspace(file("files/secrets/password"))}",
  ]
}
```