### PR TITLE
provider/docker: Stop providing the hostConfig while starting the container

### DIFF
--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -171,7 +171,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	creationTime = time.Now()
-	if err := client.StartContainer(retContainer.ID, hostConfig); err != nil {
+	if err := client.StartContainer(retContainer.ID, nil); err != nil {
 		return fmt.Errorf("Unable to start container: %s", err)
 	}
 


### PR DESCRIPTION
Since docker 1.10, providing the hostConfig when starting the container is deprecated:
https://docs.docker.com/engine/deprecated/#hostconfig-at-api-container-start