### PR TITLE
provider/azurerm: Add `azurerm_sql_firewall_rule` resource

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -70,6 +70,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_dns_srv_record":         resourceArmDnsSrvRecord(),
 			"azurerm_sql_server":             resourceArmSqlServer(),
 			"azurerm_sql_database":           resourceArmSqlDatabase(),
+			"azurerm_sql_firewall_rule":      resourceArmSqlFirewallRule(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/resource_arm_sql_firewall_rule.go
+++ b/builtin/providers/azurerm/resource_arm_sql_firewall_rule.go
@@ -1,0 +1,134 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+	"github.com/jen20/riviera/sql"
+)
+
+func resourceArmSqlFirewallRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmSqlFirewallRuleCreate,
+		Read:   resourceArmSqlFirewallRuleRead,
+		Update: resourceArmSqlFirewallRuleCreate,
+		Delete: resourceArmSqlFirewallRuleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"server_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"start_ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"end_ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceArmSqlFirewallRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	createRequest := rivieraClient.NewRequest()
+	createRequest.Command = &sql.CreateOrUpdateFirewallRule{
+		Name:              d.Get("name").(string),
+		ResourceGroupName: d.Get("resource_group_name").(string),
+		ServerName:        d.Get("server_name").(string),
+		StartIPAddress:    azure.String(d.Get("start_ip_address").(string)),
+		EndIPAddress:      azure.String(d.Get("end_ip_address").(string)),
+	}
+
+	createResponse, err := createRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error creating SQL Server Firewall Rule: %s", err)
+	}
+	if !createResponse.IsSuccessful() {
+		return fmt.Errorf("Error creating SQL Server Firewall Rule: %s", createResponse.Error)
+	}
+
+	readRequest := rivieraClient.NewRequest()
+	readRequest.Command = &sql.GetFirewallRule{
+		Name:              d.Get("name").(string),
+		ResourceGroupName: d.Get("resource_group_name").(string),
+		ServerName:        d.Get("server_name").(string),
+	}
+
+	readResponse, err := readRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error reading SQL Server Firewall Rule: %s", err)
+	}
+	if !readResponse.IsSuccessful() {
+		return fmt.Errorf("Error reading SQL Server Firewall Rule: %s", readResponse.Error)
+	}
+
+	resp := readResponse.Parsed.(*sql.GetFirewallRuleResponse)
+	d.SetId(*resp.ID)
+
+	return resourceArmSqlFirewallRuleRead(d, meta)
+}
+
+func resourceArmSqlFirewallRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	readRequest := rivieraClient.NewRequestForURI(d.Id())
+	readRequest.Command = &sql.GetFirewallRule{}
+
+	readResponse, err := readRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error reading SQL Server Firewall Rule: %s", err)
+	}
+	if !readResponse.IsSuccessful() {
+		log.Printf("[INFO] Error reading SQL Server Firewall Rule %q - removing from state", d.Id())
+		d.SetId("")
+		return fmt.Errorf("Error reading SQL Server Firewall Rule: %s", readResponse.Error)
+	}
+
+	resp := readResponse.Parsed.(*sql.GetFirewallRuleResponse)
+
+	d.Set("start_ip_address", resp.StartIPAddress)
+	d.Set("end_ip_address", resp.EndIPAddress)
+
+	return nil
+}
+
+func resourceArmSqlFirewallRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	deleteRequest := rivieraClient.NewRequestForURI(d.Id())
+	deleteRequest.Command = &sql.DeleteFirewallRule{}
+
+	deleteResponse, err := deleteRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error deleting SQL Server Firewall Rule: %s", err)
+	}
+	if !deleteResponse.IsSuccessful() {
+		return fmt.Errorf("Error deleting SQL Server Firewall Rule: %s", deleteResponse.Error)
+	}
+
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_sql_firewall_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_sql_firewall_rule_test.go
@@ -1,0 +1,137 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/jen20/riviera/sql"
+)
+
+func TestAccAzureRMSqlFirewallRule_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMSqlFirewallRule_basic, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSqlFirewallRule_withUpdates, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSqlFirewallRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlFirewallRuleExists("azurerm_sql_firewall_rule.test"),
+					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "start_ip_address", "0.0.0.0"),
+					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "end_ip_address", "255.255.255.255"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlFirewallRuleExists("azurerm_sql_firewall_rule.test"),
+					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "start_ip_address", "10.0.17.62"),
+					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "end_ip_address", "10.0.17.62"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMSqlFirewallRuleExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).rivieraClient
+
+		readRequest := conn.NewRequestForURI(rs.Primary.ID)
+		readRequest.Command = &sql.GetFirewallRule{}
+
+		readResponse, err := readRequest.Execute()
+		if err != nil {
+			return fmt.Errorf("Bad: GetFirewallRule: %s", err)
+		}
+		if !readResponse.IsSuccessful() {
+			return fmt.Errorf("Bad: GetFirewallRule: %s", readResponse.Error)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMSqlFirewallRuleDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).rivieraClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_sql_firewall_rule" {
+			continue
+		}
+
+		readRequest := conn.NewRequestForURI(rs.Primary.ID)
+		readRequest.Command = &sql.GetFirewallRule{}
+
+		readResponse, err := readRequest.Execute()
+		if err != nil {
+			return fmt.Errorf("Bad: GetFirewallRule: %s", err)
+		}
+
+		if readResponse.IsSuccessful() {
+			return fmt.Errorf("Bad: SQL Server Firewall Rule still exists: %s", readResponse.Error)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMSqlFirewallRule_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_sql_firewall_rule" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    server_name = "${azurerm_sql_server.test.name}"
+    start_ip_address = "0.0.0.0"
+    end_ip_address = "255.255.255.255"
+}
+`
+
+var testAccAzureRMSqlFirewallRule_withUpdates = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_sql_firewall_rule" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    server_name = "${azurerm_sql_server.test.name}"
+    start_ip_address = "10.0.17.62"
+    end_ip_address = "10.0.17.62"
+}
+`

