### PR TITLE
Add storage_encrypted as an optional parameter to aws_rds_cluster

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -74,6 +74,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 			"storage_encrypted": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  false,
 				ForceNew: true,
 			},
 

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -71,6 +71,12 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"storage_encrypted": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"final_snapshot_identifier": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -167,6 +173,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		Engine:              aws.String("aurora"),
 		MasterUserPassword:  aws.String(d.Get("master_password").(string)),
 		MasterUsername:      aws.String(d.Get("master_username").(string)),
+		StorageEncrypted:    aws.Bool(d.Get("storage_encrypted").(bool)),
 	}
 
 	if v := d.Get("database_name"); v.(string) != "" {
@@ -276,6 +283,7 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("engine", dbc.Engine)
 	d.Set("master_username", dbc.MasterUsername)
 	d.Set("port", dbc.Port)
+	d.Set("storage_encrypted", dbc.StorageEncrypted)
 	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
 	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", dbc.PreferredMaintenanceWindow)

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -37,6 +37,29 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRDSCluster_encrypted(t *testing.T) {
+	var v rds.DBCluster
+
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	encConfig := fmt.Sprintf(testAccAWSClusterConfig_encrypted, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: encConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "storage_encrypted", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 	var v rds.DBCluster
 
@@ -150,6 +173,16 @@ resource "aws_rds_cluster" "default" {
   database_name = "mydb"
   master_username = "foo"
   master_password = "mustbeeightcharaters"
+}`
+
+var testAccAWSClusterConfig_encrypted = `
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  storage_encrypted = true
 }`
 
 var testAccAWSClusterConfig_backups = `

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -29,6 +29,8 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "storage_encrypted", "false"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -71,6 +71,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `port` - (Optional) The port on which the DB accepts connections
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
   with the Cluster
+* `storage_encrypted` - (Optional) Specifies whether the DB cluster is encrypted. The default is `false` if not specified.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications
      are applied immediately, or during the next maintenance window. Default is
      `false`. See [Amazon RDS Documentation for more information.](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
@@ -97,7 +98,7 @@ The following attributes are exported:
 * `port` - The database port
 * `status` - The RDS instance status
 * `username` - The master username for the database
-* `storage_encrypted` - Specifies whether the DB instance is encrypted
+* `storage_encrypted` - Specifies whether the DB cluster is encrypted
 * `preferred_backup_window` - The daily time range during which the backups happen
 
 [1]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html


### PR DESCRIPTION
Provides a basic implementation of #4414, matching the current implementation for `aws_db_instance` added in #1041. This basic implementation allows the user to set the value of the StorageEncrypted flag at creation time, but does not allow customizing the KMS parameters as requested in #4414. I feel like that should be done in a separate PR, so that it can be added in a uniform way to all AWS resources that can accept KMS parameters.