### PR TITLE
AWS: codecommit set default_branch only if defined

### DIFF
--- a/builtin/providers/aws/resource_aws_codecommit_repository.go
+++ b/builtin/providers/aws/resource_aws_codecommit_repository.go
@@ -104,9 +104,11 @@ func resourceAwsCodeCommitRepositoryCreate(d *schema.ResourceData, meta interfac
 func resourceAwsCodeCommitRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codecommitconn
 
-	if d.HasChange("default_branch") {
-		if err := resourceAwsCodeCommitUpdateDefaultBranch(conn, d); err != nil {
-			return err
+	if _, ok := d.GetOk("default_branch"); ok {
+		if d.HasChange("default_branch") {
+			if err := resourceAwsCodeCommitUpdateDefaultBranch(conn, d); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -135,8 +137,11 @@ func resourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interface{
 	d.Set("arn", *out.RepositoryMetadata.Arn)
 	d.Set("clone_url_http", *out.RepositoryMetadata.CloneUrlHttp)
 	d.Set("clone_url_ssh", *out.RepositoryMetadata.CloneUrlSsh)
-	if out.RepositoryMetadata.DefaultBranch != nil {
-		d.Set("default_branch", *out.RepositoryMetadata.DefaultBranch)
+
+	if _, ok := d.GetOk("default_branch"); ok {
+		if out.RepositoryMetadata.DefaultBranch != nil {
+			d.Set("default_branch", *out.RepositoryMetadata.DefaultBranch)
+		}
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_codecommit_repository.go
+++ b/builtin/providers/aws/resource_aws_codecommit_repository.go
@@ -176,12 +176,26 @@ func resourceAwsCodeCommitUpdateDescription(conn *codecommit.CodeCommit, d *sche
 }
 
 func resourceAwsCodeCommitUpdateDefaultBranch(conn *codecommit.CodeCommit, d *schema.ResourceData) error {
+	input := &codecommit.ListBranchesInput{
+		RepositoryName: aws.String(d.Id()),
+	}
+
+	out, err := conn.ListBranches(input)
+	if err != nil {
+		return fmt.Errorf("Error reading CodeCommit Repository branches: %s", err.Error())
+	}
+
+	if len(out.Branches) == 0 {
+		log.Printf("[WARN] Not setting Default Branch CodeCommit Repository that has no branches: %s", d.Id())
+		return nil
+	}
+
 	branchInput := &codecommit.UpdateDefaultBranchInput{
 		RepositoryName:    aws.String(d.Id()),
 		DefaultBranchName: aws.String(d.Get("default_branch").(string)),
 	}
 
-	_, err := conn.UpdateDefaultBranch(branchInput)
+	_, err = conn.UpdateDefaultBranch(branchInput)
 	if err != nil {
 		return fmt.Errorf("Error Updating Default Branch for CodeCommit Repository: %s", err.Error())
 	}

--- a/builtin/providers/aws/resource_aws_codecommit_repository_test.go
+++ b/builtin/providers/aws/resource_aws_codecommit_repository_test.go
@@ -53,6 +53,50 @@ func TestAccAWSCodeCommitRepository_withChanges(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodeCommitRepository_create_default_branch(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCodeCommitRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCodeCommitRepository_with_default_branch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
+					resource.TestCheckResourceAttr(
+						"aws_codecommit_repository.test", "default_branch", "master"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeCommitRepository_create_and_update_default_branch(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCodeCommitRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCodeCommitRepository_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
+					resource.TestCheckResourceAttr(
+						"aws_codecommit_repository.test", "default_branch", ""),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCodeCommitRepository_with_default_branch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
+					resource.TestCheckResourceAttr(
+						"aws_codecommit_repository.test", "default_branch", "master"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCodeCommitRepositoryExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -127,5 +171,16 @@ provider "aws" {
 resource "aws_codecommit_repository" "test" {
   repository_name = "my_test_repository"
   description = "This is a test description - with changes"
+}
+`
+
+const testAccCodeCommitRepository_with_default_branch = `
+provider "aws" {
+  region = "us-east-1"
+}
+resource "aws_codecommit_repository" "test" {
+  repository_name = "my_test_repository"
+  description = "This is a test description"
+  default_branch = "master"
 }
 `


### PR DESCRIPTION
Do not try to update the AWS codecommit repository default branch if the resource definition does not set it or is an empty string.

Fixes #5641

Note: Not sure if this is the best approach to handle the issue, as terraform reports changes all time. But it does not crash. Comments?