### PR TITLE
provider/test: a test provider

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -1,0 +1,19 @@
+package test
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"test_resource": testResource(),
+		},
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	return nil, nil
+}

--- a/builtin/providers/test/provider_test.go
+++ b/builtin/providers/test/provider_test.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"test": testAccProvider,
+	}
+}

--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -1,0 +1,53 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResource() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceCreate,
+		Read:   testResourceRead,
+		Update: testResourceUpdate,
+		Delete: testResourceDelete,
+		Schema: map[string]*schema.Schema{
+			"required": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"optional": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"optional_force_new": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func testResourceCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("testId")
+
+	// Required must make it through to Create
+	if _, ok := d.GetOk("required"); !ok {
+		return fmt.Errorf("Missing attribute 'required', but it's required!")
+	}
+	return nil
+}
+
+func testResourceRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResource_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+	required = "yep"
+}
+				`),
+				Check: func(s *terraform.State) error {
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckResourceDestroy(s *terraform.State) error {
+	return nil
+}


### PR DESCRIPTION
Here we also introduce a `test` provider meant as an aid to exposing
via automated tests issues involving interactions between
`helper/schema` and Terraform core.

This has been helpful so far in diagnosing `ignore_changes` problems,
and I imagine it will be helpful in other contexts as well.

We'll have to be careful to prevent the `test` provider from becoming a
dumping ground for poorly specified tests that have a clear home
elsewhere. But for bug exposure I think it's useful to have.