### PR TITLE
provider/aws: Fix reading auto scaling group load balancers

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -243,7 +243,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("health_check_grace_period", g.HealthCheckGracePeriod)
 	d.Set("health_check_type", g.HealthCheckType)
 	d.Set("launch_configuration", g.LaunchConfigurationName)
-	d.Set("load_balancers", g.LoadBalancerNames)
+	d.Set("load_balancers", flattenStringList(g.LoadBalancerNames))
 	d.Set("min_size", g.MinSize)
 	d.Set("max_size", g.MaxSize)
 	d.Set("placement_group", g.PlacementGroup)


### PR DESCRIPTION
A similar issue to pull requests #4597 and #5044 that fixes reading an auto scaling group's associated elastic load balancers.