### PR TITLE
provider/aws: More Acc test updates

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -13,16 +14,18 @@ import (
 func TestAccAWSAutoscalingLifecycleHook_basic(t *testing.T) {
 	var hook autoscaling.LifecycleHook
 
+	resourceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingLifecycleHookDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAutoscalingLifecycleHookConfig,
+				Config: testAccAWSAutoscalingLifecycleHookConfig(resourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLifecycleHookExists("aws_autoscaling_lifecycle_hook.foobar", &hook),
-					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "autoscaling_group_name", "terraform-test-foobar5"),
+					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "autoscaling_group_name", resourceName),
 					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "default_result", "CONTINUE"),
 					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "heartbeat_timeout", "2000"),
 					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "lifecycle_transition", "autoscaling:EC2_INSTANCE_LAUNCHING"),
@@ -41,7 +44,7 @@ func TestAccAWSAutoscalingLifecycleHook_omitDefaultResult(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAutoscalingLifecycleHookDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAutoscalingLifecycleHookConfig_omitDefaultResult,
+				Config: testAccAWSAutoscalingLifecycleHookConfig_omitDefaultResult(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLifecycleHookExists("aws_autoscaling_lifecycle_hook.foobar", &hook),
 					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "default_result", "ABANDON"),
@@ -101,9 +104,10 @@ func testAccCheckAWSAutoscalingLifecycleHookDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAWSAutoscalingLifecycleHookConfig = fmt.Sprintf(`
+func testAccAWSAutoscalingLifecycleHookConfig(name string) string {
+	return fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
-    name = "terraform-test-foobar5"
+    name = "%s"
     image_id = "ami-21f78e11"
     instance_type = "t1.micro"
 }
@@ -154,8 +158,8 @@ EOF
 
 resource "aws_autoscaling_group" "foobar" {
     availability_zones = ["us-west-2a"]
-    name = "terraform-test-foobar5"
-    max_size = 5
+    name = "%s"
+		max_size = 5
     min_size = 2
     health_check_grace_period = 300
     health_check_type = "ELB"
@@ -183,26 +187,29 @@ EOF
     notification_target_arn = "${aws_sqs_queue.foobar.arn}"
     role_arn = "${aws_iam_role.foobar.arn}"
 }
-`)
+`, name, name)
+}
 
-var testAccAWSAutoscalingLifecycleHookConfig_omitDefaultResult = fmt.Sprintf(`
+func testAccAWSAutoscalingLifecycleHookConfig_omitDefaultResult(name string) string {
+	return fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
-    name = "terraform-test-foobar5"
-    image_id = "ami-21f78e11"
-    instance_type = "t1.micro"
+  name          = "%s"
+  image_id      = "ami-21f78e11"
+  instance_type = "t1.micro"
 }
 
 resource "aws_sqs_queue" "foobar" {
-  name = "foobar"
-  delay_seconds = 90
-  max_message_size = 2048
+  name                      = "foobar"
+  delay_seconds             = 90
+  max_message_size          = 2048
   message_retention_seconds = 86400
   receive_wait_time_seconds = 10
 }
 
 resource "aws_iam_role" "foobar" {
-    name = "foobar"
-    assume_role_policy = <<EOF
+  name = "foobar"
+
+  assume_role_policy = <<EOF
 {
   "Version" : "2012-10-17",
   "Statement": [ {
@@ -215,9 +222,10 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foobar" {
-    name = "foobar"
-    role = "${aws_iam_role.foobar.id}"
-    policy = <<EOF
+  name = "foobar"
+  role = "${aws_iam_role.foobar.id}"
+
+  policy = <<EOF
 {
     "Version" : "2012-10-17",
     "Statement": [ {
@@ -235,35 +243,37 @@ resource "aws_iam_role_policy" "foobar" {
 EOF
 }
 
-
 resource "aws_autoscaling_group" "foobar" {
-    availability_zones = ["us-west-2a"]
-    name = "terraform-test-foobar5"
-    max_size = 5
-    min_size = 2
-    health_check_grace_period = 300
-    health_check_type = "ELB"
-    force_delete = true
-    termination_policies = ["OldestInstance"]
-    launch_configuration = "${aws_launch_configuration.foobar.name}"
-    tag {
-        key = "Foo"
-        value = "foo-bar"
-        propagate_at_launch = true
-    }
+  availability_zones        = ["us-west-2a"]
+  name                      = "%s"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  force_delete              = true
+  termination_policies      = ["OldestInstance"]
+  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key                 = "Foo"
+    value               = "foo-bar"
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_autoscaling_lifecycle_hook" "foobar" {
-    name = "foobar"
-    autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
-    heartbeat_timeout = 2000
-    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
-    notification_metadata = <<EOF
+  name                   = "foobar"
+  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  heartbeat_timeout      = 2000
+  lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
+
+  notification_metadata = <<EOF
 {
   "foo": "bar"
 }
 EOF
-    notification_target_arn = "${aws_sqs_queue.foobar.arn}"
-    role_arn = "${aws_iam_role.foobar.arn}"
+
+  notification_target_arn = "${aws_sqs_queue.foobar.arn}"
+  role_arn                = "${aws_iam_role.foobar.arn}"
+}`, name, name)
 }
-`)

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -944,7 +944,7 @@ resource "aws_subnet" "foo" {
 resource "aws_instance" "foo_instance" {
   ami = "ami-21f78e11"
   instance_type = "t1.micro"
-  security_groups = ["${aws_security_group.tf_test_foo.id}"]
+  vpc_security_group_ids = ["${aws_security_group.tf_test_foo.id}"]
   subnet_id = "${aws_subnet.foo.id}"
   associate_public_ip_address = true
 	depends_on = ["aws_internet_gateway.gw"]


### PR DESCRIPTION
Working on the green

- randomize some Autoscaling lifecycle hook test names
- use vpc_security_group_ids for this test

I ran one of the test configs through `hclfmt` so that explains much of the whitespace changes 