### PR TITLE
Use new link ldflags syntax

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ echo "==> Building..."
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
-    -ldflags "-X=main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}" \
     -output "pkg/{{.OS}}_{{.Arch}}/terraform-{{.Dir}}" \
     $(go list ./... | grep -v /vendor/)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ echo "==> Building..."
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
-    -ldflags "-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "-X=main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
     -output "pkg/{{.OS}}_{{.Arch}}/terraform-{{.Dir}}" \
     $(go list ./... | grep -v /vendor/)
 


### PR DESCRIPTION
While trying to upgrade to use Go, I came across this error:

```
link: warning: option -X main.GitCommit $WORK/github.com/hashicorp/terraform/builtin/bins/provider-digitalocean.a may not work in future releases; use -X main.GitCommit=/tmp/go-build115042645/github.com/hashicorp/terraform/builtin/bins/provider-digitalocean.a
```

which causes the build to fail completely. https://github.com/golang/go/issues/12338 talks about the error, and highlights that the old options may be removed in go 1.7