### PR TITLE
provider/azurerm: Add Search Service resource

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -536,16 +536,20 @@
 		},
 		{
 			"ImportPath": "github.com/jen20/riviera/azure",
-			"Rev": "31f4644de1f4931e43271240069bf2b896f47005"
+			"Rev": "64de55fa8cdd0c52f7d59494c1b03c1b583c52b4"
 		},
 		{
 			"ImportPath": "github.com/jen20/riviera/dns",
-			"Rev": "31f4644de1f4931e43271240069bf2b896f47005"
+			"Rev": "64de55fa8cdd0c52f7d59494c1b03c1b583c52b4"
+		},
+		{
+			"ImportPath": "github.com/jen20/riviera/search",
+			"Rev": "64de55fa8cdd0c52f7d59494c1b03c1b583c52b4"
 		},
 		{
 			"ImportPath": "github.com/jen20/riviera/sql",
-			"Rev": "31f4644de1f4931e43271240069bf2b896f47005"
-		},
+			"Rev": "64de55fa8cdd0c52f7d59494c1b03c1b583c52b4"
+        },
 		{
 			"ImportPath": "github.com/jmespath/go-jmespath",
 			"Comment": "0.2.2-2-gc01cf91",

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -74,6 +74,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_sql_server":             resourceArmSqlServer(),
 			"azurerm_sql_database":           resourceArmSqlDatabase(),
 			"azurerm_sql_firewall_rule":      resourceArmSqlFirewallRule(),
+			"azurerm_search_service":         resourceArmSearchService(),
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -141,7 +142,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 func registerAzureResourceProvidersWithSubscription(config *Config, client *ArmClient) error {
 	providerClient := client.providers
 
-	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage", "Microsoft.Sql"}
+	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage", "Microsoft.Sql", "Microsoft.Search"}
 
 	for _, v := range providers {
 		res, err := providerClient.Register(v)

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_sql_server":             resourceArmSqlServer(),
 			"azurerm_sql_database":           resourceArmSqlDatabase(),
 			"azurerm_sql_firewall_rule":      resourceArmSqlFirewallRule(),
+			"azurerm_search_service":         resourceArmSearchService(),
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -138,7 +139,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 func registerAzureResourceProvidersWithSubscription(config *Config, client *ArmClient) error {
 	providerClient := client.providers
 
-	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage", "Microsoft.Sql"}
+	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage", "Microsoft.Sql", "Microsoft.Search"}
 
 	for _, v := range providers {
 		res, err := providerClient.Register(v)

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/helper/mutexkv"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	riviera "github.com/jen20/riviera/azure"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -71,7 +74,6 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_sql_server":             resourceArmSqlServer(),
 			"azurerm_sql_database":           resourceArmSqlDatabase(),
 			"azurerm_sql_firewall_rule":      resourceArmSqlFirewallRule(),
-			"azurerm_search_service":         resourceArmSearchService(),
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -139,7 +141,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 func registerAzureResourceProvidersWithSubscription(config *Config, client *ArmClient) error {
 	providerClient := client.providers
 
-	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage", "Microsoft.Sql", "Microsoft.Search"}
+	providers := []string{"Microsoft.Network", "Microsoft.Compute", "Microsoft.Cdn", "Microsoft.Storage", "Microsoft.Sql"}
 
 	for _, v := range providers {
 		res, err := providerClient.Register(v)
@@ -199,3 +201,32 @@ func pollIndefinitelyAsNeeded(client autorest.Client, response *http.Response, a
 
 // armMutexKV is the instance of MutexKV for ARM resources
 var armMutexKV = mutexkv.NewMutexKV()
+
+func azureStateRefreshFunc(resourceURI string, client *ArmClient, command riviera.APICall) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		req := client.rivieraClient.NewRequestForURI(resourceURI)
+		req.Command = command
+
+		res, err := req.Execute()
+		if err != nil {
+			return nil, "", fmt.Errorf("Error executing %T command in azureStateRefreshFunc", req.Command)
+		}
+
+		var value reflect.Value
+		if reflect.ValueOf(res.Parsed).Kind() == reflect.Ptr {
+			value = reflect.ValueOf(res.Parsed).Elem()
+		} else {
+			value = reflect.ValueOf(res.Parsed)
+		}
+
+		for i := 0; i < value.NumField(); i++ { // iterates through every struct type field
+			tag := value.Type().Field(i).Tag // returns the tag string
+			tagValue := tag.Get("mapstructure")
+			if tagValue == "provisioningState" {
+				return res.Parsed, value.Field(i).Elem().String(), nil
+			}
+		}
+
+		panic(fmt.Errorf("azureStateRefreshFunc called on structure %T with no mapstructure:provisioningState tag. This is a bug", res.Parsed))
+	}
+}

--- a/builtin/providers/azurerm/resource_arm_search_service.go
+++ b/builtin/providers/azurerm/resource_arm_search_service.go
@@ -1,0 +1,155 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+	"github.com/jen20/riviera/search"
+)
+
+func resourceArmSearchService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmSearchServiceCreate,
+		Read:   resourceArmSearchServiceRead,
+		Update: resourceArmSearchServiceCreate,
+		Delete: resourceArmSearchServiceDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"sku": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"replica_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"partition_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmSearchServiceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	tags := d.Get("tags").(map[string]interface{})
+	expandedTags := expandTags(tags)
+
+	command := &search.CreateOrUpdateSearchService{
+		Name:              d.Get("name").(string),
+		Location:          d.Get("location").(string),
+		ResourceGroupName: d.Get("resource_group_name").(string),
+		Tags:              *expandedTags,
+		Sku: search.Sku{
+			Name: d.Get("sku").(string),
+		},
+	}
+
+	if v, ok := d.GetOk("replica_count"); ok {
+		command.ReplicaCount = azure.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("partition_count"); ok {
+		command.PartitionCount = azure.String(v.(string))
+	}
+
+	createRequest := rivieraClient.NewRequest()
+	createRequest.Command = command
+
+	createResponse, err := createRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error creating Search Service: %s", err)
+	}
+	if !createResponse.IsSuccessful() {
+		return fmt.Errorf("Error creating Search Service: %s", createResponse.Error)
+	}
+
+	readRequest := rivieraClient.NewRequest()
+	readRequest.Command = &search.GetSearchService{
+		Name:              d.Get("name").(string),
+		ResourceGroupName: d.Get("resource_group_name").(string),
+	}
+
+	readResponse, err := readRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error reading Search Service: %s", err)
+	}
+	if !readResponse.IsSuccessful() {
+		return fmt.Errorf("Error reading Search Service: %s", readResponse.Error)
+	}
+
+	resp := readResponse.Parsed.(*search.GetSearchServiceResponse)
+	d.SetId(*resp.ID)
+
+	return resourceArmSearchServiceRead(d, meta)
+}
+
+func resourceArmSearchServiceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	readRequest := rivieraClient.NewRequestForURI(d.Id())
+	readRequest.Command = &search.GetSearchService{}
+
+	readResponse, err := readRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error reading Search Service: %s", err)
+	}
+	if !readResponse.IsSuccessful() {
+		log.Printf("[INFO] Error reading Search Service %q - removing from state", d.Id())
+		d.SetId("")
+		return fmt.Errorf("Error reading Search Service: %s", readResponse.Error)
+	}
+
+	resp := readResponse.Parsed.(*search.GetSearchServiceResponse)
+	d.Set("sku", resp.Sku)
+	return nil
+}
+
+func resourceArmSearchServiceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	rivieraClient := client.rivieraClient
+
+	deleteRequest := rivieraClient.NewRequestForURI(d.Id())
+	deleteRequest.Command = &search.DeleteSearchService{}
+
+	deleteResponse, err := deleteRequest.Execute()
+	if err != nil {
+		return fmt.Errorf("Error deleting Search Service: %s", err)
+	}
+	if !deleteResponse.IsSuccessful() {
+		return fmt.Errorf("Error deleting Search Service: %s", deleteResponse.Error)
+	}
+
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_search_service.go
+++ b/builtin/providers/azurerm/resource_arm_search_service.go
@@ -3,7 +3,9 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jen20/riviera/azure"
 	"github.com/jen20/riviera/search"
@@ -94,11 +96,13 @@ func resourceArmSearchServiceCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating Search Service: %s", createResponse.Error)
 	}
 
