### PR TITLE
provider/openstack: Add Support for Domain environment variables

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -47,14 +47,14 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: envDefaultFuncAllowMissing("OS_AUTH_TOKEN"),
 			},
 			"domain_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: envDefaultFuncAllowMissing("OS_DOMAIN_ID"),
 			},
 			"domain_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: envDefaultFuncAllowMissing("OS_DOMAIN_NAME"),
 			},
 			"insecure": &schema.Schema{
 				Type:     schema.TypeBool,

--- a/website/source/docs/providers/openstack/index.html.markdown
+++ b/website/source/docs/providers/openstack/index.html.markdown
@@ -48,9 +48,11 @@ The following arguments are supported:
 
 * `api_key` - (Optional; Required if not using `password`)
 
-* `domain_id` - (Optional)
+* `domain_id` - (Optional) If omitted, the `OS_DOMAIN_ID` environment
+    variable is used.
 
-* `domain_name` - (Optional)
+* `domain_name` - (Optional) If omitted, the `OS_DOMAIN_NAME`
+    environment variable is used.
 
 * `tenant_id` - (Optional)
 


### PR DESCRIPTION
This commit adds the ability to specify the Domain ID and Domain Name
by OS_DOMAIN_ID and OS_DOMAIN_NAME respectively.

Fixes #5206 