### PR TITLE
provider/aws: Manage Triggers for AWS CodeDeploy Event Notifications

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -125,6 +125,35 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 				},
 				Set: resourceAwsCodeDeployTagFilterHash,
 			},
+
+			"trigger_configuration": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"trigger_events": &schema.Schema{
+							Type:     schema.TypeSet,
+							Required: true,
+							Set:      schema.HashString,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateTriggerEvent,
+							},
+						},
+
+						"trigger_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"trigger_target_arn": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAwsCodeDeployTriggerConfigHash,
+			},
 		},
 	}
 }
@@ -153,6 +182,10 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 	if attr, ok := d.GetOk("ec2_tag_filter"); ok {
 		ec2TagFilters := buildEC2TagFilters(attr.(*schema.Set).List())
 		input.Ec2TagFilters = ec2TagFilters
+	}
+	if attr, ok := d.GetOk("trigger_configuration"); ok {
+		triggerConfigs := buildTriggerConfigs(attr.(*schema.Set).List())
+		input.TriggerConfigurations = triggerConfigs
 	}
 
 	// Retry to handle IAM role eventual consistency.
@@ -207,6 +240,9 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 	if err := d.Set("on_premises_instance_tag_filter", onPremisesTagFiltersToMap(resp.DeploymentGroupInfo.OnPremisesInstanceTagFilters)); err != nil {
 		return err
 	}
+	if err := d.Set("trigger_configuration", triggerConfigsToMap(resp.DeploymentGroupInfo.TriggerConfigurations)); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -242,6 +278,11 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 		_, n := d.GetChange("ec2_tag_filter")
 		ec2Filters := buildEC2TagFilters(n.(*schema.Set).List())
 		input.Ec2TagFilters = ec2Filters
+	}
+	if d.HasChange("trigger_configuration") {
+		_, n := d.GetChange("trigger_configuration")
+		triggerConfigs := buildTriggerConfigs(n.(*schema.Set).List())
+		input.TriggerConfigurations = triggerConfigs
 	}
 
 	log.Printf("[DEBUG] Updating CodeDeploy DeploymentGroup %s", d.Id())
@@ -306,6 +347,23 @@ func buildEC2TagFilters(configured []interface{}) []*codedeploy.EC2TagFilter {
 	return filters
 }
 
+// buildTriggerConfigs converts a raw schema list into a list of
+// codedeploy.TriggerConfig.
+func buildTriggerConfigs(configured []interface{}) []*codedeploy.TriggerConfig {
+	configs := make([]*codedeploy.TriggerConfig, 0, len(configured))
+	for _, raw := range configured {
+		var config codedeploy.TriggerConfig
+		m := raw.(map[string]interface{})
+
+		config.TriggerEvents = expandStringList(m["trigger_events"].(*schema.Set).List())
+		config.TriggerName = aws.String(m["trigger_name"].(string))
+		config.TriggerTargetArn = aws.String(m["trigger_target_arn"].(string))
+
+		configs = append(configs, &config)
+	}
+	return configs
+}
+
 // ec2TagFiltersToMap converts lists of tag filters into a []map[string]string.
 func ec2TagFiltersToMap(list []*codedeploy.EC2TagFilter) []map[string]string {
 	result := make([]map[string]string, 0, len(list))
@@ -344,6 +402,19 @@ func onPremisesTagFiltersToMap(list []*codedeploy.TagFilter) []map[string]string
 	return result
 }
 
+// triggerConfigsToMap converts a list of []*codedeploy.TriggerConfig into a []map[string]interface{}
+func triggerConfigsToMap(list []*codedeploy.TriggerConfig) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, tc := range list {
+		item := make(map[string]interface{})
+		item["trigger_events"] = schema.NewSet(schema.HashString, flattenStringList(tc.TriggerEvents))
+		item["trigger_name"] = *tc.TriggerName
+		item["trigger_target_arn"] = *tc.TriggerTargetArn
+		result = append(result, item)
+	}
+	return result
+}
+
 func resourceAwsCodeDeployTagFilterHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
