### PR TITLE
provider/aws: Support S3 bucket notification

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -226,6 +226,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route_table_association":                  resourceAwsRouteTableAssociation(),
 			"aws_s3_bucket":                                resourceAwsS3Bucket(),
 			"aws_s3_bucket_object":                         resourceAwsS3BucketObject(),
+			"aws_s3_bucket_notification":                   resourceAwsS3BucketNotification(),
 			"aws_security_group":                           resourceAwsSecurityGroup(),
 			"aws_security_group_rule":                      resourceAwsSecurityGroupRule(),
 			"aws_spot_instance_request":                    resourceAwsSpotInstanceRequest(),

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification.go
@@ -46,7 +46,7 @@ func resourceAwsS3BucketNotification() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"topic": &schema.Schema{
+						"topic_arn": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -78,7 +78,7 @@ func resourceAwsS3BucketNotification() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"queue": &schema.Schema{
+						"queue_arn": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -110,7 +110,7 @@ func resourceAwsS3BucketNotification() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"lambda_function": &schema.Schema{
+						"lambda_function_arn": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -147,7 +147,7 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		}
 
 		// TopicArn
-		if val, ok := c["topic"].(string); ok {
+		if val, ok := c["topic_arn"].(string); ok {
 			tc.TopicArn = aws.String(val)
 		}
 
@@ -199,7 +199,7 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		}
 
 		// LambdaFunctionArn
-		if val, ok := c["lambda_function"].(string); ok {
+		if val, ok := c["lambda_function_arn"].(string); ok {
 			lc.LambdaFunctionArn = aws.String(val)
 		}
 
@@ -251,7 +251,7 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		}
 
 		// QueueArn
-		if val, ok := c["queue"].(string); ok {
+		if val, ok := c["queue_arn"].(string); ok {
 			qc.QueueArn = aws.String(val)
 		}
 
@@ -415,7 +415,7 @@ func flattenTopicConfigurations(configs []*s3.TopicConfiguration) []map[string]i
 
 		conf["id"] = *notification.Id
 		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
-		conf["topic"] = *notification.TopicArn
+		conf["topic_arn"] = *notification.TopicArn
 		topicNotifications = append(topicNotifications, conf)
 	}
 
@@ -434,7 +434,7 @@ func flattenQueueConfigurations(configs []*s3.QueueConfiguration) []map[string]i
 
 		conf["id"] = *notification.Id
 		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
-		conf["queue"] = *notification.QueueArn
+		conf["queue_arn"] = *notification.QueueArn
 		queueNotifications = append(queueNotifications, conf)
 	}
 
@@ -453,7 +453,7 @@ func flattenLambdaFunctionConfigurations(configs []*s3.LambdaFunctionConfigurati
 
 		conf["id"] = *notification.Id
 		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
-		conf["lambda_function"] = *notification.LambdaFunctionArn
+		conf["lambda_function_arn"] = *notification.LambdaFunctionArn
 		lambdaFunctionNotifications = append(lambdaFunctionNotifications, conf)
 	}
 

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification.go
@@ -168,10 +168,12 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 			}
 			filterRules = append(filterRules, filterRule)
 		}
-		tc.Filter = &s3.NotificationConfigurationFilter{
-			Key: &s3.KeyFilter{
-				FilterRules: filterRules,
-			},
+		if len(filterRules) > 0 {
+			tc.Filter = &s3.NotificationConfigurationFilter{
+				Key: &s3.KeyFilter{
+					FilterRules: filterRules,
+				},
+			}
 		}
 		topicConfigs = append(topicConfigs, tc)
 	}
@@ -218,10 +220,12 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 			}
 			filterRules = append(filterRules, filterRule)
 		}
-		lc.Filter = &s3.NotificationConfigurationFilter{
-			Key: &s3.KeyFilter{
-				FilterRules: filterRules,
-			},
+		if len(filterRules) > 0 {
+			lc.Filter = &s3.NotificationConfigurationFilter{
+				Key: &s3.KeyFilter{
+					FilterRules: filterRules,
+				},
+			}
 		}
 		lambdaConfigs = append(lambdaConfigs, lc)
 	}
@@ -268,10 +272,12 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 			}
 			filterRules = append(filterRules, filterRule)
 		}
-		qc.Filter = &s3.NotificationConfigurationFilter{
-			Key: &s3.KeyFilter{
-				FilterRules: filterRules,
-			},
+		if len(filterRules) > 0 {
+			qc.Filter = &s3.NotificationConfigurationFilter{
+				Key: &s3.KeyFilter{
+					FilterRules: filterRules,
+				},
+			}
 		}
 		queueConfigs = append(queueConfigs, qc)
 	}
@@ -357,12 +363,14 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 			conf["id"] = *notification.Id
 		}
 
