### PR TITLE
aws: Fix CloudFormation update for parameters & capabilities if not modified

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack.go
@@ -268,7 +268,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 		StackName: aws.String(d.Get("name").(string)),
 	}
 
-	// Either TemplateBody or TemplateURL are required for each change
+	// Either TemplateBody, TemplateURL or UsePreviousTemplate are required
 	if v, ok := d.GetOk("template_url"); ok {
 		input.TemplateURL = aws.String(v.(string))
 	}
@@ -276,15 +276,20 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 		input.TemplateBody = aws.String(normalizeJson(v.(string)))
 	}
 
-	if d.HasChange("capabilities") {
-		input.Capabilities = expandStringList(d.Get("capabilities").(*schema.Set).List())
+	// Capabilities must be present whether they are changed or not
+	if v, ok := d.GetOk("capabilities"); ok {
+		input.Capabilities = expandStringList(v.(*schema.Set).List())
 	}
+
 	if d.HasChange("notification_arns") {
 		input.NotificationARNs = expandStringList(d.Get("notification_arns").(*schema.Set).List())
 	}
-	if d.HasChange("parameters") {
-		input.Parameters = expandCloudFormationParameters(d.Get("parameters").(map[string]interface{}))
+
+	// Parameters must be present whether they are changed or not
+	if v, ok := d.GetOk("parameters"); ok {
+		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
 	}
+
 	if d.HasChange("policy_body") {
 		input.StackPolicyBody = aws.String(normalizeJson(d.Get("policy_body").(string)))
 	}


### PR DESCRIPTION
Based on @olegch's work from https://github.com/hashicorp/terraform/pull/5264

I resolved conflicts, omitted unrelated changes in the build script and enhanced existing acceptance test to cover this bug.

#### Test plan

```sh
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSCloudFormation_allAttributes'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSCloudFormation_allAttributes -timeout 120m
=== RUN   TestAccAWSCloudFormation_allAttributes
--- PASS: TestAccAWSCloudFormation_allAttributes (153.44s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	153.464s
```