### PR TITLE
Allow running `terraform plan` without persisting refreshed state

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -16,7 +16,7 @@ type PlanCommand struct {
 }
 
 func (c *PlanCommand) Run(args []string) int {
-	var destroy, refresh, detailed bool
+	var destroy, refresh, persist, detailed bool
 	var outPath string
 	var moduleDepth int
 
@@ -25,6 +25,7 @@ func (c *PlanCommand) Run(args []string) int {
 	cmdFlags := c.Meta.flagSet("plan")
 	cmdFlags.BoolVar(&destroy, "destroy", false, "destroy")
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
+	cmdFlags.BoolVar(&persist, "persist", true, "persist")
 	c.addModuleDepthFlag(cmdFlags, &moduleDepth)
 	cmdFlags.StringVar(&outPath, "out", "", "path")
 	cmdFlags.IntVar(
@@ -87,7 +88,7 @@ func (c *PlanCommand) Run(args []string) int {
 		}
 		c.Ui.Output("")
 
-		if state != nil {
+		if persist && state != nil {
 			log.Printf("[INFO] Writing state output to: %s", c.Meta.StateOutPath())
 			if err := c.Meta.PersistState(state); err != nil {
 				c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
@@ -189,6 +190,8 @@ Options:
                       input to the "apply" command.
 
   -parallelism=n      Limit the number of concurrent operations. Defaults to 10.
+
+  -persist=true       Persist state after refreshing.
 
   -refresh=true       Update state prior to checking for differences.
 


### PR DESCRIPTION
In the case of running with a remote state file that one only has read-only
permissions on, `terraform plan` currently fails as it can't rewrite the remote
state file. Running with `-refresh=false` isn't a great option either, as then
the state we are planning from is not guaranteed to be current.

Add a new `-persist` flag that defaults to true to match existing behavior. If
this is set to false, we will continue to refresh remote state, but won't try
to write back our changes, allowing a read-only state file.

This addresses #2548.