### PR TITLE
provider/aws: fix crash when Aurora instance disappears

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -899,6 +899,10 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	return resourceAwsDbInstanceRead(d, meta)
 }
 
+// resourceAwsDbInstanceRetrieve fetches DBInstance information from the AWS
+// API. It returns an error if there is a communication problem or unexpected
+// error with AWS. When the DBInstance is not found, it returns no error and a
+// nil pointer.
 func resourceAwsDbInstanceRetrieve(
 	d *schema.ResourceData, meta interface{}) (*rds.DBInstance, error) {
 	conn := meta.(*AWSClient).rdsconn

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -123,8 +123,13 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 
 func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	db, err := resourceAwsDbInstanceRetrieve(d, meta)
+	// Errors from this helper are always reportable
 	if err != nil {
-		log.Printf("[WARN] Error on retrieving RDS Cluster Instance (%s): %s", d.Id(), err)
+		return fmt.Errorf("[WARN] Error on retrieving RDS Cluster Instance (%s): %s", d.Id(), err)
+	}
+	// A nil response means "not found"
+	if db == nil {
+		log.Printf("[WARN] RDS Cluster Instance (%s): not found, removing from state.", d.Id())
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
Usage of a helper function was assuming that an error would be returned
in a not found condition, when in fact a nil pointer was
returned.

Attached test crashes w/o fix, passes with it.

Fixes #5350
Refs #5418