### PR TITLE
README: link off to CONTRIBUTING for acctest info

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,28 +124,10 @@ git push origin my-feature-branch
 
 ### Acceptance Tests
 
-Terraform also has a comprehensive [acceptance test](http://en.wikipedia.org/wiki/Acceptance_testing) suite covering most of the major features of the built-in providers.
+Terraform has a comprehensive [acceptance
+test](http://en.wikipedia.org/wiki/Acceptance_testing) suite covering the
+built-in providers. Our [Contributing Guide](https://github.com/hashicorp/terraform/blob/master/CONTRIBUTING.md) includes details about how and when to write and run acceptance tests in order to help contributions get accepted quickly.
 
-If you're working on a feature of a provider and want to verify it is functioning (and hasn't broken anything else), we recommend running the acceptance tests. Note that we *do not require* that you run or write acceptance tests to have a PR accepted. The acceptance tests are just here for your convenience.
-
-**Warning:** The acceptance tests create/destroy/modify *real resources*, which may incur real costs. In the presence of a bug, it is technically possible that broken providers could corrupt existing infrastructure as well. Therefore, please run the acceptance providers at your own risk. At the very least, we recommend running them in their own private account for whatever provider you're testing.
-
-To run the acceptance tests, invoke `make testacc`:
-
-```sh
-$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=Vpc'
-go generate ./...
-TF_ACC=1 go test ./builtin/providers/aws -v -run=Vpc -timeout 90m
-=== RUN TestAccVpc_basic
-2015/02/10 14:11:17 [INFO] Test: Using us-west-2 as test region
-[...]
-[...]
-...
-```
-
-The `TEST` variable is required, and you should specify the folder where the provider is. The `TESTARGS` variable is recommended to filter down to a specific resource to test, since testing all of them at once can take a very long time.
-
-Acceptance tests typically require other environment variables to be set for things such as access keys. The provider itself should error early and tell you what to set, so it is not documented here.
 
 ### Cross Compilation and Building for Distribution
 


### PR DESCRIPTION
Acctest info in README was a bit stale since the enhanced contributing
guide landed.