### PR TITLE
Error out on negative indices in element()

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -475,7 +475,7 @@ func interpolationFuncElement() ast.Function {
 			list := StringList(args[0].(string))
 
 			index, err := strconv.Atoi(args[1].(string))
-			if err != nil {
+			if err != nil || index < 0 {
 				return "", fmt.Errorf(
 					"invalid number for index, got %s", args[1])
 			}

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -778,6 +778,14 @@ func TestInterpolateFuncElement(t *testing.T) {
 				false,
 			},
 
+			// Negative number should fail
+			{
+				fmt.Sprintf(`${element("%s", "-1")}`,
+					NewStringList([]string{"foo"}).String()),
+				nil,
+				true,
+			},
+
 			// Too many args
 			{
 				fmt.Sprintf(`${element("%s", "0", "2")}`,


### PR DESCRIPTION
prevents a negative offset in `StringList.Element()`:

```go
return sl.Slice()[index%sl.Length()]
```

fixes the following crash:



```
panic: runtime error: index out of range

goroutine 5424 [running]:
panic(0xa00f20, 0xc82001a160)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/panic.go:464 +0x3e6
github.com/hashicorp/terraform/config.StringList.Element(0xc8209c6300, 0x16a, 0xfffffffffffffffb, 0x0, 0x0)
    /Users/bill/goprojects/src/github.com/hashicorp/terraform/config/string_list.go:60 +0xef
github.com/hashicorp/terraform/config.interpolationFuncElement.func1(0xc820654e40, 0x2, 0x2, 0x0, 0x0, 0x0, 0x0)
    /Users/bill/goprojects/src/github.com/hashicorp/terraform/config/interpolate_funcs.go:483 +0x2bd
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.(*evalCall).Eval(0xc820ab63a0, 0x24c0a48, 0xc820e8d290, 0xc820f14dd0, 0x0, 0x0, 0x139aa58, 0x0, 0x0)
    /Users/bill/goprojects/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/eval.go:179 +0x41f
...
```

