### PR TITLE
provider/postgresql:  Add support for 'sslmode' options present in lib/pq

### DIFF
--- a/builtin/providers/postgresql/config.go
+++ b/builtin/providers/postgresql/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Port     int
 	Username string
 	Password string
+	SslMode  string
 }
 
 // Client struct holding connection string
@@ -23,7 +24,7 @@ type Client struct {
 
 //NewClient returns new client config
 func (c *Config) NewClient() (*Client, error) {
-	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=postgres", c.Host, c.Port, c.Username, c.Password)
+	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=postgres sslmode=%s", c.Host, c.Port, c.Username, c.Password, c.SslMode)
 
 	client := Client{
 		connStr:  connStr,

--- a/builtin/providers/postgresql/provider.go
+++ b/builtin/providers/postgresql/provider.go
@@ -35,6 +35,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("POSTGRESQL_PASSWORD", nil),
 				Description: "Password for postgresql server connection",
 			},
+			"ssl_mode": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "require",
+				Description: "Connection mode for postgresql server",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -52,6 +58,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Port:     d.Get("port").(int),
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
+		SslMode:  d.Get("ssl_mode").(string),
 	}
 
 	client, err := config.NewClient()

--- a/website/source/docs/providers/postgresql/index.html.markdown
+++ b/website/source/docs/providers/postgresql/index.html.markdown
@@ -20,6 +20,7 @@ provider "postgresql" {
   port = 5432
   username = "postgres_user"
   password = "postgres_password"
+  ssl_mode = "require"
 }
 
 ```
@@ -61,3 +62,4 @@ The following arguments are supported:
 * `port` - (Optional) The port for the postgresql server connection. (Default 5432)
 * `username` - (Required) Username for the server connection.
 * `password` - (Optional) Password for the server connection.
+* `ssl_mode` - (Optional) Set connection mode for postgresql server (Default "require", more options [lib/pq documentations](https://godoc.org/github.com/lib/pq)).


### PR DESCRIPTION
- Update postgresql provider's documentation
- Enforce default value to 'require' for sslmode