### PR TITLE
provider/aws: Retry DB Creation on IAM propigation error

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -514,7 +514,7 @@ resource "aws_db_instance" "enhanced_monitoring" {
 	allocated_storage = 5
 	engine = "mysql"
 	engine_version = "5.6.21"
-	instance_class = "db.t2.small"
+	instance_class = "db.m3.medium"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"


### PR DESCRIPTION
For Enhanced Monitoring, there may be a different delay in propagation. Here we retry the creation in the event of a prop. error from IAM

Also bump the instance type in the acceptance test, to avoid some instance availability issues we were seeing in the nightly test runs.