### PR TITLE
[WIP] provider/aws: fix #4913 aws_cloudformation_stack update doesn't send parameters if parameters are not modified

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack.go
@@ -282,9 +282,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 	if d.HasChange("notification_arns") {
 		input.NotificationARNs = expandStringList(d.Get("notification_arns").(*schema.Set).List())
 	}
-	if d.HasChange("parameters") {
-		input.Parameters = expandCloudFormationParameters(d.Get("parameters").(map[string]interface{}))
-	}
+	input.Parameters = expandCloudFormationParameters(d.Get("parameters").(map[string]interface{}))
 	if d.HasChange("policy_body") {
 		input.StackPolicyBody = aws.String(normalizeJson(d.Get("policy_body").(string)))
 	}


### PR DESCRIPTION
This change fixes issue #4913 in AWS CloudFormation stack resource 