### PR TITLE
CHANGELOG: generate links, tweak script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,89 +10,89 @@ BUG FIXES:
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
-  * provider/aws: `aws_s3_bucket_object` field `etag` is now trimming off quotes (returns raw MD5 hash) [GH-5305]
+  * provider/aws: `aws_s3_bucket_object` field `etag` is now trimming off quotes (returns raw MD5 hash) ([#5305](https://github.com/hashicorp/terraform/issues/5305))
   * provider/consul: `consul_keys` `key` blocks now respect `delete` flag for removing individual blocks. Previously keys would be deleted only when the entire resource was removed.
-  * provider/google: `next_hop_network` on `google_compute_route` is now read-only, to mirror the behavior in the official docs [GH-5564]
-  * state/remote/http: PUT requests for this backend will now have `Content-Type: application/json` instead of `application/octet-stream` [GH-5499]
+  * provider/google: `next_hop_network` on `google_compute_route` is now read-only, to mirror the behavior in the official docs ([#5564](https://github.com/hashicorp/terraform/issues/5564))
+  * state/remote/http: PUT requests for this backend will now have `Content-Type: application/json` instead of `application/octet-stream` ([#5499](https://github.com/hashicorp/terraform/issues/5499))
 
 FEATURES:
 
-  * **New command:** `terraform untaint` [GH-5527]
-  * **New resource:** `aws_api_gateway_api_key` [GH-4295]
-  * **New resource:** `aws_api_gateway_deployment` [GH-4295]
-  * **New resource:** `aws_api_gateway_integration_response` [GH-4295]
-  * **New resource:** `aws_api_gateway_integration` [GH-4295]
-  * **New resource:** `aws_api_gateway_method_response` [GH-4295]
-  * **New resource:** `aws_api_gateway_method` [GH-4295]
-  * **New resource:** `aws_api_gateway_model` [GH-4295]
-  * **New resource:** `aws_api_gateway_resource` [GH-4295]
-  * **New resource:** `aws_api_gateway_rest_api` [GH-4295]
-  * **New resource:** `aws_elastic_beanstalk_application` [GH-3157]
-  * **New resource:** `aws_elastic_beanstalk_configuration_template` [GH-3157]
-  * **New resource:** `aws_elastic_beanstalk_environment` [GH-3157]
-  * **New resource:** `aws_iam_account_password_policy` [GH-5029]
-  * **New resource:** `aws_kms_alias` [GH-3928]
-  * **New resource:** `aws_kms_key` [GH-3928]
-  * **New resource:** `google_compute_instance_group` [GH-4087]
+  * **New command:** `terraform untaint` ([#5527](https://github.com/hashicorp/terraform/issues/5527))
+  * **New resource:** `aws_api_gateway_api_key` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_deployment` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_integration_response` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_integration` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_method_response` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_method` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_model` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_resource` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_api_gateway_rest_api` ([#4295](https://github.com/hashicorp/terraform/issues/4295))
+  * **New resource:** `aws_elastic_beanstalk_application` ([#3157](https://github.com/hashicorp/terraform/issues/3157))
+  * **New resource:** `aws_elastic_beanstalk_configuration_template` ([#3157](https://github.com/hashicorp/terraform/issues/3157))
+  * **New resource:** `aws_elastic_beanstalk_environment` ([#3157](https://github.com/hashicorp/terraform/issues/3157))
+  * **New resource:** `aws_iam_account_password_policy` ([#5029](https://github.com/hashicorp/terraform/issues/5029))
+  * **New resource:** `aws_kms_alias` ([#3928](https://github.com/hashicorp/terraform/issues/3928))
+  * **New resource:** `aws_kms_key` ([#3928](https://github.com/hashicorp/terraform/issues/3928))
+  * **New resource:** `google_compute_instance_group` ([#4087](https://github.com/hashicorp/terraform/issues/4087))
 
 IMPROVEMENTS:
 
-  * provider/aws: Add `repository_link` as a computed field for `aws_ecr_repository` [GH-5524]
-  * provider/aws: Add ability to update Route53 zone comments [GH-5318]
-  * provider/aws: Add support for Metrics Collection to `aws_autoscaling_group` [GH-4688]
-  * provider/aws: Add support for `description` to `aws_network_interface` [GH-5523]
-  * provider/aws: Add support for `storage_encrypted` to `aws_rds_cluster` [GH-5520]
-  * provider/aws: Add support for routing rules on `aws_s3_bucket` resources [GH-5327]
-  * provider/aws: Enable updates & versioning for `aws_s3_bucket_object` [GH-5305]
-  * provider/aws: Guard against Nil Reference in Redshift Endpoints [GH-5593]
-  * provider/aws: Lambda S3 object version defaults to `$LATEST` if unspecified [GH-5370]
-  * provider/aws: Retry DB Creation on IAM propigation error [GH-5515]
-  * provider/aws: Support KMS encryption of S3 objects [GH-5453]
-  * provider/aws: `aws_autoscaling_lifecycle_hook` now have `notification_target_arn` and `role_arn` as optional [GH-5616]
-  * provider/aws: `aws_ecs_service` validates number of `load_balancer`s before creation/updates [GH-5605]
-  * provider/aws: `aws_instance` now allows changes to security groups without force new resource [GH-5193]
-  * provider/aws: send Terraform version in User-Agent [GH-5621]
-  * provider/cloudflare: Change `cloudflare_record` type to ForceNew [GH-5353]
-  * provider/consul: `consul_keys` now detects drift and supports deletion of individual `key` blocks [GH-5210]
-  * provider/digitalocean: Guard against Nil reference in `digitalocean_droplet` [GH-5588]
-  * provider/docker: Add support for `unless-stopped` to docker container `restart_policy` [GH-5337]
-  * provider/google: Mark `next_hop_network` as read-only on `google_compute_route` [GH-5564]
-  * provider/google: Validate VPN tunnel peer_ip at plan time [GH-5501]
-  * provider/openstack: Add Support for Domain ID and Domain Name environment variables [GH-5355]
-  * provider/openstack: Add support for instances to have multiple ephemeral disks. [GH-5131]
-  * provider/openstack: Re-Add server.AccessIPv4 and server.AccessIPv6 [GH-5366]
-  * provider/vsphere: Add support for disk init types [GH-4284]
-  * provisioner/remote-exec: Clear out scripts after uploading [GH-5577]
-  * state/remote/http: Change content type of PUT requests to the more appropriate `application/json` [GH-5499]
+  * provider/aws: Add `repository_link` as a computed field for `aws_ecr_repository` ([#5524](https://github.com/hashicorp/terraform/issues/5524))
+  * provider/aws: Add ability to update Route53 zone comments ([#5318](https://github.com/hashicorp/terraform/issues/5318))
+  * provider/aws: Add support for Metrics Collection to `aws_autoscaling_group` ([#4688](https://github.com/hashicorp/terraform/issues/4688))
+  * provider/aws: Add support for `description` to `aws_network_interface` ([#5523](https://github.com/hashicorp/terraform/issues/5523))
+  * provider/aws: Add support for `storage_encrypted` to `aws_rds_cluster` ([#5520](https://github.com/hashicorp/terraform/issues/5520))
+  * provider/aws: Add support for routing rules on `aws_s3_bucket` resources ([#5327](https://github.com/hashicorp/terraform/issues/5327))
+  * provider/aws: Enable updates & versioning for `aws_s3_bucket_object` ([#5305](https://github.com/hashicorp/terraform/issues/5305))
+  * provider/aws: Guard against Nil Reference in Redshift Endpoints ([#5593](https://github.com/hashicorp/terraform/issues/5593))
+  * provider/aws: Lambda S3 object version defaults to `$LATEST` if unspecified ([#5370](https://github.com/hashicorp/terraform/issues/5370))
+  * provider/aws: Retry DB Creation on IAM propigation error ([#5515](https://github.com/hashicorp/terraform/issues/5515))
+  * provider/aws: Support KMS encryption of S3 objects ([#5453](https://github.com/hashicorp/terraform/issues/5453))
+  * provider/aws: `aws_autoscaling_lifecycle_hook` now have `notification_target_arn` and `role_arn` as optional ([#5616](https://github.com/hashicorp/terraform/issues/5616))
+  * provider/aws: `aws_ecs_service` validates number of `load_balancer`s before creation/updates ([#5605](https://github.com/hashicorp/terraform/issues/5605))
+  * provider/aws: `aws_instance` now allows changes to security groups without force new resource ([#5193](https://github.com/hashicorp/terraform/issues/5193))
+  * provider/aws: send Terraform version in User-Agent ([#5621](https://github.com/hashicorp/terraform/issues/5621))
+  * provider/cloudflare: Change `cloudflare_record` type to ForceNew ([#5353](https://github.com/hashicorp/terraform/issues/5353))
+  * provider/consul: `consul_keys` now detects drift and supports deletion of individual `key` blocks ([#5210](https://github.com/hashicorp/terraform/issues/5210))
+  * provider/digitalocean: Guard against Nil reference in `digitalocean_droplet` ([#5588](https://github.com/hashicorp/terraform/issues/5588))
+  * provider/docker: Add support for `unless-stopped` to docker container `restart_policy` ([#5337](https://github.com/hashicorp/terraform/issues/5337))
+  * provider/google: Mark `next_hop_network` as read-only on `google_compute_route` ([#5564](https://github.com/hashicorp/terraform/issues/5564))
+  * provider/google: Validate VPN tunnel peer_ip at plan time ([#5501](https://github.com/hashicorp/terraform/issues/5501))
+  * provider/openstack: Add Support for Domain ID and Domain Name environment variables ([#5355](https://github.com/hashicorp/terraform/issues/5355))
+  * provider/openstack: Add support for instances to have multiple ephemeral disks. ([#5131](https://github.com/hashicorp/terraform/issues/5131))
+  * provider/openstack: Re-Add server.AccessIPv4 and server.AccessIPv6 ([#5366](https://github.com/hashicorp/terraform/issues/5366))
+  * provider/vsphere: Add support for disk init types ([#4284](https://github.com/hashicorp/terraform/issues/4284))
+  * provisioner/remote-exec: Clear out scripts after uploading ([#5577](https://github.com/hashicorp/terraform/issues/5577))
+  * state/remote/http: Change content type of PUT requests to the more appropriate `application/json` ([#5499](https://github.com/hashicorp/terraform/issues/5499))
 
 BUG FIXES:
 
-  * core: Disallow negative indices in the element() interpolation function, preventing crash [GH-5263]
-  * core: Fix issue that caused tainted resource destroys to be improperly filtered out when using -target and a plan file [GH-5516]
-  * core: Fix several issues with retry logic causing spurious "timeout while waiting for state to become ..." errors and unnecessary retry loops [GH-5460], [GH-5538], [GH-5543], [GH-5553]
-  * core: Includes upstream HCL fix to properly detect unbalanced braces and throw an error [GH-5400]
-  * provider/aws: Allow recovering from failed CloudWatch Event Target creation [GH-5395]
-  * provider/aws: Fix EC2 Classic SG Rule issue when referencing rules by name [GH-5533]
-  * provider/aws: Fix `aws_cloudformation_stack` update for `parameters` & `capabilities` if unmodified [GH-5603]
-  * provider/aws: Fix a bug where AWS Kinesis Stream includes closed shards in the shard_count [GH-5401]
-  * provider/aws: Fix a bug where ElasticSearch Domain tags were not being set correctly [GH-5361]
-  * provider/aws: Fix a bug where `aws_route` would show continual changes in the plan when not computed [GH-5321]
-  * provider/aws: Fix a bug where `publicly_assessible` wasn't being set to state in `aws_db_instance` [GH-5535]
-  * provider/aws: Fix a bug where listener protocol on `aws_elb` resources was case insensitive [GH-5376]
-  * provider/aws: Fix a bug which caused panics creating rules on security groups in EC2 Classic [GH-5329]
-  * provider/aws: Fix crash when `aws_lambda_function` VpcId is nil [GH-5182]
-  * provider/aws: Fix error with parsing JSON in `aws_s3_bucket` policy attribute [GH-5474]  
-  * provider/aws: `aws_lambda_function` can be properly updated, either via `s3_object_version` or via `filename` & `source_code_hash` as described in docs [GH-5239]
-  * provider/google: Fix managed instance group preemptible instance creation [GH-4834]
-  * provider/openstack: Account for a 403 reply when os-tenant-networks is disabled [GH-5432]
-  * provider/openstack: Fix crashing during certain network updates in instances [GH-5365]
-  * provider/openstack: Fix create/delete statuses in load balancing resources [GH-5557]
-  * provider/openstack: Fix race condition between instance deletion and volume detachment [GH-5359]
-  * provider/template: Warn when `template` attribute specified as path [GH-5563]
+  * core: Disallow negative indices in the element() interpolation function, preventing crash ([#5263](https://github.com/hashicorp/terraform/issues/5263))
+  * core: Fix issue that caused tainted resource destroys to be improperly filtered out when using -target and a plan file ([#5516](https://github.com/hashicorp/terraform/issues/5516))
+  * core: Fix several issues with retry logic causing spurious "timeout while waiting for state to become ..." errors and unnecessary retry loops ([#5460](https://github.com/hashicorp/terraform/issues/5460)), ([#5538](https://github.com/hashicorp/terraform/issues/5538)), ([#5543](https://github.com/hashicorp/terraform/issues/5543)), ([#5553](https://github.com/hashicorp/terraform/issues/5553))
+  * core: Includes upstream HCL fix to properly detect unbalanced braces and throw an error ([#5400](https://github.com/hashicorp/terraform/issues/5400))
+  * provider/aws: Allow recovering from failed CloudWatch Event Target creation ([#5395](https://github.com/hashicorp/terraform/issues/5395))
+  * provider/aws: Fix EC2 Classic SG Rule issue when referencing rules by name ([#5533](https://github.com/hashicorp/terraform/issues/5533))
+  * provider/aws: Fix `aws_cloudformation_stack` update for `parameters` & `capabilities` if unmodified ([#5603](https://github.com/hashicorp/terraform/issues/5603))
+  * provider/aws: Fix a bug where AWS Kinesis Stream includes closed shards in the shard_count ([#5401](https://github.com/hashicorp/terraform/issues/5401))
+  * provider/aws: Fix a bug where ElasticSearch Domain tags were not being set correctly ([#5361](https://github.com/hashicorp/terraform/issues/5361))
+  * provider/aws: Fix a bug where `aws_route` would show continual changes in the plan when not computed ([#5321](https://github.com/hashicorp/terraform/issues/5321))
+  * provider/aws: Fix a bug where `publicly_assessible` wasn't being set to state in `aws_db_instance` ([#5535](https://github.com/hashicorp/terraform/issues/5535))
+  * provider/aws: Fix a bug where listener protocol on `aws_elb` resources was case insensitive ([#5376](https://github.com/hashicorp/terraform/issues/5376))
+  * provider/aws: Fix a bug which caused panics creating rules on security groups in EC2 Classic ([#5329](https://github.com/hashicorp/terraform/issues/5329))
+  * provider/aws: Fix crash when `aws_lambda_function` VpcId is nil ([#5182](https://github.com/hashicorp/terraform/issues/5182))
+  * provider/aws: Fix error with parsing JSON in `aws_s3_bucket` policy attribute ([#5474](https://github.com/hashicorp/terraform/issues/5474))  
+  * provider/aws: `aws_lambda_function` can be properly updated, either via `s3_object_version` or via `filename` & `source_code_hash` as described in docs ([#5239](https://github.com/hashicorp/terraform/issues/5239))
+  * provider/google: Fix managed instance group preemptible instance creation ([#4834](https://github.com/hashicorp/terraform/issues/4834))
+  * provider/openstack: Account for a 403 reply when os-tenant-networks is disabled ([#5432](https://github.com/hashicorp/terraform/issues/5432))
+  * provider/openstack: Fix crashing during certain network updates in instances ([#5365](https://github.com/hashicorp/terraform/issues/5365))
+  * provider/openstack: Fix create/delete statuses in load balancing resources ([#5557](https://github.com/hashicorp/terraform/issues/5557))
+  * provider/openstack: Fix race condition between instance deletion and volume detachment ([#5359](https://github.com/hashicorp/terraform/issues/5359))
+  * provider/template: Warn when `template` attribute specified as path ([#5563](https://github.com/hashicorp/terraform/issues/5563))
 
 INTERNAL IMPROVEMENTS:
 
-  * helper/schema: `MaxItems` attribute on schema lists and sets [GH-5218]
+  * helper/schema: `MaxItems` attribute on schema lists and sets ([#5218](https://github.com/hashicorp/terraform/issues/5218))
 
 ## 0.6.12 (February 24, 2016)
 
@@ -433,7 +433,7 @@ FEATURES:
   * **New provider: `tls`** - A utility provider for generating TLS keys/self-signed certificates for development and testing ([#2778](https://github.com/hashicorp/terraform/issues/2778))
   * **New provider: `dyn`** - Manage DNS records on Dyn
   * **New resource: `aws_cloudformation_stack`** ([#2636](https://github.com/hashicorp/terraform/issues/2636))
-  * **New resource: `aws_cloudtrail`** ([#3094](https://github.com/hashicorp/terraform/issues/3094)), [GH-4010]
+  * **New resource: `aws_cloudtrail`** ([#3094](https://github.com/hashicorp/terraform/issues/3094)), ([#4010](https://github.com/hashicorp/terraform/issues/4010))
   * **New resource: `aws_route`** ([#3548](https://github.com/hashicorp/terraform/issues/3548))
   * **New resource: `aws_codecommit_repository`** ([#3274](https://github.com/hashicorp/terraform/issues/3274))
   * **New resource: `aws_kinesis_firehose_delivery_stream`** ([#3833](https://github.com/hashicorp/terraform/issues/3833))
@@ -575,7 +575,7 @@ INTERNAL IMPROVEMENTS:
 FEATURES:
 
   * **New provider: `rundeck`** ([#2412](https://github.com/hashicorp/terraform/issues/2412))
-  * **New provider: `packet`** ([#2260](https://github.com/hashicorp/terraform/issues/2260)), [GH-3472]
+  * **New provider: `packet`** ([#2260](https://github.com/hashicorp/terraform/issues/2260)), ([#3472](https://github.com/hashicorp/terraform/issues/3472))
   * **New provider: `vsphere`**: Initial support for a VM resource ([#3419](https://github.com/hashicorp/terraform/issues/3419))
   * **New resource: `cloudstack_loadbalancer_rule`** ([#2934](https://github.com/hashicorp/terraform/issues/2934))
   * **New resource: `google_compute_project_metadata`** ([#3065](https://github.com/hashicorp/terraform/issues/3065))
@@ -601,7 +601,7 @@ IMPROVEMENTS:
   * core: In plan output summary, count resource replacement as Add/Remove instead of Change ([#3173](https://github.com/hashicorp/terraform/issues/3173))
   * core: Add interpolation functions for base64 encoding and decoding. ([#3325](https://github.com/hashicorp/terraform/issues/3325))
   * core: Expose parallelism as a CLI option instead of a hard-coding the default of 10 ([#3365](https://github.com/hashicorp/terraform/issues/3365))
-  * core: Add interpolation function `compact`, to remove empty elements from a list. ([#3239](https://github.com/hashicorp/terraform/issues/3239)), [GH-3479]
+  * core: Add interpolation function `compact`, to remove empty elements from a list. ([#3239](https://github.com/hashicorp/terraform/issues/3239)), ([#3479](https://github.com/hashicorp/terraform/issues/3479))
   * core: Allow filtering of log output by level, using e.g. ``TF_LOG=INFO`` ([#3380](https://github.com/hashicorp/terraform/issues/3380))
   * provider/aws: Add `instance_initiated_shutdown_behavior` to AWS Instance ([#2887](https://github.com/hashicorp/terraform/issues/2887))
   * provider/aws: Support IAM role names (previously just ARNs) in `aws_ecs_service.iam_role` ([#3061](https://github.com/hashicorp/terraform/issues/3061))
@@ -1082,7 +1082,7 @@ IMPROVEMENTS:
   * provider/aws: `aws_elb` increase default idle timeout to 60s ([#1646](https://github.com/hashicorp/terraform/issues/1646))
   * provider/aws: `aws_key_pair` name can be omitted and generated ([#1751](https://github.com/hashicorp/terraform/issues/1751))
   * provider/aws: `aws_network_acl` improved validation for network ACL ports
-      and protocols ([#1798](https://github.com/hashicorp/terraform/issues/1798)) [GH-1808]
+      and protocols ([#1798](https://github.com/hashicorp/terraform/issues/1798)) ([#1808](https://github.com/hashicorp/terraform/issues/1808))
   * provider/aws: `aws_route_table` can target network interfaces ([#968](https://github.com/hashicorp/terraform/issues/968))
   * provider/aws: `aws_route_table` can specify propagating VGWs ([#1516](https://github.com/hashicorp/terraform/issues/1516))
   * provider/aws: `aws_route53_record` supports weighted sets ([#1578](https://github.com/hashicorp/terraform/issues/1578))
@@ -1108,7 +1108,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-  * core: Fix graph cycle issues surrounding modules ([#1582](https://github.com/hashicorp/terraform/issues/1582)) [GH-1637]
+  * core: Fix graph cycle issues surrounding modules ([#1582](https://github.com/hashicorp/terraform/issues/1582)) ([#1637](https://github.com/hashicorp/terraform/issues/1637))
   * core: math on arbitrary variables works if first operand isn't a
       numeric primitive. ([#1381](https://github.com/hashicorp/terraform/issues/1381))
   * core: avoid unnecessary cycles by pruning tainted destroys from
@@ -1280,7 +1280,7 @@ BUG FIXES:
 
   * core: module outputs can be used as inputs to other modules ([#822](https://github.com/hashicorp/terraform/issues/822))
   * core: Self-referencing splat variables are no longer allowed in
-      provisioners. ([#795](https://github.com/hashicorp/terraform/issues/795))[GH-868]
+      provisioners. ([#795](https://github.com/hashicorp/terraform/issues/795))([#868](https://github.com/hashicorp/terraform/issues/868))
   * core: Validate that `depends_on` doesn't contain interpolations. ([#1015](https://github.com/hashicorp/terraform/issues/1015))
   * core: Module inputs can be non-strings. ([#819](https://github.com/hashicorp/terraform/issues/819))
   * core: Fix invalid plan that resulted in "diffs don't match" error when

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -10,7 +10,20 @@
 
 set -e
 
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+if [[ ! -f CHANGELOG.md ]]; then
+  echo "ERROR: CHANGELOG.md not found in pwd."
+  echo "Please run this from the root of the terraform source repository"
+  exit 1
+fi
 
-cd "$SCRIPT_DIR/.."
-sed -ri 's/\[GH-([0-9]+)\]/\(\[#\1\]\(https:\/\/github.com\/hashicorp\/terraform\/issues\/\1\)\)/' CHANGELOG.md
+if [[ `uname` == "Darwin" ]]; then
+  echo "Using BSD sed"
+  SED="sed -i.bak -E -e"
+else
+  echo "Using GNU sed"
+  SED="sed -i.bak -r -e"
+fi
+
+$SED 's/\[GH-([0-9]+)\]/\(\[#\1\]\(https:\/\/github.com\/hashicorp\/terraform\/issues\/\1\)\)/g' CHANGELOG.md
+
+rm CHANGELOG.md.bak


### PR DESCRIPTION
Changelog link generation script gets:

 * OS X compatibility
 * Support for multiple links on a line