### PR TITLE
provider/aws Always transform aws_security_group protocol to lower case

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -817,7 +818,7 @@ func idHash(rType, protocol string, toPort, fromPort int64, self bool) string {
 	buf.WriteString(fmt.Sprintf("%s-", rType))
 	buf.WriteString(fmt.Sprintf("%d-", toPort))
 	buf.WriteString(fmt.Sprintf("%d-", fromPort))
-	buf.WriteString(fmt.Sprintf("%s-", protocol))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(protocol)))
 	buf.WriteString(fmt.Sprintf("%t-", self))
 
 	return fmt.Sprintf("rule-%d", hashcode.String(buf.String()))

--- a/builtin/providers/aws/resource_aws_security_group_rules_matching_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rules_matching_test.go
@@ -186,6 +186,30 @@ func TestRulesMixedMatching(t *testing.T) {
 				},
 			},
 		},
+		// test lower/ uppercase handling
+		{
+			local: []interface{}{
+				map[string]interface{}{
+					"from_port": 80,
+					"to_port":   8000,
+					"protocol":  "TCP",
+				},
+			},
+			remote: []map[string]interface{}{
+				map[string]interface{}{
+					"from_port": int64(80),
+					"to_port":   int64(8000),
+					"protocol":  "tcp",
+				},
+			},
+			saves: []map[string]interface{}{
+				map[string]interface{}{
+					"from_port": 80,
+					"to_port":   8000,
+					"protocol":  "tcp",
+				},
+			},
+		},
 		// local and remote differ
 		{
 			local: []interface{}{


### PR DESCRIPTION
This PR fixes #5489 - I've also included a regression test.