### PR TITLE
provider/aws: Allow `aws_redshift_security_group` ingress rules to change

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_security_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_security_group.go
@@ -20,6 +20,7 @@ func resourceAwsRedshiftSecurityGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsRedshiftSecurityGroupCreate,
 		Read:   resourceAwsRedshiftSecurityGroupRead,
+		Update: resourceAwsRedshiftSecurityGroupUpdate,
 		Delete: resourceAwsRedshiftSecurityGroupDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -39,7 +40,6 @@ func resourceAwsRedshiftSecurityGroup() *schema.Resource {
 			"ingress": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cidr": &schema.Schema{
@@ -148,6 +148,55 @@ func resourceAwsRedshiftSecurityGroupRead(d *schema.ResourceData, meta interface
 	d.Set("description", *sg.Description)
 
 	return nil
+}
+
+func resourceAwsRedshiftSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).redshiftconn
+
+	if d.HasChange("ingress") {
+		o, n := d.GetChange("ingress")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		removeIngressRules, err := expandRedshiftSGRevokeIngress(os.Difference(ns).List())
+		if err != nil {
+			return err
+		}
+		if len(removeIngressRules) > 0 {
+			for _, r := range removeIngressRules {
+				r.ClusterSecurityGroupName = aws.String(d.Id())
+
+				_, err := conn.RevokeClusterSecurityGroupIngress(&r)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		addIngressRules, err := expandRedshiftSGAuthorizeIngress(ns.Difference(os).List())
+		if err != nil {
+			return err
+		}
+		if len(addIngressRules) > 0 {
+			for _, r := range addIngressRules {
+				r.ClusterSecurityGroupName = aws.String(d.Id())
+
+				_, err := conn.AuthorizeClusterSecurityGroupIngress(&r)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+	}
+	return resourceAwsRedshiftSecurityGroupRead(d, meta)
 }
 
 func resourceAwsRedshiftSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
@@ -288,4 +337,60 @@ func resourceAwsRedshiftSecurityGroupStateRefreshFunc(
 
 		return v, "authorized", nil
 	}
+}
+
+func expandRedshiftSGAuthorizeIngress(configured []interface{}) ([]redshift.AuthorizeClusterSecurityGroupIngressInput, error) {
+	var ingress []redshift.AuthorizeClusterSecurityGroupIngressInput
+
+	// Loop over our configured parameters and create
+	// an array of aws-sdk-go compatabile objects
+	for _, pRaw := range configured {
+		data := pRaw.(map[string]interface{})
+
+		i := redshift.AuthorizeClusterSecurityGroupIngressInput{}
+
+		if v, ok := data["cidr"]; ok {
+			i.CIDRIP = aws.String(v.(string))
+		}
+
+		if v, ok := data["security_group_name"]; ok {
+			i.EC2SecurityGroupName = aws.String(v.(string))
+		}
+
+		if v, ok := data["security_group_owner_id"]; ok {
+			i.EC2SecurityGroupOwnerId = aws.String(v.(string))
+		}
+
+		ingress = append(ingress, i)
+	}
+
+	return ingress, nil
+}
+
+func expandRedshiftSGRevokeIngress(configured []interface{}) ([]redshift.RevokeClusterSecurityGroupIngressInput, error) {
+	var ingress []redshift.RevokeClusterSecurityGroupIngressInput
+
+	// Loop over our configured parameters and create
+	// an array of aws-sdk-go compatabile objects
+	for _, pRaw := range configured {
+		data := pRaw.(map[string]interface{})
+
+		i := redshift.RevokeClusterSecurityGroupIngressInput{}
+
+		if v, ok := data["cidr"]; ok {
+			i.CIDRIP = aws.String(v.(string))
+		}
+
+		if v, ok := data["security_group_name"]; ok {
+			i.EC2SecurityGroupName = aws.String(v.(string))
+		}
+
+		if v, ok := data["security_group_owner_id"]; ok {
+			i.EC2SecurityGroupOwnerId = aws.String(v.(string))
+		}
+
+		ingress = append(ingress, i)
+	}
+
+	return ingress, nil
 }

--- a/builtin/providers/aws/resource_aws_redshift_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_security_group_test.go
@@ -37,6 +37,44 @@ func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
 	})
 }
 
