### PR TITLE
Added support for redshift destination to firehose delivery streams

### DIFF
--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -37,37 +37,93 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 				},
 			},
 
-			"role_arn": &schema.Schema{
-				Type:     schema.TypeString,
+			"s3_configuration": &schema.Schema{
+				Type:     schema.TypeSet,
 				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_arn": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"buffer_size": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  5,
+						},
+
+						"buffer_interval": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  300,
+						},
+
+						"compression_format": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "UNCOMPRESSED",
+						},
+
+						"kms_key_arn": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"role_arn": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"prefix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 
-			"s3_bucket_arn": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"s3_prefix": &schema.Schema{
-				Type:     schema.TypeString,
+			"redshift_configuration": &schema.Schema{
+				Type:     schema.TypeSet,
 				Optional: true,
-			},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_jdbcurl": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
 
-			"s3_buffer_size": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  5,
-			},
+						"username": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
 
-			"s3_buffer_interval": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  300,
-			},
+						"password": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
 
-			"s3_data_compression": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "UNCOMPRESSED",
+						"role_arn": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"copy_options": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"data_table_columns": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"data_table_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
 			},
 
 			"arn": &schema.Schema{
@@ -91,49 +147,157 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 	}
 }
 
+func validateConfiguration(d *schema.ResourceData) error {
+	destination := d.Get("destination").(string)
+	if destination != "s3" && destination != "redshift" {
+		return fmt.Errorf("[ERROR] Destination must be s3 or redshift")
+	}
+
+	s3Configuration := d.Get("s3_configuration").(*schema.Set).List()
+	if len(s3Configuration) > 1 {
+		return fmt.Errorf("[ERROR] You can only define a single s3_configuration per delivery stream")
+	}
+
+	return nil
+}
+
+func createS3Config(d *schema.ResourceData) *firehose.S3DestinationConfiguration {
+	s3 := d.Get("s3_configuration").(*schema.Set).List()[0].(map[string]interface{})
+
+	return &firehose.S3DestinationConfiguration{
+		BucketARN: aws.String(s3["bucket_arn"].(string)),
+		RoleARN:   aws.String(s3["role_arn"].(string)),
+		BufferingHints: &firehose.BufferingHints{
+			IntervalInSeconds: aws.Int64(int64(s3["buffer_interval"].(int))),
+			SizeInMBs:         aws.Int64(int64(s3["buffer_size"].(int))),
+		},
+		Prefix:                  extractPrefixConfiguration(s3),
+		CompressionFormat:       aws.String(s3["compression_format"].(string)),
+		EncryptionConfiguration: extractEncryptionConfiguration(s3),
+	}
+}
+
+func updateS3Config(d *schema.ResourceData) *firehose.S3DestinationUpdate {
+	s3 := d.Get("s3_configuration").(*schema.Set).List()[0].(map[string]interface{})
+
+	return &firehose.S3DestinationUpdate{
+		BucketARN: aws.String(s3["bucket_arn"].(string)),
+		RoleARN:   aws.String(s3["role_arn"].(string)),
+		BufferingHints: &firehose.BufferingHints{
+			IntervalInSeconds: aws.Int64((int64)(s3["buffer_interval"].(int))),
+			SizeInMBs:         aws.Int64((int64)(s3["buffer_size"].(int))),
+		},
+		Prefix:                  extractPrefixConfiguration(s3),
+		CompressionFormat:       aws.String(s3["compression_format"].(string)),
+		EncryptionConfiguration: extractEncryptionConfiguration(s3),
+	}
+}
+
+func extractEncryptionConfiguration(s3 map[string]interface{}) *firehose.EncryptionConfiguration {
+	if key, ok := s3["kms_key_arn"]; ok && len(key.(string)) > 0 {
+		return &firehose.EncryptionConfiguration{
+			KMSEncryptionConfig: &firehose.KMSEncryptionConfig{
+				AWSKMSKeyARN: aws.String(key.(string)),
+			},
+		}
+	}
+
+	return &firehose.EncryptionConfiguration{
+		NoEncryptionConfig: aws.String("NoEncryption"),
+	}
+}
+
+func extractPrefixConfiguration(s3 map[string]interface{}) *string {
+	if v, ok := s3["prefix"]; ok {
+		return aws.String(v.(string))
+	}
+
+	return nil
+}
+
+func createRedshiftConfig(d *schema.ResourceData, s3Config *firehose.S3DestinationConfiguration) *firehose.RedshiftDestinationConfiguration {
+	redshift := d.Get("redshift_configuration").(*schema.Set).List()[0].(map[string]interface{})
+
+	return &firehose.RedshiftDestinationConfiguration{
+		ClusterJDBCURL:  aws.String(redshift["cluster_jdbcurl"].(string)),
+		Password:        aws.String(redshift["password"].(string)),
+		Username:        aws.String(redshift["username"].(string)),
+		RoleARN:         aws.String(redshift["role_arn"].(string)),
+		CopyCommand:     extractCopyCommandConfiguration(redshift),
+		S3Configuration: s3Config,
+	}
+}
+
+func updateRedshiftConfig(d *schema.ResourceData, s3Update *firehose.S3DestinationUpdate) *firehose.RedshiftDestinationUpdate {
+	redshift := d.Get("redshift_configuration").(*schema.Set).List()[0].(map[string]interface{})
+
+	return &firehose.RedshiftDestinationUpdate{
+		ClusterJDBCURL: aws.String(redshift["cluster_jdbcurl"].(string)),
+		Password:       aws.String(redshift["password"].(string)),
+		Username:       aws.String(redshift["username"].(string)),
+		RoleARN:        aws.String(redshift["role_arn"].(string)),
+		CopyCommand:    extractCopyCommandConfiguration(redshift),
+		S3Update:       s3Update,
+	}
+}
+
+func extractCopyCommandConfiguration(redshift map[string]interface{}) *firehose.CopyCommand {
+	cmd := &firehose.CopyCommand{
+		DataTableName: aws.String(redshift["data_table_name"].(string)),
+	}
+	if copyOptions, ok := redshift["copy_options"]; ok {
+		cmd.CopyOptions = aws.String(copyOptions.(string))
+	}
+	if columns, ok := redshift["data_table_columns"]; ok {
+		cmd.DataTableColumns = aws.String(columns.(string))
+	}
+
+	return cmd
+}
+
 func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).firehoseconn
 
