### PR TITLE
Make datadog message, escalation_message, and query work with heredoc

### DIFF
--- a/builtin/providers/datadog/resource_datadog_monitor.go
+++ b/builtin/providers/datadog/resource_datadog_monitor.go
@@ -27,14 +27,23 @@ func resourceDatadogMonitor() *schema.Resource {
 			"message": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				StateFunc: func(val interface{}) string {
+					return strings.TrimSpace(val.(string))
+				},
 			},
 			"escalation_message": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				StateFunc: func(val interface{}) string {
+					return strings.TrimSpace(val.(string))
+				},
 			},
 			"query": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				StateFunc: func(val interface{}) string {
+					return strings.TrimSpace(val.(string))
+				},
 			},
 			"type": &schema.Schema{
 				Type:     schema.TypeString,
@@ -296,7 +305,7 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 	m.Options = o
 
 	if err = client.UpdateMonitor(m); err != nil {
-		return fmt.Errorf("error updating montor: %s", err.Error())
+		return fmt.Errorf("error updating monitor: %s", err.Error())
 	}
 
 	return resourceDatadogMonitorRead(d, meta)


### PR DESCRIPTION
I wrote this patch for my own company (Meteor), after running in to the issue covered by:
https://github.com/hashicorp/terraform/issues/5642
This patch uses the same fix suggested there, just applied to a couple other relevant fields where heredocs are desirable. Datadog didn't seem to strip "name" based on my testing.

Here's the output from a run of the acceptance tests (including the one I'm adding)

==> Checking that code complies with gofmt requirements...
/usr/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/datadog -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDatadogMonitor_Basic
--- PASS: TestAccDatadogMonitor_Basic (97.48s)
=== RUN   TestAccDatadogMonitor_Updated
--- PASS: TestAccDatadogMonitor_Updated (95.86s)
=== RUN   TestAccDatadogMonitor_TrimWhitespace
--- PASS: TestAccDatadogMonitor_TrimWhitespace (68.40s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/datadog	261.738s

Sorry if I missed anything... first time contributing to terraform :).