### PR TITLE
provider/aws: ElasticBeanstalk environment tests now use a less brittle test env case

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -189,8 +189,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name = "tf-test-name"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.8 running Go 1.4"
-  #solution_stack_name =
+  solution_stack_name = "64bit Amazon Linux running Python"
 }
 `
 
@@ -204,7 +203,7 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name = "tf-test-name"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
   tier = "Worker"
-  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux running Python"
 }
 `
 
@@ -219,7 +218,7 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 name = "tf-test-name"
 application = "${aws_elastic_beanstalk_application.tftest.name}"
 cname_prefix = "%s"
-solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4"
+solution_stack_name = "64bit Amazon Linux running Python"
 }
 `, randString)
 }


### PR DESCRIPTION
The previous tests were potentially a little brittle as they had this `64bit Amazon Linux 2015.09 v2.0.8 running Go 1.4` - this had been revved from `64bit Amazon Linux 2015.09 v2.0.4 running Go 1.4` this week

```
TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSBeanstalkEnv' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkEnv -timeout 120m
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (450.68s)
=== RUN   TestAccAWSBeanstalkEnv_tier
--- PASS: TestAccAWSBeanstalkEnv_tier (626.64s)
=== RUN   TestAccAWSBeanstalkEnv_cname_prefix
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (421.42s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1498.770s
```