-	readRequest := rivieraClient.NewRequest()
-	readRequest.Command = &search.GetSearchService{
+	getSearchServiceCommand := &search.GetSearchService{
 		Name:              d.Get("name").(string),
 		ResourceGroupName: d.Get("resource_group_name").(string),
 	}
+
+	readRequest := rivieraClient.NewRequest()
+	readRequest.Command = getSearchServiceCommand
 
 	readResponse, err := readRequest.Execute()
 	if err != nil {
@@ -107,8 +111,20 @@ func resourceArmSearchServiceCreate(d *schema.ResourceData, meta interface{}) er
 	if !readResponse.IsSuccessful() {
 		return fmt.Errorf("Error reading Search Service: %s", readResponse.Error)
 	}
-
 	resp := readResponse.Parsed.(*search.GetSearchServiceResponse)
+
+	log.Printf("[DEBUG] Waiting for Search Service (%s) to become available", d.Get("name"))
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"provisioning"},
+		Target:  []string{"succeeded"},
+		Refresh: azureStateRefreshFunc(*resp.ID, client, getSearchServiceCommand),
+		// ¯\_(ツ)_/¯
+		Timeout: 30 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Search Service (%s) to become available: %s", d.Get("name"), err)
+	}
+
 	d.SetId(*resp.ID)
 
 	return resourceArmSearchServiceRead(d, meta)

