### PR TITLE
provider/aws: Allow recovering from failed CloudWatch Event Target creation

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
@@ -61,9 +61,6 @@ func resourceAwsCloudWatchEventTargetCreate(d *schema.ResourceData, meta interfa
 	rule := d.Get("rule").(string)
 	targetId := d.Get("target_id").(string)
 
-	id := rule + "-" + targetId
-	d.SetId(id)
-
 	input := buildPutTargetInputStruct(d)
 	log.Printf("[DEBUG] Creating CloudWatch Event Target: %s", input)
 	out, err := conn.PutTargets(input)
@@ -75,6 +72,9 @@ func resourceAwsCloudWatchEventTargetCreate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Creating CloudWatch Event Target failed: %s",
 			out.FailedEntries)
 	}
+
+	id := rule + "-" + targetId
+	d.SetId(id)
 
 	log.Printf("[INFO] CloudWatch Event Target %q created", d.Id())
 

--- a/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
@@ -15,7 +15,7 @@ Provides a CloudWatch Event Target resource.
 ```
 resource "aws_cloudwatch_event_target" "yada" {
   target_id = "Yada"
-  rule = "${aws_cloudwatch_event_rule.console.arn}"
+  rule = "${aws_cloudwatch_event_rule.console.name}"
   arn = "${aws_kinesis_stream.test_stream.arn}"
 }
 


### PR DESCRIPTION
Closes #5389

### Test plan
```sh
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSCloudWatchEventTarget'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSCloudWatchEventTarget -timeout 120m
=== RUN   TestAccAWSCloudWatchEventTarget_basic
--- PASS: TestAccAWSCloudWatchEventTarget_basic (22.41s)
=== RUN   TestAccAWSCloudWatchEventTarget_full
--- PASS: TestAccAWSCloudWatchEventTarget_full (94.04s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	116.482s
```
