### PR TITLE
provider/cloudflare: Change CloudFlare record TTL property to be `computed`

### DIFF
--- a/builtin/providers/cloudflare/resource_cloudflare_record.go
+++ b/builtin/providers/cloudflare/resource_cloudflare_record.go
@@ -45,6 +45,7 @@ func resourceCloudFlareRecord() *schema.Resource {
 			"ttl": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"priority": &schema.Schema{


### PR DESCRIPTION
Fixes #5040

This just required the TTL value to be computed