### PR TITLE
build.sh: don't dive into vendored deps when building

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,7 +41,7 @@ gox \
     -arch="${XC_ARCH}" \
     -ldflags "-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
     -output "pkg/{{.OS}}_{{.Arch}}/terraform-{{.Dir}}" \
-    ./...
+    $(go list ./... | grep -v /vendor/)
 
 # Make sure "terraform-terraform" is renamed properly
 for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do


### PR DESCRIPTION
Doing a straight `./...`  build results in errors from unvendored
package references being picked up in some vendored libraries'
`examples/` subdirs.

So we'll switch to the recommended `go list | grep -v /vendor/` strategy
to determine what to build.