### PR TITLE
Redshift master usernames may contain underscores

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -579,7 +579,7 @@ func validateRedshiftClusterFinalSnapshotIdentifier(v interface{}, k string) (ws
 
 func validateRedshiftClusterMasterUsername(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[A-Za-z0-9]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^\w+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only alphanumeric characters in %q", k))
 	}

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -257,6 +257,10 @@ func TestResourceAWSRedshiftClusterMasterUsernameValidation(t *testing.T) {
 			Value:    randomString(129),
 			ErrCount: 1,
 		},
+		{
+			Value:    "testing_testing123",
+			ErrCount: 0,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Ran into this when trying to bootstrap Terraform for my company. Our Redshift master username currently has an underscore in it.