### PR TITLE
Add optional cacert_file parameter to openstack provider

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -66,6 +66,11 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: envDefaultFuncAllowMissing("OS_ENDPOINT_TYPE"),
 			},
+			"cacert_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: envDefaultFuncAllowMissing("OS_CACERT"),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -108,6 +113,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		DomainName:       d.Get("domain_name").(string),
 		Insecure:         d.Get("insecure").(bool),
 		EndpointType:     d.Get("endpoint_type").(string),
+		CACertFile:       d.Get("cacert_file").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {


### PR DESCRIPTION
Official OpenStack clients support [1] specifing custom CA certificate file
that should be used when communicating with OpenStack server. This patch
adds similar behavior to Terraform OpenStack provider, by:
- Using OS_CACERT environmental variable, if available
- Using cacert_file provider parameter, if configured

[1] http://docs.openstack.org/developer/python-openstackclient/man/openstack.html#options