### PR TITLE
provider/aws: Update IAM Server Cert

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_server_certificate.go
+++ b/builtin/providers/aws/resource_aws_iam_server_certificate.go
@@ -58,9 +58,9 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if len(value) > 255 {
+					if len(value) > 128 {
 						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 255 characters", k))
+							"%q cannot be longer than 128 characters", k))
 					}
 					return
 				},
@@ -72,9 +72,9 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if len(value) > 100 {
+					if len(value) > 30 {
 						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 100 characters, name is limited to 128", k))
+							"%q cannot be longer than 30 characters, name is limited to 128", k))
 					}
 					return
 				},

--- a/builtin/providers/aws/resource_aws_iam_server_certificate.go
+++ b/builtin/providers/aws/resource_aws_iam_server_certificate.go
@@ -51,9 +51,33 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 			},
 
 			"name": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 255 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 255 characters", k))
+					}
+					return
+				},
+			},
+
+			"name_prefix": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) > 100 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 100 characters, name is limited to 128", k))
+					}
+					return
+				},
 			},
 
 			"arn": &schema.Schema{
@@ -68,10 +92,19 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 func resourceAwsIAMServerCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).iamconn
 
+	var sslCertName string
+	if v, ok := d.GetOk("name"); ok {
+		sslCertName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		sslCertName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		sslCertName = resource.UniqueId()
+	}
+
 	createOpts := &iam.UploadServerCertificateInput{
 		CertificateBody:       aws.String(d.Get("certificate_body").(string)),
 		PrivateKey:            aws.String(d.Get("private_key").(string)),
-		ServerCertificateName: aws.String(d.Get("name").(string)),
+		ServerCertificateName: aws.String(sslCertName),
 	}
 
 	if v, ok := d.GetOk("certificate_chain"); ok {
@@ -92,6 +125,7 @@ func resourceAwsIAMServerCertificateCreate(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(*resp.ServerCertificateMetadata.ServerCertificateId)
+	d.Set("name", sslCertName)
 
 	return resourceAwsIAMServerCertificateRead(d, meta)
 }
@@ -135,7 +169,8 @@ func resourceAwsIAMServerCertificateDelete(d *schema.ResourceData, meta interfac
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if awsErr.Code() == "DeleteConflict" && strings.Contains(awsErr.Message(), "currently in use by arn") {
-					return fmt.Errorf("[WARN] Conflict deleting server certificate: %s, retrying", awsErr.Message())
+					log.Printf("[WARN] Conflict deleting server certificate: %s, retrying", awsErr.Message())
+					return err
 				}
 			}
 			return resource.RetryError{Err: err}

--- a/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
+++ b/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
@@ -32,6 +32,25 @@ func TestAccAWSIAMServerCertificate_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
+	var cert iam.ServerCertificate
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMServerCertConfig_random,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
+					testAccCheckAWSServerCertAttributes(&cert),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCertExists(n string, cert *iam.ServerCertificate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -60,7 +79,7 @@ func testAccCheckCertExists(n string, cert *iam.ServerCertificate) resource.Test
 
 func testAccCheckAWSServerCertAttributes(cert *iam.ServerCertificate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if !strings.HasPrefix(*cert.ServerCertificateMetadata.ServerCertificateName, "terraform-test-cert") {
+		if !strings.Contains(*cert.ServerCertificateMetadata.ServerCertificateName, "terraform-test-cert") {
 			return fmt.Errorf("Bad Server Cert Name: %s", *cert.ServerCertificateMetadata.ServerCertificateName)
 		}
 
@@ -189,3 +208,75 @@ O57Z0RUNQ8DRyymhLd2t5nAHTfpcFA1sBeKE6CziLbZB
 EOF
 }
 `, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+
+var testAccIAMServerCertConfig_random = `
+resource "aws_iam_server_certificate" "test_cert" {
+  name_prefix = "terraform-test-cert"
+  certificate_body = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDCDCCAfACAQEwDQYJKoZIhvcNAQELBQAwgY4xCzAJBgNVBAYTAlVTMREwDwYD
+VQQIDAhOZXcgWW9yazERMA8GA1UEBwwITmV3IFlvcmsxFjAUBgNVBAoMDUJhcmVm
+b290IExhYnMxGDAWBgNVBAMMD0phc29uIEJlcmxpbnNreTEnMCUGCSqGSIb3DQEJ
+ARYYamFzb25AYmFyZWZvb3Rjb2RlcnMuY29tMB4XDTE1MDYyMTA1MzcwNVoXDTE2
+MDYyMDA1MzcwNVowgYgxCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhOZXcgWW9yazEL
+MAkGA1UEBwwCTlkxFjAUBgNVBAoMDUJhcmVmb290IExhYnMxGDAWBgNVBAMMD0ph
+c29uIEJlcmxpbnNreTEnMCUGCSqGSIb3DQEJARYYamFzb25AYmFyZWZvb3Rjb2Rl
+cnMuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD2AVGKRIx+EFM0kkg7
+6GoJv9uy0biEDHB4phQBqnDIf8J8/gq9eVvQrR5jJC9Uz4zp5wG/oLZlGuF92/jD
+bI/yS+DOAjrh30vN79Au74jGN2Cw8fIak40iDUwjZaczK2Gkna54XIO9pqMcbQ6Q
+mLUkQXsqlJ7Q4X2kL3b9iMsXcQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCDGNvU
+eioQMVPNlmmxW3+Rwo0Kl+/HtUOmqUDKUDvJnelxulBr7O8w75N/Z7h7+aBJCUkt
+tz+DwATZswXtsal6TuzHHpAhpFql82jQZVE8OYkrX84XKRQpm8ZnbyZObMdXTJWk
+ArC/rGVIWsvhlbgGM8zu7a3zbeuAESZ8Bn4ZbJxnoaRK8p36/alvzAwkgzSf3oUX
+HtU4LrdunevBs6/CbKCWrxYcvNCy8EcmHitqCfQL5nxCCXpgf/Mw1vmIPTwbPSJq
+oUkh5yjGRKzhh7QbG1TlFX6zUp4vb+UJn5+g4edHrqivRSjIqYrC45ygVMOABn21
+hpMXOlZL+YXfR4Kp
+-----END CERTIFICATE-----
+EOF
+
+  certificate_chain = <<EOF
+-----BEGIN CERTIFICATE-----
+MIID8TCCAtmgAwIBAgIJAKX2xeCkfFcbMA0GCSqGSIb3DQEBCwUAMIGOMQswCQYD
+VQQGEwJVUzERMA8GA1UECAwITmV3IFlvcmsxETAPBgNVBAcMCE5ldyBZb3JrMRYw
+FAYDVQQKDA1CYXJlZm9vdCBMYWJzMRgwFgYDVQQDDA9KYXNvbiBCZXJsaW5za3kx
+JzAlBgkqhkiG9w0BCQEWGGphc29uQGJhcmVmb290Y29kZXJzLmNvbTAeFw0xNTA2
+MjEwNTM2MDZaFw0yNTA2MTgwNTM2MDZaMIGOMQswCQYDVQQGEwJVUzERMA8GA1UE
+CAwITmV3IFlvcmsxETAPBgNVBAcMCE5ldyBZb3JrMRYwFAYDVQQKDA1CYXJlZm9v
+dCBMYWJzMRgwFgYDVQQDDA9KYXNvbiBCZXJsaW5za3kxJzAlBgkqhkiG9w0BCQEW
+GGphc29uQGJhcmVmb290Y29kZXJzLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAMteFbwfLz7NyQn3eDxxw22l1ZPBrzfPON0HOAq8nHat4kT4A2cI
+45kCtxKMzCVoG84tXoX/rbjGkez7lz9lEfvEuSh+I+UqinFA/sefhcE63foVMZu1
+2t6O3+utdxBvOYJwAQaiGW44x0h6fTyqDv6Gc5Ml0uoIVeMWPhT1MREoOcPDz1gb
+Ep3VT2aqFULLJedP37qbzS4D04rn1tS7pcm3wYivRyjVNEvs91NsWEvvE1WtS2Cl
+2RBt+ihXwq4UNB9UPYG75+FuRcQQvfqameyweyKT9qBmJLELMtYa/KTCYvSch4JY
+YVPAPOlhFlO4BcTto/gpBes2WEAWZtE/jnECAwEAAaNQME4wHQYDVR0OBBYEFOna
+aiYnm5583EY7FT/mXwTBuLZgMB8GA1UdIwQYMBaAFOnaaiYnm5583EY7FT/mXwTB
+uLZgMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBABp/dKQ489CCzzB1
+IX78p6RFAdda4e3lL6uVjeS3itzFIIiKvdf1/txhmsEeCEYz0El6aMnXLkpk7jAr
+kCwlAOOz2R2hlA8k8opKTYX4IQQau8DATslUFAFOvRGOim/TD/Yuch+a/VF2VQKz
+L2lUVi5Hjp9KvWe2HQYPjnJaZs/OKAmZQ4uP547dqFrTz6sWfisF1rJ60JH70cyM
+qjZQp/xYHTZIB8TCPvLgtVIGFmd/VAHVBFW2p9IBwtSxBIsEPwYQOV3XbwhhmGIv
+DWx5TpnEzH7ZM33RNbAKcdwOBxdRY+SI/ua5hYCm4QngAqY69lEuk4zXZpdDLPq1
+qxxQx0E=
+-----END CERTIFICATE-----
+EOF
+
+	private_key =  <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQD2AVGKRIx+EFM0kkg76GoJv9uy0biEDHB4phQBqnDIf8J8/gq9
+eVvQrR5jJC9Uz4zp5wG/oLZlGuF92/jDbI/yS+DOAjrh30vN79Au74jGN2Cw8fIa
+k40iDUwjZaczK2Gkna54XIO9pqMcbQ6QmLUkQXsqlJ7Q4X2kL3b9iMsXcQIDAQAB
+AoGALmVBQ5p6BKx/hMKx7NqAZSZSAP+clQrji12HGGlUq/usanZfAC0LK+f6eygv
+5QbfxJ1UrxdYTukq7dm2qOSooOMUuukWInqC6ztjdLwH70CKnl0bkNB3/NkW2VNc
+32YiUuZCM9zaeBuEUclKNs+dhD2EeGdJF8KGntWGOTU/M4ECQQD9gdYb38PvaMdu
+opM3sKJF5n9pMoLDleBpCGqq3nD3DFn0V6PHQAwn30EhRN+7BbUEpde5PmfoIdAR
+uDlj/XPlAkEA+GyY1e4uU9rz+1K4ubxmtXTp9ZIR2LsqFy5L/MS5hqX2zq5GGq8g
+jZYDxnxPEUrxaWQH4nh0qdu3skUBi4a0nQJBAKJaqLkpUd7eB/t++zHLWeHSgP7q
+bny8XABod4f+9fICYwntpuJQzngqrxeTeIXaXdggLkxg/0LXhN4UUg0LoVECQQDE
+Pi1h2dyY+37/CzLH7q+IKopjJneYqQmv9C+sxs70MgjM7liM3ckub9IdqrdfJr+c
+DJw56APo5puvZNm6mbf1AkBVMDyfdOOyoHpJjrhmZWo6QqynujfwErrBYQ0sZQ3l
+O57Z0RUNQ8DRyymhLd2t5nAHTfpcFA1sBeKE6CziLbZB
+-----END RSA PRIVATE KEY-----
+EOF
+}
+`

--- a/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
@@ -78,8 +78,10 @@ resource "aws_elb" "ourapp" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Server Certificate. Do not include the 
-  path in this value.
+* `name` - (Optional) The name of the Server Certificate. Do not include the 
+  path in this value.If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
 * `certificate_body` – (Required) The contents of the public key certificate in 
   PEM-encoded format.
 * `certificate_chain` – (Optional) The contents of the certificate chain. 


### PR DESCRIPTION
This PR updates IAM Server Cert to allow `name_prefix`, auto generated names.

This will fix #5158 by allowing users to use the `create_before_destroy` lifecycle block with IAM Server Certificate resources. 

Also fixes:
- #4673 
- #4689 
- #4614