### PR TITLE
fix: Return non-aws errors if bucket creation fails

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -219,8 +219,11 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("[WARN] Error creating S3 bucket %s, retrying: %s",
 					bucket, err)
 			}
+		}
+		if err != nil {
 			return resource.RetryError{Err: err}
 		}
+
 		return nil
 	})
 


### PR DESCRIPTION
With the current version of code, any error that we'd be unable to cast to `awserr.Error` is ignored.

This was unintentionally introduced by myself in recently merged https://github.com/hashicorp/terraform/pull/4826

### Test plan

```sh
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSS3Bucket'
```
```
==> Checking that code complies with gofmt requirements...
/Users/radek/gopath/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run=AWSS3Bucket -timeout 120m
=== RUN   TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_source (19.12s)
=== RUN   TestAccAWSS3BucketObject_content
--- PASS: TestAccAWSS3BucketObject_content (18.43s)
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (18.97s)
=== RUN   TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_basic (18.83s)
=== RUN   TestAccAWSS3Bucket_Policy
--- PASS: TestAccAWSS3Bucket_Policy (37.46s)
=== RUN   TestAccAWSS3Bucket_UpdateAcl
--- PASS: TestAccAWSS3Bucket_UpdateAcl (32.08s)
=== RUN   TestAccAWSS3Bucket_Website_Simple
--- PASS: TestAccAWSS3Bucket_Website_Simple (47.47s)
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (47.18s)
=== RUN   TestAccAWSS3Bucket_shouldFailNotFound
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (11.46s)
=== RUN   TestAccAWSS3Bucket_Versioning
--- PASS: TestAccAWSS3Bucket_Versioning (47.10s)
=== RUN   TestAccAWSS3Bucket_Cors
--- PASS: TestAccAWSS3Bucket_Cors (19.28s)
=== RUN   TestAccAWSS3Bucket_Logging
--- PASS: TestAccAWSS3Bucket_Logging (29.67s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	347.078s
```

If we merge it before the next release, I think it doesn't even need to be mentioned in the Changelog.