### PR TITLE
Add hint to download modules for new users.

### DIFF
--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -163,7 +163,7 @@ func (t *Tree) Load(s getter.Storage, mode GetMode) error {
 		}
 		if !ok {
 			return fmt.Errorf(
-				"module %s: not found, may need to be downloaded", m.Name)
+				"module %s: not found, may need to be downloaded using 'terraform get'", m.Name)
 		}
 
 		// If we have a subdirectory, then merge that in


### PR DESCRIPTION
Trivial change.  I am starting on a project using Terraform, and on my first run through was given the warning "module %s: not found, may need to be downloaded".  Googling returned issue https://github.com/hashicorp/terraform/issues/706.  The site has been updated, maybe adding this small hint to the code would nudge new users in the right direction faster.  Maybe not, please close it if it's not useful.  Thanks, jz