### PR TITLE
fix #4913 aws_cloudformation_stack update must send parameters and capabilities even if they are not modified

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack.go
@@ -276,14 +276,16 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 		input.TemplateBody = aws.String(normalizeJson(v.(string)))
 	}
 
-	if d.HasChange("capabilities") {
-		input.Capabilities = expandStringList(d.Get("capabilities").(*schema.Set).List())
+	// Capabilities must be present whether they are changed or not
+	if v, ok := d.GetOk("capabilities"); ok {
+		input.Capabilities = expandStringList(v.(*schema.Set).List())
 	}
 	if d.HasChange("notification_arns") {
 		input.NotificationARNs = expandStringList(d.Get("notification_arns").(*schema.Set).List())
 	}
-	if d.HasChange("parameters") {
-		input.Parameters = expandCloudFormationParameters(d.Get("parameters").(map[string]interface{}))
+	// Parameters must be present whether they are changed or not
+	if v, ok := d.GetOk("parameters"); ok {
+		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
 	}
 	if d.HasChange("policy_body") {
 		input.StackPolicyBody = aws.String(normalizeJson(d.Get("policy_body").(string)))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,14 +34,20 @@ if [ "${TF_DEV}x" != "x" ]; then
     XC_ARCH=$(go env GOARCH)
 fi
 
+XC_LIST=${XC_LIST:-$(go list ./... | grep -v /vendor/)}
+
 # Build!
+echo "==> OS: $XC_OS"
+echo "==> Arch: $XC_ARCH"
+echo "==> Modules: $XC_LIST"
+
 echo "==> Building..."
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
     -ldflags "-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}" \
     -output "pkg/{{.OS}}_{{.Arch}}/terraform-{{.Dir}}" \
-    $(go list ./... | grep -v /vendor/)
+    $XC_LIST
 
 # Make sure "terraform-terraform" is renamed properly
 for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do


### PR DESCRIPTION
fix #4913 aws_cloudformation_stack update must send parameters and capabilities even if they are not modified
Build script updated to enable building specified module(s) for specified OS(s) and architecture(s)