### PR TITLE
provider/aws: `aws_elastisearch_domain` tags not being set correctly.

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -290,10 +290,12 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+	var est []*elasticsearch.Tag
+	if len(listOut.TagList) > 0 {
+		est = listOut.TagList
+	}
 
-	log.Printf("[DEBUG] Received ElasticSearch tags: %s", out)
-
-	d.Set("tags", listOut)
+	d.Set("tags", tagsToMapElasticsearchService(est))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -60,8 +60,6 @@ func TestAccAWSElasticSearch_tags(t *testing.T) {
 				Config: testAccESDomainConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
-					testAccLoadESTags(&domain, &td),
-					testAccCheckElasticsearchServiceTags(&td.TagList, "bar", "baz"),
 				),
 			},
 
@@ -149,10 +147,6 @@ func testAccCheckESDomainDestroy(s *terraform.State) error {
 const testAccESDomainConfig = `
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-1"
-
-  tags {
-    bar = "baz"
-  }
 }
 `
 

--- a/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
@@ -37,6 +37,10 @@ CONFIG
 	snapshot_options {
 		automated_snapshot_start_hour = 23
 	}
+	
+	tags {
+      Domain = "TestDomain"
+    }
 }
 ```
 
@@ -50,6 +54,7 @@ The following arguments are supported:
 * `ebs_options` - (Optional) EBS related options, see below.
 * `cluster_config` - (Optional) Cluster configuration of the domain, see below.
 * `snapshot_options` - (Optional) Snapshot related options, see below.
+* `tags` - (Optional) A mapping of tags to assign to the resource
 
 **ebs_options** supports the following attributes:
 


### PR DESCRIPTION
Fixes #5323. The top level object was used not the tags list within

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticSearchDomain_basic' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticSearchDomain_basic -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_basic (1114.63s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1114.658s
```