### PR TITLE
Added disk_size_gb documentation to resource "google_compute_instance_template"

### DIFF
--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -138,6 +138,9 @@ The `disk` block supports:
 * `disk_type` - (Optional) The GCE disk type. Can be either `"pd-ssd"`,
 	`"local-ssd"`, or `"pd-standard"`.
 
+* `disk_size_gb` - (Optional) The size of the image in gigabytes. If not specified, 
+	it will inherit the size of its base image.
+
 * `type` - (Optional) The type of GCE disk, can be either `"SCRATCH"` or
 	`"PERSISTENT"`.
 


### PR DESCRIPTION
This was missing in the docs yet was implemented in Terraform. See line 81 in https://github.com/hashicorp/terraform/blob/master/builtin/providers/google/resource_compute_instance_template.go