### PR TITLE
provider/docker fix image test assertions

### DIFF
--- a/builtin/providers/docker/resource_docker_image_test.go
+++ b/builtin/providers/docker/resource_docker_image_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
+var contentDigestRegexp = regexp.MustCompile(`\A[A-Za-z0-9_\+\.-]+:[A-Fa-f0-9]+\z`)
+
 func TestAccDockerImage_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -15,7 +17,7 @@ func TestAccDockerImage_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccDockerImageConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("docker_image.foo", "latest", regexp.MustCompile(`\A[a-f0-9]{64}\z`)),
+					resource.TestMatchResourceAttr("docker_image.foo", "latest", contentDigestRegexp),
 				),
 			},
 		},
@@ -30,7 +32,7 @@ func TestAccDockerImage_private(t *testing.T) {
 			resource.TestStep{
 				Config: testAddDockerPrivateImageConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("docker_image.foobar", "latest", regexp.MustCompile(`\A[a-f0-9]{64}\z`)),
+					resource.TestMatchResourceAttr("docker_image.foobar", "latest", contentDigestRegexp),
 				),
 			},
 		},


### PR DESCRIPTION
Currently the tests for docker image fail:

```
# make testacc TEST=./builtin/providers/docker TESTARGS='-run=TestAccDockerImage_basic'
==> Checking that code complies with gofmt requirements...
/Users/nicolai86/go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/docker -v -run=TestAccDockerImage_basic -timeout 120m
=== RUN   TestAccDockerImage_basic
--- FAIL: TestAccDockerImage_basic (0.25s)
	testing.go:148: Step 0 error: Check failed: Check 1/1 error: docker_image.foo: Attribute 'latest' didn't match "\\A[a-f0-9]{64}\\z", got "sha256:dc77b9cbf14ef1c21392a0e1e355eb33707296be0c17b9107f6d1a386aa4a06c"
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/docker	0.265s
make: *** [testacc] Error 1
```

The tag returned from dockerhub contains the hashing algorithm, as detailed in the [V2 API spec](https://docs.docker.com/registry/spec/api/) Content-Digest.

This PR updates the regular expression according to the latest docs.

The V1 API seems to conform to the old regexp - but I think we should be targeting the more up2date version.