### PR TITLE
provider/google: Fix VPN Region bug

### DIFF
--- a/builtin/providers/google/resource_compute_vpn_gateway.go
+++ b/builtin/providers/google/resource_compute_vpn_gateway.go
@@ -83,7 +83,7 @@ func resourceComputeVpnGatewayRead(d *schema.ResourceData, meta interface{}) err
 	config := meta.(*Config)
 
 	name := d.Get("name").(string)
-	region := d.Get("region").(string)
+	region := getOptionalRegion(d, config)
 	project := config.Project
 
 	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)
@@ -111,7 +111,7 @@ func resourceComputeVpnGatewayDelete(d *schema.ResourceData, meta interface{}) e
 	config := meta.(*Config)
 
 	name := d.Get("name").(string)
-	region := d.Get("region").(string)
+	region := getOptionalRegion(d, config)
 	project := config.Project
 
 	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)

--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -113,7 +113,7 @@ func resourceComputeVpnTunnelRead(d *schema.ResourceData, meta interface{}) erro
 	config := meta.(*Config)
 
 	name := d.Get("name").(string)
-	region := d.Get("region").(string)
+	region := getOptionalRegion(d, config)
 	project := config.Project
 
 	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)
@@ -143,7 +143,7 @@ func resourceComputeVpnTunnelDelete(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*Config)
 
 	name := d.Get("name").(string)
-	region := d.Get("region").(string)
+	region := getOptionalRegion(d, config)
 	project := config.Project
 
 	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)


### PR DESCRIPTION
It was pointed out in #5027 that the `google_compute_vpn_*` resources were failing to `Read` when region was left unspecified.