### PR TITLE
Add link to Route table page, remove self-reference

### DIFF
--- a/website/source/docs/providers/aws/r/route.html.markdown
+++ b/website/source/docs/providers/aws/r/route.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides a resource to create a routing table entry (a route) in a VPC routing table.
 
 ~> **NOTE on Route Tables and Routes:** Terraform currently
-provides both a standalone [Route resource](route.html) and a Route Table resource with routes
+provides both a standalone Route resource and a [Route Table](route_table.html) resource with routes
 defined in-line. At this time you cannot use a Route Table with in-line routes
 in conjunction with any Route resources. Doing so will cause
 a conflict of rule settings and will overwrite rules.


### PR DESCRIPTION
This note must have been copied from the Route table page.
It makes more sense to remove the self reference and add a link to the Route table page.