### PR TITLE
provider/template: warn when template specified as path

### DIFF
--- a/builtin/providers/template/resource_template_file.go
+++ b/builtin/providers/template/resource_template_file.go
@@ -29,6 +29,7 @@ func resourceFile() *schema.Resource {
 				Description:   "Contents of the template",
 				ForceNew:      true,
 				ConflictsWith: []string{"filename"},
+				ValidateFunc:  validateTemplateAttribute,
 			},
 			"filename": &schema.Schema{
 				Type:        schema.TypeString,
@@ -173,4 +174,18 @@ func execute(s string, vars map[string]interface{}) (string, error) {
 func hash(s string) string {
 	sha := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sha[:])
+}
+
+func validateTemplateAttribute(v interface{}, key string) (ws []string, es []error) {
+	_, wasPath, err := pathorcontents.Read(v.(string))
+	if err != nil {
+		es = append(es, err)
+		return
+	}
+
+	if wasPath {
+		ws = append(ws, fmt.Sprintf("%s: looks like you specified a path instead of file contents. Use `file()` to load this path. Specifying a path directly is deprecated and will be removed in a future version.", key))
+	}
+
+	return
 }

--- a/builtin/providers/template/resource_template_file_test.go
+++ b/builtin/providers/template/resource_template_file_test.go
@@ -2,6 +2,9 @@ package template
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -75,6 +78,30 @@ func TestTemplateVariableChange(t *testing.T) {
 		Providers: testProviders,
 		Steps:     testSteps,
 	})
+}
+
+func TestValidateTemplateAttribute(t *testing.T) {
+	file, err := ioutil.TempFile("", "testtemplate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.WriteString("Hello world.")
+	file.Close()
+	defer os.Remove(file.Name())
+
+	ws, es := validateTemplateAttribute(file.Name(), "test")
+
+	if len(es) != 0 {
+		t.Fatalf("Unexpected errors: %#v", es)
+	}
+
+	if len(ws) != 1 {
+		t.Fatalf("Expected 1 warning, got %d", len(ws))
+	}
+
+	if !strings.Contains(ws[0], "Specifying a path directly is deprecated") {
+		t.Fatalf("Expected warning about path, got: %s", ws[0])
+	}
 }
 
 // This test covers a panic due to config.Func formerly being a


### PR DESCRIPTION
Turns out the BC code allowed users to move from `filename` to
`template` to squash the warning without having to switch from template
paths to template contents.

Here we warn when `template` is specified as a path so we can remove the
functionality in the future and remove this source of confusion.

refs #3732