### PR TITLE
provider/google: Fix VPN tunnel creation test

### DIFF
--- a/builtin/providers/google/resource_compute_vpn_tunnel_test.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel_test.go
@@ -122,7 +122,7 @@ resource "google_compute_vpn_tunnel" "foobar" {
 	region = "${google_compute_forwarding_rule.foobar_udp4500.region}"
 	target_vpn_gateway = "${google_compute_vpn_gateway.foobar.self_link}"
 	shared_secret = "unguessable"
-	peer_ip = "0.0.0.0"
+	peer_ip = "8.8.8.8"
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
 	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
 	acctest.RandString(10))


### PR DESCRIPTION
The GCE API for creating VPN tunnels began validating the `peerIp` field
and rejecting RFC5735 addresses. The previous test was using one of
these addresses and failing as a result. This commit uses 8.8.8.8
for the peerIp.

See #5431 