### PR TITLE
provider/aws: Adding outputs for elastic_beanstalk_environment resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
@@ -126,16 +126,10 @@ resource "aws_elastic_beanstalk_application" "tftest" {
   description = "tf-test-desc"
 }
 
-#resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-#  name = "tf-test-name"
-#  application = "${aws_elastic_beanstalk_application.tftest.name}"
-#  solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
-#}
-
 resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
   name = "tf-test-template-config"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.8 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux running Python"
 }
 `
 
@@ -167,7 +161,7 @@ resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
   name        = "tf-test-%s"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
 
-  solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux running Python"
 
   setting {
     namespace = "aws:ec2:vpc"

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -34,6 +34,7 @@ func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 
 func TestAccAWSBeanstalkEnv_tier(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
+	beanstalkQueuesNameRegexp := regexp.MustCompile("https://sqs.+?awseb[^,]+")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,6 +45,38 @@ func TestAccAWSBeanstalkEnv_tier(t *testing.T) {
 				Config: testAccBeanstalkWorkerEnvConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBeanstalkEnvTier("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					resource.TestMatchResourceAttr(
+						"aws_elastic_beanstalk_environment.tfenvtest", "queues.0", beanstalkQueuesNameRegexp),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBeanstalkEnv_outputs(t *testing.T) {
+	var app elasticbeanstalk.EnvironmentDescription
+	beanstalkAsgNameRegexp := regexp.MustCompile("awseb.+?AutoScalingGroup[^,]+")
+	beanstalkElbNameRegexp := regexp.MustCompile("awseb.+?EBLoa[^,]+")
+	beanstalkInstancesNameRegexp := regexp.MustCompile("i-([0-9a-fA-F]{8}|[0-9a-fA-F]{17})")
+	beanstalkLcNameRegexp := regexp.MustCompile("awseb.+?AutoScalingLaunch[^,]+")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBeanstalkEnvConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					resource.TestMatchResourceAttr(
+						"aws_elastic_beanstalk_environment.tfenvtest", "autoscaling_groups.0", beanstalkAsgNameRegexp),
+					resource.TestMatchResourceAttr(
+						"aws_elastic_beanstalk_environment.tfenvtest", "load_balancers.0", beanstalkElbNameRegexp),
+					resource.TestMatchResourceAttr(
+						"aws_elastic_beanstalk_environment.tfenvtest", "instances.0", beanstalkInstancesNameRegexp),
+					resource.TestMatchResourceAttr(
+						"aws_elastic_beanstalk_environment.tfenvtest", "launch_configurations.0", beanstalkLcNameRegexp),
 				),
 			},
 		},
@@ -189,8 +222,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name = "tf-test-name"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.8 running Go 1.4"
-  #solution_stack_name =
+  solution_stack_name = "64bit Amazon Linux running Python"
 }
 `
 
@@ -204,7 +236,7 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name = "tf-test-name"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
   tier = "Worker"
-  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux running Python"
 }
 `
 
@@ -219,7 +251,7 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 name = "tf-test-name"
 application = "${aws_elastic_beanstalk_application.tftest.name}"
 cname_prefix = "%s"
-solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
+solution_stack_name = "64bit Amazon Linux running Python"
 }
 `, randString)
 }

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -1015,4 +1016,64 @@ func flattenCloudWachLogMetricTransformations(ts []*cloudwatchlogs.MetricTransfo
 	m["value"] = *ts[0].MetricValue
 
 	return m
+}
+
+func flattenBeanstalkAsg(list []*elasticbeanstalk.AutoScalingGroup) []string {
+	strs := make([]string, 0, len(list))
+	for _, r := range list {
+		if r.Name != nil {
+			strs = append(strs, *r.Name)
+		}
+	}
+	return strs
+}
+
+func flattenBeanstalkInstances(list []*elasticbeanstalk.Instance) []string {
+	strs := make([]string, 0, len(list))
+	for _, r := range list {
+		if r.Id != nil {
+			strs = append(strs, *r.Id)
+		}
+	}
+	return strs
+}
+
+func flattenBeanstalkLc(list []*elasticbeanstalk.LaunchConfiguration) []string {
+	strs := make([]string, 0, len(list))
+	for _, r := range list {
+		if r.Name != nil {
+			strs = append(strs, *r.Name)
+		}
+	}
+	return strs
+}
+
+func flattenBeanstalkElb(list []*elasticbeanstalk.LoadBalancer) []string {
+	strs := make([]string, 0, len(list))
+	for _, r := range list {
+		if r.Name != nil {
+			strs = append(strs, *r.Name)
+		}
+	}
+	return strs
+}
+
+func flattenBeanstalkSqs(list []*elasticbeanstalk.Queue) []string {
+	strs := make([]string, 0, len(list))
+	for _, r := range list {
+		if r.URL != nil {
+			strs = append(strs, *r.URL)
+		}
+	}
+	return strs
+}
+
+func flattenBeanstalkTrigger(list []*elasticbeanstalk.Trigger) []string {
+	strs := make([]string, 0, len(list))
+	for _, r := range list {
+		if r.Name != nil {
+			strs = append(strs, *r.Name)
+		}
+	}
+	return strs
 }

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -74,15 +74,22 @@ The `setting` and `all_settings` mappings support the following format:
 
 The following attributes are exported:
 
