### PR TITLE
provider/aws: Change Redshift Cluster cluster_type to be computed

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -37,7 +37,8 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			},
 			"cluster_type": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 
 			"node_type": &schema.Schema{
@@ -200,15 +201,19 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		Port:                aws.Int64(int64(d.Get("port").(int))),
 		MasterUserPassword:  aws.String(d.Get("master_password").(string)),
 		MasterUsername:      aws.String(d.Get("master_username").(string)),
-		ClusterType:         aws.String(d.Get("cluster_type").(string)),
 		ClusterVersion:      aws.String(d.Get("cluster_version").(string)),
 		NodeType:            aws.String(d.Get("node_type").(string)),
 		DBName:              aws.String(d.Get("database_name").(string)),
 		AllowVersionUpgrade: aws.Bool(d.Get("allow_version_upgrade").(bool)),
 	}
-	if d.Get("cluster_type") == "multi-node" {
+
+	if v := d.Get("number_of_nodes").(int); v > 1 {
+		createOpts.ClusterType = aws.String("multi-node")
 		createOpts.NumberOfNodes = aws.Int64(int64(d.Get("number_of_nodes").(int)))
+	} else {
+		createOpts.ClusterType = aws.String("single-node")
 	}
+
 	if v := d.Get("cluster_security_groups").(*schema.Set); v.Len() > 0 {
 		createOpts.ClusterSecurityGroups = expandStringList(v.List())
 	}
@@ -316,6 +321,11 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("preferred_maintenance_window", rsc.PreferredMaintenanceWindow)
 	d.Set("endpoint", aws.String(fmt.Sprintf("%s:%d", *rsc.Endpoint.Address, *rsc.Endpoint.Port)))
 	d.Set("cluster_parameter_group_name", rsc.ClusterParameterGroups[0].ParameterGroupName)
+	if len(rsc.ClusterNodes) > 1 {
+		d.Set("cluster_type", "multi-node")
+	} else {
+		d.Set("cluster_type", "single-node")
+	}
 
 	var vpcg []string
 	for _, g := range rsc.VpcSecurityGroups {
@@ -356,9 +366,12 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if d.HasChange("number_of_nodes") {
-		log.Printf("[INFO] When changing the NumberOfNodes in a Redshift Cluster, NodeType is required")
-		req.NumberOfNodes = aws.Int64(int64(d.Get("number_of_nodes").(int)))
-		req.NodeType = aws.String(d.Get("node_type").(string))
+		if v := d.Get("number_of_nodes").(int); v > 1 {
+			req.ClusterType = aws.String("multi-node")
+			req.NumberOfNodes = aws.Int64(int64(d.Get("number_of_nodes").(int)))
+		} else {
+			req.ClusterType = aws.String("single-node")
+		}
 	}
 
 	if d.HasChange("cluster_security_groups") {

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -28,6 +28,8 @@ func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "cluster_type", "single-node"),
 				),
 			},
 		},
@@ -243,7 +245,6 @@ resource "aws_redshift_cluster" "default" {
   master_username = "foo"
   master_password = "Mustbe8characters"
   node_type = "dc1.large"
-  cluster_type = "single-node"
   automated_snapshot_retention_period = 7
   allow_version_upgrade = false
 }`

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -32,7 +32,6 @@ The following arguments are supported:
 string.
 * `database_name` - (Optional) The name of the first database to be created when the cluster is created.
  If you do not provide a name, Amazon Redshift will create a default database called `dev`.
-* `cluster_type` - (Required) The type of the cluster. Valid values are `multi-node` and `single-node`
 * `node_type` - (Required) The node type to be provisioned for the cluster.
 * `master_password` - (Required) Password for the master DB user. Note that this may
     show up in logs, and it will be stored in the state file


### PR DESCRIPTION
It will be based off the number of nodes. Can only be multi-node (>1 node) or single-node (nodes=1)

As requested in #5235 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftCluster' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftCluster -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_basic
--- PASS: TestAccAWSRedshiftCluster_basic (598.03s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	598.047s
```