### PR TITLE
provider/google: Fix Pubsub acceptance tests

### DIFF
--- a/builtin/providers/google/resource_pubsub_subscription_test.go
+++ b/builtin/providers/google/resource_pubsub_subscription_test.go
@@ -34,8 +34,8 @@ func testAccCheckPubsubSubscriptionDestroy(s *terraform.State) error {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		_, err := config.clientPubsub.Projects.Subscriptions.Get(rs.Primary.ID).Do()
-		if err != nil {
+		sub, _ := config.clientPubsub.Projects.Subscriptions.Get(rs.Primary.ID).Do()
+		if sub != nil {
 			return fmt.Errorf("Subscription still present")
 		}
 	}
@@ -56,7 +56,7 @@ func testAccPubsubSubscriptionExists(n string) resource.TestCheckFunc {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientPubsub.Projects.Subscriptions.Get(rs.Primary.ID).Do()
 		if err != nil {
-			return fmt.Errorf("Subscription still present")
+			return fmt.Errorf("Subscription does not exist")
 		}
 
 		return nil

--- a/builtin/providers/google/resource_pubsub_topic_test.go
+++ b/builtin/providers/google/resource_pubsub_topic_test.go
@@ -34,8 +34,8 @@ func testAccCheckPubsubTopicDestroy(s *terraform.State) error {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		_, err := config.clientPubsub.Projects.Topics.Get(rs.Primary.ID).Do()
-		if err != nil {
+		topic, _ := config.clientPubsub.Projects.Topics.Get(rs.Primary.ID).Do()
+		if topic != nil {
 			return fmt.Errorf("Topic still present")
 		}
 	}
@@ -56,7 +56,7 @@ func testAccPubsubTopicExists(n string) resource.TestCheckFunc {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientPubsub.Projects.Topics.Get(rs.Primary.ID).Do()
 		if err != nil {
-			return fmt.Errorf("Topic still present")
+			return fmt.Errorf("Topic does not exist")
 		}
 
 		return nil


### PR DESCRIPTION
Acceptance tests for Pubsub topics and subscriptions failed after
incorrectly determining that resources were not deleted in the
CheckDestroy phase.

Fixes #5437 