### PR TITLE
provider/aws: Fix reading auto scaling group availability zones

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -92,6 +92,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			"availability_zones": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -237,7 +237,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	d.Set("availability_zones", g.AvailabilityZones)
+	d.Set("availability_zones", flattenStringList(g.AvailabilityZones))
 	d.Set("default_cooldown", g.DefaultCooldown)
 	d.Set("desired_capacity", g.DesiredCapacity)
 	d.Set("health_check_grace_period", g.HealthCheckGracePeriod)

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -300,7 +300,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("availability_zones") {
 		if v, ok := d.GetOk("availability_zones"); ok && v.(*schema.Set).Len() > 0 {
-			opts.AvailabilityZones = expandStringList(d.Get("availability_zones").(*schema.Set).List())
+			opts.AvailabilityZones = expandStringList(v.(*schema.Set).List())
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -138,6 +138,12 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 				Config: testAccAWSAutoScalingGroupConfigWithAZ,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "availability_zones.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "availability_zones.2487133097", "us-west-2a"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "1"),
 				),
 			},
 
@@ -146,6 +152,14 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckAWSAutoScalingGroupAttributesVPCZoneIdentifer(&group),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "availability_zones.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "availability_zones.2487133097", "us-west-2a"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "availability_zones.221770259", "us-west-2b"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
A similar issue to pull request #4597 that fixes reading an auto scaling group's associated availability zones when only VPC zone identifiers (e.g. subnets) are specified. The availability zone attribute is now computed since AWS will supply the availability zones corresponding to the VPC zone identifiers.