### PR TITLE
provider/aws: Return instance state message if state is terminated on create

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -690,7 +690,7 @@ func InstanceStateRefreshFunc(conn *ec2.EC2, instanceID string) resource.StateRe
 				return nil, "", errors.New(*i.StateReason.Message)
 			}
 
-			return nil, "", fmt.Errorf("Instance state is 'terminated' for unknown reasons")
+			return nil, "", fmt.Errorf("Instance state is 'terminated'. Please check AWS Console for more information")
 		}
 		return i, *i.State.Name, nil
 	}

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -683,6 +684,14 @@ func InstanceStateRefreshFunc(conn *ec2.EC2, instanceID string) resource.StateRe
 		}
 
 		i := resp.Reservations[0].Instances[0]
+
+		if i.State != nil && *i.State.Name == "terminated" {
+			if i.StateReason != nil {
+				return nil, "", errors.New(*i.StateReason.Message)
+			}
+
+			return nil, "", fmt.Errorf("Instance state is 'terminated' for unknown reasons")
+		}
 		return i, *i.State.Name, nil
 	}
 }


### PR DESCRIPTION
There exist configurations that result in a failed state of launch for AWS Instances. We account for many when an error is returned on initial create, however, a `RunInstances` command can _succeed_ but still result in a failed launch. 

Here we bubble up an error message if the initial `DescribeInstances` call returns an instance that is `terminated. 

This "fixes" #2564 in that it reveals a more descriptive error message, though it's still not as crystal as I'd like:

```
* aws_instance.tf_test: Error waiting for instance (i-036d83a5fe0a39848) to become ready: Client.InvalidParameterCombination: Could not create volume with size 20GiB and iops 20100 from snapshot 'null'
```

The iops limit is 20,000, and that's the error message we get. Unfortunately it doesn't explicitly say "too many iops", but it's a step closer than our current response:

```
* Error waiting for instance (i-81795976) to become ready: unexpected state 'terminated', wanted target 'running'
```

The [documentation][docs] do not give us a lot of information as to what states could be returned, or why

[docs]: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_StateReason.html