@@ -361,4 +432,21 @@ func resourceAwsCodeDeployTagFilterHash(v interface{}) int {
 	}
 
 	return hashcode.String(buf.String())
+}
+
+func resourceAwsCodeDeployTriggerConfigHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["trigger_name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["trigger_target_arn"].(string)))
+	return hashcode.String(buf.String())
+}
+
+func validateTriggerEvent(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value != "DeploymentStart" && value != "DeploymentSuccess" && value != "DeploymentFailure" && value != "DeploymentStop" && value != "InstanceStart" && value != "InstanceSuccess" && value != "InstanceFailure" {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid event type value: %q", k, value))
+	}
+	return
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -355,7 +355,7 @@ func buildTriggerConfigs(configured []interface{}) []*codedeploy.TriggerConfig {
 		var config codedeploy.TriggerConfig
 		m := raw.(map[string]interface{})
 
-		config.TriggerEvents = expandStringList(m["trigger_events"].(*schema.Set).List())
+		config.TriggerEvents = expandStringSet(m["trigger_events"].(*schema.Set))
 		config.TriggerName = aws.String(m["trigger_name"].(string))
 		config.TriggerTargetArn = aws.String(m["trigger_target_arn"].(string))
 

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -444,9 +444,18 @@ func resourceAwsCodeDeployTriggerConfigHash(v interface{}) int {
 
 func validateTriggerEvent(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if value != "DeploymentStart" && value != "DeploymentSuccess" && value != "DeploymentFailure" && value != "DeploymentStop" && value != "InstanceStart" && value != "InstanceSuccess" && value != "InstanceFailure" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be a valid event type value: %q", k, value))
+	triggerEvents := map[string]bool{
+		"DeploymentStart":   true,
+		"DeploymentStop":    true,
+		"DeploymentSuccess": true,
+		"DeploymentFailure": true,
+		"InstanceStart":     true,
+		"InstanceSuccess":   true,
+		"InstanceFailure":   true,
+	}
+
+	if !triggerEvents[value] {
+		errors = append(errors, fmt.Errorf("%q must be a valid event type value: %q", k, value))
 	}
 	return
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -21,12 +21,42 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 				Config: testAccAWSCodeDeployDeploymentGroup,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.key", "filterkey"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.value", "filtervalue"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccAWSCodeDeployDeploymentGroupModified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "bar"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.key", "filterkey"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
 				),
 			},
 		},
@@ -43,12 +73,24 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 				),
 			},
 		},
@@ -65,12 +107,24 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 				),
 			},
 		},
@@ -186,25 +240,25 @@ resource "aws_iam_role_policy" "foo_policy" {
 	role = "${aws_iam_role.foo_role.id}"
 	policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:CompleteLifecycleAction",
-                "autoscaling:DeleteLifecycleHook",
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeLifecycleHooks",
-                "autoscaling:PutLifecycleHook",
-                "autoscaling:RecordLifecycleActionHeartbeat",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "tag:GetTags",
-                "tag:GetResources"
-            ],
-            "Resource": "*"
-        }
-    ]
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"autoscaling:CompleteLifecycleAction",
+				"autoscaling:DeleteLifecycleHook",
+				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeLifecycleHooks",
+				"autoscaling:PutLifecycleHook",
+				"autoscaling:RecordLifecycleActionHeartbeat",
+				"ec2:DescribeInstances",
+				"ec2:DescribeInstanceStatus",
+				"tag:GetTags",
+				"tag:GetResources"
+			],
+			"Resource": "*"
+		}
+	]
 }
 EOF
 }
@@ -213,19 +267,19 @@ resource "aws_iam_role" "foo_role" {
 	name = "foo_role"
 	assume_role_policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "codedeploy.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"codedeploy.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
 }
 EOF
 }
