### PR TITLE
provider/aws: apply security group changes in EC2 Classic RDS for aws_db_instance 

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -775,7 +775,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		requestUpdate = true
 	}
 
-	if d.HasChange("vpc_security_group_ids") {
+	if d.HasChange("security_group_names") {
 		if attr := d.Get("security_group_names").(*schema.Set); attr.Len() > 0 {
 			var s []*string
 			for _, v := range attr.List() {


### PR DESCRIPTION
This addresses https://github.com/hashicorp/terraform/issues/4963, which had an issue with not applying security group changes to RDS databases in EC2 classic. 

The fix was very simple - it seemed that the wrong attribute name was pasted. 
