### PR TITLE
provider/aws: Cleanup auto scaling group wait for capacity logic

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -235,7 +235,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	d.SetId(d.Get("name").(string))
 	log.Printf("[INFO] AutoScaling Group ID: %s", d.Id())
 
-	if err := waitForASGCapacity(d, meta, capacitySatifiedCreate); err != nil {
+	if err := waitForASGCapacity(d, meta); err != nil {
 		return err
 	}
 
@@ -298,7 +298,6 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
-	shouldWaitForCapacity := false
 
 	opts := autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(d.Id()),
@@ -310,7 +309,6 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("desired_capacity") {
 		opts.DesiredCapacity = aws.Int64(int64(d.Get("desired_capacity").(int)))
-		shouldWaitForCapacity = true
 	}
 
 	if d.HasChange("launch_configuration") {
@@ -319,7 +317,6 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("min_size") {
 		opts.MinSize = aws.Int64(int64(d.Get("min_size").(int)))
-		shouldWaitForCapacity = true
 	}
 
 	if d.HasChange("max_size") {
@@ -409,8 +406,8 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if shouldWaitForCapacity {
-		waitForASGCapacity(d, meta, capacitySatifiedUpdate)
+	if err := waitForASGCapacity(d, meta); err != nil {
+		return err
 	}
 
 	if d.HasChange("enabled_metrics") {

--- a/builtin/providers/aws/resource_aws_autoscaling_group_waiting.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_waiting.go
@@ -16,10 +16,7 @@ import (
 // the capacitySatisfiedFunc returns true.
 //
 // See "Waiting for Capacity" in docs for more discussion of the feature.
-func waitForASGCapacity(
-	d *schema.ResourceData,
-	meta interface{},
-	satisfiedFunc capacitySatisfiedFunc) error {
+func waitForASGCapacity(d *schema.ResourceData, meta interface{}) error {
 	wait, err := time.ParseDuration(d.Get("wait_for_capacity_timeout").(string))
 	if err != nil {
 		return err
@@ -77,7 +74,7 @@ func waitForASGCapacity(
 			}
 		}
 
-		satisfied, reason := satisfiedFunc(d, haveASG, haveELB)
+		satisfied, reason := checkCapacitySatisfied(d, haveASG, haveELB)
 
 		log.Printf("[DEBUG] %q Capacity: %d ASG, %d ELB, satisfied: %t, reason: %q",
 			d.Id(), haveASG, haveELB, satisfied, reason)
@@ -91,42 +88,27 @@ func waitForASGCapacity(
 	})
 }
 
-type capacitySatisfiedFunc func(*schema.ResourceData, int, int) (bool, string)
-
-// capacitySatifiedCreate treats all targets as minimums
-func capacitySatifiedCreate(d *schema.ResourceData, haveASG, haveELB int) (bool, string) {
-	minASG := d.Get("min_size").(int)
-	if wantASG := d.Get("desired_capacity").(int); wantASG > 0 {
-		minASG = wantASG
-	}
-	if haveASG < minASG {
+// checkCapacitySatisfied determines if required ASG and ELB targets are met.
+func checkCapacitySatisfied(d *schema.ResourceData, haveASG, haveELB int) (bool, string) {
+	if desiredASG, ok := d.GetOk("desired_capacity"); ok && desiredASG.(int) != haveASG {
 		return false, fmt.Sprintf(
-			"Need at least %d healthy instances in ASG, have %d", minASG, haveASG)
+			"Need exactly %d healthy instances in ASG, have %d", desiredASG.(int), haveASG)
 	}
-	minELB := d.Get("min_elb_capacity").(int)
-	if wantELB := d.Get("wait_for_elb_capacity").(int); wantELB > 0 {
-		minELB = wantELB
-	}
-	if haveELB < minELB {
-		return false, fmt.Sprintf(
-			"Need at least %d healthy instances in ELB, have %d", minELB, haveELB)
-	}
-	return true, ""
-}
 
-// capacitySatifiedUpdate only cares about specific targets
-func capacitySatifiedUpdate(d *schema.ResourceData, haveASG, haveELB int) (bool, string) {
-	if wantASG := d.Get("desired_capacity").(int); wantASG > 0 {
-		if haveASG != wantASG {
-			return false, fmt.Sprintf(
-				"Need exactly %d healthy instances in ASG, have %d", wantASG, haveASG)
-		}
+	if minASG, ok := d.GetOk("min_size"); ok && minASG.(int) > haveASG {
+		return false, fmt.Sprintf(
+			"Need at least %d healthy instances in ASG, have %d", minASG.(int), haveASG)
 	}
-	if wantELB := d.Get("wait_for_elb_capacity").(int); wantELB > 0 {
-		if haveELB != wantELB {
-			return false, fmt.Sprintf(
-				"Need exactly %d healthy instances in ELB, have %d", wantELB, haveELB)
-		}
+
+	if desiredELB, ok := d.GetOk("wait_for_elb_capacity"); ok && desiredELB.(int) != haveELB {
+		return false, fmt.Sprintf(
+			"Need exactly %d healthy instances in ELB, have %d", desiredELB.(int), haveELB)
 	}
+
+	if minELB, ok := d.GetOk("min_elb_capacity"); ok && minELB.(int) > haveELB {
+		return false, fmt.Sprintf(
+			"Need at least %d healthy instances in ELB, have %d", minELB.(int), haveELB)
+	}
+
 	return true, ""
 }

--- a/builtin/providers/aws/resource_aws_autoscaling_group_waiting.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_waiting.go
@@ -100,6 +100,11 @@ func checkCapacitySatisfied(d *schema.ResourceData, haveASG, haveELB int) (bool,
 			"Need at least %d healthy instances in ASG, have %d", minASG.(int), haveASG)
 	}
 
+	if maxASG, ok := d.GetOk("max_size"); ok && maxASG.(int) < haveASG {
+		return false, fmt.Sprintf(
+			"Need at most %d healthy instances in ASG, have %d", maxASG.(int), haveASG)
+	}
+
 	if desiredELB, ok := d.GetOk("wait_for_elb_capacity"); ok && desiredELB.(int) != haveELB {
 		return false, fmt.Sprintf(
 			"Need exactly %d healthy instances in ELB, have %d", desiredELB.(int), haveELB)

--- a/builtin/providers/aws/resource_aws_autoscaling_group_waiting_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_waiting_test.go
@@ -56,6 +56,36 @@ func TestCapacitySatisfied(t *testing.T) {
 			HaveASG:         5,
 			ExpectSatisfied: true,
 		},
+		"max_size, have less": {
+			Data: map[string]interface{}{
+				"max_size": 5,
+			},
+			HaveASG:         2,
+			ExpectSatisfied: true,
+		},
+		"max_size, have more": {
+			Data: map[string]interface{}{
+				"max_size": 5,
+			},
+			HaveASG:         10,
+			ExpectSatisfied: false,
+			ExpectReason:    "Need at most 5 healthy instances in ASG, have 10",
+		},
+		"max_size, got it": {
+			Data: map[string]interface{}{
+				"max_size": 5,
+			},
+			HaveASG:         5,
+			ExpectSatisfied: true,
+		},
+		"min_size, max_size, between": {
+			Data: map[string]interface{}{
+				"min_size": 1,
+				"max_size": 5,
+			},
+			HaveASG:         2,
+			ExpectSatisfied: true,
+		},
 		"min_elb_capacity, have less": {
 			Data: map[string]interface{}{
 				"min_elb_capacity": 5,


### PR DESCRIPTION
Consolidates the create/update auto scaling group's wait for capacity logic into a single method. Also, adds support for waiting for excess instances to terminate when the max size is lowered.

CC @phinze
