### PR TITLE
docs: Update azure provider documentation

### DIFF
--- a/website/source/docs/providers/azure/index.html.markdown
+++ b/website/source/docs/providers/azure/index.html.markdown
@@ -20,7 +20,7 @@ Use the navigation to the left to read about the available resources.
 ```
 # Configure the Azure Provider
 provider "azure" {
-  settings_file = "${file("credentials.publishsettings")}"
+  publish_settings = "${file("credentials.publishsettings")}"
 }
 
 # Create a web server

--- a/website/source/docs/providers/azure/r/dns_server.html.markdown
+++ b/website/source/docs/providers/azure/r/dns_server.html.markdown
@@ -17,7 +17,6 @@ resource "azure_dns_server" "google-dns" {
     name = "google"
     dns_address = "8.8.8.8"
 }
-`
 ```
 
 ## Argument Reference


### PR DESCRIPTION
`settings_file` option was deprecated, but an example was only partially updated making documentation incorrect. Also, I've fixed a small typo in other section of azure docs.
This update can be merged immediately.