### PR TITLE
command: "terraform state show"

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1145,6 +1145,11 @@
 			"Rev": "f3d053460f7c37970af6733bf370a3256e3648fb"
 		},
 		{
+			"ImportPath": "github.com/ryanuber/columnize",
+			"Comment": "v2.0.1-8-g983d3a5",
+			"Rev": "983d3a5fab1bf04d1b412465d2d9f8430e2e917e"
+		},
+		{
 			"ImportPath": "github.com/satori/go.uuid",
 			"Rev": "d41af8bb6a7704f00bc3b7cba9355ae6a5a80048"
 		},

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -54,19 +54,19 @@ func (c *StateListCommand) Run(args []string) int {
 
 func (c *StateListCommand) Help() string {
 	helpText := `
-Usage: terraform state list [options] [pattern...]
+Usage: terraform state list [options] [address...]
 
   List resources in the Terraform state.
 
-  This command lists resources in the Terraform state. The pattern argument
-  can be used to filter the resources by resource or module. If no pattern
+  This command lists resources in the Terraform state. The address argument
+  can be used to filter the resources by resource or module. If no address
   is given, all resources are listed.
 
-  The pattern argument is meant to provide very simple filtering. For
+  The address argument is meant to provide very simple filtering. For
   advanced filtering, please use tools such as "grep". The output of this
   command is designed to be friendly for this usage.
 
-  The pattern argument accepts any resource targeting syntax. Please
+  The address argument accepts any resource targeting syntax. Please
   refer to the documentation on resource targeting syntax for more
   information.
 

--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -1,0 +1,34 @@
+package command
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// StateMeta is the meta struct that should be embedded in state subcommands.
+type StateMeta struct{}
+
+// filterInstance filters a single instance out of filter results.
+func (c *StateMeta) filterInstance(rs []*terraform.StateFilterResult) (*terraform.StateFilterResult, error) {
+	var result *terraform.StateFilterResult
+	for _, r := range rs {
+		if _, ok := r.Value.(*terraform.InstanceState); !ok {
+			continue
+		}
+
+		if result != nil {
+			return nil, errors.New(errStateMultiple)
+		}
+
+		result = r
+	}
+
+	return result, nil
+}
+
+const errStateMultiple = `Multiple instances found for the given pattern!
+
+This command requires that the pattern match exactly one instance
+of a resource. To view the matched instances, use "terraform state list".
+Please modify the pattern to match only a single instance.`

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -77,12 +77,12 @@ func (c *StateShowCommand) Run(args []string) int {
 
 func (c *StateShowCommand) Help() string {
 	helpText := `
-Usage: terraform state show [options] PATTERN
+Usage: terraform state show [options] ADDRESS
 
   Shows the attributes of a resource in the Terraform state.
 
   This command shows the attributes of a single resource in the Terraform
-  state. The pattern argument must be used to specify a single resource.
+  state. The address argument must be used to specify a single resource.
   You can view the list of available resources with "terraform state list".
 
 Options:

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -63,7 +63,9 @@ func (c *StateShowCommand) Run(args []string) int {
 	output := make([]string, 0, len(is.Attributes)+1)
 	output = append(output, fmt.Sprintf("id | %s", is.ID))
 	for _, k := range keys {
-		output = append(output, fmt.Sprintf("%s | %s", k, is.Attributes[k]))
+		if k != "id" {
+			output = append(output, fmt.Sprintf("%s | %s", k, is.Attributes[k]))
+		}
 	}
 
 	// Output

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/cli"
+	"github.com/ryanuber/columnize"
+)
+
+// StateShowCommand is a Command implementation that shows a single resource.
+type StateShowCommand struct {
+	Meta
+	StateMeta
+}
+
+func (c *StateShowCommand) Run(args []string) int {
+	args = c.Meta.process(args, true)
+
+	cmdFlags := c.Meta.flagSet("state show")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	if err := cmdFlags.Parse(args); err != nil {
+		return cli.RunResultHelp
+	}
+	args = cmdFlags.Args()
+
+	state, err := c.State()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
+		return cli.RunResultHelp
+	}
+
+	stateReal := state.State()
+	if stateReal == nil {
+		c.Ui.Error(fmt.Sprintf(errStateNotFound))
+		return 1
+	}
+
+	filter := &terraform.StateFilter{State: stateReal}
+	results, err := filter.Filter(args...)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(errStateFilter, err))
+		return 1
+	}
+
+	instance, err := c.filterInstance(results)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	is := instance.Value.(*terraform.InstanceState)
+
+	// Sort the keys
+	keys := make([]string, 0, len(is.Attributes))
+	for k, _ := range is.Attributes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Build the output
+	output := make([]string, 0, len(is.Attributes)+1)
+	output = append(output, fmt.Sprintf("id | %s", is.ID))
+	for _, k := range keys {
+		output = append(output, fmt.Sprintf("%s | %s", k, is.Attributes[k]))
+	}
+
+	// Output
+	config := columnize.DefaultConfig()
+	config.Glue = " = "
+	c.Ui.Output(columnize.Format(output, config))
+	return 0
+}
+
+func (c *StateShowCommand) Help() string {
+	helpText := `
+Usage: terraform state show [options] PATTERN
+
+  Shows the attributes of a resource in the Terraform state.
+
+  This command shows the attributes of a single resource in the Terraform
+  state. The pattern argument must be used to specify a single resource.
+  You can view the list of available resources with "terraform state list".
+
+Options:
+
+  -state=statefile    Path to a Terraform state file to use to look
+                      up Terraform-managed resources. By default it will
+                      use the state "terraform.tfstate" if it exists.
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *StateShowCommand) Synopsis() string {
+	return "Show a resource in the state"
+}

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -1,0 +1,82 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/cli"
+)
+
+func TestStateShow(t *testing.T) {
+	state := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo": &terraform.ResourceState{
+						Type: "test_instance",
+						Primary: &terraform.InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo": "value",
+								"bar": "value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &StateShowCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	expected := strings.TrimSpace(testStateShowOutput) + "\n"
+	actual := ui.OutputWriter.String()
+	if actual != expected {
+		t.Fatalf("Expected:\n%q\n\nTo equal: %q", actual, expected)
+	}
+}
+
+func TestStateShow_noState(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &StateShowCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
+const testStateShowOutput = `
+id  = bar
+bar = value
+foo = value
+`

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -56,6 +56,57 @@ func TestStateShow(t *testing.T) {
 	}
 }
 
+func TestStateShow_multi(t *testing.T) {
+	state := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo.0": &terraform.ResourceState{
+						Type: "test_instance",
+						Primary: &terraform.InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo": "value",
+								"bar": "value",
+							},
+						},
+					},
+					"test_instance.foo.1": &terraform.ResourceState{
+						Type: "test_instance",
+						Primary: &terraform.InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo": "value",
+								"bar": "value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &StateShowCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
 func TestStateShow_noState(t *testing.T) {
 	tmp, cwd := testCwd(t)
 	defer testFixCwd(t, tmp, cwd)

--- a/commands.go
+++ b/commands.go
@@ -152,6 +152,12 @@ func init() {
 				Meta: meta,
 			}, nil
 		},
+
+		"state show": func() (cli.Command, error) {
+			return &command.StateShowCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 }
 

--- a/terraform/state_filter.go
+++ b/terraform/state_filter.go
@@ -36,7 +36,7 @@ func (f *StateFilter) Filter(fs ...string) ([]*StateFilterResult, error) {
 
 	// If we werent given any filters, then we list all
 	if len(fs) == 0 {
-		as = append(as, &ResourceAddress{})
+		as = append(as, &ResourceAddress{Index: -1})
 	}
 
 	// Filter each of the address. We keep track of this in a map to
@@ -91,6 +91,11 @@ func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
 				if err != nil {
 					// If we get an error parsing, then just ignore it
 					// out of the state.
+					continue
+				}
+
+				if a.Index >= 0 && key.Index != a.Index {
+					// Index doesn't match
 					continue
 				}
 

--- a/terraform/state_filter.go
+++ b/terraform/state_filter.go
@@ -108,11 +108,12 @@ func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
 				}
 
 				// Add the resource level result
-				results = append(results, &StateFilterResult{
+				resourceResult := &StateFilterResult{
 					Path:    addr.Path,
 					Address: addr.String(),
 					Value:   r,
-				})
+				}
+				results = append(results, resourceResult)
 
 				// Add the instances
 				if r.Primary != nil {
@@ -120,6 +121,7 @@ func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
 					results = append(results, &StateFilterResult{
 						Path:    addr.Path,
 						Address: addr.String(),
+						Parent:  resourceResult,
 						Value:   r.Primary,
 					})
 				}
@@ -130,6 +132,7 @@ func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
 						results = append(results, &StateFilterResult{
 							Path:    addr.Path,
 							Address: addr.String(),
+							Parent:  resourceResult,
 							Value:   instance,
 						})
 					}
@@ -141,6 +144,7 @@ func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
 						results = append(results, &StateFilterResult{
 							Path:    addr.Path,
 							Address: addr.String(),
+							Parent:  resourceResult,
 							Value:   instance,
 						})
 					}
@@ -199,6 +203,11 @@ type StateFilterResult struct {
 
 	// Address is the address that can be used to reference this exact result.
 	Address string
+
+	// Parent, if non-nil, is a parent of this result. For instances, the
+	// parent would be a resource. For resources, the parent would be
+	// a module. For modules, this is currently nil.
+	Parent *StateFilterResult
 
 	// Value is the actual value. This must be type switched on. It can be
 	// any data structures that `State` can hold: `ModuleState`,

--- a/terraform/state_filter_test.go
+++ b/terraform/state_filter_test.go
@@ -51,6 +51,15 @@ func TestStateFilterFilter(t *testing.T) {
 				"*terraform.InstanceState: module.bootstrap.aws_route53_zone.oasis-consul-bootstrap",
 			},
 		},
+
+		"single count index": {
+			"complete.tfstate",
+			[]string{"module.consul.aws_instance.consul-green[0]"},
+			[]string{
+				"*terraform.ResourceState: module.consul.aws_instance.consul-green[0]",
+				"*terraform.InstanceState: module.consul.aws_instance.consul-green[0]",
+			},
+		},
 	}
 
 	for n, tc := range cases {

--- a/vendor/github.com/ryanuber/columnize/.travis.yml
+++ b/vendor/github.com/ryanuber/columnize/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+  - tip

--- a/vendor/github.com/ryanuber/columnize/COPYING
+++ b/vendor/github.com/ryanuber/columnize/COPYING
@@ -1,0 +1,20 @@
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/ryanuber/columnize/README.md
+++ b/vendor/github.com/ryanuber/columnize/README.md
@@ -1,0 +1,75 @@
+Columnize
+=========
+
+Easy column-formatted output for golang
+
+[![Build Status](https://travis-ci.org/ryanuber/columnize.svg)](https://travis-ci.org/ryanuber/columnize)
+
+Columnize is a really small Go package that makes building CLI's a little bit
+easier. In some CLI designs, you want to output a number similar items in a
+human-readable way with nicely aligned columns. However, figuring out how wide
+to make each column is a boring problem to solve and eats your valuable time.
+
+Here is an example:
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/ryanuber/columnize"
+)
+
+func main() {
+    output := []string{
+        "Name | Gender | Age",
+        "Bob | Male | 38",
+        "Sally | Female | 26",
+    }
+    result := columnize.SimpleFormat(output)
+    fmt.Println(result)
+}
+```
+
+As you can see, you just pass in a list of strings. And the result:
+
+```
+Name   Gender  Age
+Bob    Male    38
+Sally  Female  26
+```
+
+Columnize is tolerant of missing or empty fields, or even empty lines, so
+passing in extra lines for spacing should show up as you would expect.
+
+Configuration
+=============
+
+Columnize is configured using a `Config`, which can be obtained by calling the
+`DefaultConfig()` method. You can then tweak the settings in the resulting
+`Config`:
+
+```
+config := columnize.DefaultConfig()
+config.Delim = "|"
+config.Glue = "  "
+config.Prefix = ""
+config.Empty = ""
+```
+
+* `Delim` is the string by which columns of **input** are delimited
+* `Glue` is the string by which columns of **output** are delimited
+* `Prefix` is a string by which each line of **output** is prefixed
+* `Empty` is a string used to replace blank values found in output
+
+You can then pass the `Config` in using the `Format` method (signature below) to
+have text formatted to your liking.
+
+Usage
+=====
+
+```go
+SimpleFormat(intput []string) string
+
+Format(input []string, config *Config) string
+```

--- a/vendor/github.com/ryanuber/columnize/columnize.go
+++ b/vendor/github.com/ryanuber/columnize/columnize.go
@@ -1,0 +1,134 @@
+package columnize
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Config struct {
+	// The string by which the lines of input will be split.
+	Delim string
+
+	// The string by which columns of output will be separated.
+	Glue string
+
+	// The string by which columns of output will be prefixed.
+	Prefix string
+
+	// A replacement string to replace empty fields
+	Empty string
+}
+
+// Returns a Config with default values.
+func DefaultConfig() *Config {
+	return &Config{
+		Delim:  "|",
+		Glue:   "  ",
+		Prefix: "",
+	}
+}
+
+// Returns a list of elements, each representing a single item which will
+// belong to a column of output.
+func getElementsFromLine(config *Config, line string) []interface{} {
+	elements := make([]interface{}, 0)
+	for _, field := range strings.Split(line, config.Delim) {
+		value := strings.TrimSpace(field)
+		if value == "" && config.Empty != "" {
+			value = config.Empty
+		}
+		elements = append(elements, value)
+	}
+	return elements
+}
+
+// Examines a list of strings and determines how wide each column should be
+// considering all of the elements that need to be printed within it.
+func getWidthsFromLines(config *Config, lines []string) []int {
+	var widths []int
+
+	for _, line := range lines {
+		elems := getElementsFromLine(config, line)
+		for i := 0; i < len(elems); i++ {
+			l := len(elems[i].(string))
+			if len(widths) <= i {
+				widths = append(widths, l)
+			} else if widths[i] < l {
+				widths[i] = l
+			}
+		}
+	}
+	return widths
+}
+
+// Given a set of column widths and the number of columns in the current line,
+// returns a sprintf-style format string which can be used to print output
+// aligned properly with other lines using the same widths set.
+func (c *Config) getStringFormat(widths []int, columns int) string {
+	// Start with the prefix, if any was given.
+	stringfmt := c.Prefix
+
+	// Create the format string from the discovered widths
+	for i := 0; i < columns && i < len(widths); i++ {
+		if i == columns-1 {
+			stringfmt += "%s\n"
+		} else {
+			stringfmt += fmt.Sprintf("%%-%ds%s", widths[i], c.Glue)
+		}
+	}
+	return stringfmt
+}
+
+// MergeConfig merges two config objects together and returns the resulting
+// configuration. Values from the right take precedence over the left side.
+func MergeConfig(a, b *Config) *Config {
+	var result Config = *a
+
+	// Return quickly if either side was nil
+	if a == nil || b == nil {
+		return &result
+	}
+
+	if b.Delim != "" {
+		result.Delim = b.Delim
+	}
+	if b.Glue != "" {
+		result.Glue = b.Glue
+	}
+	if b.Prefix != "" {
+		result.Prefix = b.Prefix
+	}
+	if b.Empty != "" {
+		result.Empty = b.Empty
+	}
+
+	return &result
+}
+
+// Format is the public-facing interface that takes either a plain string
+// or a list of strings and returns nicely aligned output.
+func Format(lines []string, config *Config) string {
+	var result string
+
+	conf := MergeConfig(DefaultConfig(), config)
+	widths := getWidthsFromLines(conf, lines)
+
+	// Create the formatted output using the format string
+	for _, line := range lines {
+		elems := getElementsFromLine(conf, line)
+		stringfmt := conf.getStringFormat(widths, len(elems))
+		result += fmt.Sprintf(stringfmt, elems...)
+	}
+
+	// Remove trailing newline without removing leading/trailing space
+	if n := len(result); n > 0 && result[n-1] == '\n' {
+		result = result[:n-1]
+	}
+
+	return result
+}
+
+// Convenience function for using Columnize as easy as possible.
+func SimpleFormat(lines []string) string {
+	return Format(lines, nil)
+}

--- a/website/source/docs/commands/state/list.html.md
+++ b/website/source/docs/commands/state/list.html.md
@@ -13,10 +13,10 @@ The `terraform state list` command is used to list resources within a
 
 ## Usage
 
-Usage: `terraform state list [options] [pattern...]`
+Usage: `terraform state list [options] [address...]`
 
 The command will list all resources in the state file matching the given
-patterns (if any). If no patterns are given, all resources are listed.
+addresses (if any). If no addresses are given, all resources are listed.
 
 The resources listed are sorted according to module depth order followed
 by alphabetical. This means that resources that are in your immediate
@@ -24,7 +24,7 @@ configuration are listed first, and resources that are more deeply nested
 within modules are listed last.
 
 For complex infrastructures, the state can contain thousands of resources.
-To filter these, provide one or more patterns to the command. Patterns are
+To filter these, provide one or more addresses to the command. Addresses are
 in [resource addressing format](/docs/commands/state/addressing.html).
 
 The command-line flags are all optional. The list of available flags are:

--- a/website/source/docs/commands/state/list.html.md
+++ b/website/source/docs/commands/state/list.html.md
@@ -3,7 +3,7 @@ layout: "commands-state"
 page_title: "Command: state list"
 sidebar_current: "docs-state-sub-list"
 description: |-
-  The `terraform init` command is used to initialize a Terraform configuration using another module as a skeleton.
+  The terraform state list command is used to list resources within a Terraform state.
 ---
 
 # Command: state list

--- a/website/source/docs/commands/state/show.html.md
+++ b/website/source/docs/commands/state/show.html.md
@@ -14,17 +14,17 @@ single resource in the
 
 ## Usage
 
-Usage: `terraform state show [options] PATTERN`
+Usage: `terraform state show [options] ADDRESS`
 
 The command will show the attributes of a single resource in the
-state file that matches the given pattern.
+state file that matches the given address.
 
 The attributes are listed in alphabetical order (with the except of "id"
 which is always at the top). They are outputted in a way that is easy
 to parse on the command-line.
 
-This command requires a pattern that points to a single resource in the
-state. Patterns are
+This command requires a address that points to a single resource in the
+state. Addresses are
 in [resource addressing format](/docs/commands/state/addressing.html).
 
 The command-line flags are all optional. The list of available flags are:

--- a/website/source/docs/commands/state/show.html.md
+++ b/website/source/docs/commands/state/show.html.md
@@ -1,0 +1,47 @@
+---
+layout: "commands-state"
+page_title: "Command: state show"
+sidebar_current: "docs-state-sub-show"
+description: |-
+  The `terraform state show` command is used to show the attributes of a single resource in the Terraform state.
+---
+
+# Command: state show
+
+The `terraform state show` command is used to show the attributes of a
+single resource in the
+[Terraform state](/docs/state/index.html).
+
+## Usage
+
+Usage: `terraform state show [options] PATTERN`
+
+The command will show the attributes of a single resource in the
+state file that matches the given pattern.
+
+The attributes are listed in alphabetical order (with the except of "id"
+which is always at the top). They are outputted in a way that is easy
+to parse on the command-line.
+
+This command requires a pattern that points to a single resource in the
+state. Patterns are
+in [resource addressing format](/docs/commands/state/addressing.html).
+
+The command-line flags are all optional. The list of available flags are:
+
+* `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+
+## Example: Show a Resource
+
+The example below shows a resource:
+
+```
+$ terraform state show module.foo.packet_device.worker[0]
+id                = 6015bg2b-b8c4-4925-aad2-f0671d5d3b13
+billing_cycle     = hourly
+created           = 2015-12-17T00:06:56Z
+facility          = ewr1
+hostname          = prod-xyz01
+locked            = false
+...
+```

--- a/website/source/layouts/commands-state.erb
+++ b/website/source/layouts/commands-state.erb
@@ -20,6 +20,10 @@
 						<li<%= sidebar_current("docs-state-sub-list") %>>
 							<a href="/docs/commands/state/list.html">list</a>
 						</li>
+
+						<li<%= sidebar_current("docs-state-sub-show") %>>
+							<a href="/docs/commands/state/show.html">show</a>
+						</li>
 					</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
This adds the command `terraform state show` for showing the attributes of a single resource within the Terraform state. See the docs in the changes for more information.

This required some bug fixing on `terraform.StateFilter` as well.

Going forward, I notice we also have a `terraform show` command as a top-level porcelain command. I think this command has very little utility in its current form (shows the entire state). I think we should change this to behave similarly to `terraform state show` and I'll do a PR for that after. I think it should remain a different command though since it gives us the ability to add more fine-grained flags to the plumbing.