@@ -251,25 +305,25 @@ resource "aws_iam_role_policy" "foo_policy" {
 	role = "${aws_iam_role.foo_role.id}"
 	policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:CompleteLifecycleAction",
-                "autoscaling:DeleteLifecycleHook",
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeLifecycleHooks",
-                "autoscaling:PutLifecycleHook",
-                "autoscaling:RecordLifecycleActionHeartbeat",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "tag:GetTags",
-                "tag:GetResources"
-            ],
-            "Resource": "*"
-        }
-    ]
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"autoscaling:CompleteLifecycleAction",
+				"autoscaling:DeleteLifecycleHook",
+				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeLifecycleHooks",
+				"autoscaling:PutLifecycleHook",
+				"autoscaling:RecordLifecycleActionHeartbeat",
+				"ec2:DescribeInstances",
+				"ec2:DescribeInstanceStatus",
+				"tag:GetTags",
+				"tag:GetResources"
+			],
+			"Resource": "*"
+		}
+	]
 }
 EOF
 }
@@ -278,19 +332,19 @@ resource "aws_iam_role" "foo_role" {
 	name = "foo_role"
 	assume_role_policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "codedeploy.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"codedeploy.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
 }
 EOF
 }
@@ -302,141 +356,141 @@ resource "aws_codedeploy_deployment_group" "foo" {
 	ec2_tag_filter {
 		key = "filterkey"
 		type = "KEY_AND_VALUE"
-		value = "filtervalue"
+		value = "anotherfiltervalue"
 	}
 }`
 
 const baseCodeDeployConfig = `
 resource "aws_codedeploy_app" "foo_app" {
-  name = "foo"
+	name = "foo-app"
 }
 
 resource "aws_iam_role_policy" "foo_policy" {
-  name = "foo"
-  role = "${aws_iam_role.foo_role.id}"
-  policy = <<EOF
+	name = "foo-policy"
+	role = "${aws_iam_role.foo_role.id}"
+	policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "autoscaling:CompleteLifecycleAction",
-        "autoscaling:DeleteLifecycleHook",
-        "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:DescribeLifecycleHooks",
-        "autoscaling:PutLifecycleHook",
-        "autoscaling:RecordLifecycleActionHeartbeat",
-        "ec2:DescribeInstances",
-        "ec2:DescribeInstanceStatus",
-        "tag:GetTags",
-        "tag:GetResources",
-        "sns:Publish"
-      ],
-      "Resource": "*"
-    }
-  ]
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"autoscaling:CompleteLifecycleAction",
+				"autoscaling:DeleteLifecycleHook",
+				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeLifecycleHooks",
+				"autoscaling:PutLifecycleHook",
+				"autoscaling:RecordLifecycleActionHeartbeat",
+				"ec2:DescribeInstances",
+				"ec2:DescribeInstanceStatus",
+				"tag:GetTags",
+				"tag:GetResources",
+				"sns:Publish"
+			],
+			"Resource": "*"
+		}
+	]
 }
 EOF
 }
 
 resource "aws_iam_role" "foo_role" {
-  name = "foo"
-  assume_role_policy = <<EOF
+	name = "foo-role"
+	assume_role_policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "codedeploy.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "codedeploy.amazonaws.com"
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
 }
 EOF
 }
 
 resource "aws_sns_topic" "foo_topic" {
-  name = "foo"
+	name = "foo-topic"
 }
 
 `
 
 const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create = baseCodeDeployConfig + `
 resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+	app_name = "${aws_codedeploy_app.foo_app.name}"
+	deployment_group_name = "foo-group"
+	service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-  trigger_configuration {
-    trigger_events = ["DeploymentFailure"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-  }
+	trigger_configuration {
+		trigger_events = ["DeploymentFailure"]
+		trigger_name = "foo-trigger"
+		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+	}
 }`
 
 const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update = baseCodeDeployConfig + `
 resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+	app_name = "${aws_codedeploy_app.foo_app.name}"
