### PR TITLE
provider/aws: Manage IAM policy documents

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_test.go
@@ -1,0 +1,107 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSIAMPolicy_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMPolicyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMPolicyExists(
+						"aws_iam_policy.foo",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccIAMPolicyConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMPolicyExists(
+						"aws_iam_policy.foo",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIAMPolicyExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		arn := rs.Primary.ID
+		//policy = policy.Attributes["policy"]
+
+		conn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		request := &iam.GetPolicyInput{
+			PolicyArn: aws.String(arn),
+		}
+
+		_, err := conn.GetPolicy(request)
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIAMPolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).iamconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iam_policy" {
+			continue
+		}
+
+		arn := rs.Primary.ID
+
+		request := &iam.GetPolicyInput{
+			PolicyArn: aws.String(arn),
+		}
+
+		_, err := conn.GetPolicy(request)
+		if err != nil {
+			// Verify the error is what we want
+			if ae, ok := err.(awserr.Error); ok && ae.Code() == "NoSuchEntity" {
+				continue
+			}
+			return err
+		}
+
+		return fmt.Errorf("IAM policy still exists")
+	}
+
+	return nil
+}
+
+const testAccIAMPolicyConfig = `
+resource "aws_iam_policy" "foo" {
+	name = "foo_policy"
+	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+}
+`
+
+const testAccIAMPolicyConfigUpdate = `
+resource "aws_iam_policy" "foo" {
+	name = "foo_policy"
+	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"ec2:Describe*\",\"Resource\":\"*\"}}"
+}
+`

--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -52,8 +53,9 @@ func resourceAwsIamRole() *schema.Resource {
 				ForceNew: true,
 			},
 			"assume_role_policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				StateFunc: normalizeJson,
 			},
 		},
 	}
@@ -128,6 +130,15 @@ func resourceAwsIamRoleReadResult(d *schema.ResourceData, role *iam.Role) error 
 	if err := d.Set("unique_id", role.RoleId); err != nil {
 		return err
 	}
+	// Remove HTML character codes from policy
+	policy, err := url.QueryUnescape(*role.AssumeRolePolicyDocument)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("assume_role_policy", normalizeJson(policy)); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This fixes #5201.

The `aws_iam_role` and `aws_iam_policy` resources don't manage policy documents because the resource never updates the policy after initial creation.
#5201 pertains to `aws_iam_policy`. This change aims to apply the same fix to `aws_iam_role`.

I have chosen to perform a more functional comparison by "normalizing" the policy documents by sorting keys and removing whitespace and newline characters. I have used `encoding/json` functions to perform that work.
