### PR TITLE
provider/aws: Return an error if no route is found for an AWS Route

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -322,5 +322,7 @@ func findResourceRoute(conn *ec2.EC2, rtbid string, cidr string) (*ec2.Route, er
 		}
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf(`
+error finding matching route for Route table (%s) and destination CIDR block (%s)`,
+		rtbid, cidr)
 }


### PR DESCRIPTION
When creating an AWS Route, we do an immediate lookup based on the Table ID and the CIDR Block. The code for this does some initial error checking, however it simply returns `nil` if nothing is found.

This PR patches that by returning an error if no error happens in the call, and no subsequent record is actually found. This should address #5097 and #5092 

/cc @RevCBH because he mentioned he may look into this