### PR TITLE
provider/aws: Add support for CloudTrail log validation + KMS encryption

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudtrail.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail.go
@@ -57,6 +57,23 @@ func resourceAwsCloudTrail() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"enable_log_file_validation": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"kms_key_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"home_region": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -80,6 +97,12 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	if v, ok := d.GetOk("is_multi_region_trail"); ok {
 		input.IsMultiRegionTrail = aws.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("enable_log_file_validation"); ok {
+		input.EnableLogFileValidation = aws.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		input.KmsKeyId = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("s3_key_prefix"); ok {
 		input.S3KeyPrefix = aws.String(v.(string))
@@ -136,6 +159,15 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("include_global_service_events", trail.IncludeGlobalServiceEvents)
 	d.Set("is_multi_region_trail", trail.IsMultiRegionTrail)
 	d.Set("sns_topic_name", trail.SnsTopicName)
+	d.Set("enable_log_file_validation", trail.LogFileValidationEnabled)
+
+	// TODO: Make it possible to use KMS Key names, not just ARNs
+	// In order to test it properly this PR needs to be merged 1st:
+	// https://github.com/hashicorp/terraform/pull/3928
+	d.Set("kms_key_id", trail.KmsKeyId)
+
+	d.Set("arn", trail.TrailARN)
+	d.Set("home_region", trail.HomeRegion)
 
 	logstatus, err := cloudTrailGetLoggingStatus(conn, trail.Name)
 	if err != nil {
@@ -170,6 +202,12 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 	if d.HasChange("is_multi_region_trail") {
 		input.IsMultiRegionTrail = aws.Bool(d.Get("is_multi_region_trail").(bool))
+	}
+	if d.HasChange("enable_log_file_validation") {
+		input.EnableLogFileValidation = aws.Bool(d.Get("enable_log_file_validation").(bool))
+	}
+	if d.HasChange("kms_key_id") {
+		input.KmsKeyId = aws.String(d.Get("kms_key_id").(string))
 	}
 	if d.HasChange("sns_topic_name") {
 		input.SnsTopicName = aws.String(d.Get("sns_topic_name").(string))

--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -75,9 +75,14 @@ The following arguments are supported:
     region or in all regions. Defaults to `false`.
 * `sns_topic_name` - (Optional) Specifies the name of the Amazon SNS topic
     defined for notification of log file delivery.
+* `enable_log_file_validation` - (Optional) Specifies whether log file integrity validation is enabled.
+    Defaults to `false`.
+* `kms_key_id` - (Optional) Specifies the KMS key ID to use to encrypt the logs delivered by CloudTrail.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
 * `id` - The name of the trail.
+* `home_region` - The region in which the trail was created.
+* `arn` - The Amazon Resource Name of the trail.


### PR DESCRIPTION
#### Acceptance tests

```sh
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSCloudTrail'
```
```
==> Checking that code complies with gofmt requirements...
/Users/rsimko1016/gopath/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run=AWSCloudTrail -timeout 120m
=== RUN   TestAccAWSCloudTrail_basic
--- PASS: TestAccAWSCloudTrail_basic (34.97s)
=== RUN   TestAccAWSCloudTrail_enable_logging
--- PASS: TestAccAWSCloudTrail_enable_logging (47.99s)
=== RUN   TestAccAWSCloudTrail_is_multi_region
--- PASS: TestAccAWSCloudTrail_is_multi_region (41.89s)
=== RUN   TestAccAWSCloudTrail_logValidation
--- PASS: TestAccAWSCloudTrail_logValidation (36.64s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	161.513s
```