### PR TITLE
Fix -module-depth typo

### DIFF
--- a/website/source/docs/configuration/environment-variables.html.md
+++ b/website/source/docs/configuration/environment-variables.html.md
@@ -44,7 +44,7 @@ export TF_INPUT=0
 
 ## TF_MODULE_DEPTH
 
-When given a value, causes terraform commands to behave as if the `-module=depth=VALUE` flag was specified. By setting this to 0, for example, you enable commands such as [plan](/docs/commands/plan.html) and [graph](/docs/commands/graph.html) to display more compressed information.
+When given a value, causes terraform commands to behave as if the `-module-depth=VALUE` flag was specified. By setting this to 0, for example, you enable commands such as [plan](/docs/commands/plan.html) and [graph](/docs/commands/graph.html) to display more compressed information.
 
 ```
 export TF_MODULE_DEPTH=0


### PR DESCRIPTION
The module depth parameter had an equal sign instead of a dash in the name.