### PR TITLE
provider/aws: DB subnet group description modification

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -165,8 +165,9 @@ func resourceAwsDbSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		_, err := conn.ModifyDBSubnetGroup(&rds.ModifyDBSubnetGroupInput{
-			DBSubnetGroupName: aws.String(d.Id()),
-			SubnetIds:         sIds,
+			DBSubnetGroupName:        aws.String(d.Id()),
+			DBSubnetGroupDescription: aws.String(d.Get("description").(string)),
+			SubnetIds:                sIds,
 		})
 
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -38,7 +38,6 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"subnet_ids": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -152,7 +152,7 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 func resourceAwsDbSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
-	if d.HasChange("subnet_ids") {
+	if d.HasChange("subnet_ids") || d.HasChange("description") {
 		_, n := d.GetChange("subnet_ids")
 		if n == nil {
 			n = new(schema.Set)


### PR DESCRIPTION
Do not force a new resource when changing the description of a db subnet group