### PR TITLE
helper/resource: Add more details (Retries) to resource.NotFoundError

### DIFF
--- a/helper/resource/error.go
+++ b/helper/resource/error.go
@@ -19,6 +19,10 @@ func (e *NotFoundError) Error() string {
 		return e.Message
 	}
 
+	if e.Retries > 0 {
+		return fmt.Sprintf("couldn't find resource (%d retries)", e.Retries)
+	}
+
 	return "couldn't find resource"
 }
 

--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -111,6 +111,7 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 				if notfoundTick > conf.NotFoundChecks {
 					result.Error = &NotFoundError{
 						LastError: err,
+						Retries:   notfoundTick,
 					}
 					lastResult.Store(result)
 					return


### PR DESCRIPTION
After gaining some inspiration in libraries we vendor and other Hashicorp repositories + https://github.com/hashicorp/terraform/pull/5543/files#diff-a1a876e10bf38cbc1b5f44a925b5293cR48 I decided to came up with this custom error to pave the way (pattern) for potential other custom errors in terms of naming convention (`CustomNameError`) and other things.

I'd like to use this specific error in cases where an extra logic is necessary to lookup a resource inside an array returned from the API:
- [`aws_autoscaling_group`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_autoscaling_group.go#L497)
- [`aws_autoscaling_hook`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook.go#L191)
- [`aws_autoscaling_notification`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_autoscaling_notification.go#L90)
- [`aws_autoscaling_schedule`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_autoscaling_schedule.go#L172)
- [`aws_cloudformation_stack`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_cloudformation_stack.go#L191-L204)
- [`aws_cloudtrail`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_cloudtrail.go#L145-L151)
- [`aws_cloudwatch_event_target`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_cloudwatch_event_target.go#L142)
- [`aws_cloudwatch_log_group`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_cloudwatch_log_group.go#L100)
- [`aws_cloudwatch_alarm_metric`](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go#L272)

etc. There's many other resources that would benefit from this. ^ that is not an exhaustive list.

Then we can also unify the approach to cases where someone deletes resource outside of Terraform.

This would also unblock https://github.com/hashicorp/terraform/pull/5205 and https://github.com/hashicorp/terraform/pull/5444

cc @Bowbaq 
