### PR TITLE
provider/azurerm: sql server resource

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -526,11 +526,15 @@
 		},
 		{
 			"ImportPath": "github.com/jen20/riviera/azure",
-			"Rev": "9f0b6c6d5e35780213c3a32976b353faca958699"
+			"Rev": "478cbee6e83468ab998195f485cf8f62069a8024"
 		},
 		{
 			"ImportPath": "github.com/jen20/riviera/dns",
-			"Rev": "9f0b6c6d5e35780213c3a32976b353faca958699"
+			"Rev": "478cbee6e83468ab998195f485cf8f62069a8024"
+		},
+		{
+			"ImportPath": "github.com/jen20/riviera/sql",
+			"Rev": "478cbee6e83468ab998195f485cf8f62069a8024"
 		},
 		{
 			"ImportPath": "github.com/jmespath/go-jmespath",

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -61,6 +61,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_storage_blob":           resourceArmStorageBlob(),
 			"azurerm_storage_queue":          resourceArmStorageQueue(),
 			"azurerm_dns_zone":               resourceArmDnsZone(),
+			"azurerm_sql_server":             resourceArmSqlServer(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -129,7 +129,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 func registerAzureResourceProvidersWithSubscription(config *Config, client *ArmClient) error {
 	providerClient := client.providers
 
-	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage"}
+	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage", "Microsoft.Sql"}
 
 	for _, v := range providers {
 		res, err := providerClient.Register(v)

--- a/builtin/providers/azurerm/resource_arm_sql_server.go
+++ b/builtin/providers/azurerm/resource_arm_sql_server.go
@@ -66,6 +66,7 @@ func resourceArmSqlServerCreate(d *schema.ResourceData, meta interface{}) error 
 	rivieraClient := client.rivieraClient
 
 	tags := d.Get("tags").(map[string]interface{})
+	expandedTags := expandTags(tags)
 
 	createRequest := rivieraClient.NewRequest()
 	createRequest.Command = &sql.CreateOrUpdateServer{
@@ -75,7 +76,7 @@ func resourceArmSqlServerCreate(d *schema.ResourceData, meta interface{}) error 
 		AdministratorLogin:         azure.String(d.Get("administrator_login").(string)),
 		AdministratorLoginPassword: azure.String(d.Get("administrator_login_password").(string)),
 		Version:                    azure.String(d.Get("version").(string)),
-		Tags:                       expandTags(tags),
+		Tags:                       *expandedTags,
 	}
 
 	createResponse, err := createRequest.Execute()

--- a/builtin/providers/azurerm/resource_arm_sql_server.go
+++ b/builtin/providers/azurerm/resource_arm_sql_server.go
@@ -1,0 +1,153 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+	"github.com/jen20/riviera/sql"
+)
+
+func resourceArmSqlServer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmSqlServerCreate,
+		Read:   resourceArmSqlServerRead,
+		Update: resourceArmSqlServerCreate,
+		Delete: resourceArmSqlServerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"version": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"administrator_login": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"administrator_login_password": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"fully_qualified_domain_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmSqlServerCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	tags := d.Get("tags").(map[string]interface{})
+
+	createRequest := rivieraClient.NewRequest()
+	createRequest.Command = &sql.CreateOrUpdateServer{
+		Name:                       d.Get("name").(string),
+		Location:                   d.Get("location").(string),
+		ResourceGroupName:          d.Get("resource_group_name").(string),
+		AdministratorLogin:         azure.String(d.Get("administrator_login").(string)),
+		AdministratorLoginPassword: azure.String(d.Get("administrator_login_password").(string)),
+		Version:                    azure.String(d.Get("version").(string)),
+		Tags:                       expandTags(tags),
+	}
+
+	createResponse, err := createRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error creating SQL Server: %s", err)
+	}
+	if !createResponse.IsSuccessful() {
+		return fmt.Errorf("Error creating SQL Server: %s", createResponse.Error)
+	}
+
+	readRequest := rivieraClient.NewRequest()
+	readRequest.Command = &sql.GetServer{
+		Name:              d.Get("name").(string),
+		ResourceGroupName: d.Get("resource_group_name").(string),
+	}
+
+	readResponse, err := readRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error reading SQL Server: %s", err)
+	}
+	if !readResponse.IsSuccessful() {
+		return fmt.Errorf("Error reading SQL Server: %s", readResponse.Error)
+	}
+
+	resp := readResponse.Parsed.(*sql.GetServerResponse)
+	d.SetId(*resp.ID)
+
+	return resourceArmSqlServerRead(d, meta)
+}
+
+func resourceArmSqlServerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	readRequest := rivieraClient.NewRequestForURI(d.Id())
+	readRequest.Command = &sql.GetServer{}
+
+	readResponse, err := readRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error reading SQL Server: %s", err)
+	}
+	if !readResponse.IsSuccessful() {
+		log.Printf("[INFO] Error reading SQL Server %q - removing from state", d.Id())
+		d.SetId("")
+		return fmt.Errorf("Error reading SQL Server: %s", readResponse.Error)
+	}
+
+	resp := readResponse.Parsed.(*sql.GetServerResponse)
+
+	d.Set("fully_qualified_domain_name", resp.FullyQualifiedDomainName)
+	d.Set("administrator_login", resp.AdministratorLogin)
+	d.Set("version", resp.Version)
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}
+
+func resourceArmSqlServerDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	deleteRequest := rivieraClient.NewRequestForURI(d.Id())
+	deleteRequest.Command = &sql.DeleteServer{}
+
+	deleteResponse, err := deleteRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error deleting SQL Server: %s", err)
+	}
+	if !deleteResponse.IsSuccessful() {
+		return fmt.Errorf("Error deleting SQL Server: %s", deleteResponse.Error)
+	}
+
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_sql_server_test.go
+++ b/builtin/providers/azurerm/resource_arm_sql_server_test.go
@@ -1,0 +1,94 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/jen20/riviera/sql"
+)
+
+func TestAccAzureRMSqlServer_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSqlServer_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSqlServerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMSqlServerExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).rivieraClient
+
+		readRequest := conn.NewRequestForURI(rs.Primary.ID)
+		readRequest.Command = &sql.GetServer{}
+
+		readResponse, err := readRequest.Execute()
+		if err != nil {
+			return fmt.Errorf("Bad: GetServer: %s", err)
+		}
+		if !readResponse.IsSuccessful() {
+			return fmt.Errorf("Bad: GetServer: %s", readResponse.Error)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMSqlServerDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).rivieraClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_sql_server" {
+			continue
+		}
+
+		readRequest := conn.NewRequestForURI(rs.Primary.ID)
+		readRequest.Command = &sql.GetServer{}
+
+		readResponse, err := readRequest.Execute()
+		if err != nil {
+			return fmt.Errorf("Bad: GetServer: %s", err)
+		}
+
+		if readResponse.IsSuccessful() {
+			return fmt.Errorf("Bad: SQL Server still exists: %s", readResponse.Error)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMSqlServer_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+}
+`

--- a/builtin/providers/azurerm/resource_arm_sql_server_test.go
+++ b/builtin/providers/azurerm/resource_arm_sql_server_test.go
@@ -29,6 +29,37 @@ func TestAccAzureRMSqlServer_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSqlServer_withTags(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMSqlServer_withTags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSqlServer_withTagsUpdated, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSqlServerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_sql_server.test", "tags.#", "2"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_sql_server.test", "tags.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMSqlServerExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -90,5 +121,44 @@ resource "azurerm_sql_server" "test" {
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
+}
+`
+
+var testAccAzureRMSqlServer_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+
+    tags {
+    	environment = "staging"
+    	database = "test"
+    }
+}
+`
+
+var testAccAzureRMSqlServer_withTagsUpdated = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+
+    tags {
+    	environment = "production"
+    }
 }
 `

