### PR TITLE
provider/aws: Fix all pointer RetryError returns

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
@@ -81,7 +81,7 @@ func resourceAwsCloudWatchEventRuleCreate(d *schema.ResourceData, meta interface
 					return err
 				}
 			}
-			return &resource.RetryError{
+			return resource.RetryError{
 				Err: err,
 			}
 		}
@@ -168,7 +168,7 @@ func resourceAwsCloudWatchEventRuleUpdate(d *schema.ResourceData, meta interface
 					return err
 				}
 			}
-			return &resource.RetryError{
+			return resource.RetryError{
 				Err: err,
 			}
 		}

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -163,7 +163,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 		if err != nil {
 			codedeployErr, ok := err.(awserr.Error)
 			if !ok {
-				return &resource.RetryError{Err: err}
+				return resource.RetryError{Err: err}
 			}
 			if codedeployErr.Code() == "InvalidRoleException" {
 				log.Printf("[DEBUG] Trying to create deployment group again: %q",
@@ -171,7 +171,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 				return err
 			}
 
-			return &resource.RetryError{Err: err}
+			return resource.RetryError{Err: err}
 		}
 		return nil
 	})

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -137,7 +137,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			ec2err, ok := err.(awserr.Error)
 			if !ok {
-				return &resource.RetryError{Err: err}
+				return resource.RetryError{Err: err}
 			}
 			if ec2err.Code() == "InvalidParameterException" {
 				log.Printf("[DEBUG] Trying to create ECS service again: %q",
@@ -145,7 +145,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 				return err
 			}
 
-			return &resource.RetryError{Err: err}
+			return resource.RetryError{Err: err}
 		}
 
 		return nil
@@ -322,7 +322,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 
 		ec2err, ok := err.(awserr.Error)
 		if !ok {
-			return &resource.RetryError{Err: err}
+			return resource.RetryError{Err: err}
 		}
 		if ec2err.Code() == "InvalidParameterException" {
 			// Prevent "The service cannot be stopped while deployments are active."
@@ -331,7 +331,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 			return err
 		}
 
-		return &resource.RetryError{Err: err}
+		return resource.RetryError{Err: err}
 
 	})
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_iam_policy_attachment.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment.go
@@ -223,7 +223,7 @@ func attachPolicyToRoles(conn *iam.IAM, roles []*string, arn string) error {
 
 			attachedPolicies, err := conn.ListRolePolicies(&input)
 			if err != nil {
-				return &resource.RetryError{Err: err}
+				return resource.RetryError{Err: err}
 			}
 
 			if len(attachedPolicies.PolicyNames) > 0 {
@@ -236,7 +236,7 @@ func attachPolicyToRoles(conn *iam.IAM, roles []*string, arn string) error {
 				}
 
 				if !foundPolicy {
-					return &resource.RetryError{Err: fmt.Errorf("Policy (%q) not yet found", arn)}
+					return resource.RetryError{Err: fmt.Errorf("Policy (%q) not yet found", arn)}
 				}
 			}
 

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -436,7 +436,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 					return err
 				}
 			}
-			return &resource.RetryError{
+			return resource.RetryError{
 				Err: err,
 			}
 		}

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -316,7 +316,7 @@ func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
 
 		ec2err, ok := err.(awserr.Error)
 		if !ok {
-			return &resource.RetryError{Err: err}
+			return resource.RetryError{Err: err}
 		}
 
 		switch ec2err.Code() {
@@ -326,7 +326,7 @@ func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		return &resource.RetryError{
+		return resource.RetryError{
 			Err: fmt.Errorf("Error deleting VPC: %s", err),
 		}
 	})


### PR DESCRIPTION
All of these RetryErrors were meant to fail right away, but instead
caused retry looping because the typecheck in the implementation of
`resource.Retry()` only catches the value type, and not the pointer
type.

Refs #5537