### PR TITLE
provider/aws: Fix multiple root block devices detection logic

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -274,11 +274,11 @@ func resourceAwsInstance() *schema.Resource {
 			},
 
 			"root_block_device": &schema.Schema{
-				// TODO: This is a set because we don't support singleton
+				// TODO: This is a list because we don't support singleton
 				//       sub-resources today. We'll enforce that the set only ever has
 				//       length zero or one below. When TF gains support for
 				//       sub-resources this can be converted.
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -314,10 +314,6 @@ func resourceAwsInstance() *schema.Resource {
 							ForceNew: true,
 						},
 					},
-				},
-				Set: func(v interface{}) int {
-					// there can be only one root device; no need to hash anything
-					return 0
 				},
 			},
 		},
@@ -879,7 +875,7 @@ func readBlockDeviceMappingsFromConfig(
 	}
 
 	if v, ok := d.GetOk("root_block_device"); ok {
-		vL := v.(*schema.Set).List()
+		vL := v.([]interface{})
 		if len(vL) > 1 {
 			return nil, fmt.Errorf("Cannot specify more than one root_block_device.")
 		}

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -297,6 +297,31 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_withMultipleRootBlockDevices(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: `
+				resource "aws_instance" "foo" {
+					ami = "ami-5189a661"
+					instance_type = "t2.micro"
+					root_block_device {
+						volume_type = "gp2"
+						volume_size = 10
+					}
+					root_block_device {
+						volume_type = "standard"
+						volume_size = 10
+					}
+				}`,
+				ExpectApplyError: "Cannot specify more than one root_block_device.",
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_multipleRegions(t *testing.T) {
 	var v ec2.Instance
 

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -230,11 +230,11 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 			},
 
 			"root_block_device": &schema.Schema{
-				// TODO: This is a set because we don't support singleton
+				// TODO: This is a list because we don't support singleton
 				//       sub-resources today. We'll enforce that the set only ever has
 				//       length zero or one below. When TF gains support for
 				//       sub-resources this can be converted.
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -270,10 +270,6 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							ForceNew: true,
 						},
 					},
-				},
-				Set: func(v interface{}) int {
-					// there can be only one root device; no need to hash anything
-					return 0
 				},
 			},
 		},
@@ -371,7 +367,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("root_block_device"); ok {
-		vL := v.(*schema.Set).List()
+		vL := v.([]interface{})
 		if len(vL) > 1 {
 			return fmt.Errorf("Cannot specify more than one root_block_device.")
 		}

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -135,6 +135,31 @@ func TestAccAWSLaunchConfiguration_withEncryption(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchConfiguration_withMultipleRootBlockDevices(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: `
+				resource "aws_launch_configuration" "foo" {
+					image_id = "ami-5189a661"
+					instance_type = "t2.micro"
+					root_block_device {
+						volume_type = "gp2"
+						volume_size = 10
+					}
+					root_block_device {
+						volume_type = "standard"
+						volume_size = 10
+					}
+				}`,
+				ExpectApplyError: "Cannot specify more than one root_block_device.",
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(
 	resource, prefix string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -87,6 +87,10 @@ type TestStep struct {
 	// Destroy will create a destroy plan if set to true.
 	Destroy bool
 
+	// ExpectApplyError can be set to an error string for tests that expect
+	// an apply error to occur. Can be used to validate bad configurations.
+	ExpectApplyError string
+
 	// ExpectNonEmptyPlan can be set to true for specific types of tests that are
 	// looking to verify that a diff occurs
 	ExpectNonEmptyPlan bool
@@ -281,7 +285,12 @@ func testStep(
 	// Apply!
 	state, err = ctx.Apply()
 	if err != nil {
+		if strings.Contains(err.Error(), step.ExpectApplyError) {
+			return state, nil
+		}
 		return state, fmt.Errorf("Error applying: %s", err)
+	} else if len(step.ExpectApplyError) > 0 {
+		return state, fmt.Errorf("Expected apply error: %s", step.ExpectApplyError)
 	}
 
 	// Check! Excitement!


### PR DESCRIPTION
Fix the multiple root block device detection logic for the AWS instance and launch configuration resources. The resources were originally modeled as a TypeSet with a zero hash function. This would silently result in an unexpected configuration if multiple root block devices were specified since they all hashed to the same value.
