### PR TITLE
provider/aws: Fix EC2 Classic SG Rule issue

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -58,7 +58,7 @@ func TestResourceAwsSecurityGroupIPPermGather(t *testing.T) {
 		},
 	}
 
-	out := resourceAwsSecurityGroupIPPermGather("sg-22222", raw)
+        out := resourceAwsSecurityGroupIPPermGather("sg-22222", raw, true)
 	for _, i := range out {
 		// loop and match rules, because the ordering is not guarneteed
 		for _, l := range local {
@@ -118,6 +118,31 @@ func TestAccAWSSecurityGroup_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAWSSecurityGroup_ingressWithCidrAndSGs(t *testing.T) {
+        var group ec2.SecurityGroup
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
+                                        testAccCheckAWSSecurityGroupSGandCidrAttributes(&group),
+                                        resource.TestCheckResourceAttr(
+                                                "aws_security_group.web", "name", "terraform_acceptance_test_example"),
+                                        resource.TestCheckResourceAttr(
+                                                "aws_security_group.web", "description", "Used in the terraform acceptance tests"),
+                                        resource.TestCheckResourceAttr(
+                                                "aws_security_group.web", "ingress.#", "2"),
+                                ),
+                        },
+                },
+        })
 }
 
 func TestAccAWSSecurityGroup_namePrefix(t *testing.T) {
@@ -525,6 +550,43 @@ func testAccCheckAWSSecurityGroupExists(n string, group *ec2.SecurityGroup) reso
 	}
 }
 
