### PR TITLE
Support KMS encryption of S3 objects

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
@@ -247,6 +247,24 @@ func testAccCheckAWSS3BucketObjectExists(n string, obj *s3.GetObjectOutput) reso
 	}
 }
 
+func TestAccAWSS3BucketObject_kms(t *testing.T) {
+	rInt := acctest.RandInt()
+	var obj s3.GetObjectOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				PreConfig: func() {},
+				Config:    testAccAWSS3BucketObjectConfig_withKMSId(rInt),
+				Check:     testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
+			},
+		},
+	})
+}
+
 func testAccAWSS3BucketObjectConfigSource(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
@@ -321,4 +339,19 @@ resource "aws_s3_bucket_object" "object" {
 	etag = "${md5(file("%s"))}"
 }
 `, randInt, source, source)
+}
+
+func testAccAWSS3BucketObjectConfig_withKMSId(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket_2" {
+	bucket = "tf-object-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "object" {
+	bucket = "${aws_s3_bucket.object_bucket_2.bucket}"
+	key = "test-key"
+	content = "stuff"
+	kms_key_id = "01961aed-d0b6-4ad3-9f7f-8264818ea611"
+}
+`, randInt)
 }

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `content_language` - (Optional) The language the content is in e.g. en-US or en-GB.
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`
+* `kms_key_id` - (Optional) Specifies the AWS KMS key ID to use for object encryption.
 
 Either `source` or `content` must be provided to specify the bucket content.
 These two arguments are mutually-exclusive.


### PR DESCRIPTION
I've added a kms_key_id parameter to aws_s3_bucket_object that will allow you to encrypt objects placed into a bucket.