### PR TITLE
provider/postgresql: Add name attribute to postgresql_role docs

### DIFF
--- a/website/source/docs/providers/postgresql/r/postgresql_database.html.markdown
+++ b/website/source/docs/providers/postgresql/r/postgresql_database.html.markdown
@@ -17,7 +17,7 @@ server.
 ```
 resource "postgresql_database" "my_db" {
    name = "my_db"
-   owner = "my_role
+   owner = "my_role"
 }
 
 ```

--- a/website/source/docs/providers/postgresql/r/postgresql_role.html.markdown
+++ b/website/source/docs/providers/postgresql/r/postgresql_role.html.markdown
@@ -35,3 +35,10 @@ clauses in 'CREATE ROLE'. Default value is false.
 * `password` - (Optional) Sets the role's password. (A password is only of use for roles having the LOGIN attribute, but you can nonetheless define one for roles without it.) If you do not plan to use password authentication you can omit this option. If no password is specified, the password will be set to null and password authentication will always fail for that user.
 
 * `encrypted` - (Optional) Corresponds to ENCRYPTED, UNENCRYPTED in PostgreSQL. This controls whether the password is stored encrypted in the system catalogs. Default is false.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the role


### PR DESCRIPTION
The name of the role is exported but it was not reflected in the documentation.
This attribute can be referenced from the 'owner' argument of the postgresql_database resource.