### PR TITLE
provider/cloudflare: Change `cloudflare_record` type to ForceNew

### DIFF
--- a/builtin/providers/cloudflare/resource_cloudflare_record.go
+++ b/builtin/providers/cloudflare/resource_cloudflare_record.go
@@ -35,6 +35,7 @@ func resourceCloudFlareRecord() *schema.Resource {
 			"type": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"value": &schema.Schema{


### PR DESCRIPTION
The CloudFlare API does not allow types to be changed (i.e. A to CNAME)
after creation

Fixes #5316 

```
make testacc TEST=./builtin/providers/cloudflare TESTARGS='-run=TestAccCLOudflareRecord'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/cloudflare -v -run=TestAccCLOudflareRecord -timeout 120m
=== RUN   TestAccCLOudflareRecord_Basic
--- PASS: TestAccCLOudflareRecord_Basic (5.61s)
=== RUN   TestAccCLOudflareRecord_Updated
--- PASS: TestAccCLOudflareRecord_Updated (9.08s)
=== RUN   TestAccCLOudflareRecord_forceNewRecord
--- PASS: TestAccCLOudflareRecord_forceNewRecord (9.87s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/cloudflare	24.574s
```