### PR TITLE
Add warning for users who already use ClassicLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
   * Users of `consul_keys` should note that the `value` sub-attribute of `key` will no longer be updated with the remote value of the key. It should be only used to _set_ a key in Consul K/V. To reference key values, use the `var` attribute.
   * The 0.6.9 release contained a regression in `aws_autoscaling_group` capacity waiting behavior for configs where `min_elb_capacity != desired_capacity` or `min_size != desired_capacity`. This release remedies that regression by un-deprecating `min_elb_capacity` and restoring the prior behavior.
   * Users of `aws_security_group` may notice new diffs in initial plans with 0.6.10 due to a bugfix that fixes drift detection on nested security group rules. These new diffs should reflect the actual state of the resources, which Terraform previously was unable to see.
+  * Users of AWS VPC who have already configured ClassicLink manually must set `enable_classiclink` to `true` in their `aws_vpc` resource configs to ensure ClassicLink is not disabled by Terraform.
 
 
 FEATURES:


### PR DESCRIPTION
Glad I noticed this on an otherwise diff-free plan, or it could have caused us some real grief!