### PR TITLE
Fix panic in digital_ocean_droplet if resp is nil

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -189,7 +189,7 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	droplet, resp, err := client.Droplets.Get(id)
 	if err != nil {
 		// check if the droplet no longer exists.
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("[WARN] DigitalOcean Droplet (%s) not found", d.Id())
 			d.SetId("")
 			return nil


### PR DESCRIPTION
This probably occurs if there is transport failure, though I could not reproduce it locally. The report of the panic indicates the source of the problem though - we should fail gracefully in this case.

Fixes #5583.