### PR TITLE
[WIP] add allowed_address_pairs

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -96,6 +96,25 @@ func resourceNetworkingPortV2() *schema.Resource {
 					},
 				},
 			},
+			"allowed_address_pairs": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip_address": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mac_address": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -108,15 +127,16 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 	}
 
 	createOpts := ports.CreateOpts{
-		Name:           d.Get("name").(string),
-		AdminStateUp:   resourcePortAdminStateUpV2(d),
-		NetworkID:      d.Get("network_id").(string),
-		MACAddress:     d.Get("mac_address").(string),
-		TenantID:       d.Get("tenant_id").(string),
-		DeviceOwner:    d.Get("device_owner").(string),
-		SecurityGroups: resourcePortSecurityGroupsV2(d),
-		DeviceID:       d.Get("device_id").(string),
-		FixedIPs:       resourcePortFixedIpsV2(d),
+		Name:                d.Get("name").(string),
+		AdminStateUp:        resourcePortAdminStateUpV2(d),
+		NetworkID:           d.Get("network_id").(string),
+		MACAddress:          d.Get("mac_address").(string),
+		TenantID:            d.Get("tenant_id").(string),
+		DeviceOwner:         d.Get("device_owner").(string),
+		SecurityGroups:      resourcePortSecurityGroupsV2(d),
+		DeviceID:            d.Get("device_id").(string),
+		FixedIPs:            resourcePortFixedIpsV2(d),
+		AllowedAddressPairs: resourcePortAllowedAddressPairsV2(d),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -176,6 +196,16 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	}
 	d.Set("fixed_ip", ips)
 
+	// Convert AllowedAddressPairs to list of map
+	var pairs []map[string]interface{}
+	for _, pairObject := range p.AllowedAddressPairs {
+		pair := make(map[string]interface{})
+		pair["ip_address"] = pairObject.IPAddress
+		pair["mac_address"] = pairObject.MACAddress
+		pairs = append(pairs, pair)
+	}
+	d.Set("allowed_address_pairs", pairs)
+
 	return nil
 }
 
@@ -210,6 +240,10 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("fixed_ip") {
 		updateOpts.FixedIPs = resourcePortFixedIpsV2(d)
+	}
+
+	if d.HasChange("allowed_address_pairs") {
+		updateOpts.AllowedAddressPairs = resourceAllowedAddressPairsV2(d)
 	}
 
 	log.Printf("[DEBUG] Updating Port %s with options: %+v", d.Id(), updateOpts)
@@ -272,7 +306,24 @@ func resourcePortFixedIpsV2(d *schema.ResourceData) interface{} {
 		}
 	}
 	return ip
+}
 
+func resourcePortAllowedAddressPairsV2(d *schema.ResourceData) interface{} {
+	rawPairs := d.Get("allowed_address_pairs").([]interface{})
+
+	if len(rawPairs) == 0 {
+		return nil
+	}
+
+	pairs := make([]ports.Pair, len(rawPair))
+	for i, raw := range rawPair {
+		rawMap := raw.(map[string]interface{})
+		pair[i] = ports.Pair{
+			ip_address:  rawMap["ip_address"].(string),
+			mac_address: rawMap["mac_address"].(string),
+		}
+	}
+	return pair
 }
 
 func resourcePortAdminStateUpV2(d *schema.ResourceData) *bool {


### PR DESCRIPTION
Opening this PR (as requested by @jtopjian) as a work in progress to support Allowed Address Pairs[1] now that gophercloud has support has been merged[2].

[1] http://specs.openstack.org/openstack/neutron-specs/specs/api/allowed_address_pairs.html
[2] https://github.com/rackspace/gophercloud/pull/488#issuecomment-182002690