### PR TITLE
Bypass CreateBeforeDestroyTransformer on terraform destroy

### DIFF
--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -152,7 +152,10 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 
 			// Create the destruction nodes
 			&DestroyTransformer{FullDestroy: b.Destroy},
-			&CreateBeforeDestroyTransformer{},
+			b.conditional(&conditionalOpts{
+				If:   func() bool { return !b.Destroy },
+				Then: &CreateBeforeDestroyTransformer{},
+			}),
 			b.conditional(&conditionalOpts{
 				If:   func() bool { return !b.Verbose },
 				Then: &PruneDestroyTransformer{Diff: b.Diff, State: b.State},

--- a/terraform/graph_builder_test.go
+++ b/terraform/graph_builder_test.go
@@ -109,6 +109,56 @@ func TestBuiltinGraphBuilder_Verbose(t *testing.T) {
 	}
 }
 
+// This tests that the CreateBeforeDestoryTransformer is not present when
+// we perform a "terraform destroy" operation. We don't actually do anything
+// else.
+func TestBuiltinGraphBuilder_CreateBeforeDestroy_Destroy_Bypass(t *testing.T) {
+	b := &BuiltinGraphBuilder{
+		Root:     testModule(t, "graph-builder-basic"),
+		Validate: true,
+		Destroy:  true,
+	}
+
+	steps := b.Steps([]string{})
+
+	actual := false
+	expected := false
+	for _, v := range steps {
+		switch v.(type) {
+		case *CreateBeforeDestroyTransformer:
+			actual = true
+		}
+	}
+
+	if actual != expected {
+		t.Fatalf("bad: CreateBeforeDestroyTransformer still in root path")
+	}
+}
+
+// This tests that the CreateBeforeDestoryTransformer *is* present
+// during a non-destroy operation (ie: Destroy not set).
+func TestBuiltinGraphBuilder_CreateBeforeDestroy_NonDestroy_Present(t *testing.T) {
+	b := &BuiltinGraphBuilder{
+		Root:     testModule(t, "graph-builder-basic"),
+		Validate: true,
+	}
+
+	steps := b.Steps([]string{})
+
+	actual := false
+	expected := true
+	for _, v := range steps {
+		switch v.(type) {
+		case *CreateBeforeDestroyTransformer:
+			actual = true
+		}
+	}
+
+	if actual != expected {
+		t.Fatalf("bad: CreateBeforeDestroyTransformer not in root path")
+	}
+}
+
 // This tests a cycle we got when a CBD resource depends on a non-CBD
 // resource. This cycle shouldn't happen in the general case anymore.
 func TestBuiltinGraphBuilder_cbdDepNonCbd(t *testing.T) {


### PR DESCRIPTION
Reference: #3294, #2493, #2359, possibly others.

This patch ensures that create_before_destroy is ignored during a `terraform destroy` operation by ensuring its graph transformer does not get added at all. If `Destroy` is true (ultimately passed in through context), it just gets skipped.

This ensures that this is not even considered during a destroy operation (where destroying resources is the only thing that makes sense), versus a replacement operation (where if you have specified `create_before_destroy`, you obviously want it).

Also, I have included a couple of simple tests that ensures the presence/non-presence of the transformer appropriately.