### PR TITLE
Renumber original binary state as V0

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1191,18 +1191,18 @@ func (e *EphemeralState) deepcopy() *EphemeralState {
 func ReadState(src io.Reader) (*State, error) {
 	buf := bufio.NewReader(src)
 
-	// Check if this is a V1 format
+	// Check if this is a V0 format
 	start, err := buf.Peek(len(stateFormatMagic))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to check for magic bytes: %v", err)
 	}
 	if string(start) == stateFormatMagic {
 		// Read the old state
-		old, err := ReadStateV1(buf)
+		old, err := ReadStateV0(buf)
 		if err != nil {
 			return nil, err
 		}
-		return upgradeV1State(old)
+		return upgradeV0State(old)
 	}
 
 	// Otherwise, must be V2
@@ -1250,9 +1250,9 @@ func WriteState(d *State, dst io.Writer) error {
 	return nil
 }
 
-// upgradeV1State is used to upgrade a V1 state representation
+// upgradeV0State is used to upgrade a V0 state representation
 // into a proper State representation.
-func upgradeV1State(old *StateV1) (*State, error) {
+func upgradeV0State(old *StateV0) (*State, error) {
 	s := &State{}
 	s.init()
 

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -830,15 +830,15 @@ func TestInstanceState_MergeDiff_nilDiff(t *testing.T) {
 }
 
 func TestReadUpgradeState(t *testing.T) {
-	state := &StateV1{
-		Resources: map[string]*ResourceStateV1{
-			"foo": &ResourceStateV1{
+	state := &StateV0{
+		Resources: map[string]*ResourceStateV0{
+			"foo": &ResourceStateV0{
 				ID: "bar",
 			},
 		},
 	}
 	buf := new(bytes.Buffer)
-	if err := testWriteStateV1(state, buf); err != nil {
+	if err := testWriteStateV0(state, buf); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -849,7 +849,7 @@ func TestReadUpgradeState(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	upgraded, err := upgradeV1State(state)
+	upgraded, err := upgradeV0State(state)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -935,20 +935,20 @@ func TestReadStateNewVersion(t *testing.T) {
 	}
 }
 
-func TestUpgradeV1State(t *testing.T) {
-	old := &StateV1{
+func TestUpgradeV0State(t *testing.T) {
+	old := &StateV0{
 		Outputs: map[string]string{
 			"ip": "127.0.0.1",
 		},
-		Resources: map[string]*ResourceStateV1{
-			"foo": &ResourceStateV1{
+		Resources: map[string]*ResourceStateV0{
+			"foo": &ResourceStateV0{
 				Type: "test_resource",
 				ID:   "bar",
 				Attributes: map[string]string{
 					"key": "val",
 				},
 			},
-			"bar": &ResourceStateV1{
+			"bar": &ResourceStateV0{
 				Type: "test_resource",
 				ID:   "1234",
 				Attributes: map[string]string{
@@ -960,7 +960,7 @@ func TestUpgradeV1State(t *testing.T) {
 			"bar": struct{}{},
 		},
 	}
-	state, err := upgradeV1State(old)
+	state, err := upgradeV0State(old)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/terraform/state_v0_test.go
+++ b/terraform/state_v0_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/mitchellh/hashstructure"
 )
 
-func TestReadWriteStateV1(t *testing.T) {
-	state := &StateV1{
-		Resources: map[string]*ResourceStateV1{
-			"foo": &ResourceStateV1{
+func TestReadWriteStateV0(t *testing.T) {
+	state := &StateV0{
+		Resources: map[string]*ResourceStateV0{
+			"foo": &ResourceStateV0{
 				ID: "bar",
 				ConnInfo: map[string]string{
 					"type":     "ssh",
@@ -33,7 +33,7 @@ func TestReadWriteStateV1(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	if err := testWriteStateV1(state, buf); err != nil {
+	if err := testWriteStateV0(state, buf); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -47,7 +47,7 @@ func TestReadWriteStateV1(t *testing.T) {
 		t.Fatalf("structure changed during serialization!")
 	}
 
-	actual, err := ReadStateV1(buf)
+	actual, err := ReadStateV0(buf)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -75,9 +75,9 @@ func (s *sensitiveState) init() {
 	})
 }
 
-// testWriteStateV1 writes a state somewhere in a binary format.
+// testWriteStateV0 writes a state somewhere in a binary format.
 // Only for testing now
-func testWriteStateV1(d *StateV1, dst io.Writer) error {
+func testWriteStateV0(d *StateV0, dst io.Writer) error {
 	// Write the magic bytes so we can determine the file format later
 	n, err := dst.Write([]byte(stateFormatMagic))
 	if err != nil {


### PR DESCRIPTION
This commit rectifies the fact that the original binary state is referred to as V1 in the source code, but the first version of the JSON state uses StateVersion: 1. We instead make the code refer to V0 as the binary state, and V1 as the first version of JSON state.