### PR TITLE
provider/aws: Enabled Enhanced Monitoring for RDS

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -270,6 +270,18 @@ func resourceAwsDbInstance() *schema.Resource {
 				Optional: true,
 			},
 
+			"monitoring_role_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"monitoring_interval": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -309,6 +321,14 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
 			opts.DBSubnetGroupName = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("monitoring_role_arn"); ok {
+			opts.MonitoringRoleArn = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("monitoring_interval"); ok {
+			opts.MonitoringInterval = aws.Int64(int64(attr.(int)))
 		}
 
 		log.Printf("[DEBUG] DB Instance Replica create configuration: %#v", opts)
@@ -494,6 +514,14 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.PubliclyAccessible = aws.Bool(attr.(bool))
 		}
 
+		if attr, ok := d.GetOk("monitoring_role_arn"); ok {
+			opts.MonitoringRoleArn = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("monitoring_interval"); ok {
+			opts.MonitoringInterval = aws.Int64(int64(attr.(int)))
+		}
+
 		log.Printf("[DEBUG] DB Instance create configuration: %#v", opts)
 		var err error
 		_, err = conn.CreateDBInstance(&opts)
@@ -574,6 +602,14 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("status", v.DBInstanceStatus)
 	d.Set("storage_encrypted", v.StorageEncrypted)
+
+	if v.MonitoringInterval != nil {
+		d.Set("monitoring_interval", v.MonitoringInterval)
+	}
+
+	if v.MonitoringRoleArn != nil {
+		d.Set("monitoring_role_arn", v.MonitoringRoleArn)
+	}
 
 	// list tags for resource
 	// set tags
@@ -761,6 +797,18 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("auto_minor_version_upgrade") {
 		d.SetPartial("auto_minor_version_upgrade")
 		req.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
+		requestUpdate = true
+	}
+
+	if d.HasChange("monitoring_role_arn") {
+		d.SetPartial("monitoring_role_arn")
+		req.MonitoringRoleArn = aws.String(d.Get("monitoring_role_arn").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("monitoring_interval") {
+		d.SetPartial("monitoring_interval")
+		req.MonitoringInterval = aws.Int64(int64(d.Get("monitoring_interval").(int)))
 		requestUpdate = true
 	}
 

--- a/builtin/providers/aws/resource_aws_iam_policy_attachment.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment.go
@@ -3,10 +3,13 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -209,6 +212,39 @@ func attachPolicyToRoles(conn *iam.IAM, roles []*string, arn string) error {
 		})
 		if err != nil {
 			return err
+		}
+
+		var attachmentErr error
+		attachmentErr = resource.Retry(2*time.Minute, func() error {
+
+			input := iam.ListRolePoliciesInput{
+				RoleName: r,
+			}
+
+			attachedPolicies, err := conn.ListRolePolicies(&input)
+			if err != nil {
+				return &resource.RetryError{Err: err}
+			}
+
+			if len(attachedPolicies.PolicyNames) > 0 {
+				var foundPolicy bool
+				for _, policyName := range attachedPolicies.PolicyNames {
+					if strings.HasSuffix(arn, *policyName) {
+						foundPolicy = true
+						break
+					}
+				}
+
+				if !foundPolicy {
+					return &resource.RetryError{Err: fmt.Errorf("Policy (%q) not yet found", arn)}
+				}
+			}
+
+			return nil
+		})
+
+		if attachmentErr != nil {
+			return attachmentErr
 		}
 	}
 	return nil

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -99,6 +99,10 @@ database, and to use this value as the source database. This correlates to the
 * `license_model` - (Optional, but required for some DB engines, i.e. Oracle SE1) License model information for this DB instance.
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Defaults to true.
 * `allow_major_version_upgrade` - (Optional) Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.
+* `monitoring_role_arn` - (Optional) The ARN for the IAM role that permits RDS to send 
+enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html) 
+what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
+* `monitoring_interval` - (Optional) The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully


### PR DESCRIPTION
As requested in: #4940

Test Results:

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBInstance_enhancedMonitoring' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBInstance_enhancedMonitoring -timeout 120m
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (1202.80s)
PASS
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/aws	1202.823s
```