### PR TITLE
provider/aws: `repository_url` is computed for `aws_ecr_repository`

### DIFF
--- a/builtin/providers/aws/resource_aws_ecr_repository.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"log"
 
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -26,6 +28,10 @@ func resourceAwsEcrRepository() *schema.Resource {
 				Computed: true,
 			},
 			"registry_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"repository_url": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -81,7 +87,15 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("arn", *repository.RepositoryArn)
 	d.Set("registry_id", *repository.RegistryId)
 
+	repositoryUrl := buildRepositoryUrl(repository, meta.(*AWSClient).region)
+	log.Printf("[INFO] Setting the repository url to be %s", repositoryUrl)
+	d.Set("repository_url", repositoryUrl)
+
 	return nil
+}
+
+func buildRepositoryUrl(repo *ecr.Repository, region string) string {
+	return fmt.Sprintf("https://%s.dkr.ecr.%s.amazonaws.com/%s", *repo.RegistryId, region, *repo.RepositoryName)
 }
 
 func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) error {

--- a/website/source/docs/providers/aws/r/ecr_repository.html.markdown
+++ b/website/source/docs/providers/aws/r/ecr_repository.html.markdown
@@ -37,3 +37,4 @@ The following attributes are exported:
 * `arn` - Full ARN of the repository.
 * `name` - The name of the repository.
 * `registry_id` - The registry ID where the repository was created.
+* `repository_url` - The URL of the repository (in the form `https://aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`


### PR DESCRIPTION
As requested in #5518, we can compute the repository_url for ECR using a known format:

```
https://aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName
```

```
ake testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcrRepository_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcrRepository_basic -timeout 120m
=== RUN   TestAccAWSEcrRepository_basic
--- PASS: TestAccAWSEcrRepository_basic (6.97s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	6.983s
```

FYI, I didn't want to hardcode an account_id into the tests :)

But when I run this locally, I get the following output:

```
STATE:

aws_ecr_repository.default:
  ID = foo-repository-terraform
  arn = arn:aws:ecr:us-east-1:<ID>:repository/foo-repository-terraform
  name = foo-repository-terraform
  registry_id = <ID>
  repository_url = https://<ID>.dkr.ecr.us-east-1.amazonaws.com/foo-repository-terraform
```