### PR TITLE
provider/aws: Fix copy_tags_to_snapshot for DB Instance

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -165,7 +165,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set("publicly_accessible", db.PubliclyAccessible)
 
 	// Fetch and save tags
-	arn, err := buildRDSARN(d, meta)
+	arn, err := buildRDSARN(d.Id(), meta)
 	if err != nil {
 		log.Printf("[DEBUG] Error building ARN for RDS Cluster Instance (%s), not setting Tags", *db.DBInstanceIdentifier)
 	} else {
@@ -180,7 +180,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
-	if arn, err := buildRDSARN(d, meta); err == nil {
+	if arn, err := buildRDSARN(d.Id(), meta); err == nil {
 		if err := setTagsRDS(conn, d, arn); err != nil {
 			return err
 		}


### PR DESCRIPTION
The `copy_tags_to_snapshot` attribute is only being applied on creation of read replicas of DB Instances. For new DBs or DBs created from a snapshot, it was only being applied after a new plan->apply, because it was only checked in the update method.

This PR addresses that, applying it to all 3 creation scenarios, and expands an acceptance test to confirm this. 


Fixes #5154 