### PR TITLE
provider/heroku: address cert test failure

### DIFF
--- a/builtin/providers/heroku/resource_heroku_cert.go
+++ b/builtin/providers/heroku/resource_heroku_cert.go
@@ -58,7 +58,7 @@ func resourceHerokuCertCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] SSL Certificate create configuration: %#v, %#v", app, opts)
 	a, err := client.SSLEndpointCreate(app, opts)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("Error creating SSL endpoint: %s", err)
 	}
 
 	d.SetId(a.ID)

--- a/builtin/providers/heroku/resource_heroku_cert_test.go
+++ b/builtin/providers/heroku/resource_heroku_cert_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -17,9 +18,10 @@ func TestAccHerokuCert_Basic(t *testing.T) {
 	certificateChainFile := wd + "/test-fixtures/terraform.cert"
 	certificateChainBytes, _ := ioutil.ReadFile(certificateChainFile)
 	certificateChain := string(certificateChainBytes)
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	testAccCheckHerokuCertConfig_basic := `
     resource "heroku_app" "foobar" {
-        name = "terraform-test-cert-app"
+        name = "` + appName + `"
         region = "eu"
     }
 
@@ -47,7 +49,8 @@ func TestAccHerokuCert_Basic(t *testing.T) {
 					testAccCheckHerokuCertExists("heroku_cert.ssl_certificate", &endpoint),
 					testAccCheckHerokuCertificateChain(&endpoint, certificateChain),
 					resource.TestCheckResourceAttr(
-						"heroku_cert.ssl_certificate", "cname", "terraform-test-cert-app.herokuapp.com"),
+						"heroku_cert.ssl_certificate",
+						"cname", fmt.Sprintf("%s.herokuapp.com", appName)),
 				),
 			},
 		},


### PR DESCRIPTION
 * Randomize app name in test
 * Return error and don't panic when there is a problem

It's possible there may still be an underlying problem that caused the
error that made the cert leak in the first place - this should help us
diagnose it.

```
=== RUN   TestAccHerokuCert_Basic
--- PASS: TestAccHerokuCert_Basic (23.79s)
```