+	deployment_group_name = "foo-group"
+	service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-  trigger_configuration {
-    trigger_events = ["DeploymentSuccess", "DeploymentFailure"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-  }
+	trigger_configuration {
+		trigger_events = ["DeploymentSuccess", "DeploymentFailure"]
+		trigger_name = "foo-trigger"
+		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+	}
 }`
 
 const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple = baseCodeDeployConfig + `
 resource "aws_sns_topic" "bar_topic" {
-  name = "bar"
+	name = "bar-topic"
 }
 
 resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+	app_name = "${aws_codedeploy_app.foo_app.name}"
+	deployment_group_name = "foo-group"
+	service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-  trigger_configuration {
-    trigger_events = ["DeploymentFailure"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-  }
+	trigger_configuration {
+		trigger_events = ["DeploymentFailure"]
+		trigger_name = "foo-trigger"
+		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+	}
 
-  trigger_configuration {
-    trigger_events = ["InstanceFailure"]
-    trigger_name = "bar-trigger"
-    trigger_target_arn = "${aws_sns_topic.bar_topic.arn}"
-  }
+	trigger_configuration {
+		trigger_events = ["InstanceFailure"]
+		trigger_name = "bar-trigger"
+		trigger_target_arn = "${aws_sns_topic.bar_topic.arn}"
+	}
 }`
 
 const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple = baseCodeDeployConfig + `
 resource "aws_sns_topic" "bar_topic" {
-  name = "bar"
+	name = "bar-topic"
 }
 
 resource "aws_sns_topic" "baz_topic" {
-  name = "baz"
+	name = "baz-topic"
 }
 
 resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+	app_name = "${aws_codedeploy_app.foo_app.name}"
+	deployment_group_name = "foo-group"
+	service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-  trigger_configuration {
-    trigger_events = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-  }
+	trigger_configuration {
+		trigger_events = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
+		trigger_name = "foo-trigger"
+		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+	}
 
