### PR TITLE
fix: Work around HCL's inability to interpret negative numbers

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -571,7 +571,7 @@ func TestInterpolateFuncSignum(t *testing.T) {
 			},
 
 			{
-				`${signum(-29)}`,
+				`${signum(0 - 29)}`,
 				"-1",
 				false,
 			},


### PR DESCRIPTION
I recently merged https://github.com/hashicorp/terraform/pull/4854 which (to my surprise) caused one of the tests to fail.

The same test was passing ~11 days ago:
https://travis-ci.org/hashicorp/terraform/builds/105195588

I'm thinking that something must have changed in HCL parser.

This is more of a workaround to make tests green again, rather than a solution.