-		for _, f := range notification.Filter.Key.FilterRules {
-			if strings.ToLower(*f.Name) == "prefix" {
-				conf["filter_prefix"] = *f.Value
-			}
-			if strings.ToLower(*f.Name) == "suffix" {
-				conf["filter_suffix"] = *f.Value
+		if filter := notification.Filter; filter != nil {
+			for _, f := range filter.Key.FilterRules {
+				if strings.ToLower(*f.Name) == "prefix" {
+					conf["filter_prefix"] = *f.Value
+				}
+				if strings.ToLower(*f.Name) == "suffix" {
+					conf["filter_suffix"] = *f.Value
+				}
 			}
 		}
 
@@ -383,12 +391,14 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 			conf["id"] = *notification.Id
 		}
 
-		for _, f := range notification.Filter.Key.FilterRules {
-			if strings.ToLower(*f.Name) == "prefix" {
-				conf["filter_prefix"] = *f.Value
-			}
-			if strings.ToLower(*f.Name) == "suffix" {
-				conf["filter_suffix"] = *f.Value
+		if filter := notification.Filter; filter != nil {
+			for _, f := range filter.Key.FilterRules {
+				if strings.ToLower(*f.Name) == "prefix" {
+					conf["filter_prefix"] = *f.Value
+				}
+				if strings.ToLower(*f.Name) == "suffix" {
+					conf["filter_suffix"] = *f.Value
+				}
 			}
 		}
 
@@ -409,12 +419,14 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 			conf["id"] = *notification.Id
 		}
 
-		for _, f := range notification.Filter.Key.FilterRules {
-			if strings.ToLower(*f.Name) == "prefix" {
-				conf["filter_prefix"] = *f.Value
-			}
-			if strings.ToLower(*f.Name) == "suffix" {
-				conf["filter_suffix"] = *f.Value
+		if filter := notification.Filter; filter != nil {
+			for _, f := range filter.Key.FilterRules {
+				if strings.ToLower(*f.Name) == "prefix" {
+					conf["filter_prefix"] = *f.Value
+				}
+				if strings.ToLower(*f.Name) == "suffix" {
+					conf["filter_suffix"] = *f.Value
+				}
 			}
 		}
 

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification.go
@@ -1,0 +1,453 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func resourceAwsS3BucketNotification() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsS3BucketNotificationPut,
+		Read:   resourceAwsS3BucketNotificationRead,
+		Update: resourceAwsS3BucketNotificationPut,
+		Delete: resourceAwsS3BucketNotificationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"bucket": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"topic": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter_prefix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter_suffix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"topic": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"events": &schema.Schema{
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%t-", m["filter_prefix"].(string)))
+					buf.WriteString(fmt.Sprintf("%t-", m["filter_suffix"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+
+			"queue": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter_prefix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter_suffix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"queue": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"events": &schema.Schema{
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%t-", m["filter_prefix"].(string)))
+					buf.WriteString(fmt.Sprintf("%t-", m["filter_suffix"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+
+			"lambda_function": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter_prefix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter_suffix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"lambda_function": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"events": &schema.Schema{
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%t-", m["filter_prefix"].(string)))
+					buf.WriteString(fmt.Sprintf("%t-", m["filter_suffix"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}) error {
+	s3conn := meta.(*AWSClient).s3conn
+	bucket := d.Get("bucket").(string)
+
+	// TopicNotifications
+	topicNotifications := d.Get("topic").(*schema.Set).List()
+	topicConfigs := make([]*s3.TopicConfiguration, 0, len(topicNotifications))
+	for _, c := range topicNotifications {
+		tc := &s3.TopicConfiguration{}
+
+		c := c.(map[string]interface{})
+
+		// Id
+		if val, ok := c["id"].(string); ok {
+			tc.Id = aws.String(val)
+		}
+
+		// TopicArn
+		if val, ok := c["topic"].(string); ok {
+			tc.TopicArn = aws.String(val)
+		}
+
+		// Events
+		if v := c["events"].(*schema.Set); v.Len() > 0 {
+			tc.Events = make([]*string, 0, v.Len())
+			for _, val := range v.List() {
+				tc.Events = append(tc.Events, aws.String(val.(string)))
+			}
+		}
+
+		// Filter
+		filterRules := make([]*s3.FilterRule, 0, 2)
+		if val, ok := c["filter_prefix"].(string); ok && val != "" {
+			filterRule := &s3.FilterRule{
+				Name:  aws.String("prefix"),
+				Value: aws.String(val),
+			}
+			filterRules = append(filterRules, filterRule)
+		}
+		if val, ok := c["filter_suffix"].(string); ok && val != "" {
+			filterRule := &s3.FilterRule{
+				Name:  aws.String("suffix"),
+				Value: aws.String(val),
+			}
+			filterRules = append(filterRules, filterRule)
+		}
+		tc.Filter = &s3.NotificationConfigurationFilter{
+			Key: &s3.KeyFilter{
+				FilterRules: filterRules,
+			},
+		}
+		topicConfigs = append(topicConfigs, tc)
+	}
+
+	// Lambda
+	lambdaFunctionNotifications := d.Get("lambda_function").(*schema.Set).List()
+	lambdaConfigs := make([]*s3.LambdaFunctionConfiguration, 0, len(lambdaFunctionNotifications))
+	for _, c := range lambdaFunctionNotifications {
+		lc := &s3.LambdaFunctionConfiguration{}
+
+		c := c.(map[string]interface{})
+
+		// Id
+		if val, ok := c["id"].(string); ok {
+			lc.Id = aws.String(val)
+		}
+
+		// LambdaFunctionArn
+		if val, ok := c["lambda_function"].(string); ok {
+			lc.LambdaFunctionArn = aws.String(val)
+		}
+
+		// Events
+		if v := c["events"].(*schema.Set); v.Len() > 0 {
+			lc.Events = make([]*string, 0, v.Len())
+			for _, val := range v.List() {
+				lc.Events = append(lc.Events, aws.String(val.(string)))
+			}
+		}
+
+		// Filter
+		filterRules := make([]*s3.FilterRule, 0, 2)
+		if val, ok := c["filter_prefix"].(string); ok && val != "" {
+			filterRule := &s3.FilterRule{
+				Name:  aws.String("prefix"),
+				Value: aws.String(val),
+			}
+			filterRules = append(filterRules, filterRule)
+		}
+		if val, ok := c["filter_suffix"].(string); ok && val != "" {
+			filterRule := &s3.FilterRule{
+				Name:  aws.String("suffix"),
+				Value: aws.String(val),
+			}
+			filterRules = append(filterRules, filterRule)
+		}
+		lc.Filter = &s3.NotificationConfigurationFilter{
+			Key: &s3.KeyFilter{
+				FilterRules: filterRules,
+			},
+		}
+		lambdaConfigs = append(lambdaConfigs, lc)
+	}
+
+	// SQS
+	queueNotifications := d.Get("queue").(*schema.Set).List()
+	queueConfigs := make([]*s3.QueueConfiguration, 0, len(queueNotifications))
+	for _, c := range queueNotifications {
+		qc := &s3.QueueConfiguration{}
+
+		c := c.(map[string]interface{})
+
+		// Id
+		if val, ok := c["id"].(string); ok {
+			qc.Id = aws.String(val)
+		}
+
+		// QueueArn
+		if val, ok := c["queue"].(string); ok {
+			qc.QueueArn = aws.String(val)
+		}
+
+		// Events
+		if v := c["events"].(*schema.Set); v.Len() > 0 {
+			qc.Events = make([]*string, 0, v.Len())
+			for _, val := range v.List() {
+				qc.Events = append(qc.Events, aws.String(val.(string)))
+			}
+		}
+
+		// Filter
+		filterRules := make([]*s3.FilterRule, 0, 2)
+		if val, ok := c["filter_prefix"].(string); ok && val != "" {
+			filterRule := &s3.FilterRule{
+				Name:  aws.String("prefix"),
+				Value: aws.String(val),
+			}
+			filterRules = append(filterRules, filterRule)
+		}
+		if val, ok := c["filter_suffix"].(string); ok && val != "" {
+			filterRule := &s3.FilterRule{
+				Name:  aws.String("suffix"),
+				Value: aws.String(val),
+			}
+			filterRules = append(filterRules, filterRule)
+		}
+		qc.Filter = &s3.NotificationConfigurationFilter{
+			Key: &s3.KeyFilter{
+				FilterRules: filterRules,
+			},
+		}
+		queueConfigs = append(queueConfigs, qc)
+	}
+
+	notificationConfiguration := &s3.NotificationConfiguration{}
+	if len(lambdaConfigs) > 0 {
+		notificationConfiguration.LambdaFunctionConfigurations = lambdaConfigs
+	}
+	if len(queueConfigs) > 0 {
+		notificationConfiguration.QueueConfigurations = queueConfigs
+	}
+	if len(topicConfigs) > 0 {
+		notificationConfiguration.TopicConfigurations = topicConfigs
+	}
+	i := &s3.PutBucketNotificationConfigurationInput{
+		Bucket: aws.String(bucket),
+		NotificationConfiguration: notificationConfiguration,
+	}
+
+	log.Printf("[DEBUG] S3 bucket: %s, Putting notification: %v", bucket, i)
+	_, err := s3conn.PutBucketNotificationConfiguration(i)
+	if err != nil {
+		return fmt.Errorf("Error putting S3 notification configuration: %s", err)
+	}
+
+	d.SetId(bucket)
+
+	return resourceAwsS3BucketNotificationRead(d, meta)
+}
+
+func resourceAwsS3BucketNotificationDelete(d *schema.ResourceData, meta interface{}) error {
+	s3conn := meta.(*AWSClient).s3conn
+
+	i := &s3.PutBucketNotificationConfigurationInput{
+		Bucket: aws.String(d.Id()),
+		NotificationConfiguration: &s3.NotificationConfiguration{},
+	}
+
+	log.Printf("[DEBUG] S3 bucket: %s, Deleting notification: %v", d.Id(), i)
+	_, err := s3conn.PutBucketNotificationConfiguration(i)
+	if err != nil {
+		return fmt.Errorf("Error deleting S3 notification configuration: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{}) error {
+	s3conn := meta.(*AWSClient).s3conn
+
+	var err error
+	_, err = s3conn.HeadBucket(&s3.HeadBucketInput{
+		Bucket: aws.String(d.Id()),
+	})
+	if err != nil {
+		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() == 404 {
+			log.Printf("[WARN] S3 Bucket (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		} else {
+			// some of the AWS SDK's errors can be empty strings, so let's add
+			// some additional context.
+			return fmt.Errorf("error reading S3 bucket \"%s\": %s", d.Id(), err)
+		}
+	}
+
+	// Read the notification configuration
+	notificationConfigs, err := s3conn.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+		Bucket: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] S3 Bucket: %s, get notification: %v", d.Id(), notificationConfigs)
+	// Topic Notification
+	topicNotifications := make([]map[string]interface{}, 0, len(notificationConfigs.TopicConfigurations))
+	for _, notification := range notificationConfigs.TopicConfigurations {
+		conf := map[string]interface{}{}
+
+		if notification.Id != nil {
+			conf["id"] = *notification.Id
+		}
+
+		for _, f := range notification.Filter.Key.FilterRules {
+			if strings.ToLower(*f.Name) == "prefix" {
+				conf["filter_prefix"] = *f.Value
+			}
+			if strings.ToLower(*f.Name) == "suffix" {
+				conf["filter_suffix"] = *f.Value
+			}
+		}
+
+		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
+		conf["topic"] = *notification.TopicArn
+		topicNotifications = append(topicNotifications, conf)
+	}
+	if err := d.Set("topic", topicNotifications); err != nil {
+		return fmt.Errorf("error reading S3 bucket \"%s\" topic notification: %s", d.Id(), err)
+	}
+
+	// Lambda Notification
+	lambdaFunctionNotifications := make([]map[string]interface{}, 0, len(notificationConfigs.LambdaFunctionConfigurations))
+	for _, notification := range notificationConfigs.LambdaFunctionConfigurations {
+		conf := map[string]interface{}{}
+
+		if notification.Id != nil {
+			conf["id"] = *notification.Id
+		}
+
+		for _, f := range notification.Filter.Key.FilterRules {
+			if strings.ToLower(*f.Name) == "prefix" {
+				conf["filter_prefix"] = *f.Value
+			}
+			if strings.ToLower(*f.Name) == "suffix" {
+				conf["filter_suffix"] = *f.Value
+			}
+		}
+
+		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
+		conf["lambda_function"] = *notification.LambdaFunctionArn
+		lambdaFunctionNotifications = append(lambdaFunctionNotifications, conf)
+	}
+	if err := d.Set("lambda_function", lambdaFunctionNotifications); err != nil {
+		return fmt.Errorf("error reading S3 bucket \"%s\" lambda function notification: %s", d.Id(), err)
+	}
+
+	// SQS Notification
+	queueNotifications := make([]map[string]interface{}, 0, len(notificationConfigs.QueueConfigurations))
+	for _, notification := range notificationConfigs.QueueConfigurations {
+		conf := map[string]interface{}{}
+
+		if notification.Id != nil {
+			conf["id"] = *notification.Id
+		}
+
+		for _, f := range notification.Filter.Key.FilterRules {
+			if strings.ToLower(*f.Name) == "prefix" {
+				conf["filter_prefix"] = *f.Value
+			}
+			if strings.ToLower(*f.Name) == "suffix" {
+				conf["filter_suffix"] = *f.Value
+			}
+		}
+
+		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
+		conf["queue"] = *notification.QueueArn
+		queueNotifications = append(queueNotifications, conf)
+	}
+	if err := d.Set("queue", queueNotifications); err != nil {
+		return fmt.Errorf("error reading S3 bucket \"%s\" queue notification: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification.go
@@ -1,12 +1,10 @@
 package aws
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -57,13 +55,6 @@ func resourceAwsS3BucketNotification() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-					m := v.(map[string]interface{})
-					buf.WriteString(fmt.Sprintf("%t-", m["filter_prefix"].(string)))
-					buf.WriteString(fmt.Sprintf("%t-", m["filter_suffix"].(string)))
-					return hashcode.String(buf.String())
-				},
 			},
 
 			"queue": &schema.Schema{
@@ -95,13 +86,6 @@ func resourceAwsS3BucketNotification() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-					m := v.(map[string]interface{})
-					buf.WriteString(fmt.Sprintf("%t-", m["filter_prefix"].(string)))
-					buf.WriteString(fmt.Sprintf("%t-", m["filter_suffix"].(string)))
-					return hashcode.String(buf.String())
-				},
 			},
 
 			"lambda_function": &schema.Schema{
@@ -132,13 +116,6 @@ func resourceAwsS3BucketNotification() *schema.Resource {
 							Set:      schema.HashString,
 						},
 					},
-				},
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-					m := v.(map[string]interface{})
-					buf.WriteString(fmt.Sprintf("%t-", m["filter_prefix"].(string)))
-					buf.WriteString(fmt.Sprintf("%t-", m["filter_suffix"].(string)))
-					return hashcode.String(buf.String())
 				},
 			},
 		},

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification.go
@@ -134,7 +134,7 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 	// TopicNotifications
 	topicNotifications := d.Get("topic").([]interface{})
 	topicConfigs := make([]*s3.TopicConfiguration, 0, len(topicNotifications))
-	for _, c := range topicNotifications {
+	for i, c := range topicNotifications {
 		tc := &s3.TopicConfiguration{}
 
 		c := c.(map[string]interface{})
@@ -152,8 +152,9 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		}
 
 		// Events
-		tc.Events = make([]*string, 0, len(c["events"].(*schema.Set).List()))
-		for _, e := range c["events"].(*schema.Set).List() {
+		events := d.Get(fmt.Sprintf("topic.%d.events", i)).(*schema.Set).List()
+		tc.Events = make([]*string, 0, len(events))
+		for _, e := range events {
 			tc.Events = append(tc.Events, aws.String(e.(string)))
 		}
 
@@ -186,7 +187,7 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 	// Lambda
 	lambdaFunctionNotifications := d.Get("lambda_function").([]interface{})
 	lambdaConfigs := make([]*s3.LambdaFunctionConfiguration, 0, len(lambdaFunctionNotifications))
-	for _, c := range lambdaFunctionNotifications {
+	for i, c := range lambdaFunctionNotifications {
 		lc := &s3.LambdaFunctionConfiguration{}
 
 		c := c.(map[string]interface{})
@@ -204,8 +205,9 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		}
 
 		// Events
-		lc.Events = make([]*string, 0, len(c["events"].(*schema.Set).List()))
-		for _, e := range c["events"].(*schema.Set).List() {
+		events := d.Get(fmt.Sprintf("lambda_function.%d.events", i)).(*schema.Set).List()
+		lc.Events = make([]*string, 0, len(events))
+		for _, e := range events {
 			lc.Events = append(lc.Events, aws.String(e.(string)))
 		}
 
@@ -238,7 +240,7 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 	// SQS
 	queueNotifications := d.Get("queue").([]interface{})
 	queueConfigs := make([]*s3.QueueConfiguration, 0, len(queueNotifications))
-	for _, c := range queueNotifications {
+	for i, c := range queueNotifications {
 		qc := &s3.QueueConfiguration{}
 
 		c := c.(map[string]interface{})
@@ -256,8 +258,9 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		}
 
 		// Events
-		qc.Events = make([]*string, 0, len(c["events"].(*schema.Set).List()))
-		for _, e := range c["events"].(*schema.Set).List() {
+		events := d.Get(fmt.Sprintf("queue.%d.events", i)).(*schema.Set).List()
+		qc.Events = make([]*string, 0, len(events))
+		for _, e := range events {
 			qc.Events = append(qc.Events, aws.String(e.(string)))
 		}
 

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
@@ -1,0 +1,429 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func TestAccAWSS3Bucket_Notification(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithTopicNotification(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketTopicNotification(
+						"aws_s3_bucket.bucket",
+						"notification-sns1",
+						"aws_sns_topic.topic",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						&s3.KeyFilter{
+							FilterRules: []*s3.FilterRule{
+								&s3.FilterRule{
+									Name:  aws.String("Prefix"),
+									Value: aws.String(fmt.Sprintf("%d/", rInt)),
+								},
+								&s3.FilterRule{
+									Name:  aws.String("Suffix"),
+									Value: aws.String(".txt"),
+								},
+							},
+						},
+					),
+					testAccCheckAWSS3BucketTopicNotification(
+						"aws_s3_bucket.bucket",
+						"notification-sns2",
+						"aws_sns_topic.topic",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						&s3.KeyFilter{
+							FilterRules: []*s3.FilterRule{
+								&s3.FilterRule{
+									Name:  aws.String("Suffix"),
+									Value: aws.String(".log"),
+								},
+							},
+						},
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithQueueNotification(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketQueueNotification(
+						"aws_s3_bucket.bucket",
+						"notification-sqs",
+						"aws_sqs_queue.queue",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						&s3.KeyFilter{
+							FilterRules: []*s3.FilterRule{
+								&s3.FilterRule{
+									Name:  aws.String("Prefix"),
+									Value: aws.String(fmt.Sprintf("%d/", rInt)),
+								},
+								&s3.FilterRule{
+									Name:  aws.String("Suffix"),
+									Value: aws.String(".mp4"),
+								},
+							},
+						},
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithLambdaNotification(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketLambdaFunctionConfiguration(
+						"aws_s3_bucket.bucket",
+						"notification-lambda",
+						"aws_lambda_function.func",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						&s3.KeyFilter{
+							FilterRules: []*s3.FilterRule{
+								&s3.FilterRule{
+									Name:  aws.String("Prefix"),
+									Value: aws.String(fmt.Sprintf("%d/", rInt)),
+								},
+								&s3.FilterRule{
+									Name:  aws.String("Suffix"),
+									Value: aws.String(".png"),
+								},
+							},
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSS3BucketNotificationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_s3_bucket_notification" {
+			continue
+		}
+		out, err := conn.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoSuchBucket" {
+				return nil
+			}
+			return err
+		}
+		if len(out.TopicConfigurations) > 0 {
+			return fmt.Errorf("TopicConfigurations is exists: %v", out)
+		}
+		if len(out.LambdaFunctionConfigurations) > 0 {
+			return fmt.Errorf("LambdaFunctionConfigurations is exists: %v", out)
+		}
+		if len(out.QueueConfigurations) > 0 {
+			return fmt.Errorf("QueueConfigurations is exists: %v", out)
+		}
+	}
+	return nil
+}
+
+func testAccCheckAWSS3BucketTopicNotification(n, i, t string, events []string, filters *s3.KeyFilter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[n]
+		topicArn := s.RootModule().Resources[t].Primary.ID
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		out, err := conn.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("GetBucketNotification error: %v", err)
+		}
+
+		eventSlice := sort.StringSlice(events)
+		eventSlice.Sort()
+
+		outputTopics := out.TopicConfigurations
+		matched := false
+		for _, outputTopic := range outputTopics {
+			if *outputTopic.Id == i {
+				matched = true
+
+				if *outputTopic.TopicArn != topicArn {
+					return fmt.Errorf("bad topic arn, expected: %s, got %#v", topicArn, *outputTopic.TopicArn)
+				}
+				if !reflect.DeepEqual(filters, outputTopic.Filter.Key) {
+					return fmt.Errorf("bad notification filters, expected: %#v, got %#v", filters, outputTopic.Filter.Key)
+				}
+
+				outputEventSlice := sort.StringSlice(aws.StringValueSlice(outputTopic.Events))
+				outputEventSlice.Sort()
+				if !reflect.DeepEqual(eventSlice, outputEventSlice) {
+					return fmt.Errorf("bad notification events, expected: %#v, got %#v", events, outputEventSlice)
+				}
+			}
+		}
+
+		if !matched {
+			return fmt.Errorf("No match topic configurations: %#v", out)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSS3BucketQueueNotification(n, i, t string, events []string, filters *s3.KeyFilter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[n]
+		queueArn := s.RootModule().Resources[t].Primary.Attributes["arn"]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		out, err := conn.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("GetBucketNotification error: %v", err)
+		}
+
+		eventSlice := sort.StringSlice(events)
+		eventSlice.Sort()
+
+		outputQueues := out.QueueConfigurations
+		matched := false
+		for _, outputQueue := range outputQueues {
+			if *outputQueue.Id == i {
+				matched = true
+
+				if *outputQueue.QueueArn != queueArn {
+					return fmt.Errorf("bad queue arn, expected: %s, got %#v", queueArn, *outputQueue.QueueArn)
+				}
+				if !reflect.DeepEqual(filters, outputQueue.Filter.Key) {
+					return fmt.Errorf("bad notification filters, expected: %#v, got %#v", filters, outputQueue.Filter.Key)
+				}
+
+				outputEventSlice := sort.StringSlice(aws.StringValueSlice(outputQueue.Events))
+				outputEventSlice.Sort()
+				if !reflect.DeepEqual(eventSlice, outputEventSlice) {
+					return fmt.Errorf("bad notification events, expected: %#v, got %#v", events, outputEventSlice)
+				}
+			}
+		}
+
+		if !matched {
+			return fmt.Errorf("No match queue configurations: %#v", out)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSS3BucketLambdaFunctionConfiguration(n, i, t string, events []string, filters *s3.KeyFilter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[n]
+		funcArn := s.RootModule().Resources[t].Primary.Attributes["arn"]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		out, err := conn.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("GetBucketNotification error: %v", err)
+		}
+
+		eventSlice := sort.StringSlice(events)
+		eventSlice.Sort()
+
+		outputFunctions := out.LambdaFunctionConfigurations
+		matched := false
+		for _, outputFunc := range outputFunctions {
+			if *outputFunc.Id == i {
+				matched = true
+
+				if *outputFunc.LambdaFunctionArn != funcArn {
+					return fmt.Errorf("bad lambda function arn, expected: %s, got %#v", funcArn, *outputFunc.LambdaFunctionArn)
+				}
+				if !reflect.DeepEqual(filters, outputFunc.Filter.Key) {
+					return fmt.Errorf("bad notification filters, expected: %#v, got %#v", filters, outputFunc.Filter.Key)
+				}
+
+				outputEventSlice := sort.StringSlice(aws.StringValueSlice(outputFunc.Events))
+				outputEventSlice.Sort()
+				if !reflect.DeepEqual(eventSlice, outputEventSlice) {
+					return fmt.Errorf("bad notification events, expected: %#v, got %#v", events, outputEventSlice)
+				}
+			}
+		}
+
+		if !matched {
+			return fmt.Errorf("No match lambda function configurations: %#v", out)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSS3BucketConfigWithTopicNotification(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "topic" {
+    name = "terraform-test-topic"
+	policy = <<POLICY
+{
+	"Version":"2012-10-17",
+	"Statement":[{
+		"Sid": "",
+		"Effect": "Allow",
+		"Principal": {"AWS":"*"},
+		"Action": "SNS:Publish",
+		"Resource": "arn:aws:sns:*:*:terraform-test-topic",
+		"Condition":{
+			"ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
+		}
+	}]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+}
+
+resource "aws_s3_bucket_notification" "notification" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	topic {
+		id = "notification-sns1"
+		topic = "${aws_sns_topic.topic.arn}"
+		events = [
+		  "s3:ObjectCreated:*",
+		  "s3:ObjectRemoved:Delete",
+		]
+		filter_prefix = "%d/"
+		filter_suffix = ".txt"
+	}
+	topic {
+		id = "notification-sns2"
+		topic = "${aws_sns_topic.topic.arn}"
+		events = [
+		  "s3:ObjectCreated:*",
+		  "s3:ObjectRemoved:Delete",
+		]
+		filter_suffix = ".log"
+	}
+}
+`, randInt, randInt)
+}
+
+func testAccAWSS3BucketConfigWithQueueNotification(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+    name = "terraform-test-queue-%d"
+	policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+	  "Resource": "arn:aws:sqs:*:*:terraform-test-queue-%d",
+      "Condition": {
+        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.bucket.arn}" }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+}
+
+resource "aws_s3_bucket_notification" "notification" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	queue {
+		id = "notification-sqs"
+		queue = "${aws_sqs_queue.queue.arn}"
+		events = [
+		  "s3:ObjectCreated:*",
+		  "s3:ObjectRemoved:Delete",
+		]
+		filter_prefix = "%d/"
+		filter_suffix = ".mp4"
+	}
+}
+`, randInt, randInt, randInt, randInt)
+}
+
+func testAccAWSS3BucketConfigWithLambdaNotification(randInt int) string {
+	return fmt.Sprintf(`
+
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "iam_for_lambda"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_permission" "allow_bucket" {
+    statement_id = "AllowExecutionFromS3Bucket"
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.func.arn}"
+    principal = "s3.amazonaws.com"
+    source_arn = "${aws_s3_bucket.bucket.arn}"
+}
+
+resource "aws_lambda_function" "func" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "example_lambda_name"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+}
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+}
+
+resource "aws_s3_bucket_notification" "notification" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	lambda_function {
+		id = "notification-lambda"
+		lambda_function = "${aws_lambda_function.func.arn}"
+		events = [
+		  "s3:ObjectCreated:*",
+		  "s3:ObjectRemoved:Delete",
+		]
+		filter_prefix = "%d/"
+		filter_suffix = ".png"
+	}
+}
+`, randInt, randInt)
+}

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
@@ -331,22 +331,7 @@ func testAccAWSS3BucketConfigWithQueueNotification(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "queue" {
     name = "terraform-test-queue-%d"
-	policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "sqs:SendMessage",
-	  "Resource": "arn:aws:sqs:*:*:terraform-test-queue-%d",
-      "Condition": {
-        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.bucket.arn}" }
-      }
-    }
-  ]
-}
-POLICY
+	policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"sqs:SendMessage\",\"Resource\":\"arn:aws:sqs:*:*:terraform-test-queue-%d\",\"Condition\":{\"ArnEquals\":{\"aws:SourceArn\":\"${aws_s3_bucket.bucket.arn}\"}}}]}"
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
@@ -371,7 +371,7 @@ resource "aws_s3_bucket_notification" "notification" {
 	bucket = "${aws_s3_bucket.bucket.id}"
 	topic {
 		id = "notification-sns1"
-		topic = "${aws_sns_topic.topic.arn}"
+		topic_arn = "${aws_sns_topic.topic.arn}"
 		events = [
 		  "s3:ObjectCreated:*",
 		  "s3:ObjectRemoved:Delete",
@@ -381,7 +381,7 @@ resource "aws_s3_bucket_notification" "notification" {
 	}
 	topic {
 		id = "notification-sns2"
-		topic = "${aws_sns_topic.topic.arn}"
+		topic_arn = "${aws_sns_topic.topic.arn}"
 		events = [
 		  "s3:ObjectCreated:*",
 		  "s3:ObjectRemoved:Delete",
@@ -408,7 +408,7 @@ resource "aws_s3_bucket_notification" "notification" {
 	bucket = "${aws_s3_bucket.bucket.id}"
 	queue {
 		id = "notification-sqs"
-		queue = "${aws_sqs_queue.queue.arn}"
+		queue_arn = "${aws_sqs_queue.queue.arn}"
 		events = [
 		  "s3:ObjectCreated:*",
 		  "s3:ObjectRemoved:Delete",
@@ -466,7 +466,7 @@ resource "aws_s3_bucket_notification" "notification" {
 	bucket = "${aws_s3_bucket.bucket.id}"
 	lambda_function {
 		id = "notification-lambda"
-		lambda_function = "${aws_lambda_function.func.arn}"
+		lambda_function_arn = "${aws_lambda_function.func.arn}"
 		events = [
 		  "s3:ObjectCreated:*",
 		  "s3:ObjectRemoved:Delete",
@@ -508,7 +508,7 @@ resource "aws_s3_bucket_notification" "notification" {
 	bucket = "${aws_s3_bucket.bucket.id}"
 	topic {
 		id = "notification-sns1"
-		topic = "${aws_sns_topic.topic.arn}"
+		topic_arn = "${aws_sns_topic.topic.arn}"
 		events = [
 		  "s3:ObjectCreated:*",
 		  "s3:ObjectRemoved:Delete",

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -64,8 +64,9 @@ func resourceAwsSqsQueue() *schema.Resource {
 				Computed: true,
 			},
 			"policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				StateFunc: normalizeJson,
 			},
 			"redrive_policy": &schema.Schema{
 				Type:     schema.TypeString,
@@ -177,6 +178,9 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 					}
 					d.Set(iKey, value)
 				} else {
+					if iKey == "policy" {
+						*attrmap[oKey] = normalizeJson(*attrmap[oKey])
+					}
 					d.Set(iKey, *attrmap[oKey])
 				}
 			}

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -64,9 +64,8 @@ func resourceAwsSqsQueue() *schema.Resource {
 				Computed: true,
 			},
 			"policy": &schema.Schema{
-				Type:      schema.TypeString,
-				Optional:  true,
-				StateFunc: normalizeJson,
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"redrive_policy": &schema.Schema{
 				Type:     schema.TypeString,
@@ -178,9 +177,6 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 					}
 					d.Set(iKey, value)
 				} else {
-					if iKey == "policy" {
-						*attrmap[oKey] = normalizeJson(*attrmap[oKey])
-					}
 					d.Set(iKey, *attrmap[oKey])
 				}
 			}

--- a/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
@@ -40,7 +40,7 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_notification" "bucket_notification" {
 	bucket = "${aws_s3_bucket.bucket.id}"
 	topic {
-		topic = "${aws_sns_topic.topic.arn}"
+		topic_arn = "${aws_sns_topic.topic.arn}"
 		events = ["s3:ObjectCreated:*"]
 		filter_suffix = ".log"
 	}
@@ -77,7 +77,7 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_notification" "bucket_notification" {
 	bucket = "${aws_s3_bucket.bucket.id}"
 	queue {
-		queue = "${aws_sqs_queue.queue.arn}"
+		queue_arn = "${aws_sqs_queue.queue.arn}"
 		events = ["s3:ObjectCreated:*"]
 		filter_suffix = ".log"
 	}
@@ -127,7 +127,7 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_notification" "bucket_notification" {
 	bucket = "${aws_s3_bucket.bucket.id}"
 	lambda_function {
-		lambda_function = "${aws_lambda_function.func.arn}"
+		lambda_function_arn = "${aws_lambda_function.func.arn}"
 		events = ["s3:ObjectCreated:*"]
 		filter_prefix = "AWSLogs/"
 		filter_suffix = ".log"
@@ -147,7 +147,7 @@ The following arguments are supported:
 The `topic` notification configuration supports the following:
 
 * `id` - (Optional) Specifies unique identifier for each of the notification configurations.
-* `topic` - (Required) Specifies Amazon SNS topic ARN.
+* `topic_arn` - (Required) Specifies Amazon SNS topic ARN.
 * `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
 * `filter_prefix` - (Optional) Specifies object key name prefix.
 * `filter_suffix` - (Optional) Specifies object key name suffix.
@@ -155,7 +155,7 @@ The `topic` notification configuration supports the following:
 The `queue` notification configuration supports the following:
 
 * `id` - (Optional) Specifies unique identifier for each of the notification configurations.
-* `queue` - (Required) Specifies Amazon SQS queue ARN.
+* `queue_arn` - (Required) Specifies Amazon SQS queue ARN.
 * `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
 * `filter_prefix` - (Optional) Specifies object key name prefix.
 * `filter_suffix` - (Optional) Specifies object key name suffix.
@@ -163,7 +163,7 @@ The `queue` notification configuration supports the following:
 The `lambda_function` notification configuration supports the following:
 
 * `id` - (Optional) Specifies unique identifier for each of the notification configurations.
-* `lambda_function` - (Required) Specifies Amazon Lambda function ARN.
+* `lambda_function_arn` - (Required) Specifies Amazon Lambda function ARN.
 * `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
 * `filter_prefix` - (Optional) Specifies object key name prefix.
 * `filter_suffix` - (Optional) Specifies object key name suffix.

--- a/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
@@ -1,0 +1,170 @@
+---
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_notification"
+side_bar_current: "docs-aws-resource-s3-bucket-notification"
+description: |-
+  Provides a S3 bucket notification resource.
+---
+
+# aws\_s3\_bucket\_notification
+
+Provides a S3 bucket notification resource.
+
+## Example Usage
+
+### Add notification configuration to SNS Topic
+
+```
+resource "aws_sns_topic" "topic" {
+    name = "s3-event-notification-topic"
+    policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[{
+        "Effect": "Allow",
+        "Principal": {"AWS":"*"},
+        "Action": "SNS:Publish",
+        "Resource": "arn:aws:sns:*:*:terraform-test-topic",
+        "Condition":{
+            "ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
+        }
+    }]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "your_bucket_name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	topic {
+		topic = "${aws_sns_topic.topic.arn}"
+		events = ["s3:ObjectCreated:*"]
+		filter_suffix = ".log"
+	}
+}
+```
+
+### Add notification configuration to SQS Queue
+
+```
+resource "aws_sqs_queue" "queue" {
+    name = "s3-event-notification-queue"
+    policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+	  "Resource": "arn:aws:sqs:*:*:s3-event-notification-queue",
+      "Condition": {
+        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.bucket.arn}" }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "your_bucket_name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	queue {
+		queue = "${aws_sqs_queue.queue.arn}"
+		events = ["s3:ObjectCreated:*"]
+		filter_suffix = ".log"
+	}
+}
+```
+
+### Add notification configuration to Lambda Function
+
+```
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "iam_for_lambda"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_permission" "allow_bucket" {
+    statement_id = "AllowExecutionFromS3Bucket"
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.func.arn}"
+    principal = "s3.amazonaws.com"
+    source_arn = "${aws_s3_bucket.bucket.arn}"
+}
+
+resource "aws_lambda_function" "func" {
+    filename = "your-function.zip"
+    function_name = "example_lambda_name"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+}
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "your_bucket_name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	lambda_function {
+		lambda_function = "${aws_lambda_function.func.arn}"
+		events = ["s3:ObjectCreated:*"]
+		filter_prefix = "AWSLogs/"
+		filter_suffix = ".log"
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket to put notification configuration.
+* `topic` - (Optional) The notification configuration to SNS Topic (documented below).
+* `queue` - (Optional) The notification configuration to SQS Queue (documented below).
+* `lambda_function` - (Optional) The notification configuration to Lambda Function (documented below).
+
+The `topic` notification configuration supports the following:
+
+* `id` - (Optional) Specifies unique identifier for each of the notification configurations.
+* `topic` - (Required) Specifies Amazon SNS topic ARN.
+* `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
+* `filter_prefix` - (Optional) Specifies object key name prefix.
+* `filter_suffix` - (Optional) Specifies object key name suffix.
+
+The `queue` notification configuration supports the following:
+
+* `id` - (Optional) Specifies unique identifier for each of the notification configurations.
+* `queue` - (Required) Specifies Amazon SQS queue ARN.
+* `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
+* `filter_prefix` - (Optional) Specifies object key name prefix.
+* `filter_suffix` - (Optional) Specifies object key name suffix.
+
+The `lambda_function` notification configuration supports the following:
+
+* `id` - (Optional) Specifies unique identifier for each of the notification configurations.
+* `lambda_function` - (Required) Specifies Amazon Lambda function ARN.
+* `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
+* `filter_prefix` - (Optional) Specifies object key name prefix.
+* `filter_suffix` - (Optional) Specifies object key name suffix.
+

--- a/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
@@ -24,7 +24,7 @@ resource "aws_sns_topic" "topic" {
         "Effect": "Allow",
         "Principal": {"AWS":"*"},
         "Action": "SNS:Publish",
-        "Resource": "arn:aws:sns:*:*:terraform-test-topic",
+        "Resource": "arn:aws:sns:*:*:s3-event-notification-topic",
         "Condition":{
             "ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
         }

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -588,6 +588,10 @@
                             <a href="/docs/providers/aws/r/s3_bucket_object.html">aws_s3_bucket_object</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-s3-bucket-notification") %>>
+                            <a href="/docs/providers/aws/r/s3_bucket_notification.html">aws_s3_bucket_notification</a>
+                        </li>
+
                     </ul>
                 </li>
 


### PR DESCRIPTION
Add [S3 bucket notification](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html) resource.

The reason for creating a new resource is to avoid the circular reference.

```
resource "aws_sns_topic" "topic" {
    name = "terraform-test-topic"
        policy = <<POLICY
{
        "Version":"2012-10-17",
        "Statement":[{
                "Effect": "Allow",
                "Principal": {"AWS":"*"},
                "Action": "SNS:Publish",
                "Resource": "arn:aws:sns:*:*:terraform-test-topic",
                "Condition":{
                        "ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
                }
        }]
}
POLICY
}

resource "aws_s3_bucket" "bucket" {
        bucket = "tf-test-bucket-1928392189481395839258"
}

resource "aws_s3_bucket_notification" "bucket_notification" {
	bucket = "${aws_s3_bucket.bucket.id}"
	topic {
		topic_arn = "${aws_sns_topic.topic.arn}"
		events = ["s3:ObjectCreated:*"]
		filter_suffix = ".log"
	}
	queue {
		...
	}
	lambda_function {
		...
	}
}
```

### Acceptance test

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3Bucket_Notification'                                                         
==> Checking that code complies with gofmt requirements...
/home/kjmkznr/go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3Bucket_Notification -timeout 120m
=== RUN   TestAccAWSS3Bucket_Notification
--- PASS: TestAccAWSS3Bucket_Notification (66.94s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    66.945s
```