### PR TITLE
Enable `go vet` on Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - echo noop
 
 script:
-  - make test
+  - make test vet
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TEST?=$$(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
-VETARGS?=-asmdecl -atomic -bool -buildtags -composites -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unreachable -unsafeptr -unusedresult
+VETARGS?=-all
 
 default: test
 


### PR DESCRIPTION
A follow up to #5172 and #5122 that enables all `go vet` warnings by default and runs the target during Travis CI builds.

cc: @jen20, @phinze 