-  trigger_configuration {
-    trigger_events = ["InstanceFailure"]
-    trigger_name = "bar-trigger"
-    trigger_target_arn = "${aws_sns_topic.baz_topic.arn}"
-  }
+	trigger_configuration {
+		trigger_events = ["InstanceFailure"]
+		trigger_name = "bar-trigger"
+		trigger_target_arn = "${aws_sns_topic.baz_topic.arn}"
+	}
 }`

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -33,7 +33,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration(t *testing.T) {
+func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -78,34 +78,60 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 }
 
 func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
-	validEvents := []string{
-		"DeploymentStart",
-		"DeploymentSuccess",
-		"DeploymentFailure",
-		"DeploymentStop",
-		"InstanceStart",
-		"InstanceSuccess",
-		"InstanceFailure",
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "DeploymentStart",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DeploymentStop",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DeploymentSuccess",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DeploymentFailure",
+			ErrCount: 0,
+		},
+		{
+			Value:    "InstanceStart",
+			ErrCount: 0,
+		},
+		{
+			Value:    "InstanceSuccess",
+			ErrCount: 0,
+		},
+		{
+			Value:    "InstanceFailure",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DeploymentStarts",
+			ErrCount: 1,
+		},
+		{
+			Value:    "InstanceFail",
+			ErrCount: 1,
+		},
+		{
+			Value:    "Foo",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
 	}
 
-	for _, v := range validEvents {
-		_, errors := validateTriggerEvent(v, "trigger_event")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid trigger event type: %q", v, errors)
-		}
-	}
-
-	invalidEvents := []string{
-		"DeploymentStarts",
-		"InstanceFail",
-		"Foo",
-		"",
-	}
-
-	for _, v := range invalidEvents {
-		_, errors := validateTriggerEvent(v, "trigger_event")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid trigger event type: %q", v, errors)
+	for _, tc := range cases {
+		_, errors := validateTriggerEvent(tc.Value, "trigger_event")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Trigger event validation failed for event type %q: %q", tc.Value, errors)
 		}
 	}
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -33,6 +33,83 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group"),
+				),
+			},
+		},
+	})
+}
+
+func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
+	validEvents := []string{
+		"DeploymentStart",
+		"DeploymentSuccess",
+		"DeploymentFailure",
+		"DeploymentStop",
+		"InstanceStart",
+		"InstanceSuccess",
+		"InstanceFailure",
+	}
+
+	for _, v := range validEvents {
+		_, errors := validateTriggerEvent(v, "trigger_event")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid trigger event type: %q", v, errors)
+		}
+	}
+
+	invalidEvents := []string{
+		"DeploymentStarts",
+		"InstanceFail",
+		"Foo",
+		"",
+	}
+
+	for _, v := range invalidEvents {
+		_, errors := validateTriggerEvent(v, "trigger_event")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid trigger event type: %q", v, errors)
+		}
+	}
+}
+
 func testAccCheckAWSCodeDeployDeploymentGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).codedeployconn
 
@@ -90,14 +167,14 @@ resource "aws_iam_role_policy" "foo_policy" {
             "Action": [
                 "autoscaling:CompleteLifecycleAction",
                 "autoscaling:DeleteLifecycleHook",
-	        "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeLifecycleHooks",
                 "autoscaling:PutLifecycleHook",
                 "autoscaling:RecordLifecycleActionHeartbeat",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
                 "tag:GetTags",
-	        "tag:GetResources"
+                "tag:GetResources"
             ],
             "Resource": "*"
         }
@@ -155,14 +232,14 @@ resource "aws_iam_role_policy" "foo_policy" {
             "Action": [
                 "autoscaling:CompleteLifecycleAction",
                 "autoscaling:DeleteLifecycleHook",
-	        "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeLifecycleHooks",
                 "autoscaling:PutLifecycleHook",
                 "autoscaling:RecordLifecycleActionHeartbeat",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
                 "tag:GetTags",
-	        "tag:GetResources"
+                "tag:GetResources"
             ],
             "Resource": "*"
         }
@@ -201,4 +278,139 @@ resource "aws_codedeploy_deployment_group" "foo" {
 		type = "KEY_AND_VALUE"
 		value = "filtervalue"
 	}
+}`
+
+const baseCodeDeployConfig = `
+resource "aws_codedeploy_app" "foo_app" {
+  name = "foo"
+}
+
+resource "aws_iam_role_policy" "foo_policy" {
+  name = "foo"
+  role = "${aws_iam_role.foo_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLifecycleHooks",
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "tag:GetTags",
+        "tag:GetResources",
+        "sns:Publish"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "foo_role" {
+  name = "foo"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codedeploy.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_sns_topic" "foo_topic" {
+  name = "foo"
+}
+
+`
+
+const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create = baseCodeDeployConfig + `
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  trigger_configuration {
+    trigger_events = ["DeploymentFailure"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
+}`
+
+const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update = baseCodeDeployConfig + `
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  trigger_configuration {
+    trigger_events = ["DeploymentSuccess", "DeploymentFailure"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
+}`
+
+const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple = baseCodeDeployConfig + `
+resource "aws_sns_topic" "bar_topic" {
+  name = "bar"
+}
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  trigger_configuration {
+    trigger_events = ["DeploymentFailure"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
+
+  trigger_configuration {
+    trigger_events = ["InstanceFailure"]
+    trigger_name = "bar-trigger"
+    trigger_target_arn = "${aws_sns_topic.bar_topic.arn}"
+  }
+}`
+
+const testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple = baseCodeDeployConfig + `
+resource "aws_sns_topic" "bar_topic" {
+  name = "bar"
+}
+
+resource "aws_sns_topic" "baz_topic" {
+  name = "baz"
+}
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  trigger_configuration {
+    trigger_events = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
+
+  trigger_configuration {
+    trigger_events = ["InstanceFailure"]
+    trigger_name = "bar-trigger"
+    trigger_target_arn = "${aws_sns_topic.baz_topic.arn}"
+  }
 }`

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -29,14 +29,14 @@ resource "aws_iam_role_policy" "foo_policy" {
             "Action": [
                 "autoscaling:CompleteLifecycleAction",
                 "autoscaling:DeleteLifecycleHook",
-            "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeLifecycleHooks",
                 "autoscaling:PutLifecycleHook",
                 "autoscaling:RecordLifecycleActionHeartbeat",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
                 "tag:GetTags",
-            "tag:GetResources"
+                "tag:GetResources"
             ],
             "Resource": "*"
         }
