### PR TITLE
provider/aws: Use the GroupName in EC2-Classic security group

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -273,8 +273,8 @@ func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 	sg := sgRaw.(*ec2.SecurityGroup)
 
-	remoteIngressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), sg.IpPermissions)
-	remoteEgressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), sg.IpPermissionsEgress)
+	remoteIngressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), sg.IpPermissions, sg.OwnerId)
+	remoteEgressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), sg.IpPermissionsEgress, sg.OwnerId)
 
 	//
 	// TODO enforce the seperation of ips and security_groups in a rule block
@@ -409,7 +409,7 @@ func resourceAwsSecurityGroupRuleHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpPermission) []map[string]interface{} {
+func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpPermission, ownerId *string) []map[string]interface{} {
 	ruleMap := make(map[string]map[string]interface{})
 	for _, perm := range permissions {
 		var fromPort, toPort int64
@@ -445,12 +445,9 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 			m["cidr_blocks"] = list
 		}
 
-		var groups []string
-		if len(perm.UserIdGroupPairs) > 0 {
-			groups = flattenSecurityGroups(perm.UserIdGroupPairs)
-		}
-		for i, id := range groups {
-			if id == groupId {
+		groups := flattenSecurityGroups(perm.UserIdGroupPairs, ownerId)
+		for i, g := range groups {
+			if *g.GroupId == groupId {
 				groups[i], groups = groups[len(groups)-1], groups[:len(groups)-1]
 				m["self"] = true
 			}
@@ -464,7 +461,11 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 			list := raw.(*schema.Set)
 
 			for _, g := range groups {
-				list.Add(g)
+				if g.GroupName != nil {
+					list.Add(*g.GroupName)
+				} else {
+					list.Add(*g.GroupId)
+				}
 			}
 
 			m["security_groups"] = list
@@ -531,12 +532,16 @@ func resourceAwsSecurityGroupUpdateRules(
 						GroupId:       group.GroupId,
 						IpPermissions: remove,
 					}
+					if group.VpcId == nil || *group.VpcId == "" {
+						req.GroupId = nil
+						req.GroupName = group.GroupName
+					}
 					_, err = conn.RevokeSecurityGroupIngress(req)
 				}
 
 				if err != nil {
 					return fmt.Errorf(
-						"Error authorizing security group %s rules: %s",
+						"Error revoking security group %s rules: %s",
 						ruleset, err)
 				}
 			}

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -136,7 +136,7 @@ func expandEcsLoadBalancers(configured []interface{}) []*ecs.LoadBalancer {
 // to_port or from_port set to a non-zero value.
 func expandIPPerms(
 	group *ec2.SecurityGroup, configured []interface{}) ([]*ec2.IpPermission, error) {
-	vpc := group.VpcId != nil
+	vpc := group.VpcId != nil && *group.VpcId != ""
 
 	perms := make([]*ec2.IpPermission, len(configured))
 	for i, mRaw := range configured {
@@ -321,10 +321,36 @@ func flattenHealthCheck(check *elb.HealthCheck) []map[string]interface{} {
 }
 
 // Flattens an array of UserSecurityGroups into a []string
-func flattenSecurityGroups(list []*ec2.UserIdGroupPair) []string {
-	result := make([]string, 0, len(list))
+func flattenSecurityGroups(list []*ec2.UserIdGroupPair, ownerId *string) []*ec2.GroupIdentifier {
+	result := make([]*ec2.GroupIdentifier, 0, len(list))
 	for _, g := range list {
-		result = append(result, *g.GroupId)
+		var userId *string
+		if g.UserId != nil && *g.UserId != "" && (ownerId == nil || *ownerId != *g.UserId) {
+			userId = g.UserId
+		}
+
+		vpc := g.GroupName == nil || *g.GroupName == ""
+		var id *string
+		if vpc {
+			id = g.GroupId
+		} else {
+			id = g.GroupName
+		}
+
+		if userId != nil {
+			id = aws.String(*userId + "/" + *id)
+		}
+
+		if vpc {
+			result = append(result, &ec2.GroupIdentifier{
+				GroupId: id,
+			})
+		} else {
+			result = append(result, &ec2.GroupIdentifier{
+				GroupId:   g.GroupId,
+				GroupName: id,
+			})
+		}
 	}
 	return result
 }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -82,7 +82,7 @@ func TestExpandIPPerms(t *testing.T) {
 					GroupId: aws.String("sg-22222"),
 				},
 				&ec2.UserIdGroupPair{
-					GroupId: aws.String("sg-22222"),
+					GroupId: aws.String("sg-11111"),
 				},
 			},
 		},
@@ -92,7 +92,7 @@ func TestExpandIPPerms(t *testing.T) {
 			ToPort:     aws.Int64(int64(-1)),
 			UserIdGroupPairs: []*ec2.UserIdGroupPair{
 				&ec2.UserIdGroupPair{
-					UserId: aws.String("foo"),
+					GroupId: aws.String("foo"),
 				},
 			},
 		},
@@ -122,6 +122,29 @@ func TestExpandIPPerms(t *testing.T) {
 			*exp.UserIdGroupPairs[0].UserId)
 	}
 
+	if *exp.UserIdGroupPairs[0].GroupId != *perm.UserIdGroupPairs[0].GroupId {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIdGroupPairs[0].GroupId,
+			*exp.UserIdGroupPairs[0].GroupId)
+	}
+
+	if *exp.UserIdGroupPairs[1].GroupId != *perm.UserIdGroupPairs[1].GroupId {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIdGroupPairs[1].GroupId,
+			*exp.UserIdGroupPairs[1].GroupId)
+	}
+
+	exp = expected[1]
+	perm = perms[1]
+
+	if *exp.UserIdGroupPairs[0].GroupId != *perm.UserIdGroupPairs[0].GroupId {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIdGroupPairs[0].GroupId,
+			*exp.UserIdGroupPairs[0].GroupId)
+	}
 }
 
 func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