--- a/builtin/providers/azurerm/resource_arm_search_service_test.go
+++ b/builtin/providers/azurerm/resource_arm_search_service_test.go
@@ -1,0 +1,162 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/jen20/riviera/search"
+)
+
+func TestAccAzureRMSearchService_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSearchService_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
+				),
+			},
+		},
+	})
+}
+
+//func TestAccAzureRMSearchService_withTags(t *testing.T) {
+//	ri := acctest.RandInt()
+//	preConfig := fmt.Sprintf(testAccAzureRMSearchService_withTags, ri, ri)
+//	postConfig := fmt.Sprintf(testAccAzureRMSearchService_withTagsUpdated, ri, ri)
+//
+//	resource.Test(t, resource.TestCase{
+//		PreCheck:     func() { testAccPreCheck(t) },
+//		Providers:    testAccProviders,
+//		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+//		Steps: []resource.TestStep{
+//			resource.TestStep{
+//				Config: preConfig,
+//				Check: resource.ComposeTestCheckFunc(
+//					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
+//					resource.TestCheckResourceAttr(
+//						"azurerm_search_service.test", "tags.#", "2"),
+//				),
+//			},
+//
+//			resource.TestStep{
+//				Config: postConfig,
+//				Check: resource.ComposeTestCheckFunc(
+//					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
+//					resource.TestCheckResourceAttr(
+//						"azurerm_search_service.test", "tags.#", "1"),
+//				),
+//			},
+//		},
+//	})
+//}
+
+func testCheckAzureRMSearchServiceExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).rivieraClient
+
+		readRequest := conn.NewRequestForURI(rs.Primary.ID)
+		readRequest.Command = &search.GetSearchService{}
+
+		readResponse, err := readRequest.Execute()
+		if err != nil {
+			return fmt.Errorf("Bad: GetSearchService: %s", err)
+		}
+		if !readResponse.IsSuccessful() {
+			return fmt.Errorf("Bad: GetSearchService: %s", readResponse.Error)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMSearchServiceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).rivieraClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_search_service" {
+			continue
+		}
+
+		readRequest := conn.NewRequestForURI(rs.Primary.ID)
+		readRequest.Command = &search.GetSearchService{}
+
+		readResponse, err := readRequest.Execute()
+		if err != nil {
+			return fmt.Errorf("Bad: GetSearchService: %s", err)
+		}
+
+		if readResponse.IsSuccessful() {
+			return fmt.Errorf("Bad: Search Service still exists: %s", readResponse.Error)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureRMSearchService_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_search_service" "test" {
+    name = "acctestsearchservice%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    sku = "standard"
+}
+`
+
+//var testAccAzureRMSearchService_withTags = `
+//resource "azurerm_resource_group" "test" {
+//    name = "acctest_rg_%d"
+//    location = "West US"
+//}
+//resource "azurerm_sql_server" "test" {
+//    name = "acctestsqlserver%d"
+//    resource_group_name = "${azurerm_resource_group.test.name}"
+//    location = "West US"
+//    version = "12.0"
+//    administrator_login = "mradministrator"
+//    administrator_login_password = "thisIsDog11"
+//
+//    tags {
+//    	environment = "staging"
+//    	database = "test"
+//    }
+//}
+//`
+//
+//var testAccAzureRMSearchService_withTagsUpdated = `
+//resource "azurerm_resource_group" "test" {
+//    name = "acctest_rg_%d"
+//    location = "West US"
+//}
+//resource "azurerm_sql_server" "test" {
+//    name = "acctestsqlserver%d"
+//    resource_group_name = "${azurerm_resource_group.test.name}"
+//    location = "West US"
+//    version = "12.0"
+//    administrator_login = "mradministrator"
+//    administrator_login_password = "thisIsDog11"
+//
+//    tags {
+//    	environment = "production"
+//    }
+//}
+//`

