### PR TITLE
provider/aws: Normalize and compact SQS Redrive, Policy JSON

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -177,14 +177,14 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 		resource := *resourceAwsSnsTopic()
 		// iKey = internal struct key, oKey = AWS Attribute Map key
 		for iKey, oKey := range SNSAttributeMap {
-			log.Printf("[DEBUG] Updating %s => %s", iKey, oKey)
+			log.Printf("[DEBUG] Reading %s => %s", iKey, oKey)
 
 			if attrmap[oKey] != nil {
 				// Some of the fetched attributes are stateful properties such as
 				// the number of subscriptions, the owner, etc. skip those
 				if resource.Schema[iKey] != nil {
 					value := *attrmap[oKey]
-					log.Printf("[DEBUG] Updating %s => %s -> %s", iKey, oKey, value)
+					log.Printf("[DEBUG] Reading %s => %s -> %s", iKey, oKey, value)
 					d.Set(iKey, *attrmap[oKey])
 				}
 			}

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -68,8 +68,9 @@ func resourceAwsSqsQueue() *schema.Resource {
 				Optional: true,
 			},
 			"redrive_policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				StateFunc: normalizeJson,
 			},
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -66,6 +68,19 @@ func resourceAwsSqsQueue() *schema.Resource {
 			"policy": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				StateFunc: func(v interface{}) string {
+					s, ok := v.(string)
+					if !ok || s == "" {
+						return ""
+					}
+					jsonb := []byte(s)
+					buffer := new(bytes.Buffer)
+					if err := json.Compact(buffer, jsonb); err != nil {
+						log.Printf("[WARN] Error compacting JSON for Policy in SNS Queue")
+						return ""
+					}
+					return buffer.String()
+				},
 			},
 			"redrive_policy": &schema.Schema{
 				Type:      schema.TypeString,
@@ -177,7 +192,9 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 						return err
 					}
 					d.Set(iKey, value)
+					log.Printf("[DEBUG] Reading %s => %s -> %d", iKey, oKey, value)
 				} else {
+					log.Printf("[DEBUG] Reading %s => %s -> %s", iKey, oKey, *attrmap[oKey])
 					d.Set(iKey, *attrmap[oKey])
 				}
 			}

--- a/website/source/docs/providers/aws/r/sqs_queue.html.markdown
+++ b/website/source/docs/providers/aws/r/sqs_queue.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `delay_seconds` - (Optional) The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). The default for this attribute is 0 seconds.
 * `receive_wait_time_seconds` - (Optional) The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately.
 * `policy` - (Optional) The JSON policy for the SQS queue
-* `redrive_policy` - (Optional) The JSON policy to set up the Dead Letter Queue, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html).
+* `redrive_policy` - (Optional) The JSON policy to set up the Dead Letter Queue, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html). **Note:** when specifying `maxReceiveCount`, you must specify it as an integer (`5`), and not a string (`"5"`). 
 
 ## Attributes Reference
 


### PR DESCRIPTION
The `redrive_policy` needs to be normalized on save to state, and we now document that the `maxReceiveCount` should be an integer, not a string. Unfortunately the AWS API accepts either, but will always return an integer. 

Fixes #5119 