+func TestAccAWSRedshiftSecurityGroup_updateIngressCidr(t *testing.T) {
+	var v redshift.ClusterSecurityGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSRedshiftSecurityGroupConfig_ingressCidr,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSecurityGroupExists("aws_redshift_security_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_security_group.bar", "ingress.#", "1"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAWSRedshiftSecurityGroupConfig_ingressCidrAdd,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSecurityGroupExists("aws_redshift_security_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_security_group.bar", "ingress.#", "3"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAWSRedshiftSecurityGroupConfig_ingressCidrReduce,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSecurityGroupExists("aws_redshift_security_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_security_group.bar", "ingress.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
 	var v redshift.ClusterSecurityGroup
 
@@ -57,6 +95,44 @@ func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
 						"aws_redshift_security_group.bar", "ingress.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_security_group.bar", "ingress.220863.security_group_name", "terraform_redshift_acceptance_test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup(t *testing.T) {
+	var v redshift.ClusterSecurityGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSRedshiftSecurityGroupConfig_ingressSgId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSecurityGroupExists("aws_redshift_security_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_security_group.bar", "ingress.#", "1"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAWSRedshiftSecurityGroupConfig_ingressSgIdAdd,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSecurityGroupExists("aws_redshift_security_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_security_group.bar", "ingress.#", "3"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAWSRedshiftSecurityGroupConfig_ingressSgIdReduce,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSecurityGroupExists("aws_redshift_security_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_security_group.bar", "ingress.#", "2"),
 				),
 			},
 		},
@@ -177,6 +253,46 @@ resource "aws_redshift_security_group" "bar" {
     }
 }`
 
+const testAccAWSRedshiftSecurityGroupConfig_ingressCidrAdd = `
+provider "aws" {
+    region = "us-east-1"
+}
+
+resource "aws_redshift_security_group" "bar" {
+    name = "redshift-sg-terraform"
+    description = "this is a description"
+
+    ingress {
+        cidr = "10.0.0.1/24"
+    }
+
+    ingress {
+        cidr = "10.0.10.1/24"
+    }
+
+    ingress {
+        cidr = "10.0.20.1/24"
+    }
+}`
+
+const testAccAWSRedshiftSecurityGroupConfig_ingressCidrReduce = `
+provider "aws" {
+    region = "us-east-1"
+}
+
+resource "aws_redshift_security_group" "bar" {
+    name = "redshift-sg-terraform"
+    description = "this is a description"
+
+    ingress {
+        cidr = "10.0.0.1/24"
+    }
+
+    ingress {
+        cidr = "10.0.10.1/24"
+    }
+}`
+
 const testAccAWSRedshiftSecurityGroupConfig_ingressSgId = `
 provider "aws" {
     region = "us-east-1"
@@ -200,6 +316,111 @@ resource "aws_redshift_security_group" "bar" {
 
     ingress {
         security_group_name = "${aws_security_group.redshift.name}"
+        security_group_owner_id = "${aws_security_group.redshift.owner_id}"
+    }
+}`
+
+const testAccAWSRedshiftSecurityGroupConfig_ingressSgIdAdd = `
+provider "aws" {
+    region = "us-east-1"
+}
+
+resource "aws_security_group" "redshift" {
+	name = "terraform_redshift_acceptance_test"
+	description = "Used in the redshift acceptance tests"
+
+	ingress {
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		cidr_blocks = ["10.0.0.0/8"]
+	}
+}
+
+resource "aws_security_group" "redshift2" {
+	name = "terraform_redshift_acceptance_test_2"
+	description = "Used in the redshift acceptance tests #2"
+
+	ingress {
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		cidr_blocks = ["10.0.10.0/8"]
+	}
+}
+
+resource "aws_security_group" "redshift3" {
+	name = "terraform_redshift_acceptance_test_3"
+	description = "Used in the redshift acceptance tests #3"
+
+	ingress {
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		cidr_blocks = ["10.0.20.0/8"]
+	}
+}
+
+resource "aws_redshift_security_group" "bar" {
+    name = "redshift-sg-terraform"
+    description = "this is a description"
+
+    ingress {
+        security_group_name = "${aws_security_group.redshift.name}"
+        security_group_owner_id = "${aws_security_group.redshift.owner_id}"
+    }
+
+    ingress {
+        security_group_name = "${aws_security_group.redshift2.name}"
+        security_group_owner_id = "${aws_security_group.redshift.owner_id}"
+    }
+
+    ingress {
+        security_group_name = "${aws_security_group.redshift3.name}"
+        security_group_owner_id = "${aws_security_group.redshift.owner_id}"
+    }
+}`
+
+const testAccAWSRedshiftSecurityGroupConfig_ingressSgIdReduce = `
+provider "aws" {
+    region = "us-east-1"
+}
+
+resource "aws_security_group" "redshift" {
+	name = "terraform_redshift_acceptance_test"
+	description = "Used in the redshift acceptance tests"
+
+	ingress {
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		cidr_blocks = ["10.0.0.0/8"]
+	}
+}
+
+resource "aws_security_group" "redshift2" {
+	name = "terraform_redshift_acceptance_test_2"
+	description = "Used in the redshift acceptance tests #2"
+
+	ingress {
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		cidr_blocks = ["10.0.10.0/8"]
+	}
+}
+
+resource "aws_redshift_security_group" "bar" {
+    name = "redshift-sg-terraform"
+    description = "this is a description"
+
+    ingress {
+        security_group_name = "${aws_security_group.redshift.name}"
+        security_group_owner_id = "${aws_security_group.redshift.owner_id}"
+    }
+
+    ingress {
+        security_group_name = "${aws_security_group.redshift2.name}"
         security_group_owner_id = "${aws_security_group.redshift.owner_id}"
     }
 }`


### PR DESCRIPTION
As requested in #5707 : Allows the ability to change `aws_redshift_security_group` ingress rules

This can only be tested on an account with EC2-classic :(