### PR TITLE
provider/aws: Improve the randomization in RDS tests

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -22,7 +23,7 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSDBParameterGroupConfig,
+				Config: testAccAWSDBParameterGroupConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v),
@@ -49,7 +50,7 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSDBParameterGroupAddParametersConfig,
+				Config: testAccAWSDBParameterGroupAddParametersConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v),
@@ -96,7 +97,7 @@ func TestAccAWSDBParameterGroupOnly(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSDBParameterGroupOnlyConfig,
+				Config: testAccAWSDBParameterGroupOnlyConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v),
@@ -249,9 +250,10 @@ func randomString(strlen int) string {
 	return string(result)
 }
 
-const testAccAWSDBParameterGroupConfig = `
+func testAccAWSDBParameterGroupConfig(n int) string {
+	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "bar" {
-	name = "parameter-group-test-terraform"
+	name = "parameter-group-test-terraform-%d"
 	family = "mysql5.6"
 	description = "Test parameter group for terraform"
 	parameter {
@@ -269,12 +271,13 @@ resource "aws_db_parameter_group" "bar" {
 	tags {
 		foo = "bar"
 	}
+}`, n)
 }
-`
 
-const testAccAWSDBParameterGroupAddParametersConfig = `
+func testAccAWSDBParameterGroupAddParametersConfig(n int) string {
+	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "bar" {
-	name = "parameter-group-test-terraform"
+	name = "parameter-group-test-terraform-%d"
 	family = "mysql5.6"
 	description = "Test parameter group for terraform"
 	parameter {
@@ -301,13 +304,14 @@ resource "aws_db_parameter_group" "bar" {
 		foo = "bar"
 		baz = "foo"
 	}
+}`, n)
 }
-`
 
-const testAccAWSDBParameterGroupOnlyConfig = `
+func testAccAWSDBParameterGroupOnlyConfig(n int) string {
+	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "bar" {
-	name = "parameter-group-test-terraform"
+	name = "parameter-group-test-terraform-%d"
 	family = "mysql5.6"
 	description = "Test parameter group for terraform"
+}`, n)
 }
-`

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -24,7 +24,7 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSClusterInstanceConfig,
+				Config: testAccAWSClusterInstanceConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
@@ -44,7 +44,7 @@ func TestAccAWSRDSClusterInstance_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSClusterInstanceConfig,
+				Config: testAccAWSClusterInstanceConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
 					testAccAWSClusterInstanceDisappears(&v),
@@ -166,7 +166,8 @@ func testAccCheckAWSClusterInstanceExists(n string, v *rds.DBInstance) resource.
 }
 
 // Add some random to the name, to avoid collision
-var testAccAWSClusterInstanceConfig = fmt.Sprintf(`
+func testAccAWSClusterInstanceConfig(n int) string {
+	return fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-test-%d"
   availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
@@ -181,4 +182,5 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   instance_class     = "db.r3.large"
 }
 
-`, acctest.RandInt(), acctest.RandInt())
+`, n, n)
+}

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -2,10 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -17,16 +16,13 @@ import (
 func TestAccAWSRDSCluster_basic(t *testing.T) {
 	var v rds.DBCluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	config := fmt.Sprintf(testAccAWSClusterConfig, ri)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: config,
+				Config: testAccAWSClusterConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
 					resource.TestCheckResourceAttr(
@@ -40,16 +36,13 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 	var v rds.DBCluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	encConfig := fmt.Sprintf(testAccAWSClusterConfig_encrypted, ri)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: encConfig,
+				Config: testAccAWSClusterConfig_encrypted(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
 					resource.TestCheckResourceAttr(
@@ -63,17 +56,14 @@ func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 	var v rds.DBCluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	preConfig := fmt.Sprintf(testAccAWSClusterConfig_backups, ri)
-	postConfig := fmt.Sprintf(testAccAWSClusterConfig_backupsUpdate, ri)
-
+	ri := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: preConfig,
+				Config: testAccAWSClusterConfig_backups(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
 					resource.TestCheckResourceAttr(
@@ -86,7 +76,7 @@ func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: postConfig,
+				Config: testAccAWSClusterConfig_backupsUpdate(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
 					resource.TestCheckResourceAttr(
@@ -166,16 +156,19 @@ func testAccCheckAWSClusterExists(n string, v *rds.DBCluster) resource.TestCheck
 	}
 }
 
-var testAccAWSClusterConfig = `
+func testAccAWSClusterConfig(n int) string {
+	return fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-%d"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   database_name = "mydb"
   master_username = "foo"
   master_password = "mustbeeightcharaters"
-}`
+}`, n)
+}
 
-var testAccAWSClusterConfig_encrypted = `
+func testAccAWSClusterConfig_encrypted(n int) string {
+	return fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-%d"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
@@ -183,9 +176,11 @@ resource "aws_rds_cluster" "default" {
   master_username = "foo"
   master_password = "mustbeeightcharaters"
   storage_encrypted = true
-}`
+}`, n)
+}
 
-var testAccAWSClusterConfig_backups = `
+func testAccAWSClusterConfig_backups(n int) string {
+	return fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-%d"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
@@ -195,9 +190,11 @@ resource "aws_rds_cluster" "default" {
   backup_retention_period = 5
   preferred_backup_window = "07:00-09:00"
   preferred_maintenance_window = "tue:04:00-tue:04:30"
-}`
+}`, n)
+}
 
-var testAccAWSClusterConfig_backupsUpdate = `
+func testAccAWSClusterConfig_backupsUpdate(n int) string {
+	return fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-%d"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
@@ -208,4 +205,5 @@ resource "aws_rds_cluster" "default" {
   preferred_backup_window = "03:00-09:00"
   preferred_maintenance_window = "wed:01:00-wed:01:30"
   apply_immediately = true
-}`
+}`, n)
+}


### PR DESCRIPTION
Update how we randomize the database names, to help reduce collision in our acceptance tests.