### PR TITLE
docs: Make a separate Elastic Beanstalk section in sidebar

### DIFF
--- a/website/source/docs/providers/aws/r/elastic_beanstalk_configuration_template.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_configuration_template.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_elastic_beanstalk_configuration_template"
-sidebar_current: "docs-aws-resource-elastic-configuration-template"
+sidebar_current: "docs-aws-resource-elastic-beanstalk-configuration-template"
 description: |-
   Provides an Elastic Beanstalk Configuration Template
 ---

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -132,7 +132,7 @@
                 </li>
 
 
-                <li<%= sidebar_current(/^docs-aws-resource-(ami|app|autoscaling|ebs|elb|eip|elastic-beanstalk|instance|launch|lb|proxy|spot|volume|placement|key-pair)/) %>>
+                <li<%= sidebar_current(/^docs-aws-resource-(ami|app|autoscaling|ebs|elb|eip|instance|launch|lb|proxy|spot|volume|placement|key-pair)/) %>>
                     <a href="#">EC2 Resources</a>
                     <ul class="nav nav-visible">
 
@@ -182,18 +182,6 @@
 
                         <li<%= sidebar_current("docs-aws-resource-elb") %>>
                             <a href="/docs/providers/aws/r/elb.html">aws_elb</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-aws-resource-elastic-beanstalk-application") %>>
-                            <a href="/docs/providers/aws/r/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-aws-resource-elastic-beanstalk-configuration-template") %>>
-                            <a href="/docs/providers/aws/r/elastic_beanstalk_configuration_template.html">aws_elastic_configuation_template</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-aws-resource-elastic-beanstalk-environment") %>>
-                            <a href="/docs/providers/aws/r/elastic_beanstalk_environment.html">aws_elastic_beanstalk_environment</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-instance") %>>
@@ -298,6 +286,23 @@
                     </ul>
                 </li>
 
+
+                <li<%= sidebar_current(/^docs-aws-resource-elastic-beanstalk/) %>>
+                    <a href="#">Elastic Beanstalk Resources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-resource-elastic-beanstalk-application") %>>
+                            <a href="/docs/providers/aws/r/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-elastic-beanstalk-configuration-template") %>>
+                            <a href="/docs/providers/aws/r/elastic_beanstalk_configuration_template.html">aws_elastic_beanstalk_configuration_template</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-elastic-beanstalk-environment") %>>
+                            <a href="/docs/providers/aws/r/elastic_beanstalk_environment.html">aws_elastic_beanstalk_environment</a>
+                        </li>
+                    </ul>
+                </li>
 
                 <li<%= sidebar_current(/^docs-aws-resource-elasticsearch/) %>>
                     <a href="#">ElasticSearch Resources</a>


### PR DESCRIPTION
I don't think Elastic Beanstalk should be under EC2.

Also I fixed the link title for the :trophy: longest AWS resource name:
![screen shot 2016-03-08 at 09 55 45](https://cloud.githubusercontent.com/assets/287584/13598105/fc0f328c-e513-11e5-81ab-a640749515c9.png)
