### PR TITLE
provider/aws: Guard against empty responses from Lambda Permissions

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_permission.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission.go
@@ -121,7 +121,11 @@ func resourceAwsLambdaPermissionCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	log.Printf("[DEBUG] Created new Lambda permission: %s", *out.Statement)
+	if out != nil && out.Statement != nil {
+		log.Printf("[DEBUG] Created new Lambda permission: %s", *out.Statement)
+	} else {
+		log.Printf("[DEBUG] Created new Lambda permission, but no Statement was included")
+	}
 
 	d.SetId(d.Get("statement_id").(string))
 


### PR DESCRIPTION
Fixes #5536 by guarding against a nil response (or nil `Statement`) from `lambda.AddPermission`. It's not clear if just the `Statement` is nil, or the entire response is nil, so we guard against both