### PR TITLE
Lambda S3 object version defaults to '$LATEST' if unspecified

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -151,13 +151,15 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		s3Bucket, bucketOk := d.GetOk("s3_bucket")
 		s3Key, keyOk := d.GetOk("s3_key")
 		s3ObjectVersion, versionOk := d.GetOk("s3_object_version")
-		if !bucketOk || !keyOk || !versionOk {
-			return errors.New("s3_bucket, s3_key and s3_object_version must all be set while using S3 code source")
+		if !bucketOk || !keyOk {
+			return errors.New("s3_bucket and s3_key must all be set while using S3 code source")
 		}
 		functionCode = &lambda.FunctionCode{
-			S3Bucket:        aws.String(s3Bucket.(string)),
-			S3Key:           aws.String(s3Key.(string)),
-			S3ObjectVersion: aws.String(s3ObjectVersion.(string)),
+			S3Bucket: aws.String(s3Bucket.(string)),
+			S3Key:    aws.String(s3Key.(string)),
+		}
+		if versionOk {
+			functionCode.S3ObjectVersion = aws.String(s3ObjectVersion.(string))
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -21,8 +23,9 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSLambdaConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", &conf),
-					testAccCheckAWSLambdaAttributes(&conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", "example_lambda_name", &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, "example_lambda_name"),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":example_lambda_name"),
 				),
 			},
 		},
@@ -40,8 +43,31 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSLambdaConfigWithVPC,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", &conf),
-					testAccCheckAWSLambdaAttributes(&conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", "example_lambda_name", &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, "example_lambda_name"),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":example_lambda_name"),
+					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaFunction_s3(t *testing.T) {
+	var conf lambda.GetFunctionOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSLambdaConfigS3,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3test", "example_lambda_name_s3", &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, "example_lambda_name_s3"),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":example_lambda_name_s3"),
+					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 				),
 			},
 		},
@@ -70,12 +96,12 @@ func testAccCheckLambdaFunctionDestroy(s *terraform.State) error {
 
 }
 
-func testAccCheckAwsLambdaFunctionExists(n string, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
+func testAccCheckAwsLambdaFunctionExists(res, funcName string, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
 	// Wait for IAM role
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
+		rs, ok := s.RootModule().Resources[res]
 		if !ok {
-			return fmt.Errorf("Lambda function not found: %s", n)
+			return fmt.Errorf("Lambda function not found: %s", res)
 		}
 
 		if rs.Primary.ID == "" {
@@ -85,7 +111,7 @@ func testAccCheckAwsLambdaFunctionExists(n string, function *lambda.GetFunctionO
 		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
 
 		params := &lambda.GetFunctionInput{
-			FunctionName: aws.String("example_lambda_name"),
+			FunctionName: aws.String(funcName),
 		}
 
 		getFunction, err := conn.GetFunction(params)
@@ -99,16 +125,32 @@ func testAccCheckAwsLambdaFunctionExists(n string, function *lambda.GetFunctionO
 	}
 }
 
-func testAccCheckAWSLambdaAttributes(function *lambda.GetFunctionOutput) resource.TestCheckFunc {
+func testAccCheckAwsLambdaFunctionName(function *lambda.GetFunctionOutput, expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		c := function.Configuration
-		const expectedName = "example_lambda_name"
 		if *c.FunctionName != expectedName {
 			return fmt.Errorf("Expected function name %s, got %s", expectedName, *c.FunctionName)
 		}
 
-		if *c.FunctionArn == "" {
-			return fmt.Errorf("Could not read Lambda Function's ARN")
+		return nil
+	}
+}
+
+func testAccCheckAWSLambdaFunctionVersion(function *lambda.GetFunctionOutput, expectedVersion string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		c := function.Configuration
+		if *c.Version != expectedVersion {
+			return fmt.Errorf("Expected version %s, got %s", expectedVersion, *c.Version)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAwsLambdaFunctionArnHasSuffix(function *lambda.GetFunctionOutput, arnSuffix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		c := function.Configuration
+		if !strings.HasSuffix(*c.FunctionArn, arnSuffix) {
+			return fmt.Errorf("Expected function ARN %s to have suffix %s", *c.FunctionArn, arnSuffix)
 		}
 
 		return nil
@@ -222,3 +264,42 @@ resource "aws_lambda_function" "lambda_function_test" {
     }
 }
 `
+
+var testAccAWSLambdaConfigS3 = fmt.Sprintf(`
+resource "aws_s3_bucket" "lambda_bucket" {
+  bucket = "tf-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "lambda_code" {
+  bucket = "${aws_s3_bucket.lambda_bucket.id}"
+  key = "lambdatest.zip"
+  source = "test-fixtures/lambdatest.zip"
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "iam_for_lambda"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "lambda_function_s3test" {
+    s3_bucket = "${aws_s3_bucket.lambda_bucket.id}"
+    s3_key = "${aws_s3_bucket_object.lambda_code.id}"
+    function_name = "example_lambda_name_s3"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+}
+`, acctest.RandInt())


### PR DESCRIPTION
This is a rebased and polished version of https://github.com/hashicorp/terraform/pull/4770

Essentially I just resolved conflicts with some latest changes in the Lambda Function acceptance tests and replaced `rand.New(rand.NewSource(time.Now().UnixNano())).Int()` with `acctest.RandInt()`.

The original credit obviously goes to @Bowbaq :wink: 

I will merge this myself once Travis turns green since it's just polished version of someone else's PR and the changes were quite trivial, but feel free to do code review afterwards.

I also ran acceptance tests:

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSLambdaFunction -timeout 120m
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (30.24s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (33.40s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (32.21s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	95.874s
```