### PR TITLE
add missing sidebar link to new google_compute_subnetwork resource

### DIFF
--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -81,6 +81,10 @@
 			<a href="/docs/providers/google/r/compute_ssl_certificate.html">google_compute_ssl_certificate</a>
 			</li>
 
+			<li<%= sidebar_current("docs-google-compute-subnetwork") %>>
+			<a href="/docs/providers/google/r/compute_subnetwork.html">google_compute_subnetwork</a>
+			</li>
+
 			<li<%= sidebar_current("docs-google-compute-target-http-proxy") %>>
 			<a href="/docs/providers/google/r/compute_target_http_proxy.html">google_compute_target_http_proxy</a>
 			</li>


### PR DESCRIPTION
The `google_compute_subnetwork` resource was added in 0.6.12 but the resource documentation is not visible on [terraform.io](https://www.terraform.io/docs/providers/google/index.html).