### PR TITLE
Adds `wait_for_ready_timeout` option to `aws_elastic_beanstalk_environment`.

### DIFF
--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -8,11 +8,11 @@ description: |-
 
 # aws\_elastic\_beanstalk\_<wbr>environment
 
-Provides an Elastic Beanstalk Environment Resource. Elastic Beanstalk allows 
-you to deploy and manage applications in the AWS cloud without worrying about 
+Provides an Elastic Beanstalk Environment Resource. Elastic Beanstalk allows
+you to deploy and manage applications in the AWS cloud without worrying about
 the infrastructure that runs those applications.
 
-Environments are often things such as `development`, `integration`, or 
+Environments are often things such as `development`, `integration`, or
 `production`.
 
 ## Example Usage
@@ -35,20 +35,24 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 
 The following arguments are supported:
 
-* `name` - (Required) A unique name for this Environment. This name is used 
+* `name` - (Required) A unique name for this Environment. This name is used
   in the application URL
-* `application` – (Required) Name of the application that contains the version 
+* `application` – (Required) Name of the application that contains the version
   to be deployed
-* `description` - (Optional) Short description of the Environment 
-* `tier` - (Optional) Elastic Beanstalk Environment tier. Valid values are `Worker` 
+* `description` - (Optional) Short description of the Environment
+* `tier` - (Optional) Elastic Beanstalk Environment tier. Valid values are `Worker`
   or `WebServer`. If tier is left blank `WebServer` will be used.
 * `setting` – (Optional) Option settings to configure the new Environment. These
   override specific values that are set as defaults. The format is detailed
   below in [Option Settings](#option-settings)
 * `solution_stack_name` – (Optional) A solution stack to base your environment
 off of. Example stacks can be found in the [Amazon API documentation][1]
-* `template_name` – (Optional) The name of the Elastic Beanstalk Configuration 
+* `template_name` – (Optional) The name of the Elastic Beanstalk Configuration
   template to use in deployment
+* `wait_for_ready_timeout` - (Default: "10m") The maximum
+  [duration](https://golang.org/pkg/time/#ParseDuration) that Terraform should
+  wait for an Elastic Beanstalk Environment to be in a ready state before timing
+  out. 
 * `tags` – (Optional) A set of tags to apply to the Environment. **Note:** at
 this time the Elastic Beanstalk API does not provide a programatic way of
 changing these tags after initial application
@@ -59,7 +63,7 @@ changing these tags after initial application
 
 The `setting` and `all_settings` mappings support the following format:
 
-* `namespace` - (Optional) unique namespace identifying the option's 
+* `namespace` - (Optional) unique namespace identifying the option's
   associated AWS resource
 * `name` - (Optional) name of the configuration option
 * `value` - (Optional) value for the configuration option
@@ -70,14 +74,12 @@ The following attributes are exported:
 
 * `name`
 * `description`
-* `tier` - the environment tier specified. 
+* `tier` - the environment tier specified.
 * `application` – the application specified
 * `setting` – Settings specifically set for this Environment
 * `all_settings` – List of all option settings configured in the Environment. These
   are a combination of default settings and their overrides from `settings` in
-  the configuration 
+  the configuration
 
 
 [1]: http://docs.aws.amazon.com/fr_fr/elasticbeanstalk/latest/dg/concepts.platforms.html
-
-


### PR DESCRIPTION
We have found that some of our Elastic Beanstalk Environments take longer than 10 minutes to reach a 'ready' state. This option allows the timeout value to be configured in the terraform document.

Example Terraform document:

```
provider "aws" {
  region = "us-east-1"
}

resource "aws_elastic_beanstalk_application" "default" {
  name        = "tf-test-name"
  description = "tf-test-desc"
}

resource "aws_elastic_beanstalk_environment" "default" {
  name                   = "tf-test-name"
  application            = "${aws_elastic_beanstalk_application.default.name}"
  solution_stack_name    = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
  wait_for_ready_timeout = "15m"
}
```