### PR TITLE
provider/aws: Document lifecycle block needs for IAM Server Certificate

### DIFF
--- a/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
@@ -17,7 +17,7 @@ Certs uploaded to IAM can easily work with other AWS services such as:
 - AWS OpsWorks
 
 For information about server certificates in IAM, see [Managing Server
-Certficates][2] in AWS Documentation.
+Certificates][2] in AWS Documentation.
 
 ## Example Usage
 
@@ -52,23 +52,35 @@ EOF
 
 **Use in combination with an AWS ELB resource:**
 
+Some properties of an IAM Server Certificates cannot be updated while they are
+in use. In order for Terraform to effectively manage a Certificate in this situation, it is
+recommended you utilize the `name_prefix` attribute and enable the
+`create_before_destroy` [lifecycle block][lifecycle]. This will allow Terraform
+to create a new, updated `aws_iam_server_certificate` resource and replace it in
+dependant resources before attempting to destroy the old version.
+
+
 ```
 resource "aws_iam_server_certificate" "test_cert" {
-  name = "some_test_cert"
+  name_prefix      = "example-cert"
   certificate_body = "${file("self-ca-cert.pem")}"
-  private_key = "${file("test-key.pem")}"
+  private_key      = "${file("test-key.pem")}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_elb" "ourapp" {
-  name = "terraform-asg-deployment-example"
-  availability_zones = ["us-west-2a"]
+  name                      = "terraform-asg-deployment-example"
+  availability_zones        = ["us-west-2a"]
   cross_zone_load_balancing = true
 
   listener {
-    instance_port = 8000
-    instance_protocol = "http"
-    lb_port = 443
-    lb_protocol = "https"
+    instance_port      = 8000
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
     ssl_certificate_id = "${aws_iam_server_certificate.test_cert.arn}"
   }
 }
@@ -104,3 +116,5 @@ The following arguments are supported:
 
 [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html
 [2]: https://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingServerCerts.html
+[lifecycle]: http://localhost:4567/docs/configuration/resources.html
+


### PR DESCRIPTION
IAM Server Certificates need the `name_prefix`, `create_before_destroy` treatment if users are to use them with other resources and still want to be able to update them. This PR documents the format and reasoning for this.