### PR TITLE
provider/aws: Add resource for an ELB SSL negotiation policy

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -192,6 +192,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lambda_permission":                        resourceAwsLambdaPermission(),
 			"aws_launch_configuration":                     resourceAwsLaunchConfiguration(),
 			"aws_lb_cookie_stickiness_policy":              resourceAwsLBCookieStickinessPolicy(),
+			"aws_lb_ssl_negotiation_policy":                resourceAwsLBSSLNegotiationPolicy(),
 			"aws_main_route_table_association":             resourceAwsMainRouteTableAssociation(),
 			"aws_nat_gateway":                              resourceAwsNatGateway(),
 			"aws_network_acl":                              resourceAwsNetworkAcl(),

--- a/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -1,0 +1,181 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLBSSLNegotiationPolicy() *schema.Resource {
+	return &schema.Resource{
+		// There is no concept of "updating" an LB policy in
+		// the AWS API.
+		Create: resourceAwsLBSSLNegotiationPolicyCreate,
+		Read:   resourceAwsLBSSLNegotiationPolicyRead,
+		Delete: resourceAwsLBSSLNegotiationPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"load_balancer": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"lb_port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"attribute": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsLBSSLNegotiationPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	// Provision the SSLNegotiationPolicy
+	lbspOpts := &elb.CreateLoadBalancerPolicyInput{
+		LoadBalancerName: aws.String(d.Get("load_balancer").(string)),
+		PolicyName:       aws.String(d.Get("name").(string)),
+		PolicyTypeName:   aws.String("SSLNegotiationPolicyType"),
+	}
+
+	// Check for Policy Attributes
+	if v, ok := d.GetOk("attribute"); ok {
+		// Expand the "attribute" set to aws-sdk-go compat []*elb.PolicyAttribute
+		lbspOpts.PolicyAttributes = expandPolicyAttributes(v.(*schema.Set).List())
+	}
+
+	log.Printf("[DEBUG] Load Balancer Policy opts: %#v", lbspOpts)
+	if _, err := elbconn.CreateLoadBalancerPolicy(lbspOpts); err != nil {
+		return fmt.Errorf("Error creating Load Balancer Policy: %s", err)
+	}
+
+	setLoadBalancerOpts := &elb.SetLoadBalancerPoliciesOfListenerInput{
+		LoadBalancerName: aws.String(d.Get("load_balancer").(string)),
+		LoadBalancerPort: aws.Int64(int64(d.Get("lb_port").(int))),
+		PolicyNames:      []*string{aws.String(d.Get("name").(string))},
+	}
+
+	log.Printf("[DEBUG] SSL Negotiation create configuration: %#v", setLoadBalancerOpts)
+	if _, err := elbconn.SetLoadBalancerPoliciesOfListener(setLoadBalancerOpts); err != nil {
+		return fmt.Errorf("Error setting SSLNegotiationPolicy: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%d:%s",
+		*lbspOpts.LoadBalancerName,
+		*setLoadBalancerOpts.LoadBalancerPort,
+		*lbspOpts.PolicyName))
+	return nil
+}
+
+func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	lbName, lbPort, policyName := resourceAwsLBSSLNegotiationPolicyParseId(d.Id())
+
+	request := &elb.DescribeLoadBalancerPoliciesInput{
+		LoadBalancerName: aws.String(lbName),
+		PolicyNames:      []*string{aws.String(policyName)},
+	}
+
+	getResp, err := elbconn.DescribeLoadBalancerPolicies(request)
+	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "PolicyNotFound" {
+			// The policy is gone.
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving policy: %s", err)
+	}
+
+	if len(getResp.PolicyDescriptions) != 1 {
+		return fmt.Errorf("Unable to find policy %#v", getResp.PolicyDescriptions)
+	}
+
+	// We can get away with this because there's only one policy returned
+	policyDesc := getResp.PolicyDescriptions[0]
+	attributes := flattenPolicyAttributes(policyDesc.PolicyAttributeDescriptions)
+	d.Set("attributes", attributes)
+
+	d.Set("name", policyName)
+	d.Set("load_balancer", lbName)
+	d.Set("lb_port", lbPort)
+
+	return nil
+}
+
+func resourceAwsLBSSLNegotiationPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	lbName, _, policyName := resourceAwsLBSSLNegotiationPolicyParseId(d.Id())
+
+	// Perversely, if we Set an empty list of PolicyNames, we detach the
+	// policies attached to a listener, which is required to delete the
+	// policy itself.
+	setLoadBalancerOpts := &elb.SetLoadBalancerPoliciesOfListenerInput{
+		LoadBalancerName: aws.String(d.Get("load_balancer").(string)),
+		LoadBalancerPort: aws.Int64(int64(d.Get("lb_port").(int))),
+		PolicyNames:      []*string{},
+	}
+
+	if _, err := elbconn.SetLoadBalancerPoliciesOfListener(setLoadBalancerOpts); err != nil {
+		return fmt.Errorf("Error removing SSLNegotiationPolicy: %s", err)
+	}
+
+	request := &elb.DeleteLoadBalancerPolicyInput{
+		LoadBalancerName: aws.String(lbName),
+		PolicyName:       aws.String(policyName),
+	}
+
+	if _, err := elbconn.DeleteLoadBalancerPolicy(request); err != nil {
+		return fmt.Errorf("Error deleting SSL negotiation policy %s: %s", d.Id(), err)
+	}
+	return nil
+}
+
+// resourceAwsLBSSLNegotiationPolicyParseId takes an ID and parses it into
+// it's constituent parts. You need three axes (LB name, policy name, and LB
+// port) to create or identify an SSL negotiation policy in AWS's API.
+func resourceAwsLBSSLNegotiationPolicyParseId(id string) (string, string, string) {
+	parts := strings.SplitN(id, ":", 3)
+	return parts[0], parts[1], parts[2]
+}

