### PR TITLE
helper/resource: Error shouldn't be returned in case of success

### DIFF
--- a/helper/resource/wait.go
+++ b/helper/resource/wait.go
@@ -21,6 +21,7 @@ func Retry(timeout time.Duration, f RetryFunc) error {
 		Refresh: func() (interface{}, string, error) {
 			rerr := f()
 			if rerr == nil {
+				resultErr = nil
 				return 42, "success", nil
 			}
 

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -12,14 +12,14 @@ func TestRetry(t *testing.T) {
 	tries := 0
 	f := func() *RetryError {
 		tries++
-		if tries == 1 {
+		if tries == 3 {
 			return nil
 		}
 
 		return RetryableError(fmt.Errorf("error"))
 	}
 
-	err := Retry(2*time.Second, f)
+	err := Retry(10*time.Second, f)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
This is fixing a bug that was introduced in https://github.com/hashicorp/terraform/pull/5460

It is easily reproducible by running any acceptance test of a resource which uses `resource.Retry`, e.g. Lambda function:

```sh
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSLambdaFunction_basic'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSLambdaFunction_basic -timeout 120m
=== RUN   TestAccAWSLambdaFunction_basic
--- FAIL: TestAccAWSLambdaFunction_basic (29.64s)
	testing.go:148: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_lambda_function.lambda_function_test: Error creating Lambda function: InvalidParameterValueException: The role defined for the function cannot be assumed by Lambda.
status code: 400, request id: *REDACTED*
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/aws	29.665s
make: *** [testacc] Error 1
```

Any time API returned error and we retried the request, we also saved the error into `resultErr`. Then after few retries, even if we received no error, we still returned the `resultErr` we had from the last failed API call.