### PR TITLE
provider/aws: Enable updates & versioning for s3_bucket_object

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -20,6 +20,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsS3BucketObjectPut,
 		Read:   resourceAwsS3BucketObjectRead,
+		Update: resourceAwsS3BucketObjectPut,
 		Delete: resourceAwsS3BucketObjectDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -32,31 +33,26 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			"cache_control": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"content_disposition": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"content_encoding": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"content_language": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"content_type": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 
@@ -69,19 +65,21 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			"source": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"content"},
 			},
 
 			"content": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"source"},
 			},
 
 			"etag": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
+				// This will conflict with SSE-C and SSE-KMS encryption and multi-part upload
+				// if/when it's actually implemented. The Etag then won't match raw-file MD5.
+				// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+				Optional: true,
 				Computed: true,
 			},
 		},
@@ -149,7 +147,7 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 	d.Set("etag", strings.Trim(*resp.ETag, `"`))
 
 	d.SetId(key)
-	return nil
+	return resourceAwsS3BucketObjectRead(d, meta)
 }
 
 func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/mitchellh/go-homedir"
@@ -144,7 +145,9 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error putting object in S3 bucket (%s): %s", bucket, err)
 	}
 
-	d.Set("etag", resp.ETag)
+	// See https://forums.aws.amazon.com/thread.jspa?threadID=44003
+	d.Set("etag", strings.Trim(*resp.ETag, `"`))
+
 	d.SetId(key)
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -111,9 +111,9 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 		content := v.(string)
 		body = bytes.NewReader([]byte(content))
 	} else {
-
 		return fmt.Errorf("Must specify \"source\" or \"content\" field")
 	}
+
 	putInput := &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),

--- a/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
@@ -27,6 +27,7 @@ func TestAccAWSS3BucketObject_source(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,7 +36,7 @@ func TestAccAWSS3BucketObject_source(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAWSS3BucketObjectConfigSource(rInt, tmpFile.Name()),
-				Check:  testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object"),
+				Check:  testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
 			},
 		},
 	})
@@ -43,6 +44,7 @@ func TestAccAWSS3BucketObject_source(t *testing.T) {
 
 func TestAccAWSS3BucketObject_content(t *testing.T) {
 	rInt := acctest.RandInt()
+	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,7 +54,7 @@ func TestAccAWSS3BucketObject_content(t *testing.T) {
 			resource.TestStep{
 				PreConfig: func() {},
 				Config:    testAccAWSS3BucketObjectConfigContent(rInt),
-				Check:     testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object"),
+				Check:     testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
 			},
 		},
 	})
@@ -72,6 +74,8 @@ func TestAccAWSS3BucketObject_withContentCharacteristics(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var obj s3.GetObjectOutput
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -80,7 +84,7 @@ func TestAccAWSS3BucketObject_withContentCharacteristics(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSS3BucketObjectConfig_withContentCharacteristics(rInt, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object"),
+					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket_object.object", "content_type", "binary/octet-stream"),
 				),
@@ -101,6 +105,7 @@ func TestAccAWSS3BucketObject_updates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -110,7 +115,7 @@ func TestAccAWSS3BucketObject_updates(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSS3BucketObjectConfig_updates(rInt, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object"),
+					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
 					resource.TestCheckResourceAttr("aws_s3_bucket_object.object", "etag", "647d1d58e1011c743ec67d5e8af87b53"),
 				),
 			},
@@ -123,12 +128,74 @@ func TestAccAWSS3BucketObject_updates(t *testing.T) {
 				},
 				Config: testAccAWSS3BucketObjectConfig_updates(rInt, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object"),
+					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
 					resource.TestCheckResourceAttr("aws_s3_bucket_object.object", "etag", "1c7fd13df1515c2a13ad9eb068931f09"),
 				),
 			},
 		},
 	})
