### PR TITLE
provider/aws: Enable DynamoDB Table to output `stream_arm` when streams are enabled

### DIFF
--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -175,6 +175,10 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 				},
 				ValidateFunc: validateStreamViewType,
 			},
+			"stream_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -641,6 +645,7 @@ func resourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) erro
 	if table.StreamSpecification != nil {
 		d.Set("stream_view_type", table.StreamSpecification.StreamViewType)
 		d.Set("stream_enabled", table.StreamSpecification.StreamEnabled)
+		d.Set("stream_arn", table.LatestStreamArn)
 	}
 
 	err = d.Set("global_secondary_index", gsiList)

--- a/website/source/docs/providers/aws/r/dynamodb_table.html.markdown
+++ b/website/source/docs/providers/aws/r/dynamodb_table.html.markdown
@@ -84,7 +84,7 @@ parameter.
 * `non_key_attributes` - (Optional) Only required with *INCLUDE* as a
   projection type; a list of attributes to project into the index. These
 do not need to be defined as attributes on the table.
-* `stream_enabled` - (Optional) Indicates whether Streams is to be enabled (true) or disabled (false).
+* `stream_enabled` - (Optional) Indicates whether Streams are to be enabled (true) or disabled (false).
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES.
 
 For `global_secondary_index` objects only, you need to specify
@@ -114,4 +114,5 @@ The following attributes are exported:
 
 * `arn` - The arn of the table
 * `id` - The name of the table
+* `stream_arm` - The ARN of the Table Stream. Only available when `stream_enabled = true`
 


### PR DESCRIPTION
Fixes #5266 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDynamoDbTable' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
GO15VENDOREXPERIMENT=1 go generate $(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run=TestAccAWSDynamoDbTable -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (325.21s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (33.70s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	358.925s
```