### PR TITLE
provider/google: Address flaky GCS acceptance tests.

### DIFF
--- a/builtin/providers/google/resource_storage_bucket_acl_test.go
+++ b/builtin/providers/google/resource_storage_bucket_acl_test.go
@@ -18,12 +18,12 @@ var roleEntityBasic3_owner = "OWNER:user-yetanotheremail@gmail.com"
 
 var roleEntityBasic3_reader = "READER:user-yetanotheremail@gmail.com"
 
-func testAclBucketName() string {
+func testBucketName() string {
 	return fmt.Sprintf("%s-%d", "tf-test-acl-bucket", acctest.RandInt())
 }
 
 func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
-	bucketName := testAclBucketName()
+	bucketName := testBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -41,7 +41,7 @@ func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
-	bucketName := testAclBucketName()
+	bucketName := testBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -76,7 +76,7 @@ func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
-	bucketName := testAclBucketName()
+	bucketName := testBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -111,6 +111,7 @@ func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_predefined(t *testing.T) {
+	bucketName := testBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/google/resource_storage_bucket_object_test.go
+++ b/builtin/providers/google/resource_storage_bucket_object_test.go
@@ -19,6 +19,7 @@ var objectName = "tf-gce-test"
 var content = "now this is content!"
 
 func TestAccGoogleStorageObject_basic(t *testing.T) {
+	bucketName := testBucketName()
 	data := []byte("data data data")
 	h := md5.New()
 	h.Write(data)
@@ -36,7 +37,7 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsObjectBasic,
+				Config: testGoogleStorageBucketsObjectBasic(bucketName),
 				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, data_md5),
 			},
 		},
@@ -44,6 +45,7 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageObject_content(t *testing.T) {
+	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
 	h.Write(data)
@@ -61,7 +63,7 @@ func TestAccGoogleStorageObject_content(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsObjectContent,
+				Config: testGoogleStorageBucketsObjectContent(bucketName),
 				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, data_md5),
 			},
 		},
@@ -113,7 +115,8 @@ func testAccGoogleStorageObjectDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testGoogleStorageBucketsObjectContent = fmt.Sprintf(`
+func testGoogleStorageBucketsObjectContent(bucketName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -125,8 +128,9 @@ resource "google_storage_bucket_object" "object" {
 	predefined_acl = "projectPrivate"
 }
 `, bucketName, objectName, content)
-
-var testGoogleStorageBucketsObjectBasic = fmt.Sprintf(`
+}
+func testGoogleStorageBucketsObjectBasic(bucketName string) string {
+	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
 }
@@ -138,3 +142,4 @@ resource "google_storage_bucket_object" "object" {
 	predefined_acl = "projectPrivate"
 }
 `, bucketName, objectName, tf.Name())
+}

--- a/builtin/providers/google/resource_storage_object_acl_test.go
+++ b/builtin/providers/google/resource_storage_object_acl_test.go
@@ -20,7 +20,7 @@ func testAclObjectName() string {
 }
 
 func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
-	bucketName := testAclBucketName()
+	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
@@ -48,7 +48,7 @@ func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
-	bucketName := testAclBucketName()
+	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
@@ -98,7 +98,7 @@ func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
-	bucketName := testAclBucketName()
+	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
@@ -148,7 +148,7 @@ func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_predefined(t *testing.T) {
-	bucketName := testAclBucketName()
+	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
 	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)


### PR DESCRIPTION
Acceptance tests for GCS that do rapid create/delete/create
on GCS buckets using the same name sometimes fail as the
bucket namespace is eventually consistent. This change makes
tests use a random bucket name for each test (adapted from
the existing ACL tests).