### PR TITLE
communicator/winrm: Fixed HTTPS when using copy client.

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -193,12 +193,21 @@ func (c *Communicator) UploadDir(dst string, src string) error {
 
 func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 	addr := fmt.Sprintf("%s:%d", c.endpoint.Host, c.endpoint.Port)
-	return winrmcp.New(addr, &winrmcp.Config{
+
+	config := winrmcp.Config{
 		Auth: winrmcp.Auth{
 			User:     c.connInfo.User,
 			Password: c.connInfo.Password,
 		},
+		Https:                 c.connInfo.HTTPS,
+		Insecure:              c.connInfo.Insecure,
 		OperationTimeout:      c.Timeout(),
 		MaxOperationsPerShell: 15, // lowest common denominator
-	})
+	}
+
+	if c.connInfo.CACert != nil {
+		config.CACertBytes = *c.connInfo.CACert
+	}
+
+	return winrmcp.New(addr, &config)
 }


### PR DESCRIPTION
HTTPS connection info was not being passed to winrmcp in the WinRM communicator.  This prevented provisioners from working properly over HTTPS when copying files to the VM.  This PR fixes this.

This is related to [issue #3473](https://github.com/hashicorp/terraform/issues/3473).