### PR TITLE
config: remove missing equals test to fix build

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -242,13 +242,6 @@ func TestConfigValidate_outputBadField(t *testing.T) {
 	}
 }
 
-func TestConfigValidate_outputMissingEquals(t *testing.T) {
-	c := testConfig(t, "validate-output-missing-equals")
-	if err := c.Validate(); err == nil {
-		t.Fatal("should not be valid")
-	}
-}
-
 func TestConfigValidate_pathVar(t *testing.T) {
 	c := testConfig(t, "validate-path-var")
 	if err := c.Validate(); err != nil {

--- a/config/test-fixtures/validate-output-missing-equals/main.tf
+++ b/config/test-fixtures/validate-output-missing-equals/main.tf
@@ -1,3 +1,0 @@
-output "whoops" {
-  value "wheresmyequals"
-}


### PR DESCRIPTION
This is behavior that's covered in the parser now - and the error
message is nicer to boot!