### PR TITLE
provider/docker: #2417 Add support for restart policy unless-stopped

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -101,9 +101,9 @@ func resourceDockerContainer() *schema.Resource {
 				Default:  "no",
 				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 					value := v.(string)
-					if !regexp.MustCompile(`^(no|on-failure|always)$`).MatchString(value) {
+					if !regexp.MustCompile(`^(no|on-failure|always|unless-stopped)$`).MatchString(value) {
 						es = append(es, fmt.Errorf(
-							"%q must be one of \"no\", \"on-failure\", or \"always\"", k))
+							"%q must be one of \"no\", \"on-failure\", \"always\" or \"unless-stopped\"", k))
 					}
 					return
 				},

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 * `hostname` - (Optional, string) Hostname of the container.
 * `domainname` - (Optional, string) Domain name of the container.
 * `restart` - (Optional, string) The restart policy for the container. Must be
-  one of "no", "on-failure", "always".
+  one of "no", "on-failure", "always", "unless-stopped".
 * `max_retry_count` - (Optional, int) The maximum amount of times to an attempt
   a restart when `restart` is set to "on-failure"
 * `must_run` - (Optional, bool) If true, then the Docker container will be


### PR DESCRIPTION
When docker restart policy support #2417 start, [unless-stopped](https://docs.docker.com/engine/reference/run/#restart-policies-restart) did not exists so i add it now.