### PR TITLE
IGW detatch waiter tweak, 30 not found checks w/15 min max

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -204,11 +204,12 @@ func resourceAwsInternetGatewayDetach(d *schema.ResourceData, meta interface{}) 
 	// Wait for it to be fully detached before continuing
 	log.Printf("[DEBUG] Waiting for internet gateway (%s) to detach", d.Id())
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"detaching"},
-		Target:  []string{"detached"},
-		Refresh: detachIGStateRefreshFunc(conn, d.Id(), vpcID.(string)),
-		Timeout: 5 * time.Minute,
-		Delay:   10 * time.Second,
+		Pending:        []string{"detaching"},
+		Target:         []string{"detached"},
+		Refresh:        detachIGStateRefreshFunc(conn, d.Id(), vpcID.(string)),
+		Timeout:        15 * time.Minute,
+		Delay:          10 * time.Second,
+		NotFoundChecks: 30,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
Looks like this was the fix to #3747, for me anyway, the issue is not that the IGW is missing, it's that it's actually waiting for the route detachment, more than likely. "not found" was more than likely due to it hitting the `NotFoundChecks` default threshold of 20 while waiting for the `DependencyViolation` to resolve (possibly from routes and what not). `InvalidInternetGatewayID.NotFound` triggers an immediate error.
