### PR TITLE
provider/aws: Add support for updating Lambda function

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -192,6 +192,7 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		_, err := conn.CreateFunction(params)
 		if err != nil {
+			log.Printf("[ERROR] Received %q, retrying CreateFunction", err)
 			if awserr, ok := err.(awserr.Error); ok {
 				if awserr.Code() == "InvalidParameterValueException" {
 					log.Printf("[DEBUG] InvalidParameterValueException creating Lambda Function: %s", awserr)

--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -58,18 +58,15 @@ func resourceAwsLambdaFunction() *schema.Resource {
 			"handler": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true, // TODO make this editable
 			},
 			"memory_size": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  128,
-				ForceNew: true, // TODO make this editable
 			},
 			"role": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true, // TODO make this editable
 			},
 			"runtime": &schema.Schema{
 				Type:     schema.TypeString,
@@ -81,7 +78,6 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  3,
-				ForceNew: true, // TODO make this editable
 			},
 			"vpc_config": &schema.Schema{
 				Type:     schema.TypeList,
@@ -135,15 +131,11 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 
 	var functionCode *lambda.FunctionCode
 	if v, ok := d.GetOk("filename"); ok {
-		filename, err := homedir.Expand(v.(string))
+		zipfile, shaSum, err := loadLocalZipFile(v.(string))
 		if err != nil {
 			return err
 		}
-		zipfile, err := ioutil.ReadFile(filename)
-		if err != nil {
-			return err
-		}
-		d.Set("source_code_hash", sha256.Sum256(zipfile))
+		d.Set("source_code_hash", shaSum)
 		functionCode = &lambda.FunctionCode{
 			ZipFile: zipfile,
 		}
@@ -284,7 +276,102 @@ func resourceAwsLambdaFunctionDelete(d *schema.ResourceData, meta interface{}) e
 // resourceAwsLambdaFunctionUpdate maps to:
 // UpdateFunctionCode in the API / SDK
 func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	conn := meta.(*AWSClient).lambdaconn
+
+	d.Partial(true)
+
+	codeReq := &lambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String(d.Id()),
+	}
+
+	codeUpdate := false
+	if sourceHash, ok := d.GetOk("source_code_hash"); ok {
+		zipfile, shaSum, err := loadLocalZipFile(d.Get("filename").(string))
+		if err != nil {
+			return err
+		}
+		if sourceHash != shaSum {
+			d.SetPartial("filename")
+			d.SetPartial("source_code_hash")
+		}
+		codeReq.ZipFile = zipfile
+		codeUpdate = true
+	}
+	if d.HasChange("s3_bucket") || d.HasChange("s3_key") || d.HasChange("s3_object_version") {
+		codeReq.S3Bucket = aws.String(d.Get("s3_bucket").(string))
+		codeReq.S3Key = aws.String(d.Get("s3_key").(string))
+		codeReq.S3ObjectVersion = aws.String(d.Get("s3_object_version").(string))
+		codeUpdate = true
+	}
+
+	log.Printf("[DEBUG] Send Update Lambda Function Code request: %#v", codeReq)
+	if codeUpdate {
+		_, err := conn.UpdateFunctionCode(codeReq)
+		if err != nil {
+			return fmt.Errorf("Error modifying Lambda Function Code %s: %s", d.Id(), err)
+		}
+
+		d.SetPartial("filename")
+		d.SetPartial("source_code_hash")
+		d.SetPartial("s3_bucket")
+		d.SetPartial("s3_key")
+		d.SetPartial("s3_object_version")
+	}
+
+	configReq := &lambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String(d.Id()),
+	}
+
+	configUpdate := false
+	if d.HasChange("description") {
+		configReq.Description = aws.String(d.Get("description").(string))
+		configUpdate = true
+	}
+	if d.HasChange("handler") {
+		configReq.Handler = aws.String(d.Get("handler").(string))
+		configUpdate = true
+	}
+	if d.HasChange("memory_size") {
+		configReq.MemorySize = aws.Int64(int64(d.Get("memory_size").(int)))
+		configUpdate = true
+	}
+	if d.HasChange("role") {
+		configReq.Role = aws.String(d.Get("role").(string))
+		configUpdate = true
+	}
+	if d.HasChange("timeout") {
+		configReq.Timeout = aws.Int64(int64(d.Get("timeout").(int)))
+		configUpdate = true
+	}
+
+	log.Printf("[DEBUG] Send Update Lambda Function Configuration request: %#v", configReq)
+	if configUpdate {
+		_, err := conn.UpdateFunctionConfiguration(configReq)
+		if err != nil {
+			return fmt.Errorf("Error modifying Lambda Function Configuration %s: %s", d.Id(), err)
+		}
+		d.SetPartial("description")
+		d.SetPartial("handler")
+		d.SetPartial("memory_size")
+		d.SetPartial("role")
+		d.SetPartial("timeout")
+	}
+	d.Partial(false)
+
+	return resourceAwsLambdaFunctionRead(d, meta)
+}
+
+func loadLocalZipFile(v string) ([]byte, string, error) {
+	filename, err := homedir.Expand(v)
+	if err != nil {
+		return nil, "", err
+	}
+	zipfile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, "", err
+	}
+	sum := sha256.Sum256(zipfile)
+	return zipfile, string(sum[:32]), nil
 }
 
 func validateVPCConfig(v interface{}) (map[string]interface{}, error) {

--- a/builtin/providers/aws/test-fixtures/lambda_func.js
+++ b/builtin/providers/aws/test-fixtures/lambda_func.js
@@ -1,0 +1,9 @@
+var http = require('http')
+
+exports.handler = function(event, context) {
+    http.get("http://requestb.in/10m32wg1", function(res) {
+        console.log("success", res.statusCode, res.body)
+    }).on('error', function(e) {
+        console.log("error", e)
+    })
+}

--- a/builtin/providers/aws/test-fixtures/lambda_func_modified.js
+++ b/builtin/providers/aws/test-fixtures/lambda_func_modified.js
@@ -1,0 +1,9 @@
+var http = require('http')
+
+exports.handler = function(event, context) {
+    http.get("http://requestb.in/MODIFIED", function(res) {
+        console.log("success", res.statusCode, res.body)
+    }).on('error', function(e) {
+        console.log("error", e)
+    })
+}

--- a/website/source/docs/providers/aws/r/lambda_function.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_function.html.markdown
@@ -39,6 +39,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "lambda_function_name"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.test"
+    source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
 }
 ```
 
@@ -56,6 +57,8 @@ resource "aws_lambda_function" "test_lambda" {
 * `runtime` - (Optional) Defaults to `nodejs`. See [Runtimes][6] for valid values.
 * `timeout` - (Optional) The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
 * `vpc_config` - (Optional) Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]
+* `source_code_hash` - (Optional) Used to trigger updates. This is only useful in conjuction with `filename`.
+  The only useful value is `${base64sha256(file("file.zip"))}`.
 
 **vpc\_config** requires the following:
 
@@ -66,6 +69,8 @@ resource "aws_lambda_function" "test_lambda" {
 
 * `arn` - The Amazon Resource Name (ARN) identifying your Lambda Function.
 * `last_modified` - The date this resource was last modified.
+* `source_code_hash` - Base64-encoded representation of raw SHA-256 sum of the zip file
+  provided either via `filename` or `s3_*` parameters
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html
 [2]: https://docs.aws.amazon.com/lambda/latest/dg/walkthrough-s3-events-adminuser-create-test-function-create-function.html


### PR DESCRIPTION
This supersedes #3825 

### To do:

 - [x] Working implementation of updates via `source_code_hash = base64sha256()`
 - [x] Test for updating local ZIP file
 - [x] Test cleanup - Replace generic function `testAccCheckAWSLambdaAttributes()` with more specific ones - `testAccCheckAwsLambdaFunctionName` & `testAccCheckAwsLambdaFunctionArn`
 - [x] Test for updating S3 version ID - would have been a lot cleaner if  https://github.com/hashicorp/terraform/pull/4846 & https://github.com/hashicorp/terraform/pull/5330 were merged
 - [x] Document how to trigger updates