### PR TITLE
Fix Getting Started AWS Instance Information

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -59,8 +59,8 @@ provider "aws" {
 }
 
 resource "aws_instance" "example" {
-	ami = "ami-408c7f28"
-	instance_type = "t1.micro"
+	ami = "ami-9abea4fb"
+	instance_type = "t2.micro"
 }
 ```
 


### PR DESCRIPTION
ami-408c7f28 no longer exists, is replaced by ami-9abea4fb
ami-9abea4fb needs to be run on t2.micro