### PR TITLE
provider/aws: Test to validate that db subnet group description can be updated

### DIFF
--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -66,6 +66,37 @@ func TestAccAWSDBSubnetGroup_withUndocumentedCharacters(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBSubnetGroup_updateDescription(t *testing.T) {
+	var v rds.DBSubnetGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBSubnetGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBSubnetGroupExists(
+						"aws_db_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_subnet_group.foo", "description", "foo description"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccDBSubnetGroupConfig_updatedDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBSubnetGroupExists(
+						"aws_db_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_subnet_group.foo", "description", "foo description updated"),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceAWSDBSubnetGroupNameValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -183,6 +214,39 @@ resource "aws_subnet" "bar" {
 resource "aws_db_subnet_group" "foo" {
 	name = "foo"
 	description = "foo description"
+	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+	tags {
+		Name = "tf-dbsubnet-group-test"
+	}
+}
+`
+
+const testAccDBSubnetGroupConfig_updatedDescription = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "foo" {
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-1"
+	}
+}
+
+resource "aws_subnet" "bar" {
+	cidr_block = "10.1.2.0/24"
+	availability_zone = "us-west-2b"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-2"
+	}
+}
+
+resource "aws_db_subnet_group" "foo" {
+	name = "foo"
+	description = "foo description updated"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 	tags {
 		Name = "tf-dbsubnet-group-test"


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBSubnetGroup' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBSubnetGroup -timeout 120m
=== RUN   TestAccAWSDBSubnetGroup_basic
--- PASS: TestAccAWSDBSubnetGroup_basic (21.95s)
=== RUN   TestAccAWSDBSubnetGroup_withUndocumentedCharacters
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (21.27s)
=== RUN   TestAccAWSDBSubnetGroup_updateDescription
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (31.94s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	75.182s
```