### PR TITLE
provider/google: Accept GOOGLE_CLOUD_KEYFILE_JSON env var for credentials

### DIFF
--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -22,9 +22,12 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"credentials": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("GOOGLE_CREDENTIALS", nil),
+				Type:     schema.TypeString,
+				Optional: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"GOOGLE_CREDENTIALS",
+					"GOOGLE_CLOUD_KEYFILE_JSON",
+				}, nil),
 				ValidateFunc: validateCredentials,
 			},
 

--- a/builtin/providers/google/provider_test.go
+++ b/builtin/providers/google/provider_test.go
@@ -39,7 +39,9 @@ func testAccPreCheck(t *testing.T) {
 	}
 
 	if v := os.Getenv("GOOGLE_CREDENTIALS"); v == "" {
-		t.Fatal("GOOGLE_CREDENTIALS must be set for acceptance tests")
+		if w := os.Getenv("GOOGLE_CLOUD_KEYFILE_JSON"); w == "" {
+			t.Fatal("GOOGLE_CREDENTIALS or GOOGLE_CLOUD_KEYFILE_JSON must be set for acceptance tests")
+		}
 	}
 
 	if v := os.Getenv("GOOGLE_PROJECT"); v == "" {

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -39,8 +39,8 @@ The following keys can be used to configure the provider.
   retrieving this file are below. Credentials may be blank if you are running
   Terraform from a GCE instance with a properly-configured [Compute Engine
   Service Account](https://cloud.google.com/compute/docs/authentication). This
-  can also be specified with the `GOOGLE_CREDENTIALS` shell environment
-  variable.
+  can also be specified with the `GOOGLE_CREDENTIALS` or `GOOGLE_CLOUD_KEYFILE_JSON`
+  shell environment variable, containing the contents of the credentials file.
 
 * `project` - (Required) The ID of the project to apply any resources to.  This
   can also be specified with the `GOOGLE_PROJECT` shell environment variable.


### PR DESCRIPTION
Adds support for `GOOGLE_CLOUD_KEYFILE_JSON` environment variable, to contain the contents of the Google key file information. 

It's documented in a Google Authentication guide here:

- http://googlecloudplatform.github.io/gcloud-ruby/docs/v0.1.1/AUTHENTICATION.md#label-Environment+Variables

Originally, I expanded on `GOOGLE_ACCOUNT_FILE` to also support `GOOGLE_CLOUD_KEYFILE`, as the path to the key file, however I removed that because we currently have that method (`account_file`) as deprecated.