### PR TITLE
provider/aws: Adds `arn` as an output for `aws_elb`

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -30,6 +31,11 @@ func resourceAwsElb() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validateElbName,
+			},
+
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"internal": &schema.Schema{
@@ -362,6 +368,13 @@ func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("access_logs", flattenAccessLog(lbAttrs.AccessLog)); err != nil {
 			return err
 		}
+	}
+
+	arn, arnErr := buildElbARN(d.Id(), meta)
+	if arnErr != nil {
+		return arnErr
+	} else {
+		d.Set("arn", arn)
 	}
 
 	resp, err := elbconn.DescribeTags(&elb.DescribeTagsInput{
@@ -801,4 +814,18 @@ func sourceSGIdByName(meta interface{}, sg, vpcId string) (string, error) {
 
 	group := resp.SecurityGroups[0]
 	return *group.GroupId, nil
+}
+
+func buildElbARN(identifier string, meta interface{}) (string, error) {
+	iamconn := meta.(*AWSClient).iamconn
+	region := meta.(*AWSClient).region
+	// An zero value GetUserInput{} defers to the currently logged in user
+	resp, err := iamconn.GetUser(&iam.GetUserInput{})
+	if err != nil {
+		return "", err
+	}
+	userARN := *resp.User.Arn
+	accountID := strings.Split(userARN, ":")[4]
+	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:loadbalancer:%s", region, accountID, identifier)
+	return arn, nil
 }

--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -113,6 +113,7 @@ The following attributes are exported:
 
 * `id` - The name of the ELB
 * `name` - The name of the ELB
+* `arn` - The ARN of the ELB.
 * `dns_name` - The DNS name of the ELB
 * `instances` - The list of instances in the ELB
 * `source_security_group` - The name of the security group that you can use as


### PR DESCRIPTION
As requested in #5406 

Simple addition of ARN for the ELB resource