### PR TITLE
provider/aws: Add support for `description` to `aws_network_interface` resource

### DIFF
--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -52,6 +52,11 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				Default:  true,
 			},
 
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"attachment": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -98,6 +103,10 @@ func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 		request.PrivateIpAddresses = expandPrivateIPAddresses(private_ips)
 	}
 
+	if v, ok := d.GetOk("description"); ok {
+		request.Description = aws.String(v.(string))
+	}
+
 	log.Printf("[DEBUG] Creating network interface")
 	resp, err := conn.CreateNetworkInterface(request)
 	if err != nil {
@@ -135,6 +144,10 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses))
 	d.Set("security_groups", flattenGroupIdentifiers(eni.Groups))
 	d.Set("source_dest_check", eni.SourceDestCheck)
+
+	if eni.Description != nil {
+		d.Set("description", eni.Description)
+	}
 
 	// Tags
 	d.Set("tags", tagsToMap(eni.TagSet))
@@ -294,6 +307,20 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		d.SetPartial("security_groups")
+	}
+
+	if d.HasChange("description") {
+		request := &ec2.ModifyNetworkInterfaceAttributeInput{
+			NetworkInterfaceId: aws.String(d.Id()),
+			Description:        &ec2.AttributeValue{Value: aws.String(d.Get("description").(string))},
+		}
+
+		_, err := conn.ModifyNetworkInterfaceAttribute(request)
+		if err != nil {
+			return fmt.Errorf("Failure updating ENI: %s", err)
+		}
+
+		d.SetPartial("description")
 	}
 
 	if err := setTags(conn, d); err != nil {

--- a/builtin/providers/aws/resource_aws_network_interface_test.go
+++ b/builtin/providers/aws/resource_aws_network_interface_test.go
@@ -28,6 +28,37 @@ func TestAccAWSENI_basic(t *testing.T) {
 						"aws_network_interface.bar", "private_ips.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "tags.Name", "bar_interface"),
+					resource.TestCheckResourceAttr(
+						"aws_network_interface.bar", "description", "Managed by Terraform"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSENI_updatedDescription(t *testing.T) {
+	var conf ec2.NetworkInterface
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSENIConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_network_interface.bar", "description", "Managed by Terraform"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAWSENIConfigUpdatedDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_network_interface.bar", "description", "Updated ENI Description"),
 				),
 			},
 		},
@@ -279,6 +310,42 @@ resource "aws_network_interface" "bar" {
     subnet_id = "${aws_subnet.foo.id}"
     private_ips = ["172.16.10.100"]
     security_groups = ["${aws_security_group.foo.id}"]
+    description = "Managed by Terraform"
+    tags {
+        Name = "bar_interface"
+    }
+}
+`
+
+const testAccAWSENIConfigUpdatedDescription = `
+resource "aws_vpc" "foo" {
+    cidr_block = "172.16.0.0/16"
+}
+
+resource "aws_subnet" "foo" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "172.16.10.0/24"
+    availability_zone = "us-west-2a"
+}
+
+resource "aws_security_group" "foo" {
+  vpc_id = "${aws_vpc.foo.id}"
+  description = "foo"
+  name = "foo"
+
+        egress {
+                from_port = 0
+                to_port = 0
+                protocol = "tcp"
+                cidr_blocks = ["10.0.0.0/16"]
+        }
+}
+
+resource "aws_network_interface" "bar" {
+    subnet_id = "${aws_subnet.foo.id}"
+    private_ips = ["172.16.10.100"]
+    security_groups = ["${aws_security_group.foo.id}"]
+    description = "Updated ENI Description"
     tags {
         Name = "bar_interface"
     }

--- a/website/source/docs/providers/aws/r/network_interface.markdown
+++ b/website/source/docs/providers/aws/r/network_interface.markdown
@@ -29,6 +29,7 @@ resource "aws_network_interface" "test" {
 The following arguments are supported:
 
 * `subnet_id` - (Required) Subnet ID to create the ENI in.
+* `description` - (Optional) A description for the network interface.
 * `private_ips` - (Optional) List of private IPs to assign to the ENI.
 * `security_groups` - (Optional) List of security group IDs to assign to the ENI.
 * `attachment` - (Optional) Block to define the attachment of the ENI. Documented below.
@@ -45,6 +46,7 @@ The `attachment` block supports:
 The following attributes are exported:
 
 * `subnet_id` - Subnet ID the ENI is in.
+* `description` - A description for the network interface.
 * `private_ips` - List of private IPs assigned to the ENI.
 * `security_groups` - List of security groups attached to the ENI.
 * `attachment` - Block defining the attachment of the ENI.


### PR DESCRIPTION
As requested in #5496 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSENI'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSENI -timeout 120m
=== RUN   TestAccAWSENI_basic
--- PASS: TestAccAWSENI_basic (47.64s)
=== RUN   TestAccAWSENI_updatedDescription
--- PASS: TestAccAWSENI_updatedDescription (82.32s)
=== RUN   TestAccAWSENI_attached
--- PASS: TestAccAWSENI_attached (230.88s)
=== RUN   TestAccAWSENI_ignoreExternalAttachment
--- PASS: TestAccAWSENI_ignoreExternalAttachment (248.85s)
=== RUN   TestAccAWSENI_sourceDestCheck
--- PASS: TestAccAWSENI_sourceDestCheck (37.95s)
=== RUN   TestAccAWSENI_computedIPs
--- PASS: TestAccAWSENI_computedIPs (36.09s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	683.420s
```