### PR TITLE
provider/aws: Fix error parsing JSON in S3 bucket policy

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -907,7 +907,7 @@ func removeNil(data map[string]interface{}) map[string]interface{} {
 }
 
 func normalizeJson(jsonString interface{}) string {
-	if jsonString == nil {
+	if jsonString == nil || jsonString == "" {
 		return ""
 	}
 	var j interface{}

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -69,6 +69,14 @@ func TestAccAWSS3Bucket_Policy(t *testing.T) {
 						"aws_s3_bucket.bucket", ""),
 				),
 			},
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithEmptyPolicy(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketPolicy(
+						"aws_s3_bucket.bucket", ""),
+				),
+			},
 		},
 	})
 }
@@ -720,6 +728,16 @@ func testAccAWSS3BucketDestroyedConfig(randInt int) string {
 resource "aws_s3_bucket" "bucket" {
 	bucket = "tf-test-bucket-%d"
 	acl = "public-read"
+}
+`, randInt)
+}
+
+func testAccAWSS3BucketConfigWithEmptyPolicy(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+	policy = ""
 }
 `, randInt)
 }


### PR DESCRIPTION
Specific empty string into S3 bucket policy, cause following error.

    Error parsing JSON: unexpected end of JSON input

* template

```
resource "aws_s3_bucket" "bucket" {
	bucket = "tf-test-bucket"
	policy = ""
}
```

This commit change output following:

Before:

    "" -> "Error parsing JSON: unexpected end of JSON input"

After:

    "" -> ""