### PR TITLE
provider/aws: Randomize more things in the acceptance tests

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -240,7 +240,7 @@ func TestAccAWSAutoScalingGroup_withPlacementGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "placement_group", "test"),
+						"aws_autoscaling_group.bar", "placement_group", "tf_placement_test"),
 				),
 			},
 		},
@@ -751,11 +751,11 @@ resource "aws_autoscaling_group" "bar" {
 const testAccAWSAutoScalingGroupConfig_withPlacementGroup = `
 resource "aws_launch_configuration" "foobar" {
   image_id = "ami-21f78e11"
-  instance_type = "t2.micro"
+  instance_type = "c3.large"
 }
 
 resource "aws_placement_group" "test" {
-  name = "test"
+  name = "tf_placement_test"
   strategy = "cluster"
 }
 

--- a/builtin/providers/aws/resource_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -19,7 +20,7 @@ func TestAccAWSDynamoDbTable_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSDynamoDbConfigInitialState,
+				Config: testAccAWSDynamoDbConfigInitialState(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table"),
 				),
@@ -41,7 +42,7 @@ func TestAccAWSDynamoDbTable_streamSpecification(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSDynamoDbConfigStreamSpecification,
+				Config: testAccAWSDynamoDbConfigStreamSpecification(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table"),
 					resource.TestCheckResourceAttr(
@@ -280,9 +281,10 @@ func dynamoDbAttributesToMap(attributes *[]*dynamodb.AttributeDefinition) map[st
 	return attrmap
 }
 
-const testAccAWSDynamoDbConfigInitialState = `
+func testAccAWSDynamoDbConfigInitialState() string {
+	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
-    name = "TerraformTestTable"
+    name = "TerraformTestTable-%d"
 		read_capacity = 10
 		write_capacity = 20
 		hash_key = "TestTableHashKey"
@@ -317,7 +319,8 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 			projection_type = "KEYS_ONLY"
 		}
 }
-`
+`, acctest.RandInt())
+}
 
 const testAccAWSDynamoDbConfigAddSecondaryGSI = `
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
@@ -359,9 +362,10 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 }
 `
 
-const testAccAWSDynamoDbConfigStreamSpecification = `
+func testAccAWSDynamoDbConfigStreamSpecification() string {
+	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
-    name = "TerraformTestStreamTable"
+    name = "TerraformTestStreamTable-%d"
 	read_capacity = 10
 	write_capacity = 20
 	hash_key = "TestTableHashKey"
@@ -398,4 +402,5 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 	stream_enabled = true
 	stream_view_type = "KEYS_ONLY"
 }
-`
+`, acctest.RandInt())
+}

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -1050,6 +1050,10 @@ resource "aws_security_group" "bar" {
     to_port = 80
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+	tags {
+		Name = "tf_elb_sg_test"
+	}
 }
 `
 


### PR DESCRIPTION
Updates for our acceptances tests. We're finding that as we run them in parallel we're getting name conflicts, so we randomize things when possible to avoid this.