### PR TITLE
provider/openstack: Fix create/delete statuses in load balancing resources for openstack provider.

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_member_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_member_v1.go
@@ -85,6 +85,7 @@ func resourceLBMemberV1Create(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for OpenStack LB member (%s) to become available.", m.ID)
 
 	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
 		Refresh:    waitForLBMemberActive(networkingClient, m.ID),
 		Timeout:    2 * time.Minute,
@@ -158,7 +159,7 @@ func resourceLBMemberV1Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"ACTIVE"},
+		Pending:    []string{"ACTIVE", "PENDING_DELETE"},
 		Target:     []string{"DELETED"},
 		Refresh:    waitForLBMemberDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,

--- a/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
@@ -115,7 +115,7 @@ func resourceLBMonitorV1Create(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for OpenStack LB Monitor (%s) to become available.", m.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"PENDING"},
+		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
 		Refresh:    waitForLBMonitorActive(networkingClient, m.ID),
 		Timeout:    2 * time.Minute,
@@ -205,7 +205,7 @@ func resourceLBMonitorV1Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"ACTIVE", "PENDING"},
+		Pending:    []string{"ACTIVE", "PENDING_DELETE"},
 		Target:     []string{"DELETED"},
 		Refresh:    waitForLBMonitorDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,

--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
@@ -128,6 +128,7 @@ func resourceLBPoolV1Create(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Waiting for OpenStack LB pool (%s) to become available.", p.ID)
 
 	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
 		Refresh:    waitForLBPoolActive(networkingClient, p.ID),
 		Timeout:    2 * time.Minute,
@@ -291,7 +292,7 @@ func resourceLBPoolV1Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"ACTIVE"},
+		Pending:    []string{"ACTIVE", "PENDING_DELETE"},
 		Target:     []string{"DELETED"},
 		Refresh:    waitForLBPoolDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,

--- a/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
@@ -264,7 +264,7 @@ func resourceLBVipV1Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"ACTIVE"},
+		Pending:    []string{"ACTIVE", "PENDING_DELETE"},
 		Target:     []string{"DELETED"},
 		Refresh:    waitForLBVIPDelete(networkingClient, d.Id()),
 		Timeout:    2 * time.Minute,


### PR DESCRIPTION
When trying to create a complete load balancer in Openstack, I would often run into the following error:

 `* openstack_lb_member_v1.lb_member.1: unexpected state 'PENDING_CREATE', wanted target '[ACTIVE]'`

After digging around in the code, I saw that the `Pending` status was different for the various LB resources (member, monitor, pool, and vip). Based on the source code for neutron lbaas, I found that the statuses should be as follows:

Create resource - 'PENDING_CREATE' - https://github.com/openstack/neutron-lbaas/blob/master/neutron_lbaas/db/loadbalancer/loadbalancer_db.py - lines 379, 593, 659, and 728.

Delete resource - 'PENDING_DELETE' - https://github.com/openstack/neutron-lbaas/blob/master/neutron_lbaas/services/loadbalancer/plugin.py - lines 167, 250, 277, and 341.

After making this change, and re-compiling the openstack provider, I have not seen the error after multiple deployments.

Note: the create resource for vip (resource_openstack_lb_vip_v1.go) already has the Pending status set to 'PENDING_CREATE'.