@@ -70,10 +70,17 @@ resource "aws_codedeploy_deployment_group" "foo" {
     app_name = "${aws_codedeploy_app.foo_app.name}"
     deployment_group_name = "bar"
     service_role_arn = "${aws_iam_role.foo_role.arn}"
+
     ec2_tag_filter {
         key = "filterkey"
         type = "KEY_AND_VALUE"
         value = "filtervalue"
+    }
+
+    trigger_configuration {
+        trigger_events = ["DeploymentFailure"]
+        trigger_name = "foo-trigger"
+        trigger_target_arn = "foo-topic-arn"
     }
 }
 ```
@@ -89,12 +96,19 @@ The following arguments are supported:
 * `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
 * `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
+* `trigger_configuration` - (Optional) A Trigger Configuration block. Trigger Configurations are documented below.
 
 Both ec2_tag_filter and on_premises_tag_filter blocks support the following:
 
 * `key` - (Optional) The key of the tag filter.
 * `type` - (Optional) The type of the tag filter, either KEY_ONLY, VALUE_ONLY, or KEY_AND_VALUE.
 * `value` - (Optional) The value of the tag filter.
+
+Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the SNS topic associated with the trigger. CodeDeploy must have permission to publish to the topic from this deployment group. Trigger Configurations support the following:
+
+ * `trigger_events` - (Required) The event type or types for which notifications are triggered. The following values are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.
+ * `trigger_name` - (Required) The name of the notification trigger.
+ * `trigger_target_arn` - (Required) The ARN of the SNS topic through which notifications are sent.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Manage Triggers for AWS CodeDeploy Event Notifications

All `resource_aws_codedeploy_deployment_group.go` resource tests PASS.

(During development, I sometimes got test failures, presumably because of eventual consistency errors.)

Relevant AWS links:

 * [User Guide: Manage Triggers for AWS CodeDeploy Event Notifications](http://docs.aws.amazon.com/codedeploy/latest/userguide/how-to-notification-triggers.html)
 * [aws_sdk_go: CodeDeploy](http://docs.aws.amazon.com/sdk-for-go/api/service/codedeploy.html)


#### NOTES/THOUGHTS/QUESTIONS (feedback welcome):

 * I considered putting the `validateTriggerEvent` validator function in `validators.go`. However, it seems very specific to CodeDeploy so I kept it with the resource. If it were to go in `validators.go`, it would have to be renamed to something like `validateAwsCodeDeployTriggerEvent`.

 * The `validateTriggerEvent` function is a bit clumsy and could probably be written to be more idiomatic in go.

 * I suppose `trigger_configurations` could be developed as a separate resource, although this could also be said of the other resources attached to the Deployment Group. This implementation is consistent.

 * Prefixing the `trigger_configuration` fields with `trigger` seems a tiny bit redundant, but it adheres to the structure defined in the [aws-sdk-go api](http://docs.aws.amazon.com/sdk-for-go/api/service/codedeploy.html#type-TriggerConfig), which I think is important. I briefly debated a more terse schema, like this:

```
  trigger_configuration {
    name = "foo-trigger"
    events = ["DeploymentFailure"]
    target_arn = "${aws_sns_topic.foo_topic.arn}"
  }
```

#### POSSIBLE ENHANCEMENTS
 * The *ALL* option is not yet supported for Deployment or Instance events. This appears to be a console convenience, so it is debatable whether it should be implemented as part of this PR.
 * Add acceptance tests to verify the actual structure of created trigger configurations as well as known error cases (rather than just create/update of the primary resources).
 * Consider adding unit tests for `buildTriggerConfigs` and `triggerConfigsToMap` functions.
