### PR TITLE
Revert "provider/aws: Support additional changes to security groups of instance without forcing new"

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -107,6 +107,7 @@ func resourceAwsInstance() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -577,28 +578,6 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 			log.Printf("[WARN] Attempted to modify SourceDestCheck on non VPC instance: %s", ec2err.Message())
-		}
-	}
-
-	if d.HasChange("security_groups") {
-		var groupIds []*string
-		if v := d.Get("security_groups").(*schema.Set); v.Len() > 0 {
-			resp, err := conn.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
-				GroupNames: expandStringList(v.List()),
-			})
-			if err != nil {
-				return err
-			}
-			for _, v := range resp.SecurityGroups {
-				groupIds = append(groupIds, aws.String(*v.GroupId))
-			}
-		}
-		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceId: aws.String(d.Id()),
-			Groups:     groupIds,
-		})
-		if err != nil {
-			return err
 		}
 	}
 


### PR DESCRIPTION
Reverts hashicorp/terraform#5193

After looking this over with @catsby - we're thinking it's best to back this out until we can get test coverage around it. Looks like our EC2 Classic / `security_groups` test coverage is lacking. We can revisit this change once we get some classic acctests on board. :+1: 