### PR TITLE
provider/azurerm: Fix not removing azurerm_storage_account 404 from state

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_account.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account.go
@@ -200,7 +200,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 	resp, err := client.GetProperties(resGroup, name)
 	if err != nil {
-		if resp.StatusCode == http.StatusNoContent {
+		if resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Fixes #5876 

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMStorageAccount' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMStorageAccount -timeout 120m
=== RUN   TestAccAzureRMStorageAccount_basic
--- PASS: TestAccAzureRMStorageAccount_basic (408.21s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	408.222s
```

I believe that 204 resource was an oversight and should have been a 404 - @jen20 should comment here :)