### PR TITLE
Add support for Google subnetworks

### DIFF
--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -59,6 +59,7 @@ func Provider() terraform.ResourceProvider {
 			"google_compute_project_metadata":       resourceComputeProjectMetadata(),
 			"google_compute_route":                  resourceComputeRoute(),
 			"google_compute_ssl_certificate":        resourceComputeSslCertificate(),
+			"google_compute_subnetwork":             resourceComputeSubnetwork(),
 			"google_compute_target_http_proxy":      resourceComputeTargetHttpProxy(),
 			"google_compute_target_https_proxy":     resourceComputeTargetHttpsProxy(),
 			"google_compute_target_pool":            resourceComputeTargetPool(),

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -146,6 +146,8 @@ func validateCredentials(v interface{}, k string) (warnings []string, errors []e
 	return
 }
 
+// FIXME: not sure this is the best place for this
+// Given a Google zone (e.g. us-central1-f) this func returns the Region, us-central1 in this example.
 func getRegionFromZone(zone string) string {
 	if zone != "" && len(zone) > 2 {
 		region := zone[:len(zone)-2]

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -145,3 +145,11 @@ func validateCredentials(v interface{}, k string) (warnings []string, errors []e
 
 	return
 }
+
+func getRegionFromZone(zone string) string {
+	if zone != "" && len(zone) > 2 {
+		region := zone[:len(zone)-2]
+		return region
+	}
+	return ""
+}

--- a/builtin/providers/google/provider_test.go
+++ b/builtin/providers/google/provider_test.go
@@ -50,3 +50,11 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("GOOGLE_REGION must be set to us-central1 for acceptance tests")
 	}
 }
+
+func TestProvider_getRegionFromZone(t *testing.T) {
+	expected := "us-central1"
+	actual := getRegionFromZone("us-central1-f")
+	if expected != actual {
+		t.Fatalf("Region (%s) did not match expected value: %s", actual, expected)
+	}
+}

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -684,6 +684,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 				"name":          iface.Name,
 				"address":       iface.NetworkIP,
 				"network":       d.Get(fmt.Sprintf("network_interface.%d.network", i)),
+				"subnetwork":    d.Get(fmt.Sprintf("network_interface.%d.subnetwork", i)),
 				"access_config": accessConfigs,
 			})
 		}

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -141,6 +141,12 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"subnetwork": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
 						"access_config": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
@@ -337,9 +343,12 @@ func buildNetworks(d *schema.ResourceData, meta interface{}) (error, []*compute.
 			source += v.(string)
 		}
 
+		subnetworkLink := d.Get("subnetwork").(string)
+
 		// Build the networkInterface
 		var iface compute.NetworkInterface
 		iface.Network = source
+		iface.Subnetwork = subnetworkLink
 
 		accessConfigsCount := d.Get(prefix + ".access_config.#").(int)
 		iface.AccessConfigs = make([]*compute.AccessConfig, accessConfigsCount)

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -137,7 +137,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"network": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ForceNew: true,
 						},
 
@@ -177,6 +177,12 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 				Optional:   true,
 				ForceNew:   true,
 				Deprecated: "Please use `scheduling.on_host_maintenance` instead",
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"scheduling": &schema.Schema{
@@ -333,21 +339,57 @@ func buildDisks(d *schema.ResourceData, meta interface{}) ([]*compute.AttachedDi
 
 func buildNetworks(d *schema.ResourceData, meta interface{}) (error, []*compute.NetworkInterface) {
 	// Build up the list of networks
+	config := meta.(*Config)
+
 	networksCount := d.Get("network_interface.#").(int)
 	networkInterfaces := make([]*compute.NetworkInterface, 0, networksCount)
 	for i := 0; i < networksCount; i++ {
 		prefix := fmt.Sprintf("network_interface.%d", i)
 
-		source := "global/networks/"
+		var networkName, subnetworkName string
 		if v, ok := d.GetOk(prefix + ".network"); ok {
-			source += v.(string)
+			networkName = v.(string)
+		}
+		if v, ok := d.GetOk(prefix + ".subnetwork"); ok {
+			subnetworkName = v.(string)
 		}
 
-		subnetworkLink := d.Get("subnetwork").(string)
+		if networkName == "" && subnetworkName == "" {
+			return fmt.Errorf("network or subnetwork must be provided"), nil
+		}
+		if networkName != "" && subnetworkName != "" {
+			return fmt.Errorf("network or subnetwork must not both be provided"), nil
+		}
+
+		var networkLink, subnetworkLink string
+		if networkName != "" {
+			network, err := config.clientCompute.Networks.Get(
+				config.Project, networkName).Do()
+			if err != nil {
+				return fmt.Errorf(
+					"Error referencing network '%s': %s",
+					networkName, err), nil
+			}
+			networkLink = network.SelfLink
+		} else {
+			// lookup subnetwork link using region and subnetwork name
+			region := d.Get("region").(string)
+			if region == "" {
+				region = config.Region
+			}
+			subnetwork, err := config.clientCompute.Subnetworks.Get(
+				config.Project, region, subnetworkName).Do()
+			if err != nil {
+				return fmt.Errorf(
+					"Error referencing subnetwork '%s' in region '%s': %s",
+					subnetworkName, region, err), nil
+			}
+			subnetworkLink = subnetwork.SelfLink
+		}
 
 		// Build the networkInterface
 		var iface compute.NetworkInterface
-		iface.Network = source
+		iface.Network = networkLink
 		iface.Subnetwork = subnetworkLink
 
 		accessConfigsCount := d.Get(prefix + ".access_config.#").(int)

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
+	"strings"
 )
 
 func TestAccComputeInstanceTemplate_basic(t *testing.T) {
@@ -67,6 +68,47 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140814", true, true),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
+	var instanceTemplate compute.InstanceTemplate
+	network := "network-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstanceTemplate_subnet_auto(network),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						"google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateNetworkName(&instanceTemplate, network),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
+	var instanceTemplate compute.InstanceTemplate
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstanceTemplate_subnet_custom,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						"google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateSubnetwork(&instanceTemplate),
 				),
 			},
 		},
@@ -158,6 +200,18 @@ func testAccCheckComputeInstanceTemplateNetwork(instanceTemplate *compute.Instan
 	}
 }
 
+func testAccCheckComputeInstanceTemplateNetworkName(instanceTemplate *compute.InstanceTemplate, network string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, i := range instanceTemplate.Properties.NetworkInterfaces {
+			if !strings.Contains(i.Network, network) {
+				return fmt.Errorf("Network doesn't match expected value, Expected: %s Actual: %s", network, i.Network[strings.LastIndex("/", i.Network)+1:])
+			}
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckComputeInstanceTemplateDisk(instanceTemplate *compute.InstanceTemplate, source string, delete bool, boot bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.Disks == nil {
@@ -183,6 +237,18 @@ func testAccCheckComputeInstanceTemplateDisk(instanceTemplate *compute.InstanceT
 		}
 
 		return fmt.Errorf("Disk not found: %s", source)
+	}
+}
+
+func testAccCheckComputeInstanceTemplateSubnetwork(instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, i := range instanceTemplate.Properties.NetworkInterfaces {
+			if i.Subnetwork == "" {
+				return fmt.Errorf("no subnet")
+			}
+		}
+
+		return nil
 	}
 }
 
@@ -293,3 +359,65 @@ resource "google_compute_instance_template" "foobar" {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
+
+func testAccComputeInstanceTemplate_subnet_auto(network string) string {
+	return fmt.Sprintf(`
+	resource "google_compute_network" "auto-network" {
+		name = "%s"
+		auto_create_subnetworks = true
+	}
+
+	resource "google_compute_instance_template" "foobar" {
+		name = "instance-tpl-%s"
+		machine_type = "n1-standard-1"
+
+		disk {
+			source_image = "debian-7-wheezy-v20160211"
+			auto_delete = true
+			disk_size_gb = 10
+			boot = true
+		}
+
+		network_interface {
+			network = "${google_compute_network.auto-network.name}"
+		}
+
+		metadata {
+			foo = "bar"
+		}
+	}`, network, acctest.RandString(10))
+}
+
+var testAccComputeInstanceTemplate_subnet_custom = fmt.Sprintf(`
+resource "google_compute_network" "network" {
+	name = "network-%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+	name = "subnetwork-%s"
+	ip_cidr_range = "10.0.0.0/24"
+	region = "us-central1"
+	network = "${google_compute_network.network.self_link}"
+}
+
+resource "google_compute_instance_template" "foobar" {
+	name = "instance-test-%s"
+	machine_type = "n1-standard-1"
+	region = "us-central1"
+
+	disk {
+		source_image = "debian-7-wheezy-v20160211"
+		auto_delete = true
+		disk_size_gb = 10
+		boot = true
+	}
+
+	network_interface {
+		subnetwork = "${google_compute_subnetwork.subnetwork.name}"
+	}
+
+	metadata {
+		foo = "bar"
+	}
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_network.go
+++ b/builtin/providers/google/resource_compute_network.go
@@ -24,9 +24,10 @@ func resourceComputeNetwork() *schema.Resource {
 			},
 
 			"ipv4_range": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "Please use custom subnetworks instead",
 			},
 
 			"gateway_ipv4": &schema.Schema{

--- a/builtin/providers/google/resource_compute_network_test.go
+++ b/builtin/providers/google/resource_compute_network_test.go
@@ -29,6 +29,46 @@ func TestAccComputeNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeNetwork_auto_subnet(t *testing.T) {
+	var network compute.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeNetwork_auto_subnet,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						"google_compute_network.bar", &network),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeNetwork_custom_subnet(t *testing.T) {
+	var network compute.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeNetwork_custom_subnet,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						"google_compute_network.baz", &network),
+					testAccCheckComputeNetworkIsCustomSubnet(
+						"google_compute_network.baz", &network),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeNetworkDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -76,8 +116,42 @@ func testAccCheckComputeNetworkExists(n string, network *compute.Network) resour
 	}
 }
 
+func testAccCheckComputeNetworkIsCustomSubnet(n string, network *compute.Network) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientCompute.Networks.Get(
+			config.Project, network.Name).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.AutoCreateSubnetworks {
+			return fmt.Errorf("should have AutoCreateSubnetworks = false")
+		}
+
+		if found.IPv4Range != "" {
+			return fmt.Errorf("should not have IPv4Range")
+		}
+
+		return nil
+	}
+}
+
 var testAccComputeNetwork_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "network-test-%s"
 	ipv4_range = "10.0.0.0/16"
+}`, acctest.RandString(10))
+
+var testAccComputeNetwork_auto_subnet = fmt.Sprintf(`
+resource "google_compute_network" "bar" {
+	name = "network-test-%s"
+	auto_create_subnetworks = true
+}`, acctest.RandString(10))
+
+var testAccComputeNetwork_custom_subnet = fmt.Sprintf(`
+resource "google_compute_network" "baz" {
+	name = "network-test-%s"
+	auto_create_subnetworks = false
 }`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_subnetwork.go
+++ b/builtin/providers/google/resource_compute_subnetwork.go
@@ -1,0 +1,142 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+)
+
+func resourceComputeSubnetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeSubnetworkCreate,
+		Read:   resourceComputeSubnetworkRead,
+		Delete: resourceComputeSubnetworkDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"network": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"ipCidrRange": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"gateway_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createSubnetID(s *compute.Subnetwork) string {
+	return fmt.Sprintf("%s/%s", s.Region, s.Name)
+}
+
+func resourceComputeSubnetworkCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	// Build the subnetwork parameters
+	subnetwork := &compute.Subnetwork{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		IpCidrRange: d.Get("ipCidrRange").(string),
+		Network:     d.Get("network").(string),
+	}
+	region := d.Get("region").(string)
+
+	log.Printf("[DEBUG] Subnetwork insert request: %#v", subnetwork)
+	op, err := config.clientCompute.Subnetworks.Insert(
+		config.Project, region, subnetwork).Do()
+
+	if err != nil {
+		return fmt.Errorf("Error creating subnetwork: %s", err)
+	}
+
+	// It probably maybe worked, so store the ID now
+	// Subnetwork name is not guaranteed to be unique in a project, but must be unique within a region
+	subnetwork.Region = region
+	d.SetId(createSubnetID(subnetwork))
+
+	err = computeOperationWaitRegion(config, op, region, "Creating Subnetwork")
+	if err != nil {
+		return err
+	}
+
+	return resourceComputeSubnetworkRead(d, meta)
+}
+
+func resourceComputeSubnetworkRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	name := d.Get("name").(string)
+	region := d.Get("region").(string)
+
+	subnetwork, err := config.clientCompute.Subnetworks.Get(
+		config.Project, region, name).Do()
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Subnetwork %q because it's gone", name)
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
+		return fmt.Errorf("Error reading subnetwork: %s", err)
+	}
+
+	d.Set("gateway_address", subnetwork.GatewayAddress)
+	d.Set("self_link", subnetwork.SelfLink)
+
+	return nil
+}
+
+func resourceComputeSubnetworkDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := d.Get("region").(string)
+
+	// Delete the network
+	op, err := config.clientCompute.Subnetworks.Delete(
+		config.Project, region, d.Get("name").(string)).Do()
+	if err != nil {
+		return fmt.Errorf("Error deleting network: %s", err)
+	}
+
+	err = computeOperationWaitRegion(config, op, region, "Deleting Network")
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/google/resource_compute_subnetwork.go
+++ b/builtin/providers/google/resource_compute_subnetwork.go
@@ -34,7 +34,7 @@ func resourceComputeSubnetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"ipCidrRange": &schema.Schema{
+			"ip_cidr_range": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -70,7 +70,7 @@ func resourceComputeSubnetworkCreate(d *schema.ResourceData, meta interface{}) e
 	subnetwork := &compute.Subnetwork{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		IpCidrRange: d.Get("ipCidrRange").(string),
+		IpCidrRange: d.Get("ip_cidr_range").(string),
 		Network:     d.Get("network").(string),
 	}
 	region := d.Get("region").(string)

--- a/builtin/providers/google/resource_compute_subnetwork_test.go
+++ b/builtin/providers/google/resource_compute_subnetwork_test.go
@@ -1,0 +1,92 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
+)
+
+func TestAccComputeSubnetwork_basic(t *testing.T) {
+	var subnetwork compute.Subnetwork
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSubnetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeSubnetwork_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(
+						"google_compute_subnetwork.foobar", &subnetwork),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeSubnetworkDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_compute_subnetwork" {
+			continue
+		}
+
+		region, subnet_name := splitSubnetID(rs.Primary.ID)
+		_, err := config.clientCompute.Subnetworks.Get(
+			config.Project, region, subnet_name).Do()
+		if err == nil {
+			return fmt.Errorf("Network still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckComputeSubnetworkExists(n string, subnetwork *compute.Subnetwork) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		region, subnet_name := splitSubnetID(rs.Primary.ID)
+		found, err := config.clientCompute.Subnetworks.Get(
+			config.Project, region, subnet_name).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != subnet_name {
+			return fmt.Errorf("Subnetwork not found")
+		}
+
+		*subnetwork = *found
+
+		return nil
+	}
+}
+
+var testAccComputeSubnetwork_basic = fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+	name = "network-test-%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+	name = "subnetwork-test-%s"
+	ip_cidr_range = "10.0.0.0/16"
+	region = "us-central1"
+	network = "${google_compute_network.custom-test.self_link}"
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -55,6 +55,13 @@ func resourceComputeVpnTunnel() *schema.Resource {
 				Default:  2,
 				ForceNew: true,
 			},
+			"local_traffic_selector": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 			"detailed_status": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -82,14 +89,24 @@ func resourceComputeVpnTunnelCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Only IKE version 1 or 2 supported, not %d", ikeVersion)
 	}
 
+	// Build up the list of sources
+	var localTrafficSelectors []string
+	if v := d.Get("local_traffic_selector").(*schema.Set); v.Len() > 0 {
+		localTrafficSelectors = make([]string, v.Len())
+		for i, v := range v.List() {
+			localTrafficSelectors[i] = v.(string)
+		}
+	}
+
 	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)
 
 	vpnTunnel := &compute.VpnTunnel{
-		Name:             name,
-		PeerIp:           peerIp,
-		SharedSecret:     sharedSecret,
-		TargetVpnGateway: targetVpnGateway,
-		IkeVersion:       int64(ikeVersion),
+		Name:                 name,
+		PeerIp:               peerIp,
+		SharedSecret:         sharedSecret,
+		TargetVpnGateway:     targetVpnGateway,
+		IkeVersion:           int64(ikeVersion),
+		LocalTrafficSelector: localTrafficSelectors,
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/vendor/google.golang.org/api/compute/v1/compute-api.json
+++ b/vendor/google.golang.org/api/compute/v1/compute-api.json
@@ -1,11 +1,11 @@
 {
  "kind": "discovery#restDescription",
- "etag": "\"bRFOOrZKfO9LweMbPqu0kcu6De8/aU2RyGSEMbRxHCIqylkOho4GK2M\"",
+ "etag": "\"bRFOOrZKfO9LweMbPqu0kcu6De8/c55dTQvv4NWDkglZO3_PlmckRzg\"",
  "discoveryVersion": "v1",
  "id": "compute:v1",
  "name": "compute",
  "version": "v1",
- "revision": "20160107",
+ "revision": "20160120",
  "title": "Compute Engine API",
  "description": "API for the Google Compute Engine service.",
  "ownerDomain": "google.com",
@@ -746,12 +746,12 @@
     },
     "maxRate": {
      "type": "integer",
-     "description": "The max RPS of the group. Can be used with either balancing mode, but required if RATE mode. For RATE mode, either maxRate or maxRatePerInstance must be set.",
+     "description": "The max requests per second (RPS) of the group. Can be used with either balancing mode, but required if RATE mode. For RATE mode, either maxRate or maxRatePerInstance must be set.",
      "format": "int32"
     },
     "maxRatePerInstance": {
      "type": "number",
-     "description": "The max RPS that a single backed instance can handle. This is used to calculate the capacity of the group. Can be used in either balancing mode. For RATE mode, either maxRate or maxRatePerInstance must be set.",
+     "description": "The max requests per second (RPS) that a single backed instance can handle. This is used to calculate the capacity of the group. Can be used in either balancing mode. For RATE mode, either maxRate or maxRatePerInstance must be set.",
      "format": "float"
     },
     "maxUtilization": {
@@ -764,7 +764,7 @@
   "BackendService": {
    "id": "BackendService",
    "type": "object",
-   "description": "A BackendService resource. This resource defines a group of backend virtual machines together with their serving capacity.",
+   "description": "A BackendService resource. This resource defines a group of backend virtual machines and their serving capacity.",
    "properties": {
     "backends": {
      "type": "array",
@@ -810,7 +810,7 @@
     },
     "port": {
      "type": "integer",
-     "description": "Deprecated in favor of port name. The TCP port to connect on the backend. The default value is 80.",
+     "description": "Deprecated in favor of portName. The TCP port to connect on the backend. The default value is 80.",
      "format": "int32"
     },
     "portName": {
@@ -834,7 +834,7 @@
     },
     "timeoutSec": {
      "type": "integer",
-     "description": "How many seconds to wait for the backend before considering it a failed request. Default is 30 seconds.",
+     "description": "How many seconds to wait for the backend before considering it a failed request. Default is 30 seconds. Valid range is [1, 86400].",
      "format": "int32"
     }
    }
@@ -1431,7 +1431,7 @@
     },
     "network": {
      "type": "string",
-     "description": "URL of the network resource for this firewall rule. This field is required for creating an instance but optional when creating a firewall rule. If not specified when creating a firewall rule, the default network is used:\nglobal/networks/default\nIf you choose to specify this property, you can specify the network as a full or partial URL. For example, the following are all valid URLs:  \n- https://www.googleapis.com/compute/v1/projects/myproject/global/networks/my-network \n- projects/myproject/global/networks/my-network \n- global/networks/default"
+     "description": "URL of the network resource for this firewall rule. If not specified when creating a firewall rule, the default network is used:\nglobal/networks/default\nIf you choose to specify this property, you can specify the network as a full or partial URL. For example, the following are all valid URLs:  \n- https://www.googleapis.com/compute/v1/projects/myproject/global/networks/my-network \n- projects/myproject/global/networks/my-network \n- global/networks/default"
     },
     "selfLink": {
      "type": "string",
@@ -1555,7 +1555,7 @@
     },
     "target": {
      "type": "string",
-     "description": "The URL of the target resource to receive the matched traffic. For regional forwarding rules, this target must live in the same region as the forwarding rule. For global forwarding rules, this target must be a global TargetHttpProxy or TargetHttpsProxy resource."
+     "description": "The URL of the target resource to receive the matched traffic. For regional forwarding rules, this target must live in the same region as the forwarding rule. For global forwarding rules, this target must be a global TargetHttpProxy or TargetHttpsProxy resource. The forwarded traffic must be of a type appropriate to the target object. For example, TargetHttpProxy requires HTTP traffic, and TargetHttpsProxy requires HTTPS traffic."
     }
    }
   },
