### PR TITLE
provider/aws: Add ability to update r53 zone comment

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -85,6 +85,39 @@ func TestAccAWSRoute53Zone_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Zone_updateComment(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+	var td route53.ResourceTagSet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53ZoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+					testAccLoadTagsR53(&zone, &td),
+					testAccCheckTagsR53(&td.Tags, "foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_zone.main", "comment", "Custom comment"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccRoute53ZoneConfigUpdateComment,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+					testAccLoadTagsR53(&zone, &td),
+					resource.TestCheckResourceAttr(
+						"aws_route53_zone.main", "comment", "Change Custom Comment"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute53Zone_private_basic(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
@@ -279,6 +312,18 @@ const testAccRoute53ZoneConfig = `
 resource "aws_route53_zone" "main" {
 	name = "hashicorp.com"
 	comment = "Custom comment"
+
+	tags {
+		foo = "bar"
+		Name = "tf-route53-tag-test"
+	}
+}
+`
+
+const testAccRoute53ZoneConfigUpdateComment = `
+resource "aws_route53_zone" "main" {
+	name = "hashicorp.com"
+	comment = "Change Custom Comment"
 
 	tags {
 		foo = "bar"


### PR DESCRIPTION
As per request in #5317 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRoute53Zone_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRoute53Zone -timeout 120m
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (43.16s)
=== RUN   TestAccAWSRoute53Zone_updateComment
--- PASS: TestAccAWSRoute53Zone_updateComment (49.10s)
=== RUN   TestAccAWSRoute53Zone_private_basic
--- PASS: TestAccAWSRoute53Zone_private_basic (64.86s)
=== RUN   TestAccAWSRoute53Zone_private_region
--- PASS: TestAccAWSRoute53Zone_private_region (64.09s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	231.942s
```