### PR TITLE
provider/aws: `aws_redshift_cluster` now allows`publicly_accessible` to be modified

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -173,288 +173,288 @@
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awserr",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/defaults",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/request",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/session",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/endpoints",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/signer/v4",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/waiter",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/apigateway",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/codecommit",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ec2",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ecr",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ecs",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/efs",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/elasticache",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/elb",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/firehose",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/glacier",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/iam",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/kinesis",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/kms",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/lambda",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/opsworks",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/rds",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/redshift",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/route53",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/s3",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/sns",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/sqs",
-			"Comment": "v1.1.9",
-			"Rev": "2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2"
+			"Comment": "v1.1.12",
+			"Rev": "4da0bec8953a0a540f391930a946917b12a95671"
 		},
 		{
 			"ImportPath": "github.com/bgentry/speakeasy",

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -145,7 +145,6 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			"publicly_accessible": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
 				Default:  true,
 			},
 
@@ -410,6 +409,10 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		req.AllowVersionUpgrade = aws.Bool(d.Get("allow_version_upgrade").(bool))
 	}
 
+	if d.HasChange("publicly_accessible") {
+		req.PubliclyAccessible = aws.Bool(d.Get("publicly_accessible").(bool))
+	}
+
 	log.Printf("[INFO] Modifying Redshift Cluster: %s", d.Id())
 	log.Printf("[DEBUG] Redshift Cluster Modify options: %s", req)
 	_, err := conn.ModifyCluster(req)
@@ -418,7 +421,7 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"creating", "deleting", "rebooting", "resizing", "renaming"},
+		Pending:    []string{"creating", "deleting", "rebooting", "resizing", "renaming", "modifying"},
 		Target:     []string{"available"},
 		Refresh:    resourceAwsRedshiftClusterStateRefreshFunc(d, meta),
 		Timeout:    10 * time.Minute,

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -38,11 +38,12 @@ func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRedshiftCluster_notPubliclyAccessible(t *testing.T) {
+func TestAccAWSRedshiftCluster_publiclyAccessible(t *testing.T) {
 	var v redshift.Cluster
 
 	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	config := fmt.Sprintf(testAccAWSRedshiftClusterConfig_notPubliclyAccessible, ri)
+	preConfig := fmt.Sprintf(testAccAWSRedshiftClusterConfig_notPubliclyAccessible, ri)
+	postConfig := fmt.Sprintf(testAccAWSRedshiftClusterConfig_updatePubliclyAccessible, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,11 +51,20 @@ func TestAccAWSRedshiftCluster_notPubliclyAccessible(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: config,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "publicly_accessible", "false"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "publicly_accessible", "true"),
 				),
 			},
 		},
@@ -334,4 +344,66 @@ resource "aws_redshift_cluster" "default" {
   allow_version_upgrade = false
   cluster_subnet_group_name = "${aws_redshift_subnet_group.foo.name}"
   publicly_accessible = false
+}`
+
+var testAccAWSRedshiftClusterConfig_updatePubliclyAccessible = `
+provider "aws" {
+	region = "us-west-2"
+}
+
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_internet_gateway" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		foo = "bar"
+	}
+}
+
+resource "aws_subnet" "foo" {
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-1"
+	}
+}
+
+resource "aws_subnet" "bar" {
+	cidr_block = "10.1.2.0/24"
+	availability_zone = "us-west-2b"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-2"
+	}
+}
+
+resource "aws_subnet" "foobar" {
+	cidr_block = "10.1.3.0/24"
+	availability_zone = "us-west-2c"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-3"
+	}
+}
+
+resource "aws_redshift_subnet_group" "foo" {
+	name = "foo"
+	description = "foo description"
+	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}", "${aws_subnet.foobar.id}"]
+}
+
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  availability_zone = "us-west-2a"
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "Mustbe8characters"
+  node_type = "dc1.large"
+  automated_snapshot_retention_period = 7
+  allow_version_upgrade = false
+  cluster_subnet_group_name = "${aws_redshift_subnet_group.foo.name}"
+  publicly_accessible = true
 }`

--- a/vendor/github.com/aws/aws-sdk-go/aws/awserr/error.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awserr/error.go
@@ -42,9 +42,12 @@ type Error interface {
 	OrigErr() error
 }
 
-// BatchError is a batch of errors which also wraps lower level errors with code, message,
-// and original errors. Calling Error() will only return the error that is at the end
-// of the list.
+// BatchError is a batch of errors which also wraps lower level errors with
+// code, message, and original errors. Calling Error() will include all errors
+// that occured in the batch.
+//
+// Deprecated: Replaced with BatchedErrors. Only defined for backwards
+// compatibility.
 type BatchError interface {
 	// Satisfy the generic error interface.
 	error
@@ -59,17 +62,35 @@ type BatchError interface {
 	OrigErrs() []error
 }
 
+// BatchedErrors is a batch of errors which also wraps lower level errors with
+// code, message, and original errors. Calling Error() will include all errors
+// that occured in the batch.
+//
+// Replaces BatchError
+type BatchedErrors interface {
+	// Satisfy the base Error interface.
+	Error
+
+	// Returns the original error if one was set.  Nil is returned if not set.
+	OrigErrs() []error
+}
+
 // New returns an Error object described by the code, message, and origErr.
 //
 // If origErr satisfies the Error interface it will not be wrapped within a new
 // Error object and will instead be returned.
 func New(code, message string, origErr error) Error {
-	return newBaseError(code, message, origErr)
+	var errs []error
+	if origErr != nil {
+		errs = append(errs, origErr)
+	}
+	return newBaseError(code, message, errs)
 }
 
-// NewBatchError returns an baseError with an expectation of an array of errors
-func NewBatchError(code, message string, errs []error) BatchError {
-	return newBaseErrors(code, message, errs)
+// NewBatchError returns an BatchedErrors with a collection of errors as an
+// array of errors.
+func NewBatchError(code, message string, errs []error) BatchedErrors {
+	return newBaseError(code, message, errs)
 }
 
 // A RequestFailure is an interface to extract request failure information from

--- a/vendor/github.com/aws/aws-sdk-go/aws/awserr/types.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awserr/types.go
@@ -34,36 +34,17 @@ type baseError struct {
 	errs []error
 }
 
-// newBaseError returns an error object for the code, message, and err.
+// newBaseError returns an error object for the code, message, and errors.
 //
 // code is a short no whitespace phrase depicting the classification of
 // the error that is being created.
 //
-// message is the free flow string containing detailed information about the error.
+// message is the free flow string containing detailed information about the
+// error.
 //
-// origErr is the error object which will be nested under the new error to be returned.
-func newBaseError(code, message string, origErr error) *baseError {
-	b := &baseError{
-		code:    code,
-		message: message,
-	}
-
-	if origErr != nil {
-		b.errs = append(b.errs, origErr)
-	}
-
-	return b
-}
-
-// newBaseErrors returns an error object for the code, message, and errors.
-//
-// code is a short no whitespace phrase depicting the classification of
-// the error that is being created.
-//
-// message is the free flow string containing detailed information about the error.
-//
-// origErrs is the error objects which will be nested under the new errors to be returned.
-func newBaseErrors(code, message string, origErrs []error) *baseError {
+// origErrs is the error objects which will be nested under the new errors to
+// be returned.
+func newBaseError(code, message string, origErrs []error) *baseError {
 	b := &baseError{
 		code:    code,
 		message: message,
@@ -103,19 +84,26 @@ func (b baseError) Message() string {
 	return b.message
 }
 
-// OrigErr returns the original error if one was set. Nil is returned if no error
-// was set. This only returns the first element in the list. If the full list is
-// needed, use BatchError
+// OrigErr returns the original error if one was set. Nil is returned if no
+// error was set. This only returns the first element in the list. If the full
+// list is needed, use BatchedErrors.
 func (b baseError) OrigErr() error {
-	if size := len(b.errs); size > 0 {
+	switch len(b.errs) {
+	case 0:
+		return nil
+	case 1:
 		return b.errs[0]
+	default:
+		if err, ok := b.errs[0].(Error); ok {
+			return NewBatchError(err.Code(), err.Message(), b.errs[1:])
+		}
+		return NewBatchError("BatchedErrors",
+			"multiple errors occured", b.errs)
 	}
-
-	return nil
 }
 
-// OrigErrs returns the original errors if one was set. An empty slice is returned if
-// no error was set:w
+// OrigErrs returns the original errors if one was set. An empty slice is
+// returned if no error was set.
 func (b baseError) OrigErrs() []error {
 	return b.errs
 }
@@ -133,8 +121,8 @@ type requestError struct {
 	requestID  string
 }
 
-// newRequestError returns a wrapped error with additional information for request
-// status code, and service requestID.
+// newRequestError returns a wrapped error with additional information for
+// request status code, and service requestID.
 //
 // Should be used to wrap all request which involve service requests. Even if
 // the request failed without a service response, but had an HTTP status code
@@ -171,6 +159,15 @@ func (r requestError) StatusCode() int {
 // RequestID returns the wrapped requestID
 func (r requestError) RequestID() string {
 	return r.requestID
+}
+
+// OrigErrs returns the original errors if one was set. An empty slice is
+// returned if no error was set.
+func (r requestError) OrigErrs() []error {
+	if b, ok := r.awsError.(BatchedErrors); ok {
+		return b.OrigErrs()
+	}
+	return []error{r.OrigErr()}
 }
 
 // An error list that satisfies the golang interface

--- a/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go
@@ -91,6 +91,10 @@ func prettify(v reflect.Value, indent int, buf *bytes.Buffer) {
 
 		buf.WriteString("\n" + strings.Repeat(" ", indent) + "}")
 	default:
+		if !v.IsValid() {
+			fmt.Fprint(buf, "<invalid value>")
+			return
+		}
 		format := "%v"
 		switch v.Interface().(type) {
 		case string:

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.1.9"
+const SDKVersion = "1.1.12"

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal_error.go
@@ -2,7 +2,7 @@ package query
 
 import (
 	"encoding/xml"
-	"io"
+	"io/ioutil"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -15,6 +15,10 @@ type xmlErrorResponse struct {
 	RequestID string   `xml:"RequestId"`
 }
 
+type xmlServiceUnavailableResponse struct {
+	XMLName xml.Name `xml:"ServiceUnavailableException"`
+}
+
 // UnmarshalErrorHandler is a name request handler to unmarshal request errors
 var UnmarshalErrorHandler = request.NamedHandler{Name: "awssdk.query.UnmarshalError", Fn: UnmarshalError}
 
@@ -22,11 +26,16 @@ var UnmarshalErrorHandler = request.NamedHandler{Name: "awssdk.query.UnmarshalEr
 func UnmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
-	resp := &xmlErrorResponse{}
-	err := xml.NewDecoder(r.HTTPResponse.Body).Decode(resp)
-	if err != nil && err != io.EOF {
-		r.Error = awserr.New("SerializationError", "failed to decode query XML error response", err)
-	} else {
+	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to read from query HTTP response body", err)
+		return
+	}
+
+	// First check for specific error
+	resp := xmlErrorResponse{}
+	decodeErr := xml.Unmarshal(bodyBytes, &resp)
+	if decodeErr == nil {
 		reqID := resp.RequestID
 		if reqID == "" {
 			reqID = r.RequestID
@@ -36,5 +45,22 @@ func UnmarshalError(r *request.Request) {
 			r.HTTPResponse.StatusCode,
 			reqID,
 		)
+		return
 	}
+
+	// Check for unhandled error
+	servUnavailResp := xmlServiceUnavailableResponse{}
+	unavailErr := xml.Unmarshal(bodyBytes, &servUnavailResp)
+	if unavailErr == nil {
+		r.Error = awserr.NewRequestFailure(
+			awserr.New("ServiceUnavailableException", "service is unavailable", nil),
+			r.HTTPResponse.StatusCode,
+			r.RequestID,
+		)
+		return
+	}
+
+	// Failed to retrieve any error message from the response body
+	r.Error = awserr.New("SerializationError",
+		"failed to decode query XML error response", decodeErr)
 }

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
@@ -222,8 +222,7 @@ func EscapePath(path string, encodeSep bool) string {
 		if noEscape[c] || (c == '/' && !encodeSep) {
 			buf.WriteByte(c)
 		} else {
-			buf.WriteByte('%')
-			buf.WriteString(strings.ToUpper(strconv.FormatUint(uint64(c), 16)))
+			fmt.Fprintf(&buf, "%%%02X", c)
 		}
 	}
 	return buf.String()

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -51,6 +52,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 				if payload.IsValid() {
 					switch payload.Interface().(type) {
 					case []byte:
+						defer r.HTTPResponse.Body.Close()
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
@@ -58,6 +60,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 							payload.Set(reflect.ValueOf(b))
 						}
 					case *string:
+						defer r.HTTPResponse.Body.Close()
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
@@ -72,6 +75,8 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						case "aws.ReadSeekCloser", "io.ReadCloser":
 							payload.Set(reflect.ValueOf(r.HTTPResponse.Body))
 						default:
+							io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+							defer r.HTTPResponse.Body.Close()
 							r.Error = awserr.New("SerializationError",
 								"failed to decode REST response",
 								fmt.Errorf("unknown payload type %s", payload.Type()))

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/restjson/restjson.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/restjson/restjson.go
@@ -53,6 +53,7 @@ func UnmarshalMeta(r *request.Request) {
 
 // UnmarshalError unmarshals a response error for the REST JSON protocol.
 func UnmarshalError(r *request.Request) {
+	defer r.HTTPResponse.Body.Close()
 	code := r.HTTPResponse.Header.Get("X-Amzn-Errortype")
 	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
 	if err != nil {

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudtrail/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudtrail/api.go
@@ -995,6 +995,8 @@ type PublicKey struct {
 	ValidityStartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The DER encoded public key value in PKCS#1 format.
+	//
+	// Value is automatically base64 encoded/decoded by the SDK.
 	Value []byte `type:"blob"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/codedeploy/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codedeploy/api.go
