### PR TITLE
provider/aws: ElasticBeanstalk Config template tests now use a less brittle test env case

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
@@ -126,16 +126,10 @@ resource "aws_elastic_beanstalk_application" "tftest" {
   description = "tf-test-desc"
 }
 
-#resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-#  name = "tf-test-name"
-#  application = "${aws_elastic_beanstalk_application.tftest.name}"
-#  solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
-#}
-
 resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
   name = "tf-test-template-config"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.8 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux running Python"
 }
 `
 
@@ -167,7 +161,7 @@ resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
   name        = "tf-test-%s"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
 
-  solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
+  solution_stack_name = "64bit Amazon Linux running Python"
 
   setting {
     namespace = "aws:ec2:vpc"


### PR DESCRIPTION
Similar to #5986 

```
TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSBeanstalkConfigurationTemplate' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkConfigurationTemplate -timeout 120m
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_basic
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_basic (42.50s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_VPC
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_VPC (70.55s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	113.072s
```