### PR TITLE
core: Encode Targets in saved Planfile

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -316,9 +316,10 @@ func (c *Context) Plan() (*Plan, error) {
 	defer c.releaseRun(v)
 
 	p := &Plan{
-		Module: c.module,
-		Vars:   c.variables,
-		State:  c.state,
+		Module:  c.module,
+		Vars:    c.variables,
+		State:   c.state,
+		Targets: c.targets,
 	}
 
 	var operation walkOperation

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -21,10 +21,11 @@ func init() {
 // Plan represents a single Terraform execution plan, which contains
 // all the information necessary to make an infrastructure change.
 type Plan struct {
-	Diff   *Diff
-	Module *module.Tree
-	State  *State
-	Vars   map[string]string
+	Diff    *Diff
+	Module  *module.Tree
+	State   *State
+	Vars    map[string]string
+	Targets []string
 
 	once sync.Once
 }
@@ -38,6 +39,7 @@ func (p *Plan) Context(opts *ContextOpts) *Context {
 	opts.Module = p.Module
 	opts.State = p.State
 	opts.Variables = p.Vars
+	opts.Targets = p.Targets
 	return NewContext(opts)
 }
 

--- a/terraform/test-fixtures/apply-tainted-targets/main.tf
+++ b/terraform/test-fixtures/apply-tainted-targets/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "ifailedprovisioners" { }
+
+resource "aws_instance" "iambeingadded" { }

--- a/terraform/test-fixtures/plan-targeted-with-tainted/main.tf
+++ b/terraform/test-fixtures/plan-targeted-with-tainted/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "ifailedprovisioners" {
+}
+
+resource "aws_instance" "iambeingadded" {
+}


### PR DESCRIPTION
When a user specifies `-target`s on a `terraform plan` and stores
the resulting diff in a plan file using `-out` - it usually works just
fine since the diff is scoped based on the targets.

When there are tainted resources in the state, however, graph nodes to
destroy them were popping back into the plan when it was being loaded
from a file. This was because Targets weren't being stored in the
Planfile, so Terraform didn't know to filter them out. (In the
non-Planfile scenario, we still had the Targets loaded directly from the
flags.)

By encoding Targets in with the Planfile we can ensure that the same
filters are always applied.

Backwards compatibility should be fine here, since we're just adding a
field. The gob encoder/decoder will just do the right thing (ignore/skip
the field) with planfiles stored w/ versions that don't know about
Targets.

Fixes #5183