@@ -161,7 +184,7 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 					GroupId: aws.String("sg-22222"),
 				},
 				&ec2.UserIdGroupPair{
-					GroupId: aws.String("sg-22222"),
+					GroupId: aws.String("sg-11111"),
 				},
 			},
 		},
@@ -256,7 +279,7 @@ func TestExpandIPPerms_nonVPC(t *testing.T) {
 					GroupName: aws.String("sg-22222"),
 				},
 				&ec2.UserIdGroupPair{
-					GroupName: aws.String("sg-22222"),
+					GroupName: aws.String("sg-11111"),
 				},
 			},
 		},
@@ -287,6 +310,30 @@ func TestExpandIPPerms_nonVPC(t *testing.T) {
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
 			*perm.IpRanges[0].CidrIp,
 			*exp.IpRanges[0].CidrIp)
+	}
+
+	if *exp.UserIdGroupPairs[0].GroupName != *perm.UserIdGroupPairs[0].GroupName {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIdGroupPairs[0].GroupName,
+			*exp.UserIdGroupPairs[0].GroupName)
+	}
+
+	if *exp.UserIdGroupPairs[1].GroupName != *perm.UserIdGroupPairs[1].GroupName {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIdGroupPairs[1].GroupName,
+			*exp.UserIdGroupPairs[1].GroupName)
+	}
+
+	exp = expected[1]
+	perm = perms[1]
+
+	if *exp.UserIdGroupPairs[0].GroupName != *perm.UserIdGroupPairs[0].GroupName {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			*perm.UserIdGroupPairs[0].GroupName,
+			*exp.UserIdGroupPairs[0].GroupName)
 	}
 }
 


### PR DESCRIPTION
It is related to #4983

This PR is a fix of the problems that are caused by repeating the `terraform apply`.

The fixes is the following.
- The EC2-Classic will use the GroupName rather than the GroupId.
- Handling of the OwnerId. For example, `amazon-elb/amazon-elb-sg`

`test.tf.json`
```
variable "external_security_groups" {
    default = {
        amazon-elb-sg = "amazon-elb/amazon-elb-sg"
        other         = "other"
    }
}

resource "aws_instance" "test" {
    ami = "ami-383c1956"
    instance_type = "m3.medium"
    security_groups = [
        "${aws_security_group.test.name}"
    ]
    count = 1
}

resource "aws_security_group" "test" {
    name = "test"

    ingress = {
        protocol  = "tcp"
        from_port = 22
        to_port   = 22
        security_groups = [
            "${var.external_security_groups.other}"
        ]
    }

    ingress = {
        protocol  = "tcp"
        from_port = 80
        to_port   = 80
        self      = true
        security_groups = [
            "${var.external_security_groups.amazon-elb-sg}"
        ]
    }
}
```

Part of the `terraform.tfstate` that have been created by running the `terraform apply` on v0.6.11.
```
"aws_security_group.test": {
    "type": "aws_security_group",
    "primary": {
        "id": "sg-5b7c865b",
        "attributes": {
            "description": "Managed by Terraform",
            "egress.#": "0",
            "id": "sg-5b7c865b",
            "ingress.#": "2",
            "ingress.2988994747.cidr_blocks.#": "0",
            "ingress.2988994747.from_port": "80",
            "ingress.2988994747.protocol": "tcp",
            "ingress.2988994747.security_groups.#": "1",
            "ingress.2988994747.security_groups.4257846120": "sg-d2c979d3",
            "ingress.2988994747.self": "true",
            "ingress.2988994747.to_port": "80",
            "ingress.4120346219.cidr_blocks.#": "0",
            "ingress.4120346219.from_port": "22",
            "ingress.4120346219.protocol": "tcp",
            "ingress.4120346219.security_groups.#": "1",
            "ingress.4120346219.security_groups.3428955302": "sg-24adc325",
            "ingress.4120346219.self": "false",
            "ingress.4120346219.to_port": "22",
            "name": "test",
            "tags.#": "0",
            "vpc_id": ""
        }
    }
}
```

Part of the `terraform.tfstate` that have been created by running the `terraform apply` on this PR.
```
"aws_security_group.test": {
    "type": "aws_security_group",
    "primary": {
        "id": "sg-f77e84f7",
        "attributes": {
            "description": "Managed by Terraform",
            "egress.#": "0",
            "id": "sg-f77e84f7",
            "ingress.#": "2",
            "ingress.2205382729.cidr_blocks.#": "0",
            "ingress.2205382729.from_port": "22",
            "ingress.2205382729.protocol": "tcp",
            "ingress.2205382729.security_groups.#": "1",
            "ingress.2205382729.security_groups.2282622326": "admin",
            "ingress.2205382729.self": "false",
            "ingress.2205382729.to_port": "22",
            "ingress.711875606.cidr_blocks.#": "0",
            "ingress.711875606.from_port": "80",
            "ingress.711875606.protocol": "tcp",
            "ingress.711875606.security_groups.#": "1",
            "ingress.711875606.security_groups.1062146483": "amazon-elb/amazon-elb-sg",
            "ingress.711875606.self": "true",
            "ingress.711875606.to_port": "80",
            "name": "test",
            "tags.#": "0",
            "vpc_id": ""
        }
    }
}
```