### PR TITLE
website: Sort aws_key_pair in the sidebar

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -155,6 +155,10 @@
                             <a href="/docs/providers/aws/r/instance.html">aws_instance</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-key-pair") %>>
+                            <a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-launch-configuration") %>>
                             <a href="/docs/providers/aws/r/launch_configuration.html">aws_launch_configuration</a>
                         </li>
@@ -177,9 +181,6 @@
 
                         <li<%= sidebar_current("docs-aws-resource-volume-attachment") %>>
                             <a href="/docs/providers/aws/r/volume_attachment.html">aws_volume_attachment</a>
-                        </li>
-                        <li<%= sidebar_current("docs-aws-resource-key-pair") %>>
-                            <a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
I had trouble finding this, as it was not where I expected it.