### PR TITLE
Pulling out the hardcoded test user in the Github provider for #5729

### DIFF
--- a/builtin/providers/github/provider_test.go
+++ b/builtin/providers/github/provider_test.go
@@ -35,4 +35,7 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GITHUB_ORGANIZATION"); v == "" {
 		t.Fatal("GITHUB_ORGANIZATION must be set for acceptance tests")
 	}
+	if v := os.Getenv("GITHUB_TEST_USER"); v == "" {
+		t.Fatal("GITHUB_TEST_USER must be set for acceptance tests")
+	}
 }

--- a/builtin/providers/github/resource_github_membership_test.go
+++ b/builtin/providers/github/resource_github_membership_test.go
@@ -7,10 +7,19 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"os"
 )
 
 func TestAccGithubMembership_basic(t *testing.T) {
 	var membership github.Membership
+
+	testUser := os.Getenv("GITHUB_TEST_USER")
+	testAccGithubMembershipConfig := fmt.Sprintf(`
+		resource "github_membership" "test_org_membership" {
+			username = "%s"
+			role = "member"
+		}
+	`, testUser)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -104,10 +113,3 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 		return nil
 	}
 }
-
-const testAccGithubMembershipConfig = `
-resource "github_membership" "test_org_membership" {
-	username = "TerraformDummyUser"
-	role = "member"
-}
-`

--- a/builtin/providers/github/resource_github_team_membership_test.go
+++ b/builtin/providers/github/resource_github_team_membership_test.go
@@ -7,10 +7,48 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"os"
 )
 
 func TestAccGithubTeamMembership_basic(t *testing.T) {
 	var membership github.Membership
+
+	testUser := os.Getenv("GITHUB_TEST_USER")
+	testAccGithubTeamMembershipConfig := fmt.Sprintf(`
+		resource "github_membership" "test_org_membership" {
+			username = "%s"
+			role = "member"
+		}
+
+		resource "github_team" "test_team" {
+			name = "foo"
+			description = "Terraform acc test group"
+		}
+
+		resource "github_team_membership" "test_team_membership" {
+			team_id = "${github_team.test_team.id}"
+			username = "%s"
+			role = "member"
+		}
+	`, testUser, testUser)
+
+	testAccGithubTeamMembershipUpdateConfig := fmt.Sprintf(`
+		resource "github_membership" "test_org_membership" {
+			username = "%s"
+			role = "member"
+		}
+
+		resource "github_team" "test_team" {
+			name = "foo"
+			description = "Terraform acc test group"
+		}
+
+		resource "github_team_membership" "test_team_membership" {
+			team_id = "${github_team.test_team.id}"
+			username = "%s"
+			role = "maintainer"
+		}
+	`, testUser, testUser)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -114,39 +152,3 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 		return nil
 	}
 }
-
-const testAccGithubTeamMembershipConfig = `
-resource "github_membership" "test_org_membership" {
-	username = "TerraformDummyUser"
-	role = "member"
-}
-
-resource "github_team" "test_team" {
-	name = "foo"
-	description = "Terraform acc test group"
-}
-
-resource "github_team_membership" "test_team_membership" {
-	team_id = "${github_team.test_team.id}"
-	username = "TerraformDummyUser"
-	role = "member"
-}
-`
-
-const testAccGithubTeamMembershipUpdateConfig = `
-resource "github_membership" "test_org_membership" {
-	username = "TerraformDummyUser"
-	role = "member"
-}
-
-resource "github_team" "test_team" {
-	name = "foo"
-	description = "Terraform acc test group"
-}
-
-resource "github_team_membership" "test_team_membership" {
-	team_id = "${github_team.test_team.id}"
-	username = "TerraformDummyUser"
-	role = "maintainer"
-}
-`


### PR DESCRIPTION
From now on to run the acceptance tests a `GITHUB_TEST_USER` environment variable will have to be set with a valid Github user.