### PR TITLE
core: Make copies when creating destroy nodes

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,52 @@ import (
 // This is the directory where our test fixtures are.
 const fixtureDir = "./test-fixtures"
 
+func TestConfigCopy(t *testing.T) {
+	c := testConfig(t, "copy-basic")
+	rOrig := c.Resources[0]
+	rCopy := rOrig.Copy()
+
+	if rCopy.Name != rOrig.Name {
+		t.Fatalf("Expected names to equal: %q <=> %q", rCopy.Name, rOrig.Name)
+	}
+
+	if rCopy.Type != rOrig.Type {
+		t.Fatalf("Expected types to equal: %q <=> %q", rCopy.Type, rOrig.Type)
+	}
+
+	origCount := rOrig.RawCount.Config()["count"]
+	rCopy.RawCount.Config()["count"] = "5"
+	if rOrig.RawCount.Config()["count"] != origCount {
+		t.Fatalf("Expected RawCount to be copied, but it behaves like a ref!")
+	}
+
+	rCopy.RawConfig.Config()["newfield"] = "hello"
+	if rOrig.RawConfig.Config()["newfield"] == "hello" {
+		t.Fatalf("Expected RawConfig to be copied, but it behaves like a ref!")
+	}
+
+	rCopy.Provisioners = append(rCopy.Provisioners, &Provisioner{})
+	if len(rOrig.Provisioners) == len(rCopy.Provisioners) {
+		t.Fatalf("Expected Provisioners to be copied, but it behaves like a ref!")
+	}
+
+	if rCopy.Provider != rOrig.Provider {
+		t.Fatalf("Expected providers to equal: %q <=> %q",
+			rCopy.Provider, rOrig.Provider)
+	}
+
+	rCopy.DependsOn[0] = "gotchya"
+	if rOrig.DependsOn[0] == rCopy.DependsOn[0] {
+		t.Fatalf("Expected DependsOn to be copied, but it behaves like a ref!")
+	}
+
+	rCopy.Lifecycle.IgnoreChanges[0] = "gotchya"
+	if rOrig.Lifecycle.IgnoreChanges[0] == rCopy.Lifecycle.IgnoreChanges[0] {
+		t.Fatalf("Expected Lifecycle to be copied, but it behaves like a ref!")
+	}
+
+}
+
 func TestConfigCount(t *testing.T) {
 	c := testConfig(t, "count-int")
 	actual, err := c.Resources[0].Count()

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -53,7 +53,12 @@ func (r *RawConfig) Copy() *RawConfig {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	result, err := NewRawConfig(r.Raw)
+	newRaw := make(map[string]interface{})
+	for k, v := range r.Raw {
+		newRaw[k] = v
+	}
+
+	result, err := NewRawConfig(newRaw)
 	if err != nil {
 		panic("copy failed: " + err.Error())
 	}

--- a/config/test-fixtures/copy-basic/main.tf
+++ b/config/test-fixtures/copy-basic/main.tf
@@ -1,0 +1,19 @@
+variable "ref" {
+  default = "foo"
+}
+
+resource "foo" "bar" {
+  depends_on = ["dep"]
+  provider = "foo-west"
+  count = 2
+  attr  = "value"
+  ref   = "${var.ref}"
+
+  provisioner "shell" {
+    inline = "echo"
+  }
+
+  lifecycle {
+    ignore_changes = ["config"]
+  }
+}

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -29,6 +29,22 @@ type GraphNodeConfigResource struct {
 	Path []string
 }
 
+func (n *GraphNodeConfigResource) Copy() *GraphNodeConfigResource {
+	ncr := &GraphNodeConfigResource{
+		Resource:    n.Resource.Copy(),
+		DestroyMode: n.DestroyMode,
+		Targets:     make([]ResourceAddress, 0, len(n.Targets)),
+		Path:        make([]string, 0, len(n.Path)),
+	}
+	for _, t := range n.Targets {
+		ncr.Targets = append(ncr.Targets, *t.Copy())
+	}
+	for _, p := range n.Path {
+		ncr.Path = append(ncr.Path, p)
+	}
+	return ncr
+}
+
 func (n *GraphNodeConfigResource) ConfigType() GraphNodeConfigType {
 	return GraphNodeConfigTypeResource
 }
@@ -247,7 +263,7 @@ func (n *GraphNodeConfigResource) DestroyNode(mode GraphNodeDestroyMode) GraphNo
 	}
 
 	result := &graphNodeResourceDestroy{
-		GraphNodeConfigResource: *n,
+		GraphNodeConfigResource: *n.Copy(),
 		Original:                n,
 	}
 	result.DestroyMode = mode

--- a/terraform/resource_address.go
+++ b/terraform/resource_address.go
@@ -23,6 +23,21 @@ type ResourceAddress struct {
 	Type         string
 }
 
+// Copy returns a copy of this ResourceAddress
+func (r *ResourceAddress) Copy() *ResourceAddress {
+	n := &ResourceAddress{
+		Path:         make([]string, 0, len(r.Path)),
+		Index:        r.Index,
+		InstanceType: r.InstanceType,
+		Name:         r.Name,
+		Type:         r.Type,
+	}
+	for _, p := range r.Path {
+		n.Path = append(n.Path, p)
+	}
+	return n
+}
+
 func ParseResourceAddress(s string) (*ResourceAddress, error) {
 	matches, err := tokenizeResourceAddress(s)
 	if err != nil {

--- a/terraform/test-fixtures/plan-taint-interpolated-count/main.tf
+++ b/terraform/test-fixtures/plan-taint-interpolated-count/main.tf
@@ -1,0 +1,7 @@
+variable "count" {
+  default = 3
+}
+
+resource "aws_instance" "foo" {
+  count = "${var.count}"
+}


### PR DESCRIPTION
Fixes an interpolation race that was occurring when a tainted destroy
node and a primary destroy node both tried to interpolate a computed
count in their config. Since they were sharing a pointer to the _same_
config, depending on how the race played out one of them could catch the
config uninterpolated and would then throw a syntax error.

The `Copy()` tree implemented for this fix can probably be used
elsewhere - basically we should copy the config whenever we drop nodes
into the graph - but for now I'm just applying it to the place that
fixes this bug.

Fixes #4982