### PR TITLE
website: Fix missing sidebar_current

### DIFF
--- a/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_elasticsearch_domain"
-sidebar_current: "docs-aws-elasticsearch-domain"
+sidebar_current: "docs-aws-resource-elasticsearch-domain"
 description: |-
   Provides an ElasticSearch Domain.
 ---

--- a/website/source/docs/providers/aws/r/lambda_alias.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_alias.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_lambda_alias"
-sidebar_current: "docs-aws-resource-aws-lambda-alias"
+sidebar_current: "docs-aws-resource-lambda-alias"
 description: |-
   Creates a Lambda function alias.
 ---

--- a/website/source/docs/providers/aws/r/lambda_event_source_mapping.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_event_source_mapping.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_lambda_event_source_mapping"
-sidebar_current: "docs-aws-resource-aws-lambda-event-source-mapping"
+sidebar_current: "docs-aws-resource-lambda-event-source-mapping"
 description: |-
   Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis and DynamoDB.
 ---

--- a/website/source/docs/providers/aws/r/lambda_function.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_function.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_lambda_function"
-sidebar_current: "docs-aws-resource-aws-lambda-function"
+sidebar_current: "docs-aws-resource-lambda-function"
 description: |-
   Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS. The Lambda Function itself includes source code and runtime configuration.
 ---

--- a/website/source/docs/providers/aws/r/lambda_permission.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_permission.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_lambda_permission"
-sidebar_current: "docs-aws-resource-aws-lambda-permission"
+sidebar_current: "docs-aws-resource-lambda-permission"
 description: |-
   Creates a Lambda function permission.
 ---

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_s3_bucket_object"
-side_bar_current: "docs-aws-resource-s3-bucket-object"
+sidebar_current: "docs-aws-resource-s3-bucket-object"
 description: |-
   Provides a S3 bucket object resource.
 ---

--- a/website/source/docs/providers/aws/r/sqs_queue.html.markdown
+++ b/website/source/docs/providers/aws/r/sqs_queue.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_sqs_queue"
-sidebar_current: "docs-aws-resource-sqs"
+sidebar_current: "docs-aws-resource-sqs-queue"
 description: |-
   Provides a SQS resource.
 ---

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -132,7 +132,7 @@
                 </li>
 
 
-                <li<%= sidebar_current(/^docs-aws-resource-(app|autoscaling|ebs|elb|eip|instance|launch|lb|proxy|spot|volume|placement|key-pair)/) %>>
+                <li<%= sidebar_current(/^docs-aws-resource-(ami|app|autoscaling|ebs|elb|eip|instance|launch|lb|proxy|spot|volume|placement|key-pair)/) %>>
                     <a href="#">EC2 Resources</a>
                     <ul class="nav nav-visible">
 
@@ -402,7 +402,7 @@
                       <li<%= sidebar_current("docs-aws-resource-lambda-function") %>>
                           <a href="/docs/providers/aws/r/lambda_function.html">aws_lambda_function</a>
                       </li>
-                      <li<%= sidebar_current("docs-aws-resource-aws-lambda-event-source-mapping") %>>
+                      <li<%= sidebar_current("docs-aws-resource-lambda-event-source-mapping") %>>
                           <a href="/docs/providers/aws/r/lambda_event_source_mapping.html">aws_lambda_event_source_mapping</a>
                       </li>
                       <li<%= sidebar_current("docs-aws-resource-lambda-permission") %>>


### PR DESCRIPTION
Fix missing sidebar current indicator like follow screenshot.
 
![sidebar](https://cloud.githubusercontent.com/assets/85144/13554885/b9259a2e-e3f6-11e5-8f9f-6dccd41da271.png)