### PR TITLE
Fix a typo in openstack network example

### DIFF
--- a/website/source/docs/providers/openstack/r/networking_network_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_network_v2.html.markdown
@@ -42,7 +42,7 @@ resource "openstack_networking_port_v2" "port_1" {
   admin_state_up = "true"
   security_groups = ["${openstack_compute_secgroup_v2.secgroup_1.id}"]
 
-  fixed_ips {
+  fixed_ip {
       "subnet_id" =  "008ba151-0b8c-4a67-98b5-0d2b87666062"
       "ip_address" =  "172.24.4.2"
   }


### PR DESCRIPTION
OpenStack port uses "fixed_ip" property to specify Fixed IP addresses (https://www.terraform.io/docs/providers/openstack/r/networking_port_v2.html#fixed_ip)
but network example incorrectly uses "fixed_ipS" key.