### PR TITLE
provider/aws: Change VPC ClassicLink to be computed

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -58,7 +58,7 @@ func resourceAwsVpc() *schema.Resource {
 			"enable_classiclink": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 
 			"main_route_table_id": &schema.Schema{


### PR DESCRIPTION
Update VPC ClassicLink support to be computed. AWS provides a default of false and we don't want to set this or cause plans for VPCs that have already enabled it.

Fixes https://github.com/hashicorp/terraform/pull/4930 (makes it not needed)