### PR TITLE
provider/aws: Correctly handle missing lambda function

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -226,6 +226,10 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 
 	getFunctionOutput, err := conn.GetFunction(params)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
When a function doesn't get created properly / gets externally deleted, that change should be detected. Right now, an error is returned.

@radeksimko 