### PR TITLE
core: Test fix for mismatched diffs from GH-4965

### DIFF
--- a/builtin/providers/aws/core_acceptance_test.go
+++ b/builtin/providers/aws/core_acceptance_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVPC_coreMismatchedDiffs(t *testing.T) {
+	var vpc ec2.Vpc
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testMatchedDiffs,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists("aws_vpc.test", &vpc),
+					testAccCheckVpcCidr(&vpc, "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.test", "cidr_block", "10.0.0.0/16"),
+				),
+			},
+		},
+	})
+}
+
+const testMatchedDiffs = `resource "aws_vpc" "test" {
+    cidr_block = "10.0.0.0/16"
+
+    tags {
+        Name = "Repro GH-4965"
+    }
+
+    lifecycle {
+        ignore_changes = ["tags"]
+    }
+}`


### PR DESCRIPTION
This test presents itself in an awkward manner as part of the AWS test suite rather than the core test suite - this is because you cannot use real providers in context tests because of circular references, and simplistic test providers in that package do not demonstrate the issue.  In the interests of getting this fix in quickly and still having regression coverage for it, it was agreed to include the change here instead.
  
Running the test TestAccAWSVPC_coreMismatchedDiffs without the changes in d95ab75 applied leads to the following output:

```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run TestAccAWSVPC_coreMismatchedDiffs"
==> Checking that code complies with gofmt requirements...
/Users/James/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run TestAccAWSVPC_coreMismatchedDiffs -timeout 120m
=== RUN   TestAccAWSVPC_coreMismatchedDiffs
--- FAIL: TestAccAWSVPC_coreMismatchedDiffs (2.26s)
	testing.go:148: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_vpc.test: diffs didn't match during apply. This is a bug with Terraform and should be reported.
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/aws	2.281s
make: *** [testacc] Error 1
```

Applying the changes in d95ab75 (pull request GH-4965) yields the following result when running the test:

```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run TestAccAWSVPC_coreMismatchedDiffs"
==> Checking that code complies with gofmt requirements...
/Users/James/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run TestAccAWSVPC_coreMismatchedDiffs -timeout 120m
=== RUN   TestAccAWSVPC_coreMismatchedDiffs
--- PASS: TestAccAWSVPC_coreMismatchedDiffs (15.17s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	15.183s
```

The test has a rather misleading name ("AWS") such that it is actually run as part of the nightly acceptance testing. The VPC resource is quick and free to create, hence the selection.