-	if d.Get("destination").(string) != "s3" {
-		return fmt.Errorf("[ERROR] AWS Kinesis Firehose only supports S3 destinations for the first implementation")
+	if err := validateConfiguration(d); err != nil {
+		return err
 	}
 
 	sn := d.Get("name").(string)
-	input := &firehose.CreateDeliveryStreamInput{
+	s3Config := createS3Config(d)
+
+	createInput := &firehose.CreateDeliveryStreamInput{
 		DeliveryStreamName: aws.String(sn),
 	}
 
-	s3Config := &firehose.S3DestinationConfiguration{
-		BucketARN: aws.String(d.Get("s3_bucket_arn").(string)),
-		RoleARN:   aws.String(d.Get("role_arn").(string)),
-		BufferingHints: &firehose.BufferingHints{
-			IntervalInSeconds: aws.Int64(int64(d.Get("s3_buffer_interval").(int))),
-			SizeInMBs:         aws.Int64(int64(d.Get("s3_buffer_size").(int))),
-		},
-		CompressionFormat: aws.String(d.Get("s3_data_compression").(string)),
-	}
-	if v, ok := d.GetOk("s3_prefix"); ok {
-		s3Config.Prefix = aws.String(v.(string))
+	if d.Get("destination").(string) == "s3" {
+		createInput.S3DestinationConfiguration = s3Config
+	} else {
+		createInput.RedshiftDestinationConfiguration = createRedshiftConfig(d, s3Config)
 	}
 
-	input.S3DestinationConfiguration = s3Config
+	var lastError error
+	err := resource.Retry(1*time.Minute, func() error {
+		_, err := conn.CreateDeliveryStream(createInput)
+		if err != nil {
+			log.Printf("[DEBUG] Error creating Firehose Delivery Stream: %s", err)
+			lastError = err
 
-	var err error
-	for i := 0; i < 5; i++ {
-		_, err := conn.CreateDeliveryStream(input)
-		if awsErr, ok := err.(awserr.Error); ok {
-			// IAM roles can take ~10 seconds to propagate in AWS:
-			//  http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-			if awsErr.Code() == "InvalidArgumentException" && strings.Contains(awsErr.Message(), "Firehose is unable to assume role") {
-				log.Printf("[DEBUG] Firehose could not assume role referenced, retrying...")
-				time.Sleep(2 * time.Second)
-				continue
+			if awsErr, ok := err.(awserr.Error); ok {
+				// IAM roles can take ~10 seconds to propagate in AWS:
+				// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
+				if awsErr.Code() == "InvalidArgumentException" && strings.Contains(awsErr.Message(), "Firehose is unable to assume role") {
+					log.Printf("[DEBUG] Firehose could not assume role referenced, retrying...")
+					return awsErr
+				}
 			}
+			// Not retryable
+			return resource.RetryError{Err: err}
 		}
-		break
-	}
+
+		return nil
+	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr, ok := lastError.(awserr.Error); ok {
 			return fmt.Errorf("[WARN] Error creating Kinesis Firehose Delivery Stream: \"%s\", code: \"%s\"", awsErr.Message(), awsErr.Code())
 		}
 		return err
@@ -165,45 +329,26 @@ func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta
 func resourceAwsKinesisFirehoseDeliveryStreamUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).firehoseconn
 
-	if d.Get("destination").(string) != "s3" {
-		return fmt.Errorf("[ERROR] AWS Kinesis Firehose only supports S3 destinations for the first implementation")
+	if err := validateConfiguration(d); err != nil {
+		return err
 	}
 
 	sn := d.Get("name").(string)
-	s3_config := &firehose.S3DestinationUpdate{}
+	s3Config := updateS3Config(d)
 
-	if d.HasChange("role_arn") {
-		s3_config.RoleARN = aws.String(d.Get("role_arn").(string))
-	}
-
-	if d.HasChange("s3_bucket_arn") {
-		s3_config.BucketARN = aws.String(d.Get("s3_bucket_arn").(string))
-	}
-
-	if d.HasChange("s3_prefix") {
-		s3_config.Prefix = aws.String(d.Get("s3_prefix").(string))
-	}
-
-	if d.HasChange("s3_data_compression") {
-		s3_config.CompressionFormat = aws.String(d.Get("s3_data_compression").(string))
-	}
-
-	if d.HasChange("s3_buffer_interval") || d.HasChange("s3_buffer_size") {
-		bufferingHints := &firehose.BufferingHints{
-			IntervalInSeconds: aws.Int64(int64(d.Get("s3_buffer_interval").(int))),
-			SizeInMBs:         aws.Int64(int64(d.Get("s3_buffer_size").(int))),
-		}
-		s3_config.BufferingHints = bufferingHints
-	}
-
-	destOpts := &firehose.UpdateDestinationInput{
+	updateInput := &firehose.UpdateDestinationInput{
 		DeliveryStreamName:             aws.String(sn),
 		CurrentDeliveryStreamVersionId: aws.String(d.Get("version_id").(string)),
 		DestinationId:                  aws.String(d.Get("destination_id").(string)),
-		S3DestinationUpdate:            s3_config,
 	}
 
-	_, err := conn.UpdateDestination(destOpts)
+	if d.Get("destination").(string) == "s3" {
+		updateInput.S3DestinationUpdate = s3Config
+	} else {
+		updateInput.RedshiftDestinationUpdate = updateRedshiftConfig(d, s3Config)
+	}
+
+	_, err := conn.UpdateDestination(updateInput)
 	if err != nil {
 		return fmt.Errorf(
 			"Error Updating Kinesis Firehose Delivery Stream: \"%s\"\n%s",
@@ -215,11 +360,11 @@ func resourceAwsKinesisFirehoseDeliveryStreamUpdate(d *schema.ResourceData, meta
 
 func resourceAwsKinesisFirehoseDeliveryStreamRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).firehoseconn
-	sn := d.Get("name").(string)
-	describeOpts := &firehose.DescribeDeliveryStreamInput{
-		DeliveryStreamName: aws.String(sn),
-	}
-	resp, err := conn.DescribeDeliveryStream(describeOpts)
+
+	resp, err := conn.DescribeDeliveryStream(&firehose.DescribeDeliveryStreamInput{
+		DeliveryStreamName: aws.String(d.Get("name").(string)),
+	})
+
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == "ResourceNotFoundException" {

--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -3,31 +3,25 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSKinesisFirehoseDeliveryStream_basic(t *testing.T) {
+func TestAccAWSKinesisFirehoseDeliveryStream_s3basic(t *testing.T) {
 	var stream firehose.DeliveryStreamDescription
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_basic,
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3basic,
 		os.Getenv("AWS_ACCOUNT_ID"), ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if os.Getenv("AWS_ACCOUNT_ID") == "" {
-				t.Fatal("AWS_ACCOUNT_ID must be set")
-			}
-		},
+		PreCheck:     testAccKinesisFirehosePreCheck(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -45,19 +39,14 @@ func TestAccAWSKinesisFirehoseDeliveryStream_basic(t *testing.T) {
 func TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates(t *testing.T) {
 	var stream firehose.DeliveryStreamDescription
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	preconfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3,
+	ri := acctest.RandInt()
+	preconfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3basic,
 		os.Getenv("AWS_ACCOUNT_ID"), ri, ri)
 	postConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3Updates,
 		os.Getenv("AWS_ACCOUNT_ID"), ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if os.Getenv("AWS_ACCOUNT_ID") == "" {
-				t.Fatal("AWS_ACCOUNT_ID must be set")
-			}
-		},
+		PreCheck:     testAccKinesisFirehosePreCheck(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -67,11 +56,11 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates(t *testing.T) {
 					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream", &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream),
 					resource.TestCheckResourceAttr(
-						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_buffer_size", "5"),
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_size", "5"),
 					resource.TestCheckResourceAttr(
-						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_buffer_interval", "300"),
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_interval", "300"),
 					resource.TestCheckResourceAttr(
-						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_data_compression", "UNCOMPRESSED"),
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.compression_format", "UNCOMPRESSED"),
 				),
 			},
 
@@ -81,11 +70,86 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates(t *testing.T) {
 					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream", &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream),
 					resource.TestCheckResourceAttr(
-						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_buffer_size", "10"),
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_size", "10"),
 					resource.TestCheckResourceAttr(
-						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_buffer_interval", "400"),
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_interval", "400"),
 					resource.TestCheckResourceAttr(
-						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_data_compression", "GZIP"),
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.compression_format", "GZIP"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_RedshiftBasic(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftBasic,
+		os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream", &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+
+	ri := acctest.RandInt()
+	preconfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftBasic,
+		os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftUpdates,
+		os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preconfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream", &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_size", "5"),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_interval", "300"),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.compression_format", "UNCOMPRESSED"),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "redshift_configuration.copy_options", ""),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "redshift_configuration.data_table_columns", ""),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream", &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_size", "10"),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.buffer_interval", "400"),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "s3_configuration.compression_format", "GZIP"),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "redshift_configuration.copy_options", "GZIP"),
+					resource.TestCheckResourceAttr(
+						"aws_kinesis_firehose_delivery_stream.test_stream", "redshift_configuration.data_table_columns", "test-col"),
 				),
 			},
 		},
@@ -159,10 +223,19 @@ func testAccCheckKinesisFirehoseDeliveryStreamDestroy(s *terraform.State) error 
 	return nil
 }
 
-var testAccKinesisFirehoseDeliveryStreamConfig_basic = `
+func testAccKinesisFirehosePreCheck(t *testing.T) func() {
+	return func() {
+		testAccPreCheck(t)
+		if os.Getenv("AWS_ACCOUNT_ID") == "" {
+			t.Fatal("AWS_ACCOUNT_ID must be set")
+		}
+	}
+}
+
+const testAccKinesisFirehoseDeliveryStreamBaseConfig = `
 resource "aws_iam_role" "firehose" {
-	name = "terraform_acctest_firehose_delivery_role"
-	assume_role_policy = <<EOF
+  name = "terraform_acctest_firehose_delivery_role"
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -185,14 +258,14 @@ EOF
 }
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
+  bucket = "tf-test-bucket-%d"
+  acl = "private"
 }
 
 resource "aws_iam_role_policy" "firehose" {
-	name = "terraform_acctest_firehose_delivery_policy"
-	role = "${aws_iam_role.firehose.id}"
-	policy = <<EOF
+  name = "terraform_acctest_firehose_delivery_policy"
+  role = "${aws_iam_role.firehose.id}"
+  policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -217,145 +290,80 @@ resource "aws_iam_role_policy" "firehose" {
 EOF
 }
 
+`
+
+var testAccKinesisFirehoseDeliveryStreamConfig_s3basic = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
-	depends_on = ["aws_iam_role_policy.firehose"]
-	name = "terraform-kinesis-firehose-basictest-%d"
-	destination = "s3"
-	role_arn = "${aws_iam_role.firehose.arn}"
-	s3_bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  depends_on = ["aws_iam_role_policy.firehose"]
+  name = "terraform-kinesis-firehose-basictest-%d"
+  destination = "s3"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
 }`
 
-var testAccKinesisFirehoseDeliveryStreamConfig_s3 = `
-resource "aws_iam_role" "firehose" {
-	name = "terraform_acctest_firehose_delivery_role_s3"
-	assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "firehose.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole",
-      "Condition": {
-        "StringEquals": {
-          "sts:ExternalId": "%s"
-        }
-      }
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_s3_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
-}
-
-resource "aws_iam_role_policy" "firehose" {
-	name = "terraform_acctest_firehose_delivery_policy_s3"
-	role = "${aws_iam_role.firehose.id}"
-	policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:AbortMultipartUpload",
-        "s3:GetBucketLocation",
-        "s3:GetObject",
-        "s3:ListBucket",
-        "s3:ListBucketMultipartUploads",
-        "s3:PutObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
+var testAccKinesisFirehoseDeliveryStreamConfig_s3Updates = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
-	depends_on = ["aws_iam_role_policy.firehose"]
-	name = "terraform-kinesis-firehose-s3test-%d"
-	destination = "s3"
-	role_arn = "${aws_iam_role.firehose.arn}"
-	s3_bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  depends_on = ["aws_iam_role_policy.firehose"]
+  name = "terraform-kinesis-firehose-s3test-%d"
+  destination = "s3"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    buffer_size = 10
+    buffer_interval = 400
+    compression_format = "GZIP"
+  }
 }`
 
-var testAccKinesisFirehoseDeliveryStreamConfig_s3Updates = `
-resource "aws_iam_role" "firehose" {
-	name = "terraform_acctest_firehose_delivery_role_s3"
-	assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "firehose.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole",
-      "Condition": {
-        "StringEquals": {
-          "sts:ExternalId": "%s"
-        }
-      }
-    }
-  ]
-}
-EOF
-}
+var testAccKinesisFirehoseDeliveryStreamBaseRedshiftConfig = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
+resource "aws_redshift_cluster" "test_cluster" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  database_name = "test"
+  master_username = "testuser"
+  master_password = "T3stPass"
+  node_type = "dc1.large"
+  cluster_type = "single-node"
+}`
 
-resource "aws_s3_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
-}
-
-resource "aws_iam_role_policy" "firehose" {
-	name = "terraform_acctest_firehose_delivery_policy_s3"
-	role = "${aws_iam_role.firehose.id}"
-	policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:AbortMultipartUpload",
-        "s3:GetBucketLocation",
-        "s3:GetObject",
-        "s3:ListBucket",
-        "s3:ListBucketMultipartUploads",
-        "s3:PutObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
+var testAccKinesisFirehoseDeliveryStreamConfig_RedshiftBasic = testAccKinesisFirehoseDeliveryStreamBaseRedshiftConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
-	depends_on = ["aws_iam_role_policy.firehose"]
-	name = "terraform-kinesis-firehose-s3test-%d"
-	destination = "s3"
-	role_arn = "${aws_iam_role.firehose.arn}"
-	s3_bucket_arn = "${aws_s3_bucket.bucket.arn}"
-	s3_buffer_size = 10
-	s3_buffer_interval = 400
-	s3_data_compression = "GZIP"
+  depends_on = ["aws_iam_role_policy.firehose", "aws_redshift_cluster.test_cluster"]
+  name = "terraform-kinesis-firehose-basicredshifttest-%d"
+  destination = "redshift"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+  redshift_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    cluster_jdbcurl = "jdbc:redshift://${aws_redshift_cluster.test_cluster.endpoint}/${aws_redshift_cluster.test_cluster.database_name}"
+    username = "testuser"
+    password = "T3stPass"
+    data_table_name = "test-table"
+  }
+}`
+
+var testAccKinesisFirehoseDeliveryStreamConfig_RedshiftUpdates = testAccKinesisFirehoseDeliveryStreamBaseRedshiftConfig + `
+resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
+  depends_on = ["aws_iam_role_policy.firehose", "aws_redshift_cluster.test_cluster"]
+  name = "terraform-kinesis-firehose-basicredshifttest-%d"
+  destination = "redshift"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    buffer_size = 10
+    buffer_interval = 400
+    compression_format = "GZIP"
+  }
+  redshift_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    cluster_jdbcurl = "jdbc:redshift://${aws_redshift_cluster.test_cluster.endpoint}/${aws_redshift_cluster.test_cluster.database_name}"
+    username = "testuser"
+    password = "T3stPass"
+    data_table_name = "test-table"
+    copy_options = "GZIP"
+    data_table_columns = "test-col"
+  }
 }`

--- a/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
@@ -81,6 +81,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     copy_options = "GZIP"
     data_table_columns = "test-col"
   }
+}
 ```
 
 ~> **NOTE:** Kinesis Firehose is currently only supported in us-east-1, us-west-2 and eu-west-1.

--- a/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
@@ -14,13 +14,14 @@ For more details, see the [Amazon Kinesis Firehose Documentation][1].
 
 ## Example Usage
 
+### S3 Destination
 ```
 resource "aws_s3_bucket" "bucket" {
-	bucket = "tf-test-bucket"
-	acl = "private"
+  bucket = "tf-test-bucket"
+  acl = "private"
 }
 
-esource "aws_iam_role" "firehose_role" {
+resource "aws_iam_role" "firehose_role" {
    name = "firehose_test_role"
    assume_role_policy = <<EOF
 {
@@ -40,14 +41,49 @@ EOF
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
-	name = "terraform-kinesis-firehose-test-stream"
-	destination = "s3"
-	role_arn = "${aws_iam_role.firehose_role.arn}"
-	s3_bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  name = "terraform-kinesis-firehose-test-stream"
+  destination = "s3"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose_role.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
 }
 ```
 
-~> **NOTE:** Kinesis Firehose is currently only supported in us-east-1, us-west-2 and eu-west-1. This implementation of Kinesis Firehose only supports the s3 destination type as Terraform doesn't support Redshift yet.
+### Redshift Destination
+
+```
+resource "aws_redshift_cluster" "test_cluster" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  database_name = "test"
+  master_username = "testuser"
+  master_password = "T3stPass"
+  node_type = "dc1.large"
+  cluster_type = "single-node"
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
+  name = "terraform-kinesis-firehose-test-stream"
+  destination = "redshift"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose_role.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    buffer_size = 10
+    buffer_interval = 400
+    compression_format = "GZIP"
+  }
+  redshift_configuration {
+    role_arn = "${aws_iam_role.firehose_role.arn}"
+    cluster_jdbcurl = "jdbc:redshift://${aws_redshift_cluster.test_cluster.endpoint}/${aws_redshift_cluster.test_cluster.database_name}"
+    username = "testuser"
+    password = "T3stPass"
+    data_table_name = "test-table"
+    copy_options = "GZIP"
+    data_table_columns = "test-col"
+  }
+```
+
+~> **NOTE:** Kinesis Firehose is currently only supported in us-east-1, us-west-2 and eu-west-1.
 
 ## Argument Reference
 
@@ -55,15 +91,32 @@ The following arguments are supported:
 
 * `name` - (Required) A name to identify the stream. This is unique to the
 AWS account and region the Stream is created in.
-* `destination` – (Required) This is the destination to where the data is delivered. The only options are `s3` & `redshift`
-* `role_arn` - (Required) The ARN of the AWS credentials.
-* `s3_bucket_arn` - (Required) The ARN of the S3 bucket
-* `s3_prefix` - (Optional) The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket
-* `s3_buffer_size` - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
-                                We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or highe
-* `s3_buffer_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300
-* `s3_data_compression` - (Optional) The compression format. If no value is specified, the default is NOCOMPRESSION. Other supported values are GZIP, ZIP & Snappy
+* `destination` – (Required) This is the destination to where the data is delivered. The only options are `s3` & `redshift`.
+* `s3_configuration` - (Required) Configuration options for the s3 destination (or the intermediate bucket if the destination
+is redshift). More details are given below.
+* `redshift_configuration` - (Optional) Configuration options if redshift is the destination. More details are given below.
 
+The `s3_configuration` object supports the following:
+
+* `role_arn` - (Required) The ARN of the AWS credentials.
+* `bucket_arn` - (Required) The ARN of the S3 bucket
+* `prefix` - (Optional) The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket
+* `buffer_size` - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+                                We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
+* `buffer_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+* `compression_format` - (Optional) The compression format. If no value is specified, the default is NOCOMPRESSION. Other supported values are GZIP, ZIP & Snappy. If the destination is redshift you cannot use ZIP or Snappy.
+* `kms_key_arn` - (Optional) If set, the stream will encrypt data using the key in KMS, otherwise, no encryption will
+be used.
+
+The `redshift_configuration` object supports the following:
+
+* `cluster_jdbcurl` - (Required) The jdbcurl of the redshift cluster.
+* `username` - (Required) The username that the firehose delivery stream will assume. It is strongly recommend that the username and password provided is used exclusively for Amazon Kinesis Firehose purposes, and that the permissions for the account are restricted for Amazon Redshift INSERT permissions.
+* `password` - (Required) The passowrd for the username above.
+* `role_arn` - (Required) The arn of the role the stream assumes.
+* `data_table_name` - (Required) The name of the table in the redshift cluster that the s3 bucket will copy to.
+* `copy_options` - (Optional) Copy options for copying the data from the s3 intermediate bucket into redshift.
+* `data_table_columns` - (Optional) The data table columns that will be targeted by the copy command.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Previously, firehose delivery streams only supported writing to s3. This PR adds redshift as a destination for firehose delivery streams. There is also some refactoring done to clean up the s3 configuration so existing delivery stream resources will be broken.

The related issue is #5152.