### PR TITLE
core: fix bug detecting deeply nested module orphans

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -151,8 +151,23 @@ func (s *State) ModuleOrphans(path []string, c *config.Config) [][]string {
 			continue
 		}
 
+		orphanPath := m.Path[:len(path)+1]
+
+		// Don't double-add if we've already added this orphan (which can happen if
+		// there are multiple nested sub-modules that get orphaned together).
+		alreadyAdded := false
+		for _, o := range orphans {
+			if reflect.DeepEqual(o, orphanPath) {
+				alreadyAdded = true
+				break
+			}
+		}
+		if alreadyAdded {
+			continue
+		}
+
 		// Add this orphan
-		orphans = append(orphans, m.Path[:len(path)+1])
+		orphans = append(orphans, orphanPath)
 	}
 
 	return orphans

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -150,6 +150,31 @@ func TestStateModuleOrphans_nilConfig(t *testing.T) {
 	}
 }
 
+func TestStateModuleOrphans_deepNestedNilConfig(t *testing.T) {
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: RootModulePath,
+			},
+			&ModuleState{
+				Path: []string{RootModuleName, "parent", "childfoo"},
+			},
+			&ModuleState{
+				Path: []string{RootModuleName, "parent", "childbar"},
+			},
+		},
+	}
+
+	actual := state.ModuleOrphans(RootModulePath, nil)
+	expected := [][]string{
+		[]string{RootModuleName, "parent"},
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestStateEqual(t *testing.T) {
 	cases := []struct {
 		Result   bool

--- a/terraform/test-fixtures/plan-modules-remove-provisioners/main.tf
+++ b/terraform/test-fixtures/plan-modules-remove-provisioners/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "top" {}
+
+# module "test" {
+#   source = "./parent"
+# }

--- a/terraform/test-fixtures/plan-modules-remove-provisioners/parent/child/main.tf
+++ b/terraform/test-fixtures/plan-modules-remove-provisioners/parent/child/main.tf
@@ -1,0 +1,2 @@
+resource "aws_instance" "foo" {
+}

--- a/terraform/test-fixtures/plan-modules-remove-provisioners/parent/main.tf
+++ b/terraform/test-fixtures/plan-modules-remove-provisioners/parent/main.tf
@@ -1,0 +1,7 @@
+module "childone" {
+  source = "./child"
+}
+
+module "childtwo" {
+  source = "./child"
+}


### PR DESCRIPTION
Context:

As part of building up a Plan, Terraform needs to detect "orphaned"
resources--resources which are present in the state but not in the
config. This happens when config for those resources is removed by the
user, making it Terraform's responsibility to destroy them.

Both state and config are organized by Module into a logical tree, so
the process of finding orphans involves checking for orphaned Resources
in the current module and for orphaned Modules, which themselves will
have all their Resources marked as orphans.

Bug:

In #3114 a problem was exposed where, given a module tree that looked
like this:

```
root
 |
 +-- parent (empty, except for sub-modules)
       |
       +-- child1 (1 resource)
       |
       +-- child2 (1 resource)
```

If `parent` was removed, a bunch of error messages would occur during
the plan. The root cause of this was duplicate orphans appearing for the
resources in child1 and child2.

Fix:

This turned out to be a bug in orphaned module detection. When looking
for deeply nested orphaned modules, root.parent was getting added twice
as an orphaned module to the graph.

Here, we add an additional check to prevent a double add, which
addresses this scenario properly.

Fixes #3114 (the Provisioner side of it was fixed in #4877)