### PR TITLE
Add Fabric and VLAN to the Joyent Triton resource

### DIFF
--- a/builtin/providers/triton/provider.go
+++ b/builtin/providers/triton/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"triton_machine":       resourceMachine(),
 			"triton_key":           resourceKey(),
 			"triton_vlan":          resourceVLAN(),
+			"triton_fabric":        resourceFabric(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/triton/provider.go
+++ b/builtin/providers/triton/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"triton_firewall_rule": resourceFirewallRule(),
 			"triton_machine":       resourceMachine(),
 			"triton_key":           resourceKey(),
+			"triton_vlan":          resourceVLAN(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/triton/resource_fabric.go
+++ b/builtin/providers/triton/resource_fabric.go
@@ -1,0 +1,178 @@
+package triton
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/gosdc/cloudapi"
+)
+
+func resourceFabric() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceFabricCreate,
+		Exists: resourceFabricExists,
+		Read:   resourceFabricRead,
+		Delete: resourceFabricDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "network name",
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
+			"public": {
+				Description: "whether or not this is an RFC1918 network",
+				Computed:    true,
+				Type:        schema.TypeBool,
+			},
+			"fabric": {
+				Description: "whether or not this network is on a fabric",
+				Computed:    true,
+				Type:        schema.TypeBool,
+			},
+			"description": {
+				Description: "optional description of network",
+				Optional:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
+			"subnet": {
+				Description: "CIDR formatted string describing network",
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
+			"provision_start_ip": {
+				Description: "first IP on the network that can be assigned",
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
+			"provision_end_ip": {
+				Description: "last assignable IP on the network",
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
+			"gateway": {
+				Description: "optional gateway IP",
+				Optional:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+			},
+			"resolvers": {
+				Description: "array of IP addresses for resolvers",
+				Optional:    true,
+				Computed:    true,
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"routes": {
+				Description: "map of CIDR block to Gateway IP address",
+				Computed:    true,
+				Optional:    true,
+				ForceNew:    true,
+				Type:        schema.TypeMap,
+			},
+			"internet_nat": {
+				Description: "if a NAT zone is provisioned at Gateway IP address",
+				Computed:    true,
+				Optional:    true,
+				ForceNew:    true,
+				Type:        schema.TypeBool,
+			},
+			"vlan_id": {
+				Description: "VLAN network is on",
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeInt,
+			},
+		},
+	}
+}
+
+func resourceFabricCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudapi.Client)
+
+	var resolvers []string
+	for _, resolver := range d.Get("resolvers").([]interface{}) {
+		resolvers = append(resolvers, resolver.(string))
+	}
+
+	routes := map[string]string{}
+	for cidr, v := range d.Get("routes").(map[string]interface{}) {
+		ip, ok := v.(string)
+		if !ok {
+			return fmt.Errorf(`cannot use "%v" as an IP address`, v)
+		}
+		routes[cidr] = ip
+	}
+
+	fabric, err := client.CreateFabricNetwork(
+		int16(d.Get("vlan_id").(int)),
+		cloudapi.CreateFabricNetworkOpts{
+			Name:             d.Get("name").(string),
+			Description:      d.Get("description").(string),
+			Subnet:           d.Get("subnet").(string),
+			ProvisionStartIp: d.Get("provision_start_ip").(string),
+			ProvisionEndIp:   d.Get("provision_end_ip").(string),
+			Gateway:          d.Get("gateway").(string),
+			Resolvers:        resolvers,
+			Routes:           routes,
+			InternetNAT:      d.Get("internet_nat").(bool),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fabric.Id)
+
+	err = resourceFabricRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceFabricExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*cloudapi.Client)
+
+	fabric, err := client.GetFabricNetwork(int16(d.Get("vlan_id").(int)), d.Id())
+
+	return fabric != nil && err == nil, err
+}
+
+func resourceFabricRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudapi.Client)
+
+	fabric, err := client.GetFabricNetwork(int16(d.Get("vlan_id").(int)), d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fabric.Id)
+	d.Set("name", fabric.Name)
+	d.Set("public", fabric.Public)
+	d.Set("public", fabric.Public)
+	d.Set("fabric", fabric.Fabric)
+	d.Set("description", fabric.Description)
+	d.Set("subnet", fabric.Subnet)
+	d.Set("provision_start_ip", fabric.ProvisionStartIp)
+	d.Set("provision_end_ip", fabric.ProvisionEndIp)
+	d.Set("gateway", fabric.Gateway)
+	d.Set("resolvers", fabric.Resolvers)
+	d.Set("routes", fabric.Routes)
+	d.Set("internet_nat", fabric.InternetNAT)
+	d.Set("vlan_id", fabric.VLANId)
+
+	return nil
+}
+
+func resourceFabricDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudapi.Client)
+
+	return client.DeleteFabricNetwork(int16(d.Get("vlan_id").(int)), d.Id())
+}

