### PR TITLE
fix typo in datadog provider documentation

### DIFF
--- a/website/source/docs/providers/datadog/r/monitor.html.markdown
+++ b/website/source/docs/providers/datadog/r/monitor.html.markdown
@@ -16,7 +16,7 @@ Provides a Datadog monitor resource. This can be used to create and manage Datad
 # Create a new Datadog monitor
 resource "datadog_monitor" "foo" {
   name = "Name for monitor foo"
-  type = "Metric alert"
+  type = "metric alert"
   message = "Monitor triggered. Notify: @hipchat-channel"
   escalation_message = "Escalation message @pagerduty"
 


### PR DESCRIPTION
was getting this error when trying to run a `terraform apply` with the datadog provisioner when the `type` was capitalized (`type = "Metric alert"`), like in the example in the documentation:

```
module.app.datadog_monitor.memory_usage: Creating...
  message:             "" => "App #{var.env}: Memory usage is above 95% average across all nodes over the last 15 minutes #{lookup(var.notification_channel, var.env)}"
  name:                "" => "App #{var.env}: Memory alert"
  notify_no_data:      "" => "1"
  query:               "" => "avg(last_15m):avg:system.mem.pct_usable{autoscaling,env:app-#{var.env}} < 0.05"
  renotify_interval:   "" => "120"
  thresholds.#:        "0" => "3"
  thresholds.critical: "" => "0.05"
  thresholds.ok:       "" => "1"
  thresholds.warning:  "" => "0.1"
  type:                "" => "Metric alert"
module.app.datadog_monitor.cpu_usage: Creating...
  message:             "" => "App #{var.env}: CPU usage is above 95% average across all nodes over the last 15 minutes #{lookup(var.notification_channel, var.env)}"
  name:                "" => "App #{var.env}: CPU alert"
  notify_no_data:      "" => "1"
  query:               "" => "avg(last_15m):avg:system.cpu.idle{autoscaling,env:app-#{var.env}} < 5"
  renotify_interval:   "" => "120"
  thresholds.#:        "0" => "3"
  thresholds.critical: "" => "5"
  thresholds.ok:       "" => "100"
  thresholds.warning:  "" => "10"
  type:                "" => "Metric alert"
Error applying plan:

2 error(s) occurred:

* datadog_monitor.memory_usage: error updating montor: API error 400 Bad Request: {"errors":["The value provided for parameter 'type' is invalid"]}
* datadog_monitor.cpu_usage: error updating montor: API error 400 Bad Request: {"errors":["The value provided for parameter 'type' is invalid"]}
```

changing that to lower case `metric alert`, like it states in the documentation below the example, fixes the issue.  was just a little confusing at first.
