### PR TITLE
Connect network after docker container has been started.

### DIFF
--- a/builtin/providers/docker/provider_test.go
+++ b/builtin/providers/docker/provider_test.go
@@ -4,6 +4,8 @@ import (
 	"os/exec"
 	"testing"
 
+	dc "github.com/fsouza/go-dockerclient"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -15,6 +17,11 @@ func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"docker": testAccProvider,
+	}
+
+	// Use local socket for the acceptance tests
+	testAccProvider.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+		return dc.NewClient("unix://var/run/docker.sock")
 	}
 }
 

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -159,6 +159,12 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(retContainer.ID)
 
+	creationTime = time.Now()
+	if err := client.StartContainer(retContainer.ID, hostConfig); err != nil {
+		return fmt.Errorf("Unable to start container: %s", err)
+	}
+
+	// docker 1.9 compatibility: only connect network after container is running
 	if v, ok := d.GetOk("networks"); ok {
 		connectionOpts := dc.NetworkConnectionOptions{Container: retContainer.ID}
 
@@ -168,11 +174,6 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 				return fmt.Errorf("Unable to connect to network '%s': %s", network, err)
 			}
 		}
-	}
-
-	creationTime = time.Now()
-	if err := client.StartContainer(retContainer.ID, hostConfig); err != nil {
-		return fmt.Errorf("Unable to start container: %s", err)
 	}
 
 	return resourceDockerContainerRead(d, meta)


### PR DESCRIPTION
Fixes #5033

As mentioned in that issue, this is no longer an issue in the recently released Docker 1.10, but the fix might be useful still for those on older versions (as there is no enforcement of versions in Terraform).

Test before and after on Docker 1.9.1:
```
root@terraform:/opt/gopath/src/github.com/hashicorp/terraform# make testacc TEST=./builtin/providers/docker TESTARGS="-run network"
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/docker -v -run network -timeout 120m
=== RUN   TestAccDockerContainer_network
--- FAIL: TestAccDockerContainer_network (0.30s)
	testing.go:148: Step 0 error: Error applying: 1 error(s) occurred:

		* docker_container.foo: Unable to connect to network 'b4205fd0054921585655a8924d43eaefd751bdf952495ff747f3266981fc9f2a': API error (500): Container 3184345d4aede934df0de5e07767e635ee0d212d12e4d435dc0c0931fd10833e is not running

FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/docker	0.312s
make: *** [testacc] Error 1
root@terraform:/opt/gopath/src/github.com/hashicorp/terraform# make testacc TEST=./builtin/providers/docker TESTARGS="-run network"
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/docker -v -run network -timeout 120m
=== RUN   TestAccDockerContainer_network
--- PASS: TestAccDockerContainer_network (0.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/docker	0.932s
```

