### PR TITLE
documentation: Reshuffle the AzureRM provider documentation headings

### DIFF
--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -11,8 +11,13 @@
               <a href="/docs/providers/azurerm/index.html">Azure Resource Manager Provider</a>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-resource-group") %>>
-              <a href="/docs/providers/azurerm/r/resource_group.html">azurerm_resource_group</a>
+            <li<%= sidebar_current(/^docs-azurerm-resource-resource/) %>>
+              <a href="#">Base Resources</a>
+              <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-azurerm-resource-resource-group") %>>
+                  <a href="/docs/providers/azurerm/r/resource_group.html">azurerm_resource_group</a>
+                </li>
+              </ul>
             </li>
 
             <li<%= sidebar_current(/^docs-azurerm-resource-cdn/) %>>
@@ -163,9 +168,16 @@
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-template-deployment") %>>
-              <a href="/docs/providers/azurerm/r/template_deployment.html">azurerm_template_deployment</a>
+            <li<%= sidebar_current(/^docs-azurerm-resource-template/) %>>
+              <a href="#">Template Resources</a>
+              <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-azurerm-resource-template-deployment") %>>
+                  <a href="/docs/providers/azurerm/r/template_deployment.html">azurerm_template_deployment</a>
+                </li>
+              </ul>
             </li>
+
+
 
             <li<%= sidebar_current(/^docs-azurerm-resource-virtualmachine/) %>>
               <a href="#">Virtual Machine Resources</a>


### PR DESCRIPTION
<img width="301" alt="screen shot 2016-03-22 at 14 18 44" src="https://cloud.githubusercontent.com/assets/227823/13954512/0afca7fe-f039-11e5-8e07-d8b9e981ad93.png">

<img width="294" alt="screen shot 2016-03-22 at 14 18 49" src="https://cloud.githubusercontent.com/assets/227823/13954522/1713183e-f039-11e5-9bbc-c004dd054211.png">
