### PR TITLE
provider/aws: Fix launch_config waiting for IAM instance profile

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -432,7 +433,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		_, err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
-				if awsErr.Message() == "Invalid IamInstanceProfile" {
+				if strings.Contains(awsErr.Message(), "Invalid IamInstanceProfile") {
 					return resource.RetryableError(err)
 				}
 			}


### PR DESCRIPTION
AWS changed their error message, which was being used for detection of
the specific error that indicates we need to wait for IAM propagation.

Behavior is covered by a test now.

Fixes #5862