### PR TITLE
Force ECR region

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -232,7 +232,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.ec2conn = ec2.New(awsEc2Sess)
 
 		log.Println("[INFO] Initializing ECR Connection")
-		client.ecrconn = ecr.New(sess)
+		client.ecrconn = ecr.New(sess, &aws.Config{Region: aws.String("us-east-1")})
 
 		log.Println("[INFO] Initializing ECS Connection")
 		client.ecsconn = ecs.New(sess)


### PR DESCRIPTION
As ECR is currently available only in a certain region.
However the cluster itself might not be in the same region as ECR, which leads to issues.
For now, this fixes the issue, at least until ECR will be available in another region when this will break.
This fixes #5137 