### PR TITLE
provider/aws: Elastic Beanstalk Tier Attribute

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -30,6 +30,24 @@ func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSBeanstalkEnv_tier(t *testing.T) {
+	var app elasticbeanstalk.EnvironmentDescription
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBeanstalkWorkerEnvConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBeanstalkEnvTier("aws_elastic_beanstalk_environment.tfenvtest", &app),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBeanstalkEnvDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).elasticbeanstalkconn
 
@@ -81,25 +99,61 @@ func testAccCheckBeanstalkEnvExists(n string, app *elasticbeanstalk.EnvironmentD
 			return fmt.Errorf("Elastic Beanstalk ENV is not set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).elasticbeanstalkconn
-		describeBeanstalkEnvOpts := &elasticbeanstalk.DescribeEnvironmentsInput{
-			EnvironmentIds: []*string{aws.String(rs.Primary.ID)},
-		}
-
-		log.Printf("[DEBUG] Elastic Beanstalk Environment TEST describe opts: %s", describeBeanstalkEnvOpts)
-
-		resp, err := conn.DescribeEnvironments(describeBeanstalkEnvOpts)
+		env, err := describeBeanstalkEnv(testAccProvider.Meta().(*AWSClient).elasticbeanstalkconn, aws.String(rs.Primary.ID))
 		if err != nil {
 			return err
 		}
-		if len(resp.Environments) == 0 {
-			return fmt.Errorf("Elastic Beanstalk ENV not found.")
-		}
 
-		*app = *resp.Environments[0]
+		*app = *env
 
 		return nil
 	}
+}
+
+func testAccCheckBeanstalkEnvTier(n string, app *elasticbeanstalk.EnvironmentDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Elastic Beanstalk ENV is not set")
+		}
+
+		env, err := describeBeanstalkEnv(testAccProvider.Meta().(*AWSClient).elasticbeanstalkconn, aws.String(rs.Primary.ID))
+		if err != nil {
+			return err
+		}
+		if *env.Tier.Name != "Worker" {
+			return fmt.Errorf("Beanstalk Environment tier is %s, expected Worker", *env.Tier.Name)
+		}
+
+		*app = *env
+
+		return nil
+	}
+}
+
+func describeBeanstalkEnv(conn *elasticbeanstalk.ElasticBeanstalk,
+	envID *string) (*elasticbeanstalk.EnvironmentDescription, error) {
+	describeBeanstalkEnvOpts := &elasticbeanstalk.DescribeEnvironmentsInput{
+		EnvironmentIds: []*string{envID},
+	}
+
+	log.Printf("[DEBUG] Elastic Beanstalk Environment TEST describe opts: %s", describeBeanstalkEnvOpts)
+
+	resp, err := conn.DescribeEnvironments(describeBeanstalkEnvOpts)
+	if err != nil {
+		return &elasticbeanstalk.EnvironmentDescription{}, err
+	}
+	if len(resp.Environments) == 0 {
+		return &elasticbeanstalk.EnvironmentDescription{}, fmt.Errorf("Elastic Beanstalk ENV not found.")
+	}
+	if len(resp.Environments) > 1 {
+		return &elasticbeanstalk.EnvironmentDescription{}, fmt.Errorf("Found %d environments, expected 1.", len(resp.Environments))
+	}
+	return resp.Environments[0], nil
 }
 
 const testAccBeanstalkEnvConfig = `
@@ -113,5 +167,19 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   application = "${aws_elastic_beanstalk_application.tftest.name}"
   solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
   #solution_stack_name =
+}
+`
+
+const testAccBeanstalkWorkerEnvConfig = `
+resource "aws_elastic_beanstalk_application" "tftest" {
+  name = "tf-test-name"
+  description = "tf-test-desc"
+}
+
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name = "tf-test-name"
+  application = "${aws_elastic_beanstalk_application.tftest.name}"
+  tier = "Worker"
+  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
 }
 `

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 * `application` – (Required) Name of the application that contains the version 
   to be deployed
 * `description` - (Optional) Short description of the Environment 
+* `tier` - (Optional) Elastic Beanstalk Environment tier. Valid values are `Worker` 
+  or `WebServer`. If tier is left blank `WebServer` will be used.
 * `setting` – (Optional) Option settings to configure the new Environment. These
   override specific values that are set as defaults. The format is detailed
   below in [Option Settings](#option-settings)
@@ -68,6 +70,7 @@ The following attributes are exported:
 
 * `name`
 * `description`
+* `tier` - the environment tier specified. 
 * `application` – the application specified
 * `setting` – Settings specifically set for this Environment
 * `all_settings` – List of all option settings configured in the Environment. These


### PR DESCRIPTION
@catsby

This adds support for the tier attribute when creating a Beanstalk Environment. This attribute doesn't support updates because a new environment must be created in order to change the tier type. 

[http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk-environment-tier.html](url)

In the course of adding a new test for this attribute, I also added the describeBeanstalkEnv func to remove some code duplication that shows up with multiple tests.