@@ -2128,7 +2128,7 @@
     },
     "description": {
      "type": "string",
-     "description": "An optional textual description of the resource; provided by the client when the resource is created."
+     "description": "An optional description of this resource. Provide this property when you create the resource."
     },
     "disks": {
      "type": "array",
@@ -2139,7 +2139,7 @@
     },
     "id": {
      "type": "string",
-     "description": "[Output Only] Unique identifier for the resource. This identifier is defined by the server.",
+     "description": "[Output Only] The unique identifier for the resource. This identifier is defined by the server.",
      "format": "uint64"
     },
     "kind": {
@@ -2162,7 +2162,7 @@
     },
     "name": {
      "type": "string",
-     "description": "Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash."
+     "description": "The name of the resource, provided by the client when initially creating the resource. The resource name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash."
     },
     "networkInterfaces": {
      "type": "array",
@@ -2177,7 +2177,7 @@
     },
     "selfLink": {
      "type": "string",
-     "description": "[Output Only] Server defined URL for this resource."
+     "description": "[Output Only] Server-defined URL for this resource."
     },
     "serviceAccounts": {
      "type": "array",
@@ -2247,11 +2247,11 @@
     },
     "nextPageToken": {
      "type": "string",
-     "description": "[Output Only] A token used to continue a truncated list request."
+     "description": "[Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results."
     },
     "selfLink": {
      "type": "string",
-     "description": "[Output Only] Server defined URL for this resource."
+     "description": "[Output Only] Server-defined URL for this resource."
     }
    }
   },
@@ -2311,6 +2311,10 @@
      "type": "integer",
      "description": "[Output Only] The total number of instances in the instance group.",
      "format": "int32"
+    },
+    "subnetwork": {
+     "type": "string",
+     "description": "[Output Only] The URL of the subnetwork to which all instances in the instance group belong."
     },
     "zone": {
      "type": "string",
@@ -2490,7 +2494,7 @@
     },
     "creating": {
      "type": "integer",
-     "description": "[Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created.",
+     "description": "[Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create one of these instances, it tries again until it creates the instance successfully.",
      "format": "int32"
     },
     "deleting": {
@@ -2929,11 +2933,11 @@
     },
     "nextPageToken": {
      "type": "string",
-     "description": "[Output Only] A token used to continue a truncated list request."
+     "description": "[Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results."
     },
     "selfLink": {
      "type": "string",
-     "description": "[Output Only] Server defined URL for this resource."
+     "description": "[Output Only] Server-defined URL for this resource."
     }
    }
   },
@@ -3209,6 +3213,16 @@
     }
    }
   },
+  "InstancesSetMachineTypeRequest": {
+   "id": "InstancesSetMachineTypeRequest",
+   "type": "object",
+   "properties": {
+    "machineType": {
+     "type": "string",
+     "description": "Full or partial URL of the machine type resource. See Machine Types for a full list of machine types. For example: zones/us-central1-f/machineTypes/n1-standard-1"
+    }
+   }
+  },
   "License": {
    "id": "License",
    "type": "object",
@@ -3464,7 +3478,7 @@
    "properties": {
     "currentAction": {
      "type": "string",
-     "description": "[Output Only] The current action that the managed instance group has scheduled for the instance. Possible values: \n- NONE The instance is running, and the managed instance group does not have any scheduled actions for this instance. \n- CREATING The managed instance group is creating this instance. \n- RECREATING The managed instance group is recreating this instance. \n- DELETING The managed instance group is permanently deleting this instance. \n- ABANDONING The managed instance group is abandoning this instance. The instance will be removed from the instance group and from any target pools that are associated with this group. \n- RESTARTING The managed instance group is restarting the instance. \n- REFRESHING The managed instance group is applying configuration changes to the instance without stopping it. For example, the group can update the target pool list for an instance without stopping that instance.",
+     "description": "[Output Only] The current action that the managed instance group has scheduled for the instance. Possible values: \n- NONE The instance is running, and the managed instance group does not have any scheduled actions for this instance. \n- CREATING The managed instance group is creating this instance. If the group fails to create this instance, it will try again until it is successful. \n- CREATING_WITHOUT_RETRIES The managed instance group is attempting to create this instance only once. If the group fails to create this instance, it does not try again and the group's target_size value is decreased. \n- RECREATING The managed instance group is recreating this instance. \n- DELETING The managed instance group is permanently deleting this instance. \n- ABANDONING The managed instance group is abandoning this instance. The instance will be removed from the instance group and from any target pools that are associated with this group. \n- RESTARTING The managed instance group is restarting the instance. \n- REFRESHING The managed instance group is applying configuration changes to the instance without stopping it. For example, the group can update the target pool list for an instance without stopping that instance.",
      "enum": [
       "ABANDONING",
       "CREATING",
@@ -3629,6 +3643,10 @@
      "description": "The range of internal addresses that are legal on this network. This range is a CIDR specification, for example: 192.168.0.0/16. Provided by the client when the network is created.",
      "pattern": "[0-9]{1,3}(?:\\.[0-9]{1,3}){3}/[0-9]{1,2}"
     },
+    "autoCreateSubnetworks": {
+     "type": "boolean",
+     "description": "When set to true, the network is created in \"auto subnet mode\". When set to false, the network is in \"custom subnet mode\".\n\nIn \"auto subnet mode\", a newly created network is assigned the default CIDR of 10.128.0.0/9 and it automatically creates one subnetwork per region."
+    },
     "creationTimestamp": {
      "type": "string",
      "description": "[Output Only] Creation timestamp in RFC3339 text format."
@@ -3665,6 +3683,13 @@
     "selfLink": {
      "type": "string",
      "description": "[Output Only] Server-defined URL for the resource."
+    },
+    "subnetworks": {
+     "type": "array",
+     "description": "[Output Only] Server-defined fully-qualified URLs for all subnetworks in this network.",
+     "items": {
+      "type": "string"
+     }
     }
    }
   },
@@ -3696,6 +3721,10 @@
     "networkIP": {
      "type": "string",
      "description": "[Output Only] An optional IPV4 internal network address assigned to the instance for this network interface."
+    },
+    "subnetwork": {
+     "type": "string",
+     "description": "The URL of the Subnetwork resource for this instance. If the network resource is in legacy mode, do not provide this property. If the network is in auto subnet mode, providing the subnetwork is optional. If the network is in custom subnet mode, then this field should be specified. If you specify this property, you can specify the subnetwork as a full or partial URL. For example, the following are all valid URLs:  \n- https://www.googleapis.com/compute/v1/projects/project/zones/zone/subnetworks/subnetwork \n- zones/zone/subnetworks/subnetwork"
     }
    }
   },
@@ -3784,7 +3813,7 @@
     },
     "httpErrorStatusCode": {
      "type": "integer",
-     "description": "[Output Only] If the operation fails, this field contains the HTTP error message that was returned. For example, a 404 means the resource was not found.",
+     "description": "[Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a 404 means the resource was not found.",
      "format": "int32"
     },
     "id": {
@@ -3811,12 +3840,12 @@
     },
     "progress": {
      "type": "integer",
-     "description": "[Output Only] An optional progress indicator that ranges from 0 to 100. There is no requirement that this be linear or support any granularity of operations. This should not be used to guess at when the operation will be complete. This number should monotonically increase as the operation progresses.",
+     "description": "[Output Only] An optional progress indicator that ranges from 0 to 100. There is no requirement that this be linear or support any granularity of operations. This should not be used to guess when the operation will be complete. This number should monotonically increase as the operation progresses.",
      "format": "int32"
     },
     "region": {
      "type": "string",
-     "description": "[Output Only] URL of the region where the operation resides. Only applicable for regional resources."
+     "description": "[Output Only] URL of the region where the operation resides. Only available when performing regional operations."
     },
     "selfLink": {
      "type": "string",
@@ -3925,7 +3954,7 @@
     },
     "zone": {
      "type": "string",
-     "description": "[Output Only] URL of the zone where the operation resides."
+     "description": "[Output Only] URL of the zone where the operation resides. Only available when performing per-zone operations."
     }
    }
   },
@@ -4074,7 +4103,7 @@
    "properties": {
     "defaultService": {
      "type": "string",
-     "description": "The URL to the BackendService resource. This will be used if none of the pathRules defined by this PathMatcher is met by the URL's path portion."
+     "description": "The full or partial URL to the BackendService resource. This will be used if none of the pathRules defined by this PathMatcher is matched by the URL's path portion. For example, the following are all valid URLs to a BackendService resource:  \n- https://www.googleapis.com/compute/v1/projects/project/global/backendServices/backendService \n- compute/v1/projects/project/global/backendServices/backendService \n- global/backendServices/backendService"
     },
     "description": {
      "type": "string",
@@ -4162,7 +4191,7 @@
     },
     "usageExportLocation": {
      "$ref": "UsageExportLocation",
-     "description": "The location in Cloud Storage and naming method of the daily usage report."
+     "description": "The naming prefix for daily usage reports and the Google Cloud Storage bucket where they are stored."
     }
    }
   },
@@ -4200,6 +4229,7 @@
       "SSD_TOTAL_GB",
       "SSL_CERTIFICATES",
       "STATIC_ADDRESSES",
+      "SUBNETWORKS",
       "TARGET_HTTPS_PROXIES",
       "TARGET_HTTP_PROXIES",
       "TARGET_INSTANCES",
