### PR TITLE
provider/aws: Fixes the use of Uppercase chars in ELB Listeners

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -49,7 +49,7 @@ func expandListeners(configured []interface{}) ([]*elb.Listener, error) {
 		if l.SSLCertificateId != nil && *l.SSLCertificateId != "" {
 			// validate the protocol is correct
 			for _, p := range []string{"https", "ssl"} {
-				if (*l.InstanceProtocol == p) || (*l.Protocol == p) {
+				if (strings.ToLower(*l.InstanceProtocol) == p) || (strings.ToLower(*l.Protocol) == p) {
 					valid = true
 				}
 			}


### PR DESCRIPTION
Fixes #5303 - where the usage of uppercase characters in https / ssl listener said the listener was added when it wasn't. This PR doesn't change the behviour at all - it just changes how we check that we are creating a valid ELB listener config

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSELB' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSELB -timeout 120m
=== RUN   TestAccAWSELB_basic
--- PASS: TestAccAWSELB_basic (30.14s)
=== RUN   TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_fullCharacterRange (25.72s)
=== RUN   TestAccAWSELB_AccessLogs
--- PASS: TestAccAWSELB_AccessLogs (74.76s)
=== RUN   TestAccAWSELB_generatedName
--- PASS: TestAccAWSELB_generatedName (22.79s)
=== RUN   TestAccAWSELB_availabilityZones
--- PASS: TestAccAWSELB_availabilityZones (39.87s)
=== RUN   TestAccAWSELB_tags
--- PASS: TestAccAWSELB_tags (42.28s)
=== RUN   TestAccAWSELB_iam_server_cert
--- PASS: TestAccAWSELB_iam_server_cert (33.54s)
=== RUN   TestAccAWSELB_InstanceAttaching
--- PASS: TestAccAWSELB_InstanceAttaching (142.16s)
=== RUN   TestAccAWSELBUpdate_Listener
--- PASS: TestAccAWSELBUpdate_Listener (51.82s)
=== RUN   TestAccAWSELB_HealthCheck
--- PASS: TestAccAWSELB_HealthCheck (26.24s)
=== RUN   TestAccAWSELBUpdate_HealthCheck
--- PASS: TestAccAWSELBUpdate_HealthCheck (50.48s)
=== RUN   TestAccAWSELB_Timeout
--- PASS: TestAccAWSELB_Timeout (38.09s)
=== RUN   TestAccAWSELBUpdate_Timeout
--- PASS: TestAccAWSELBUpdate_Timeout (56.80s)
=== RUN   TestAccAWSELB_ConnectionDraining
--- PASS: TestAccAWSELB_ConnectionDraining (30.56s)
=== RUN   TestAccAWSELBUpdate_ConnectionDraining
--- PASS: TestAccAWSELBUpdate_ConnectionDraining (69.16s)
=== RUN   TestAccAWSELB_SecurityGroups
--- PASS: TestAccAWSELB_SecurityGroups (55.63s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	790.071s
```