### PR TITLE
provisioner/remote-exec: Move script cleanup after command wait

### DIFF
--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -176,8 +176,8 @@ func (p *ResourceProvisioner) runScripts(
 		go p.copyOutput(o, outR, outDoneCh)
 		go p.copyOutput(o, errR, errDoneCh)
 
+		remotePath := comm.ScriptPath()
 		err = retryFunc(comm.Timeout(), func() error {
-			remotePath := comm.ScriptPath()
 
 			if err := comm.UploadScript(remotePath, script); err != nil {
 				return fmt.Errorf("Failed to upload script: %v", err)
@@ -190,13 +190,6 @@ func (p *ResourceProvisioner) runScripts(
 			}
 			if err := comm.Start(cmd); err != nil {
 				return fmt.Errorf("Error starting script: %v", err)
-			}
-
-			// Upload a blank follow up file in the same path to prevent residual
-			// script contents from remaining on remote machine
-			empty := bytes.NewReader([]byte(""))
-			if err := comm.Upload(remotePath, empty); err != nil {
-				return fmt.Errorf("Failed to upload empty follow up script: %v", err)
 			}
 
 			return nil
@@ -213,6 +206,14 @@ func (p *ResourceProvisioner) runScripts(
 		errW.Close()
 		<-outDoneCh
 		<-errDoneCh
+
+		// Upload a blank follow up file in the same path to prevent residual
+		// script contents from remaining on remote machine
+		empty := bytes.NewReader([]byte(""))
+		if err := comm.Upload(remotePath, empty); err != nil {
+			// This feature is best-effort.
+			log.Printf("[WARN] Failed to upload empty follow up script: %v", err)
+		}
 
 		// If we have an error, return it out now that we've cleaned up
 		if err != nil {


### PR DESCRIPTION
The script cleanup step added in #5577 was positioned before the
`cmd.Wait()` call to ensure the command completes. This was causing
non-deterministic failures, especially for longer running scripts.

Fixes #5699
Fixes #5737