### PR TITLE
Added KMS alias name_prefix

### DIFF
--- a/builtin/providers/aws/resource_aws_kms_alias.go
+++ b/builtin/providers/aws/resource_aws_kms_alias.go
@@ -68,7 +68,7 @@ func resourceAwsKmsAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	} else if v, ok := d.GetOk("name_prefix"); ok {
 		name = resource.PrefixedUniqueId(v.(string))
 	} else {
-		name = resource.UniqueId()
+		name = resource.PrefixedUniqueId("alias/")
 	}
 
 	targetKeyId := d.Get("target_key_id").(string)

--- a/builtin/providers/aws/resource_aws_kms_alias.go
+++ b/builtin/providers/aws/resource_aws_kms_alias.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -24,8 +25,22 @@ func resourceAwsKmsAlias() *schema.Resource {
 				Computed: true,
 			},
 			"name": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9:/_-]+$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9:/_-]", k))
+					}
+					return
+				},
+			},
+			"name_prefix": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 					value := v.(string)
@@ -46,7 +61,16 @@ func resourceAwsKmsAlias() *schema.Resource {
 
 func resourceAwsKmsAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kmsconn
-	name := d.Get("name").(string)
+
+	var name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		name = resource.PrefixedUniqueId(v.(string))
+	} else {
+		name = resource.UniqueId()
+	}
+
 	targetKeyId := d.Get("target_key_id").(string)
 
 	log.Printf("[DEBUG] KMS alias create name: %s, target_key: %s", name, targetKeyId)

--- a/builtin/providers/aws/resource_aws_kms_alias_test.go
+++ b/builtin/providers/aws/resource_aws_kms_alias_test.go
@@ -138,7 +138,6 @@ resource "aws_kms_alias" "single" {
     target_key_id = "${aws_kms_key.one.key_id}"
 }`, kmsAliasTimestamp, kmsAliasTimestamp)
 
-
 var testAccAWSKmsSingleAlias_modified = fmt.Sprintf(`
 resource "aws_kms_key" "one" {
     description = "Terraform acc test One %s"

--- a/builtin/providers/aws/resource_aws_kms_alias_test.go
+++ b/builtin/providers/aws/resource_aws_kms_alias_test.go
@@ -31,6 +31,38 @@ func TestAccAWSKmsAlias_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSKmsAlias_name_prefix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSKmsSingleAlias,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsAliasExists("aws_kms_alias.name_prefix"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsAlias_no_name(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSKmsSingleAlias,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsAliasExists("aws_kms_alias.nothing"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSKmsAlias_multiple(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -92,10 +124,20 @@ resource "aws_kms_key" "two" {
     deletion_window_in_days = 7
 }
 
+resource "aws_kms_alias" "name_prefix" {
+	name_prefix = "alias/tf-acc-key-alias"
+	target_key_id = "${aws_kms_key.one.key_id}"
+}
+
+resource "aws_kms_alias" "nothing" {
+	target_key_id = "${aws_kms_key.one.key_id}"
+}
+
 resource "aws_kms_alias" "single" {
     name = "alias/tf-acc-key-alias"
     target_key_id = "${aws_kms_key.one.key_id}"
 }`, kmsAliasTimestamp, kmsAliasTimestamp)
+
 
 var testAccAWSKmsSingleAlias_modified = fmt.Sprintf(`
 resource "aws_kms_key" "one" {

--- a/website/source/docs/providers/aws/r/kms_alias.html.markdown
+++ b/website/source/docs/providers/aws/r/kms_alias.html.markdown
@@ -28,7 +28,10 @@ resource "aws_kms_alias" "a" {
 
 The following arguments are supported:
 
-* `name` - (Required) The display name of the alias. The name must start with the word "alias" followed by a forward slash (alias/)
+
+* `name` - (Optional) The display name of the alias. The name must start with the word "alias" followed by a forward slash (alias/)
+* `name_prefix` - (Optional) Creates an unique alias beginning with the specified prefix.  
+The name must start with the word "alias" followed by a forward slash (alias/).  Conflicts with `name`.
 * `target_key_id` - (Required) Identifier for the key for which the alias is for, can be either an ARN or key_id.
 
 ## Attributes Reference


### PR DESCRIPTION
Instead of a static KMS alias name, it allows either name_prefix or generate unique name.