### PR TITLE
description is now a required field for google_dns_managed_zone

### DIFF
--- a/builtin/providers/google/resource_dns_managed_zone.go
+++ b/builtin/providers/google/resource_dns_managed_zone.go
@@ -32,6 +32,7 @@ func resourceDnsManagedZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"name_servers": &schema.Schema{

--- a/builtin/providers/google/resource_dns_managed_zone_test.go
+++ b/builtin/providers/google/resource_dns_managed_zone_test.go
@@ -80,5 +80,4 @@ var testAccDnsManagedZone_basic = fmt.Sprintf(`
 resource "google_dns_managed_zone" "foobar" {
 	name = "mzone-test-%s"
 	dns_name = "terraform.test."
-	description = "Test Description"
 }`, acctest.RandString(10))

--- a/website/source/docs/providers/google/r/dns_managed_zone.markdown
+++ b/website/source/docs/providers/google/r/dns_managed_zone.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `dns_name` - (Required) The DNS name of this zone, e.g. "terraform.io".
 
-* `description` - (Optional) A textual description field.
+* `description` - (Optional) A textual description field. Defaults to 'Managed by Terraform'.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The description field for a managed-zone is now a required field when using the Cloud API.
Ref: https://cloud.google.com/sdk/gcloud/reference/dns/managed-zones/create

--
The test case already included the (previously optional) description so that's why this wasn't picked up.