### PR TITLE
ISSUE-5702: Making the Cloudwatch Event Rule Target target_id optional

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
@@ -29,10 +29,10 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 			},
 
 			"target_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
 				ValidateFunc: validateCloudWatchEventTargetId,
 			},
 

--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,7 +30,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 
 			"target_id": &schema.Schema{
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateCloudWatchEventTargetId,
 			},
@@ -60,7 +61,13 @@ func resourceAwsCloudWatchEventTargetCreate(d *schema.ResourceData, meta interfa
 	conn := meta.(*AWSClient).cloudwatcheventsconn
 
 	rule := d.Get("rule").(string)
-	targetId := d.Get("target_id").(string)
+
+	var targetId string
+	if v, ok := d.GetOk("target_id"); ok {
+		targetId = v.(string)
+	} else {
+		targetId = resource.UniqueId()
+	}
 
 	input := buildPutTargetInputStruct(d)
 	log.Printf("[DEBUG] Creating CloudWatch Event Target: %s", input)

--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
@@ -42,6 +42,27 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
+	var target events.Target
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudWatchEventTargetConfigMissingTargetId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
+					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "rule", "tf-acc-cw-event-rule-basic"),
+					resource.TestMatchResourceAttr("aws_cloudwatch_event_target.moobar", "arn", regexp.MustCompile(":tf-acc-moon$")),
+					testAccCheckTargetIdExists("aws_cloudwatch_event_target.target_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudWatchEventTarget_full(t *testing.T) {
 	var target events.Target
 
@@ -105,6 +126,17 @@ func testAccCheckAWSCloudWatchEventTargetDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckTargetIdExists(targetId string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[targetId]
+		if !ok {
+			return fmt.Errorf("Not found: %s", targetId)
+		}
+
+		return nil
+	}
+}
+
 var testAccAWSCloudWatchEventTargetConfig = `
 resource "aws_cloudwatch_event_rule" "foo" {
 	name = "tf-acc-cw-event-rule-basic"
@@ -114,6 +146,22 @@ resource "aws_cloudwatch_event_rule" "foo" {
 resource "aws_cloudwatch_event_target" "moobar" {
 	rule = "${aws_cloudwatch_event_rule.foo.name}"
 	target_id = "tf-acc-cw-target-basic"
+	arn = "${aws_sns_topic.moon.arn}"
+}
+
+resource "aws_sns_topic" "moon" {
+	name = "tf-acc-moon"
+}
+`
+
+var testAccAWSCloudWatchEventTargetConfigMissingTargetId = `
+resource "aws_cloudwatch_event_rule" "foo" {
+	name = "tf-acc-cw-event-rule-basic"
+	schedule_expression = "rate(1 hour)"
+}
+
+resource "aws_cloudwatch_event_target" "moobar" {
+	rule = "${aws_cloudwatch_event_rule.foo.name}"
 	arn = "${aws_sns_topic.moon.arn}"
 }
 

--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
@@ -43,6 +43,8 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 }
 
 func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
+	var target events.Target
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -51,7 +53,10 @@ func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSCloudWatchEventTargetConfigMissingTargetId,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetIdExists("aws_cloudwatch_event_target.target_id"),
+					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
+					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "rule", "tf-acc-cw-event-rule-missing-target-id"),
+					resource.TestMatchResourceAttr("aws_cloudwatch_event_target.moobar", "arn",
+						regexp.MustCompile(":tf-acc-moon$")),
 				),
 			},
 		},
@@ -151,7 +156,7 @@ resource "aws_sns_topic" "moon" {
 
 var testAccAWSCloudWatchEventTargetConfigMissingTargetId = `
 resource "aws_cloudwatch_event_rule" "foo" {
-	name = "tf-acc-cw-event-rule-basic"
+	name = "tf-acc-cw-event-rule-missing-target-id"
 	schedule_expression = "rate(1 hour)"
 }
 
@@ -161,7 +166,7 @@ resource "aws_cloudwatch_event_target" "moobar" {
 }
 
 resource "aws_sns_topic" "moon" {
-	name = "tf-acc-moon"
+	name = "tf-acc-moon-1"
 }
 `
 

--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
@@ -166,7 +166,7 @@ resource "aws_cloudwatch_event_target" "moobar" {
 }
 
 resource "aws_sns_topic" "moon" {
-	name = "tf-acc-moon-1"
+	name = "tf-acc-moon"
 }
 `
 

--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
@@ -43,8 +43,6 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 }
 
 func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
-	var target events.Target
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -53,9 +51,6 @@ func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSCloudWatchEventTargetConfigMissingTargetId,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "rule", "tf-acc-cw-event-rule-basic"),
-					resource.TestMatchResourceAttr("aws_cloudwatch_event_target.moobar", "arn", regexp.MustCompile(":tf-acc-moon$")),
 					testAccCheckTargetIdExists("aws_cloudwatch_event_target.target_id"),
 				),
 			},

--- a/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
@@ -50,7 +50,7 @@ resource "aws_kinesis_stream" "test_stream" {
 The following arguments are supported:
 
 * `rule` - (Required) The name of the rule you want to add targets to.
-* `target_id` - (Required) The unique target assignment ID.
+* `target_id` - (Optional) The unique target assignment ID.  If missing, will generate an unique id. 
 * `arn` - (Required) The Amazon Resource Name (ARN) associated of the target.
 * `input` - (Optional) Valid JSON text passed to the target.
 * `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/)

--- a/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
@@ -50,7 +50,7 @@ resource "aws_kinesis_stream" "test_stream" {
 The following arguments are supported:
 
 * `rule` - (Required) The name of the rule you want to add targets to.
-* `target_id` - (Optional) The unique target assignment ID.  If missing, will generate an unique id. 
+* `target_id` - (Optional) The unique target assignment ID.  If missing, will generate a random, unique id. 
 * `arn` - (Required) The Amazon Resource Name (ARN) associated of the target.
 * `input` - (Optional) Valid JSON text passed to the target.
 * `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/)


### PR DESCRIPTION
According to the AWS documentation, the target_id is being used to guarantee the uniqueness of the CloudWatch rule target.  According to the discussion in https://github.com/hashicorp/terraform/issues/5702, it makes developer life eaiser by having target_id be optional and let terraform to generate the unique ID.
