### PR TITLE
provider/openstack: Making Block Device Size Required

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -201,7 +201,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 						},
 						"volume_size": &schema.Schema{
 							Type:     schema.TypeInt,
-							Optional: true,
+							Required: true,
 						},
 						"destination_type": &schema.Schema{
 							Type:     schema.TypeString,

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -121,7 +121,7 @@ The `block_device` block supports:
 * `source_type` - (Required) The source type of the device. Must be one of
     "image", "volume", or "snapshot".
 
-* `volume_size` - (Optional) The size of the volume to create (in gigabytes).
+* `volume_size` - (Required) The size of the volume to create (in gigabytes).
 
 * `boot_index` - (Optional) The boot index of the volume. It defaults to 0.
 


### PR DESCRIPTION
The `volume_size` of a `block_device` was originally set to Optional,
but it's a required parameter in the OpenStack/Nova API. While it's
possible to infer a default size of the block device, making it required
more closely matches the Nova CLI client as well as provides consistent
experience when working with multiple block_devices.

Fixes #5098 