### PR TITLE
provider/aws: Fixes terraform crash when lambda VpcId is nil

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -19,7 +19,26 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSLambdaConfig,
+				Config: testAccAWSLambdaConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", &conf),
+					testAccCheckAWSLambdaAttributes(&conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaFunction_VPC(t *testing.T) {
+	var conf lambda.GetFunctionOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSLambdaConfigWithVPC,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", &conf),
 					testAccCheckAWSLambdaAttributes(&conf),
@@ -96,7 +115,7 @@ func testAccCheckAWSLambdaAttributes(function *lambda.GetFunctionOutput) resourc
 	}
 }
 
-const testAccAWSLambdaConfig = `
+const baseAccAWSLambdaConfig = `
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
     name = "iam_policy_for_lambda"
     role = "${aws_iam_role.iam_for_lambda.id}"
@@ -179,6 +198,18 @@ resource "aws_security_group" "sg_for_lambda" {
   }
 }
 
+`
+
+const testAccAWSLambdaConfigBasic = baseAccAWSLambdaConfig + `
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "example_lambda_name"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+}
+`
+
+const testAccAWSLambdaConfigWithVPC = baseAccAWSLambdaConfig + `
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "example_lambda_name"

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -690,7 +690,9 @@ func flattenLambdaVpcConfigResponse(s *lambda.VpcConfigResponse) []map[string]in
 
 	settings["subnet_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SubnetIds))
 	settings["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SecurityGroupIds))
-	settings["vpc_id"] = *s.VpcId
+	if s.VpcId != nil {
+		settings["vpc_id"] = *s.VpcId
+	}
 
 	return []map[string]interface{}{settings}
 }

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -688,11 +688,14 @@ func flattenLambdaVpcConfigResponse(s *lambda.VpcConfigResponse) []map[string]in
 		return nil
 	}
 
+	// Empty
+	if len(s.SubnetIds) == 0 && len(s.SecurityGroupIds) == 0 && s.VpcId == nil {
+		return nil
+	}
+
 	settings["subnet_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SubnetIds))
 	settings["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SecurityGroupIds))
-	if s.VpcId != nil {
-		settings["vpc_id"] = *s.VpcId
-	}
+	settings["vpc_id"] = *s.VpcId
 
 	return []map[string]interface{}{settings}
 }

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -688,6 +688,10 @@ func flattenLambdaVpcConfigResponse(s *lambda.VpcConfigResponse) []map[string]in
 		return nil
 	}
 
+	if len(s.SubnetIds) == 0 && len(s.SecurityGroupIds) == 0 && s.VpcId == nil {
+		return nil
+	}
+
 	settings["subnet_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SubnetIds))
 	settings["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SecurityGroupIds))
 	if s.VpcId != nil {

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -688,14 +688,11 @@ func flattenLambdaVpcConfigResponse(s *lambda.VpcConfigResponse) []map[string]in
 		return nil
 	}
 
-	// Empty
-	if len(s.SubnetIds) == 0 && len(s.SecurityGroupIds) == 0 && s.VpcId == nil {
-		return nil
-	}
-
 	settings["subnet_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SubnetIds))
 	settings["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SecurityGroupIds))
-	settings["vpc_id"] = *s.VpcId
+	if s.VpcId != nil {
+		settings["vpc_id"] = *s.VpcId
+	}
 
 	return []map[string]interface{}{settings}
 }


### PR DESCRIPTION
@vincer @radeksimko @jen20 apparently, with existing lambdas (created before VPC support), `VpcId` can be nil, which causes `terraform` to panic.

Extract from `crash.log`
```
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: panic: runtime error: invalid memory address or nil pointer dereference
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: [signal 0xb code=0x1 addr=0x0 pc=0x249c26]
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: goroutine 775 [running]:
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: github.com/hashicorp/terraform/builtin/providers/aws.flattenLambdaVpcConfigResponse(0xc8203de7c0, 0x0, 0x0, 0x0)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/Users/bowbaq/Dropbox/Dev/go/src/github.com/hashicorp/terraform/builtin/providers/aws/structure.go:693 +0x336
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsLambdaFunctionRead(0xc8207d6540, 0xa30a80, 0xc820416000, 0x0, 0x0)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/Users/bowbaq/Dropbox/Dev/go/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_lambda_function.go:264 +0x596
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc82059b600, 0xc8207e8990, 0xa30a80, 0xc820416000, 0xc820079d88, 0x0, 0x0)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/Users/bowbaq/Dropbox/Dev/go/src/github.com/hashicorp/terraform/helper/schema/resource.go:209 +0x430
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc820425a40, 0xc820693580, 0xc8207e8990, 0x201, 0x0, 0x0)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/Users/bowbaq/Dropbox/Dev/go/src/github.com/hashicorp/terraform/helper/schema/provider.go:187 +0x1da
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: github.com/hashicorp/terraform/rpc.(*ResourceProviderServer).Refresh(0xc820578be0, 0xc82058e340, 0xc82058e910, 0x0, 0x0)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/Users/bowbaq/Dropbox/Dev/go/src/github.com/hashicorp/terraform/rpc/resource_provider.go:345 +0x6a
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: reflect.Value.call(0xc6cfc0, 0xf33000, 0x13, 0xfd98f0, 0x4, 0xc820391ee8, 0x3, 0x3, 0x0, 0x0, ...)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/usr/local/Cellar/go/1.5.3/libexec/src/reflect/value.go:432 +0x120a
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: reflect.Value.Call(0xc6cfc0, 0xf33000, 0x13, 0xc820391ee8, 0x3, 0x3, 0x0, 0x0, 0x0)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/usr/local/Cellar/go/1.5.3/libexec/src/reflect/value.go:300 +0xb1
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: net/rpc.(*service).call(0xc820562d00, 0xc820562cc0, 0xc820594840, 0xc820242200, 0xc8203562e0, 0xa31bc0, 0xc82058e340, 0x16, 0xa31c20, 0xc82058e910, ...)
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/usr/local/Cellar/go/1.5.3/libexec/src/net/rpc/server.go:383 +0x1c1
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: created by net/rpc.(*Server).ServeCodec
2016/02/17 19:47:26 [DEBUG] terraform-provider-aws: 	/usr/local/Cellar/go/1.5.3/libexec/src/net/rpc/server.go:477 +0x4ac
```