### PR TITLE
provider/azurerm: Fix a potential panic in the `azurerm_template_deployment` resource

### DIFF
--- a/builtin/providers/azurerm/resource_arm_template_deployment.go
+++ b/builtin/providers/azurerm/resource_arm_template_deployment.go
@@ -143,9 +143,8 @@ func resourceArmTemplateDeploymentRead(d *schema.ResourceData, meta interface{})
 	}
 	var outputs map[string]string
 	if resp.Properties.Outputs != nil && len(*resp.Properties.Outputs) > 0 {
+		outputs = make(map[string]string)
 		for key, output := range *resp.Properties.Outputs {
-			log.Printf("[INFO] Found Key %s", key)
-
 			outputMap := output.(map[string]interface{})
 			outputValue, ok := outputMap["value"]
 			if !ok {
@@ -156,6 +155,7 @@ func resourceArmTemplateDeploymentRead(d *schema.ResourceData, meta interface{})
 			outputs[key] = outputValue.(string)
 		}
 	}
+
 	d.Set("outputs", outputs)
 
 	return nil


### PR DESCRIPTION
There was a panic because I wasn't actually constructing the map after the var declaration

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMTemplateDeployment' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMTemplateDeployment -timeout 120m
=== RUN   TestAccAzureRMTemplateDeployment_basic
--- PASS: TestAccAzureRMTemplateDeployment_basic (374.77s)
=== RUN   TestAccAzureRMTemplateDeployment_withParams
--- PASS: TestAccAzureRMTemplateDeployment_withParams (413.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	788.662s
```