+func testAccCheckAWSSecurityGroupSGandCidrAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
+        return func(s *terraform.State) error {
+                if *group.GroupName != "terraform_acceptance_test_example" {
+                        return fmt.Errorf("Bad name: %s", *group.GroupName)
+                }
+
+                if *group.Description != "Used in the terraform acceptance tests" {
+                        return fmt.Errorf("Bad description: %s", *group.Description)
+                }
+
+                if len(group.IpPermissions) == 0 {
+                        return fmt.Errorf("No IPPerms")
+                }
+
+                if len(group.IpPermissions) != 2 {
+                        return fmt.Errorf("Expected 2 ingress rules, got %d", len(group.IpPermissions))
+                }
+
+                for _, p := range group.IpPermissions {
+                        if *p.FromPort == int64(22) {
+                                if len(p.IpRanges) != 1 || p.UserIdGroupPairs != nil {
+                                        return fmt.Errorf("Found ip perm of 22, but not the right ipranges / pairs: %s", p)
+                                }
+                                continue
+                        } else if *p.FromPort == int64(80) {
+                                if len(p.IpRanges) != 1 || len(p.UserIdGroupPairs) != 1 {
+                                        return fmt.Errorf("Found ip perm of 80, but not the right ipranges / pairs: %s", p)
+                                }
+                                continue
+                        }
+                        return fmt.Errorf("Found a rouge rule")
+                }
+
+                return nil
+        }
+}
+
 func testAccCheckAWSSecurityGroupAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		p := &ec2.IpPermission{
@@ -746,6 +808,51 @@ resource "aws_security_group" "web" {
 	tags {
 		Name = "tf-acc-test"
 	}
+}
+`
+
+const testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs = `
+resource "aws_security_group" "other_web" {
+  name        = "tf_other_acc_tests"
+  description = "Used in the terraform acceptance tests"
+
+  tags {
+    Name = "tf-acc-test"
+  }
+}
+
+resource "aws_security_group" "web" {
+  name        = "terraform_acceptance_test_example"
+  description = "Used in the terraform acceptance tests"
+
+  ingress {
+    protocol  = "tcp"
+    from_port = "22"
+    to_port   = "22"
+
+    cidr_blocks = [
+      "192.168.0.1/32",
+    ]
+  }
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 80
+    to_port         = 8000
+    cidr_blocks     = ["10.0.0.0/8"]
+    security_groups = ["${aws_security_group.other_web.id}"]
+  }
+
+  egress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+
+  tags {
+    Name = "tf-acc-test"
+  }
 }
 `
 

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -58,7 +58,7 @@ func TestResourceAwsSecurityGroupIPPermGather(t *testing.T) {
 		},
 	}
 
-        out := resourceAwsSecurityGroupIPPermGather("sg-22222", raw, true)
+	out := resourceAwsSecurityGroupIPPermGather("sg-22222", raw, true)
 	for _, i := range out {
 		// loop and match rules, because the ordering is not guarneteed
 		for _, l := range local {
@@ -121,28 +121,54 @@ func TestAccAWSSecurityGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSSecurityGroup_ingressWithCidrAndSGs(t *testing.T) {
-        var group ec2.SecurityGroup
+	var group ec2.SecurityGroup
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
-                Steps: []resource.TestStep{
-                        resource.TestStep{
-                                Config: testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs,
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
-                                        testAccCheckAWSSecurityGroupSGandCidrAttributes(&group),
-                                        resource.TestCheckResourceAttr(
-                                                "aws_security_group.web", "name", "terraform_acceptance_test_example"),
-                                        resource.TestCheckResourceAttr(
-                                                "aws_security_group.web", "description", "Used in the terraform acceptance tests"),
-                                        resource.TestCheckResourceAttr(
-                                                "aws_security_group.web", "ingress.#", "2"),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupSGandCidrAttributes(&group),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "name", "terraform_acceptance_test_example"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "description", "Used in the terraform acceptance tests"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+// This test requires an EC2 Classic region
+func TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic(t *testing.T) {
+	var group ec2.SecurityGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs_classic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupSGandCidrAttributes(&group),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "name", "terraform_acceptance_test_example"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "description", "Used in the terraform acceptance tests"),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.#", "2"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSSecurityGroup_namePrefix(t *testing.T) {
@@ -551,40 +577,40 @@ func testAccCheckAWSSecurityGroupExists(n string, group *ec2.SecurityGroup) reso
 }
 
 func testAccCheckAWSSecurityGroupSGandCidrAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
-        return func(s *terraform.State) error {
-                if *group.GroupName != "terraform_acceptance_test_example" {
-                        return fmt.Errorf("Bad name: %s", *group.GroupName)
-                }
+	return func(s *terraform.State) error {
+		if *group.GroupName != "terraform_acceptance_test_example" {
+			return fmt.Errorf("Bad name: %s", *group.GroupName)
+		}
 
-                if *group.Description != "Used in the terraform acceptance tests" {
-                        return fmt.Errorf("Bad description: %s", *group.Description)
-                }
+		if *group.Description != "Used in the terraform acceptance tests" {
+			return fmt.Errorf("Bad description: %s", *group.Description)
+		}
 
-                if len(group.IpPermissions) == 0 {
-                        return fmt.Errorf("No IPPerms")
-                }
+		if len(group.IpPermissions) == 0 {
+			return fmt.Errorf("No IPPerms")
+		}
 
-                if len(group.IpPermissions) != 2 {
-                        return fmt.Errorf("Expected 2 ingress rules, got %d", len(group.IpPermissions))
-                }
+		if len(group.IpPermissions) != 2 {
+			return fmt.Errorf("Expected 2 ingress rules, got %d", len(group.IpPermissions))
+		}
 
-                for _, p := range group.IpPermissions {
-                        if *p.FromPort == int64(22) {
-                                if len(p.IpRanges) != 1 || p.UserIdGroupPairs != nil {
-                                        return fmt.Errorf("Found ip perm of 22, but not the right ipranges / pairs: %s", p)
-                                }
-                                continue
-                        } else if *p.FromPort == int64(80) {
-                                if len(p.IpRanges) != 1 || len(p.UserIdGroupPairs) != 1 {
-                                        return fmt.Errorf("Found ip perm of 80, but not the right ipranges / pairs: %s", p)
-                                }
-                                continue
-                        }
-                        return fmt.Errorf("Found a rouge rule")
-                }
+		for _, p := range group.IpPermissions {
+			if *p.FromPort == int64(22) {
+				if len(p.IpRanges) != 1 || p.UserIdGroupPairs != nil {
+					return fmt.Errorf("Found ip perm of 22, but not the right ipranges / pairs: %s", p)
+				}
+				continue
+			} else if *p.FromPort == int64(80) {
+				if len(p.IpRanges) != 1 || len(p.UserIdGroupPairs) != 1 {
+					return fmt.Errorf("Found ip perm of 80, but not the right ipranges / pairs: %s", p)
+				}
+				continue
+			}
+			return fmt.Errorf("Found a rouge rule")
+		}
 
-                return nil
-        }
+		return nil
+	}
 }
 
 func testAccCheckAWSSecurityGroupAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
@@ -848,6 +874,48 @@ resource "aws_security_group" "web" {
     from_port   = 80
     to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
+  }
+
+  tags {
+    Name = "tf-acc-test"
+  }
+}
+`
+
+const testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs_classic = `
+provider "aws" {
+        region = "us-east-1"
+}
+
+resource "aws_security_group" "other_web" {
+  name        = "tf_other_acc_tests"
+  description = "Used in the terraform acceptance tests"
+
+  tags {
+    Name = "tf-acc-test"
+  }
+}
+
+resource "aws_security_group" "web" {
+  name        = "terraform_acceptance_test_example"
+  description = "Used in the terraform acceptance tests"
+
+  ingress {
+    protocol  = "tcp"
+    from_port = "22"
+    to_port   = "22"
+
+    cidr_blocks = [
+      "192.168.0.1/32",
+    ]
+  }
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 80
+    to_port         = 8000
+    cidr_blocks     = ["10.0.0.0/8"]
+    security_groups = ["${aws_security_group.other_web.name}"]
   }
 
   tags {

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -322,10 +322,14 @@ func flattenHealthCheck(check *elb.HealthCheck) []map[string]interface{} {
 }
 
 // Flattens an array of UserSecurityGroups into a []string
-func flattenSecurityGroups(list []*ec2.UserIdGroupPair) []string {
+func flattenSecurityGroups(list []*ec2.UserIdGroupPair, useVpc bool) []string {
 	result := make([]string, 0, len(list))
 	for _, g := range list {
-		result = append(result, *g.GroupId)
+                if useVpc {
+                        result = append(result, *g.GroupId)
+                } else {
+                        result = append(result, *g.GroupName)
+                }
 	}
 	return result
 }

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -325,11 +325,11 @@ func flattenHealthCheck(check *elb.HealthCheck) []map[string]interface{} {
 func flattenSecurityGroups(list []*ec2.UserIdGroupPair, useVpc bool) []string {
 	result := make([]string, 0, len(list))
 	for _, g := range list {
-                if useVpc {
-                        result = append(result, *g.GroupId)
-                } else {
-                        result = append(result, *g.GroupName)
-                }
+		if useVpc {
+			result = append(result, *g.GroupId)
+		} else {
+			result = append(result, *g.GroupName)
+		}
 	}
 	return result
 }

--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -83,26 +83,24 @@ assign a random, unique name
 
 The `ingress` block supports:
 
-* `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be used with `security_groups`.
+* `cidr_blocks` - (Optional) List of CIDR blocks.
 * `from_port` - (Required) The start port.
 * `protocol` - (Required) The protocol. If you select a protocol of
 "-1", you must specify a "from_port" and "to_port" equal to 0.
 * `security_groups` - (Optional) List of security group Group Names if using
     EC2-Classic or the default VPC, or Group IDs if using a non-default VPC.
