### PR TITLE
provider/aws: Add a regression test for Route53 records

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -355,7 +355,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	// Create the new records
+	// Change batch for deleting
 	changeBatch := &route53.ChangeBatch{
 		Comment: aws.String("Deleted by Terraform"),
 		Changes: []*route53.Change{


### PR DESCRIPTION
This is a follow up on #4892 with tests that demonstrate creating a record and a zone, then destroying said record, and confirming that a new plan is generated, using the `ExpectNonEmptyPlan` flag

This simulates the bug reported in https://github.com/hashicorp/terraform/issues/4641 by mimicking the state file that one would have if they created a record with Terraform v0.6.6, which is to say a `weight = 0` for a default value. 

When upgrading, there would be an expected plan change to get that to `-1`. To mimic the statefile we apply the record and then in a follow up step change the attributes directly. We then try to delete the record. 

I tested this by grabbing the source of `aws_resource_route53.go` from Terraform v0.6.9 and running the included test, which fails. The test will pass with #4892 , because we no longer reconstruct what the record should be based on the state (instead finding via the API and elimination/matching)

