### PR TITLE
Makefile/docs: Lock in 1.6 req, doc vendored deps

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,15 +41,12 @@ vagrant ssh
 # The current "terraform" directory is then sync'd into the gopath
 cd /opt/gopath/src/github.com/hashicorp/terraform/
 
-# Fetch dependencies
-make updatedeps
-
 # Verify unit tests pass
 make test
 
 # Build the release
 # This generates binaries for each platform and places them in the pkg folder
-make release
+make bin
 ```
 
 After running these commands, you should have binaries for all supported

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST?=$$(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
+TEST?=$$(go list ./... | grep -v /vendor/)
 VETARGS?=-all
 
 default: test vet
@@ -19,7 +19,7 @@ quickdev: generate
 # changes will require a rebuild of everything, in which case the dev
 # target should be used.
 core-dev: fmtcheck generate
-	GO15VENDOREXPERIMENT=1 go install github.com/hashicorp/terraform
+	go install github.com/hashicorp/terraform
 
 # Shorthand for quickly testing the core of Terraform (i.e. "not providers")
 core-test: generate
@@ -28,12 +28,12 @@ core-test: generate
 # Shorthand for building and installing just one plugin for local testing.
 # Run as (for example): make plugin-dev PLUGIN=provider-aws
 plugin-dev: fmtcheck generate
-	GO15VENDOREXPERIMENT=1 go install github.com/hashicorp/terraform/builtin/bins/$(PLUGIN)
+	go install github.com/hashicorp/terraform/builtin/bins/$(PLUGIN)
 	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
 
 # test runs the unit tests
 test: fmtcheck generate
-	TF_ACC= GO15VENDOREXPERIMENT=1 go test $(TEST) $(TESTARGS) -timeout=30s -parallel=4
+	TF_ACC= go test $(TEST) $(TESTARGS) -timeout=30s -parallel=4
 
 # testacc runs acceptance tests
 testacc: fmtcheck generate
@@ -42,30 +42,18 @@ testacc: fmtcheck generate
 		echo "  make testacc TEST=./builtin/providers/aws"; \
 		exit 1; \
 	fi
-	TF_ACC=1 GO15VENDOREXPERIMENT=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 # testrace runs the race checker
 testrace: fmtcheck generate
-	TF_ACC= GO15VENDOREXPERIMENT=1 go test -race $(TEST) $(TESTARGS)
-
-# updatedeps installs all the dependencies that Terraform needs to run
-# and build.
-updatedeps:
-	go get -u github.com/mitchellh/gox
-	go get -u golang.org/x/tools/cmd/stringer
-	go list ./... \
-		| xargs go list -f '{{join .Deps "\n"}}' \
-		| grep -v github.com/hashicorp/terraform \
-		| grep -v '/internal/' \
-		| sort -u \
-		| xargs go get -f -u -v
+	TF_ACC= go test -race $(TEST) $(TESTARGS)
 
 cover:
 	@go tool cover 2>/dev/null; if [ $$? -eq 3 ]; then \
 		go get -u golang.org/x/tools/cmd/cover; \
 	fi
-	GO15VENDOREXPERIMENT=1 go test $(TEST) -coverprofile=coverage.out
-	GO15VENDOREXPERIMENT=1 go tool cover -html=coverage.out
+	go test $(TEST) -coverprofile=coverage.out
+	go tool cover -html=coverage.out
 	rm coverage.out
 
 # vet runs the Go source code static analysis tool `vet` to find
@@ -75,7 +63,7 @@ vet:
 		go get golang.org/x/tools/cmd/vet; \
 	fi
 	@echo "go tool vet $(VETARGS) ."
-	@GO15VENDOREXPERIMENT=1 go tool vet $(VETARGS) $$(ls -d */ | grep -v vendor) ; if [ $$? -eq 1 ]; then \
+	@go tool vet $(VETARGS) $$(ls -d */ | grep -v vendor) ; if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \
@@ -88,7 +76,7 @@ generate:
 	@which stringer ; if [ $$? -ne 0 ]; then \
 	  go get -u golang.org/x/tools/cmd/stringer; \
 	fi
-	GO15VENDOREXPERIMENT=1 go generate $$(GO15VENDOREXPERIMENT=1 go list ./... | grep -v /vendor/)
+	go generate $$(go list ./... | grep -v /vendor/)
 
 fmt:
 	gofmt -w .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,15 +18,11 @@ GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
 
-# Use vendored dependencies
-export GO15VENDOREXPERIMENT=1
-
 # Delete the old dir
 echo "==> Removing old directory..."
 rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
-
 
 # If its dev mode, only build for ourself
 if [ "${TF_DEV}x" != "x" ]; then


### PR DESCRIPTION
 * Drop Go 1.5 compatibility env vars
 * Drop `make updatedeps` from `Makefile` and docs
 * Update README w/ vendored dep instructions