### PR TITLE
provider/digitalocean: Adds a FQDN out to the `digitalocean_record`

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_record.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record.go
@@ -62,6 +62,11 @@ func resourceDigitalOceanRecord() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
+			"fqdn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -146,6 +151,10 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("priority", strconv.Itoa(rec.Priority))
 	d.Set("port", strconv.Itoa(rec.Port))
 
+	en := constructFqdn(rec.Name, d.Get("domain").(string))
+	log.Printf("[DEBUG] Constructred FQDN: %s", en)
+	d.Set("fqdn", en)
+
 	return nil
 }
 
@@ -195,4 +204,13 @@ func resourceDigitalOceanRecordDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	return nil
+}
+
+func constructFqdn(name, domain string) string {
+	rn := strings.ToLower(strings.TrimSuffix(name, "."))
+	domain = strings.TrimSuffix(domain, ".")
+	if !strings.HasSuffix(rn, domain) {
+		rn = strings.Join([]string{name, domain}, ".")
+	}
+	return rn
 }

--- a/website/source/docs/providers/do/r/record.html.markdown
+++ b/website/source/docs/providers/do/r/record.html.markdown
@@ -45,4 +45,5 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The record ID
+* `fqdn` - The FQDN of the record
 


### PR DESCRIPTION
resource. This is a computed field

Fixes #5064

```
make testacc TEST=./builtin/providers/digitalocean TESTARGS='-run=DigitalOceanRecord_Basic' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/digitalocean -v -run=DigitalOceanRecord_Basic -timeout 120m
=== RUN   TestAccDigitalOceanRecord_Basic
--- PASS: TestAccDigitalOceanRecord_Basic (3.79s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/digitalocean	3.801s
```