--- a/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -42,7 +42,7 @@ func resourceAwsLBSSLNegotiationPolicy() *schema.Resource {
 
 			"attribute": &schema.Schema{
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -80,8 +80,12 @@ func resourceAwsLBSSLNegotiationPolicyCreate(d *schema.ResourceData, meta interf
 
 	// Check for Policy Attributes
 	if v, ok := d.GetOk("attribute"); ok {
+		var err error
 		// Expand the "attribute" set to aws-sdk-go compat []*elb.PolicyAttribute
-		lbspOpts.PolicyAttributes = expandPolicyAttributes(v.(*schema.Set).List())
+		lbspOpts.PolicyAttributes, err = expandPolicyAttributes(v.(*schema.Set).List())
+		if err != nil {
+			return err
+		}
 	}
 
 	log.Printf("[DEBUG] Load Balancer Policy opts: %#v", lbspOpts)

--- a/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy_test.go
+++ b/builtin/providers/aws/resource_aws_lb_ssl_negotiation_policy_test.go
@@ -1,0 +1,272 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elb"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSLBSSLNegotiationPolicy_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBSSLNegotiationPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccSslNegotiationPolicyConfig(
+					fmt.Sprintf("tf-acctest-%s", acctest.RandString(10))),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBSSLNegotiationPolicy(
+						"aws_elb.lb",
+						"aws_lb_ssl_negotiation_policy.foo",
+					),
+					resource.TestCheckResourceAttr(
+						"aws_lb_ssl_negotiation_policy.foo", "attribute.#", "7"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLBSSLNegotiationPolicyDestroy(s *terraform.State) error {
+	elbconn := testAccProvider.Meta().(*AWSClient).elbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elb" && rs.Type != "aws_lb_ssl_negotiation_policy" {
+			continue
+		}
+
+		// Check that the ELB is destroyed
+		if rs.Type == "aws_elb" {
+			describe, err := elbconn.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+				LoadBalancerNames: []*string{aws.String(rs.Primary.ID)},
+			})
+
+			if err == nil {
+				if len(describe.LoadBalancerDescriptions) != 0 &&
+					*describe.LoadBalancerDescriptions[0].LoadBalancerName == rs.Primary.ID {
+					return fmt.Errorf("ELB still exists")
+				}
+			}
+
+			// Verify the error
+			providerErr, ok := err.(awserr.Error)
+			if !ok {
+				return err
+			}
+
+			if providerErr.Code() != "LoadBalancerNotFound" {
+				return fmt.Errorf("Unexpected error: %s", err)
+			}
+		} else {
+			// Check that the SSL Negotiation Policy is destroyed
+			elbName, _, policyName := resourceAwsLBSSLNegotiationPolicyParseId(rs.Primary.ID)
+			_, err := elbconn.DescribeLoadBalancerPolicies(&elb.DescribeLoadBalancerPoliciesInput{
+				LoadBalancerName: aws.String(elbName),
+				PolicyNames:      []*string{aws.String(policyName)},
+			})
+
+			if err == nil {
+				return fmt.Errorf("ELB SSL Negotiation Policy still exists")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckLBSSLNegotiationPolicy(elbResource string, policyResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[elbResource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", elbResource)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		policy, ok := s.RootModule().Resources[policyResource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", policyResource)
+		}
+
+		elbconn := testAccProvider.Meta().(*AWSClient).elbconn
+
+		elbName, _, policyName := resourceAwsLBSSLNegotiationPolicyParseId(policy.Primary.ID)
+		resp, err := elbconn.DescribeLoadBalancerPolicies(&elb.DescribeLoadBalancerPoliciesInput{
+			LoadBalancerName: aws.String(elbName),
+			PolicyNames:      []*string{aws.String(policyName)},
+		})
+
+		if err != nil {
+			fmt.Printf("[ERROR] Problem describing load balancer policy '%s': %s", policyName, err)
+			return err
+		}
+
+		if len(resp.PolicyDescriptions) != 1 {
+			return fmt.Errorf("Unable to find policy %#v", resp.PolicyDescriptions)
+		}
+
+		attrmap := policyAttributesToMap(&resp.PolicyDescriptions[0].PolicyAttributeDescriptions)
+		if attrmap["Protocol-TLSv1"] != "false" {
+			return fmt.Errorf("Policy attribute 'Protocol-TLSv1' was of value %s instead of false!", attrmap["Protocol-TLSv1"])
+		}
+		if attrmap["Protocol-TLSv1.1"] != "false" {
+			return fmt.Errorf("Policy attribute 'Protocol-TLSv1.1' was of value %s instead of false!", attrmap["Protocol-TLSv1.1"])
+		}
+		if attrmap["Protocol-TLSv1.2"] != "true" {
+			return fmt.Errorf("Policy attribute 'Protocol-TLSv1.2' was of value %s instead of true!", attrmap["Protocol-TLSv1.2"])
+		}
+		if attrmap["Server-Defined-Cipher-Order"] != "true" {
+			return fmt.Errorf("Policy attribute 'Server-Defined-Cipher-Order' was of value %s instead of true!", attrmap["Server-Defined-Cipher-Order"])
+		}
+		if attrmap["ECDHE-RSA-AES128-GCM-SHA256"] != "true" {
+			return fmt.Errorf("Policy attribute 'ECDHE-RSA-AES128-GCM-SHA256' was of value %s instead of true!", attrmap["ECDHE-RSA-AES128-GCM-SHA256"])
+		}
+		if attrmap["AES128-GCM-SHA256"] != "true" {
+			return fmt.Errorf("Policy attribute 'AES128-GCM-SHA256' was of value %s instead of true!", attrmap["AES128-GCM-SHA256"])
+		}
+		if attrmap["EDH-RSA-DES-CBC3-SHA"] != "false" {
+			return fmt.Errorf("Policy attribute 'EDH-RSA-DES-CBC3-SHA' was of value %s instead of false!", attrmap["EDH-RSA-DES-CBC3-SHA"])
+		}
+
+		return nil
+	}
+}
+
+func policyAttributesToMap(attributes *[]*elb.PolicyAttributeDescription) map[string]string {
+	attrmap := make(map[string]string)
+
+	for _, attrdef := range *attributes {
+		attrmap[*attrdef.AttributeName] = *attrdef.AttributeValue
+	}
+
+	return attrmap
+}
+
+// Sets the SSL Negotiation policy with attributes.
+// The IAM Server Cert config is lifted from
+// builtin/providers/aws/resource_aws_iam_server_certificate_test.go
+func testAccSslNegotiationPolicyConfig(certName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_server_certificate" "test_cert" {
+  name = "%s"
+  certificate_body = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDCDCCAfACAQEwDQYJKoZIhvcNAQELBQAwgY4xCzAJBgNVBAYTAlVTMREwDwYD
+VQQIDAhOZXcgWW9yazERMA8GA1UEBwwITmV3IFlvcmsxFjAUBgNVBAoMDUJhcmVm
+b290IExhYnMxGDAWBgNVBAMMD0phc29uIEJlcmxpbnNreTEnMCUGCSqGSIb3DQEJ
+ARYYamFzb25AYmFyZWZvb3Rjb2RlcnMuY29tMB4XDTE1MDYyMTA1MzcwNVoXDTE2
+MDYyMDA1MzcwNVowgYgxCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhOZXcgWW9yazEL
+MAkGA1UEBwwCTlkxFjAUBgNVBAoMDUJhcmVmb290IExhYnMxGDAWBgNVBAMMD0ph
+c29uIEJlcmxpbnNreTEnMCUGCSqGSIb3DQEJARYYamFzb25AYmFyZWZvb3Rjb2Rl
+cnMuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD2AVGKRIx+EFM0kkg7
+6GoJv9uy0biEDHB4phQBqnDIf8J8/gq9eVvQrR5jJC9Uz4zp5wG/oLZlGuF92/jD
+bI/yS+DOAjrh30vN79Au74jGN2Cw8fIak40iDUwjZaczK2Gkna54XIO9pqMcbQ6Q
+mLUkQXsqlJ7Q4X2kL3b9iMsXcQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCDGNvU
+eioQMVPNlmmxW3+Rwo0Kl+/HtUOmqUDKUDvJnelxulBr7O8w75N/Z7h7+aBJCUkt
+tz+DwATZswXtsal6TuzHHpAhpFql82jQZVE8OYkrX84XKRQpm8ZnbyZObMdXTJWk
+ArC/rGVIWsvhlbgGM8zu7a3zbeuAESZ8Bn4ZbJxnoaRK8p36/alvzAwkgzSf3oUX
+HtU4LrdunevBs6/CbKCWrxYcvNCy8EcmHitqCfQL5nxCCXpgf/Mw1vmIPTwbPSJq
+oUkh5yjGRKzhh7QbG1TlFX6zUp4vb+UJn5+g4edHrqivRSjIqYrC45ygVMOABn21
+hpMXOlZL+YXfR4Kp
+-----END CERTIFICATE-----
+EOF
+  certificate_chain = <<EOF
+-----BEGIN CERTIFICATE-----
+MIID8TCCAtmgAwIBAgIJAKX2xeCkfFcbMA0GCSqGSIb3DQEBCwUAMIGOMQswCQYD
+VQQGEwJVUzERMA8GA1UECAwITmV3IFlvcmsxETAPBgNVBAcMCE5ldyBZb3JrMRYw
+FAYDVQQKDA1CYXJlZm9vdCBMYWJzMRgwFgYDVQQDDA9KYXNvbiBCZXJsaW5za3kx
+JzAlBgkqhkiG9w0BCQEWGGphc29uQGJhcmVmb290Y29kZXJzLmNvbTAeFw0xNTA2
+MjEwNTM2MDZaFw0yNTA2MTgwNTM2MDZaMIGOMQswCQYDVQQGEwJVUzERMA8GA1UE
+CAwITmV3IFlvcmsxETAPBgNVBAcMCE5ldyBZb3JrMRYwFAYDVQQKDA1CYXJlZm9v
+dCBMYWJzMRgwFgYDVQQDDA9KYXNvbiBCZXJsaW5za3kxJzAlBgkqhkiG9w0BCQEW
+GGphc29uQGJhcmVmb290Y29kZXJzLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAMteFbwfLz7NyQn3eDxxw22l1ZPBrzfPON0HOAq8nHat4kT4A2cI
+45kCtxKMzCVoG84tXoX/rbjGkez7lz9lEfvEuSh+I+UqinFA/sefhcE63foVMZu1
+2t6O3+utdxBvOYJwAQaiGW44x0h6fTyqDv6Gc5Ml0uoIVeMWPhT1MREoOcPDz1gb
+Ep3VT2aqFULLJedP37qbzS4D04rn1tS7pcm3wYivRyjVNEvs91NsWEvvE1WtS2Cl
+2RBt+ihXwq4UNB9UPYG75+FuRcQQvfqameyweyKT9qBmJLELMtYa/KTCYvSch4JY
+YVPAPOlhFlO4BcTto/gpBes2WEAWZtE/jnECAwEAAaNQME4wHQYDVR0OBBYEFOna
+aiYnm5583EY7FT/mXwTBuLZgMB8GA1UdIwQYMBaAFOnaaiYnm5583EY7FT/mXwTB
+uLZgMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBABp/dKQ489CCzzB1
+IX78p6RFAdda4e3lL6uVjeS3itzFIIiKvdf1/txhmsEeCEYz0El6aMnXLkpk7jAr
+kCwlAOOz2R2hlA8k8opKTYX4IQQau8DATslUFAFOvRGOim/TD/Yuch+a/VF2VQKz
+L2lUVi5Hjp9KvWe2HQYPjnJaZs/OKAmZQ4uP547dqFrTz6sWfisF1rJ60JH70cyM
+qjZQp/xYHTZIB8TCPvLgtVIGFmd/VAHVBFW2p9IBwtSxBIsEPwYQOV3XbwhhmGIv
+DWx5TpnEzH7ZM33RNbAKcdwOBxdRY+SI/ua5hYCm4QngAqY69lEuk4zXZpdDLPq1
+qxxQx0E=
+-----END CERTIFICATE-----
+EOF
+	private_key =  <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQD2AVGKRIx+EFM0kkg76GoJv9uy0biEDHB4phQBqnDIf8J8/gq9
+eVvQrR5jJC9Uz4zp5wG/oLZlGuF92/jDbI/yS+DOAjrh30vN79Au74jGN2Cw8fIa
+k40iDUwjZaczK2Gkna54XIO9pqMcbQ6QmLUkQXsqlJ7Q4X2kL3b9iMsXcQIDAQAB
+AoGALmVBQ5p6BKx/hMKx7NqAZSZSAP+clQrji12HGGlUq/usanZfAC0LK+f6eygv
+5QbfxJ1UrxdYTukq7dm2qOSooOMUuukWInqC6ztjdLwH70CKnl0bkNB3/NkW2VNc
+32YiUuZCM9zaeBuEUclKNs+dhD2EeGdJF8KGntWGOTU/M4ECQQD9gdYb38PvaMdu
+opM3sKJF5n9pMoLDleBpCGqq3nD3DFn0V6PHQAwn30EhRN+7BbUEpde5PmfoIdAR
+uDlj/XPlAkEA+GyY1e4uU9rz+1K4ubxmtXTp9ZIR2LsqFy5L/MS5hqX2zq5GGq8g
+jZYDxnxPEUrxaWQH4nh0qdu3skUBi4a0nQJBAKJaqLkpUd7eB/t++zHLWeHSgP7q
+bny8XABod4f+9fICYwntpuJQzngqrxeTeIXaXdggLkxg/0LXhN4UUg0LoVECQQDE
+Pi1h2dyY+37/CzLH7q+IKopjJneYqQmv9C+sxs70MgjM7liM3ckub9IdqrdfJr+c
+DJw56APo5puvZNm6mbf1AkBVMDyfdOOyoHpJjrhmZWo6QqynujfwErrBYQ0sZQ3l
+O57Z0RUNQ8DRyymhLd2t5nAHTfpcFA1sBeKE6CziLbZB
+-----END RSA PRIVATE KEY-----
+EOF
+}
+resource "aws_elb" "lb" {
+	name = "test-lb"
+    availability_zones = ["us-east-1a"]
+    listener {
+    	instance_port = 8000
+        instance_protocol = "https"
+        lb_port = 443
+        lb_protocol = "https"
+        ssl_certificate_id = "${aws_iam_server_certificate.test_cert.arn}"
+	}
+}
+resource "aws_lb_ssl_negotiation_policy" "foo" {
+	name = "foo-policy"
+	load_balancer = "${aws_elb.lb.id}"
+	lb_port = 443
+	attribute {
+    	name = "Protocol-TLSv1"
+        value = "false"
+    }
+    attribute {
+        name = "Protocol-TLSv1.1"
+        value = "false" 
+    }       
+    attribute {
+        name = "Protocol-TLSv1.2"
+        value = "true"
+    }
+    attribute {
+        name = "Server-Defined-Cipher-Order"
+        value = "true"
+    }       
+    attribute {
+        name = "ECDHE-RSA-AES128-GCM-SHA256"
+        value = "true"
+    }
+    attribute {
+        name = "AES128-GCM-SHA256"
+        value = "true"
+    }
+    attribute {
+        name = "EDH-RSA-DES-CBC3-SHA"
+        value = "false"
+    }
+}
+`, certName)
+}

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -924,3 +924,41 @@ func expandApiGatewayStageKeyOperations(d *schema.ResourceData) []*apigateway.Pa
 
 	return operations
 }
+
+// Takes the result of flatmap.Expand for an array of policy attributes and
+// returns ELB API compatible objects
+func expandPolicyAttributes(configured []interface{}) []*elb.PolicyAttribute {
+	attributes := make([]*elb.PolicyAttribute, 0, len(configured))
+
+	// Loop over our configured attributes and create
+	// an array of aws-sdk-go compatible objects
+	for _, lRaw := range configured {
+		data := lRaw.(map[string]interface{})
+
+		a := &elb.PolicyAttribute{
+			AttributeName:  aws.String(data["name"].(string)),
+			AttributeValue: aws.String(data["value"].(string)),
+		}
+
+		attributes = append(attributes, a)
+
+	}
+
+	return attributes
+}
+
+// Flattens an array of PolicyAttributes into a []interface{}
+func flattenPolicyAttributes(list []*elb.PolicyAttributeDescription) []interface{} {
+	attributes := []interface{}{}
+	for _, attrdef := range list {
+		attribute := map[string]string{
+			"name":  *attrdef.AttributeName,
+			"value": *attrdef.AttributeValue,
+		}
+
+		attributes = append(attributes, attribute)
+
+	}
+
+	return attributes
+}

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -927,7 +927,7 @@ func expandApiGatewayStageKeyOperations(d *schema.ResourceData) []*apigateway.Pa
 
 // Takes the result of flatmap.Expand for an array of policy attributes and
 // returns ELB API compatible objects
-func expandPolicyAttributes(configured []interface{}) []*elb.PolicyAttribute {
+func expandPolicyAttributes(configured []interface{}) ([]*elb.PolicyAttribute, error) {
 	attributes := make([]*elb.PolicyAttribute, 0, len(configured))
 
 	// Loop over our configured attributes and create
@@ -944,7 +944,7 @@ func expandPolicyAttributes(configured []interface{}) []*elb.PolicyAttribute {
 
 	}
 
-	return attributes
+	return attributes, nil
 }
 
 // Flattens an array of PolicyAttributes into a []interface{}

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -873,7 +873,7 @@ func TestExpandPolicyAttributes(t *testing.T) {
 	}
 
 	if len(attributes) != 3 {
-		t.Fatalf("expected number of attributes to be 3, but got %s", len(attributes))
+		t.Fatalf("expected number of attributes to be 3, but got %d", len(attributes))
 	}
 
 	expected := &elb.PolicyAttribute{
@@ -923,7 +923,7 @@ func TestExpandPolicyAttributes_empty(t *testing.T) {
 	}
 
 	if len(attributes) != 0 {
-		t.Fatalf("expected number of attributes to be 0, but got %s", len(attributes))
+		t.Fatalf("expected number of attributes to be 0, but got %d", len(attributes))
 	}
 }
 

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -851,3 +851,107 @@ func TestFlattenSecurityGroups(t *testing.T) {
 		}
 	}
 }
+
+func TestExpandPolicyAttributes(t *testing.T) {
+	expanded := []interface{}{
+		map[string]interface{}{
+			"name":  "Protocol-TLSv1",
+			"value": "false",
+		},
+		map[string]interface{}{
+			"name":  "Protocol-TLSv1.1",
+			"value": "false",
+		},
+		map[string]interface{}{
+			"name":  "Protocol-TLSv1.2",
+			"value": "true",
+		},
+	}
+	attributes, err := expandPolicyAttributes(expanded)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if len(attributes) != 3 {
+		t.Fatalf("expected number of attributes to be 3, but got %s", len(attributes))
+	}
+
+	expected := &elb.PolicyAttribute{
+		AttributeName:  aws.String("Protocol-TLSv1.2"),
+		AttributeValue: aws.String("true"),
+	}
+
+	if !reflect.DeepEqual(attributes[2], expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			attributes[2],
+			expected)
+	}
+}
+
+func TestExpandPolicyAttributes_invalid(t *testing.T) {
+	expanded := []interface{}{
+		map[string]interface{}{
+			"name":  "Protocol-TLSv1.2",
+			"value": "true",
+		},
+	}
+	attributes, err := expandPolicyAttributes(expanded)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	expected := &elb.PolicyAttribute{
+		AttributeName:  aws.String("Protocol-TLSv1.2"),
+		AttributeValue: aws.String("false"),
+	}
+
+	if reflect.DeepEqual(attributes[0], expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			attributes[0],
+			expected)
+	}
+}
+
+func TestExpandPolicyAttributes_empty(t *testing.T) {
+	var expanded []interface{}
+
+	attributes, err := expandPolicyAttributes(expanded)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if len(attributes) != 0 {
+		t.Fatalf("expected number of attributes to be 0, but got %s", len(attributes))
+	}
+}
+
+func TestFlattenPolicyAttributes(t *testing.T) {
+	cases := []struct {
+		Input  []*elb.PolicyAttributeDescription
+		Output []interface{}
+	}{
+		{
+			Input: []*elb.PolicyAttributeDescription{
+				&elb.PolicyAttributeDescription{
+					AttributeName:  aws.String("Protocol-TLSv1.2"),
+					AttributeValue: aws.String("true"),
+				},
+			},
+			Output: []interface{}{
+				map[string]string{
+					"name":  "Protocol-TLSv1.2",
+					"value": "true",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenPolicyAttributes(tc.Input)
+		if !reflect.DeepEqual(output, tc.Output) {
+			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
+		}
+	}
+}

--- a/website/source/docs/providers/aws/r/lb_ssl_negotiation_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/lb_ssl_negotiation_policy.html.markdown
@@ -70,11 +70,11 @@ The following arguments are supported:
 * `lb_port` - (Required) The load balancer port to which the policy
   should be applied. This must be an active listener on the load
 balancer.
-* `attribute` - (At least one Required) An SSL Negotiation policy attribute. Each has two properties:
+* `attribute` - (Optional) An SSL Negotiation policy attribute. Each has two properties:
 	* `name` - The name of the attribute
 	* `value` - The value of the attribute
 
-To set your attributes, please see the [AWS Elastic Load Balancer Developer Guide](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-security-policy-table.html) for a listing of the supported SSL protocols, SSL options, and SSL ciphers.
+To set your attributes, please see the [AWS Elastic Load Balancing Developer Guide](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-security-policy-table.html) for a listing of the supported SSL protocols, SSL options, and SSL ciphers.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/lb_ssl_negotiation_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/lb_ssl_negotiation_policy.html.markdown
@@ -1,0 +1,87 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lb_ssl_negotiation_policy"
+sidebar_current: "docs-aws-resource-lb-ssl-negotiation-policy"
+description: |-
+  Provides a load balancer SSL negotiation policy, which allows an ELB to control which ciphers and protocols are supported during SSL negotiations between a client and a load balancer.
+---
+
+# aws\_lb\_ssl\_negotiation\_policy
+
+Provides a load balancer SSL negotiation policy, which allows an ELB to control the ciphers and protocols that are supported during SSL negotiations between a client and a load balancer.
+
+## Example Usage
+
+```
+resource "aws_elb" "lb" {
+	name = "test-lb"
+    availability_zones = ["us-east-1a"]
+    listener {
+        instance_port = 8000
+        instance_protocol = "https"
+        lb_port = 443
+        lb_protocol = "https"
+        ssl_certificate_id = "arn:aws:iam::123456789012:server-certificate/certName"
+    }
+}
+
+resource "aws_lb_ssl_negotiation_policy" "foo" {
+	name = "foo-policy"
+	load_balancer = "${aws_elb.lb.id}"
+	lb_port = 443
+	attribute {
+    	name = "Protocol-TLSv1"
+        value = "false"
+    }
+    attribute {
+        name = "Protocol-TLSv1.1"
+        value = "false" 
+    }       
+    attribute {
+        name = "Protocol-TLSv1.2"
+        value = "true"
+    }
+    attribute {
+        name = "Server-Defined-Cipher-Order"
+        value = "true"
+    }       
+    attribute {
+        name = "ECDHE-RSA-AES128-GCM-SHA256"
+        value = "true"
+    }
+    attribute {
+        name = "AES128-GCM-SHA256"
+        value = "true"
+    }
+    attribute {
+        name = "EDH-RSA-DES-CBC3-SHA"
+        value = "false"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the SSL negotiation policy.
+* `load_balancer` - (Required) The load balancer to which the policy
+  should be attached.
+* `lb_port` - (Required) The load balancer port to which the policy
+  should be applied. This must be an active listener on the load
+balancer.
+* `attribute` - (At least one Required) An SSL Negotiation policy attribute. Each has two properties:
+	* `name` - The name of the attribute
+	* `value` - The value of the attribute
+
+To set your attributes, please see the [AWS Elastic Load Balancer Developer Guide](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-security-policy-table.html) for a listing of the supported SSL protocols, SSL options, and SSL ciphers.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the policy.
+* `name` - The name of the stickiness policy.
+* `load_balancer` - The load balancer to which the policy is attached.
+* `lb_port` - The load balancer port to which the policy is applied.
+* `attribute` - The SSL Negotiation policy attributes.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -200,6 +200,10 @@
                             <a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-lb-ssl-negotiation-policy") %>>
+                            <a href="/docs/providers/aws/r/lb_ssl_negotiation_policy.html">aws_lb_ssl_negotiation_policy</a>
+                        </li>
+                        
                         <li<%= sidebar_current("docs-aws-resource-placement-group") %>>
                             <a href="/docs/providers/aws/r/placement_group.html">aws_placement_group</a>
                         </li>


### PR DESCRIPTION
This was added based on a need to be able to set a custom SSL policy on an ELB, due to weaknesses found in certain SSL/TLS protocols/ciphers, and the need to meet certain compliance requirements.

This would close issue #2171.

## Example Usage

```
resource "aws_elb" "lb" {
	name = "test-lb"
    availability_zones = ["us-east-1a"]
    listener {
        instance_port = 8000
        instance_protocol = "https"
        lb_port = 443
        lb_protocol = "https"
        ssl_certificate_id = "arn:aws:iam::123456789012:server-certificate/certName"
    }
}

resource "aws_lb_ssl_negotiation_policy" "foo" {
	name = "foo-policy"
	load_balancer = "${aws_elb.lb.id}"
	lb_port = 443
	attribute {
    	name = "Protocol-TLSv1"
        value = "false"
    }
    attribute {
        name = "Protocol-TLSv1.1"
        value = "false" 
    }       
    attribute {
        name = "Protocol-TLSv1.2"
        value = "true"
    }
    attribute {
        name = "Server-Defined-Cipher-Order"
        value = "true"
    }       
    attribute {
        name = "ECDHE-RSA-AES128-GCM-SHA256"
        value = "true"
    }
    attribute {
        name = "AES128-GCM-SHA256"
        value = "true"
    }
    attribute {
        name = "EDH-RSA-DES-CBC3-SHA"
        value = "false"
    }
}
```