### PR TITLE
Added a cast to "(*schema.Provider)"

### DIFF
--- a/website/source/docs/plugins/provider.html.md
+++ b/website/source/docs/plugins/provider.html.md
@@ -102,7 +102,7 @@ an error if it is invalid. An example test is shown below:
 
 ```
 func TestProvider(t *testing.T) {
-	if err := Provider().InternalValidate(); err != nil {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }


### PR DESCRIPTION
In the standard TestProvider function example. This seems to be required in current versions of Go at least.