### PR TITLE
provider/aws: Add support for CloudTrail tags

### DIFF
--- a/builtin/providers/aws/tagsCloudtrail.go
+++ b/builtin/providers/aws/tagsCloudtrail.go
@@ -1,0 +1,92 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudtrail"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsCloudtrail(conn *cloudtrail.CloudTrail, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsCloudtrail(tagsFromMapCloudtrail(o), tagsFromMapCloudtrail(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			input := cloudtrail.RemoveTagsInput{
+				ResourceId: aws.String(d.Get("arn").(string)),
+				TagsList:   remove,
+			}
+			log.Printf("[DEBUG] Removing CloudTrail tags: %s", input)
+			_, err := conn.RemoveTags(&input)
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			input := cloudtrail.AddTagsInput{
+				ResourceId: aws.String(d.Get("arn").(string)),
+				TagsList:   create,
+			}
+			log.Printf("[DEBUG] Adding CloudTrail tags: %s", input)
+			_, err := conn.AddTags(&input)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsCloudtrail(oldTags, newTags []*cloudtrail.Tag) ([]*cloudtrail.Tag, []*cloudtrail.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*cloudtrail.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapCloudtrail(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapCloudtrail(m map[string]interface{}) []*cloudtrail.Tag {
+	var result []*cloudtrail.Tag
+	for k, v := range m {
+		result = append(result, &cloudtrail.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapCloudtrail(ts []*cloudtrail.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		result[*t.Key] = *t.Value
+	}
+
+	return result
+}

--- a/builtin/providers/aws/tagsCloudtrail_test.go
+++ b/builtin/providers/aws/tagsCloudtrail_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudtrail"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDiffCloudtrailTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsCloudtrail(tagsFromMapCloudtrail(tc.Old), tagsFromMapCloudtrail(tc.New))
+		cm := tagsToMapCloudtrail(c)
+		rm := tagsToMapCloudtrail(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// testAccCheckCloudTrailCheckTags can be used to check the tags on a trail
+func testAccCheckCloudTrailCheckTags(tags *[]*cloudtrail.Tag, expectedTags map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !reflect.DeepEqual(expectedTags, tagsToMapCloudtrail(*tags)) {
+			return fmt.Errorf("Tags mismatch.\nExpected: %#v\nGiven: %#v",
+				expectedTags, tagsToMapCloudtrail(*tags))
+		}
+		return nil
+	}
+}

--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -78,6 +78,7 @@ The following arguments are supported:
 * `enable_log_file_validation` - (Optional) Specifies whether log file integrity validation is enabled.
     Defaults to `false`.
 * `kms_key_id` - (Optional) Specifies the KMS key ID to use to encrypt the logs delivered by CloudTrail.
+* `tags` - (Optional) A mapping of tags to assign to the trail
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Acceptance tests
```sh
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSCloudtrail'
```