--- a/builtin/providers/triton/resource_fabric_test.go
+++ b/builtin/providers/triton/resource_fabric_test.go
@@ -1,0 +1,104 @@
+package triton
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/joyent/gosdc/cloudapi"
+)
+
+func TestAccTritonFabric_basic(t *testing.T) {
+	fabricName := fmt.Sprintf("acctest-%d", acctest.RandInt())
+	config := fmt.Sprintf(testAccTritonFabric_basic, fabricName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTritonFabricDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonFabricExists("triton_fabric.test"),
+					func(*terraform.State) error {
+						time.Sleep(10 * time.Second)
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testCheckTritonFabricExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		conn := testAccProvider.Meta().(*cloudapi.Client)
+
+		id, err := strconv.ParseInt(rs.Primary.Attributes["vlan_id"], 10, 16)
+		if err != nil {
+			return err
+		}
+
+		fabric, err := conn.GetFabricNetwork(int16(id), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Bad: Check Fabric Exists: %s", err)
+		}
+
+		if fabric == nil {
+			return fmt.Errorf("Bad: Fabric %q does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testCheckTritonFabricDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*cloudapi.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "triton_fabric" {
+			continue
+		}
+
+		id, err := strconv.ParseInt(rs.Primary.Attributes["vlan_id"], 10, 16)
+		if err != nil {
+			return err
+		}
+
+		fabric, err := conn.GetFabricNetwork(int16(id), rs.Primary.ID)
+		if err != nil {
+			return nil
+		}
+
+		if fabric != nil {
+			return fmt.Errorf("Bad: Fabric %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+var testAccTritonFabric_basic = `
+resource "triton_fabric" "test" {
+  name = "%s"
+  description = "test network"
+  vlan_id = 2 # every DC seems to have a vlan 2 available
+
+  subnet = "10.0.0.0/22"
+  gateway = "10.0.0.1"
+  provision_start_ip = "10.0.0.5"
+  provision_end_ip = "10.0.3.250"
+
+  resolvers = ["8.8.8.8", "8.8.4.4"]
+}
+`

--- a/builtin/providers/triton/resource_vlan.go
+++ b/builtin/providers/triton/resource_vlan.go
@@ -1,0 +1,132 @@
+package triton
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/gosdc/cloudapi"
+)
+
+func resourceVLAN() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVLANCreate,
+		Exists: resourceVLANExists,
+		Read:   resourceVLANRead,
+		Update: resourceVLANUpdate,
+		Delete: resourceVLANDelete,
+
+		Schema: map[string]*schema.Schema{
+			"vlan_id": {
+				Description: "number between 2-4095 indicating VLAN ID",
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeInt,
+				ValidateFunc: func(val interface{}, field string) (warn []string, err []error) {
+					value := val.(int)
+					if value < 0 || value > 4095 {
+						err = append(err, errors.New("id must be between 2 and 4095"))
+					}
+					return
+				},
+			},
+			"name": {
+				Description: "Unique name to identify VLAN",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"description": {
+				Description: "Optional description of the VLAN",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+		},
+	}
+}
+
+func resourceVLANCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudapi.Client)
+
+	vlan, err := client.CreateFabricVLAN(cloudapi.FabricVLAN{
+		Id:          int16(d.Get("vlan_id").(int)),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resourceVLANIDString(vlan.Id))
+	return resourceVLANRead(d, meta)
+}
+
+func resourceVLANExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*cloudapi.Client)
+
+	id, err := resourceVLANIDInt16(d.Id())
+	if err != nil {
+		return false, err
+	}
+
+	vlan, err := client.GetFabricVLAN(id)
+
+	return vlan != nil && err == nil, err
+}
+
+func resourceVLANRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudapi.Client)
+
+	vlan, err := client.GetFabricVLAN(int16(d.Get("vlan_id").(int)))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resourceVLANIDString(vlan.Id))
+	d.Set("vlan_id", vlan.Id)
+	d.Set("name", vlan.Name)
+	d.Set("description", vlan.Description)
+
+	return nil
+}
+
+func resourceVLANUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudapi.Client)
+
+	vlan, err := client.UpdateFabricVLAN(cloudapi.FabricVLAN{
+		Id:          int16(d.Get("vlan_id").(int)),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resourceVLANIDString(vlan.Id))
+	return resourceVLANRead(d, meta)
+}
+
+func resourceVLANDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudapi.Client)
+
+	id, err := resourceVLANIDInt16(d.Id())
+	if err != nil {
+		return err
+	}
+
+	return client.DeleteFabricVLAN(id)
+}
+
+// convenience conversion functions
+
+func resourceVLANIDString(id int16) string {
+	return strconv.Itoa(int(id))
+}
+
+func resourceVLANIDInt16(id string) (int16, error) {
+	result, err := strconv.ParseInt(id, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+
+	return int16(result), nil
+}

--- a/builtin/providers/triton/resource_vlan_test.go
+++ b/builtin/providers/triton/resource_vlan_test.go
@@ -1,0 +1,127 @@
+package triton
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/joyent/gosdc/cloudapi"
+)
+
+func TestAccTritonVLAN_basic(t *testing.T) {
+	config := testAccTritonVLAN_basic
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTritonVLANDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonVLANExists("triton_vlan.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTritonVLAN_update(t *testing.T) {
+	preConfig := testAccTritonVLAN_basic
+	postConfig := testAccTritonVLAN_update
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTritonVLANDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonVLANExists("triton_vlan.test"),
+					resource.TestCheckResourceAttr("triton_vlan.test", "name", "test-vlan"),
+					resource.TestCheckResourceAttr("triton_vlan.test", "description", "test vlan"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonVLANExists("triton_vlan.test"),
+					resource.TestCheckResourceAttr("triton_vlan.test", "name", "test-vlan-2"),
+					resource.TestCheckResourceAttr("triton_vlan.test", "description", "test vlan 2"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckTritonVLANExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		conn := testAccProvider.Meta().(*cloudapi.Client)
+
+		id, err := resourceVLANIDInt16(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		rule, err := conn.GetFabricVLAN(id)
+		if err != nil {
+			return fmt.Errorf("Bad: Check VLAN Exists: %s", err)
+		}
+
+		if rule == nil {
+			return fmt.Errorf("Bad: VLAN %q does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testCheckTritonVLANDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*cloudapi.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "triton_vlan" {
+			continue
+		}
+
+		id, err := resourceVLANIDInt16(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := conn.GetFabricVLAN(id)
+		if err != nil {
+			return nil
+		}
+
+		if resp != nil {
+			return fmt.Errorf("Bad: VLAN %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+var testAccTritonVLAN_basic = `
+resource "triton_vlan" "test" {
+  vlan_id = 1024
+  name = "test-vlan"
+  description = "test vlan"
+}
+`
+
+var testAccTritonVLAN_update = `
+resource "triton_vlan" "test" {
+  vlan_id = 1024
+  name = "test-vlan-2"
+  description = "test vlan 2"
+}
+`


### PR DESCRIPTION
Hi there! This PR adds Fabric and VLAN support to the Joyent Triton resource. All the acceptance tests (including internal validation) pass. As far as I'm concerned, this is ready to merge.

New resources:

- `triton_vlan`
- `triton_fabric`

New tests:

- VLAN: create and update
- Fabric: create (update not allowed)

Test output:

```
$ TF_ACC=1 go test -v .
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccTritonFabric_basic
--- PASS: TestAccTritonFabric_basic (19.44s)
=== RUN   TestAccTritonFirewallRule_basic
--- PASS: TestAccTritonFirewallRule_basic (6.24s)
=== RUN   TestAccTritonFirewallRule_update
--- PASS: TestAccTritonFirewallRule_update (9.32s)
=== RUN   TestAccTritonFirewallRule_enable
--- PASS: TestAccTritonFirewallRule_enable (10.07s)
=== RUN   TestAccTritonKey_basic
--- PASS: TestAccTritonKey_basic (19.52s)
=== RUN   TestAccTritonMachine_basic
--- PASS: TestAccTritonMachine_basic (198.85s)
=== RUN   TestAccTritonVLAN_basic
--- PASS: TestAccTritonVLAN_basic (5.31s)
=== RUN   TestAccTritonVLAN_update
--- PASS: TestAccTritonVLAN_update (9.84s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/triton 278.607s
```