### PR TITLE
add link to CHANGELOG

### DIFF
--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -28,6 +28,9 @@ description: |-
         which has been signed using <a href="https://www.hashicorp.com/security.html" target="_TOP">HashiCorp's GPG key</a>.
         You can also <a href="https://releases.hashicorp.com/terraform/" target="_TOP">download older versions of Terraform</a> from the releases service.
       </p>
+      <p>
+        <a href="https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md">CHANGELOG</a>
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
On the downloads page add a link to the CHANGELOG so that evaluating new versions is easier.

I usually want to review the CHANGELOG to see whether the update is relevant to my needs.