-    Cannot be used with `cidr_blocks`.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this ingress rule.
 * `to_port` - (Required) The end range port.
 
 The `egress` block supports:
 
-* `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be used with `security_groups`.
+* `cidr_blocks` - (Optional) List of CIDR blocks.
 * `from_port` - (Required) The start port.
 * `protocol` - (Required) The protocol. If you select a protocol of
 "-1", you must specify a "from_port" and "to_port" equal to 0.
 * `security_groups` - (Optional) List of security group Group Names if using
     EC2-Classic or the default VPC, or Group IDs if using a non-default VPC.
-    Cannot be used with `cidr_blocks`.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this egress rule.
 * `to_port` - (Required) The end range port.


### PR DESCRIPTION
Fixes an issue where security groups would fail to update after applying an initial `security_group`, because we were improperly saving the id of the group and not the name (EC2 Classic only).

Given a config like so:

```hcl
provider "aws" {
  region = "us-east-1"
}

resource "aws_security_group" "other_web" {
  name        = "tf_other_acc_tests"
  description = "Used in the terraform acceptance tests"

  tags {
    Name = "tf-acc-test"
  }
}

resource "aws_security_group" "web" {
  name        = "terraform_acceptance_test_example"
  description = "Used in the terraform acceptance tests"

  ingress {
    protocol        = "tcp"
    from_port       = 80
    to_port         = 8000
    security_groups = ["${aws_security_group.other_web.name}"]
  }

  tags {
    Name = "tf-acc-test"
  }
}

```

In **EC2 Classic**, you'll get a non-empty follow up plan: 

```
~ aws_security_group.web
    [...]
    ingress.2770275604.security_groups.1579452417: "" => "tf_other_acc_tests"
    [...]
    ingress.3820341472.security_groups.1357244208: "sg-2a5c5340" => ""
    [...]
```

and an error trying to make modifications:

```
1 error(s) occurred:

* aws_security_group.web: Error authorizing security group ingress rules: InvalidGroup.NotFound: Unable to find group 'sg-2a5c5340'
	status code: 400, request id:
```

Prior to https://github.com/hashicorp/terraform/pull/4779, saving the rules to local state was actually failing, so the state reflected what was in the config. In reality, there is an issue with `flattenSecurityGroups`, in that it only flattened groups using their ID, which is invalid if you're on EC2 Classic (supposed to reference them by name). 

After #4779, those records were being saved _incorrectly_ to the statefile:

```
ingress.3820341472.security_groups.1357244208 = sg-2a5c5340
```

note the `sg-2a5c5340` when it should be the name `terraform_acceptance_test_example`.

This PR corrects the issue with `flattenSecurityGroups`, toggling what value to use based on if the SG is in a VPC or not. 