### PR TITLE
provider/vsphere: provide `host` to provisioner connections

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -439,6 +439,15 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 			}
 		}
 	}
+
+	if ip, ok := d.GetOk("network_interface.0.ipv4_address"); ok {
+		d.SetConnInfo(map[string]string{
+			"host": ip.(string),
+		})
+	} else {
+		log.Printf("[DEBUG] Could not get IP address for %s", d.Id())
+	}
+
 	d.SetId(vm.Path())
 	log.Printf("[INFO] Created virtual machine: %s", d.Id())
 


### PR DESCRIPTION
Provide `host` to provisioner connections to enable to use provisioner with vsphere provider.
We cannot use remote-exec provisioner with vsphere provider for now, because vsphere provider doesn't provide `host` to provisioner connections. And the debug log is following:

```
(remote-exec): Connecting to remote host via SSH...
(remote-exec):   Host: 
(remote-exec):   User: root
(remote-exec):   Password: true
(remote-exec):   Private key: false
(remote-exec):   SSH Agent: false
```

Workaround:

```
proivsioner "remote-exec" {
  scripts = {
    "aaa.sh"
  }
  connections = {
    user = "${var.ssh_user}"
    password = "${var.ssh_password}"
    host = "${self.network_interface.0.ipv4_address}"
}
```