### PR TITLE
provider/aws: Provide iops when changing storage type to io1 on RDS

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -815,6 +815,10 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		d.SetPartial("storage_type")
 		req.StorageType = aws.String(d.Get("storage_type").(string))
 		requestUpdate = true
+
+		if *req.StorageType == "io1" {
+			req.Iops = aws.Int64(int64(d.Get("iops").(int)))
+		}
 	}
 	if d.HasChange("auto_minor_version_upgrade") {
 		d.SetPartial("auto_minor_version_upgrade")


### PR DESCRIPTION
`iops` is required when specifying a `storage_type` of `io1`. In most cases, `iops` will also have changed when `storage_type` changes, but not always. For example:

```
resource "aws_db_instance" "instance" {
  ...

  allocated_storage = "100"
  storage_type      = "gp2"
  iops              = "1000"
}
```
then
```
resource "aws_db_instance" "instance" {
  ...

  allocated_storage = "100"
  storage_type      = "io1"
  iops              = "1000"
}
```