### PR TITLE
terraform: upgrade resource name regexp failure to error

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -576,10 +576,10 @@ func TestContext2Validate_resourceNameSymbol(t *testing.T) {
 	})
 
 	w, e := c.Validate()
-	if len(w) == 0 {
+	if len(w) > 0 {
 		t.Fatalf("bad: %#v", w)
 	}
-	if len(e) > 0 {
+	if len(e) == 0 {
 		t.Fatalf("bad: %s", e)
 	}
 }

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -119,11 +119,10 @@ func (n *EvalValidateResource) Eval(ctx EvalContext) (interface{}, error) {
 	// If the resouce name doesn't match the name regular
 	// expression, show a warning.
 	if !config.NameRegexp.Match([]byte(n.ResourceName)) {
-		warns = append(warns, fmt.Sprintf(
+		errs = append(errs, fmt.Errorf(
 			"%s: resource name can only contain letters, numbers, "+
-				"dashes, and underscores.\n"+
-				"This will be an error in Terraform 0.4",
-			n.ResourceName))
+				"dashes, and underscores."+
+				n.ResourceName))
 	}
 
 	if len(warns) == 0 && len(errs) == 0 {


### PR DESCRIPTION
We're well past Terraform 0.4, so it's time to finally make good on the
original promise. :)

Fixes #5243