### PR TITLE
provider/digitalocean: Check for nil response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ BUG FIXES:
   * core: Modules sourced from a Mercurial repository now work correctly on Windows [GH-5739]
   * provider/aws: Fix crash when an `aws_rds_cluster_instance` is removed outside of Terraform [GH-5717]
   * provider/aws: `aws_lambda_function` resources no longer error on refresh if deleted externally to Terraform [GH-5668]
+  * provider/aws: `aws_vpn_connection` resources deleted via the console on longer cause a crash [GH-5747]
   * provider/google: Default description `google_dns_managed_zone` resources to "Managed By Terraform" [GH-5428]
   * provider/google: Fix error message on invalid instance URL for `google_compute_instance_group` [GH-5715]
 

--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
@@ -74,7 +74,7 @@ func resourceDigitalOceanSSHKeyRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		// If the key is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
This applies the same fix to `digitalocean_ssh_key` as #5588 applies to droplets. The report there gives weight to my theory that this occurs when there are transport issues.

Fixes #5402.