### PR TITLE
Documentation: Link to vsphere_folder resource missing in vsphere provider layout

### DIFF
--- a/website/source/docs/providers/vsphere/r/folder.html.markdown
+++ b/website/source/docs/providers/vsphere/r/folder.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a VMware vSphere virtual machine folder resource. This can be used to create and delete virtual machine folders.
 ---
 
-# vsphere\_virtual\_machine
+# vsphere\_folder
 
 Provides a VMware vSphere virtual machine folder resource. This can be used to create and delete virtual machine folders.
 

--- a/website/source/layouts/vsphere.erb
+++ b/website/source/layouts/vsphere.erb
@@ -16,6 +16,9 @@
             <li<%= sidebar_current("docs-vsphere-resource-virtual-machine") %>>
               <a href="/docs/providers/vsphere/r/virtual_machine.html">vsphere_virtual_machine</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-resource-folder") %>>
+              <a href="/docs/providers/vsphere/r/folder.html">vsphere_folder</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
Reasoning for docs update: I noticed the vsphere provider layout was missing a link to the folder resource docs and the title in the folder html file was also wrong
