### PR TITLE
provider/aws: Change ELB access_logs to list type

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -106,7 +106,7 @@ func resourceAwsElb() *schema.Resource {
 			},
 
 			"access_logs": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -125,7 +125,6 @@ func resourceAwsElb() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceAwsElbAccessLogsHash,
 			},
 
 			"listener": &schema.Schema{
@@ -493,7 +492,7 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 			},
 		}
 
-		logs := d.Get("access_logs").(*schema.Set).List()
+		logs := d.Get("access_logs").([]interface{})
 		if len(logs) > 1 {
 			return fmt.Errorf("Only one access logs config per ELB is supported")
 		} else if len(logs) == 1 {
@@ -711,19 +710,6 @@ func resourceAwsElbDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func resourceAwsElbAccessLogsHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%d-", m["interval"].(int)))
-	buf.WriteString(fmt.Sprintf("%s-",
-		strings.ToLower(m["bucket"].(string))))
-	if v, ok := m["bucket_prefix"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
-	}
-
-	return hashcode.String(buf.String())
 }
 
 func resourceAwsElbListenerHash(v interface{}) int {

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -102,9 +102,9 @@ func TestAccAWSELB_AccessLogs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_elb.foo", "access_logs.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.1713209538.bucket", "terraform-access-logs-bucket"),
+						"aws_elb.foo", "access_logs.0.bucket", "terraform-access-logs-bucket"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.1713209538.interval", "5"),
+						"aws_elb.foo", "access_logs.0.interval", "5"),
 				),
 			},
 


### PR DESCRIPTION
Changes the access_logs type from set to list to makes it easier to compare updates when executing a plan.