### PR TITLE
Added documentation for creating Azure RM credentials

### DIFF
--- a/website/source/docs/providers/azurerm/index.html.markdown
+++ b/website/source/docs/providers/azurerm/index.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The tenant ID to use. It can also be sourced from the
   `ARM_TENANT_ID` environment variable.
 
-## Testing:
+## Testing
 
 Credentials must be provided via the `ARM_SUBSCRIPTION_ID`, `ARM_CLIENT_ID`,
 `ARM_CLIENT_SECRET` and `ARM_TENANT_ID` environment variables in order to run

--- a/website/source/docs/providers/azurerm/index.html.markdown
+++ b/website/source/docs/providers/azurerm/index.html.markdown
@@ -73,6 +73,30 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The tenant ID to use. It can also be sourced from the
   `ARM_TENANT_ID` environment variable.
 
+## Creating Credentials
+
+Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details).
+
+Using the 'Classic' Portal:
+
+- Select **Active Directory** from the left pane and select the directory you wish to use
+- Select **Applications** from the options at the top of the page
+- Select **Add** from the bottom of the page. Choose **Add an application my organization is developing**
+- Add a friendly name for the application e.g. **Terraform**. Leave **Web Application And/Or Web API** selected and click the arrow for the next page
+- Add two valid URIs. These aren't used an can be anything e.g. http://terra.form. Click the arrow to complete the wizard
+- You should now be on the page for the application. Click on **Configure** at the top of the page. Scroll down to the middle of the page where you will see the value for `client_id`
+- In the **Keys** section of the page, select a suitable duration and click **Save** at the bottom of the page. This will then display the value for `client_secret`. This will disappear once you move off the page
+- Click **View Endpoints** at the bottom of the page. This will display a list of URIs. Extract the GUID from the bottom URI for **OAUTH 2.0 AUTHORIZATION ENDPOINT**. This is the `tenant_id`
+
+To enable the application for use with Azure RM, you now need to switch to the 'New' Portal:
+
+- Select **Subscriptions** from the left panel. Select the subscription that you want to use. In the Subscription details pane, click **All Settings** and then **Users**
+- Click **Add** and then select an appropriate role for the tasks you want to complete with Terraform. You can find details on the built in roles [here](https://azure.microsoft.com/en-gb/documentation/articles/role-based-access-built-in-roles/)
+- Type in the name of the application added in the 'Classic' Portal. You need to type this as it won't be shown in the user list. Click on the appropriate user in the list and then click **Select**
+- Click **OK** in the **Add Access** panel. The changes will now be saved   
+
+Microsoft have a more complete guide in the Azure documentation: [Create Active Directory application and service principle](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/)
+
 ## Testing
 
 Credentials must be provided via the `ARM_SUBSCRIPTION_ID`, `ARM_CLIENT_ID`,


### PR DESCRIPTION
Added documentation on creating credentials that can be used with Terraform and Azure RM. This is to help with issues #5399 and #5082. 

This update isn't version dependent (I've been using 0.6.12 and 0.6.14 to test).