-* `name`
-* `description`
-* `tier` - the environment tier specified.
-* `application` – the application specified
-* `setting` – Settings specifically set for this Environment
+* `name` - Name of the Elastic Beanstalk Environment.
+* `description` - Description of the Elastic Beanstalk Environment.
+* `tier` - The environment tier specified.
+* `application` – The Elastic Beanstalk Application specified for this environment.
+* `setting` – Settings specifically set for this Environment.
 * `all_settings` – List of all option settings configured in the Environment. These
   are a combination of default settings and their overrides from `settings` in
-  the configuration
+  the configuration.
 * `cname` - Fully qualified DNS name for the Environment.
+* `autoscaling_groups` - The autoscaling groups used by this environment.
+* `instances` - Instances used by this environment.
+* `launch_configurations` - Launch configurations in use by this environment.
+* `load_balancers` - Elastic load balancers in use by this environment.
+* `queues` - SQS queues in use by this environment.
+* `triggers` - Autoscaling triggers in use by this environment.
+
 
 
 [1]: http://docs.aws.amazon.com/fr_fr/elasticbeanstalk/latest/dg/concepts.platforms.html


### PR DESCRIPTION
For #5798  This adds a few resource outputs for an Elastic Beanstalk Environment.

Example config using these outputs for cloudwatch:
```
provider "aws" {
  region = "us-east-1"
}

resource "aws_elastic_beanstalk_application" "default" {
  name        = "tf-test-name"
  description = "tf-test-desc"
}

resource "aws_elastic_beanstalk_environment" "default" {
  name                = "tf-test-name"
  application         = "${aws_elastic_beanstalk_application.default.name}"
  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
  tier                = "Worker"
}

resource "aws_cloudwatch_metric_alarm" "sqs" {
  alarm_name          = "terraform-test-beanstalk-sqs"
  comparison_operator = "GreaterThanOrEqualToThreshold"
  evaluation_periods  = "1"
  metric_name         = "NumberOfMessagesSent"
  namespace           = "AWS/SQS"
  period              = "3600"
  statistic           = "Sum"
  threshold           = "100"

  dimensions {
    QueueName = "${element(split("/", aws_elastic_beanstalk_environment.default.queues.0), 4)}"
  }
}

resource "aws_cloudwatch_metric_alarm" "asg" {
  alarm_name          = "terraform-test-beanstalak-asg"
  comparison_operator = "GreaterThanOrEqualToThreshold"
  evaluation_periods  = "2"
  metric_name         = "CPUUtilization"
  namespace           = "AWS/EC2"
  period              = "120"
  statistic           = "Average"
  threshold           = "80"

  dimensions {
    AutoScalingGroupName = "${aws_elastic_beanstalk_environment.default.autoscaling_groups.0}"
  }
}
```

Tests:
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkEnv -timeout 120m
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (341.29s)
=== RUN   TestAccAWSBeanstalkEnv_tier
--- PASS: TestAccAWSBeanstalkEnv_tier (535.16s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	876.455s
```