### PR TITLE
terraform: don't prune resource if count has interpolations

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"reflect"
@@ -3977,11 +3978,22 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	t.Logf("Plan for Step 1: %s", plan)
+	// Write / Read plan to simulate running it through a Plan file
+	var buf bytes.Buffer
+	if err := WritePlan(plan, &buf); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	planFromFile, err := ReadPlan(&buf)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	t.Logf("Plan for Step 1: %s", planFromFile)
 
 	// Apply the plan
 	t.Log("Applying Step 1 (from plan)")
-	ctx = plan.Context(&ContextOpts{
+	ctx = planFromFile.Context(&ContextOpts{
 		Providers: map[string]ResourceProviderFactory{
 			"template": testProviderFuncFixed(p),
 		},

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -3964,6 +3964,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 	}
 
 	// Application success. Now make the modification and store a plan
+	println("Planning Step 1")
 	t.Log("Planning Step 1")
 	ctx = testContext2(t, &ContextOpts{
 		Module: testModule(t, "issue-5254/step-1"),
@@ -3992,6 +3993,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 	t.Logf("Plan for Step 1: %s", planFromFile)
 
 	// Apply the plan
+	println("Applying Step 1 (from Plan)")
 	t.Log("Applying Step 1 (from plan)")
 	ctx = planFromFile.Context(&ContextOpts{
 		Providers: map[string]ResourceProviderFactory{

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -52,6 +52,11 @@ func testDiffFn(
 			continue
 		}
 
+		// Ignore __-prefixed keys since they're used for magic
+		if k[0] == '_' && k[1] == '_' {
+			continue
+		}
+
 		if k == "nil" {
 			return nil, nil
 		}
@@ -98,6 +103,9 @@ func testDiffFn(
 		}
 
 		if k == "require_new" {
+			attrDiff.RequiresNew = true
+		}
+		if _, ok := c.Raw["__"+k+"_requires_new"]; ok {
 			attrDiff.RequiresNew = true
 		}
 		diff.Attributes[k] = attrDiff

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -283,6 +283,13 @@ func (n *GraphNodeConfigResource) Noop(opts *NoopOpts) bool {
 		return false
 	}
 
+	// If the count has any interpolations, we can't prune this node since
+	// we need to be sure to evaluate the count so that splat variables work
+	// later (which need to know the full count).
+	if len(n.Resource.RawCount.Interpolations) > 0 {
+		return false
+	}
+
 	// If we have no module diff, we're certainly a noop. This is because
 	// it means there is a diff, and that the module we're in just isn't
 	// in it, meaning we're not doing anything.

--- a/terraform/test-fixtures/issue-5254/step-0/main.tf
+++ b/terraform/test-fixtures/issue-5254/step-0/main.tf
@@ -1,0 +1,10 @@
+variable "c" { default = 1 }
+
+resource "template_file" "parent" {
+  count = "${var.c}"
+  template = "Hi"
+}
+
+resource "template_file" "child" {
+  template = "${join(",", template_file.parent.*.template)} ok"
+}

--- a/terraform/test-fixtures/issue-5254/step-1/main.tf
+++ b/terraform/test-fixtures/issue-5254/step-1/main.tf
@@ -1,0 +1,11 @@
+variable "c" { default = 1 }
+
+resource "template_file" "parent" {
+  count = "${var.c}"
+  template = "Hi"
+}
+
+resource "template_file" "child" {
+  template = "${join(",", template_file.parent.*.template)}"
+  __template_requires_new = 1
+}


### PR DESCRIPTION
Fixes #5254 

If the count has interpolations, we can't prune the resource since we need to interpolate the count for splat variables. This only manifests itself if we persist the plan file since that doesn't include interpolations. This might be a bigger issue as well, but let's address that later.