### PR TITLE
provider/openstack: Re-Add server.AccessIPv4 and server.AccessIPv6

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -497,6 +497,14 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	// Determine the best IPv4 and IPv6 addresses to access the instance with
 	hostv4, hostv6 := getInstanceAccessAddresses(d, networks)
 
+	if server.AccessIPv4 != "" && hostv4 == "" {
+		hostv4 = server.AccessIPv4
+	}
+
+	if server.AccessIPv6 != "" && hostv6 == "" {
+		hostv6 = server.AccessIPv6
+	}
+
 	d.Set("network", networks)
 	d.Set("access_ip_v4", hostv4)
 	d.Set("access_ip_v6", hostv6)


### PR DESCRIPTION
GH-4812 removed reading server.AccessIPv4 and server.AccessIPv6
because, AFAICT, they are not set by Nova. After removal, a user
reported that they were no longer able to read IPs from access_ip_v4
and access_ip_v6 on Rackspace. It's possible that Rackspace sets
the AccessIPv* attributes, and if that's true, other cloud providers
might as well through custom extensions.

The priority of how access_ip_v* is set might require some tweaks in
the future.

Fixes #5358 