### PR TITLE
core: output "diffs didn't match" error details

### DIFF
--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -45,7 +45,18 @@ func (n *EvalCompareDiff) Eval(ctx EvalContext) (interface{}, error) {
 		log.Printf("[ERROR] %s: diff two: %#v", n.Info.Id, two)
 		return nil, fmt.Errorf(
 			"%s: diffs didn't match during apply. This is a bug with "+
-				"Terraform and should be reported.", n.Info.Id)
+				"Terraform and should be reported as a GitHub Issue.\n"+
+				"\n"+
+				"Please include the following information in your report:\n"+
+				"  Terraform Version: %s\n"+
+				"  Resource ID: %s\n"+
+				"  Mismatch reason: %s\n"+
+				"  Diff One (usually from plan): %#v\n"+
+				"  Diff Two (usually from apply): %#v\n"+
+				"\n"+
+				"Also include as much context as you can about your config, state,\n"+
+				"  and the steps you performed to trigger this error.\n",
+			n.Info.Id, Version, n.Info.Id, reason, one, two)
 	}
 
 	return nil, nil


### PR DESCRIPTION
Previously these details were relegated to the debug logs, which forces
the user to reproduce the error condition and then go digging for the
error message. Since we're asking users to report this error, let's give
them all the details they need right up front to make it a little easier
on them.