### PR TITLE
provider/openstack: Add detaching as valid pending state

### DIFF
--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -242,7 +242,7 @@ func resourceBlockStorageVolumeV1Delete(d *schema.ResourceData, meta interface{}
 			}
 
 			stateConf := &resource.StateChangeConf{
-				Pending:    []string{"in-use", "attaching"},
+				Pending:    []string{"in-use", "attaching", "detaching"},
 				Target:     []string{"available"},
 				Refresh:    VolumeV1StateRefreshFunc(blockStorageClient, d.Id()),
 				Timeout:    10 * time.Minute,


### PR DESCRIPTION
This commit allows "detaching" to be a valid pending state when
detaching a volume. Despite being obvious pending state, it also
helps in race situations when a volume is implicitly being detached
by Nova.