### PR TITLE
provider/aws: log HTTP req/resp at DEBUG level

### DIFF
--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -22,8 +22,9 @@ var validLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 // LogOutput determines where we should send logs (if anywhere) and the log level.
 func LogOutput() (logOutput io.Writer, err error) {
 	logOutput = ioutil.Discard
-	envLevel := os.Getenv(EnvLog)
-	if envLevel == "" {
+
+	logLevel := LogLevel()
+	if logLevel == "" {
 		return
 	}
 
@@ -37,23 +38,38 @@ func LogOutput() (logOutput io.Writer, err error) {
 	}
 
 	// This was the default since the beginning
-	logLevel := logutils.LogLevel("TRACE")
+	logOutput = &logutils.LevelFilter{
+		Levels:   validLevels,
+		MinLevel: logutils.LogLevel(logLevel),
+		Writer:   logOutput,
+	}
 
+	return
+}
+
+// LogLevel returns the current log level string based the environment vars
+func LogLevel() string {
+	envLevel := os.Getenv(EnvLog)
+	if envLevel == "" {
+		return ""
+	}
+
+	logLevel := "TRACE"
 	if isValidLogLevel(envLevel) {
 		// allow following for better ux: info, Info or INFO
-		logLevel = logutils.LogLevel(strings.ToUpper(envLevel))
+		logLevel = strings.ToUpper(envLevel)
 	} else {
 		log.Printf("[WARN] Invalid log level: %q. Defaulting to level: TRACE. Valid levels are: %+v",
 			envLevel, validLevels)
 	}
 
-	logOutput = &logutils.LevelFilter{
-		Levels:   validLevels,
-		MinLevel: logLevel,
-		Writer:   logOutput,
-	}
+	return logLevel
+}
 
-	return
+// IsDebugOrHigher returns whether or not the current log level is debug or trace
+func IsDebugOrHigher() bool {
+	level := string(LogLevel())
+	return level == "DEBUG" || level == "TRACE"
 }
 
 func isValidLogLevel(level string) bool {


### PR DESCRIPTION
This should be quite helpful in debugging aws-sdk-go operations.

Required some tweaking around the `helper/logging` functions to expose an
`IsDebugOrHigher()` helper for us to use.