### PR TITLE
provider/aws: Document volume_size requirement if using EBS in ElasticSearch Domain

### DIFF
--- a/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
@@ -60,7 +60,8 @@ The following arguments are supported:
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain
 * `volume_type` - (Optional) The type of EBS volumes attached to data nodes.
-* `volume_size` - (Optional) The size of EBS volumes attached to data nodes.
+* `volume_size` - The size of EBS volumes attached to data nodes.
+**Required** if `ebs_enabled` is set to `true`.
 * `iops` - (Optional) The baseline input/output (I/O) performance of EBS volumes
 	attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
 


### PR DESCRIPTION
Fixed #5665 by documenting that `volume_size` is required **if** you have set `ebs_enabled = true`. It's not required otherwise, and Terraform doesn't yet have `RequiredIf` support