### PR TITLE
provider/aws: Switch to session.Copy to build up configs

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -159,10 +159,7 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing IAM Connection")
 		sess := session.New(awsConfig)
 
-		awsIamConfig := *awsConfig
-		awsIamConfig.Endpoint = aws.String(c.IamEndpoint)
-
-		awsIamSess := session.New(&awsIamConfig)
+		awsIamSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.IamEndpoint)})
 		client.iamconn = iam.New(awsIamSess)
 
 		err = c.ValidateCredentials(client.iamconn)
@@ -175,27 +172,14 @@ func (c *Config) Client() (interface{}, error) {
 		// signature format v4 requires region to be us-east-1 for global
 		// endpoints:
 		// http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
-		usEast1AwsConfig := &aws.Config{
-			Credentials: creds,
-			Region:      aws.String("us-east-1"),
-			MaxRetries:  aws.Int(c.MaxRetries),
-			HTTPClient:  cleanhttp.DefaultClient(),
-		}
-		usEast1Sess := session.New(usEast1AwsConfig)
-
-		awsDynamoDBConfig := *awsConfig
-		awsDynamoDBConfig.Endpoint = aws.String(c.DynamoDBEndpoint)
+		usEast1Sess := sess.Copy(&aws.Config{Region: aws.String("us-east-1")})
 
 		log.Println("[INFO] Initializing DynamoDB connection")
-		dynamoSess := session.New(&awsDynamoDBConfig)
+		dynamoSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DynamoDBEndpoint)})
 		client.dynamodbconn = dynamodb.New(dynamoSess)
 
 		log.Println("[INFO] Initializing ELB connection")
-		awsElbConfig := *awsConfig
-		awsElbConfig.Endpoint = aws.String(c.ElbEndpoint)
-
-		awsElbSess := session.New(&awsElbConfig)
-
+		awsElbSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.ElbEndpoint)})
 		client.elbconn = elb.New(awsElbSess)
 
 		log.Println("[INFO] Initializing S3 connection")
@@ -210,11 +194,8 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing RDS Connection")
 		client.rdsconn = rds.New(sess)
 
-		awsKinesisConfig := *awsConfig
-		awsKinesisConfig.Endpoint = aws.String(c.KinesisEndpoint)
-
 		log.Println("[INFO] Initializing Kinesis Connection")
-		kinesisSess := session.New(&awsKinesisConfig)
+		kinesisSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.KinesisEndpoint)})
 		client.kinesisconn = kinesis.New(kinesisSess)
 
 		log.Println("[INFO] Initializing Elastic Beanstalk Connection")
@@ -233,10 +214,7 @@ func (c *Config) Client() (interface{}, error) {
 
 		log.Println("[INFO] Initializing EC2 Connection")
 
-		awsEc2Config := *awsConfig
-		awsEc2Config.Endpoint = aws.String(c.Ec2Endpoint)
-
-		awsEc2Sess := session.New(&awsEc2Config)
+		awsEc2Sess := sess.Copy(&aws.Config{Endpoint: aws.String(c.Ec2Endpoint)})
 		client.ec2conn = ec2.New(awsEc2Sess)
 
 		log.Println("[INFO] Initializing ECR Connection")


### PR DESCRIPTION
Found this function which makes the config setup much nicer - looks like
it's meant to be used for the very thing we're doing, which is starting
w/ a base config and customizing it slightly.

https://docs.aws.amazon.com/sdk-for-go/api/aws/session/Session.html#Copy-instance_method

This will make the User-Agent setting code to follow much simpler.