--- a/website/source/docs/providers/azurerm/r/sql_firewall_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/sql_firewall_rule.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sql_firewall_rule"
+sidebar_current: "docs-azurerm-resource-sql-firewall_rule"
+description: |-
+  Create a SQL Firewall Rule.
+---
+
+# azurerm\_sql\_firewall\_rule
+
+Allows you to manage an Azure SQL Firewall Rule
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+   name = "acceptanceTestResourceGroup1"
+   location = "West US"
+}
+resource "azurerm_sql_database" "test" {
+    name = "MySQLDatabase"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    
+
+    tags {
+    	environment = "production"
+    }
+}
+
+resource "azurerm_sql_firewall_rule" "test" {
+    name = "FirewallRule1"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    server_name = "${azurerm_sql_server.test.name}"
+    start_ip_address = "10.0.17.62"
+    end_ip_address = "10.0.17.62"
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the SQL Server.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the sql server.
+
+* `server_name` - (Required) The name of the SQL Server on which to create the Firewall Rule.
+
+* `start_ip_address` - (Required) The starting IP address to allow through the firewall for this rule.
+
+* `end_ip_address` - (Required) The ending IP address to allow through the firewall for this rule.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The SQL Firewall Rule ID.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -120,6 +120,10 @@
                   <a href="/docs/providers/azurerm/r/sql_database.html">azurerm_sql_database</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-sql-firewall-rule") %>>
+                  <a href="/docs/providers/azurerm/r/sql_firewall_rule.html">azurerm_sql_filewall_rule</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-resource-sql-server") %>>
                   <a href="/docs/providers/azurerm/r/sql_server.html">azurerm_sql_server</a>
                 </li>


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMSqlFirewallRule' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/azurerm -v -run=AzureRMSqlFirewallRule -timeout 120m
=== RUN   TestAccAzureRMSqlFirewallRule_basic
--- PASS: TestAccAzureRMSqlFirewallRule_basic (436.22s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	436.237s
```

The test includes the update of the firewall rule IP addresses