### PR TITLE
Address #5912: google-two-tier example incomplete

### DIFF
--- a/examples/google-two-tier/README.md
+++ b/examples/google-two-tier/README.md
@@ -11,6 +11,17 @@ getting your application onto the servers. However, you could do so either via
 management tool, or by pre-baking configured images with
 [Packer](https://packer.io/docs/builders/googlecompute.html).
 
+You will need to generate SSH keys as follows:
+
+```sh
+$ ssh-keygen -f ~/.ssh/gcloud_id_rsa
+# press <Enter> when asked (twice) for a pass-phrase
+```
+
+Then [download your credentials from Google Cloud Console](https://www.terraform.io/docs/providers/google/#credentials); suggested path for downloaded file is `~/.gcloud/Terraform.json`.
+
+Optionally update `variables.tf` to specify a default value for the `project_name` variable, and check other variables.
+
 After you run `terraform apply` on this configuration, it will
 automatically output the public IP address of the load balancer.
 After your instance registers, the LB should respond with a simple header:
@@ -33,7 +44,7 @@ terraform apply \
 	-var="region=us-central1" \
 	-var="region_zone=us-central1-f" \
 	-var="project_name=my-project-id-123" \
-	-var="account_file_path=~/.gcloud/Terraform.json" \
+	-var="credentials_file_path=~/.gcloud/Terraform.json" \
 	-var="public_key_path=~/.ssh/gcloud_id_rsa.pub" \
 	-var="private_key_path=~/.ssh/gcloud_id_rsa"
 ```

--- a/examples/google-two-tier/output.tf
+++ b/examples/google-two-tier/output.tf
@@ -3,5 +3,5 @@ output "pool_public_ip" {
 }
 
 output "instance_ips" {
-  value = "${join(" ", google_compute_instance.www.*.network_interface.0.access_config.0.nat_ip)}"
+  value = "${join(" ", google_compute_instance.www.*.network_interface.0.access_config.0.assigned_nat_ip)}"
 }

--- a/examples/google-two-tier/scripts/install.sh
+++ b/examples/google-two-tier/scripts/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -xe
+
+RESOURCE_INDEX=$1
+apt-get -y update
+apt-get -y install nginx
+IP=$(curl -s -H "Metadata-Flavor:Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/ip)
+echo "Welcome to Resource ${RESOURCE_INDEX} - ${HOSTNAME} (${IP})" > /usr/share/nginx/html/index.html
+service nginx start

--- a/examples/google-two-tier/variables.tf
+++ b/examples/google-two-tier/variables.tf
@@ -10,6 +10,27 @@ variable "project_name" {
   description = "The ID of the Google Cloud project"
 }
 
-variable "account_file_path" {
+variable "credentials_file_path" {
   description = "Path to the JSON file used to describe your account credentials"
+  default = "~/.gcloud/Terraform.json"
+}
+
+variable "public_key_path" {
+  description = "Path to file containing public key"
+  default = "~/.ssh/gcloud_id_rsa.pub"
+}
+
+variable "private_key_path" {
+  description = "Path to file containing private key"
+  default = "~/.ssh/gcloud_id_rsa"
+}
+
+variable "install_script_src_path" {
+  description = "Path to install script within this repository"
+  default = "scripts/install.sh"
+}
+
+variable "install_script_dest_path" {
+  description = "Path to put the install script on each destination resource"
+  default = "/tmp/install.sh"
 }


### PR DESCRIPTION
This addresses #5912.

After these modifications to the `google-two-tier` example have been made, it now works when instructions are followed.

I made the following changes:
* updated the `README` with additional instructions on how to run this example, including private/public key generation
* changed `machine_type` from `n1-standard-1` to `f1-micro`
* updated the ubuntu image to one that makes use of `ssh-keys` instead of `sshKeys`
* use a `provisioner` instead of `startup-script` &ndash; the latter neither shows errors, nor causes `terraform` to fail on error; the former does
* added `scripts/install.sh`, which is used by the `provisioner`
* run SSH install script as `root` instead of `ubuntu` (the script runs `apt-get`, which requires root privileges)

If all defaults are used, the minimum command for running this example is:

```sh
$ terraform apply -var="project_name=your-google-compute-project-name"
```