--- a/builtin/providers/azurerm/resource_arm_search_service_test.go
+++ b/builtin/providers/azurerm/resource_arm_search_service_test.go
@@ -23,42 +23,48 @@ func TestAccAzureRMSearchService_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_search_service.test", "tags.#", "2"),
 				),
 			},
 		},
 	})
 }
 
-//func TestAccAzureRMSearchService_withTags(t *testing.T) {
-//	ri := acctest.RandInt()
-//	preConfig := fmt.Sprintf(testAccAzureRMSearchService_withTags, ri, ri)
-//	postConfig := fmt.Sprintf(testAccAzureRMSearchService_withTagsUpdated, ri, ri)
-//
-//	resource.Test(t, resource.TestCase{
-//		PreCheck:     func() { testAccPreCheck(t) },
-//		Providers:    testAccProviders,
-//		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
-//		Steps: []resource.TestStep{
-//			resource.TestStep{
-//				Config: preConfig,
-//				Check: resource.ComposeTestCheckFunc(
-//					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
-//					resource.TestCheckResourceAttr(
-//						"azurerm_search_service.test", "tags.#", "2"),
-//				),
-//			},
-//
-//			resource.TestStep{
-//				Config: postConfig,
-//				Check: resource.ComposeTestCheckFunc(
-//					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
-//					resource.TestCheckResourceAttr(
-//						"azurerm_search_service.test", "tags.#", "1"),
-//				),
-//			},
-//		},
-//	})
-//}
+func TestAccAzureRMSearchService_updateReplicaCountAndTags(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMSearchService_basic, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSearchService_updated, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_search_service.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_search_service.test", "replica_count", "1"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_search_service.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_search_service.test", "replica_count", "2"),
+				),
+			},
+		},
+	})
+}
 
 func testCheckAzureRMSearchServiceExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -119,44 +125,28 @@ resource "azurerm_search_service" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     location = "West US"
     sku = "standard"