+}
+
+func TestAccAWSS3BucketObject_updatesWithVersioning(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj-updates-w-versions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	rInt := acctest.RandInt()
+	err = ioutil.WriteFile(tmpFile.Name(), []byte("initial versioned object state"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var originalObj, modifiedObj s3.GetObjectOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketObjectConfig_updatesWithVersioning(rInt, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &originalObj),
+					resource.TestCheckResourceAttr("aws_s3_bucket_object.object", "etag", "cee4407fa91906284e2a5e5e03e86b1b"),
+				),
+			},
+			resource.TestStep{
+				PreConfig: func() {
+					err = ioutil.WriteFile(tmpFile.Name(), []byte("modified versioned object"), 0644)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testAccAWSS3BucketObjectConfig_updatesWithVersioning(rInt, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &modifiedObj),
+					resource.TestCheckResourceAttr("aws_s3_bucket_object.object", "etag", "00b8c73b1b50e7cc932362c7225b8e29"),
+					testAccCheckAWSS3BucketObjectVersionIdDiffers(&originalObj, &modifiedObj),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSS3BucketObjectVersionIdDiffers(first, second *s3.GetObjectOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if first.VersionId == nil {
+			return fmt.Errorf("Expected first object to have VersionId: %s", first)
+		}
+		if second.VersionId == nil {
+			return fmt.Errorf("Expected second object to have VersionId: %s", second)
+		}
+
+		if *first.VersionId == *second.VersionId {
+			return fmt.Errorf("Expected Version IDs to differ, but they are equal (%s)", *first.VersionId)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckAWSS3BucketObjectDestroy(s *terraform.State) error {
@@ -152,7 +219,7 @@ func testAccCheckAWSS3BucketObjectDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSS3BucketObjectExists(n string) resource.TestCheckFunc {
+func testAccCheckAWSS3BucketObjectExists(n string, obj *s3.GetObjectOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -164,7 +231,7 @@ func testAccCheckAWSS3BucketObjectExists(n string) resource.TestCheckFunc {
 		}
 
 		s3conn := testAccProvider.Meta().(*AWSClient).s3conn
-		_, err := s3conn.GetObject(
+		out, err := s3conn.GetObject(
 			&s3.GetObjectInput{
 				Bucket:  aws.String(rs.Primary.Attributes["bucket"]),
 				Key:     aws.String(rs.Primary.Attributes["key"]),
@@ -173,6 +240,9 @@ func testAccCheckAWSS3BucketObjectExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("S3Bucket Object error: %s", err)
 		}
+
+		*obj = *out
+
 		return nil
 	}
 }
@@ -224,6 +294,24 @@ func testAccAWSS3BucketObjectConfig_updates(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket_3" {
 	bucket = "tf-object-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "object" {
+	bucket = "${aws_s3_bucket.object_bucket_3.bucket}"
+	key = "updateable-key"
+	source = "%s"
+	etag = "${md5(file("%s"))}"
+}
+`, randInt, source, source)
+}
+
+func testAccAWSS3BucketObjectConfig_updatesWithVersioning(randInt int, source string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket_3" {
+	bucket = "tf-object-test-bucket-%d"
+	versioning {
+		enabled = true
+	}
 }
 
 resource "aws_s3_bucket_object" "object" {

--- a/builtin/providers/aws/resource_aws_security_group_rules_matching_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rules_matching_test.go
@@ -565,9 +565,6 @@ func TestRulesMixedMatching(t *testing.T) {
 	for i, c := range cases {
 		saves := matchRules("ingress", c.local, c.remote)
 		log.Printf("\n======\n\nSaves:\n%#v\n\nCS Saves:\n%#v\n\n======\n", saves, c.saves)
-		if err != nil {
-			t.Fatal(err)
-		}
 		log.Printf("\n\tTest %d:\n", i)
 
 		if len(saves) != len(c.saves) {


### PR DESCRIPTION
This is closing https://github.com/hashicorp/terraform/issues/3068 and will help finishing https://github.com/hashicorp/terraform/pull/5239

It also introduces a **breaking change** - `etag` is now returned without quotes - frankly I don't see the "quoted" version being useful in any context.

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSS3BucketObject'
```
```
TF_ACC=1 GO15VENDOREXPERIMENT=1 go test ./builtin/providers/aws -v -run=AWSS3BucketObject -timeout 120m
=== RUN   TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_source (96.96s)
=== RUN   TestAccAWSS3BucketObject_content
--- PASS: TestAccAWSS3BucketObject_content (36.43s)
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (37.41s)
=== RUN   TestAccAWSS3BucketObject_updates
--- PASS: TestAccAWSS3BucketObject_updates (58.90s)
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (60.36s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	290.076s
```