### PR TITLE
Improve performance of fmtcheck

### DIFF
--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,7 +2,7 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -l . | grep -v vendor)
+gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"


### PR DESCRIPTION
Previously gofmt would run even on files under vendor which we don't care about, and then discard the results. This approach instead selects only the files we want to pass into gofmt.

- Before takes around 6.5 seconds
- Now takes around 2 seconds