### PR TITLE
state: Add support for outputs of multiple types

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -97,7 +97,13 @@ func (c *OutputCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(v)
+	switch output := v.(type) {
+	case string:
+		c.Ui.Output(output)
+	default:
+		panic(fmt.Errorf("Unknown output type: %T", output))
+	}
+
 	return 0
 }
 

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -16,7 +16,7 @@ func TestOutput(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
@@ -52,13 +52,13 @@ func TestModuleOutput(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
 			&terraform.ModuleState{
 				Path: []string{"root", "my_module"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"blah": "tastatur",
 				},
 			},
@@ -96,7 +96,7 @@ func TestMissingModuleOutput(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
@@ -129,7 +129,7 @@ func TestOutput_badVar(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
@@ -160,7 +160,7 @@ func TestOutput_blank(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo":  "bar",
 					"name": "john-doe",
 				},
@@ -253,7 +253,7 @@ func TestOutput_noVars(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path:    []string{"root"},
-				Outputs: map[string]string{},
+				Outputs: map[string]interface{}{},
 			},
 		},
 	}
@@ -282,7 +282,7 @@ func TestOutput_stateDefault(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},

--- a/state/remote/atlas_test.go
+++ b/state/remote/atlas_test.go
@@ -245,7 +245,7 @@ func (f *fakeAtlas) handler(resp http.ResponseWriter, req *http.Request) {
 // loads the state.
 var testStateModuleOrderChange = []byte(
 	`{
-    "version": 1,
+    "version": 2,
     "serial": 1,
     "modules": [
         {
@@ -276,7 +276,7 @@ var testStateModuleOrderChange = []byte(
 
 var testStateSimple = []byte(
 	`{
-    "version": 1,
+    "version": 2,
     "serial": 1,
     "modules": [
         {

--- a/state/testing.go
+++ b/state/testing.go
@@ -36,7 +36,7 @@ func TestState(t *testing.T, s interface{}) {
 	if ws, ok := s.(StateWriter); ok {
 		current.Modules = append(current.Modules, &terraform.ModuleState{
 			Path: []string{"root"},
-			Outputs: map[string]string{
+			Outputs: map[string]interface{}{
 				"bar": "baz",
 			},
 		})
@@ -94,7 +94,7 @@ func TestState(t *testing.T, s interface{}) {
 		current.Modules = []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path:    []string{"root", "somewhere"},
-				Outputs: map[string]string{"serialCheck": "true"},
+				Outputs: map[string]interface{}{"serialCheck": "true"},
 			},
 		}
 		if err := writer.WriteState(current); err != nil {
@@ -123,7 +123,7 @@ func TestStateInitial() *terraform.State {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root", "child"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -969,7 +969,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 						},
 					},
 				},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"a_output": "a",
 				},
 			},
@@ -1397,7 +1397,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 		Modules: []*ModuleState{
 			&ModuleState{
 				Path: rootModulePath,
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 					"bar": "baz",
 				},

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -452,7 +452,7 @@ func TestContext2Refresh_output(t *testing.T) {
 						},
 					},
 
-					Outputs: map[string]string{
+					Outputs: map[string]interface{}{
 						"foo": "foo",
 					},
 				},
@@ -738,7 +738,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 						},
 					},
 				},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"id":            "i-bcd234",
 					"grandchild_id": "i-cde345",
 				},
@@ -752,7 +752,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 						},
 					},
 				},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"id": "i-cde345",
 				},
 			},

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -67,7 +67,7 @@ func TestInterpolater_moduleVariable(t *testing.T) {
 			},
 			&ModuleState{
 				Path: []string{RootModuleName, "child"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// StateVersion is the current version for our state file
-	StateVersion = 1
+	StateVersion = 2
 )
 
 // rootModulePath is the path of the root module
@@ -407,7 +407,7 @@ type ModuleState struct {
 	// Outputs declared by the module and maintained for each module
 	// even though only the root module technically needs to be kept.
 	// This allows operators to inspect values at the boundaries.
-	Outputs map[string]string `json:"outputs"`
+	Outputs map[string]interface{} `json:"outputs"`
 
 	// Resources is a mapping of the logically named resource to
 	// the state of the resource. Each resource may actually have
@@ -532,7 +532,7 @@ func (m *ModuleState) View(id string) *ModuleState {
 
 func (m *ModuleState) init() {
 	if m.Outputs == nil {
-		m.Outputs = make(map[string]string)
+		m.Outputs = make(map[string]interface{})
 	}
 	if m.Resources == nil {
 		m.Resources = make(map[string]*ResourceState)
@@ -545,7 +545,7 @@ func (m *ModuleState) deepcopy() *ModuleState {
 	}
 	n := &ModuleState{
 		Path:      make([]string, len(m.Path)),
-		Outputs:   make(map[string]string, len(m.Outputs)),
+		Outputs:   make(map[string]interface{}, len(m.Outputs)),
 		Resources: make(map[string]*ResourceState, len(m.Resources)),
 	}
 	copy(n.Path, m.Path)
@@ -1205,7 +1205,8 @@ func ReadState(src io.Reader) (*State, error) {
 		return upgradeV0State(old)
 	}
 
-	// Otherwise, must be V2
+	// Otherwise, must be V2 or V3 - V2 reads as V3 however so we need take
+	// no special action here - new state will be written as V3.
 	dec := json.NewDecoder(buf)
 	state := &State{}
 	if err := dec.Decode(state); err != nil {
@@ -1260,8 +1261,12 @@ func upgradeV0State(old *StateV0) (*State, error) {
 	// directly into the root module.
 	root := s.RootModule()
 
-	// Copy the outputs
-	root.Outputs = old.Outputs
+	// Copy the outputs, first converting them to map[string]interface{}
+	oldOutputs := make(map[string]interface{}, len(old.Outputs))
+	for key, value := range old.Outputs {
+		oldOutputs[key] = value
+	}
+	root.Outputs = oldOutputs
 
 	// Upgrade the resources
 	for id, rs := range old.Resources {

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -76,6 +76,38 @@ func TestStateAddModule(t *testing.T) {
 	}
 }
 
+func TestStateOutputTypeRoundTrip(t *testing.T) {
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: RootModulePath,
+				Outputs: map[string]interface{}{
+					"string_output": "String Value",
+					"list_output":   []interface{}{"List", "Value"},
+					"map_output": map[string]interface{}{
+						"key1": "Map",
+						"key2": "Value",
+					},
+				},
+			},
+		},
+	}
+
+	buf := new(bytes.Buffer)
+	if err := WriteState(state, buf); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	roundTripped, err := ReadState(buf)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(state, roundTripped) {
+		t.Fatalf("bad: %#v", roundTripped)
+	}
+}
+
 func TestStateModuleOrphans(t *testing.T) {
 	state := &State{
 		Modules: []*ModuleState{
@@ -829,6 +861,33 @@ func TestInstanceState_MergeDiff_nilDiff(t *testing.T) {
 	}
 }
 
+func TestReadUpgradeStateV1toV2(t *testing.T) {
+	// ReadState should transparently detect the old version but will upgrade
+	// it on Write.
+	actual, err := ReadState(strings.NewReader(testV1State))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	buf := new(bytes.Buffer)
+	if err := WriteState(actual, buf); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if actual.Version != 2 {
+		t.Fatalf("bad: State version not incremented; is %d", actual.Version)
+	}
+
+	roundTripped, err := ReadState(buf)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(actual, roundTripped) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestReadUpgradeState(t *testing.T) {
 	state := &StateV0{
 		Resources: map[string]*ResourceStateV0{
@@ -1062,3 +1121,34 @@ func TestParseResourceStateKey(t *testing.T) {
 		}
 	}
 }
+
+const testV1State = `{
+    "version": 1,
+    "serial": 9,
+    "remote": {
+        "type": "http",
+        "config": {
+            "url": "http://my-cool-server.com/"
+        }
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": null,
+            "resources": {
+                "foo": {
+                    "type": "",
+                    "primary": {
+                        "id": "bar"
+                    }
+                }
+            },
+            "depends_on": [
+                "aws_instance.bar"
+            ]
+        }
+    ]
+}
+`

--- a/terraform/transform_output_test.go
+++ b/terraform/transform_output_test.go
@@ -11,7 +11,7 @@ func TestAddOutputOrphanTransformer(t *testing.T) {
 		Modules: []*ModuleState{
 			&ModuleState{
 				Path: RootModulePath,
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 					"bar": "baz",
 				},


### PR DESCRIPTION
This commit adds the groundwork for supporting module outputs of types other than string. In order to do so, the state version is increased from 1 to 2 (though the "public-facing" state version is actually as the
first state file was binary).

Tests are added to ensure that V2 (1) state is upgraded to V3 (2) state, though no separate read path is required since the V2 JSON will unmarshal correctly into the V3 structure.

Outputs in a ModuleState are now of type map[string]interface{}, and a test covers round-tripping string, []string and map[string]string, which should cover all of the types in question.

Type switches have been added where necessary to deal with the interface{} value, but they currently default to panicking when the input is not a string.