### PR TITLE
Make aws_iam_role resource update assume_role_policy on diff.

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -126,6 +127,14 @@ func resourceAwsIamRoleReadResult(d *schema.ResourceData, role *iam.Role) error 
 		return err
 	}
 	if err := d.Set("unique_id", role.RoleId); err != nil {
+		return err
+	}
+
+	policy, err := url.QueryUnescape(*role.AssumeRolePolicyDocument)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("assume_role_policy", policy); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Currently, Terraform does not pick up changes to the assume role policy.

One issue we found while writing these tests is that TestAccAWSRole_basic
currently fails for us on master because AWS returns a differently formatted
policy document than Terraform is expecting so it fails the step because there
is still a diff while planning.

We weren't sure if this is something specific to our AWS account, or if an
underlying change caused this dirty plan issue to start occurring. We can
submit another PR to update the remaining policy docs if it is the latter.

Signed-off-by: Michael Nussbaum michael.nussbaum@getbraintree.com