+
+    tags {
+    	environment = "staging"
+    	database = "test"
+    }
 }
 `
 
-//var testAccAzureRMSearchService_withTags = `
-//resource "azurerm_resource_group" "test" {
-//    name = "acctest_rg_%d"
-//    location = "West US"
-//}
-//resource "azurerm_sql_server" "test" {
-//    name = "acctestsqlserver%d"
-//    resource_group_name = "${azurerm_resource_group.test.name}"
-//    location = "West US"
-//    version = "12.0"
-//    administrator_login = "mradministrator"
-//    administrator_login_password = "thisIsDog11"
-//
-//    tags {
-//    	environment = "staging"
-//    	database = "test"
-//    }
-//}
-//`
-//
-//var testAccAzureRMSearchService_withTagsUpdated = `
-//resource "azurerm_resource_group" "test" {
-//    name = "acctest_rg_%d"
-//    location = "West US"
-//}
-//resource "azurerm_sql_server" "test" {
-//    name = "acctestsqlserver%d"
-//    resource_group_name = "${azurerm_resource_group.test.name}"
-//    location = "West US"
-//    version = "12.0"
-//    administrator_login = "mradministrator"
-//    administrator_login_password = "thisIsDog11"
-//
-//    tags {
-//    	environment = "production"
-//    }
-//}
-//`
+var testAccAzureRMSearchService_updated = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_search_service" "test" {
+    name = "acctestsearchservice%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    sku = "standard"
+    replica_count = 2
+
+    tags {
+    	environment = "production"
+    }
+}
+`

--- a/vendor/github.com/jen20/riviera/azure/request.go
+++ b/vendor/github.com/jen20/riviera/azure/request.go
@@ -37,7 +37,6 @@ func readTaggedFields(command interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	for i := 0; i < value.NumField(); i++ { // iterates through every struct type field
-		fmt.Println(i, value.Type().Field(i).Name)
 		tag := value.Type().Field(i).Tag // returns the tag string
 		tagValue := tag.Get("riviera")
 		if tagValue != "" {

--- a/vendor/github.com/jen20/riviera/azure/request.go
+++ b/vendor/github.com/jen20/riviera/azure/request.go
@@ -37,6 +37,7 @@ func readTaggedFields(command interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	for i := 0; i < value.NumField(); i++ { // iterates through every struct type field
+		fmt.Println(i, value.Type().Field(i).Name)
 		tag := value.Type().Field(i).Tag // returns the tag string
 		tagValue := tag.Get("riviera")
 		if tagValue != "" {

--- a/vendor/github.com/jen20/riviera/search/api.go
+++ b/vendor/github.com/jen20/riviera/search/api.go
@@ -1,0 +1,12 @@
+package search
+
+import "fmt"
+
+const apiVersion = "2015-08-19"
+const apiProvider = "Microsoft.Search"
+
+func searchServiceDefaultURLPath(resourceGroupName, serviceName string) func() string {
+	return func() string {
+		return fmt.Sprintf("resourceGroups/%s/providers/%s/searchServices/%s", resourceGroupName, apiProvider, serviceName)
+	}
+}

--- a/vendor/github.com/jen20/riviera/search/create_or_update_search_service.go
+++ b/vendor/github.com/jen20/riviera/search/create_or_update_search_service.go
@@ -1,0 +1,41 @@
+package search
+
+import "github.com/jen20/riviera/azure"
+
+type Sku struct {
+	Name string `json:"name" mapstructure:"name"`
+}
+
+type CreateOrUpdateSearchServiceResponse struct {
+	ID                 *string             `mapstructure:"id"`
+	Name               *string             `mapstructure:"name"`
+	Location           *string             `mapstructure:"location"`
+	Tags               *map[string]*string `mapstructure:"tags"`
+	Sku                *Sku                `json:"sku,omitempty"`
+	ReplicaCount       *string             `json:"replicaCount,omitempty"`
+	PartitionCount     *string             `json:"partitionCount,omitempty"`
+	Status             *string             `mapstructure:"status"`
+	StatusDetails      *string             `mapstructure:"statusDetails"`
+	ProvisioningStatus *string             `mapstructure:"provisioningStatus"`
+}
+
+type CreateOrUpdateSearchService struct {
+	Name              string             `json:"-"`
+	ResourceGroupName string             `json:"-"`
+	Location          string             `json:"-" riviera:"location"`
+	Tags              map[string]*string `json:"-" riviera:"tags"`
+	Sku               Sku                `json:"-" riviera:"sku"`
+	ReplicaCount      *string            `json:"replicaCount,omitempty"`
+	PartitionCount    *string            `json:"partitionCount,omitempty"`
+}
+
+func (s CreateOrUpdateSearchService) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
+		Method:      "PUT",
+		URLPathFunc: searchServiceDefaultURLPath(s.ResourceGroupName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &CreateOrUpdateSearchServiceResponse{}
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/search/create_or_update_search_service.go
+++ b/vendor/github.com/jen20/riviera/search/create_or_update_search_service.go
@@ -11,9 +11,9 @@ type CreateOrUpdateSearchServiceResponse struct {
 	Name               *string             `mapstructure:"name"`
 	Location           *string             `mapstructure:"location"`
 	Tags               *map[string]*string `mapstructure:"tags"`
-	Sku                *Sku                `json:"sku,omitempty"`
-	ReplicaCount       *string             `json:"replicaCount,omitempty"`
-	PartitionCount     *string             `json:"partitionCount,omitempty"`
+	Sku                *Sku                `mapstructure:"sku"`
+	ReplicaCount       *int                `mapstructure:"replicaCount"`
+	PartitionCount     *int                `mapstructure:"partitionCount"`
 	Status             *string             `mapstructure:"status"`
 	StatusDetails      *string             `mapstructure:"statusDetails"`
 	ProvisioningStatus *string             `mapstructure:"provisioningStatus"`
@@ -25,8 +25,8 @@ type CreateOrUpdateSearchService struct {
 	Location          string             `json:"-" riviera:"location"`
 	Tags              map[string]*string `json:"-" riviera:"tags"`
 	Sku               Sku                `json:"-" riviera:"sku"`
-	ReplicaCount      *string            `json:"replicaCount,omitempty"`
-	PartitionCount    *string            `json:"partitionCount,omitempty"`
+	ReplicaCount      *int               `json:"replicaCount,omitempty"`
+	PartitionCount    *int               `json:"partitionCount,omitempty"`
 }
 
 func (s CreateOrUpdateSearchService) APIInfo() azure.APIInfo {

--- a/vendor/github.com/jen20/riviera/search/delete_search_service.go
+++ b/vendor/github.com/jen20/riviera/search/delete_search_service.go
@@ -1,0 +1,19 @@
+package search
+
+import "github.com/jen20/riviera/azure"
+
+type DeleteSearchService struct {
+	Name              string `json:"-"`
+	ResourceGroupName string `json:"-"`
+}
+
+func (s DeleteSearchService) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
+		Method:      "DELETE",
+		URLPathFunc: searchServiceDefaultURLPath(s.ResourceGroupName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return nil
+		},
+	}
+}

--- a/vendor/github.com/jen20/riviera/search/get_search_service.go
+++ b/vendor/github.com/jen20/riviera/search/get_search_service.go
@@ -3,17 +3,17 @@ package search
 import "github.com/jen20/riviera/azure"
 
 type GetSearchServiceResponse struct {
-	ID                 *string            `mapstructure:"id"`
-	Name               string             `json:"-"`
-	ResourceGroupName  string             `json:"-"`
-	Location           string             `json:"-" riviera:"location"`
-	Tags               map[string]*string `json:"-" riviera:"tags"`
-	Sku                *Sku               `json:"sku,omitempty"`
-	ReplicaCount       *string            `json:"replicaCount,omitempty"`
-	PartitionCount     *string            `json:"partitionCount,omitempty"`
-	Status             *string            `mapstructure:"status"`
-	StatusDetails      *string            `mapstructure:"statusDetails"`
-	ProvisioningStatus *string            `mapstructure:"provisioningStatus"`
+	ID                *string            `mapstructure:"id"`
+	Name              string             `json:"-"`
+	ResourceGroupName string             `json:"-"`
+	Location          string             `json:"-" riviera:"location"`
+	Tags              map[string]*string `json:"-" riviera:"tags"`
+	Sku               *Sku               `json:"sku,omitempty"`
+	ReplicaCount      *string            `json:"replicaCount,omitempty"`
+	PartitionCount    *string            `json:"partitionCount,omitempty"`
+	Status            *string            `mapstructure:"status"`
+	StatusDetails     *string            `mapstructure:"statusDetails"`
+	ProvisioningState *string            `mapstructure:"provisioningState"`
 }
 
 type GetSearchService struct {

--- a/vendor/github.com/jen20/riviera/search/get_search_service.go
+++ b/vendor/github.com/jen20/riviera/search/get_search_service.go
@@ -4,13 +4,13 @@ import "github.com/jen20/riviera/azure"
 
 type GetSearchServiceResponse struct {
 	ID                *string            `mapstructure:"id"`
-	Name              string             `json:"-"`
-	ResourceGroupName string             `json:"-"`
-	Location          string             `json:"-" riviera:"location"`
-	Tags              map[string]*string `json:"-" riviera:"tags"`
-	Sku               *Sku               `json:"sku,omitempty"`
-	ReplicaCount      *string            `json:"replicaCount,omitempty"`
-	PartitionCount    *string            `json:"partitionCount,omitempty"`
+	Name              string             `mapstructure:"name"`
+	ResourceGroupName string             `mapstructure:"-"`
+	Location          string             `mapstructure:"location"`
+	Tags              map[string]*string `mapstructure:"tags"`
+	Sku               *Sku               `mapstructure:"sku"`
+	ReplicaCount      *int               `mapstructure:"replicaCount"`
+	PartitionCount    *int               `mapstructure:"partitionCount"`
 	Status            *string            `mapstructure:"status"`
 	StatusDetails     *string            `mapstructure:"statusDetails"`
 	ProvisioningState *string            `mapstructure:"provisioningState"`

--- a/vendor/github.com/jen20/riviera/search/get_search_service.go
+++ b/vendor/github.com/jen20/riviera/search/get_search_service.go
@@ -1,0 +1,33 @@
+package search
+
+import "github.com/jen20/riviera/azure"
+
+type GetSearchServiceResponse struct {
+	ID                 *string            `mapstructure:"id"`
+	Name               string             `json:"-"`
+	ResourceGroupName  string             `json:"-"`
+	Location           string             `json:"-" riviera:"location"`
+	Tags               map[string]*string `json:"-" riviera:"tags"`
+	Sku                *Sku               `json:"sku,omitempty"`
+	ReplicaCount       *string            `json:"replicaCount,omitempty"`
+	PartitionCount     *string            `json:"partitionCount,omitempty"`
+	Status             *string            `mapstructure:"status"`
+	StatusDetails      *string            `mapstructure:"statusDetails"`
+	ProvisioningStatus *string            `mapstructure:"provisioningStatus"`
+}
+
+type GetSearchService struct {
+	Name              string `json:"-"`
+	ResourceGroupName string `json:"-"`
+}
+
+func (s GetSearchService) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
+		Method:      "GET",
+		URLPathFunc: searchServiceDefaultURLPath(s.ResourceGroupName, s.Name),
+		ResponseTypeFunc: func() interface{} {
+			return &GetSearchServiceResponse{}
+		},
+	}
+}

--- a/website/source/docs/providers/azurerm/r/search_service.html.markdown
+++ b/website/source/docs/providers/azurerm/r/search_service.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_search_service"
+sidebar_current: "docs-azurerm-resource-search-service"
+description: |-
+  Manage a Search Service.
+---
+
+# azurerm\_search\_service
+
+Allows you to manage an Azure Search Service
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+   name = "acceptanceTestResourceGroup1"
+   location = "West US"
+}
+resource "azurerm_search_service" "test" {
+    name = "acceptanceTestSearchService1"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    sku = "standard"
+
+    tags {
+    	environment = "staging"
+    	database = "test"
+    }
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Search Service.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the Search Service.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `sku` - (Required) Valid values are `free` and `standard`. `standard2` is also valid, but can only be used when it's enabled on the backend by Microsoft support. `free` provisions the service in shared clusters. `standard` provisions the service in dedicated clusters
+
+* `replica_count` - (Optional) Default is 1. Valid values include 1 through 12. Valid only when `sku` is `standard`.
+
+* `partition_count` - (Optional) Default is 1. Valid values include 1, 2, 3, 4, 6, or 12. Valid only when `sku` is `standard`.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Search Service ID.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -112,6 +112,15 @@
               </ul>
             </li>
 
+            <li<%= sidebar_current(/^docs-azurerm-resource-search/) %>>
+              <a href="#">Search Resources</a>
+              <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-azurerm-resource-search-service") %>>
+                  <a href="/docs/providers/azurerm/r/search_service.html">azurerm_search_service</a>
+                </li>
+              </ul>
+            </li>
+
             <li<%= sidebar_current(/^docs-azurerm-resource-sql/) %>>
               <a href="#">SQL Resources</a>
               <ul class="nav nav-visible">


### PR DESCRIPTION
Adds `azurerm_search_service`

Test Results:
```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=AzureRMSearchService' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/azurerm -v -run=AzureRMSearchService -timeout 120m
=== RUN   TestAccAzureRMSearchService_basic
--- PASS: TestAccAzureRMSearchService_basic (1531.80s)
=== RUN   TestAccAzureRMSearchService_updateReplicaCountAndTags
--- PASS: TestAccAzureRMSearchService_updateReplicaCountAndTags (3170.12s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	4701.9s
```

**YES - The Tests do indeed take 78minutes!!!**