### PR TITLE
provider/aws: Redshift Cluster Documentation for `skip_final_snapshot` should be true

### DIFF
--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -54,7 +54,7 @@ string.
 * `publicly_accessible` - (Optional) If true , the cluster can be accessed from a public network.
 * `encrypted` - (Optional) If true , the data in the cluster is encrypted at rest.
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
-* `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is false.
+* `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is true.
 * `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.                                                                                                     
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes #4925

Changing the default for ship_final_snapshot on redshift_cluster to be true so as to match the code