### PR TITLE
provider/aws: aws_db_instance doesn't read publicly_accessible from AWS

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -591,6 +591,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("backup_window", v.PreferredBackupWindow)
 	d.Set("license_model", v.LicenseModel)
 	d.Set("maintenance_window", v.PreferredMaintenanceWindow)
+	d.Set("publicly_accessible", v.PubliclyAccessible)
 	d.Set("multi_az", v.MultiAZ)
 	if v.DBSubnetGroup != nil {
 		d.Set("db_subnet_group_name", v.DBSubnetGroup.DBSubnetGroupName)


### PR DESCRIPTION
The `aws_db_instance` wasn't reading the `publicly_accessible` attribute back. I notice because of the instances I created got manually changed to no longer be accessible in AWS, and terraform didn't complain about that change.