### PR TITLE
provider/openstack: Fix crash when access_network was not defined

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -998,7 +998,7 @@ func getInstanceAccessAddresses(d *schema.ResourceData, networks []map[string]in
 			hostv6 = n["fixed_ip_v6"].(string)
 		}
 
-		if n["access_network"].(bool) {
+		if n["access_network"] != nil && n["access_network"].(bool) {
 			break
 		}
 	}


### PR DESCRIPTION
Fixes #4954