--- a/vendor/github.com/jen20/riviera/sql/api.go
+++ b/vendor/github.com/jen20/riviera/sql/api.go
@@ -1,0 +1,30 @@
+package sql
+
+import "fmt"
+
+const apiVersion = "2014-04-01-preview"
+const apiProvider = "Microsoft.Sql"
+
+func sqlServerDefaultURLPath(resourceGroupName, serverName string) func() string {
+	return func() string {
+		return fmt.Sprintf("resourceGroups/%s/providers/%s/servers/%s", resourceGroupName, apiProvider, serverName)
+	}
+}
+
+func sqlElasticPoolDefaultURLPath(resourceGroupName, serverName, elasticPoolName string) func() string {
+	return func() string {
+		return fmt.Sprintf("resourceGroups/%s/providers/%s/servers/%s/elasticPools/%s", resourceGroupName, apiProvider, serverName, elasticPoolName)
+	}
+}
+
+func sqlDatabaseDefaultURLPath(resourceGroupName, serverName, databaseName string) func() string {
+	return func() string {
+		return fmt.Sprintf("resourceGroups/%s/providers/%s/servers/%s/databases/%s", resourceGroupName, apiProvider, serverName, databaseName)
+	}
+}
+
+func sqlServerFirewallDefaultURLPath(resourceGroupName, serverName, firewallRuleName string) func() string {
+	return func() string {
+		return fmt.Sprintf("resourceGroups/%s/providers/%s/servers/%s/firewallRules/%s", resourceGroupName, apiProvider, serverName, firewallRuleName)
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/create_elastic_database_pool.go
+++ b/vendor/github.com/jen20/riviera/sql/create_elastic_database_pool.go
@@ -1,0 +1,27 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type CreateElasticDatabasePool struct {
+	Name              string             `json:"-"`
+	ServerName        string             `json:"-"`
+	ResourceGroupName string             `json:"-"`
+	Location          string             `json:"-" riviera:"location"`
+	Tags              map[string]*string `json:"-" riviera:"tags"`
+	Edition           *string            `json:"edition,omitempty"`
+	DTU               *string            `json:"dtu,omitempty"`
+	StorageMB         *string            `json:"storageMB,omitempty"`
+	DatabaseDTUMin    *string            `json:"databaseDtuMin,omitempty"`
+	DatabaseDTUMax    *string            `json:"databaseDtuMax,omitempty"`
+}
+
+func (s CreateElasticDatabasePool) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "PUT",
+		URLPathFunc: sqlElasticPoolDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return nil
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/create_or_update_database.go
+++ b/vendor/github.com/jen20/riviera/sql/create_or_update_database.go
@@ -1,0 +1,49 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type CreateOrUpdateDatabaseResponse struct {
+	ID                             *string            `mapstructure:"id"`
+	Name                           *string            `mapstructure:"name"`
+	Location                       *string            `mapstructure:"location"`
+	Tags                           *map[string]string `mapstructure:"tags"`
+	DatabaseID                     *string            `mapstructure:"databaseId"`
+	DatabaseName                   *string            `mapstructure:"databaseName"`
+	Edition                        *string            `mapstructure:"edition"`
+	ServiceLevelObjective          *string            `mapstructure:"serviceLevelObjective"`
+	MaxSizeInBytes                 *string            `mapstructure:"maxSizeInBytes"`
+	CreationDate                   *string            `mapstructure:"creationDate"`
+	CurrentServiceLevelObjectiveID *string            `mapstructure:"currentServiceLevelObjectiveId"`
+	RequestedServiceObjectiveID    *string            `mapstructure:"requestedServiceObjectiveId"`
+	DefaultSecondaryLocation       *string            `mapstructure:"defaultSecondaryLocation"`
+	Encryption                     *string            `mapstructure:"encryption"`
+}
+
+type CreateOrUpdateDatabase struct {
+	Name                          string             `json:"-"`
+	ResourceGroupName             string             `json:"-"`
+	ServerName                    string             `json:"-"`
+	Location                      string             `json:"-" riviera:"location"`
+	Tags                          map[string]*string `json:"-" riviera:"tags"`
+	Edition                       *string            `json:"edition,omitempty"`
+	Collation                     *string            `json:"collation,omitempty"`
+	MaxSizeBytes                  *string            `json:"maxSizeBytes,omitempty"`
+	RequestedServiceObjectiveName *string            `json:"requestedServiceObjectiveName,omitempty"`
+	RequestedServiceObjectiveId   *string            `json:"requestedServiceObjectiveId,omitempty"`
+	CreateMode                    *string            `json:"createMode,omitempty"`
+	SourceDatabaseID              *string            `json:"sourceDatabaseId,omitempty"`
+	SourceDatabaseDeletionDate    *string            `json:"sourceDatabaseDeletionDate,omitempty"`
+	RestorePointInTime            *string            `json:"restorePointInTime,omitempty"`
+	ElasticPoolName               *string            `json:"elasticPoolName,omitempty"`
+}
+
+func (s CreateOrUpdateDatabase) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "PUT",
+		URLPathFunc: sqlDatabaseDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &CreateOrUpdateDatabaseResponse{}
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/create_or_update_firewall_rule.go
+++ b/vendor/github.com/jen20/riviera/sql/create_or_update_firewall_rule.go
@@ -1,0 +1,30 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type CreateOrUpdateFirewallRuleResponse struct {
+	ID             *string `mapstructure:"id"`
+	Name           *string `mapstructure:"name"`
+	Location       *string `mapstructure:"location"`
+	StartIpAddress *string `json:"startIpAddress,omitempty"`
+	EndIpAddress   *string `json:"endIpAddress,omitempty"`
+}
+
+type CreateOrUpdateFirewallRule struct {
+	Name              string  `json:"-"`
+	ResourceGroupName string  `json:"-"`
+	ServerName        string  `json:"-"`
+	StartIpAddress    *string `json:"startIpAddress,omitempty"`
+	EndIpAddress      *string `json:"endIpAddress,omitempty"`
+}
+
+func (s CreateOrUpdateFirewallRule) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "PUT",
+		URLPathFunc: sqlServerFirewallDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &CreateOrUpdateFirewallRuleResponse{}
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/create_or_update_server.go
+++ b/vendor/github.com/jen20/riviera/sql/create_or_update_server.go
@@ -1,0 +1,39 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type CreateOrUpdateServerResponse struct {
+	ID                         *string             `mapstructure:"id"`
+	Name                       *string             `mapstructure:"name"`
+	Location                   *string             `mapstructure:"location"`
+	Tags                       *map[string]*string `mapstructure:"tags"`
+	Kind                       *string             `mapstructure:"kind"`
+	FullyQualifiedDomainName   *string             `mapstructure:"fullyQualifiedDomainName"`
+	AdministratorLogin         *string             `mapstructure:"administratorLogin"`
+	AdministratorLoginPassword *string             `mapstructure:"administratorLoginPassword"`
+	ExternalAdministratorLogin *string             `mapstructure:"externalAdministratorLogin"`
+	ExternalAdministratorSid   *string             `mapstructure:"externalAdministratorSid"`
+	Version                    *string             `mapstructure:"version"`
+	State                      *string             `mapstructure:"state"`
+}
+
+type CreateOrUpdateServer struct {
+	Name                       string             `json:"-"`
+	ResourceGroupName          string             `json:"-"`
+	Location                   string             `json:"-" riviera:"location"`
+	Tags                       map[string]*string `json:"-" riviera:"tags"`
+	AdministratorLogin         *string            `json:"administratorLogin,omitempty"`
+	AdministratorLoginPassword *string            `json:"administratorLoginPassword,omitempty"`
+	Version                    *string            `json:"version,omitempty"`
+}
+
+func (s CreateOrUpdateServer) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "PUT",
+		URLPathFunc: sqlServerDefaultURLPath(s.ResourceGroupName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &CreateOrUpdateServerResponse{}
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/delete_database.go
+++ b/vendor/github.com/jen20/riviera/sql/delete_database.go
@@ -1,0 +1,20 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type DeleteDatabase struct {
+	Name              string `json:"-"`
+	ServerName        string `json:"-"`
+	ResourceGroupName string `json:"-"`
+}
+
+func (s DeleteDatabase) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "DELETE",
+		URLPathFunc: sqlDatabaseDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return nil
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/delete_elastic_database_pool.go
+++ b/vendor/github.com/jen20/riviera/sql/delete_elastic_database_pool.go
@@ -1,0 +1,20 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type DeleteElasticDatabasePool struct {
+	Name              string `json:"-"`
+	ServerName        string `json:"-"`
+	ResourceGroupName string `json:"-"`
+}
+
+func (s DeleteElasticDatabasePool) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "DELETE",
+		URLPathFunc: sqlElasticPoolDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return nil
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/delete_firewall_rule.go
+++ b/vendor/github.com/jen20/riviera/sql/delete_firewall_rule.go
@@ -1,0 +1,20 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type DeleteFirewallRule struct {
+	Name              string `json:"-"`
+	ResourceGroupName string `json:"-"`
+	ServerName        string `json:"-"`
+}
+
+func (s DeleteFirewallRule) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "DELETE",
+		URLPathFunc: sqlServerFirewallDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return nil
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/delete_server.go
+++ b/vendor/github.com/jen20/riviera/sql/delete_server.go
@@ -1,0 +1,19 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type DeleteServer struct {
+	Name              string `json:"-"`
+	ResourceGroupName string `json:"-"`
+}
+
+func (s DeleteServer) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "DELETE",
+		URLPathFunc: sqlServerDefaultURLPath(s.ResourceGroupName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return nil
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/get_database.go
+++ b/vendor/github.com/jen20/riviera/sql/get_database.go
@@ -1,0 +1,37 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type GetDatabaseResponse struct {
+	ID                             *string            `mapstructure:"id"`
+	Name                           *string            `mapstructure:"name"`
+	Location                       *string            `mapstructure:"location"`
+	Tags                           *map[string]string `mapstructure:"tags"`
+	DatabaseID                     *string            `mapstructure:"databaseId"`
+	DatabaseName                   *string            `mapstructure:"databaseName"`
+	Edition                        *string            `mapstructure:"edition"`
+	ServiceLevelObjective          *string            `mapstructure:"serviceLevelObjective"`
+	MaxSizeInBytes                 *string            `mapstructure:"maxSizeInBytes"`
+	CreationDate                   *string            `mapstructure:"creationDate"`
+	CurrentServiceLevelObjectiveID *string            `mapstructure:"currentServiceLevelObjectiveId"`
+	RequestedServiceObjectiveID    *string            `mapstructure:"requestedServiceObjectiveId"`
+	DefaultSecondaryLocation       *string            `mapstructure:"defaultSecondaryLocation"`
+	Encryption                     *string            `mapstructure:"encryption"`
+}
+
+type GetDatabase struct {
+	Name              string `json:"-"`
+	ServerName        string `json:"-"`
+	ResourceGroupName string `json:"-"`
+}
+
+func (s GetDatabase) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "GET",
+		URLPathFunc: sqlDatabaseDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &GetDatabaseResponse{}
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/get_firewall_rule.go
+++ b/vendor/github.com/jen20/riviera/sql/get_firewall_rule.go
@@ -1,0 +1,28 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type GetFirewallRuleResponse struct {
+	ID             *string `mapstructure:"id"`
+	Name           *string `mapstructure:"name"`
+	Location       *string `mapstructure:"location"`
+	StartIpAddress *string `json:"startIpAddress,omitempty"`
+	EndIpAddress   *string `json:"endIpAddress,omitempty"`
+}
+
+type GetFirewallRule struct {
+	Name              string `json:"-"`
+	ResourceGroupName string `json:"-"`
+	ServerName        string `json:"-"`
+}
+
+func (s GetFirewallRule) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "GET",
+		URLPathFunc: sqlServerFirewallDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &GetFirewallRuleResponse{}
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/sql/get_server.go
+++ b/vendor/github.com/jen20/riviera/sql/get_server.go
@@ -1,0 +1,34 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type GetServerResponse struct {
+	ID                         *string             `mapstructure:"id"`
+	Name                       *string             `mapstructure:"name"`
+	Location                   *string             `mapstructure:"location"`
+	Tags                       *map[string]*string `mapstructure:"tags"`
+	Kind                       *string             `mapstructure:"kind"`
+	FullyQualifiedDomainName   *string             `mapstructure:"fullyQualifiedDomainName"`
+	AdministratorLogin         *string             `mapstructure:"administratorLogin"`
+	AdministratorLoginPassword *string             `mapstructure:"administratorLoginPassword"`
+	ExternalAdministratorLogin *string             `mapstructure:"externalAdministratorLogin"`
+	ExternalAdministratorSid   *string             `mapstructure:"externalAdministratorSid"`
+	Version                    *string             `mapstructure:"version"`
+	State                      *string             `mapstructure:"state"`
+}
+
+type GetServer struct {
+	Name              string `json:"-"`
+	ResourceGroupName string `json:"-"`
+}
+
+func (s GetServer) ApiInfo() azure.ApiInfo {
+	return azure.ApiInfo{
+		ApiVersion:  apiVersion,
+		Method:      "GET",
+		URLPathFunc: sqlServerDefaultURLPath(s.ResourceGroupName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &GetServerResponse{}
+		},
+	}
+}

--- a/website/source/docs/providers/azurerm/r/sql_server.html.markdown
+++ b/website/source/docs/providers/azurerm/r/sql_server.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sql_server"
+sidebar_current: "docs-azurerm-resource-sql-server"
+description: |-
+  Create a SQL Server.
+---
+
+# azurerm\_sql\_server
+
+Allows you to manage an Azure SQL Database Server
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+   name = "acceptanceTestResourceGroup1"
+   location = "West US"
+}
+resource "azurerm_sql_server" "test" {
+    name = "MySqlServer"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+
+    tags {
+    	environment = "production"
+    }
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the SQL Server.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the sql server.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `version` - (Required) The version for the new server. Valid values are: 2.0 (for v11 server) and 12.0 (for v12 server).
+
+* `administrator_login` - (Required) The administrator login name for the new server.
+
+* `administrator_login_password` - (Required) The password for the new AdministratorLogin. Please following Azures [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx)
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The DNS Zone ID.
+* `fully_qualified_domain_name` - The fully qualified domain name of the Azure SQL Server (e.g. myServerName.database.windows.net)

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -83,6 +83,17 @@
 
               </ul>
             </li>
+
+            <li<%= sidebar_current(/^docs-azurerm-resource-sql/) %>>
+              <a href="#">SQL Resources</a>
+              <ul class="nav nav-visible">
+
+                <li<%= sidebar_current("docs-azurerm-resource-sql-server") %>>
+                  <a href="/docs/providers/azurerm/r/sql_server.html">azurerm_sql_server</a>
+                </li>
+
+              </ul>
+            </li>
             
             <li<%= sidebar_current(/^docs-azurerm-resource-storage/) %>>
               <a href="#">Storage Resources</a>


### PR DESCRIPTION
Adding `sql_server`:

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMSqlServer' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/azurerm -v -run=AzureRMSqlServer -timeout 120m
=== RUN   TestAccAzureRMSqlServer_basic
--- PASS: TestAccAzureRMSqlServer_basic (253.29s)
=== RUN   TestAccAzureRMSqlServer_withTags
--- PASS: TestAccAzureRMSqlServer_withTags (394.56s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	647.869s
```