### PR TITLE
provider/aws: Document set_identifer requirement for Route53 weighted and failover types

### DIFF
--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -93,7 +93,8 @@ The following arguments are supported:
 * `records` - (Required for non-alias records) A string list of records.
 * `weight` - (Optional) The weight of weighted record (0-255).
 * `set_identifier` - (Optional) Unique identifier to differentiate weighted
-record from one another. Required for each weighted record.
+ and failover records from one another. Required if using `weighted` or
+ `failover` attributes
 * `failover` - (Optional) The routing behavior when associated health check fails. Must be PRIMARY or SECONDARY.
 * `health_check_id` - (Optional) The health check the record should be associated with.
 * `alias` - (Optional) An alias block. Conflicts with `ttl` & `records`.


### PR DESCRIPTION
The documentation does not mention that a `set_identifier` is required for creating `failover` records, only `weighted` records. 