### PR TITLE
provider/aws: Fix aws_route panic when destination CIDR block is nil

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -294,7 +294,7 @@ func resourceAwsRouteExists(d *schema.ResourceData, meta interface{}) (bool, err
 
 	cidr := d.Get("destination_cidr_block").(string)
 	for _, route := range (*res.RouteTables[0]).Routes {
-		if *route.DestinationCidrBlock == cidr {
+		if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == cidr {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Fixes #5754