@@ -95,6 +95,33 @@ func (c *CodeDeploy) BatchGetApplications(input *BatchGetApplicationsInput) (*Ba
 	return out, err
 }
 
+const opBatchGetDeploymentGroups = "BatchGetDeploymentGroups"
+
+// BatchGetDeploymentGroupsRequest generates a request for the BatchGetDeploymentGroups operation.
+func (c *CodeDeploy) BatchGetDeploymentGroupsRequest(input *BatchGetDeploymentGroupsInput) (req *request.Request, output *BatchGetDeploymentGroupsOutput) {
+	op := &request.Operation{
+		Name:       opBatchGetDeploymentGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &BatchGetDeploymentGroupsInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &BatchGetDeploymentGroupsOutput{}
+	req.Data = output
+	return
+}
+
+// Get information about one or more deployment groups.
+func (c *CodeDeploy) BatchGetDeploymentGroups(input *BatchGetDeploymentGroupsInput) (*BatchGetDeploymentGroupsOutput, error) {
+	req, out := c.BatchGetDeploymentGroupsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opBatchGetDeploymentInstances = "BatchGetDeploymentInstances"
 
 // BatchGetDeploymentInstancesRequest generates a request for the BatchGetDeploymentInstances operation.
@@ -115,7 +142,7 @@ func (c *CodeDeploy) BatchGetDeploymentInstancesRequest(input *BatchGetDeploymen
 	return
 }
 
-// Gets information about one or more instances that are part of a deployment
+// Gets information about one or more instance that are part of a deployment
 // group.
 func (c *CodeDeploy) BatchGetDeploymentInstances(input *BatchGetDeploymentInstancesInput) (*BatchGetDeploymentInstancesOutput, error) {
 	req, out := c.BatchGetDeploymentInstancesRequest(input)
@@ -197,7 +224,7 @@ func (c *CodeDeploy) CreateApplicationRequest(input *CreateApplicationInput) (re
 	return
 }
 
-// Creates a new application.
+// Creates an application.
 func (c *CodeDeploy) CreateApplication(input *CreateApplicationInput) (*CreateApplicationOutput, error) {
 	req, out := c.CreateApplicationRequest(input)
 	err := req.Send()
@@ -251,7 +278,7 @@ func (c *CodeDeploy) CreateDeploymentConfigRequest(input *CreateDeploymentConfig
 	return
 }
 
-// Creates a new deployment configuration.
+// Creates a deployment configuration.
 func (c *CodeDeploy) CreateDeploymentConfig(input *CreateDeploymentConfigInput) (*CreateDeploymentConfigOutput, error) {
 	req, out := c.CreateDeploymentConfigRequest(input)
 	err := req.Send()
@@ -278,7 +305,7 @@ func (c *CodeDeploy) CreateDeploymentGroupRequest(input *CreateDeploymentGroupIn
 	return
 }
 
-// Creates a new deployment group for application revisions to be deployed to.
+// Creates a deployment group to which application revisions will be deployed.
 func (c *CodeDeploy) CreateDeploymentGroup(input *CreateDeploymentGroupInput) (*CreateDeploymentGroupOutput, error) {
 	req, out := c.CreateDeploymentGroupRequest(input)
 	err := req.Send()
@@ -339,7 +366,7 @@ func (c *CodeDeploy) DeleteDeploymentConfigRequest(input *DeleteDeploymentConfig
 // Deletes a deployment configuration.
 //
 // A deployment configuration cannot be deleted if it is currently in use.
-// Also, predefined configurations cannot be deleted.
+// Predefined configurations cannot be deleted.
 func (c *CodeDeploy) DeleteDeploymentConfig(input *DeleteDeploymentConfigInput) (*DeleteDeploymentConfigOutput, error) {
 	req, out := c.DeleteDeploymentConfigRequest(input)
 	err := req.Send()
@@ -782,7 +809,7 @@ func (c *CodeDeploy) ListDeploymentInstancesRequest(input *ListDeploymentInstanc
 	return
 }
 
-// Lists the instances for a deployment associated with the applicable IAM user
+// Lists the instance for a deployment associated with the applicable IAM user
 // or AWS account.
 func (c *CodeDeploy) ListDeploymentInstances(input *ListDeploymentInstancesInput) (*ListDeploymentInstancesOutput, error) {
 	req, out := c.ListDeploymentInstancesRequest(input)
@@ -824,7 +851,7 @@ func (c *CodeDeploy) ListDeploymentsRequest(input *ListDeploymentsInput) (req *r
 	return
 }
 
-// Lists the deployments within a deployment group for an application registered
+// Lists the deployments in a deployment group for an application registered
 // with the applicable IAM user or AWS account.
 func (c *CodeDeploy) ListDeployments(input *ListDeploymentsInput) (*ListDeploymentsOutput, error) {
 	req, out := c.ListDeploymentsRequest(input)
@@ -860,7 +887,7 @@ func (c *CodeDeploy) ListOnPremisesInstancesRequest(input *ListOnPremisesInstanc
 	return
 }
 
-// Gets a list of one or more on-premises instance names.
+// Gets a list of names for one or more on-premises instances.
 //
 // Unless otherwise specified, both registered and deregistered on-premises
 // instance names will be listed. To list only registered or deregistered on-premises
@@ -1007,7 +1034,7 @@ func (c *CodeDeploy) UpdateApplicationRequest(input *UpdateApplicationInput) (re
 	return
 }
 
-// Changes an existing application's name.
+// Changes the name of an application.
 func (c *CodeDeploy) UpdateApplication(input *UpdateApplicationInput) (*UpdateApplicationOutput, error) {
 	req, out := c.UpdateApplicationRequest(input)
 	err := req.Send()
@@ -1034,23 +1061,23 @@ func (c *CodeDeploy) UpdateDeploymentGroupRequest(input *UpdateDeploymentGroupIn
 	return
 }
 
-// Changes information about an existing deployment group.
+// Changes information about a deployment group.
 func (c *CodeDeploy) UpdateDeploymentGroup(input *UpdateDeploymentGroupInput) (*UpdateDeploymentGroupOutput, error) {
 	req, out := c.UpdateDeploymentGroupRequest(input)
 	err := req.Send()
 	return out, err
 }
 
-// Represents the input of and adds tags to on-premises instance operation.
+// Represents the input of, and adds tags to, an on-premises instance operation.
 type AddTagsToOnPremisesInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The names of the on-premises instances to add tags to.
+	// The names of the on-premises instances to which to add tags.
 	InstanceNames []*string `locationName:"instanceNames" type:"list" required:"true"`
 
 	// The tag key-value pairs to add to the on-premises instances.
 	//
-	// Keys and values are both required. Keys cannot be nulls or empty strings.
+	// Keys and values are both required. Keys cannot be null or empty strings.
 	// Value-only tags are not allowed.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
 }
@@ -1089,7 +1116,7 @@ type ApplicationInfo struct {
 	// The application name.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
-	// The time that the application was created.
+	// The time at which the application was created.
 	CreateTime *time.Time `locationName:"createTime" type:"timestamp" timestampFormat:"unix"`
 
 	// True if the user has authenticated with GitHub for the specified application;
@@ -1132,12 +1159,10 @@ func (s AutoScalingGroup) GoString() string {
 type BatchGetApplicationRevisionsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application to get revision information
-	// about.
+	// The name of an AWS CodeDeploy application about which to get revision information.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
-	// Information to get about the application revisions, including revision type
-	// and location.
+	// Information to get about the application revisions, including type and location.
 	Revisions []*RevisionLocation `locationName:"revisions" type:"list" required:"true"`
 }
 
@@ -1161,8 +1186,7 @@ type BatchGetApplicationRevisionsOutput struct {
 	// Information about errors that may have occurred during the API call.
 	ErrorMessage *string `locationName:"errorMessage" type:"string"`
 
-	// Additional information about the revisions, including the revision type and
-	// location.
+	// Additional information about the revisions, including the type and location.
 	Revisions []*RevisionInfo `locationName:"revisions" type:"list"`
 }
 
@@ -1180,8 +1204,7 @@ func (s BatchGetApplicationRevisionsOutput) GoString() string {
 type BatchGetApplicationsInput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of application names, with multiple application names separated by
-	// spaces.
+	// A list of application names separated by spaces.
 	ApplicationNames []*string `locationName:"applicationNames" type:"list"`
 }
 
@@ -1213,6 +1236,49 @@ func (s BatchGetApplicationsOutput) GoString() string {
 	return s.String()
 }
 
+// Represents the input of a batch get deployment groups operation.
+type BatchGetDeploymentGroupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of an AWS CodeDeploy application associated with the applicable
+	// IAM user or AWS account.
+	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
+
+	// The deployment groups' names.
+	DeploymentGroupNames []*string `locationName:"deploymentGroupNames" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s BatchGetDeploymentGroupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetDeploymentGroupsInput) GoString() string {
+	return s.String()
+}
+
+// Represents the output of a batch get deployment groups operation.
+type BatchGetDeploymentGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the deployment groups.
+	DeploymentGroupsInfo []*DeploymentGroupInfo `locationName:"deploymentGroupsInfo" type:"list"`
+
+	// Information about errors that may have occurred during the API call.
+	ErrorMessage *string `locationName:"errorMessage" type:"string"`
+}
+
+// String returns the string representation
+func (s BatchGetDeploymentGroupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetDeploymentGroupsOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a batch get deployment instances operation.
 type BatchGetDeploymentInstancesInput struct {
 	_ struct{} `type:"structure"`
@@ -1220,7 +1286,7 @@ type BatchGetDeploymentInstancesInput struct {
 	// The unique ID of a deployment.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 
-	// The unique IDs of instances in the deployment's deployment group.
+	// The unique IDs of instances in the deployment group.
 	InstanceIds []*string `locationName:"instanceIds" type:"list" required:"true"`
 }
 
@@ -1234,14 +1300,14 @@ func (s BatchGetDeploymentInstancesInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a batch get deployment instances operation.
+// Represents the output of a batch get deployment instance operation.
 type BatchGetDeploymentInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Information about errors that may have occurred during the API call.
 	ErrorMessage *string `locationName:"errorMessage" type:"string"`
 
-	// Information about the instances.
+	// Information about the instance.
 	InstancesSummary []*InstanceSummary `locationName:"instancesSummary" type:"list"`
 }
 
@@ -1259,7 +1325,7 @@ func (s BatchGetDeploymentInstancesOutput) GoString() string {
 type BatchGetDeploymentsInput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of deployment IDs, with multiple deployment IDs separated by spaces.
+	// A list of deployment IDs, separated by spaces.
 	DeploymentIds []*string `locationName:"deploymentIds" type:"list"`
 }
 
@@ -1295,7 +1361,7 @@ func (s BatchGetDeploymentsOutput) GoString() string {
 type BatchGetOnPremisesInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The names of the on-premises instances to get information about.
+	// The names of the on-premises instances about which to get information.
 	InstanceNames []*string `locationName:"instanceNames" type:"list"`
 }
 
@@ -1378,14 +1444,14 @@ type CreateDeploymentConfigInput struct {
 	// The type parameter takes either of the following values:
 	//
 	//  HOST_COUNT: The value parameter represents the minimum number of healthy
-	// instances, as an absolute value. FLEET_PERCENT: The value parameter represents
-	// the minimum number of healthy instances, as a percentage of the total number
-	// of instances in the deployment. If you specify FLEET_PERCENT, then at the
-	// start of the deployment AWS CodeDeploy converts the percentage to the equivalent
-	// number of instances and rounds fractional instances up.  The value parameter
+	// instances as an absolute value. FLEET_PERCENT: The value parameter represents
+	// the minimum number of healthy instances as a percentage of the total number
+	// of instances in the deployment. If you specify FLEET_PERCENT, at the start
+	// of the deployment, AWS CodeDeploy converts the percentage to the equivalent
+	// number of instance and rounds up fractional instances.  The value parameter
 	// takes an integer.
 	//
-	// For example, to set a minimum of 95% healthy instances, specify a type of
+	// For example, to set a minimum of 95% healthy instance, specify a type of
 	// FLEET_PERCENT and a value of 95.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
 }
@@ -1422,7 +1488,7 @@ func (s CreateDeploymentConfigOutput) GoString() string {
 type CreateDeploymentGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
@@ -1430,65 +1496,66 @@ type CreateDeploymentGroupInput struct {
 	AutoScalingGroups []*string `locationName:"autoScalingGroups" type:"list"`
 
 	// If specified, the deployment configuration name can be either one of the
-	// predefined configurations provided with AWS CodeDeploy, or a custom deployment
-	// configuration that you created by calling the create deployment configuration
+	// predefined configurations provided with AWS CodeDeploy or a custom deployment
+	// configuration that you create by calling the create deployment configuration
 	// operation.
 	//
-	//  CodeDeployDefault.OneAtATime is the default deployment configuration that
-	// is used if a configuration isn't specified for either the deployment or the
-	// deployment group.
+	//  CodeDeployDefault.OneAtATime is the default deployment configuration. It
+	// is used if a configuration isn't specified for the deployment or the deployment
+	// group.
 	//
-	//  The predefined deployment configurations including the following:
+	//  The predefined deployment configurations include the following:
 	//
 	//   CodeDeployDefault.AllAtOnce attempts to deploy an application revision
-	// to as many instances as possible at once. The status of the overall deployment
+	// to as many instance as possible at once. The status of the overall deployment
 	// will be displayed as Succeeded if the application revision is deployed to
 	// one or more of the instances. The status of the overall deployment will be
 	// displayed as Failed if the application revision is not deployed to any of
-	// the instances. Using an example of nine instances, CodeDeployDefault.AllAtOnce
-	// will attempt to deploy to all nine instances at once. The overall deployment
+	// the instances. Using an example of nine instance, CodeDeployDefault.AllAtOnce
+	// will attempt to deploy to all nine instance at once. The overall deployment
 	// will succeed if deployment to even a single instance is successful; it will
-	// fail only if deployments to all nine instances fail.
+	// fail only if deployments to all nine instance fail.
 	//
 	//   CodeDeployDefault.HalfAtATime deploys to up to half of the instances at
 	// a time (with fractions rounded down). The overall deployment succeeds if
-	// the application revision deploys to at least half of the instances (with
-	// fractions rounded up); otherwise, the deployment fails. For example, for
-	// nine instances, deploy to up to four instances at a time. The overall deployment
-	// succeeds if deployment to five or more instances succeed; otherwise, the
-	// deployment fails. Note that the deployment may successfully deploy to some
-	// instances, even if the overall deployment fails.
+	// the application revision is deployed to at least half of the instances (with
+	// fractions rounded up); otherwise, the deployment fails. In the example of
+	// nine instances, it will deploy to up to four instance at a time. The overall
+	// deployment succeeds if deployment to five or more instances succeed; otherwise,
+	// the deployment fails. The deployment may be successfully deployed to some
+	// instances even if the overall deployment fails.
 	//
 	//   CodeDeployDefault.OneAtATime deploys the application revision to only
 	// one instance at a time.
 	//
 	// For deployment groups that contain more than one instance:
 	//
-	//   The overall deployment succeeds if the application revision deploys to
-	// all of the instances. The exception to this rule is that if deployment to
-	// the last instance fails, the overall deployment still succeeds. This is because
-	// AWS CodeDeploy allows only one instance to be taken offline at a time with
+	//   The overall deployment succeeds if the application revision is deployed
+	// to all of the instances. The exception to this rule is if deployment to the
+	// last instance fails, the overall deployment still succeeds. This is because
+	// AWS CodeDeploy allows only one instance at a time to be taken offline with
 	// the CodeDeployDefault.OneAtATime configuration.
 	//
 	//   The overall deployment fails as soon as the application revision fails
-	// to deploy to any but the last instance. Note that the deployment may successfully
-	// deploy to some instances, even if the overall deployment fails.
+	// to be deployed to any but the last instance. The deployment may be successfully
+	// deployed to some instances even if the overall deployment fails.
 	//
-	//   Example: For nine instances, deploy to one instance at a time. The overall
-	// deployment succeeds if the first eight instances are successfully deployed
-	// to, but it fails if deployment to any of the first eight instances fails.
+	//   In an example using nine instance, it will deploy to one instance at a
+	// time. The overall deployment succeeds if deployment to the first eight instance
+	// is successful; the overall deployment fails if deployment to any of the first
+	// eight instance fails.
 	//
 	//   For deployment groups that contain only one instance, the overall deployment
-	// is of course successful only if deployment to the single instance succeeds.
+	// is successful only if deployment to the single instance is successful
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string"`
 
 	// The name of a new deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string" required:"true"`
 
-	// The Amazon EC2 tags to filter on.
+	// The Amazon EC2 tags on which to filter.
 	Ec2TagFilters []*EC2TagFilter `locationName:"ec2TagFilters" type:"list"`
 
-	// The on-premises instance tags to filter on.
+	// The on-premises instance tags on which to filter.
 	OnPremisesInstanceTagFilters []*TagFilter `locationName:"onPremisesInstanceTagFilters" type:"list"`
 
 	// A service role ARN that allows AWS CodeDeploy to act on the user's behalf
@@ -1531,37 +1598,36 @@ func (s CreateDeploymentGroupOutput) GoString() string {
 type CreateDeploymentInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
-	// The name of an existing deployment configuration associated with the applicable
-	// IAM user or AWS account.
+	// The name of a deployment configuration associated with the applicable IAM
+	// user or AWS account.
 	//
 	// If not specified, the value configured in the deployment group will be used
 	// as the default. If the deployment group does not have a deployment configuration
 	// associated with it, then CodeDeployDefault.OneAtATime will be used by default.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string"`
 
-	// The deployment group's name.
+	// The name of the deployment group.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string"`
 
 	// A comment about the deployment.
 	Description *string `locationName:"description" type:"string"`
 
 	// If set to true, then if the deployment causes the ApplicationStop deployment
-	// lifecycle event to fail to a specific instance, the deployment will not be
-	// considered to have failed to that instance at that point and will continue
-	// on to the BeforeInstall deployment lifecycle event.
+	// lifecycle event to an instance to fail, the deployment to that instance will
+	// not be considered to have failed at that point and will continue on to the
+	// BeforeInstall deployment lifecycle event.
 	//
 	// If set to false or not specified, then if the deployment causes the ApplicationStop
-	// deployment lifecycle event to fail to a specific instance, the deployment
-	// will stop to that instance, and the deployment to that instance will be considered
+	// deployment lifecycle event to fail to an instance, the deployment to that
+	// instance will stop, and the deployment to that instance will be considered
 	// to have failed.
 	IgnoreApplicationStopFailures *bool `locationName:"ignoreApplicationStopFailures" type:"boolean"`
 
-	// The type of revision to deploy, along with information about the revision's
-	// location.
+	// The type and location of the revision to deploy.
 	Revision *RevisionLocation `locationName:"revision" type:"structure"`
 }
 
@@ -1597,7 +1663,7 @@ func (s CreateDeploymentOutput) GoString() string {
 type DeleteApplicationInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 }
@@ -1630,8 +1696,8 @@ func (s DeleteApplicationOutput) GoString() string {
 type DeleteDeploymentConfigInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing deployment configuration associated with the applicable
-	// IAM user or AWS account.
+	// The name of a deployment configuration associated with the applicable IAM
+	// user or AWS account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string" required:"true"`
 }
 
@@ -1663,7 +1729,7 @@ func (s DeleteDeploymentConfigOutput) GoString() string {
 type DeleteDeploymentGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
@@ -1688,7 +1754,7 @@ type DeleteDeploymentGroupOutput struct {
 	// If the output contains no data, and the corresponding deployment group contained
 	// at least one Auto Scaling group, AWS CodeDeploy successfully removed all
 	// corresponding Auto Scaling lifecycle event hooks from the Amazon EC2 instances
-	// in the Auto Scaling. If the output does contain data, AWS CodeDeploy could
+	// in the Auto Scaling group. If the output contains data, AWS CodeDeploy could
 	// not remove some Auto Scaling lifecycle event hooks from the Amazon EC2 instances
 	// in the Auto Scaling group.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
@@ -1708,7 +1774,7 @@ func (s DeleteDeploymentGroupOutput) GoString() string {
 type DeploymentConfigInfo struct {
 	_ struct{} `type:"structure"`
 
-	// The time that the deployment configuration was created.
+	// The time at which the deployment configuration was created.
 	CreateTime *time.Time `locationName:"createTime" type:"timestamp" timestampFormat:"unix"`
 
 	// The deployment configuration ID.
@@ -1717,7 +1783,7 @@ type DeploymentConfigInfo struct {
 	// The deployment configuration name.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string"`
 
-	// Information about the number or percentage of minimum healthy instances.
+	// Information about the number or percentage of minimum healthy instance.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
 }
 
@@ -1750,17 +1816,17 @@ type DeploymentGroupInfo struct {
 	// The deployment group name.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string"`
 
-	// The Amazon EC2 tags to filter on.
+	// The Amazon EC2 tags on which to filter.
 	Ec2TagFilters []*EC2TagFilter `locationName:"ec2TagFilters" type:"list"`
 
-	// The on-premises instance tags to filter on.
+	// The on-premises instance tags on which to filter.
 	OnPremisesInstanceTagFilters []*TagFilter `locationName:"onPremisesInstanceTagFilters" type:"list"`
 
 	// A service role ARN.
 	ServiceRoleArn *string `locationName:"serviceRoleArn" type:"string"`
 
-	// Information about the deployment group's target revision, including the revision's
-	// type and its location.
+	// Information about the deployment group's target revision, including type
+	// and location.
 	TargetRevision *RevisionLocation `locationName:"targetRevision" type:"structure"`
 
 	// A list of associated triggers.
@@ -1784,13 +1850,13 @@ type DeploymentInfo struct {
 	// The application name.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
-	// A timestamp indicating when the deployment was completed.
+	// A timestamp indicating when the deployment was complete.
 	CompleteTime *time.Time `locationName:"completeTime" type:"timestamp" timestampFormat:"unix"`
 
 	// A timestamp indicating when the deployment was created.
 	CreateTime *time.Time `locationName:"createTime" type:"timestamp" timestampFormat:"unix"`
 
-	// How the deployment was created:
+	// The means by which the deployment was created:
 	//
 	//  user: A user created the deployment. autoscaling: Auto Scaling created
 	// the deployment.
@@ -1815,26 +1881,26 @@ type DeploymentInfo struct {
 	ErrorInformation *ErrorInformation `locationName:"errorInformation" type:"structure"`
 
 	// If true, then if the deployment causes the ApplicationStop deployment lifecycle
-	// event to fail to a specific instance, the deployment will not be considered
-	// to have failed to that instance at that point and will continue on to the
-	// BeforeInstall deployment lifecycle event.
+	// event to an instance to fail, the deployment to that instance will not be
+	// considered to have failed at that point and will continue on to the BeforeInstall
+	// deployment lifecycle event.
 	//
 	// If false or not specified, then if the deployment causes the ApplicationStop
-	// deployment lifecycle event to fail to a specific instance, the deployment
-	// will stop to that instance, and the deployment to that instance will be considered
+	// deployment lifecycle event to an instance to fail, the deployment to that
+	// instance will stop, and the deployment to that instance will be considered
 	// to have failed.
 	IgnoreApplicationStopFailures *bool `locationName:"ignoreApplicationStopFailures" type:"boolean"`
 
-	// Information about the location of application artifacts that are stored and
-	// the service to retrieve them from.
+	// Information about the location of stored application artifacts and the service
+	// from which to retrieve them.
 	Revision *RevisionLocation `locationName:"revision" type:"structure"`
 
-	// A timestamp indicating when the deployment began deploying to the deployment
+	// A timestamp indicating when the deployment was deployed to the deployment
 	// group.
 	//
-	// Note that in some cases, the reported value of the start time may be later
-	// than the complete time. This is due to differences in the clock settings
-	// of various back-end servers that participate in the overall deployment process.
+	// In some cases, the reported value of the start time may be later than the
+	// complete time. This is due to differences in the clock settings of back-end
+	// servers that participate in the deployment process.
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"unix"`
 
 	// The current state of the deployment as a whole.
@@ -1855,19 +1921,20 @@ func (s DeploymentInfo) GoString() string {
 type DeploymentOverview struct {
 	_ struct{} `type:"structure"`
 
-	// The number of instances that have failed in the deployment.
+	// The number of instances in the deployment in a failed state.
 	Failed *int64 `type:"long"`
 
-	// The number of instances that are in progress in the deployment.
+	// The number of instances in which the deployment is in progress.
 	InProgress *int64 `type:"long"`
 
-	// The number of instances that are pending in the deployment.
+	// The number of instances in the deployment in a pending state.
 	Pending *int64 `type:"long"`
 
-	// The number of instances that have been skipped in the deployment.
+	// The number of instances in the deployment in a skipped state.
 	Skipped *int64 `type:"long"`
 
-	// The number of instances that have succeeded in the deployment.
+	// The number of instances in the deployment to which revisions have been successfully
+	// deployed.
 	Succeeded *int64 `type:"long"`
 }
 
@@ -1927,10 +1994,10 @@ type Diagnostics struct {
 	// script did not run for an unknown reason.
 	ErrorCode *string `locationName:"errorCode" type:"string" enum:"LifecycleErrorCode"`
 
-	// The last portion of the associated diagnostic log.
+	// The last portion of the diagnostic log.
 	//
-	// If available, AWS CodeDeploy returns up to the last 4 KB of the associated
-	// diagnostic log.
+	// If available, AWS CodeDeploy returns up to the last 4 KB of the diagnostic
+	// log.
 	LogTail *string `locationName:"logTail" type:"string"`
 
 	// The message associated with the error.
@@ -1982,25 +2049,24 @@ type ErrorInformation struct {
 
 	// The error code:
 	//
-	//  APPLICATION_MISSING: The application was missing. Note that this error
-	// code will most likely be raised if the application is deleted after the deployment
-	// is created but before it starts. DEPLOYMENT_GROUP_MISSING: The deployment
-	// group was missing. Note that this error code will most likely be raised if
-	// the deployment group is deleted after the deployment is created but before
-	// it starts. HEALTH_CONSTRAINTS: The deployment failed on too many instances
-	// to be able to successfully deploy within the specified instance health constraints.
-	// HEALTH_CONSTRAINTS_INVALID: The revision can never successfully deploy within
-	// the instance health constraints as specified. IAM_ROLE_MISSING: The service
-	// role cannot be accessed. IAM_ROLE_PERMISSIONS: The service role does not
-	// have the correct permissions. INTERNAL_ERROR: There was an internal error.
-	// NO_EC2_SUBSCRIPTION: The calling account is not subscribed to the Amazon
-	// EC2 service. NO_INSTANCES: No instances were specified, or no instances can
-	// be found. OVER_MAX_INSTANCES: The maximum number of instances was exceeded.
-	// THROTTLED: The operation was throttled because the calling account exceeded
-	// the throttling limits of one or more AWS services. TIMEOUT: The deployment
-	// has timed out. REVISION_MISSING: The revision ID was missing. Note that this
-	// error code will most likely be raised if the revision is deleted after the
-	// deployment is created but before it starts.
+	//  APPLICATION_MISSING: The application was missing. This error code will
+	// most likely be raised if the application is deleted after the deployment
+	// is created but before it is started. DEPLOYMENT_GROUP_MISSING: The deployment
+	// group was missing. This error code will most likely be raised if the deployment
+	// group is deleted after the deployment is created but before it is started.
+	// HEALTH_CONSTRAINTS: The deployment failed on too many instances to be successfully
+	// deployed within the instance health constraints specified. HEALTH_CONSTRAINTS_INVALID:
+	// The revision cannot be successfully deployed within the instance health constraints
+	// specified. IAM_ROLE_MISSING: The service role cannot be accessed. IAM_ROLE_PERMISSIONS:
+	// The service role does not have the correct permissions. INTERNAL_ERROR: There
+	// was an internal error. NO_EC2_SUBSCRIPTION: The calling account is not subscribed
+	// to the Amazon EC2 service. NO_INSTANCES: No instance were specified, or no
+	// instance can be found. OVER_MAX_INSTANCES: The maximum number of instance
+	// was exceeded. THROTTLED: The operation was throttled because the calling
+	// account exceeded the throttling limits of one or more AWS services. TIMEOUT:
+	// The deployment has timed out. REVISION_MISSING: The revision ID was missing.
+	// This error code will most likely be raised if the revision is deleted after
+	// the deployment is created but before it is started.
 	Code *string `locationName:"code" type:"string" enum:"ErrorCode"`
 
 	// An accompanying error message.
@@ -2021,7 +2087,7 @@ func (s ErrorInformation) GoString() string {
 type GenericRevisionInfo struct {
 	_ struct{} `type:"structure"`
 
-	// The deployment groups where this is the current target revision.
+	// The deployment groups for which this is the current target revision.
 	DeploymentGroups []*string `locationName:"deploymentGroups" type:"list"`
 
 	// A comment about the revision.
@@ -2051,7 +2117,7 @@ func (s GenericRevisionInfo) GoString() string {
 type GetApplicationInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 }
@@ -2091,8 +2157,7 @@ type GetApplicationRevisionInput struct {
 	// The name of the application that corresponds to the revision.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
-	// Information about the application revision to get, including the revision's
-	// type and its location.
+	// Information about the application revision to get, including type and location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
 }
 
@@ -2113,8 +2178,7 @@ type GetApplicationRevisionOutput struct {
 	// The name of the application that corresponds to the revision.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
-	// Additional information about the revision, including the revision's type
-	// and its location.
+	// Additional information about the revision, including type and location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure"`
 
 	// General information about the revision.
@@ -2135,8 +2199,8 @@ func (s GetApplicationRevisionOutput) GoString() string {
 type GetDeploymentConfigInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing deployment configuration associated with the applicable
-	// IAM user or AWS account.
+	// The name of a deployment configuration associated with the applicable IAM
+	// user or AWS account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string" required:"true"`
 }
 
@@ -2172,7 +2236,7 @@ func (s GetDeploymentConfigOutput) GoString() string {
 type GetDeploymentGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
@@ -2212,8 +2276,7 @@ func (s GetDeploymentGroupOutput) GoString() string {
 type GetDeploymentInput struct {
 	_ struct{} `type:"structure"`
 
-	// An existing deployment ID associated with the applicable IAM user or AWS
-	// account.
+	// A deployment ID associated with the applicable IAM user or AWS account.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 }
 
@@ -2234,7 +2297,7 @@ type GetDeploymentInstanceInput struct {
 	// The unique ID of a deployment.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 
-	// The unique ID of an instance in the deployment's deployment group.
+	// The unique ID of an instance in the deployment group.
 	InstanceId *string `locationName:"instanceId" type:"string" required:"true"`
 }
 
@@ -2288,7 +2351,7 @@ func (s GetDeploymentOutput) GoString() string {
 type GetOnPremisesInstanceInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the on-premises instance to get information about
+	// The name of the on-premises instance about which to get information.
 	InstanceName *string `locationName:"instanceName" type:"string" required:"true"`
 }
 
@@ -2320,8 +2383,7 @@ func (s GetOnPremisesInstanceOutput) GoString() string {
 	return s.String()
 }
 
-// Information about the location of application artifacts that are stored in
-// GitHub.
+// Information about the location of application artifacts stored in GitHub.
 type GitHubLocation struct {
 	_ struct{} `type:"structure"`
 
@@ -2350,7 +2412,7 @@ func (s GitHubLocation) GoString() string {
 type InstanceInfo struct {
 	_ struct{} `type:"structure"`
 
-	// If the on-premises instance was deregistered, the time that the on-premises
+	// If the on-premises instance was deregistered, the time at which the on-premises
 	// instance was deregistered.
 	DeregisterTime *time.Time `locationName:"deregisterTime" type:"timestamp" timestampFormat:"unix"`
 
@@ -2363,10 +2425,10 @@ type InstanceInfo struct {
 	// The name of the on-premises instance.
 	InstanceName *string `locationName:"instanceName" type:"string"`
 
-	// The time that the on-premises instance was registered.
+	// The time at which the on-premises instance was registered.
 	RegisterTime *time.Time `locationName:"registerTime" type:"timestamp" timestampFormat:"unix"`
 
-	// The tags that are currently associated with the on-premises instance.
+	// The tags currently associated with the on-premises instance.
 	Tags []*Tag `locationName:"tags" type:"list"`
 }
 
@@ -2437,7 +2499,7 @@ type LifecycleEvent struct {
 	//
 	//  Pending: The deployment lifecycle event is pending. InProgress: The deployment
 	// lifecycle event is in progress. Succeeded: The deployment lifecycle event
-	// has succeeded. Failed: The deployment lifecycle event has failed. Skipped:
+	// ran successfully. Failed: The deployment lifecycle event has failed. Skipped:
 	// The deployment lifecycle event has been skipped. Unknown: The deployment
 	// lifecycle event is unknown.
 	Status *string `locationName:"status" type:"string" enum:"LifecycleEventStatus"`
@@ -2457,7 +2519,7 @@ func (s LifecycleEvent) GoString() string {
 type ListApplicationRevisionsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
@@ -2466,37 +2528,34 @@ type ListApplicationRevisionsInput struct {
 	//
 	//  include: List revisions that are target revisions of a deployment group.
 	// exclude: Do not list revisions that are target revisions of a deployment
-	// group. ignore: List all revisions, regardless of whether they are target
-	// revisions of a deployment group.
+	// group. ignore: List all revisions.
 	Deployed *string `locationName:"deployed" type:"string" enum:"ListStateFilterAction"`
 
-	// An identifier that was returned from the previous list application revisions
-	// call, which can be used to return the next set of applications in the list.
+	// An identifier returned from the previous list application revisions call.
+	// It can be used to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// A specific Amazon S3 bucket name to limit the search for revisions.
+	// An Amazon S3 bucket name to limit the search for revisions.
 	//
-	// If set to null, then all of the user's buckets will be searched.
+	// If set to null, all of the user's buckets will be searched.
 	S3Bucket *string `locationName:"s3Bucket" type:"string"`
 
-	// A specific key prefix for the set of Amazon S3 objects to limit the search
-	// for revisions.
+	// A key prefix for the set of Amazon S3 objects to limit the search for revisions.
 	S3KeyPrefix *string `locationName:"s3KeyPrefix" type:"string"`
 
-	// The column name to sort the list results by:
+	// The column name to use to sort the list results:
 	//
-	//  registerTime: Sort the list results by when the revisions were registered
-	// with AWS CodeDeploy. firstUsedTime: Sort the list results by when the revisions
-	// were first used by in a deployment. lastUsedTime: Sort the list results by
-	// when the revisions were last used in a deployment.  If not specified or set
-	// to null, the results will be returned in an arbitrary order.
+	//  registerTime: Sort by the time the revisions were registered with AWS CodeDeploy.
+	// firstUsedTime: Sort by the time the revisions were first used in a deployment.
+	// lastUsedTime: Sort by the time the revisions were last used in a deployment.
+	//  If not specified or set to null, the results will be returned in an arbitrary
+	// order.
 	SortBy *string `locationName:"sortBy" type:"string" enum:"ApplicationRevisionSortBy"`
 
-	// The order to sort the list results by:
+	// The order in which to sort the list results:
 	//
-	//  ascending: Sort the list of results in ascending order. descending: Sort
-	// the list of results in descending order.  If not specified, the results will
-	// be sorted in ascending order.
+	//  ascending: ascending order. descending: descending order.  If not specified,
+	// the results will be sorted in ascending order.
 	//
 	// If set to null, the results will be sorted in an arbitrary order.
 	SortOrder *string `locationName:"sortOrder" type:"string" enum:"SortOrder"`
@@ -2516,13 +2575,12 @@ func (s ListApplicationRevisionsInput) GoString() string {
 type ListApplicationRevisionsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// If the amount of information that is returned is significantly large, an
-	// identifier will also be returned, which can be used in a subsequent list
-	// application revisions call to return the next set of application revisions
-	// in the list.
+	// If a large amount of information is returned, an identifier will also be
+	// returned. It can be used in a subsequent list application revisions call
+	// to return the next set of application revisions in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// A list of revision locations that contain the matching revisions.
+	// A list of locations that contain the matching revisions.
 	Revisions []*RevisionLocation `locationName:"revisions" type:"list"`
 }
 
@@ -2540,8 +2598,8 @@ func (s ListApplicationRevisionsOutput) GoString() string {
 type ListApplicationsInput struct {
 	_ struct{} `type:"structure"`
 
-	// An identifier that was returned from the previous list applications call,
-	// which can be used to return the next set of applications in the list.
+	// An identifier returned from the previous list applications call. It can be
+	// used to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2562,9 +2620,9 @@ type ListApplicationsOutput struct {
 	// A list of application names.
 	Applications []*string `locationName:"applications" type:"list"`
 
-	// If the amount of information that is returned is significantly large, an
-	// identifier will also be returned, which can be used in a subsequent list
-	// applications call to return the next set of applications in the list.
+	// If a large amount of information is returned, an identifier is also returned.
+	// It can be used in a subsequent list applications call to return the next
+	// set of applications, will also be returned. in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2582,9 +2640,9 @@ func (s ListApplicationsOutput) GoString() string {
 type ListDeploymentConfigsInput struct {
 	_ struct{} `type:"structure"`
 
-	// An identifier that was returned from the previous list deployment configurations
-	// call, which can be used to return the next set of deployment configurations
-	// in the list.
+	// An identifier returned from the previous list deployment configurations call.
+	// It can be used to return the next set of deployment configurations in the
+	// list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2602,14 +2660,13 @@ func (s ListDeploymentConfigsInput) GoString() string {
 type ListDeploymentConfigsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of deployment configurations, including the built-in configurations
-	// such as CodeDeployDefault.OneAtATime.
+	// A list of deployment configurations, including built-in configurations such
+	// as CodeDeployDefault.OneAtATime.
 	DeploymentConfigsList []*string `locationName:"deploymentConfigsList" type:"list"`
 
-	// If the amount of information that is returned is significantly large, an
-	// identifier will also be returned, which can be used in a subsequent list
-	// deployment configurations call to return the next set of deployment configurations
-	// in the list.
+	// If a large amount of information is returned, an identifier is also returned.
+	// It can be used in a subsequent list deployment configurations call to return
+	// the next set of deployment configurations in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2627,13 +2684,12 @@ func (s ListDeploymentConfigsOutput) GoString() string {
 type ListDeploymentGroupsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
-	// An identifier that was returned from the previous list deployment groups
-	// call, which can be used to return the next set of deployment groups in the
-	// list.
+	// An identifier returned from the previous list deployment groups call. It
+	// can be used to return the next set of deployment groups in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2657,10 +2713,9 @@ type ListDeploymentGroupsOutput struct {
 	// A list of corresponding deployment group names.
 	DeploymentGroups []*string `locationName:"deploymentGroups" type:"list"`
 
-	// If the amount of information that is returned is significantly large, an
-	// identifier will also be returned, which can be used in a subsequent list
-	// deployment groups call to return the next set of deployment groups in the
-	// list.
+	// If a large amount of information is returned, an identifier is also returned.
+	// It can be used in a subsequent list deployment groups call to return the
+	// next set of deployment groups in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2681,20 +2736,17 @@ type ListDeploymentInstancesInput struct {
 	// The unique ID of a deployment.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 
-	// A subset of instances to list, by status:
+	// A subset of instances to list by status:
 	//
-	//  Pending: Include in the resulting list those instances with pending deployments.
-	// InProgress: Include in the resulting list those instances with in-progress
-	// deployments. Succeeded: Include in the resulting list those instances with
-	// succeeded deployments. Failed: Include in the resulting list those instances
-	// with failed deployments. Skipped: Include in the resulting list those instances
-	// with skipped deployments. Unknown: Include in the resulting list those instances
-	// with deployments in an unknown state.
+	//  Pending: Include those instance with pending deployments. InProgress: Include
+	// those instance where deployments are still in progress. Succeeded: Include
+	// those instances with successful deployments. Failed: Include those instance
+	// with failed deployments. Skipped: Include those instance with skipped deployments.
+	// Unknown: Include those instance with deployments in an unknown state.
 	InstanceStatusFilter []*string `locationName:"instanceStatusFilter" type:"list"`
 
-	// An identifier that was returned from the previous list deployment instances
-	// call, which can be used to return the next set of deployment instances in
-	// the list.
+	// An identifier returned from the previous list deployment instances call.
+	// It can be used to return the next set of deployment instances in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2712,13 +2764,12 @@ func (s ListDeploymentInstancesInput) GoString() string {
 type ListDeploymentInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of instances IDs.
+	// A list of instance IDs.
 	InstancesList []*string `locationName:"instancesList" type:"list"`
 
-	// If the amount of information that is returned is significantly large, an
-	// identifier will also be returned, which can be used in a subsequent list
-	// deployment instances call to return the next set of deployment instances
-	// in the list.
+	// If a large amount of information is returned, an identifier is also returned.
+	// It can be used in a subsequent list deployment instances call to return the
+	// next set of deployment instances in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2736,28 +2787,27 @@ func (s ListDeploymentInstancesOutput) GoString() string {
 type ListDeploymentsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
-	// A deployment creation start- and end-time range for returning a subset of
-	// the list of deployments.
+	// A time range (start and end) for returning a subset of the list of deployments.
 	CreateTimeRange *TimeRange `locationName:"createTimeRange" type:"structure"`
 
 	// The name of an existing deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string"`
 
-	// A subset of deployments to list, by status:
+	// A subset of deployments to list by status:
 	//
-	//  Created: Include in the resulting list created deployments. Queued: Include
-	// in the resulting list queued deployments. In Progress: Include in the resulting
-	// list in-progress deployments. Succeeded: Include in the resulting list succeeded
-	// deployments. Failed: Include in the resulting list failed deployments. Aborted:
-	// Include in the resulting list aborted deployments.
+	//  Created: Include created deployments in the resulting list. Queued: Include
+	// queued deployments in the resulting list. In Progress: Include in-progress
+	// deployments in the resulting list. Succeeded: Include successful deployments
+	// in the resulting list. Failed: Include failed deployments in the resulting
+	// list. Aborted: Include aborted deployments in the resulting list.
 	IncludeOnlyStatuses []*string `locationName:"includeOnlyStatuses" type:"list"`
 
-	// An identifier that was returned from the previous list deployments call,
-	// which can be used to return the next set of deployments in the list.
+	// An identifier returned from the previous list deployments call. It can be
+	// used to return the next set of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2778,9 +2828,9 @@ type ListDeploymentsOutput struct {
 	// A list of deployment IDs.
 	Deployments []*string `locationName:"deployments" type:"list"`
 
-	// If the amount of information that is returned is significantly large, an
-	// identifier will also be returned, which can be used in a subsequent list
-	// deployments call to return the next set of deployments in the list.
+	// If a large amount of information is returned, an identifier is also returned.
+	// It can be used in a subsequent list deployments call to return the next set
+	// of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2800,19 +2850,19 @@ func (s ListDeploymentsOutput) GoString() string {
 type ListOnPremisesInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// An identifier that was returned from the previous list on-premises instances
-	// call, which can be used to return the next set of on-premises instances in
-	// the list.
+	// An identifier returned from the previous list on-premises instances call.
+	// It can be used to return the next set of on-premises instances in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The on-premises instances registration status:
+	// The registration status of the on-premises instances:
 	//
-	//  Deregistered: Include in the resulting list deregistered on-premises instances.
-	// Registered: Include in the resulting list registered on-premises instances.
+	//  Deregistered: Include deregistered on-premises instances in the resulting
+	// list. Registered: Include registered on-premises instances in the resulting
+	// list.
 	RegistrationStatus *string `locationName:"registrationStatus" type:"string" enum:"RegistrationStatus"`
 
 	// The on-premises instance tags that will be used to restrict the corresponding
-	// on-premises instance names that are returned.
+	// on-premises instance names returned.
 	TagFilters []*TagFilter `locationName:"tagFilters" type:"list"`
 }
 
@@ -2833,10 +2883,9 @@ type ListOnPremisesInstancesOutput struct {
 	// The list of matching on-premises instance names.
 	InstanceNames []*string `locationName:"instanceNames" type:"list"`
 
-	// If the amount of information that is returned is significantly large, an
-	// identifier will also be returned, which can be used in a subsequent list
-	// on-premises instances call to return the next set of on-premises instances
-	// in the list.
+	// If a large amount of information is returned, an identifier is also returned.
+	// It can be used in a subsequent list on-premises instances call to return
+	// the next set of on-premises instances in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2850,33 +2899,34 @@ func (s ListOnPremisesInstancesOutput) GoString() string {
 	return s.String()
 }
 
-// Information about minimum healthy instances.
+// Information about minimum healthy instance.
 type MinimumHealthyHosts struct {
 	_ struct{} `type:"structure"`
 
-	// The minimum healthy instances type:
+	// The minimum healthy instance type:
 	//
-	//  HOST_COUNT: The minimum number of healthy instances, as an absolute value.
-	// FLEET_PERCENT: The minimum number of healthy instances, as a percentage of
-	// the total number of instances in the deployment.  For example, for 9 instances,
-	// if a HOST_COUNT of 6 is specified, deploy to up to 3 instances at a time.
-	// The deployment succeeds if 6 or more instances are successfully deployed
-	// to; otherwise, the deployment fails. If a FLEET_PERCENT of 40 is specified,
-	// deploy to up to 5 instances at a time. The deployment succeeds if 4 or more
-	// instances are successfully deployed to; otherwise, the deployment fails.
+	//  HOST_COUNT: The minimum number of healthy instance as an absolute value.
+	// FLEET_PERCENT: The minimum number of healthy instance as a percentage of
+	// the total number of instance in the deployment.  In an example of nine instance,
+	// if a HOST_COUNT of six is specified, deploy to up to three instances at a
+	// time. The deployment will be successful if six or more instances are deployed
+	// to successfully; otherwise, the deployment fails. If a FLEET_PERCENT of 40
+	// is specified, deploy to up to five instance at a time. The deployment will
+	// be successful if four or more instance are deployed to successfully; otherwise,
+	// the deployment fails.
 	//
 	// In a call to the get deployment configuration operation, CodeDeployDefault.OneAtATime
-	// will return a minimum healthy instances type of MOST_CONCURRENCY and a value
+	// will return a minimum healthy instance type of MOST_CONCURRENCY and a value
 	// of 1. This means a deployment to only one instance at a time. (You cannot
 	// set the type to MOST_CONCURRENCY, only to HOST_COUNT or FLEET_PERCENT.) In
 	// addition, with CodeDeployDefault.OneAtATime, AWS CodeDeploy will try to ensure
-	// that all but one instance are kept in healthy states during the deployment
-	// operation. While this allows one instance at a time to be taken offline for
-	// a new deployment, it also means that if the deployment to the last instance
-	// fails, the overall deployment still succeeds.
+	// that all instances but one are kept in a healthy state during the deployment.
+	// Although this allows one instance at a time to be taken offline for a new
+	// deployment, it also means that if the deployment to the last instance fails,
+	// the overall deployment still succeeds.
 	Type *string `locationName:"type" type:"string" enum:"MinimumHealthyHostsType"`
 
-	// The minimum healthy instances value.
+	// The minimum healthy instance value.
 	Value *int64 `locationName:"value" type:"integer"`
 }
 
@@ -2894,15 +2944,15 @@ func (s MinimumHealthyHosts) GoString() string {
 type RegisterApplicationRevisionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of an existing AWS CodeDeploy application associated with the applicable
+	// The name of an AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
 	// A comment about the revision.
 	Description *string `locationName:"description" type:"string"`
 
-	// Information about the application revision to register, including the revision's
-	// type and its location.
+	// Information about the application revision to register, including type and
+	// location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
 }
 
@@ -2930,7 +2980,7 @@ func (s RegisterApplicationRevisionOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of register on-premises instance operation.
+// Represents the input of the register on-premises instance operation.
 type RegisterOnPremisesInstanceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2969,7 +3019,7 @@ func (s RegisterOnPremisesInstanceOutput) GoString() string {
 type RemoveTagsFromOnPremisesInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The names of the on-premises instances to remove tags from.
+	// The names of the on-premises instances from which to remove tags.
 	InstanceNames []*string `locationName:"instanceNames" type:"list" required:"true"`
 
 	// The tag key-value pairs to remove from the on-premises instances.
@@ -3007,7 +3057,7 @@ type RevisionInfo struct {
 	// Information about an application revision.
 	GenericRevisionInfo *GenericRevisionInfo `locationName:"genericRevisionInfo" type:"structure"`
 
-	// Information about an application revision's location.
+	// Information about the location of an application revision.
 	RevisionLocation *RevisionLocation `locationName:"revisionLocation" type:"structure"`
 }
 
@@ -3021,22 +3071,21 @@ func (s RevisionInfo) GoString() string {
 	return s.String()
 }
 
-// Information about an application revision's location.
+// Information about the location of an application revision.
 type RevisionLocation struct {
 	_ struct{} `type:"structure"`
 
-	// Information about the location of application artifacts that are stored in
-	// GitHub.
+	// Information about the location of application artifacts stored in GitHub.
 	GitHubLocation *GitHubLocation `locationName:"gitHubLocation" type:"structure"`
 
-	// The application revision's type:
+	// The type of application revision:
 	//
 	//  S3: An application revision stored in Amazon S3. GitHub: An application
 	// revision stored in GitHub.
 	RevisionType *string `locationName:"revisionType" type:"string" enum:"RevisionLocationType"`
 
-	// Information about the location of application artifacts that are stored in
-	// Amazon S3.
+	// Information about the location of application artifacts stored in Amazon
+	// S3.
 	S3Location *S3Location `locationName:"s3Location" type:"structure"`
 }
 
@@ -3050,8 +3099,8 @@ func (s RevisionLocation) GoString() string {
 	return s.String()
 }
 
-// Information about the location of application artifacts that are stored in
-// Amazon S3.
+// Information about the location of application artifacts stored in Amazon
+// S3.
 type S3Location struct {
 	_ struct{} `type:"structure"`
 
@@ -3117,7 +3166,8 @@ type StopDeploymentOutput struct {
 
 	// The status of the stop deployment operation:
 	//
-	//  Pending: The stop operation is pending. Succeeded: The stop operation succeeded.
+	//  Pending: The stop operation is pending. Succeeded: The stop operation was
+	// successful.
 	Status *string `locationName:"status" type:"string" enum:"StopStatus"`
 
 	// An accompanying status message.
@@ -3185,14 +3235,14 @@ func (s TagFilter) GoString() string {
 type TimeRange struct {
 	_ struct{} `type:"structure"`
 
-	// The time range's end time.
+	// The end time of the time range.
 	//
-	// Specify null to leave the time range's end time open-ended.
+	// Specify null to leave the end time open-ended.
 	End *time.Time `locationName:"end" type:"timestamp" timestampFormat:"unix"`
 
-	// The time range's start time.
+	// The start time of the time range.
 	//
-	// Specify null to leave the time range's start time open-ended.
+	// Specify null to leave the start time open-ended.
 	Start *time.Time `locationName:"start" type:"timestamp" timestampFormat:"unix"`
 }
 
@@ -3221,7 +3271,7 @@ type TriggerConfig struct {
 	// The name of the notification trigger.
 	TriggerName *string `locationName:"triggerName" type:"string"`
 
-	// The arn of the Amazon Simple Notification Service topic through which notifications
+	// The ARN of the Amazon Simple Notification Service topic through which notifications
 	// about deployment or instance events are sent.
 	TriggerTargetArn *string `locationName:"triggerTargetArn" type:"string"`
 }
@@ -3240,10 +3290,10 @@ func (s TriggerConfig) GoString() string {
 type UpdateApplicationInput struct {
 	_ struct{} `type:"structure"`
 
-	// The current name of the application that you want to change.
+	// The current name of the application you want to change.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
-	// The new name that you want to change the application to.
+	// The new name to give the application.
 	NewApplicationName *string `locationName:"newApplicationName" min:"1" type:"string"`
 }
 
@@ -3279,32 +3329,32 @@ type UpdateDeploymentGroupInput struct {
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
 	// The replacement list of Auto Scaling groups to be included in the deployment
-	// group, if you want to change them. To keep the existing Auto Scaling groups,
-	// enter their names. To remove Auto Scaling groups, do not enter any Auto Scaling
+	// group, if you want to change them. To keep the Auto Scaling groups, enter
+	// their names. To remove Auto Scaling groups, do not enter any Auto Scaling
 	// group names.
 	AutoScalingGroups []*string `locationName:"autoScalingGroups" type:"list"`
 
-	// The current name of the existing deployment group.
+	// The current name of the deployment group.
 	CurrentDeploymentGroupName *string `locationName:"currentDeploymentGroupName" min:"1" type:"string" required:"true"`
 
 	// The replacement deployment configuration name to use, if you want to change
 	// it.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string"`
 
-	// The replacement set of Amazon EC2 tags to filter on, if you want to change
-	// them. To keep the existing tags, enter their names. To remove tags, do not
-	// enter any tag names.
+	// The replacement set of Amazon EC2 tags on which to filter, if you want to
+	// change them. To keep the existing tags, enter their names. To remove tags,
+	// do not enter any tag names.
 	Ec2TagFilters []*EC2TagFilter `locationName:"ec2TagFilters" type:"list"`
 
 	// The new name of the deployment group, if you want to change it.
 	NewDeploymentGroupName *string `locationName:"newDeploymentGroupName" min:"1" type:"string"`
 
-	// The replacement set of on-premises instance tags for filter on, if you want
-	// to change them. To keep the existing tags, enter their names. To remove tags,
-	// do not enter any tag names.
+	// The replacement set of on-premises instance tags on which to filter, if you
+	// want to change them. To keep the existing tags, enter their names. To remove
+	// tags, do not enter any tag names.
 	OnPremisesInstanceTagFilters []*TagFilter `locationName:"onPremisesInstanceTagFilters" type:"list"`
 
-	// A replacement service role's ARN, if you want to change it.
+	// A replacement ARN for the service role, if you want to change it.
 	ServiceRoleArn *string `locationName:"serviceRoleArn" type:"string"`
 
 	// Information about triggers to change when the deployment group is updated.
@@ -3328,7 +3378,7 @@ type UpdateDeploymentGroupOutput struct {
 	// If the output contains no data, and the corresponding deployment group contained
 	// at least one Auto Scaling group, AWS CodeDeploy successfully removed all
 	// corresponding Auto Scaling lifecycle event hooks from the AWS account. If
-	// the output does contain data, AWS CodeDeploy could not remove some Auto Scaling
+	// the output contains data, AWS CodeDeploy could not remove some Auto Scaling
 	// lifecycle event hooks from the AWS account.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
 }

--- a/vendor/github.com/aws/aws-sdk-go/service/codedeploy/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codedeploy/service.go
@@ -11,22 +11,21 @@ import (
 	"github.com/aws/aws-sdk-go/private/signer/v4"
 )
 
-// Overview This is the AWS CodeDeploy API Reference. This guide provides descriptions
-// of the AWS CodeDeploy APIs. For additional information, see the AWS CodeDeploy
-// User Guide (http://docs.aws.amazon.com/codedeploy/latest/userguide).
+// Overview This reference guide provides descriptions of the AWS CodeDeploy
+// APIs. For more information about AWS CodeDeploy, see the AWS CodeDeploy User
+// Guide (docs.aws.amazon.com/codedeploy/latest/userguide).
 //
-// Using the APIs You can use the AWS CodeDeploy APIs to work with the following
-// items:
+// Using the APIs You can use the AWS CodeDeploy APIs to work with the following:
 //
-//   Applications are unique identifiers that AWS CodeDeploy uses to ensure
-// that the correct combinations of revisions, deployment configurations, and
-// deployment groups are being referenced during deployments.
+//   Applications are unique identifiers used by AWS CodeDeploy to ensure the
+// correct combinations of revisions, deployment configurations, and deployment
+// groups are being referenced during deployments.
 //
 // You can use the AWS CodeDeploy APIs to create, delete, get, list, and update
 // applications.
 //
-//   Deployment configurations are sets of deployment rules and deployment
-// success and failure conditions that AWS CodeDeploy uses during deployments.
+//   Deployment configurations are sets of deployment rules and success and
+// failure conditions used by AWS CodeDeploy during deployments.
 //
 // You can use the AWS CodeDeploy APIs to create, delete, get, and list deployment
 // configurations.
@@ -41,22 +40,22 @@ import (
 // are deployed. Instances are identified by their Amazon EC2 tags or Auto Scaling
 // group names. Instances belong to deployment groups.
 //
-// You can use the AWS CodeDeploy APIs to get and list instances.
+// You can use the AWS CodeDeploy APIs to get and list instance.
 //
 //   Deployments represent the process of deploying revisions to instances.
 //
 // You can use the AWS CodeDeploy APIs to create, get, list, and stop deployments.
 //
-//   Application revisions are archive files that are stored in Amazon S3 buckets
-// or GitHub repositories. These revisions contain source content (such as source
-// code, web pages, executable files, any deployment scripts, and similar) along
-// with an Application Specification file (AppSpec file). (The AppSpec file
-// is unique to AWS CodeDeploy; it defines a series of deployment actions that
-// you want AWS CodeDeploy to execute.) An application revision is uniquely
-// identified by its Amazon S3 object key and its ETag, version, or both (for
-// application revisions that are stored in Amazon S3 buckets) or by its repository
-// name and commit ID (for applications revisions that are stored in GitHub
-// repositories). Application revisions are deployed through deployment groups.
+//   Application revisions are archive files stored in Amazon S3 buckets or
+// GitHub repositories. These revisions contain source content (such as source
+// code, web pages, executable files, and deployment scripts) along with an
+// application specification (AppSpec) file. (The AppSpec file is unique to
+// AWS CodeDeploy; it defines the deployment actions you want AWS CodeDeploy
+// to execute.) Ffor application revisions stored in Amazon S3 buckets, an application
+// revision is uniquely identified by its Amazon S3 object key and its ETag,
+// version, or both. For application revisions stored in GitHub repositories,
+// an application revision is uniquely identified by its repository name and
+// commit ID. Application revisions are deployed through deployment groups.
 //
 // You can use the AWS CodeDeploy APIs to get, list, and register application
 // revisions.

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
@@ -796,6 +796,8 @@ type AttributeValue struct {
 	_ struct{} `type:"structure"`
 
 	// A Binary data type.
+	//
+	// B is automatically base64 encoded/decoded by the SDK.
 	B []byte `type:"blob"`
 
 	// A Boolean data type.

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -7983,6 +7983,7 @@ func (s AvailableCapacity) GoString() string {
 type BlobAttributeValue struct {
 	_ struct{} `type:"structure"`
 
+	// Value is automatically base64 encoded/decoded by the SDK.
 	Value []byte `locationName:"value" type:"blob"`
 }
 
@@ -17436,6 +17437,8 @@ type ImportKeyPairInput struct {
 
 	// The public key. You must base64 encode the public key material before sending
 	// it to AWS.
+	//
+	// PublicKeyMaterial is automatically base64 encoded/decoded by the SDK.
 	PublicKeyMaterial []byte `locationName:"publicKeyMaterial" type:"blob" required:"true"`
 }
 
@@ -21903,6 +21906,8 @@ type S3Storage struct {
 
 	// A Base64-encoded Amazon S3 upload policy that gives Amazon EC2 permission
 	// to upload items into Amazon S3 on your behalf.
+	//
+	// UploadPolicy is automatically base64 encoded/decoded by the SDK.
 	UploadPolicy []byte `locationName:"uploadPolicy" type:"blob"`
 
 	// The signature of the Base64 encoded JSON document.

--- a/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
@@ -1349,6 +1349,8 @@ type UploadLayerPartInput struct {
 	_ struct{} `type:"structure"`
 
 	// The base64-encoded layer part payload.
+	//
+	// LayerPartBlob is automatically base64 encoded/decoded by the SDK.
 	LayerPartBlob []byte `locationName:"layerPartBlob" type:"blob" required:"true"`
 
 	// The integer value of the first byte of the layer part.

--- a/vendor/github.com/aws/aws-sdk-go/service/firehose/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/firehose/api.go
@@ -841,6 +841,8 @@ type Record struct {
 
 	// The data blob, which is base64-encoded when the blob is serialized. The maximum
 	// size of the data blob, before base64-encoding, is 1,000 KB.
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/kinesis/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kinesis/api.go
@@ -1333,6 +1333,8 @@ type PutRecordInput struct {
 	// is serialized. When the data blob (the payload before base64-encoding) is
 	// added to the partition key size, the total size must not exceed the maximum
 	// record size (1 MB).
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 
 	// The hash value used to explicitly determine the shard the data record is
@@ -1448,6 +1450,8 @@ type PutRecordsRequestEntry struct {
 	// is serialized. When the data blob (the payload before base64-encoding) is
 	// added to the partition key size, the total size must not exceed the maximum
 	// record size (1 MB).
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 
 	// The hash value used to determine explicitly the shard that the data record
@@ -1523,6 +1527,8 @@ type Record struct {
 	// the blob in any way. When the data blob (the payload before base64-encoding)
 	// is added to the partition key size, the total size must not exceed the maximum
 	// record size (1 MB).
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 
 	// Identifies which shard in the stream the data record is assigned to.

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -1268,6 +1268,8 @@ type DecryptInput struct {
 	_ struct{} `type:"structure"`
 
 	// Ciphertext to be decrypted. The blob includes metadata.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
 	// The encryption context. If this was specified in the Encrypt function, it
@@ -1301,6 +1303,8 @@ type DecryptOutput struct {
 
 	// Decrypted plaintext data. This value may not be returned if the customer
 	// master key is not available or if you didn't have permission to use it.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob"`
 }
 
@@ -1551,6 +1555,8 @@ type EncryptInput struct {
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Data to be encrypted.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" required:"true"`
 }
 
@@ -1569,6 +1575,8 @@ type EncryptOutput struct {
 
 	// The encrypted plaintext. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The ID of the key used during encryption.
@@ -1638,6 +1646,8 @@ type GenerateDataKeyOutput struct {
 	//
 	// If you are using the CLI, the value is Base64 encoded. Otherwise, it is
 	// not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// System generated unique identifier of the key to be used to decrypt the encrypted
@@ -1646,6 +1656,8 @@ type GenerateDataKeyOutput struct {
 
 	// Plaintext that contains the data key. Use this for encryption and decryption
 	// and then remove it from memory as soon as possible.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob"`
 }
 
@@ -1708,6 +1720,8 @@ type GenerateDataKeyWithoutPlaintextOutput struct {
 	//
 	// If you are using the CLI, the value is Base64 encoded. Otherwise, it is
 	// not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// System generated unique identifier of the key to be used to decrypt the encrypted
@@ -1747,6 +1761,8 @@ type GenerateRandomOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Plaintext that contains the unpredictable byte string.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob"`
 }
 
@@ -2307,6 +2323,8 @@ type ReEncryptInput struct {
 	_ struct{} `type:"structure"`
 
 	// Ciphertext of the data to re-encrypt.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
 	// Encryption context to be used when the data is re-encrypted.
@@ -2347,6 +2365,8 @@ type ReEncryptOutput struct {
 
 	// The re-encrypted data. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// Unique identifier of the key used to re-encrypt the data.

--- a/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
@@ -1341,6 +1341,8 @@ type FunctionCode struct {
 	// AWS CLI, the SDKs or CLI will do the encoding for you). For more information
 	// about creating a .zip file, go to Execution Permissions (http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#lambda-intro-execution-role.html)
 	// in the AWS Lambda Developer Guide.
+	//
+	// ZipFile is automatically base64 encoded/decoded by the SDK.
 	ZipFile []byte `type:"blob"`
 }
 
@@ -2126,6 +2128,8 @@ type UpdateFunctionCodeInput struct {
 	S3ObjectVersion *string `min:"1" type:"string"`
 
 	// Based64-encoded .zip file containing your packaged source code.
+	//
+	// ZipFile is automatically base64 encoded/decoded by the SDK.
 	ZipFile []byte `type:"blob"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/customizations.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/customizations.go
@@ -5,11 +5,20 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/restxml"
 )
 
 func init() {
 	initClient = func(c *client.Client) {
 		c.Handlers.Build.PushBack(sanitizeURL)
+	}
+
+	initRequest = func(r *request.Request) {
+		switch r.Operation.Name {
+		case opChangeResourceRecordSets:
+			r.Handlers.UnmarshalError.Remove(restxml.UnmarshalErrorHandler)
+			r.Handlers.UnmarshalError.PushBack(unmarshalChangeResourceRecordSetsError)
+		}
 	}
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/unmarshal_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/unmarshal_error.go
@@ -1,0 +1,77 @@
+package route53
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io/ioutil"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/restxml"
+)
+
+type baseXMLErrorResponse struct {
+	XMLName xml.Name
+}
+
+type standardXMLErrorResponse struct {
+	XMLName   xml.Name `xml:"ErrorResponse"`
+	Code      string   `xml:"Error>Code"`
+	Message   string   `xml:"Error>Message"`
+	RequestID string   `xml:"RequestId"`
+}
+
+type invalidChangeBatchXMLErrorResponse struct {
+	XMLName  xml.Name `xml:"InvalidChangeBatch"`
+	Messages []string `xml:"Messages>Message"`
+}
+
+func unmarshalChangeResourceRecordSetsError(r *request.Request) {
+	defer r.HTTPResponse.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(r.HTTPResponse.Body)
+
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to read Route53 XML error response", err)
+		return
+	}
+
+	baseError := &baseXMLErrorResponse{}
+
+	if err := xml.Unmarshal(responseBody, baseError); err != nil {
+		r.Error = awserr.New("SerializationError", "failed to decode Route53 XML error response", err)
+		return
+	}
+
+	switch baseError.XMLName.Local {
+	case "InvalidChangeBatch":
+		unmarshalInvalidChangeBatchError(r, responseBody)
+	default:
+		r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewReader(responseBody))
+		restxml.UnmarshalError(r)
+	}
+}
+
+func unmarshalInvalidChangeBatchError(r *request.Request, requestBody []byte) {
+	resp := &invalidChangeBatchXMLErrorResponse{}
+	err := xml.Unmarshal(requestBody, resp)
+
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to decode query XML error response", err)
+		return
+	}
+
+	const errorCode = "InvalidChangeBatch"
+	errors := []error{}
+
+	for _, msg := range resp.Messages {
+		errors = append(errors, awserr.New(errorCode, msg, nil))
+	}
+
+	r.Error = awserr.NewRequestFailure(
+		awserr.NewBatchError(errorCode, "ChangeBatch errors occured", errors),
+		r.HTTPResponse.StatusCode,
+		r.RequestID,
+	)
+
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -297,6 +297,7 @@ func (c *S3) DeleteBucketReplicationRequest(input *DeleteBucketReplicationInput)
 	return
 }
 
+// Deletes the replication configuration from the bucket.
 func (c *S3) DeleteBucketReplication(input *DeleteBucketReplicationInput) (*DeleteBucketReplicationOutput, error) {
 	req, out := c.DeleteBucketReplicationRequest(input)
 	err := req.Send()
@@ -688,6 +689,7 @@ func (c *S3) GetBucketReplicationRequest(input *GetBucketReplicationInput) (req 
 	return
 }
 
+// Deprecated, see the GetBucketReplicationConfiguration operation.
 func (c *S3) GetBucketReplication(input *GetBucketReplicationInput) (*GetBucketReplicationOutput, error) {
 	req, out := c.GetBucketReplicationRequest(input)
 	err := req.Send()
@@ -1670,6 +1672,26 @@ func (c *S3) UploadPartCopy(input *UploadPartCopyInput) (*UploadPartCopyOutput, 
 	return out, err
 }
 
+// Specifies the days since the initiation of an Incomplete Multipart Upload
+// that Lifecycle will wait before permanently removing all parts of the upload.
+type AbortIncompleteMultipartUpload struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates the number of days that must pass since initiation for Lifecycle
+	// to abort an Incomplete Multipart Upload.
+	DaysAfterInitiation *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s AbortIncompleteMultipartUpload) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AbortIncompleteMultipartUpload) GoString() string {
+	return s.String()
+}
+
 type AbortMultipartUploadInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2396,6 +2418,13 @@ func (s CreateMultipartUploadInput) GoString() string {
 type CreateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
+	// Date when multipart upload will become eligible for abort operation by lifecycle.
+	AbortDate *time.Time `location:"header" locationName:"x-amz-abort-date" type:"timestamp" timestampFormat:"rfc822"`
+
+	// Id of the lifecycle rule that makes a multipart upload eligible for abort
+	// operation.
+	AbortRuleId *string `location:"header" locationName:"x-amz-abort-rule-id" type:"string"`
+
 	// Name of the bucket to which the multipart upload was initiated.
 	Bucket *string `locationName:"Bucket" type:"string"`
 
@@ -3108,7 +3137,7 @@ func (s GetBucketLoggingOutput) GoString() string {
 type GetBucketNotificationConfigurationRequest struct {
 	_ struct{} `type:"structure"`
 
-	// Name of the buket to get the notification configuration for.
+	// Name of the bucket to get the notification configuration for.
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
@@ -3972,6 +4001,12 @@ type LifecycleExpiration struct {
 	// Indicates the lifetime, in days, of the objects that are subject to the rule.
 	// The value must be a non-zero positive integer.
 	Days *int64 `type:"integer"`
+
+	// Indicates whether Amazon S3 will remove a delete marker with no noncurrent
+	// versions. If set to true, the delete marker will be expired; if set to false
+	// the policy takes no action. This cannot be specified with Days or Date in
+	// a Lifecycle Expiration Policy.
+	ExpiredObjectDeleteMarker *bool `type:"boolean"`
 }
 
 // String returns the string representation
@@ -3986,6 +4021,10 @@ func (s LifecycleExpiration) GoString() string {
 
 type LifecycleRule struct {
 	_ struct{} `type:"structure"`
+
+	// Specifies the days since the initiation of an Incomplete Multipart Upload
+	// that Lifecycle will wait before permanently removing all parts of the upload.
+	AbortIncompleteMultipartUpload *AbortIncompleteMultipartUpload `type:"structure"`
 
 	Expiration *LifecycleExpiration `type:"structure"`
 
@@ -4358,6 +4397,13 @@ func (s ListPartsInput) GoString() string {
 
 type ListPartsOutput struct {
 	_ struct{} `type:"structure"`
+
+	// Date when multipart upload will become eligible for abort operation by lifecycle.
+	AbortDate *time.Time `location:"header" locationName:"x-amz-abort-date" type:"timestamp" timestampFormat:"rfc822"`
+
+	// Id of the lifecycle rule that makes a multipart upload eligible for abort
+	// operation.
+	AbortRuleId *string `location:"header" locationName:"x-amz-abort-rule-id" type:"string"`
 
 	// Name of the bucket to which the multipart upload was initiated.
 	Bucket *string `type:"string"`
@@ -5228,6 +5274,7 @@ type PutObjectInput struct {
 	// Object data.
 	Body io.ReadSeeker `type:"blob"`
 
+	// Name of the bucket to which the PUT operation was initiated.
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Specifies caching behavior along the request/reply chain.
@@ -5266,6 +5313,7 @@ type PutObjectInput struct {
 	// Allows grantee to write the ACL for the applicable object.
 	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
 
+	// Object key for which the PUT operation was initiated.
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
 
 	// A map of metadata to store with the object in S3.
@@ -5641,6 +5689,10 @@ func (s RoutingRule) GoString() string {
 type Rule struct {
 	_ struct{} `type:"structure"`
 
+	// Specifies the days since the initiation of an Incomplete Multipart Upload
+	// that Lifecycle will wait before permanently removing all parts of the upload.
+	AbortIncompleteMultipartUpload *AbortIncompleteMultipartUpload `type:"structure"`
+
 	Expiration *LifecycleExpiration `type:"structure"`
 
 	// Unique identifier for the rule. The value cannot be longer than 255 characters.
@@ -5947,14 +5999,17 @@ func (s UploadPartCopyOutput) GoString() string {
 type UploadPartInput struct {
 	_ struct{} `type:"structure" payload:"Body"`
 
+	// Object data.
 	Body io.ReadSeeker `type:"blob"`
 
+	// Name of the bucket to which the multipart upload was initiated.
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Size of the body in bytes. This parameter is useful when the size of the
 	// body cannot be determined automatically.
 	ContentLength *int64 `location:"header" locationName:"Content-Length" type:"integer"`
 
+	// Object key for which the multipart upload was initiated.
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
 
 	// Part number of part being uploaded. This is a positive integer between 1

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -20,6 +21,7 @@ type xmlErrorResponse struct {
 
 func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
+	defer io.Copy(ioutil.Discard, r.HTTPResponse.Body)
 
 	if r.HTTPResponse.StatusCode == http.StatusMovedPermanently {
 		r.Error = awserr.NewRequestFailure(

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/waiters.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/waiters.go
@@ -22,6 +22,12 @@ func (c *S3) WaitUntilBucketExists(input *HeadBucketInput) error {
 				State:    "success",
 				Matcher:  "status",
 				Argument: "",
+				Expected: 301,
+			},
+			{
+				State:    "success",
+				Matcher:  "status",
+				Argument: "",
 				Expected: 403,
 			},
 			{

--- a/vendor/github.com/aws/aws-sdk-go/service/sns/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sns/api.go
@@ -1608,6 +1608,8 @@ type MessageAttributeValue struct {
 
 	// Binary type attributes can store any binary data, for example, compressed
 	// data, encrypted data, or images.
+	//
+	// BinaryValue is automatically base64 encoded/decoded by the SDK.
 	BinaryValue []byte `type:"blob"`
 
 	// Amazon SNS supports the following logical data types: String, Number, and

--- a/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
@@ -1393,6 +1393,8 @@ type MessageAttributeValue struct {
 
 	// Binary type attributes can store any binary data, for example, compressed
 	// data, encrypted data, or images.
+	//
+	// BinaryValue is automatically base64 encoded/decoded by the SDK.
 	BinaryValue []byte `type:"blob"`
 
 	// Amazon SQS supports the following logical data types: String, Number, and


### PR DESCRIPTION
Fixes #5540

Also updated the AWS Go SDK from 1.1.9 -> 1.1.12 as this was required to
allow the new behavior for the Redshift API

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftCluster' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftCluster -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_basic
--- PASS: TestAccAWSRedshiftCluster_basic (651.26s)
=== RUN   TestAccAWSRedshiftCluster_publiclyAccessible
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (752.17s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1403.431s
```