### PR TITLE
Fix go vet warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TEST?=$$(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
-VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
+VETARGS?=-asmdecl -atomic -bool -buildtags -composites -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 
 default: test
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ vet:
 		go get golang.org/x/tools/cmd/vet; \
 	fi
 	@echo "go tool vet $(VETARGS) ."
-	@GO15VENDOREXPERIMENT=1 go tool vet $(VETARGS) . ; if [ $$? -eq 1 ]; then \
+	@GO15VENDOREXPERIMENT=1 go tool vet $(VETARGS) $$(ls -d */ | grep -v vendor) ; if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TEST?=$$(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
-VETARGS?=-asmdecl -atomic -bool -buildtags -composites -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
+VETARGS?=-asmdecl -atomic -bool -buildtags -composites -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr -unusedresult
 
 default: test
 

--- a/builtin/providers/aws/resource_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail_test.go
@@ -218,7 +218,7 @@ func testAccCheckCloudTrailLogValidationEnabled(n string, desired bool, trail *c
 
 		if *trail.LogFileValidationEnabled != desired {
 			return fmt.Errorf("Expected log validation status %t, given %t", desired,
-				trail.LogFileValidationEnabled)
+				*trail.LogFileValidationEnabled)
 		}
 
 		// local state comparison
@@ -229,8 +229,7 @@ func testAccCheckCloudTrailLogValidationEnabled(n string, desired bool, trail *c
 		}
 		desiredInString := fmt.Sprintf("%t", desired)
 		if enabled != desiredInString {
-			return fmt.Errorf("Expected log validation status %t, saved %t", desiredInString,
-				enabled)
+			return fmt.Errorf("Expected log validation status %s, saved %s", desiredInString, enabled)
 		}
 
 		return nil

--- a/builtin/providers/azure/resource_azure_sql_database_server_test.go
+++ b/builtin/providers/azure/resource_azure_sql_database_server_test.go
@@ -81,7 +81,7 @@ func testAccCheckAzureSqlDatabaseServerDeleted(s *terraform.State) error {
 
 		for _, srv := range servers.DatabaseServers {
 			if srv.Name == resource.Primary.ID {
-				fmt.Errorf("SQL Server %s still exists.", resource.Primary.ID)
+				return fmt.Errorf("SQL Server %s still exists.", resource.Primary.ID)
 			}
 		}
 	}

--- a/builtin/providers/azure/resource_azure_sql_database_service_test.go
+++ b/builtin/providers/azure/resource_azure_sql_database_service_test.go
@@ -156,7 +156,7 @@ func testAccCheckAzureSqlDatabaseServiceDeleted(s *terraform.State) error {
 
 		for _, srv := range dbs.ServiceResources {
 			if srv.Name == resource.Primary.ID {
-				fmt.Errorf("SQL Service %s still exists.", resource.Primary.ID)
+				return fmt.Errorf("SQL Service %s still exists.", resource.Primary.ID)
 			}
 		}
 	}

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -61,7 +61,7 @@ func testAccCheckDigitalOceanFloatingIPDestroy(s *terraform.State) error {
 		_, _, err := client.FloatingIPs.Get(rs.Primary.ID)
 
 		if err == nil {
-			fmt.Errorf("Floating IP still exists")
+			return fmt.Errorf("Floating IP still exists")
 		}
 	}
 

--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
@@ -51,7 +51,7 @@ func testAccCheckDigitalOceanSSHKeyDestroy(s *terraform.State) error {
 		_, _, err = client.Keys.GetByID(id)
 
 		if err == nil {
-			fmt.Errorf("SSH key still exists")
+			return fmt.Errorf("SSH key still exists")
 		}
 	}
 

--- a/builtin/providers/google/resource_pubsub_subscription_test.go
+++ b/builtin/providers/google/resource_pubsub_subscription_test.go
@@ -36,7 +36,7 @@ func testAccCheckPubsubSubscriptionDestroy(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientPubsub.Projects.Subscriptions.Get(rs.Primary.ID).Do()
 		if err != nil {
-			fmt.Errorf("Subscription still present")
+			return fmt.Errorf("Subscription still present")
 		}
 	}
 
@@ -56,7 +56,7 @@ func testAccPubsubSubscriptionExists(n string) resource.TestCheckFunc {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientPubsub.Projects.Subscriptions.Get(rs.Primary.ID).Do()
 		if err != nil {
-			fmt.Errorf("Subscription still present")
+			return fmt.Errorf("Subscription still present")
 		}
 
 		return nil

--- a/builtin/providers/google/resource_pubsub_topic_test.go
+++ b/builtin/providers/google/resource_pubsub_topic_test.go
@@ -36,7 +36,7 @@ func testAccCheckPubsubTopicDestroy(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientPubsub.Projects.Topics.Get(rs.Primary.ID).Do()
 		if err != nil {
-			fmt.Errorf("Topic still present")
+			return fmt.Errorf("Topic still present")
 		}
 	}
 
@@ -56,7 +56,7 @@ func testAccPubsubTopicExists(n string) resource.TestCheckFunc {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientPubsub.Projects.Topics.Get(rs.Primary.ID).Do()
 		if err != nil {
-			fmt.Errorf("Topic still present")
+			return fmt.Errorf("Topic still present")
 		}
 
 		return nil

--- a/builtin/providers/heroku/resource_heroku_domain.go
+++ b/builtin/providers/heroku/resource_heroku_domain.go
@@ -43,7 +43,7 @@ func resourceHerokuDomainCreate(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Domain create configuration: %#v, %#v", app, hostname)
 
-	do, err := client.DomainCreate(app, heroku.DomainCreateOpts{hostname})
+	do, err := client.DomainCreate(app, heroku.DomainCreateOpts{Hostname: hostname})
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/heroku/resource_heroku_drain.go
+++ b/builtin/providers/heroku/resource_heroku_drain.go
@@ -50,7 +50,7 @@ func resourceHerokuDrainCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var dr *heroku.LogDrain
 	err := resource.Retry(2*time.Minute, func() error {
-		d, err := client.LogDrainCreate(app, heroku.LogDrainCreateOpts{url})
+		d, err := client.LogDrainCreate(app, heroku.LogDrainCreateOpts{URL: url})
 		if err != nil {
 			if strings.Contains(err.Error(), retryableError) {
 				return err

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -374,8 +374,8 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 
 	if keyName, ok := d.Get("key_pair").(string); ok && keyName != "" {
 		createOpts = &keypairs.CreateOptsExt{
-			createOpts,
-			keyName,
+			CreateOptsBuilder: createOpts,
+			KeyName:           keyName,
 		}
 	}
 
@@ -384,8 +384,8 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 			blockDeviceRaw := v.(map[string]interface{})
 			blockDevice := resourceInstanceBlockDeviceV2(d, blockDeviceRaw)
 			createOpts = &bootfromvolume.CreateOptsExt{
-				createOpts,
-				blockDevice,
+				CreateOptsBuilder: createOpts,
+				BlockDevice:       blockDevice,
 			}
 			log.Printf("[DEBUG] Create BFV Options: %+v", createOpts)
 		}
@@ -396,8 +396,8 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[DEBUG] schedulerhints: %+v", schedulerHintsRaw)
 		schedulerHints := resourceInstanceSchedulerHintsV2(d, schedulerHintsRaw[0].(map[string]interface{}))
 		createOpts = &schedulerhints.CreateOptsExt{
-			createOpts,
-			schedulerHints,
+			CreateOptsBuilder: createOpts,
+			SchedulerHints:    schedulerHints,
 		}
 	}
 

--- a/builtin/providers/statuscake/resource_statuscaketest_test.go
+++ b/builtin/providers/statuscake/resource_statuscaketest_test.go
@@ -93,7 +93,6 @@ func testAccTestCheckDestroy(test *statuscake.Test) resource.TestCheckFunc {
 
 		return nil
 	}
-	return nil
 }
 
 const testAccTestConfig_basic = `

--- a/builtin/providers/tls/resource_cert_request.go
+++ b/builtin/providers/tls/resource_cert_request.go
@@ -107,7 +107,7 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 
 	certReqBytes, err := x509.CreateCertificateRequest(rand.Reader, &certReq, key)
 	if err != nil {
-		fmt.Errorf("Error creating certificate request: %s", err)
+		return fmt.Errorf("Error creating certificate request: %s", err)
 	}
 	certReqPem := string(pem.EncodeToMemory(&pem.Block{Type: pemCertReqType, Bytes: certReqBytes}))
 

--- a/builtin/providers/tls/resource_certificate.go
+++ b/builtin/providers/tls/resource_certificate.go
@@ -159,7 +159,7 @@ func createCertificate(d *schema.ResourceData, template, parent *x509.Certificat
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, pub, priv)
 	if err != nil {
-		fmt.Errorf("error creating certificate: %s", err)
+		return fmt.Errorf("error creating certificate: %s", err)
 	}
 	certPem := string(pem.EncodeToMemory(&pem.Block{Type: pemCertType, Bytes: certBytes}))
 

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -648,8 +648,8 @@ func buildNetworkDevice(f *find.Finder, label, adapterType string) (*types.Virtu
 		return &types.VirtualDeviceConfigSpec{
 			Operation: types.VirtualDeviceConfigSpecOperationAdd,
 			Device: &types.VirtualVmxnet3{
-				types.VirtualVmxnet{
-					types.VirtualEthernetCard{
+				VirtualVmxnet: types.VirtualVmxnet{
+					VirtualEthernetCard: types.VirtualEthernetCard{
 						VirtualDevice: types.VirtualDevice{
 							Key:     -1,
 							Backing: backing,
@@ -663,7 +663,7 @@ func buildNetworkDevice(f *find.Finder, label, adapterType string) (*types.Virtu
 		return &types.VirtualDeviceConfigSpec{
 			Operation: types.VirtualDeviceConfigSpecOperationAdd,
 			Device: &types.VirtualE1000{
-				types.VirtualEthernetCard{
+				VirtualEthernetCard: types.VirtualEthernetCard{
 					VirtualDevice: types.VirtualDevice{
 						Key:     -1,
 						Backing: backing,

--- a/state/remote/atlas.go
+++ b/state/remote/atlas.go
@@ -217,8 +217,6 @@ func (c *AtlasClient) Delete() error {
 			"HTTP error: %d\n\nBody: %s",
 			resp.StatusCode, c.readBody(resp.Body))
 	}
-
-	return fmt.Errorf("Unexpected HTTP response code %d", resp.StatusCode)
 }
 
 func (c *AtlasClient) readBody(b io.Reader) string {

--- a/state/remote/consul.go
+++ b/state/remote/consul.go
@@ -33,7 +33,10 @@ func consulFactory(conf map[string]string) (Client, error) {
 		} else {
 			username = auth
 		}
-		config.HttpAuth = &consulapi.HttpBasicAuth{username, password}
+		config.HttpAuth = &consulapi.HttpBasicAuth{
+			Username: username,
+			Password: password,
+		}
 	}
 
 	client, err := consulapi.NewClient(config)


### PR DESCRIPTION
Enable a few `go vet` warnings and fix discovered issues. I didn't enable the `-unreachable` check because of a really old TODO from @mitchellh commenting out a test function (d83e6878659a0f6d4a55600916f1bfd6df7d669d). FWIW, fixing that function is the only remaining issue that needs to be addressed before `go vet` can run cleanly with all warnings enabled.