### PR TITLE
provider/aws: set ASG health_check_grace_period default to 300

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -80,7 +80,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			"health_check_grace_period": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  300,
 			},
 
 			"health_check_type": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -555,7 +555,6 @@ resource "aws_autoscaling_group" "bar" {
   name = "foobar3-terraform-test"
   max_size = 5
   min_size = 2
-  health_check_grace_period = 300
   health_check_type = "ELB"
   desired_capacity = 4
   force_delete = true

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `availability_zones` - (Optional) A list of AZs to launch resources in.
    Required only if you do not specify any `vpc_zone_identifier`
 * `launch_configuration` - (Required) The name of the launch configuration to use.
-* `health_check_grace_period` - (Optional) Time after instance comes into service before checking health.
+* `health_check_grace_period` - (Optional, Default: 300) Time (in seconds) after instance comes into service before checking health.
 * `health_check_type` - (Optional) "EC2" or "ELB". Controls how health checking is done.
 * `desired_capacity` - (Optional) The number of Amazon EC2 instances that
     should be running in the group. (See also [Waiting for


### PR DESCRIPTION
Closes #5658

```
=== RUN   TestAccAWSAutoScalingGroup_basic
--- PASS: TestAccAWSAutoScalingGroup_basic (221.84s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    221.860s
```