@@ -4209,6 +4239,7 @@
       "VPN_TUNNELS"
      ],
      "enumDescriptions": [
+      "",
       "",
       "",
       "",
@@ -4352,7 +4383,7 @@
   "Route": {
    "id": "Route",
    "type": "object",
-   "description": "The route resource. A Route is a rule that specifies how certain packets should be handled by the virtual network. Routes are associated with instances by tag and the set of Routes for a particular instance is called its routing table. For each packet leaving a instance, the system searches that instance's routing table for a single best matching Route. Routes match packets by destination IP address, preferring smaller or more specific ranges over larger ones. If there is a tie, the system selects the Route with the smallest priority value. If there is still a tie, it uses the layer three and four packet headers to select just one of the remaining matching Routes. The packet is then forwarded as specified by the nextHop field of the winning Route -- either to another instance destination, a instance gateway or a Google Compute Engien-operated gateway. Packets that do not match any Route in the sending instance's routing table are dropped.",
+   "description": "The route resource. A Route is a rule that specifies how certain packets should be handled by the virtual network. Routes are associated with instances by tags and the set of Routes for a particular instance is called its routing table. For each packet leaving a instance, the system searches that instance's routing table for a single best matching Route. Routes match packets by destination IP address, preferring smaller or more specific ranges over larger ones. If there is a tie, the system selects the Route with the smallest priority value. If there is still a tie, it uses the layer three and four packet headers to select just one of the remaining matching Routes. The packet is then forwarded as specified by the nextHop field of the winning Route -- either to another instance destination, a instance gateway or a Google Compute Engien-operated gateway. Packets that do not match any Route in the sending instance's routing table are dropped.",
    "properties": {
     "creationTimestamp": {
      "type": "string",
@@ -4402,11 +4433,11 @@
     },
     "nextHopGateway": {
      "type": "string",
-     "description": "The URL to a gateway that should handle matching packets. Currently, this is only the internet gateway:  projects/\u003cproject-id\u003e/global/gateways/default-internet-gateway"
+     "description": "The URL to a gateway that should handle matching packets. You can only specify the internet gateway using a full or partial valid URL:  projects/\u003cproject-id\u003e/global/gateways/default-internet-gateway"
     },
     "nextHopInstance": {
      "type": "string",
-     "description": "The fully-qualified URL to an instance that should handle matching packets. For example:\nhttps://www.googleapis.com/compute/v1/projects/project/zones/zone/instances/"
+     "description": "The URL to an instance that should handle matching packets. You can specify this as a full or partial URL. For example:\nhttps://www.googleapis.com/compute/v1/projects/project/zones/zone/instances/"
     },
     "nextHopIp": {
      "type": "string",
@@ -4422,7 +4453,7 @@
     },
     "priority": {
      "type": "integer",
-     "description": "Breaks ties between Routes of equal specificity. Routes with smaller values win when tied with routes with larger values. Default value is 1000. A valid range is between 0 and 65535.",
+     "description": "The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In the case of two routes with equal prefix length, the one with the lowest-numbered priority value wins. Default value is 1000. Valid range is 0 through 65535.",
      "format": "uint32",
      "annotations": {
       "required": [
@@ -4525,7 +4556,7 @@
     },
     "items": {
      "type": "array",
-     "description": "A list of Route resources.",
+     "description": "[Output Only] A list of Route resources.",
      "items": {
       "$ref": "Route"
      }
@@ -4588,7 +4619,7 @@
     },
     "selfLink": {
      "type": "string",
-     "description": "[Output Only] Server defined URL for the resource."
+     "description": "[Output Only] Server-defined URL for the resource."
     }
    }
   },
@@ -4656,7 +4687,7 @@
     },
     "sourceDisk": {
      "type": "string",
-     "description": "The source disk used to create this snapshot."
+     "description": "[Output Only] The source disk used to create this snapshot."
     },
     "sourceDiskId": {
      "type": "string",
@@ -4710,7 +4741,7 @@
     },
     "items": {
      "type": "array",
-     "description": "A list of Snapshot resources.",
+     "description": "[Output Only] A list of Snapshot resources.",
      "items": {
       "$ref": "Snapshot"
      }
@@ -4733,7 +4764,7 @@
   "SslCertificate": {
    "id": "SslCertificate",
    "type": "object",
-   "description": "An SslCertificate resource. This resource provides a mechanism to upload an SSL key and certificate to global HTTPS loadbalancer to serve secure connections.",
+   "description": "An SslCertificate resource. This resource provides a mechanism to upload an SSL key and certificate to the load balancer to serve secure connections from the user.",
    "properties": {
     "certificate": {
      "type": "string",
@@ -4800,6 +4831,194 @@
     "selfLink": {
      "type": "string",
      "description": "[Output Only] Server-defined URL for this resource."
+    }
+   }
+  },
+  "Subnetwork": {
+   "id": "Subnetwork",
+   "type": "object",
+   "description": "A Subnetwork resource.",
+   "properties": {
+    "creationTimestamp": {
+     "type": "string",
+     "description": "[Output Only] Creation timestamp in RFC3339 text format."
+    },
+    "description": {
+     "type": "string",
+     "description": "An optional description of this resource. Provide this property when you create the resource."
+    },
+    "gatewayAddress": {
+     "type": "string",
+     "description": "[Output Only] The gateway address for default routes to reach destination addresses outside this subnetwork."
+    },
+    "id": {
+     "type": "string",
+     "description": "[Output Only] The unique identifier for the resource. This identifier is defined by the server.",
+     "format": "uint64"
+    },
+    "ipCidrRange": {
+     "type": "string",
+     "description": "The range of internal addresses that are owned by this subnetwork. Provide this property when you create the subnetwork. For example, 10.0.0.0/8 or 192.168.0.0/16. Ranges must be unique and non-overlapping within a network."
+    },
+    "kind": {
+     "type": "string",
+     "description": "[Output Only] Type of the resource. Always compute#subnetwork for Subnetwork resources.",
+     "default": "compute#subnetwork"
+    },
+    "name": {
+     "type": "string",
+     "description": "The name of the resource, provided by the client when initially creating the resource. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
+     "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?"
+    },
+    "network": {
+     "type": "string",
+     "description": "The URL of the network to which this subnetwork belongs, provided by the client when initially creating the subnetwork. Only networks that are in the distributed mode can have subnetworks."
+    },
+    "region": {
+     "type": "string",
+     "description": "[Output Only] URL of the region where the Subnetwork resides."
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "[Output Only] Server-defined URL for the resource."
+    }
+   }
+  },
+  "SubnetworkAggregatedList": {
+   "id": "SubnetworkAggregatedList",
+   "type": "object",
+   "properties": {
+    "id": {
+     "type": "string",
+     "description": "[Output Only] The unique identifier for the resource. This identifier is defined by the server."
+    },
+    "items": {
+     "type": "object",
+     "description": "[Output] A map of scoped Subnetwork lists.",
+     "additionalProperties": {
+      "$ref": "SubnetworksScopedList",
+      "description": "Name of the scope containing this set of Subnetworks."
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "[Output Only] Type of resource. Always compute#subnetworkAggregatedList for aggregated lists of subnetworks.",
+     "default": "compute#subnetworkAggregatedList"
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "[Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results."
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "[Output Only] Server-defined URL for this resource."
+    }
+   }
+  },
+  "SubnetworkList": {
+   "id": "SubnetworkList",
+   "type": "object",
+   "description": "Contains a list of Subnetwork resources.",
+   "properties": {
+    "id": {
+     "type": "string",
+     "description": "[Output Only] The unique identifier for the resource. This identifier is defined by the server."
+    },
+    "items": {
+     "type": "array",
+     "description": "The Subnetwork resources.",
+     "items": {
+      "$ref": "Subnetwork"
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "[Output Only] Type of resource. Always compute#subnetworkList for lists of subnetworks.",
+     "default": "compute#subnetworkList"
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "[Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results."
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "[Output Only] Server-defined URL for this resource."
+    }
+   }
+  },
+  "SubnetworksScopedList": {
+   "id": "SubnetworksScopedList",
+   "type": "object",
+   "properties": {
+    "subnetworks": {
+     "type": "array",
+     "description": "List of subnetworks contained in this scope.",
+     "items": {
+      "$ref": "Subnetwork"
+     }
+    },
+    "warning": {
+     "type": "object",
+     "description": "An informational warning that appears when the list of addresses is empty.",
+     "properties": {
+      "code": {
+       "type": "string",
+       "description": "[Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.",
+       "enum": [
+        "DEPRECATED_RESOURCE_USED",
+        "DISK_SIZE_LARGER_THAN_IMAGE_SIZE",
+        "INJECTED_KERNELS_DEPRECATED",
+        "NEXT_HOP_ADDRESS_NOT_ASSIGNED",
+        "NEXT_HOP_CANNOT_IP_FORWARD",
+        "NEXT_HOP_INSTANCE_NOT_FOUND",
+        "NEXT_HOP_INSTANCE_NOT_ON_NETWORK",
+        "NEXT_HOP_NOT_RUNNING",
+        "NOT_CRITICAL_ERROR",
+        "NO_RESULTS_ON_PAGE",
+        "REQUIRED_TOS_AGREEMENT",
+        "RESOURCE_NOT_DELETED",
+        "SINGLE_INSTANCE_PROPERTY_TEMPLATE",
+        "UNREACHABLE"
+       ],
+       "enumDescriptions": [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+       ]
+      },
+      "data": {
+       "type": "array",
+       "description": "[Output Only] Metadata about this warning in key: value format. For example:\n\"data\": [ { \"key\": \"scope\", \"value\": \"zones/us-east1-d\" }",
+       "items": {
+        "type": "object",
+        "properties": {
+         "key": {
+          "type": "string",
+          "description": "[Output Only] A key that provides more detail on the warning being returned. For example, for warnings where there are no results in a list request for a particular zone, this key might be scope and the key value might be the zone name. Other examples might be a key indicating a deprecated resource, and a suggested replacement, or a warning about invalid network settings (for example, if an instance attempts to perform IP forwarding but is not enabled for IP forwarding)."
+         },
+         "value": {
+          "type": "string",
+          "description": "[Output Only] A warning data value corresponding to the key."
+         }
+        }
+       }
+      },
+      "message": {
+       "type": "string",
+       "description": "[Output Only] A human-readable description of the warning code."
+      }
+     }
     }
    }
   },
@@ -4938,7 +5157,7 @@
     },
     "sslCertificates": {
      "type": "array",
-     "description": "URLs to SslCertificate resources that are used to authenticate connections to Backends. Currently exactly one SSL certificate must be specified.",
+     "description": "URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer. Currently exactly one SSL certificate must be specified.",
      "items": {
       "type": "string"
      }
@@ -5878,7 +6097,7 @@
    "properties": {
     "bucketName": {
      "type": "string",
-     "description": "The name of an existing bucket in Cloud Storage where the usage report object is stored. The Google Service Account is granted write access to this bucket. This is just the bucket name, with no gs:// or https://storage.googleapis.com/ in front of it."
+     "description": "The name of an existing bucket in Cloud Storage where the usage report object is stored. The Google Service Account is granted write access to this bucket. This can either be the bucket name by itself, such as example-bucket, or the bucket name with gs:// or https://storage.googleapis.com/ in front of it, such as gs://example-bucket."
     },
     "reportNamePrefix": {
      "type": "string",
@@ -5917,6 +6136,13 @@
      "description": "[Output Only] Type of resource. Always compute#vpnTunnel for VPN tunnels.",
      "default": "compute#vpnTunnel"
     },
+    "localTrafficSelector": {
+     "type": "array",
+     "description": "Local traffic selector to use when establishing the VPN tunnel with peer VPN gateway. The value should be a CIDR formatted string, for example: 192.168.0.0/16. The ranges should be disjoint.",
+     "items": {
+      "type": "string"
+     }
+    },
     "name": {
      "type": "string",
      "description": "Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
@@ -5941,7 +6167,7 @@
     },
     "sharedSecret": {
      "type": "string",
-     "description": "Shared secret used to set the secure session between the GCE VPN gateway and the peer VPN gateway."
+     "description": "Shared secret used to set the secure session between the Cloud VPN gateway and the peer VPN gateway."
     },
     "sharedSecretHash": {
      "type": "string",
@@ -6243,7 +6469,7 @@
      "id": "compute.addresses.aggregatedList",
      "path": "{project}/aggregated/addresses",
      "httpMethod": "GET",
-     "description": "Retrieves the list of addresses grouped by scope.",
+     "description": "Retrieves an aggregated list of addresses.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -6407,7 +6633,7 @@
      "id": "compute.addresses.list",
      "path": "{project}/regions/{region}/addresses",
      "httpMethod": "GET",
-     "description": "Retrieves the list of address resources contained within the specified region.",
+     "description": "Retrieves a list of address resources contained within the specified region.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -6464,7 +6690,7 @@
      "id": "compute.autoscalers.aggregatedList",
      "path": "{project}/aggregated/autoscalers",
      "httpMethod": "GET",
-     "description": "Retrieves the list of autoscalers grouped by scope.",
+     "description": "Retrieves an aggregated list of autoscalers.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -6628,7 +6854,7 @@
      "id": "compute.autoscalers.list",
      "path": "{project}/zones/{zone}/autoscalers",
      "httpMethod": "GET",
-     "description": "Retrieves the list of autoscaler resources contained within the specified zone.",
+     "description": "Retrieves a list of autoscaler resources contained within the specified zone.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -6874,7 +7100,7 @@
      "id": "compute.backendServices.insert",
      "path": "{project}/global/backendServices",
      "httpMethod": "POST",
-     "description": "Creates a BackendService resource in the specified project using the data included in the request.",
+     "description": "Creates a BackendService resource in the specified project using the data included in the request. There are several restrictions and guidelines to keep in mind when creating a backend service. Read  Restrictions and Guidelines for more information.",
      "parameters": {
       "project": {
        "type": "string",
@@ -6947,7 +7173,7 @@
      "id": "compute.backendServices.patch",
      "path": "{project}/global/backendServices/{backendService}",
      "httpMethod": "PATCH",
-     "description": "Update the entire content of the BackendService resource. This method supports patch semantics.",
+     "description": "Updates the entire content of the BackendService resource. There are several restrictions and guidelines to keep in mind when updating a backend service. Read  Restrictions and Guidelines for more information. This method supports patch semantics.",
      "parameters": {
       "backendService": {
        "type": "string",
@@ -6983,7 +7209,7 @@
      "id": "compute.backendServices.update",
      "path": "{project}/global/backendServices/{backendService}",
      "httpMethod": "PUT",
-     "description": "Update the entire content of the BackendService resource.",
+     "description": "Updates the entire content of the BackendService resource. There are several restrictions and guidelines to keep in mind when updating a backend service. Read  Restrictions and Guidelines for more information.",
      "parameters": {
       "backendService": {
        "type": "string",
@@ -7023,7 +7249,7 @@
      "id": "compute.diskTypes.aggregatedList",
      "path": "{project}/aggregated/diskTypes",
      "httpMethod": "GET",
-     "description": "Retrieves the list of disk type resources grouped by scope.",
+     "description": "Retrieves an aggregated list of disk type resources.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -7110,7 +7336,7 @@
      "id": "compute.diskTypes.list",
      "path": "{project}/zones/{zone}/diskTypes",
      "httpMethod": "GET",
-     "description": "Retrieves the list of disk type resources available to the specified project.",
+     "description": "Retrieves a list of disk type resources available to the specified project.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -7167,7 +7393,7 @@
      "id": "compute.disks.aggregatedList",
      "path": "{project}/aggregated/disks",
      "httpMethod": "GET",
-     "description": "Retrieves the list of persistent disks grouped by scope.",
+     "description": "Retrieves an aggregated list of persistent disks.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -7380,7 +7606,7 @@
      "id": "compute.disks.list",
      "path": "{project}/zones/{zone}/disks",
      "httpMethod": "GET",
-     "description": "Retrieves the list of persistent disks contained within the specified zone.",
+     "description": "Retrieves a list of persistent disks contained within the specified zone.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -7653,7 +7879,7 @@
      "id": "compute.forwardingRules.aggregatedList",
      "path": "{project}/aggregated/forwardingRules",
      "httpMethod": "GET",
-     "description": "Retrieves the list of forwarding rules grouped by scope.",
+     "description": "Retrieves an aggregated list of forwarding rules.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -7817,7 +8043,7 @@
      "id": "compute.forwardingRules.list",
      "path": "{project}/regions/{region}/forwardingRules",
      "httpMethod": "GET",
-     "description": "Retrieves the list of ForwardingRule resources available to the specified project and region.",
+     "description": "Retrieves a list of ForwardingRule resources available to the specified project and region.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -8013,7 +8239,7 @@
      "id": "compute.globalAddresses.list",
      "path": "{project}/global/addresses",
      "httpMethod": "GET",
-     "description": "Retrieves the list of global address resources.",
+     "description": "Retrieves a list of global address resources.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -8157,7 +8383,7 @@
      "id": "compute.globalForwardingRules.list",
      "path": "{project}/global/forwardingRules",
      "httpMethod": "GET",
-     "description": "Retrieves the list of ForwardingRule resources available to the specified project.",
+     "description": "Retrieves a list of ForwardingRule resources available to the specified project.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -8242,7 +8468,7 @@
      "id": "compute.globalOperations.aggregatedList",
      "path": "{project}/aggregated/operations",
      "httpMethod": "GET",
-     "description": "Retrieves the list of all operations grouped by scope.",
+     "description": "Retrieves an aggregated list of all operations.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -8351,7 +8577,7 @@
      "id": "compute.globalOperations.list",
      "path": "{project}/global/operations",
      "httpMethod": "GET",
-     "description": "Retrieves the list of Operation resources contained within the specified project.",
+     "description": "Retrieves a list of Operation resources contained within the specified project.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -9102,7 +9328,7 @@
      "id": "compute.instanceGroupManagers.delete",
      "path": "{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}",
      "httpMethod": "DELETE",
-     "description": "Deletes the specified managed instance group and all of the instances in that group.",
+     "description": "Deletes the specified managed instance group and all of the instances in that group. Note that the instance group must not belong to a backend service. Read  Deleting an instance group for more information.",
      "parameters": {
       "instanceGroupManager": {
        "type": "string",
@@ -9527,7 +9753,7 @@
      "id": "compute.instanceGroups.addInstances",
      "path": "{project}/zones/{zone}/instanceGroups/{instanceGroup}/addInstances",
      "httpMethod": "POST",
-     "description": "Adds a list of instances to the specified instance group. All of the instances in the instance group must be in the same network/subnetwork.",
+     "description": "Adds a list of instances to the specified instance group. Read  Adding instances for more information.",
      "parameters": {
       "instanceGroup": {
        "type": "string",
@@ -9614,7 +9840,7 @@
      "id": "compute.instanceGroups.delete",
      "path": "{project}/zones/{zone}/instanceGroups/{instanceGroup}",
      "httpMethod": "DELETE",
-     "description": "Deletes the specified instance group. The instances in the group are not deleted.",
+     "description": "Deletes the specified instance group. The instances in the group are not deleted. Note that instance group must not belong to a backend service. Read  Deleting an instance group for more information.",
      "parameters": {
       "instanceGroup": {
        "type": "string",
@@ -9997,7 +10223,7 @@
      "id": "compute.instanceTemplates.insert",
      "path": "{project}/global/instanceTemplates",
      "httpMethod": "POST",
-     "description": "Creates an instance template in the specified project using the data that is included in the request.",
+     "description": "Creates an instance template in the specified project using the data that is included in the request. If you are creating a new template to update an existing instance group, your new instance template must use the same network or, if applicable, the same subnetwork as the original template.",
      "parameters": {
       "project": {
        "type": "string",
@@ -10634,6 +10860,50 @@
       "https://www.googleapis.com/auth/compute"
      ]
     },
+    "setMachineType": {
+     "id": "compute.instances.setMachineType",
+     "path": "{project}/zones/{zone}/instances/{instance}/setMachineType",
+     "httpMethod": "POST",
+     "description": "Changes the machine type for a stopped instance to the machine type specified in the request.",
+     "parameters": {
+      "instance": {
+       "type": "string",
+       "description": "Name of the instance scoping this request.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "Project ID for this request.",
+       "required": true,
+       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+       "location": "path"
+      },
+      "zone": {
+       "type": "string",
+       "description": "The name of the zone for this request.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "zone",
+      "instance"
+     ],
+     "request": {
+      "$ref": "InstancesSetMachineTypeRequest"
+     },
+     "response": {
+      "$ref": "Operation"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute"
+     ]
+    },
     "setMetadata": {
      "id": "compute.instances.setMetadata",
      "path": "{project}/zones/{zone}/instances/{instance}/setMetadata",
@@ -10770,7 +11040,7 @@
      "id": "compute.instances.start",
      "path": "{project}/zones/{zone}/instances/{instance}/start",
      "httpMethod": "POST",
-     "description": "This method starts an instance that was stopped using the using the instances().stop method. For more information, see Restart an instance.",
+     "description": "Starts an instance that was stopped using the using the instances().stop method. For more information, see Restart an instance.",
      "parameters": {
       "instance": {
        "type": "string",
@@ -10811,7 +11081,7 @@
      "id": "compute.instances.stop",
      "path": "{project}/zones/{zone}/instances/{instance}/stop",
      "httpMethod": "POST",
-     "description": "This method stops a running instance, shutting it down cleanly, and allows you to restart the instance at a later time. Stopped instances do not incur per-minute, virtual machine usage charges while they are stopped, but any resources that the virtual machine is using, such as persistent disks and static IP addresses,will continue to be charged until they are deleted. For more information, see Stopping an instance.",
+     "description": "Stops a running instance, shutting it down cleanly, and allows you to restart the instance at a later time. Stopped instances do not incur per-minute, virtual machine usage charges while they are stopped, but any resources that the virtual machine is using, such as persistent disks and static IP addresses, will continue to be charged until they are deleted. For more information, see Stopping an instance.",
      "parameters": {
       "instance": {
        "type": "string",
@@ -10894,7 +11164,7 @@
      "id": "compute.machineTypes.aggregatedList",
      "path": "{project}/aggregated/machineTypes",
      "httpMethod": "GET",
-     "description": "Retrieves the list of machine type resources grouped by scope.",
+     "description": "Retrieves an aggregated list of machine type resources.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -10981,7 +11251,7 @@
      "id": "compute.machineTypes.list",
      "path": "{project}/zones/{zone}/machineTypes",
      "httpMethod": "GET",
-     "description": "Retrieves the list of machine type resources available to the specified project.",
+     "description": "Retrieves a list of machine type resources available to the specified project.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -11383,7 +11653,7 @@
       },
       "region": {
        "type": "string",
-       "description": "Name of the zone scoping this request.",
+       "description": "Name of the region scoping this request.",
        "required": true,
        "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
        "location": "path"
@@ -11407,7 +11677,7 @@
      "id": "compute.regionOperations.list",
      "path": "{project}/regions/{region}/operations",
      "httpMethod": "GET",
-     "description": "Retrieves the list of Operation resources contained within the specified region.",
+     "description": "Retrieves a list of Operation resources contained within the specified region.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -11945,6 +12215,227 @@
     }
    }
   },
+  "subnetworks": {
+   "methods": {
+    "aggregatedList": {
+     "id": "compute.subnetworks.aggregatedList",
+     "path": "{project}/aggregated/subnetworks",
+     "httpMethod": "GET",
+     "description": "Retrieves an aggregated list of subnetworks.",
+     "parameters": {
+      "filter": {
+       "type": "string",
+       "description": "Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.\n\nThe field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.\n\nFor example, filter=name ne example-instance.\n\nCompute Engine Beta API Only: If you use filtering in the Beta API, you can also filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. In particular, use filtering on nested fields to take advantage of instance labels to organize and filter results based on label values.\n\nThe Beta API also supports filtering on multiple expressions by providing each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions meaning that resources must match all expressions to pass the filters.",
+       "location": "query"
+      },
+      "maxResults": {
+       "type": "integer",
+       "description": "The maximum number of results per page that Compute Engine should return. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.",
+       "default": "500",
+       "format": "uint32",
+       "minimum": "0",
+       "maximum": "500",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.",
+       "location": "query"
+      },
+      "project": {
+       "type": "string",
+       "description": "Project ID for this request.",
+       "required": true,
+       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project"
+     ],
+     "response": {
+      "$ref": "SubnetworkAggregatedList"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/compute.readonly"
+     ]
+    },
+    "delete": {
+     "id": "compute.subnetworks.delete",
+     "path": "{project}/regions/{region}/subnetworks/{subnetwork}",
+     "httpMethod": "DELETE",
+     "description": "Deletes the specified subnetwork.",
+     "parameters": {
+      "project": {
+       "type": "string",
+       "description": "Project ID for this request.",
+       "required": true,
+       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+       "location": "path"
+      },
+      "region": {
+       "type": "string",
+       "description": "Name of the region scoping this request.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      },
+      "subnetwork": {
+       "type": "string",
+       "description": "Name of the Subnetwork resource to delete.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "region",
+      "subnetwork"
+     ],
+     "response": {
+      "$ref": "Operation"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute"
+     ]
+    },
+    "get": {
+     "id": "compute.subnetworks.get",
+     "path": "{project}/regions/{region}/subnetworks/{subnetwork}",
+     "httpMethod": "GET",
+     "description": "Returns the specified subnetwork.",
+     "parameters": {
+      "project": {
+       "type": "string",
+       "description": "Project ID for this request.",
+       "required": true,
+       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+       "location": "path"
+      },
+      "region": {
+       "type": "string",
+       "description": "Name of the region scoping this request.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      },
+      "subnetwork": {
+       "type": "string",
+       "description": "Name of the Subnetwork resource to return.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "region",
+      "subnetwork"
+     ],
+     "response": {
+      "$ref": "Subnetwork"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/compute.readonly"
+     ]
+    },
+    "insert": {
+     "id": "compute.subnetworks.insert",
+     "path": "{project}/regions/{region}/subnetworks",
+     "httpMethod": "POST",
+     "description": "Creates a subnetwork in the specified project using the data included in the request.",
+     "parameters": {
+      "project": {
+       "type": "string",
+       "description": "Project ID for this request.",
+       "required": true,
+       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+       "location": "path"
+      },
+      "region": {
+       "type": "string",
+       "description": "Name of the region scoping this request.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "region"
+     ],
+     "request": {
+      "$ref": "Subnetwork"
+     },
+     "response": {
+      "$ref": "Operation"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute"
+     ]
+    },
+    "list": {
+     "id": "compute.subnetworks.list",
+     "path": "{project}/regions/{region}/subnetworks",
+     "httpMethod": "GET",
+     "description": "Retrieves a list of subnetworks available to the specified project.",
+     "parameters": {
+      "filter": {
+       "type": "string",
+       "description": "Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.\n\nThe field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.\n\nFor example, filter=name ne example-instance.\n\nCompute Engine Beta API Only: If you use filtering in the Beta API, you can also filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. In particular, use filtering on nested fields to take advantage of instance labels to organize and filter results based on label values.\n\nThe Beta API also supports filtering on multiple expressions by providing each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions meaning that resources must match all expressions to pass the filters.",
+       "location": "query"
+      },
+      "maxResults": {
+       "type": "integer",
+       "description": "The maximum number of results per page that Compute Engine should return. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.",
+       "default": "500",
+       "format": "uint32",
+       "minimum": "0",
+       "maximum": "500",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.",
+       "location": "query"
+      },
+      "project": {
+       "type": "string",
+       "description": "Project ID for this request.",
+       "required": true,
+       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+       "location": "path"
+      },
+      "region": {
+       "type": "string",
+       "description": "Name of the region scoping this request.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "region"
+     ],
+     "response": {
+      "$ref": "SubnetworkList"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/compute.readonly"
+     ]
+    }
+   }
+  },
   "targetHttpProxies": {
    "methods": {
     "delete": {
@@ -12347,7 +12838,7 @@
      "id": "compute.targetInstances.aggregatedList",
      "path": "{project}/aggregated/targetInstances",
      "httpMethod": "GET",
-     "description": "Retrieves the list of target instances grouped by scope.",
+     "description": "Retrieves an aggregated list of target instances.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -12511,7 +13002,7 @@
      "id": "compute.targetInstances.list",
      "path": "{project}/zones/{zone}/targetInstances",
      "httpMethod": "GET",
-     "description": "Retrieves the list of TargetInstance resources available to the specified project and zone.",
+     "description": "Retrieves a list of TargetInstance resources available to the specified project and zone.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -12654,7 +13145,7 @@
      "id": "compute.targetPools.aggregatedList",
      "path": "{project}/aggregated/targetPools",
      "httpMethod": "GET",
-     "description": "Retrieves the list of target pools grouped by scope.",
+     "description": "Retrieves an aggregated list of target pools.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -12782,7 +13273,7 @@
      "id": "compute.targetPools.getHealth",
      "path": "{project}/regions/{region}/targetPools/{targetPool}/getHealth",
      "httpMethod": "POST",
-     "description": "Gets the most recent health check results for each IP for the given instance that is referenced by given TargetPool.",
+     "description": "Gets the most recent health check results for each IP for the given instance that is referenced by the given TargetPool.",
      "parameters": {
       "project": {
        "type": "string",
@@ -12862,7 +13353,7 @@
      "id": "compute.targetPools.list",
      "path": "{project}/regions/{region}/targetPools",
      "httpMethod": "GET",
-     "description": "Retrieves the list of TargetPool resources available to the specified project and region.",
+     "description": "Retrieves a list of TargetPool resources available to the specified project and region.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -13055,7 +13546,7 @@
      "id": "compute.targetVpnGateways.aggregatedList",
      "path": "{project}/aggregated/targetVpnGateways",
      "httpMethod": "GET",
-     "description": "Retrieves the list of target VPN gateways grouped by scope.",
+     "description": "Retrieves an aggregated list of target VPN gateways .",
      "parameters": {
       "filter": {
        "type": "string",
@@ -13219,7 +13710,7 @@
      "id": "compute.targetVpnGateways.list",
      "path": "{project}/regions/{region}/targetVpnGateways",
      "httpMethod": "GET",
-     "description": "Retrieves the list of TargetVpnGateway resources available to the specified project and region.",
+     "description": "Retrieves a list of TargetVpnGateway resources available to the specified project and region.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -13416,7 +13907,7 @@
      "id": "compute.urlMaps.patch",
      "path": "{project}/global/urlMaps/{urlMap}",
      "httpMethod": "PATCH",
-     "description": "Update the entire content of the UrlMap resource. This method supports patch semantics.",
+     "description": "Updates the entire content of the UrlMap resource. This method supports patch semantics.",
      "parameters": {
       "project": {
        "type": "string",
@@ -13452,7 +13943,7 @@
      "id": "compute.urlMaps.update",
      "path": "{project}/global/urlMaps/{urlMap}",
      "httpMethod": "PUT",
-     "description": "Update the entire content of the UrlMap resource.",
+     "description": "Updates the entire content of the UrlMap resource.",
      "parameters": {
       "project": {
        "type": "string",
@@ -13488,7 +13979,7 @@
      "id": "compute.urlMaps.validate",
      "path": "{project}/global/urlMaps/{urlMap}/validate",
      "httpMethod": "POST",
-     "description": "Run static validation for the UrlMap. In particular, the tests of the provided UrlMap will be run. Calling this method does NOT create the UrlMap.",
+     "description": "Runs static validation for the UrlMap. In particular, the tests of the provided UrlMap will be run. Calling this method does NOT create the UrlMap.",
      "parameters": {
       "project": {
        "type": "string",
@@ -13528,7 +14019,7 @@
      "id": "compute.vpnTunnels.aggregatedList",
      "path": "{project}/aggregated/vpnTunnels",
      "httpMethod": "GET",
-     "description": "Retrieves the list of VPN tunnels grouped by scope.",
+     "description": "Retrieves an aggregated list of VPN tunnels.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -13692,7 +14183,7 @@
      "id": "compute.vpnTunnels.list",
      "path": "{project}/regions/{region}/vpnTunnels",
      "httpMethod": "GET",
-     "description": "Retrieves the list of VpnTunnel resources contained in the specified project and region.",
+     "description": "Retrieves a list of VpnTunnel resources contained in the specified project and region.",
      "parameters": {
       "filter": {
        "type": "string",
@@ -13829,7 +14320,7 @@
      "id": "compute.zoneOperations.list",
      "path": "{project}/zones/{zone}/operations",
      "httpMethod": "GET",
-     "description": "Retrieves the list of Operation resources contained within the specified zone.",
+     "description": "Retrieves a list of Operation resources contained within the specified zone.",
      "parameters": {
       "filter": {
        "type": "string",

--- a/vendor/google.golang.org/api/compute/v1/compute-gen.go
+++ b/vendor/google.golang.org/api/compute/v1/compute-gen.go
@@ -7,7 +7,7 @@
 //   import "google.golang.org/api/compute/v1"
 //   ...
 //   computeService, err := compute.New(oauthHttpClient)
-package compute
+package compute // import "google.golang.org/api/compute/v1"
 
 import (
 	"bytes"
@@ -97,6 +97,7 @@ func New(client *http.Client) (*Service, error) {
 	s.Routes = NewRoutesService(s)
 	s.Snapshots = NewSnapshotsService(s)
 	s.SslCertificates = NewSslCertificatesService(s)
+	s.Subnetworks = NewSubnetworksService(s)
 	s.TargetHttpProxies = NewTargetHttpProxiesService(s)
 	s.TargetHttpsProxies = NewTargetHttpsProxiesService(s)
 	s.TargetInstances = NewTargetInstancesService(s)
@@ -165,6 +166,8 @@ type Service struct {
 	Snapshots *SnapshotsService
 
 	SslCertificates *SslCertificatesService
+
+	Subnetworks *SubnetworksService
 
 	TargetHttpProxies *TargetHttpProxiesService
 
@@ -423,6 +426,15 @@ func NewSslCertificatesService(s *Service) *SslCertificatesService {
 }
 
 type SslCertificatesService struct {
+	s *Service
+}
+
+func NewSubnetworksService(s *Service) *SubnetworksService {
+	rs := &SubnetworksService{s: s}
+	return rs
+}
+
+type SubnetworksService struct {
 	s *Service
 }
 
@@ -1370,15 +1382,15 @@ type Backend struct {
 	// fully-qualified URL, rather than a partial URL.
 	Group string `json:"group,omitempty"`
 
-	// MaxRate: The max RPS of the group. Can be used with either balancing
-	// mode, but required if RATE mode. For RATE mode, either maxRate or
-	// maxRatePerInstance must be set.
+	// MaxRate: The max requests per second (RPS) of the group. Can be used
+	// with either balancing mode, but required if RATE mode. For RATE mode,
+	// either maxRate or maxRatePerInstance must be set.
 	MaxRate int64 `json:"maxRate,omitempty"`
 
-	// MaxRatePerInstance: The max RPS that a single backed instance can
-	// handle. This is used to calculate the capacity of the group. Can be
-	// used in either balancing mode. For RATE mode, either maxRate or
-	// maxRatePerInstance must be set.
+	// MaxRatePerInstance: The max requests per second (RPS) that a single
+	// backed instance can handle. This is used to calculate the capacity of
+	// the group. Can be used in either balancing mode. For RATE mode,
+	// either maxRate or maxRatePerInstance must be set.
 	MaxRatePerInstance float64 `json:"maxRatePerInstance,omitempty"`
 
 	// MaxUtilization: Used when balancingMode is UTILIZATION. This ratio
@@ -1402,8 +1414,7 @@ func (s *Backend) MarshalJSON() ([]byte, error) {
 }
 
 // BackendService: A BackendService resource. This resource defines a
-// group of backend virtual machines together with their serving
-// capacity.
+// group of backend virtual machines and their serving capacity.
 type BackendService struct {
 	// Backends: The list of backends that serve this BackendService.
 	Backends []*Backend `json:"backends,omitempty"`
@@ -1445,8 +1456,8 @@ type BackendService struct {
 	// last character, which cannot be a dash.
 	Name string `json:"name,omitempty"`
 
-	// Port: Deprecated in favor of port name. The TCP port to connect on
-	// the backend. The default value is 80.
+	// Port: Deprecated in favor of portName. The TCP port to connect on the
+	// backend. The default value is 80.
 	Port int64 `json:"port,omitempty"`
 
 	// PortName: Name of backend port. The same name should appear in the
@@ -1462,7 +1473,8 @@ type BackendService struct {
 	SelfLink string `json:"selfLink,omitempty"`
 
 	// TimeoutSec: How many seconds to wait for the backend before
-	// considering it a failed request. Default is 30 seconds.
+	// considering it a failed request. Default is 30 seconds. Valid range
+	// is [1, 86400].
 	TimeoutSec int64 `json:"timeoutSec,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -2234,10 +2246,9 @@ type Firewall struct {
 	// last character, which cannot be a dash.
 	Name string `json:"name,omitempty"`
 
-	// Network: URL of the network resource for this firewall rule. This
-	// field is required for creating an instance but optional when creating
-	// a firewall rule. If not specified when creating a firewall rule, the
-	// default network is used:
+	// Network: URL of the network resource for this firewall rule. If not
+	// specified when creating a firewall rule, the default network is
+	// used:
 	// global/networks/default
 	// If you choose to specify this property, you can specify the network
 	// as a full or partial URL. For example, the following are all valid
@@ -2434,6 +2445,9 @@ type ForwardingRule struct {
 	// traffic. For regional forwarding rules, this target must live in the
 	// same region as the forwarding rule. For global forwarding rules, this
 	// target must be a global TargetHttpProxy or TargetHttpsProxy resource.
+	// The forwarded traffic must be of a type appropriate to the target
+	// object. For example, TargetHttpProxy requires HTTP traffic, and
+	// TargetHttpsProxy requires HTTPS traffic.
 	Target string `json:"target,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -3157,16 +3171,16 @@ type Instance struct {
 	// format.
 	CreationTimestamp string `json:"creationTimestamp,omitempty"`
 
-	// Description: An optional textual description of the resource;
-	// provided by the client when the resource is created.
+	// Description: An optional description of this resource. Provide this
+	// property when you create the resource.
 	Description string `json:"description,omitempty"`
 
 	// Disks: Array of disks associated with this instance. Persistent disks
 	// must be created before you can assign them.
 	Disks []*AttachedDisk `json:"disks,omitempty"`
 
-	// Id: [Output Only] Unique identifier for the resource. This identifier
-	// is defined by the server.
+	// Id: [Output Only] The unique identifier for the resource. This
+	// identifier is defined by the server.
 	Id uint64 `json:"id,omitempty,string"`
 
 	// Kind: [Output Only] Type of the resource. Always compute#instance for
@@ -3201,13 +3215,14 @@ type Instance struct {
 	// This includes custom metadata and predefined keys.
 	Metadata *Metadata `json:"metadata,omitempty"`
 
-	// Name: Name of the resource; provided by the client when the resource
-	// is created. The name must be 1-63 characters long, and comply with
-	// RFC1035. Specifically, the name must be 1-63 characters long and
-	// match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means
-	// the first character must be a lowercase letter, and all following
-	// characters must be a dash, lowercase letter, or digit, except the
-	// last character, which cannot be a dash.
+	// Name: The name of the resource, provided by the client when initially
+	// creating the resource. The resource name must be 1-63 characters
+	// long, and comply with RFC1035. Specifically, the name must be 1-63
+	// characters long and match the regular expression
+	// [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a
+	// lowercase letter, and all following characters must be a dash,
+	// lowercase letter, or digit, except the last character, which cannot
+	// be a dash.
 	Name string `json:"name,omitempty"`
 
 	// NetworkInterfaces: An array of configurations for this interface.
@@ -3218,7 +3233,7 @@ type Instance struct {
 	// Scheduling: Scheduling options for this instance.
 	Scheduling *Scheduling `json:"scheduling,omitempty"`
 
-	// SelfLink: [Output Only] Server defined URL for this resource.
+	// SelfLink: [Output Only] Server-defined URL for this resource.
 	SelfLink string `json:"selfLink,omitempty"`
 
 	// ServiceAccounts: A list of service accounts, with their specified
@@ -3289,11 +3304,15 @@ type InstanceAggregatedList struct {
 	// resources.
 	Kind string `json:"kind,omitempty"`
 
-	// NextPageToken: [Output Only] A token used to continue a truncated
-	// list request.
+	// NextPageToken: [Output Only] This token allows you to get the next
+	// page of results for list requests. If the number of results is larger
+	// than maxResults, use the nextPageToken as a value for the query
+	// parameter pageToken in the next list request. Subsequent list
+	// requests will have their own nextPageToken to continue paging through
+	// the results.
 	NextPageToken string `json:"nextPageToken,omitempty"`
 
-	// SelfLink: [Output Only] Server defined URL for this resource.
+	// SelfLink: [Output Only] Server-defined URL for this resource.
 	SelfLink string `json:"selfLink,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -3363,6 +3382,10 @@ type InstanceGroup struct {
 	// Size: [Output Only] The total number of instances in the instance
 	// group.
 	Size int64 `json:"size,omitempty"`
+
+	// Subnetwork: [Output Only] The URL of the subnetwork to which all
+	// instances in the instance group belong.
+	Subnetwork string `json:"subnetwork,omitempty"`
 
 	// Zone: [Output Only] The URL of the zone where the instance group is
 	// located.
@@ -3573,7 +3596,8 @@ type InstanceGroupManagerActionsSummary struct {
 
 	// Creating: [Output Only] The number of instances in the managed
 	// instance group that are scheduled to be created or are currently
-	// being created.
+	// being created. If the group fails to create one of these instances,
+	// it tries again until it creates the instance successfully.
 	Creating int64 `json:"creating,omitempty"`
 
 	// Deleting: [Output Only] The number of instances in the managed
@@ -4196,11 +4220,15 @@ type InstanceList struct {
 	// lists of Instance resources.
 	Kind string `json:"kind,omitempty"`
 
-	// NextPageToken: [Output Only] A token used to continue a truncated
-	// list request.
+	// NextPageToken: [Output Only] This token allows you to get the next
+	// page of results for list requests. If the number of results is larger
+	// than maxResults, use the nextPageToken as a value for the query
+	// parameter pageToken in the next list request. Subsequent list
+	// requests will have their own nextPageToken to continue paging through
+	// the results.
 	NextPageToken string `json:"nextPageToken,omitempty"`
 
-	// SelfLink: [Output Only] Server defined URL for this resource.
+	// SelfLink: [Output Only] Server-defined URL for this resource.
 	SelfLink string `json:"selfLink,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -4571,6 +4599,27 @@ func (s *InstancesScopedListWarningData) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields)
 }
 
+type InstancesSetMachineTypeRequest struct {
+	// MachineType: Full or partial URL of the machine type resource. See
+	// Machine Types for a full list of machine types. For example:
+	// zones/us-central1-f/machineTypes/n1-standard-1
+	MachineType string `json:"machineType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "MachineType") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *InstancesSetMachineTypeRequest) MarshalJSON() ([]byte, error) {
+	type noMethod InstancesSetMachineTypeRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
 // License: A license resource.
 type License struct {
 	// ChargesUseFee: [Output Only] If true, the customer will be charged
@@ -4894,7 +4943,13 @@ type ManagedInstance struct {
 	// instance group has scheduled for the instance. Possible values:
 	// - NONE The instance is running, and the managed instance group does
 	// not have any scheduled actions for this instance.
-	// - CREATING The managed instance group is creating this instance.
+	// - CREATING The managed instance group is creating this instance. If
+	// the group fails to create this instance, it will try again until it
+	// is successful.
+	// - CREATING_WITHOUT_RETRIES The managed instance group is attempting
+	// to create this instance only once. If the group fails to create this
+	// instance, it does not try again and the group's target_size value is
+	// decreased.
 	// - RECREATING The managed instance group is recreating this instance.
 	//
 	// - DELETING The managed instance group is permanently deleting this
@@ -5121,6 +5176,15 @@ type Network struct {
 	// 192.168.0.0/16. Provided by the client when the network is created.
 	IPv4Range string `json:"IPv4Range,omitempty"`
 
+	// AutoCreateSubnetworks: When set to true, the network is created in
+	// "auto subnet mode". When set to false, the network is in "custom
+	// subnet mode".
+	//
+	// In "auto subnet mode", a newly created network is assigned the
+	// default CIDR of 10.128.0.0/9 and it automatically creates one
+	// subnetwork per region.
+	AutoCreateSubnetworks bool `json:"autoCreateSubnetworks,omitempty"`
+
 	// CreationTimestamp: [Output Only] Creation timestamp in RFC3339 text
 	// format.
 	CreationTimestamp string `json:"creationTimestamp,omitempty"`
@@ -5153,6 +5217,10 @@ type Network struct {
 
 	// SelfLink: [Output Only] Server-defined URL for the resource.
 	SelfLink string `json:"selfLink,omitempty"`
+
+	// Subnetworks: [Output Only] Server-defined fully-qualified URLs for
+	// all subnetworks in this network.
+	Subnetworks []string `json:"subnetworks,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
 	// server.
@@ -5204,6 +5272,18 @@ type NetworkInterface struct {
 	// NetworkIP: [Output Only] An optional IPV4 internal network address
 	// assigned to the instance for this network interface.
 	NetworkIP string `json:"networkIP,omitempty"`
+
+	// Subnetwork: The URL of the Subnetwork resource for this instance. If
+	// the network resource is in legacy mode, do not provide this property.
+	// If the network is in auto subnet mode, providing the subnetwork is
+	// optional. If the network is in custom subnet mode, then this field
+	// should be specified. If you specify this property, you can specify
+	// the subnetwork as a full or partial URL. For example, the following
+	// are all valid URLs:
+	// -
+	// https://www.googleapis.com/compute/v1/projects/project/zones/zone/subnetworks/subnetwork
+	// - zones/zone/subnetworks/subnetwork
+	Subnetwork string `json:"subnetwork,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "AccessConfigs") to
 	// unconditionally include in API requests. By default, fields with
@@ -5291,8 +5371,8 @@ type Operation struct {
 	HttpErrorMessage string `json:"httpErrorMessage,omitempty"`
 
 	// HttpErrorStatusCode: [Output Only] If the operation fails, this field
-	// contains the HTTP error message that was returned. For example, a 404
-	// means the resource was not found.
+	// contains the HTTP error status code that was returned. For example, a
+	// 404 means the resource was not found.
 	HttpErrorStatusCode int64 `json:"httpErrorStatusCode,omitempty"`
 
 	// Id: [Output Only] The unique identifier for the resource. This
@@ -5316,13 +5396,13 @@ type Operation struct {
 
 	// Progress: [Output Only] An optional progress indicator that ranges
 	// from 0 to 100. There is no requirement that this be linear or support
-	// any granularity of operations. This should not be used to guess at
-	// when the operation will be complete. This number should monotonically
+	// any granularity of operations. This should not be used to guess when
+	// the operation will be complete. This number should monotonically
 	// increase as the operation progresses.
 	Progress int64 `json:"progress,omitempty"`
 
 	// Region: [Output Only] URL of the region where the operation resides.
-	// Only applicable for regional resources.
+	// Only available when performing regional operations.
 	Region string `json:"region,omitempty"`
 
 	// SelfLink: [Output Only] Server-defined URL for the resource.
@@ -5361,7 +5441,8 @@ type Operation struct {
 	// processing of the operation, this field will be populated.
 	Warnings []*OperationWarnings `json:"warnings,omitempty"`
 
-	// Zone: [Output Only] URL of the zone where the operation resides.
+	// Zone: [Output Only] URL of the zone where the operation resides. Only
+	// available when performing per-zone operations.
 	Zone string `json:"zone,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -5695,9 +5776,15 @@ func (s *OperationsScopedListWarningData) MarshalJSON() ([]byte, error) {
 // BackendService from the longest-matched rule will serve the URL. If
 // no rule was matched, the default service will be used.
 type PathMatcher struct {
-	// DefaultService: The URL to the BackendService resource. This will be
-	// used if none of the pathRules defined by this PathMatcher is met by
-	// the URL's path portion.
+	// DefaultService: The full or partial URL to the BackendService
+	// resource. This will be used if none of the pathRules defined by this
+	// PathMatcher is matched by the URL's path portion. For example, the
+	// following are all valid URLs to a BackendService resource:
+	// -
+	// https://www.googleapis.com/compute/v1/projects/project/global/backendServices/backendService
+	// - compute/v1/projects/project/global/backendServices/backendService
+	//
+	// - global/backendServices/backendService
 	DefaultService string `json:"defaultService,omitempty"`
 
 	// Description: An optional description of this resource. Provide this
@@ -5791,8 +5878,8 @@ type Project struct {
 	// SelfLink: [Output Only] Server-defined URL for the resource.
 	SelfLink string `json:"selfLink,omitempty"`
 
-	// UsageExportLocation: The location in Cloud Storage and naming method
-	// of the daily usage report.
+	// UsageExportLocation: The naming prefix for daily usage reports and
+	// the Google Cloud Storage bucket where they are stored.
 	UsageExportLocation *UsageExportLocation `json:"usageExportLocation,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -5843,6 +5930,7 @@ type Quota struct {
 	//   "SSD_TOTAL_GB"
 	//   "SSL_CERTIFICATES"
 	//   "STATIC_ADDRESSES"
+	//   "SUBNETWORKS"
 	//   "TARGET_HTTPS_PROXIES"
 	//   "TARGET_HTTP_PROXIES"
 	//   "TARGET_INSTANCES"
@@ -5995,7 +6083,7 @@ func (s *ResourceGroupReference) MarshalJSON() ([]byte, error) {
 
 // Route: The route resource. A Route is a rule that specifies how
 // certain packets should be handled by the virtual network. Routes are
-// associated with instances by tag and the set of Routes for a
+// associated with instances by tags and the set of Routes for a
 // particular instance is called its routing table. For each packet
 // leaving a instance, the system searches that instance's routing table
 // for a single best matching Route. Routes match packets by destination
@@ -6043,12 +6131,13 @@ type Route struct {
 	Network string `json:"network,omitempty"`
 
 	// NextHopGateway: The URL to a gateway that should handle matching
-	// packets. Currently, this is only the internet gateway:
+	// packets. You can only specify the internet gateway using a full or
+	// partial valid URL:
 	// projects/<project-id>/global/gateways/default-internet-gateway
 	NextHopGateway string `json:"nextHopGateway,omitempty"`
 
-	// NextHopInstance: The fully-qualified URL to an instance that should
-	// handle matching packets. For
+	// NextHopInstance: The URL to an instance that should handle matching
+	// packets. You can specify this as a full or partial URL. For
 	// example:
 	// https://www.googleapis.com/compute/v1/projects/project/zones/
 	// zone/instances/
@@ -6066,9 +6155,11 @@ type Route struct {
 	// packets.
 	NextHopVpnTunnel string `json:"nextHopVpnTunnel,omitempty"`
 
-	// Priority: Breaks ties between Routes of equal specificity. Routes
-	// with smaller values win when tied with routes with larger values.
-	// Default value is 1000. A valid range is between 0 and 65535.
+	// Priority: The priority of this route. Priority is used to break ties
+	// in cases where there is more than one matching route of equal prefix
+	// length. In the case of two routes with equal prefix length, the one
+	// with the lowest-numbered priority value wins. Default value is 1000.
+	// Valid range is 0 through 65535.
 	Priority int64 `json:"priority,omitempty"`
 
 	// SelfLink: [Output Only] Server-defined fully-qualified URL for this
@@ -6182,7 +6273,7 @@ type RouteList struct {
 	// server.
 	Id string `json:"id,omitempty"`
 
-	// Items: A list of Route resources.
+	// Items: [Output Only] A list of Route resources.
 	Items []*Route `json:"items,omitempty"`
 
 	// Kind: Type of resource.
@@ -6264,7 +6355,7 @@ type SerialPortOutput struct {
 	// compute#serialPortOutput for serial port output.
 	Kind string `json:"kind,omitempty"`
 
-	// SelfLink: [Output Only] Server defined URL for the resource.
+	// SelfLink: [Output Only] Server-defined URL for the resource.
 	SelfLink string `json:"selfLink,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -6346,7 +6437,8 @@ type Snapshot struct {
 	// SelfLink: [Output Only] Server-defined URL for the resource.
 	SelfLink string `json:"selfLink,omitempty"`
 
-	// SourceDisk: The source disk used to create this snapshot.
+	// SourceDisk: [Output Only] The source disk used to create this
+	// snapshot.
 	SourceDisk string `json:"sourceDisk,omitempty"`
 
 	// SourceDiskId: [Output Only] The ID value of the disk used to create
@@ -6404,7 +6496,7 @@ type SnapshotList struct {
 	// identifier is defined by the server.
 	Id string `json:"id,omitempty"`
 
-	// Items: A list of Snapshot resources.
+	// Items: [Output Only] A list of Snapshot resources.
 	Items []*Snapshot `json:"items,omitempty"`
 
 	// Kind: Type of resource.
@@ -6441,8 +6533,8 @@ func (s *SnapshotList) MarshalJSON() ([]byte, error) {
 }
 
 // SslCertificate: An SslCertificate resource. This resource provides a
-// mechanism to upload an SSL key and certificate to global HTTPS
-// loadbalancer to serve secure connections.
+// mechanism to upload an SSL key and certificate to the load balancer
+// to serve secure connections from the user.
 type SslCertificate struct {
 	// Certificate: A local certificate file. The certificate must be in PEM
 	// format. The certificate chain must be no greater than 5 certs long.
@@ -6538,6 +6630,258 @@ type SslCertificateList struct {
 
 func (s *SslCertificateList) MarshalJSON() ([]byte, error) {
 	type noMethod SslCertificateList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// Subnetwork: A Subnetwork resource.
+type Subnetwork struct {
+	// CreationTimestamp: [Output Only] Creation timestamp in RFC3339 text
+	// format.
+	CreationTimestamp string `json:"creationTimestamp,omitempty"`
+
+	// Description: An optional description of this resource. Provide this
+	// property when you create the resource.
+	Description string `json:"description,omitempty"`
+
+	// GatewayAddress: [Output Only] The gateway address for default routes
+	// to reach destination addresses outside this subnetwork.
+	GatewayAddress string `json:"gatewayAddress,omitempty"`
+
+	// Id: [Output Only] The unique identifier for the resource. This
+	// identifier is defined by the server.
+	Id uint64 `json:"id,omitempty,string"`
+
+	// IpCidrRange: The range of internal addresses that are owned by this
+	// subnetwork. Provide this property when you create the subnetwork. For
+	// example, 10.0.0.0/8 or 192.168.0.0/16. Ranges must be unique and
+	// non-overlapping within a network.
+	IpCidrRange string `json:"ipCidrRange,omitempty"`
+
+	// Kind: [Output Only] Type of the resource. Always compute#subnetwork
+	// for Subnetwork resources.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: The name of the resource, provided by the client when initially
+	// creating the resource. The name must be 1-63 characters long, and
+	// comply with RFC1035. Specifically, the name must be 1-63 characters
+	// long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?
+	// which means the first character must be a lowercase letter, and all
+	// following characters must be a dash, lowercase letter, or digit,
+	// except the last character, which cannot be a dash.
+	Name string `json:"name,omitempty"`
+
+	// Network: The URL of the network to which this subnetwork belongs,
+	// provided by the client when initially creating the subnetwork. Only
+	// networks that are in the distributed mode can have subnetworks.
+	Network string `json:"network,omitempty"`
+
+	// Region: [Output Only] URL of the region where the Subnetwork resides.
+	Region string `json:"region,omitempty"`
+
+	// SelfLink: [Output Only] Server-defined URL for the resource.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "CreationTimestamp")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Subnetwork) MarshalJSON() ([]byte, error) {
+	type noMethod Subnetwork
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+type SubnetworkAggregatedList struct {
+	// Id: [Output Only] The unique identifier for the resource. This
+	// identifier is defined by the server.
+	Id string `json:"id,omitempty"`
+
+	// Items: [Output] A map of scoped Subnetwork lists.
+	Items map[string]SubnetworksScopedList `json:"items,omitempty"`
+
+	// Kind: [Output Only] Type of resource. Always
+	// compute#subnetworkAggregatedList for aggregated lists of subnetworks.
+	Kind string `json:"kind,omitempty"`
+
+	// NextPageToken: [Output Only] This token allows you to get the next
+	// page of results for list requests. If the number of results is larger
+	// than maxResults, use the nextPageToken as a value for the query
+	// parameter pageToken in the next list request. Subsequent list
+	// requests will have their own nextPageToken to continue paging through
+	// the results.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// SelfLink: [Output Only] Server-defined URL for this resource.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Id") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SubnetworkAggregatedList) MarshalJSON() ([]byte, error) {
+	type noMethod SubnetworkAggregatedList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// SubnetworkList: Contains a list of Subnetwork resources.
+type SubnetworkList struct {
+	// Id: [Output Only] The unique identifier for the resource. This
+	// identifier is defined by the server.
+	Id string `json:"id,omitempty"`
+
+	// Items: The Subnetwork resources.
+	Items []*Subnetwork `json:"items,omitempty"`
+
+	// Kind: [Output Only] Type of resource. Always compute#subnetworkList
+	// for lists of subnetworks.
+	Kind string `json:"kind,omitempty"`
+
+	// NextPageToken: [Output Only] This token allows you to get the next
+	// page of results for list requests. If the number of results is larger
+	// than maxResults, use the nextPageToken as a value for the query
+	// parameter pageToken in the next list request. Subsequent list
+	// requests will have their own nextPageToken to continue paging through
+	// the results.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// SelfLink: [Output Only] Server-defined URL for this resource.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Id") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SubnetworkList) MarshalJSON() ([]byte, error) {
+	type noMethod SubnetworkList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+type SubnetworksScopedList struct {
+	// Subnetworks: List of subnetworks contained in this scope.
+	Subnetworks []*Subnetwork `json:"subnetworks,omitempty"`
+
+	// Warning: An informational warning that appears when the list of
+	// addresses is empty.
+	Warning *SubnetworksScopedListWarning `json:"warning,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Subnetworks") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SubnetworksScopedList) MarshalJSON() ([]byte, error) {
+	type noMethod SubnetworksScopedList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// SubnetworksScopedListWarning: An informational warning that appears
+// when the list of addresses is empty.
+type SubnetworksScopedListWarning struct {
+	// Code: [Output Only] A warning code, if applicable. For example,
+	// Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in
+	// the response.
+	//
+	// Possible values:
+	//   "DEPRECATED_RESOURCE_USED"
+	//   "DISK_SIZE_LARGER_THAN_IMAGE_SIZE"
+	//   "INJECTED_KERNELS_DEPRECATED"
+	//   "NEXT_HOP_ADDRESS_NOT_ASSIGNED"
+	//   "NEXT_HOP_CANNOT_IP_FORWARD"
+	//   "NEXT_HOP_INSTANCE_NOT_FOUND"
+	//   "NEXT_HOP_INSTANCE_NOT_ON_NETWORK"
+	//   "NEXT_HOP_NOT_RUNNING"
+	//   "NOT_CRITICAL_ERROR"
+	//   "NO_RESULTS_ON_PAGE"
+	//   "REQUIRED_TOS_AGREEMENT"
+	//   "RESOURCE_NOT_DELETED"
+	//   "SINGLE_INSTANCE_PROPERTY_TEMPLATE"
+	//   "UNREACHABLE"
+	Code string `json:"code,omitempty"`
+
+	// Data: [Output Only] Metadata about this warning in key: value format.
+	// For example:
+	// "data": [ { "key": "scope", "value": "zones/us-east1-d" }
+	Data []*SubnetworksScopedListWarningData `json:"data,omitempty"`
+
+	// Message: [Output Only] A human-readable description of the warning
+	// code.
+	Message string `json:"message,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Code") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SubnetworksScopedListWarning) MarshalJSON() ([]byte, error) {
+	type noMethod SubnetworksScopedListWarning
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+type SubnetworksScopedListWarningData struct {
+	// Key: [Output Only] A key that provides more detail on the warning
+	// being returned. For example, for warnings where there are no results
+	// in a list request for a particular zone, this key might be scope and
+	// the key value might be the zone name. Other examples might be a key
+	// indicating a deprecated resource, and a suggested replacement, or a
+	// warning about invalid network settings (for example, if an instance
+	// attempts to perform IP forwarding but is not enabled for IP
+	// forwarding).
+	Key string `json:"key,omitempty"`
+
+	// Value: [Output Only] A warning data value corresponding to the key.
+	Value string `json:"value,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Key") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SubnetworksScopedListWarningData) MarshalJSON() ([]byte, error) {
+	type noMethod SubnetworksScopedListWarningData
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields)
 }
@@ -6723,8 +7067,8 @@ type TargetHttpsProxy struct {
 	SelfLink string `json:"selfLink,omitempty"`
 
 	// SslCertificates: URLs to SslCertificate resources that are used to
-	// authenticate connections to Backends. Currently exactly one SSL
-	// certificate must be specified.
+	// authenticate connections between users and the load balancer.
+	// Currently exactly one SSL certificate must be specified.
 	SslCertificates []string `json:"sslCertificates,omitempty"`
 
 	// UrlMap: URL to the UrlMap resource that defines the mapping from URL
@@ -7984,8 +8328,10 @@ func (s *UrlMapsValidateResponse) MarshalJSON() ([]byte, error) {
 type UsageExportLocation struct {
 	// BucketName: The name of an existing bucket in Cloud Storage where the
 	// usage report object is stored. The Google Service Account is granted
-	// write access to this bucket. This is just the bucket name, with no
-	// gs:// or https://storage.googleapis.com/ in front of it.
+	// write access to this bucket. This can either be the bucket name by
+	// itself, such as example-bucket, or the bucket name with gs:// or
+	// https://storage.googleapis.com/ in front of it, such as
+	// gs://example-bucket.
 	BucketName string `json:"bucketName,omitempty"`
 
 	// ReportNamePrefix: An optional prefix for the name of the usage report
@@ -8037,6 +8383,12 @@ type VpnTunnel struct {
 	// VPN tunnels.
 	Kind string `json:"kind,omitempty"`
 
+	// LocalTrafficSelector: Local traffic selector to use when establishing
+	// the VPN tunnel with peer VPN gateway. The value should be a CIDR
+	// formatted string, for example: 192.168.0.0/16. The ranges should be
+	// disjoint.
+	LocalTrafficSelector []string `json:"localTrafficSelector,omitempty"`
+
 	// Name: Name of the resource; provided by the client when the resource
 	// is created. The name must be 1-63 characters long, and comply with
 	// RFC1035. Specifically, the name must be 1-63 characters long and
@@ -8056,7 +8408,7 @@ type VpnTunnel struct {
 	SelfLink string `json:"selfLink,omitempty"`
 
 	// SharedSecret: Shared secret used to set the secure session between
-	// the GCE VPN gateway and the peer VPN gateway.
+	// the Cloud VPN gateway and the peer VPN gateway.
 	SharedSecret string `json:"sharedSecret,omitempty"`
 
 	// SharedSecretHash: Hash of the shared secret.
@@ -8432,7 +8784,7 @@ type AddressesAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of addresses grouped by scope.
+// AggregatedList: Retrieves an aggregated list of addresses.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/addresses/aggregatedList
 func (r *AddressesService) AggregatedList(project string) *AddressesAggregatedListCall {
 	c := &AddressesAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -8573,7 +8925,7 @@ func (c *AddressesAggregatedListCall) Do(opts ...googleapi.CallOption) (*Address
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of addresses grouped by scope.",
+	//   "description": "Retrieves an aggregated list of addresses.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.addresses.aggregatedList",
 	//   "parameterOrder": [
@@ -8618,6 +8970,27 @@ func (c *AddressesAggregatedListCall) Do(opts ...googleapi.CallOption) (*Address
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *AddressesAggregatedListCall) Pages(ctx context.Context, f func(*AddressAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.addresses.delete":
@@ -9052,7 +9425,7 @@ type AddressesListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of address resources contained within the
+// List: Retrieves a list of address resources contained within the
 // specified region.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/addresses/list
 func (r *AddressesService) List(project string, region string) *AddressesListCall {
@@ -9196,7 +9569,7 @@ func (c *AddressesListCall) Do(opts ...googleapi.CallOption) (*AddressList, erro
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of address resources contained within the specified region.",
+	//   "description": "Retrieves a list of address resources contained within the specified region.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.addresses.list",
 	//   "parameterOrder": [
@@ -9251,6 +9624,27 @@ func (c *AddressesListCall) Do(opts ...googleapi.CallOption) (*AddressList, erro
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *AddressesListCall) Pages(ctx context.Context, f func(*AddressList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.autoscalers.aggregatedList":
 
 type AutoscalersAggregatedListCall struct {
@@ -9261,7 +9655,7 @@ type AutoscalersAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of autoscalers grouped by scope.
+// AggregatedList: Retrieves an aggregated list of autoscalers.
 func (r *AutoscalersService) AggregatedList(project string) *AutoscalersAggregatedListCall {
 	c := &AutoscalersAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.project = project
@@ -9401,7 +9795,7 @@ func (c *AutoscalersAggregatedListCall) Do(opts ...googleapi.CallOption) (*Autos
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of autoscalers grouped by scope.",
+	//   "description": "Retrieves an aggregated list of autoscalers.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.autoscalers.aggregatedList",
 	//   "parameterOrder": [
@@ -9446,6 +9840,27 @@ func (c *AutoscalersAggregatedListCall) Do(opts ...googleapi.CallOption) (*Autos
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *AutoscalersAggregatedListCall) Pages(ctx context.Context, f func(*AutoscalerAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.autoscalers.delete":
@@ -9877,7 +10292,7 @@ type AutoscalersListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of autoscaler resources contained within the
+// List: Retrieves a list of autoscaler resources contained within the
 // specified zone.
 func (r *AutoscalersService) List(project string, zone string) *AutoscalersListCall {
 	c := &AutoscalersListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -10020,7 +10435,7 @@ func (c *AutoscalersListCall) Do(opts ...googleapi.CallOption) (*AutoscalerList,
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of autoscaler resources contained within the specified zone.",
+	//   "description": "Retrieves a list of autoscaler resources contained within the specified zone.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.autoscalers.list",
 	//   "parameterOrder": [
@@ -10073,6 +10488,27 @@ func (c *AutoscalersListCall) Do(opts ...googleapi.CallOption) (*AutoscalerList,
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *AutoscalersListCall) Pages(ctx context.Context, f func(*AutoscalerList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.autoscalers.patch":
@@ -10778,7 +11214,9 @@ type BackendServicesInsertCall struct {
 }
 
 // Insert: Creates a BackendService resource in the specified project
-// using the data included in the request.
+// using the data included in the request. There are several
+// restrictions and guidelines to keep in mind when creating a backend
+// service. Read  Restrictions and Guidelines for more information.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/backendServices/insert
 func (r *BackendServicesService) Insert(project string, backendservice *BackendService) *BackendServicesInsertCall {
 	c := &BackendServicesInsertCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -10862,7 +11300,7 @@ func (c *BackendServicesInsertCall) Do(opts ...googleapi.CallOption) (*Operation
 	}
 	return ret, nil
 	// {
-	//   "description": "Creates a BackendService resource in the specified project using the data included in the request.",
+	//   "description": "Creates a BackendService resource in the specified project using the data included in the request. There are several restrictions and guidelines to keep in mind when creating a backend service. Read  Restrictions and Guidelines for more information.",
 	//   "httpMethod": "POST",
 	//   "id": "compute.backendServices.insert",
 	//   "parameterOrder": [
@@ -11091,6 +11529,27 @@ func (c *BackendServicesListCall) Do(opts ...googleapi.CallOption) (*BackendServ
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *BackendServicesListCall) Pages(ctx context.Context, f func(*BackendServiceList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.backendServices.patch":
 
 type BackendServicesPatchCall struct {
@@ -11102,8 +11561,10 @@ type BackendServicesPatchCall struct {
 	ctx_           context.Context
 }
 
-// Patch: Update the entire content of the BackendService resource. This
-// method supports patch semantics.
+// Patch: Updates the entire content of the BackendService resource.
+// There are several restrictions and guidelines to keep in mind when
+// updating a backend service. Read  Restrictions and Guidelines for
+// more information. This method supports patch semantics.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/backendServices/patch
 func (r *BackendServicesService) Patch(project string, backendService string, backendservice *BackendService) *BackendServicesPatchCall {
 	c := &BackendServicesPatchCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -11189,7 +11650,7 @@ func (c *BackendServicesPatchCall) Do(opts ...googleapi.CallOption) (*Operation,
 	}
 	return ret, nil
 	// {
-	//   "description": "Update the entire content of the BackendService resource. This method supports patch semantics.",
+	//   "description": "Updates the entire content of the BackendService resource. There are several restrictions and guidelines to keep in mind when updating a backend service. Read  Restrictions and Guidelines for more information. This method supports patch semantics.",
 	//   "httpMethod": "PATCH",
 	//   "id": "compute.backendServices.patch",
 	//   "parameterOrder": [
@@ -11238,7 +11699,10 @@ type BackendServicesUpdateCall struct {
 	ctx_           context.Context
 }
 
-// Update: Update the entire content of the BackendService resource.
+// Update: Updates the entire content of the BackendService resource.
+// There are several restrictions and guidelines to keep in mind when
+// updating a backend service. Read  Restrictions and Guidelines for
+// more information.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/backendServices/update
 func (r *BackendServicesService) Update(project string, backendService string, backendservice *BackendService) *BackendServicesUpdateCall {
 	c := &BackendServicesUpdateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -11324,7 +11788,7 @@ func (c *BackendServicesUpdateCall) Do(opts ...googleapi.CallOption) (*Operation
 	}
 	return ret, nil
 	// {
-	//   "description": "Update the entire content of the BackendService resource.",
+	//   "description": "Updates the entire content of the BackendService resource. There are several restrictions and guidelines to keep in mind when updating a backend service. Read  Restrictions and Guidelines for more information.",
 	//   "httpMethod": "PUT",
 	//   "id": "compute.backendServices.update",
 	//   "parameterOrder": [
@@ -11372,8 +11836,7 @@ type DiskTypesAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of disk type resources grouped by
-// scope.
+// AggregatedList: Retrieves an aggregated list of disk type resources.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/diskTypes/aggregatedList
 func (r *DiskTypesService) AggregatedList(project string) *DiskTypesAggregatedListCall {
 	c := &DiskTypesAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -11514,7 +11977,7 @@ func (c *DiskTypesAggregatedListCall) Do(opts ...googleapi.CallOption) (*DiskTyp
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of disk type resources grouped by scope.",
+	//   "description": "Retrieves an aggregated list of disk type resources.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.diskTypes.aggregatedList",
 	//   "parameterOrder": [
@@ -11559,6 +12022,27 @@ func (c *DiskTypesAggregatedListCall) Do(opts ...googleapi.CallOption) (*DiskTyp
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *DiskTypesAggregatedListCall) Pages(ctx context.Context, f func(*DiskTypeAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.diskTypes.get":
@@ -11722,7 +12206,7 @@ type DiskTypesListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of disk type resources available to the
+// List: Retrieves a list of disk type resources available to the
 // specified project.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/diskTypes/list
 func (r *DiskTypesService) List(project string, zone string) *DiskTypesListCall {
@@ -11866,7 +12350,7 @@ func (c *DiskTypesListCall) Do(opts ...googleapi.CallOption) (*DiskTypeList, err
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of disk type resources available to the specified project.",
+	//   "description": "Retrieves a list of disk type resources available to the specified project.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.diskTypes.list",
 	//   "parameterOrder": [
@@ -11921,6 +12405,27 @@ func (c *DiskTypesListCall) Do(opts ...googleapi.CallOption) (*DiskTypeList, err
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *DiskTypesListCall) Pages(ctx context.Context, f func(*DiskTypeList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.disks.aggregatedList":
 
 type DisksAggregatedListCall struct {
@@ -11931,8 +12436,7 @@ type DisksAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of persistent disks grouped by
-// scope.
+// AggregatedList: Retrieves an aggregated list of persistent disks.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/disks/aggregatedList
 func (r *DisksService) AggregatedList(project string) *DisksAggregatedListCall {
 	c := &DisksAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -12073,7 +12577,7 @@ func (c *DisksAggregatedListCall) Do(opts ...googleapi.CallOption) (*DiskAggrega
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of persistent disks grouped by scope.",
+	//   "description": "Retrieves an aggregated list of persistent disks.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.disks.aggregatedList",
 	//   "parameterOrder": [
@@ -12118,6 +12622,27 @@ func (c *DisksAggregatedListCall) Do(opts ...googleapi.CallOption) (*DiskAggrega
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *DisksAggregatedListCall) Pages(ctx context.Context, f func(*DiskAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.disks.createSnapshot":
@@ -12713,7 +13238,7 @@ type DisksListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of persistent disks contained within the
+// List: Retrieves a list of persistent disks contained within the
 // specified zone.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/disks/list
 func (r *DisksService) List(project string, zone string) *DisksListCall {
@@ -12857,7 +13382,7 @@ func (c *DisksListCall) Do(opts ...googleapi.CallOption) (*DiskList, error) {
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of persistent disks contained within the specified zone.",
+	//   "description": "Retrieves a list of persistent disks contained within the specified zone.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.disks.list",
 	//   "parameterOrder": [
@@ -12910,6 +13435,27 @@ func (c *DisksListCall) Do(opts ...googleapi.CallOption) (*DiskList, error) {
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *DisksListCall) Pages(ctx context.Context, f func(*DiskList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.firewalls.delete":
@@ -13499,6 +14045,27 @@ func (c *FirewallsListCall) Do(opts ...googleapi.CallOption) (*FirewallList, err
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *FirewallsListCall) Pages(ctx context.Context, f func(*FirewallList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.firewalls.patch":
 
 type FirewallsPatchCall struct {
@@ -13781,8 +14348,7 @@ type ForwardingRulesAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of forwarding rules grouped by
-// scope.
+// AggregatedList: Retrieves an aggregated list of forwarding rules.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/forwardingRules/aggregatedList
 func (r *ForwardingRulesService) AggregatedList(project string) *ForwardingRulesAggregatedListCall {
 	c := &ForwardingRulesAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -13923,7 +14489,7 @@ func (c *ForwardingRulesAggregatedListCall) Do(opts ...googleapi.CallOption) (*F
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of forwarding rules grouped by scope.",
+	//   "description": "Retrieves an aggregated list of forwarding rules.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.forwardingRules.aggregatedList",
 	//   "parameterOrder": [
@@ -13968,6 +14534,27 @@ func (c *ForwardingRulesAggregatedListCall) Do(opts ...googleapi.CallOption) (*F
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ForwardingRulesAggregatedListCall) Pages(ctx context.Context, f func(*ForwardingRuleAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.forwardingRules.delete":
@@ -14402,7 +14989,7 @@ type ForwardingRulesListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of ForwardingRule resources available to the
+// List: Retrieves a list of ForwardingRule resources available to the
 // specified project and region.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/forwardingRules/list
 func (r *ForwardingRulesService) List(project string, region string) *ForwardingRulesListCall {
@@ -14546,7 +15133,7 @@ func (c *ForwardingRulesListCall) Do(opts ...googleapi.CallOption) (*ForwardingR
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of ForwardingRule resources available to the specified project and region.",
+	//   "description": "Retrieves a list of ForwardingRule resources available to the specified project and region.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.forwardingRules.list",
 	//   "parameterOrder": [
@@ -14599,6 +15186,27 @@ func (c *ForwardingRulesListCall) Do(opts ...googleapi.CallOption) (*ForwardingR
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ForwardingRulesListCall) Pages(ctx context.Context, f func(*ForwardingRuleList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.forwardingRules.setTarget":
@@ -15146,7 +15754,7 @@ type GlobalAddressesListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of global address resources.
+// List: Retrieves a list of global address resources.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/globalAddresses/list
 func (r *GlobalAddressesService) List(project string) *GlobalAddressesListCall {
 	c := &GlobalAddressesListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -15287,7 +15895,7 @@ func (c *GlobalAddressesListCall) Do(opts ...googleapi.CallOption) (*AddressList
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of global address resources.",
+	//   "description": "Retrieves a list of global address resources.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.globalAddresses.list",
 	//   "parameterOrder": [
@@ -15332,6 +15940,27 @@ func (c *GlobalAddressesListCall) Do(opts ...googleapi.CallOption) (*AddressList
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *GlobalAddressesListCall) Pages(ctx context.Context, f func(*AddressList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.globalForwardingRules.delete":
@@ -15732,7 +16361,7 @@ type GlobalForwardingRulesListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of ForwardingRule resources available to the
+// List: Retrieves a list of ForwardingRule resources available to the
 // specified project.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/globalForwardingRules/list
 func (r *GlobalForwardingRulesService) List(project string) *GlobalForwardingRulesListCall {
@@ -15874,7 +16503,7 @@ func (c *GlobalForwardingRulesListCall) Do(opts ...googleapi.CallOption) (*Forwa
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of ForwardingRule resources available to the specified project.",
+	//   "description": "Retrieves a list of ForwardingRule resources available to the specified project.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.globalForwardingRules.list",
 	//   "parameterOrder": [
@@ -15919,6 +16548,27 @@ func (c *GlobalForwardingRulesListCall) Do(opts ...googleapi.CallOption) (*Forwa
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *GlobalForwardingRulesListCall) Pages(ctx context.Context, f func(*ForwardingRuleList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.globalForwardingRules.setTarget":
@@ -16067,8 +16717,7 @@ type GlobalOperationsAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of all operations grouped by
-// scope.
+// AggregatedList: Retrieves an aggregated list of all operations.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/globalOperations/aggregatedList
 func (r *GlobalOperationsService) AggregatedList(project string) *GlobalOperationsAggregatedListCall {
 	c := &GlobalOperationsAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -16209,7 +16858,7 @@ func (c *GlobalOperationsAggregatedListCall) Do(opts ...googleapi.CallOption) (*
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of all operations grouped by scope.",
+	//   "description": "Retrieves an aggregated list of all operations.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.globalOperations.aggregatedList",
 	//   "parameterOrder": [
@@ -16254,6 +16903,27 @@ func (c *GlobalOperationsAggregatedListCall) Do(opts ...googleapi.CallOption) (*
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *GlobalOperationsAggregatedListCall) Pages(ctx context.Context, f func(*OperationAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.globalOperations.delete":
@@ -16502,7 +17172,7 @@ type GlobalOperationsListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of Operation resources contained within the
+// List: Retrieves a list of Operation resources contained within the
 // specified project.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/globalOperations/list
 func (r *GlobalOperationsService) List(project string) *GlobalOperationsListCall {
@@ -16644,7 +17314,7 @@ func (c *GlobalOperationsListCall) Do(opts ...googleapi.CallOption) (*OperationL
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of Operation resources contained within the specified project.",
+	//   "description": "Retrieves a list of Operation resources contained within the specified project.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.globalOperations.list",
 	//   "parameterOrder": [
@@ -16689,6 +17359,27 @@ func (c *GlobalOperationsListCall) Do(opts ...googleapi.CallOption) (*OperationL
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *GlobalOperationsListCall) Pages(ctx context.Context, f func(*OperationList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.httpHealthChecks.delete":
@@ -17276,6 +17967,27 @@ func (c *HttpHealthChecksListCall) Do(opts ...googleapi.CallOption) (*HttpHealth
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *HttpHealthChecksListCall) Pages(ctx context.Context, f func(*HttpHealthCheckList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.httpHealthChecks.patch":
@@ -18132,6 +18844,27 @@ func (c *HttpsHealthChecksListCall) Do(opts ...googleapi.CallOption) (*HttpsHeal
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *HttpsHealthChecksListCall) Pages(ctx context.Context, f func(*HttpsHealthCheckList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.httpsHealthChecks.patch":
@@ -19140,6 +19873,27 @@ func (c *ImagesListCall) Do(opts ...googleapi.CallOption) (*ImageList, error) {
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ImagesListCall) Pages(ctx context.Context, f func(*ImageList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.instanceGroupManagers.abandonInstances":
 
 type InstanceGroupManagersAbandonInstancesCall struct {
@@ -19490,6 +20244,27 @@ func (c *InstanceGroupManagersAggregatedListCall) Do(opts ...googleapi.CallOptio
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *InstanceGroupManagersAggregatedListCall) Pages(ctx context.Context, f func(*InstanceGroupManagerAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.instanceGroupManagers.delete":
 
 type InstanceGroupManagersDeleteCall struct {
@@ -19502,7 +20277,9 @@ type InstanceGroupManagersDeleteCall struct {
 }
 
 // Delete: Deletes the specified managed instance group and all of the
-// instances in that group.
+// instances in that group. Note that the instance group must not belong
+// to a backend service. Read  Deleting an instance group for more
+// information.
 func (r *InstanceGroupManagersService) Delete(project string, zone string, instanceGroupManager string) *InstanceGroupManagersDeleteCall {
 	c := &InstanceGroupManagersDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.project = project
@@ -19582,7 +20359,7 @@ func (c *InstanceGroupManagersDeleteCall) Do(opts ...googleapi.CallOption) (*Ope
 	}
 	return ret, nil
 	// {
-	//   "description": "Deletes the specified managed instance group and all of the instances in that group.",
+	//   "description": "Deletes the specified managed instance group and all of the instances in that group. Note that the instance group must not belong to a backend service. Read  Deleting an instance group for more information.",
 	//   "httpMethod": "DELETE",
 	//   "id": "compute.instanceGroupManagers.delete",
 	//   "parameterOrder": [
@@ -20266,6 +21043,27 @@ func (c *InstanceGroupManagersListCall) Do(opts ...googleapi.CallOption) (*Insta
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *InstanceGroupManagersListCall) Pages(ctx context.Context, f func(*InstanceGroupManagerList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.instanceGroupManagers.listManagedInstances":
@@ -21011,8 +21809,7 @@ type InstanceGroupsAddInstancesCall struct {
 }
 
 // AddInstances: Adds a list of instances to the specified instance
-// group. All of the instances in the instance group must be in the same
-// network/subnetwork.
+// group. Read  Adding instances for more information.
 func (r *InstanceGroupsService) AddInstances(project string, zone string, instanceGroup string, instancegroupsaddinstancesrequest *InstanceGroupsAddInstancesRequest) *InstanceGroupsAddInstancesCall {
 	c := &InstanceGroupsAddInstancesCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.project = project
@@ -21099,7 +21896,7 @@ func (c *InstanceGroupsAddInstancesCall) Do(opts ...googleapi.CallOption) (*Oper
 	}
 	return ret, nil
 	// {
-	//   "description": "Adds a list of instances to the specified instance group. All of the instances in the instance group must be in the same network/subnetwork.",
+	//   "description": "Adds a list of instances to the specified instance group. Read  Adding instances for more information.",
 	//   "httpMethod": "POST",
 	//   "id": "compute.instanceGroups.addInstances",
 	//   "parameterOrder": [
@@ -21341,6 +22138,27 @@ func (c *InstanceGroupsAggregatedListCall) Do(opts ...googleapi.CallOption) (*In
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *InstanceGroupsAggregatedListCall) Pages(ctx context.Context, f func(*InstanceGroupAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.instanceGroups.delete":
 
 type InstanceGroupsDeleteCall struct {
@@ -21353,7 +22171,9 @@ type InstanceGroupsDeleteCall struct {
 }
 
 // Delete: Deletes the specified instance group. The instances in the
-// group are not deleted.
+// group are not deleted. Note that instance group must not belong to a
+// backend service. Read  Deleting an instance group for more
+// information.
 func (r *InstanceGroupsService) Delete(project string, zone string, instanceGroup string) *InstanceGroupsDeleteCall {
 	c := &InstanceGroupsDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.project = project
@@ -21433,7 +22253,7 @@ func (c *InstanceGroupsDeleteCall) Do(opts ...googleapi.CallOption) (*Operation,
 	}
 	return ret, nil
 	// {
-	//   "description": "Deletes the specified instance group. The instances in the group are not deleted.",
+	//   "description": "Deletes the specified instance group. The instances in the group are not deleted. Note that instance group must not belong to a backend service. Read  Deleting an instance group for more information.",
 	//   "httpMethod": "DELETE",
 	//   "id": "compute.instanceGroups.delete",
 	//   "parameterOrder": [
@@ -21961,6 +22781,27 @@ func (c *InstanceGroupsListCall) Do(opts ...googleapi.CallOption) (*InstanceGrou
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *InstanceGroupsListCall) Pages(ctx context.Context, f func(*InstanceGroupList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.instanceGroups.listInstances":
@@ -22738,7 +23579,10 @@ type InstanceTemplatesInsertCall struct {
 }
 
 // Insert: Creates an instance template in the specified project using
-// the data that is included in the request.
+// the data that is included in the request. If you are creating a new
+// template to update an existing instance group, your new instance
+// template must use the same network or, if applicable, the same
+// subnetwork as the original template.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/instanceTemplates/insert
 func (r *InstanceTemplatesService) Insert(project string, instancetemplate *InstanceTemplate) *InstanceTemplatesInsertCall {
 	c := &InstanceTemplatesInsertCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -22822,7 +23666,7 @@ func (c *InstanceTemplatesInsertCall) Do(opts ...googleapi.CallOption) (*Operati
 	}
 	return ret, nil
 	// {
-	//   "description": "Creates an instance template in the specified project using the data that is included in the request.",
+	//   "description": "Creates an instance template in the specified project using the data that is included in the request. If you are creating a new template to update an existing instance group, your new instance template must use the same network or, if applicable, the same subnetwork as the original template.",
 	//   "httpMethod": "POST",
 	//   "id": "compute.instanceTemplates.insert",
 	//   "parameterOrder": [
@@ -23049,6 +23893,27 @@ func (c *InstanceTemplatesListCall) Do(opts ...googleapi.CallOption) (*InstanceT
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *InstanceTemplatesListCall) Pages(ctx context.Context, f func(*InstanceTemplateList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.instances.addAccessConfig":
@@ -23402,6 +24267,27 @@ func (c *InstancesAggregatedListCall) Do(opts ...googleapi.CallOption) (*Instanc
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *InstancesAggregatedListCall) Pages(ctx context.Context, f func(*InstanceAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.instances.attachDisk":
@@ -24645,6 +25531,27 @@ func (c *InstancesListCall) Do(opts ...googleapi.CallOption) (*InstanceList, err
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *InstancesListCall) Pages(ctx context.Context, f func(*InstanceList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.instances.reset":
 
 type InstancesResetCall struct {
@@ -24922,6 +25829,152 @@ func (c *InstancesSetDiskAutoDeleteCall) Do(opts ...googleapi.CallOption) (*Oper
 	//     }
 	//   },
 	//   "path": "{project}/zones/{zone}/instances/{instance}/setDiskAutoDelete",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/compute"
+	//   ]
+	// }
+
+}
+
+// method id "compute.instances.setMachineType":
+
+type InstancesSetMachineTypeCall struct {
+	s                              *Service
+	project                        string
+	zone                           string
+	instance                       string
+	instancessetmachinetyperequest *InstancesSetMachineTypeRequest
+	urlParams_                     gensupport.URLParams
+	ctx_                           context.Context
+}
+
+// SetMachineType: Changes the machine type for a stopped instance to
+// the machine type specified in the request.
+func (r *InstancesService) SetMachineType(project string, zone string, instance string, instancessetmachinetyperequest *InstancesSetMachineTypeRequest) *InstancesSetMachineTypeCall {
+	c := &InstancesSetMachineTypeCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	c.zone = zone
+	c.instance = instance
+	c.instancessetmachinetyperequest = instancessetmachinetyperequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *InstancesSetMachineTypeCall) Fields(s ...googleapi.Field) *InstancesSetMachineTypeCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *InstancesSetMachineTypeCall) Context(ctx context.Context) *InstancesSetMachineTypeCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *InstancesSetMachineTypeCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.instancessetmachinetyperequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "{project}/zones/{zone}/instances/{instance}/setMachineType")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"project":  c.project,
+		"zone":     c.zone,
+		"instance": c.instance,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "compute.instances.setMachineType" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *InstancesSetMachineTypeCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Changes the machine type for a stopped instance to the machine type specified in the request.",
+	//   "httpMethod": "POST",
+	//   "id": "compute.instances.setMachineType",
+	//   "parameterOrder": [
+	//     "project",
+	//     "zone",
+	//     "instance"
+	//   ],
+	//   "parameters": {
+	//     "instance": {
+	//       "description": "Name of the instance scoping this request.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "project": {
+	//       "description": "Project ID for this request.",
+	//       "location": "path",
+	//       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "zone": {
+	//       "description": "The name of the zone for this request.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "{project}/zones/{zone}/instances/{instance}/setMachineType",
+	//   "request": {
+	//     "$ref": "InstancesSetMachineTypeRequest"
+	//   },
 	//   "response": {
 	//     "$ref": "Operation"
 	//   },
@@ -25384,9 +26437,9 @@ type InstancesStartCall struct {
 	ctx_       context.Context
 }
 
-// Start: This method starts an instance that was stopped using the
-// using the instances().stop method. For more information, see Restart
-// an instance.
+// Start: Starts an instance that was stopped using the using the
+// instances().stop method. For more information, see Restart an
+// instance.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/instances/start
 func (r *InstancesService) Start(project string, zone string, instance string) *InstancesStartCall {
 	c := &InstancesStartCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -25467,7 +26520,7 @@ func (c *InstancesStartCall) Do(opts ...googleapi.CallOption) (*Operation, error
 	}
 	return ret, nil
 	// {
-	//   "description": "This method starts an instance that was stopped using the using the instances().stop method. For more information, see Restart an instance.",
+	//   "description": "Starts an instance that was stopped using the using the instances().stop method. For more information, see Restart an instance.",
 	//   "httpMethod": "POST",
 	//   "id": "compute.instances.start",
 	//   "parameterOrder": [
@@ -25521,13 +26574,13 @@ type InstancesStopCall struct {
 	ctx_       context.Context
 }
 
-// Stop: This method stops a running instance, shutting it down cleanly,
-// and allows you to restart the instance at a later time. Stopped
-// instances do not incur per-minute, virtual machine usage charges
-// while they are stopped, but any resources that the virtual machine is
-// using, such as persistent disks and static IP addresses,will continue
-// to be charged until they are deleted. For more information, see
-// Stopping an instance.
+// Stop: Stops a running instance, shutting it down cleanly, and allows
+// you to restart the instance at a later time. Stopped instances do not
+// incur per-minute, virtual machine usage charges while they are
+// stopped, but any resources that the virtual machine is using, such as
+// persistent disks and static IP addresses, will continue to be charged
+// until they are deleted. For more information, see Stopping an
+// instance.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/instances/stop
 func (r *InstancesService) Stop(project string, zone string, instance string) *InstancesStopCall {
 	c := &InstancesStopCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -25608,7 +26661,7 @@ func (c *InstancesStopCall) Do(opts ...googleapi.CallOption) (*Operation, error)
 	}
 	return ret, nil
 	// {
-	//   "description": "This method stops a running instance, shutting it down cleanly, and allows you to restart the instance at a later time. Stopped instances do not incur per-minute, virtual machine usage charges while they are stopped, but any resources that the virtual machine is using, such as persistent disks and static IP addresses,will continue to be charged until they are deleted. For more information, see Stopping an instance.",
+	//   "description": "Stops a running instance, shutting it down cleanly, and allows you to restart the instance at a later time. Stopped instances do not incur per-minute, virtual machine usage charges while they are stopped, but any resources that the virtual machine is using, such as persistent disks and static IP addresses, will continue to be charged until they are deleted. For more information, see Stopping an instance.",
 	//   "httpMethod": "POST",
 	//   "id": "compute.instances.stop",
 	//   "parameterOrder": [
@@ -25800,8 +26853,8 @@ type MachineTypesAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of machine type resources grouped
-// by scope.
+// AggregatedList: Retrieves an aggregated list of machine type
+// resources.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/machineTypes/aggregatedList
 func (r *MachineTypesService) AggregatedList(project string) *MachineTypesAggregatedListCall {
 	c := &MachineTypesAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -25942,7 +26995,7 @@ func (c *MachineTypesAggregatedListCall) Do(opts ...googleapi.CallOption) (*Mach
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of machine type resources grouped by scope.",
+	//   "description": "Retrieves an aggregated list of machine type resources.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.machineTypes.aggregatedList",
 	//   "parameterOrder": [
@@ -25987,6 +27040,27 @@ func (c *MachineTypesAggregatedListCall) Do(opts ...googleapi.CallOption) (*Mach
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *MachineTypesAggregatedListCall) Pages(ctx context.Context, f func(*MachineTypeAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.machineTypes.get":
@@ -26150,7 +27224,7 @@ type MachineTypesListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of machine type resources available to the
+// List: Retrieves a list of machine type resources available to the
 // specified project.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/machineTypes/list
 func (r *MachineTypesService) List(project string, zone string) *MachineTypesListCall {
@@ -26294,7 +27368,7 @@ func (c *MachineTypesListCall) Do(opts ...googleapi.CallOption) (*MachineTypeLis
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of machine type resources available to the specified project.",
+	//   "description": "Retrieves a list of machine type resources available to the specified project.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.machineTypes.list",
 	//   "parameterOrder": [
@@ -26347,6 +27421,27 @@ func (c *MachineTypesListCall) Do(opts ...googleapi.CallOption) (*MachineTypeLis
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *MachineTypesListCall) Pages(ctx context.Context, f func(*MachineTypeList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.networks.delete":
@@ -26934,6 +28029,27 @@ func (c *NetworksListCall) Do(opts ...googleapi.CallOption) (*NetworkList, error
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *NetworksListCall) Pages(ctx context.Context, f func(*NetworkList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.projects.get":
@@ -27804,7 +28920,7 @@ func (c *RegionOperationsGetCall) Do(opts ...googleapi.CallOption) (*Operation, 
 	//       "type": "string"
 	//     },
 	//     "region": {
-	//       "description": "Name of the zone scoping this request.",
+	//       "description": "Name of the region scoping this request.",
 	//       "location": "path",
 	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
 	//       "required": true,
@@ -27835,7 +28951,7 @@ type RegionOperationsListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of Operation resources contained within the
+// List: Retrieves a list of Operation resources contained within the
 // specified region.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/regionOperations/list
 func (r *RegionOperationsService) List(project string, region string) *RegionOperationsListCall {
@@ -27979,7 +29095,7 @@ func (c *RegionOperationsListCall) Do(opts ...googleapi.CallOption) (*OperationL
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of Operation resources contained within the specified region.",
+	//   "description": "Retrieves a list of Operation resources contained within the specified region.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.regionOperations.list",
 	//   "parameterOrder": [
@@ -28032,6 +29148,27 @@ func (c *RegionOperationsListCall) Do(opts ...googleapi.CallOption) (*OperationL
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *RegionOperationsListCall) Pages(ctx context.Context, f func(*OperationList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.regions.get":
@@ -28370,6 +29507,27 @@ func (c *RegionsListCall) Do(opts ...googleapi.CallOption) (*RegionList, error) 
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *RegionsListCall) Pages(ctx context.Context, f func(*RegionList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.routes.delete":
@@ -28959,6 +30117,27 @@ func (c *RoutesListCall) Do(opts ...googleapi.CallOption) (*RouteList, error) {
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *RoutesListCall) Pages(ctx context.Context, f func(*RouteList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.snapshots.delete":
 
 type SnapshotsDeleteCall struct {
@@ -29425,6 +30604,27 @@ func (c *SnapshotsListCall) Do(opts ...googleapi.CallOption) (*SnapshotList, err
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *SnapshotsListCall) Pages(ctx context.Context, f func(*SnapshotList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.sslCertificates.delete":
@@ -30008,6 +31208,893 @@ func (c *SslCertificatesListCall) Do(opts ...googleapi.CallOption) (*SslCertific
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *SslCertificatesListCall) Pages(ctx context.Context, f func(*SslCertificateList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "compute.subnetworks.aggregatedList":
+
+type SubnetworksAggregatedListCall struct {
+	s            *Service
+	project      string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// AggregatedList: Retrieves an aggregated list of subnetworks.
+func (r *SubnetworksService) AggregatedList(project string) *SubnetworksAggregatedListCall {
+	c := &SubnetworksAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	return c
+}
+
+// Filter sets the optional parameter "filter": Sets a filter expression
+// for filtering listed resources, in the form filter={expression}. Your
+// {expression} must be in the format: field_name comparison_string
+// literal_string.
+//
+// The field_name is the name of the field you want to compare. Only
+// atomic field types are supported (string, number, boolean). The
+// comparison_string must be either eq (equals) or ne (not equals). The
+// literal_string is the string value to filter to. The literal value
+// must be valid for the type of field you are filtering by (string,
+// number, boolean). For string fields, the literal value is interpreted
+// as a regular expression using RE2 syntax. The literal value must
+// match the entire field.
+//
+// For example, filter=name ne example-instance.
+//
+// Compute Engine Beta API Only: If you use filtering in the Beta API,
+// you can also filter on nested fields. For example, you could filter
+// on instances that have set the scheduling.automaticRestart field to
+// true. In particular, use filtering on nested fields to take advantage
+// of instance labels to organize and filter results based on label
+// values.
+//
+// The Beta API also supports filtering on multiple expressions by
+// providing each separate expression within parentheses. For example,
+// (scheduling.automaticRestart eq true) (zone eq us-central1-f).
+// Multiple expressions are treated as AND expressions meaning that
+// resources must match all expressions to pass the filters.
+func (c *SubnetworksAggregatedListCall) Filter(filter string) *SubnetworksAggregatedListCall {
+	c.urlParams_.Set("filter", filter)
+	return c
+}
+
+// MaxResults sets the optional parameter "maxResults": The maximum
+// number of results per page that Compute Engine should return. If the
+// number of available results is larger than maxResults, Compute Engine
+// returns a nextPageToken that can be used to get the next page of
+// results in subsequent list requests.
+func (c *SubnetworksAggregatedListCall) MaxResults(maxResults int64) *SubnetworksAggregatedListCall {
+	c.urlParams_.Set("maxResults", fmt.Sprint(maxResults))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": Specifies a page
+// token to use. Set pageToken to the nextPageToken returned by a
+// previous list request to get the next page of results.
+func (c *SubnetworksAggregatedListCall) PageToken(pageToken string) *SubnetworksAggregatedListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *SubnetworksAggregatedListCall) Fields(s ...googleapi.Field) *SubnetworksAggregatedListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *SubnetworksAggregatedListCall) IfNoneMatch(entityTag string) *SubnetworksAggregatedListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *SubnetworksAggregatedListCall) Context(ctx context.Context) *SubnetworksAggregatedListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *SubnetworksAggregatedListCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "{project}/aggregated/subnetworks")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"project": c.project,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "compute.subnetworks.aggregatedList" call.
+// Exactly one of *SubnetworkAggregatedList or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *SubnetworkAggregatedList.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *SubnetworksAggregatedListCall) Do(opts ...googleapi.CallOption) (*SubnetworkAggregatedList, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &SubnetworkAggregatedList{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves an aggregated list of subnetworks.",
+	//   "httpMethod": "GET",
+	//   "id": "compute.subnetworks.aggregatedList",
+	//   "parameterOrder": [
+	//     "project"
+	//   ],
+	//   "parameters": {
+	//     "filter": {
+	//       "description": "Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.\n\nThe field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.\n\nFor example, filter=name ne example-instance.\n\nCompute Engine Beta API Only: If you use filtering in the Beta API, you can also filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. In particular, use filtering on nested fields to take advantage of instance labels to organize and filter results based on label values.\n\nThe Beta API also supports filtering on multiple expressions by providing each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions meaning that resources must match all expressions to pass the filters.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "maxResults": {
+	//       "default": "500",
+	//       "description": "The maximum number of results per page that Compute Engine should return. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.",
+	//       "format": "uint32",
+	//       "location": "query",
+	//       "maximum": "500",
+	//       "minimum": "0",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "project": {
+	//       "description": "Project ID for this request.",
+	//       "location": "path",
+	//       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "{project}/aggregated/subnetworks",
+	//   "response": {
+	//     "$ref": "SubnetworkAggregatedList"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/compute",
+	//     "https://www.googleapis.com/auth/compute.readonly"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *SubnetworksAggregatedListCall) Pages(ctx context.Context, f func(*SubnetworkAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "compute.subnetworks.delete":
+
+type SubnetworksDeleteCall struct {
+	s          *Service
+	project    string
+	region     string
+	subnetwork string
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+}
+
+// Delete: Deletes the specified subnetwork.
+func (r *SubnetworksService) Delete(project string, region string, subnetwork string) *SubnetworksDeleteCall {
+	c := &SubnetworksDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	c.region = region
+	c.subnetwork = subnetwork
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *SubnetworksDeleteCall) Fields(s ...googleapi.Field) *SubnetworksDeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *SubnetworksDeleteCall) Context(ctx context.Context) *SubnetworksDeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *SubnetworksDeleteCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "{project}/regions/{region}/subnetworks/{subnetwork}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"project":    c.project,
+		"region":     c.region,
+		"subnetwork": c.subnetwork,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "compute.subnetworks.delete" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *SubnetworksDeleteCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Deletes the specified subnetwork.",
+	//   "httpMethod": "DELETE",
+	//   "id": "compute.subnetworks.delete",
+	//   "parameterOrder": [
+	//     "project",
+	//     "region",
+	//     "subnetwork"
+	//   ],
+	//   "parameters": {
+	//     "project": {
+	//       "description": "Project ID for this request.",
+	//       "location": "path",
+	//       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "region": {
+	//       "description": "Name of the region scoping this request.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "subnetwork": {
+	//       "description": "Name of the Subnetwork resource to delete.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "{project}/regions/{region}/subnetworks/{subnetwork}",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/compute"
+	//   ]
+	// }
+
+}
+
+// method id "compute.subnetworks.get":
+
+type SubnetworksGetCall struct {
+	s            *Service
+	project      string
+	region       string
+	subnetwork   string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// Get: Returns the specified subnetwork.
+func (r *SubnetworksService) Get(project string, region string, subnetwork string) *SubnetworksGetCall {
+	c := &SubnetworksGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	c.region = region
+	c.subnetwork = subnetwork
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *SubnetworksGetCall) Fields(s ...googleapi.Field) *SubnetworksGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *SubnetworksGetCall) IfNoneMatch(entityTag string) *SubnetworksGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *SubnetworksGetCall) Context(ctx context.Context) *SubnetworksGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *SubnetworksGetCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "{project}/regions/{region}/subnetworks/{subnetwork}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"project":    c.project,
+		"region":     c.region,
+		"subnetwork": c.subnetwork,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "compute.subnetworks.get" call.
+// Exactly one of *Subnetwork or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Subnetwork.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *SubnetworksGetCall) Do(opts ...googleapi.CallOption) (*Subnetwork, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Subnetwork{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns the specified subnetwork.",
+	//   "httpMethod": "GET",
+	//   "id": "compute.subnetworks.get",
+	//   "parameterOrder": [
+	//     "project",
+	//     "region",
+	//     "subnetwork"
+	//   ],
+	//   "parameters": {
+	//     "project": {
+	//       "description": "Project ID for this request.",
+	//       "location": "path",
+	//       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "region": {
+	//       "description": "Name of the region scoping this request.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "subnetwork": {
+	//       "description": "Name of the Subnetwork resource to return.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "{project}/regions/{region}/subnetworks/{subnetwork}",
+	//   "response": {
+	//     "$ref": "Subnetwork"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/compute",
+	//     "https://www.googleapis.com/auth/compute.readonly"
+	//   ]
+	// }
+
+}
+
+// method id "compute.subnetworks.insert":
+
+type SubnetworksInsertCall struct {
+	s          *Service
+	project    string
+	region     string
+	subnetwork *Subnetwork
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+}
+
+// Insert: Creates a subnetwork in the specified project using the data
+// included in the request.
+func (r *SubnetworksService) Insert(project string, region string, subnetwork *Subnetwork) *SubnetworksInsertCall {
+	c := &SubnetworksInsertCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	c.region = region
+	c.subnetwork = subnetwork
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *SubnetworksInsertCall) Fields(s ...googleapi.Field) *SubnetworksInsertCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *SubnetworksInsertCall) Context(ctx context.Context) *SubnetworksInsertCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *SubnetworksInsertCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.subnetwork)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "{project}/regions/{region}/subnetworks")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"project": c.project,
+		"region":  c.region,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "compute.subnetworks.insert" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *SubnetworksInsertCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a subnetwork in the specified project using the data included in the request.",
+	//   "httpMethod": "POST",
+	//   "id": "compute.subnetworks.insert",
+	//   "parameterOrder": [
+	//     "project",
+	//     "region"
+	//   ],
+	//   "parameters": {
+	//     "project": {
+	//       "description": "Project ID for this request.",
+	//       "location": "path",
+	//       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "region": {
+	//       "description": "Name of the region scoping this request.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "{project}/regions/{region}/subnetworks",
+	//   "request": {
+	//     "$ref": "Subnetwork"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/compute"
+	//   ]
+	// }
+
+}
+
+// method id "compute.subnetworks.list":
+
+type SubnetworksListCall struct {
+	s            *Service
+	project      string
+	region       string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// List: Retrieves a list of subnetworks available to the specified
+// project.
+func (r *SubnetworksService) List(project string, region string) *SubnetworksListCall {
+	c := &SubnetworksListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	c.region = region
+	return c
+}
+
+// Filter sets the optional parameter "filter": Sets a filter expression
+// for filtering listed resources, in the form filter={expression}. Your
+// {expression} must be in the format: field_name comparison_string
+// literal_string.
+//
+// The field_name is the name of the field you want to compare. Only
+// atomic field types are supported (string, number, boolean). The
+// comparison_string must be either eq (equals) or ne (not equals). The
+// literal_string is the string value to filter to. The literal value
+// must be valid for the type of field you are filtering by (string,
+// number, boolean). For string fields, the literal value is interpreted
+// as a regular expression using RE2 syntax. The literal value must
+// match the entire field.
+//
+// For example, filter=name ne example-instance.
+//
+// Compute Engine Beta API Only: If you use filtering in the Beta API,
+// you can also filter on nested fields. For example, you could filter
+// on instances that have set the scheduling.automaticRestart field to
+// true. In particular, use filtering on nested fields to take advantage
+// of instance labels to organize and filter results based on label
+// values.
+//
+// The Beta API also supports filtering on multiple expressions by
+// providing each separate expression within parentheses. For example,
+// (scheduling.automaticRestart eq true) (zone eq us-central1-f).
+// Multiple expressions are treated as AND expressions meaning that
+// resources must match all expressions to pass the filters.
+func (c *SubnetworksListCall) Filter(filter string) *SubnetworksListCall {
+	c.urlParams_.Set("filter", filter)
+	return c
+}
+
+// MaxResults sets the optional parameter "maxResults": The maximum
+// number of results per page that Compute Engine should return. If the
+// number of available results is larger than maxResults, Compute Engine
+// returns a nextPageToken that can be used to get the next page of
+// results in subsequent list requests.
+func (c *SubnetworksListCall) MaxResults(maxResults int64) *SubnetworksListCall {
+	c.urlParams_.Set("maxResults", fmt.Sprint(maxResults))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": Specifies a page
+// token to use. Set pageToken to the nextPageToken returned by a
+// previous list request to get the next page of results.
+func (c *SubnetworksListCall) PageToken(pageToken string) *SubnetworksListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *SubnetworksListCall) Fields(s ...googleapi.Field) *SubnetworksListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *SubnetworksListCall) IfNoneMatch(entityTag string) *SubnetworksListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *SubnetworksListCall) Context(ctx context.Context) *SubnetworksListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *SubnetworksListCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "{project}/regions/{region}/subnetworks")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"project": c.project,
+		"region":  c.region,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "compute.subnetworks.list" call.
+// Exactly one of *SubnetworkList or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *SubnetworkList.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *SubnetworksListCall) Do(opts ...googleapi.CallOption) (*SubnetworkList, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &SubnetworkList{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves a list of subnetworks available to the specified project.",
+	//   "httpMethod": "GET",
+	//   "id": "compute.subnetworks.list",
+	//   "parameterOrder": [
+	//     "project",
+	//     "region"
+	//   ],
+	//   "parameters": {
+	//     "filter": {
+	//       "description": "Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.\n\nThe field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.\n\nFor example, filter=name ne example-instance.\n\nCompute Engine Beta API Only: If you use filtering in the Beta API, you can also filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. In particular, use filtering on nested fields to take advantage of instance labels to organize and filter results based on label values.\n\nThe Beta API also supports filtering on multiple expressions by providing each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions meaning that resources must match all expressions to pass the filters.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "maxResults": {
+	//       "default": "500",
+	//       "description": "The maximum number of results per page that Compute Engine should return. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.",
+	//       "format": "uint32",
+	//       "location": "query",
+	//       "maximum": "500",
+	//       "minimum": "0",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "project": {
+	//       "description": "Project ID for this request.",
+	//       "location": "path",
+	//       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "region": {
+	//       "description": "Name of the region scoping this request.",
+	//       "location": "path",
+	//       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "{project}/regions/{region}/subnetworks",
+	//   "response": {
+	//     "$ref": "SubnetworkList"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/compute",
+	//     "https://www.googleapis.com/auth/compute.readonly"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *SubnetworksListCall) Pages(ctx context.Context, f func(*SubnetworkList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.targetHttpProxies.delete":
@@ -30595,6 +32682,27 @@ func (c *TargetHttpProxiesListCall) Do(opts ...googleapi.CallOption) (*TargetHtt
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetHttpProxiesListCall) Pages(ctx context.Context, f func(*TargetHttpProxyList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.targetHttpProxies.setUrlMap":
@@ -31315,6 +33423,27 @@ func (c *TargetHttpsProxiesListCall) Do(opts ...googleapi.CallOption) (*TargetHt
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetHttpsProxiesListCall) Pages(ctx context.Context, f func(*TargetHttpsProxyList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.targetHttpsProxies.setSslCertificates":
 
 type TargetHttpsProxiesSetSslCertificatesCall struct {
@@ -31593,8 +33722,7 @@ type TargetInstancesAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of target instances grouped by
-// scope.
+// AggregatedList: Retrieves an aggregated list of target instances.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/targetInstances/aggregatedList
 func (r *TargetInstancesService) AggregatedList(project string) *TargetInstancesAggregatedListCall {
 	c := &TargetInstancesAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -31735,7 +33863,7 @@ func (c *TargetInstancesAggregatedListCall) Do(opts ...googleapi.CallOption) (*T
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of target instances grouped by scope.",
+	//   "description": "Retrieves an aggregated list of target instances.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.targetInstances.aggregatedList",
 	//   "parameterOrder": [
@@ -31780,6 +33908,27 @@ func (c *TargetInstancesAggregatedListCall) Do(opts ...googleapi.CallOption) (*T
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetInstancesAggregatedListCall) Pages(ctx context.Context, f func(*TargetInstanceAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.targetInstances.delete":
@@ -32214,7 +34363,7 @@ type TargetInstancesListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of TargetInstance resources available to the
+// List: Retrieves a list of TargetInstance resources available to the
 // specified project and zone.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/targetInstances/list
 func (r *TargetInstancesService) List(project string, zone string) *TargetInstancesListCall {
@@ -32358,7 +34507,7 @@ func (c *TargetInstancesListCall) Do(opts ...googleapi.CallOption) (*TargetInsta
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of TargetInstance resources available to the specified project and zone.",
+	//   "description": "Retrieves a list of TargetInstance resources available to the specified project and zone.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.targetInstances.list",
 	//   "parameterOrder": [
@@ -32411,6 +34560,27 @@ func (c *TargetInstancesListCall) Do(opts ...googleapi.CallOption) (*TargetInsta
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetInstancesListCall) Pages(ctx context.Context, f func(*TargetInstanceList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.targetPools.addHealthCheck":
@@ -32713,7 +34883,7 @@ type TargetPoolsAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of target pools grouped by scope.
+// AggregatedList: Retrieves an aggregated list of target pools.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/targetPools/aggregatedList
 func (r *TargetPoolsService) AggregatedList(project string) *TargetPoolsAggregatedListCall {
 	c := &TargetPoolsAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -32854,7 +35024,7 @@ func (c *TargetPoolsAggregatedListCall) Do(opts ...googleapi.CallOption) (*Targe
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of target pools grouped by scope.",
+	//   "description": "Retrieves an aggregated list of target pools.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.targetPools.aggregatedList",
 	//   "parameterOrder": [
@@ -32899,6 +35069,27 @@ func (c *TargetPoolsAggregatedListCall) Do(opts ...googleapi.CallOption) (*Targe
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetPoolsAggregatedListCall) Pages(ctx context.Context, f func(*TargetPoolAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.targetPools.delete":
@@ -33199,7 +35390,7 @@ type TargetPoolsGetHealthCall struct {
 }
 
 // GetHealth: Gets the most recent health check results for each IP for
-// the given instance that is referenced by given TargetPool.
+// the given instance that is referenced by the given TargetPool.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/targetPools/getHealth
 func (r *TargetPoolsService) GetHealth(project string, region string, targetPool string, instancereference *InstanceReference) *TargetPoolsGetHealthCall {
 	c := &TargetPoolsGetHealthCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -33287,7 +35478,7 @@ func (c *TargetPoolsGetHealthCall) Do(opts ...googleapi.CallOption) (*TargetPool
 	}
 	return ret, nil
 	// {
-	//   "description": "Gets the most recent health check results for each IP for the given instance that is referenced by given TargetPool.",
+	//   "description": "Gets the most recent health check results for each IP for the given instance that is referenced by the given TargetPool.",
 	//   "httpMethod": "POST",
 	//   "id": "compute.targetPools.getHealth",
 	//   "parameterOrder": [
@@ -33480,7 +35671,7 @@ type TargetPoolsListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of TargetPool resources available to the
+// List: Retrieves a list of TargetPool resources available to the
 // specified project and region.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/targetPools/list
 func (r *TargetPoolsService) List(project string, region string) *TargetPoolsListCall {
@@ -33624,7 +35815,7 @@ func (c *TargetPoolsListCall) Do(opts ...googleapi.CallOption) (*TargetPoolList,
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of TargetPool resources available to the specified project and region.",
+	//   "description": "Retrieves a list of TargetPool resources available to the specified project and region.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.targetPools.list",
 	//   "parameterOrder": [
@@ -33677,6 +35868,27 @@ func (c *TargetPoolsListCall) Do(opts ...googleapi.CallOption) (*TargetPoolList,
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetPoolsListCall) Pages(ctx context.Context, f func(*TargetPoolList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.targetPools.removeHealthCheck":
@@ -34138,8 +36350,7 @@ type TargetVpnGatewaysAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of target VPN gateways grouped by
-// scope.
+// AggregatedList: Retrieves an aggregated list of target VPN gateways .
 func (r *TargetVpnGatewaysService) AggregatedList(project string) *TargetVpnGatewaysAggregatedListCall {
 	c := &TargetVpnGatewaysAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.project = project
@@ -34279,7 +36490,7 @@ func (c *TargetVpnGatewaysAggregatedListCall) Do(opts ...googleapi.CallOption) (
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of target VPN gateways grouped by scope.",
+	//   "description": "Retrieves an aggregated list of target VPN gateways .",
 	//   "httpMethod": "GET",
 	//   "id": "compute.targetVpnGateways.aggregatedList",
 	//   "parameterOrder": [
@@ -34324,6 +36535,27 @@ func (c *TargetVpnGatewaysAggregatedListCall) Do(opts ...googleapi.CallOption) (
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetVpnGatewaysAggregatedListCall) Pages(ctx context.Context, f func(*TargetVpnGatewayAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.targetVpnGateways.delete":
@@ -34755,8 +36987,8 @@ type TargetVpnGatewaysListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of TargetVpnGateway resources available to
-// the specified project and region.
+// List: Retrieves a list of TargetVpnGateway resources available to the
+// specified project and region.
 func (r *TargetVpnGatewaysService) List(project string, region string) *TargetVpnGatewaysListCall {
 	c := &TargetVpnGatewaysListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.project = project
@@ -34898,7 +37130,7 @@ func (c *TargetVpnGatewaysListCall) Do(opts ...googleapi.CallOption) (*TargetVpn
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of TargetVpnGateway resources available to the specified project and region.",
+	//   "description": "Retrieves a list of TargetVpnGateway resources available to the specified project and region.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.targetVpnGateways.list",
 	//   "parameterOrder": [
@@ -34951,6 +37183,27 @@ func (c *TargetVpnGatewaysListCall) Do(opts ...googleapi.CallOption) (*TargetVpn
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *TargetVpnGatewaysListCall) Pages(ctx context.Context, f func(*TargetVpnGatewayList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.urlMaps.delete":
@@ -35540,6 +37793,27 @@ func (c *UrlMapsListCall) Do(opts ...googleapi.CallOption) (*UrlMapList, error) 
 
 }
 
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *UrlMapsListCall) Pages(ctx context.Context, f func(*UrlMapList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
 // method id "compute.urlMaps.patch":
 
 type UrlMapsPatchCall struct {
@@ -35551,7 +37825,7 @@ type UrlMapsPatchCall struct {
 	ctx_       context.Context
 }
 
-// Patch: Update the entire content of the UrlMap resource. This method
+// Patch: Updates the entire content of the UrlMap resource. This method
 // supports patch semantics.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/urlMaps/patch
 func (r *UrlMapsService) Patch(project string, urlMap string, urlmap *UrlMap) *UrlMapsPatchCall {
@@ -35638,7 +37912,7 @@ func (c *UrlMapsPatchCall) Do(opts ...googleapi.CallOption) (*Operation, error) 
 	}
 	return ret, nil
 	// {
-	//   "description": "Update the entire content of the UrlMap resource. This method supports patch semantics.",
+	//   "description": "Updates the entire content of the UrlMap resource. This method supports patch semantics.",
 	//   "httpMethod": "PATCH",
 	//   "id": "compute.urlMaps.patch",
 	//   "parameterOrder": [
@@ -35687,7 +37961,7 @@ type UrlMapsUpdateCall struct {
 	ctx_       context.Context
 }
 
-// Update: Update the entire content of the UrlMap resource.
+// Update: Updates the entire content of the UrlMap resource.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/urlMaps/update
 func (r *UrlMapsService) Update(project string, urlMap string, urlmap *UrlMap) *UrlMapsUpdateCall {
 	c := &UrlMapsUpdateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -35773,7 +38047,7 @@ func (c *UrlMapsUpdateCall) Do(opts ...googleapi.CallOption) (*Operation, error)
 	}
 	return ret, nil
 	// {
-	//   "description": "Update the entire content of the UrlMap resource.",
+	//   "description": "Updates the entire content of the UrlMap resource.",
 	//   "httpMethod": "PUT",
 	//   "id": "compute.urlMaps.update",
 	//   "parameterOrder": [
@@ -35822,7 +38096,7 @@ type UrlMapsValidateCall struct {
 	ctx_                   context.Context
 }
 
-// Validate: Run static validation for the UrlMap. In particular, the
+// Validate: Runs static validation for the UrlMap. In particular, the
 // tests of the provided UrlMap will be run. Calling this method does
 // NOT create the UrlMap.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/urlMaps/validate
@@ -35910,7 +38184,7 @@ func (c *UrlMapsValidateCall) Do(opts ...googleapi.CallOption) (*UrlMapsValidate
 	}
 	return ret, nil
 	// {
-	//   "description": "Run static validation for the UrlMap. In particular, the tests of the provided UrlMap will be run. Calling this method does NOT create the UrlMap.",
+	//   "description": "Runs static validation for the UrlMap. In particular, the tests of the provided UrlMap will be run. Calling this method does NOT create the UrlMap.",
 	//   "httpMethod": "POST",
 	//   "id": "compute.urlMaps.validate",
 	//   "parameterOrder": [
@@ -35958,7 +38232,7 @@ type VpnTunnelsAggregatedListCall struct {
 	ctx_         context.Context
 }
 
-// AggregatedList: Retrieves the list of VPN tunnels grouped by scope.
+// AggregatedList: Retrieves an aggregated list of VPN tunnels.
 func (r *VpnTunnelsService) AggregatedList(project string) *VpnTunnelsAggregatedListCall {
 	c := &VpnTunnelsAggregatedListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.project = project
@@ -36098,7 +38372,7 @@ func (c *VpnTunnelsAggregatedListCall) Do(opts ...googleapi.CallOption) (*VpnTun
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of VPN tunnels grouped by scope.",
+	//   "description": "Retrieves an aggregated list of VPN tunnels.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.vpnTunnels.aggregatedList",
 	//   "parameterOrder": [
@@ -36143,6 +38417,27 @@ func (c *VpnTunnelsAggregatedListCall) Do(opts ...googleapi.CallOption) (*VpnTun
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *VpnTunnelsAggregatedListCall) Pages(ctx context.Context, f func(*VpnTunnelAggregatedList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.vpnTunnels.delete":
@@ -36574,7 +38869,7 @@ type VpnTunnelsListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of VpnTunnel resources contained in the
+// List: Retrieves a list of VpnTunnel resources contained in the
 // specified project and region.
 func (r *VpnTunnelsService) List(project string, region string) *VpnTunnelsListCall {
 	c := &VpnTunnelsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
@@ -36717,7 +39012,7 @@ func (c *VpnTunnelsListCall) Do(opts ...googleapi.CallOption) (*VpnTunnelList, e
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of VpnTunnel resources contained in the specified project and region.",
+	//   "description": "Retrieves a list of VpnTunnel resources contained in the specified project and region.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.vpnTunnels.list",
 	//   "parameterOrder": [
@@ -36770,6 +39065,27 @@ func (c *VpnTunnelsListCall) Do(opts ...googleapi.CallOption) (*VpnTunnelList, e
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *VpnTunnelsListCall) Pages(ctx context.Context, f func(*VpnTunnelList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.zoneOperations.delete":
@@ -37041,7 +39357,7 @@ type ZoneOperationsListCall struct {
 	ctx_         context.Context
 }
 
-// List: Retrieves the list of Operation resources contained within the
+// List: Retrieves a list of Operation resources contained within the
 // specified zone.
 // For details, see https://cloud.google.com/compute/docs/reference/latest/zoneOperations/list
 func (r *ZoneOperationsService) List(project string, zone string) *ZoneOperationsListCall {
@@ -37185,7 +39501,7 @@ func (c *ZoneOperationsListCall) Do(opts ...googleapi.CallOption) (*OperationLis
 	}
 	return ret, nil
 	// {
-	//   "description": "Retrieves the list of Operation resources contained within the specified zone.",
+	//   "description": "Retrieves a list of Operation resources contained within the specified zone.",
 	//   "httpMethod": "GET",
 	//   "id": "compute.zoneOperations.list",
 	//   "parameterOrder": [
@@ -37238,6 +39554,27 @@ func (c *ZoneOperationsListCall) Do(opts ...googleapi.CallOption) (*OperationLis
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ZoneOperationsListCall) Pages(ctx context.Context, f func(*OperationList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }
 
 // method id "compute.zones.get":
@@ -37576,4 +39913,25 @@ func (c *ZonesListCall) Do(opts ...googleapi.CallOption) (*ZoneList, error) {
 	//   ]
 	// }
 
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ZonesListCall) Pages(ctx context.Context, f func(*ZoneList) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
 }

--- a/vendor/google.golang.org/api/gensupport/params.go
+++ b/vendor/google.golang.org/api/gensupport/params.go
@@ -14,6 +14,15 @@ import (
 // that safely builds up URL parameters for encoding.
 type URLParams map[string][]string
 
+// Get returns the first value for the given key, or "".
+func (u URLParams) Get(key string) string {
+	vs := u[key]
+	if len(vs) == 0 {
+		return ""
+	}
+	return vs[0]
+}
+
 // Set sets the key to value.
 // It replaces any existing values.
 func (u URLParams) Set(key, value string) {

--- a/vendor/google.golang.org/api/googleapi/googleapi.go
+++ b/vendor/google.golang.org/api/googleapi/googleapi.go
@@ -4,7 +4,7 @@
 
 // Package googleapi contains the common code shared by all Google API
 // libraries.
-package googleapi
+package googleapi // import "google.golang.org/api/googleapi"
 
 import (
 	"bytes"

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -120,7 +120,12 @@ the type is "local-ssd", in which case scratch must be true).
 
 The `network_interface` block supports:
 
-* `network` - (Required) The name of the network to attach this interface to.
+* `network` - (Optional) The name of the network to attach this interface to. Either
+    `network` or `subnetwork` must be provided.
+    
+*  `subnetwork` - (Optional) the name of the subnetwork to attach this interface to. The subnetwork
+     must exist in the same region this instance is to be created in. Either `network`
+     or `subnetwork` must be provided.
 
 * `access_config` - (Optional) Access configurations, i.e. IPs via which this instance can be
   accessed via the Internet.  Omit to ensure that the instance is not accessible from the Internet

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -124,7 +124,7 @@ The `network_interface` block supports:
     `network` or `subnetwork` must be provided.
     
 *  `subnetwork` - (Optional) the name of the subnetwork to attach this interface to. The subnetwork
-     must exist in the same region this instance is to be created in. Either `network`
+     must exist in the same region this instance will be created in. Either `network`
      or `subnetwork` must be provided.
 
 * `access_config` - (Optional) Access configurations, i.e. IPs via which this instance can be

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -137,7 +137,12 @@ The `disk` block supports:
 
 The `network_interface` block supports:
 
-* `network` - (Required) The name of the network to attach this interface to.
+* `network` - (Optional) The name of the network to attach this interface to. Only use `network`
+   attribute for Legacy or Auto subnetted networks, otherwise use `subnetwork` instead.
+
+* `subnetwork` - (Optional) the name of the subnetwork to attach this interface to. The subnetwork
+   must exist in the same region this instance will be created in. Either `network`
+   or `subnetwork` must be provided.
 
 * `access_config` - (Optional) Access configurations, i.e. IPs via which this instance can be
   accessed via the Internet.  Omit to ensure that the instance is not accessible from the Internet

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -85,6 +85,12 @@ The following arguments are supported:
 * `network_interface` - (Required) Networks to attach to instances created from this template.
  	This can be specified multiple times for multiple networks. Structure is
 	documented below.
+	
+* `region` - (Optional) An instance template is a global resource that is not bound to a zone 
+    or a region. However, you can still specify some regional resources in an instance template, 
+    which restricts the template to the region where that resource resides. For example, a
+    custom `subnetwork` resource is tied to a specific region.
+    Defaults to the region of the Provider if no value is given.
 
 * `automatic_restart` - (Optional, Deprecated - see `scheduling`) 
 	Specifies whether the instance should be
@@ -137,11 +143,12 @@ The `disk` block supports:
 
 The `network_interface` block supports:
 
-* `network` - (Optional) The name of the network to attach this interface to. Only use `network`
-   attribute for Legacy or Auto subnetted networks, otherwise use `subnetwork` instead.
+* `network` - (Optional) The name of the network to attach this interface to. Use `network`
+   attribute for Legacy or Auto subnetted networks and `subnetwork` for custom subnetted
+   networks.
 
 * `subnetwork` - (Optional) the name of the subnetwork to attach this interface to. The subnetwork
-   must exist in the same region this instance will be created in. Either `network`
+   must exist in the same `region` this instance will be created in. Either `network`
    or `subnetwork` must be provided.
 
 * `access_config` - (Optional) Access configurations, i.e. IPs via which this instance can be

--- a/website/source/docs/providers/google/r/compute_network.html.markdown
+++ b/website/source/docs/providers/google/r/compute_network.html.markdown
@@ -26,8 +26,17 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `ipv4_range` - (Required) The IPv4 address range that machines in this
-     network are assigned to, represented as a CIDR block.
+* `ipv4_range` - (Optional) The IPv4 address range that machines in this
+     network are assigned to, represented as a CIDR block. If not
+     set, an auto or custom subnetted network will be created, depending
+     on the value of `auto_create_subnetworks` attribute.
+     
+* `auto_create_subnetworks` - (Optional) If set to true, this network 
+     will be created in auto subnet mode, and Google will create a
+     subnet for each region automatically.
+     If set to false, and `ipv4_range` is not set, a custom subnetted
+     network will be created that can support `google_compute_subnetwork`
+     resources.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/google/r/compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/r/compute_subnetwork.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "google"
+page_title: "Google: google_compute_subnetwork"
+sidebar_current: "docs-google-compute-subnetwork"
+description: |-
+  Manages a subnetwork within GCE.
+---
+
+# google\_compute\_subnetwork
+
+Manages a subnetwork within GCE.
+
+## Example Usage
+
+```
+resource "google_compute_subnetwork" "default-us-east1" {
+	name = "default-us-east1"
+	ip_cidr_range = "10.0.0.0/16"
+	network = "${google_compute_network.default.self_link}"
+	region = "us-east1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by GCE.
+    Changing this forces a new resource to be created.
+
+* `network` - (Required) A link to the parent network of this subnetwork.
+     The parent network must have been created in custom subnet mode.
+
+* `ip_cidr_range` - (Required) The IP address range that machines in this
+     network are assigned to, represented as a CIDR block.
+     
+* `region` - (Required) The region this subnetwork will be created in. 
+
+* `description` - (Optional) Description of this subnetwork.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the resource.
+* `ip_cidr_range` - The CIDR block of this network.
+* `gateway_address` - The IP address of the gateway.

--- a/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
+++ b/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
@@ -102,6 +102,10 @@ The following arguments are supported:
 
 * `ike_version` - (Optional) Either version 1 or 2. Default is 2.
     Changing this forces a new resource to be created.
+    
+* `local_traffic_selector` - (Optional) Specifies which CIDR ranges are announced
+    to the VPN peer. Mandatory if the VPN gateway is attached to a custom subnetted
+    network. Refer to Google documentation for more information.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add support for Google's new subnetted networks, which is the default going forward:
https://cloud.google.com/compute/docs/subnetworks

- [x] update `google_compute_network` resource to allow creation of auto subnetted and custom subnetted networks
- [x] add `google_compute_subnetwork` resource 
- [x] update other google compute resources that may need to reference a subnetwork
- [x] update docs
- [x] update acceptance tests