### PR TITLE
provider/cloudstack: make the CloudStack provider more inline with the other providers

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_firewall.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_firewall.go
@@ -1,6 +1,7 @@
 package cloudstack
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -20,10 +21,19 @@ func resourceCloudStackFirewall() *schema.Resource {
 		Delete: resourceCloudStackFirewallDelete,
 
 		Schema: map[string]*schema.Schema{
+			"ip_address": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"ipaddress"},
+			},
+
 			"ipaddress": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Deprecated:    "Please use the `ip_address` field instead",
+				ConflictsWith: []string{"ip_address"},
 			},
 
 			"managed": &schema.Schema{
@@ -99,8 +109,16 @@ func resourceCloudStackFirewallCreate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	ipaddress, ok := d.GetOk("ip_address")
+	if !ok {
+		ipaddress, ok = d.GetOk("ipaddress")
+	}
+	if !ok {
+		return errors.New("Either `ip_address` or [deprecated] `ipaddress` must be provided.")
+	}
+
 	// Retrieve the ipaddress ID
-	ipaddressid, e := retrieveID(cs, "ipaddress", d.Get("ipaddress").(string))
+	ipaddressid, e := retrieveID(cs, "ip_address", ipaddress.(string))
 	if e != nil {
 		return e.Error()
 	}

--- a/builtin/providers/cloudstack/resource_cloudstack_firewall_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_firewall_test.go
@@ -21,7 +21,7 @@ func TestAccCloudStackFirewall_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStackFirewallRulesExist("cloudstack_firewall.foo"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "ipaddress", CLOUDSTACK_PUBLIC_IPADDRESS),
+						"cloudstack_firewall.foo", "ip_address", CLOUDSTACK_PUBLIC_IPADDRESS),
 					resource.TestCheckResourceAttr(
 						"cloudstack_firewall.foo", "rule.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -31,13 +31,13 @@ func TestAccCloudStackFirewall_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudstack_firewall.foo", "rule.60926170.ports.32925333", "8080"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.source_cidr", "10.0.0.0/24"),
+						"cloudstack_firewall.foo", "rule.3832507136.cidr_list.3482919157", "10.0.0.0/24"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.protocol", "tcp"),
+						"cloudstack_firewall.foo", "rule.3832507136.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.ports.1209010669", "1000-2000"),
+						"cloudstack_firewall.foo", "rule.3832507136.ports.1209010669", "1000-2000"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.ports.1889509032", "80"),
+						"cloudstack_firewall.foo", "rule.3832507136.ports.1889509032", "80"),
 				),
 			},
 		},
@@ -55,7 +55,7 @@ func TestAccCloudStackFirewall_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStackFirewallRulesExist("cloudstack_firewall.foo"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "ipaddress", CLOUDSTACK_PUBLIC_IPADDRESS),
+						"cloudstack_firewall.foo", "ip_address", CLOUDSTACK_PUBLIC_IPADDRESS),
 					resource.TestCheckResourceAttr(
 						"cloudstack_firewall.foo", "rule.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -65,13 +65,13 @@ func TestAccCloudStackFirewall_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudstack_firewall.foo", "rule.60926170.ports.32925333", "8080"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.source_cidr", "10.0.0.0/24"),
+						"cloudstack_firewall.foo", "rule.3832507136.cidr_list.3482919157", "10.0.0.0/24"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.protocol", "tcp"),
+						"cloudstack_firewall.foo", "rule.3832507136.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.ports.1209010669", "1000-2000"),
+						"cloudstack_firewall.foo", "rule.3832507136.ports.1209010669", "1000-2000"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.ports.1889509032", "80"),
+						"cloudstack_firewall.foo", "rule.3832507136.ports.1889509032", "80"),
 				),
 			},
 
@@ -80,33 +80,33 @@ func TestAccCloudStackFirewall_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStackFirewallRulesExist("cloudstack_firewall.foo"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "ipaddress", CLOUDSTACK_PUBLIC_IPADDRESS),
+						"cloudstack_firewall.foo", "ip_address", CLOUDSTACK_PUBLIC_IPADDRESS),
 					resource.TestCheckResourceAttr(
 						"cloudstack_firewall.foo", "rule.#", "3"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.2207610982.cidr_list.80081744", "10.0.1.0/24"),
+						"cloudstack_firewall.foo", "rule.2144925929.cidr_list.80081744", "10.0.1.0/24"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.2207610982.cidr_list.3482919157", "10.0.0.0/24"),
+						"cloudstack_firewall.foo", "rule.2144925929.cidr_list.3482919157", "10.0.0.0/24"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.2207610982.protocol", "tcp"),
+						"cloudstack_firewall.foo", "rule.2144925929.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.2207610982.ports.32925333", "8080"),
+						"cloudstack_firewall.foo", "rule.2144925929.ports.32925333", "8080"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.source_cidr", "10.0.0.0/24"),
+						"cloudstack_firewall.foo", "rule.3832507136.cidr_list.3482919157", "10.0.0.0/24"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.protocol", "tcp"),
+						"cloudstack_firewall.foo", "rule.3832507136.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.ports.1209010669", "1000-2000"),
+						"cloudstack_firewall.foo", "rule.3832507136.ports.1209010669", "1000-2000"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.716592205.ports.1889509032", "80"),
+						"cloudstack_firewall.foo", "rule.3832507136.ports.1889509032", "80"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.4449157.source_cidr", "172.16.100.0/24"),
+						"cloudstack_firewall.foo", "rule.302279047.cidr_list.2835005819", "172.16.100.0/24"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.4449157.protocol", "tcp"),
+						"cloudstack_firewall.foo", "rule.302279047.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.4449157.ports.1889509032", "80"),
+						"cloudstack_firewall.foo", "rule.302279047.ports.1889509032", "80"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_firewall.foo", "rule.4449157.ports.3638101695", "443"),
+						"cloudstack_firewall.foo", "rule.302279047.ports.3638101695", "443"),
 				),
 			},
 		},
@@ -174,7 +174,7 @@ func testAccCheckCloudStackFirewallDestroy(s *terraform.State) error {
 
 var testAccCloudStackFirewall_basic = fmt.Sprintf(`
 resource "cloudstack_firewall" "foo" {
-  ipaddress = "%s"
+  ip_address = "%s"
 
   rule {
     cidr_list = ["10.0.0.0/24"]
@@ -183,7 +183,7 @@ resource "cloudstack_firewall" "foo" {
   }
 
   rule {
-    source_cidr = "10.0.0.0/24"
+    cidr_list = ["10.0.0.0/24"]
     protocol = "tcp"
     ports = ["80", "1000-2000"]
   }
@@ -191,7 +191,7 @@ resource "cloudstack_firewall" "foo" {
 
 var testAccCloudStackFirewall_update = fmt.Sprintf(`
 resource "cloudstack_firewall" "foo" {
-  ipaddress = "%s"
+  ip_address = "%s"
 
   rule {
     cidr_list = ["10.0.0.0/24", "10.0.1.0/24"]
@@ -200,13 +200,13 @@ resource "cloudstack_firewall" "foo" {
   }
 
   rule {
-    source_cidr = "10.0.0.0/24"
+    cidr_list = ["10.0.0.0/24"]
     protocol = "tcp"
     ports = ["80", "1000-2000"]
   }
 
   rule {
-    source_cidr = "172.16.100.0/24"
+    cidr_list = ["172.16.100.0/24"]
     protocol = "tcp"
     ports = ["80", "443"]
   }

--- a/builtin/providers/cloudstack/resource_cloudstack_instance.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance.go
@@ -43,11 +43,19 @@ func resourceCloudStackInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"ipaddress": &schema.Schema{
+			"ip_address": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+
+			"ipaddress": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "Please use the `ip_address` field instead",
 			},
 
 			"template": &schema.Schema{
@@ -151,8 +159,12 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	// If there is a ipaddres supplied, add it to the parameter struct
-	if ipaddres, ok := d.GetOk("ipaddress"); ok {
-		p.SetIpaddress(ipaddres.(string))
+	ipaddress, ok := d.GetOk("ip_address")
+	if !ok {
+		ipaddress, ok = d.GetOk("ipaddress")
+	}
+	if ok {
+		p.SetIpaddress(ipaddress.(string))
 	}
 
 	// If there is a project supplied, we retrieve and set the project id
@@ -228,7 +240,7 @@ func resourceCloudStackInstanceRead(d *schema.ResourceData, meta interface{}) er
 	// Update the config
 	d.Set("name", vm.Name)
 	d.Set("display_name", vm.Displayname)
-	d.Set("ipaddress", vm.Nic[0].Ipaddress)
+	d.Set("ip_address", vm.Nic[0].Ipaddress)
 	//NB cloudstack sometimes sends back the wrong keypair name, so dont update it
 
 	setValueOrID(d, "network", vm.Nic[0].Networkname, vm.Nic[0].Networkid)

--- a/builtin/providers/cloudstack/resource_cloudstack_instance_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance_test.go
@@ -82,7 +82,7 @@ func TestAccCloudStackInstance_fixedIP(t *testing.T) {
 					testAccCheckCloudStackInstanceExists(
 						"cloudstack_instance.foobar", &instance),
 					resource.TestCheckResourceAttr(
-						"cloudstack_instance.foobar", "ipaddress", CLOUDSTACK_NETWORK_1_IPADDRESS1),
+						"cloudstack_instance.foobar", "ip_address", CLOUDSTACK_NETWORK_1_IPADDRESS1),
 				),
 			},
 		},
@@ -267,7 +267,7 @@ resource "cloudstack_instance" "foobar" {
   display_name = "terraform-test"
   service_offering= "%s"
   network = "%s"
-  ipaddress = "%s"
+  ip_address = "%s"
   template = "%s"
   zone = "%s"
   expunge = true
@@ -288,7 +288,7 @@ resource "cloudstack_instance" "foobar" {
   display_name = "terraform-test"
   service_offering= "%s"
   network = "%s"
-  ipaddress = "%s"
+  ip_address = "%s"
   template = "%s"
   zone = "%s"
 	keypair = "${cloudstack_ssh_keypair.foo.name}"

--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
@@ -34,7 +34,7 @@ func resourceCloudStackIPAddress() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"ipaddress": &schema.Schema{
+			"ip_address": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -100,7 +100,7 @@ func resourceCloudStackIPAddressRead(d *schema.ResourceData, meta interface{}) e
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	// Get the IP address details
-	f, count, err := cs.Address.GetPublicIpAddressByID(d.Id())
+	ip, count, err := cs.Address.GetPublicIpAddressByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf(
@@ -113,29 +113,29 @@ func resourceCloudStackIPAddressRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Updated the IP address
-	d.Set("ipaddress", f.Ipaddress)
+	d.Set("ip_address", ip.Ipaddress)
 
 	if _, ok := d.GetOk("network"); ok {
 		// Get the network details
-		n, _, err := cs.Network.GetNetworkByID(f.Associatednetworkid)
+		n, _, err := cs.Network.GetNetworkByID(ip.Associatednetworkid)
 		if err != nil {
 			return err
 		}
 
-		setValueOrID(d, "network", n.Name, f.Associatednetworkid)
+		setValueOrID(d, "network", n.Name, ip.Associatednetworkid)
 	}
 
 	if _, ok := d.GetOk("vpc"); ok {
 		// Get the VPC details
-		v, _, err := cs.VPC.GetVPCByID(f.Vpcid)
+		v, _, err := cs.VPC.GetVPCByID(ip.Vpcid)
 		if err != nil {
 			return err
 		}
 
-		setValueOrID(d, "vpc", v.Name, f.Vpcid)
+		setValueOrID(d, "vpc", v.Name, ip.Vpcid)
 	}
 
-	setValueOrID(d, "project", f.Project, f.Projectid)
+	setValueOrID(d, "project", ip.Project, ip.Projectid)
 
 	return nil
 }

--- a/builtin/providers/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -251,23 +251,11 @@ resource "cloudstack_instance" "foobar1" {
 
 resource "cloudstack_loadbalancer_rule" "foo" {
   name = "terraform-lb"
-  ipaddress = "%s"
-  # network omitted, inferred from IP
+  ip_address = "%s"
   algorithm = "roundrobin"
   public_port = 80
   private_port = 80
   members = ["${cloudstack_instance.foobar1.id}"]
-}
-
-# attempt to create dependent firewall rule
-# this will clash if cloudstack creates the implicit rule as it does by default
-resource "cloudstack_firewall" "foo" {
-  ipaddress = "${cloudstack_loadbalancer_rule.foo.ipaddress}"
-  rule {
-    source_cidr = "0.0.0.0/0"
-    protocol = "tcp"
-    ports = ["${cloudstack_loadbalancer_rule.foo.public_port}"]
-  }
 }
 `,
 	CLOUDSTACK_SERVICE_OFFERING_1,
@@ -289,23 +277,11 @@ resource "cloudstack_instance" "foobar1" {
 
 resource "cloudstack_loadbalancer_rule" "foo" {
   name = "terraform-lb-update"
-  ipaddress = "%s"
-  # network omitted, inferred from IP
+  ip_address = "%s"
   algorithm = "leastconn"
   public_port = 80
   private_port = 80
   members = ["${cloudstack_instance.foobar1.id}"]
-}
-
-# attempt to create dependent firewall rule
-# this will clash if cloudstack creates the implicit rule as it does by default
-resource "cloudstack_firewall" "foo" {
-  ipaddress = "${cloudstack_loadbalancer_rule.foo.ipaddress}"
-  rule {
-    source_cidr = "0.0.0.0/0"
-    protocol = "tcp"
-    ports = ["${cloudstack_loadbalancer_rule.foo.public_port}"]
-  }
 }
 `,
 	CLOUDSTACK_SERVICE_OFFERING_1,
@@ -327,23 +303,11 @@ resource "cloudstack_instance" "foobar1" {
 
 resource "cloudstack_loadbalancer_rule" "foo" {
   name = "terraform-lb-update"
-  ipaddress = "%s"
-  # network omitted, inferred from IP
+  ip_address = "%s"
   algorithm = "leastconn"
   public_port = 443
   private_port = 443
   members = ["${cloudstack_instance.foobar1.id}"]
-}
-
-# attempt to create dependent firewall rule
-# this will clash if cloudstack creates the implicit rule as it does by default
-resource "cloudstack_firewall" "foo" {
-  ipaddress = "${cloudstack_loadbalancer_rule.foo.ipaddress}"
-  rule {
-    source_cidr = "0.0.0.0/0"
-    protocol = "tcp"
-    ports = ["${cloudstack_loadbalancer_rule.foo.public_port}"]
-  }
 }
 `,
 	CLOUDSTACK_SERVICE_OFFERING_1,
@@ -379,13 +343,12 @@ resource "cloudstack_instance" "foobar1" {
   network = "${cloudstack_network.foo.name}"
   template = "%s"
   zone = "${cloudstack_network.foo.zone}"
-  user_data = "foobar\nfoo\nbar"
   expunge = true
 }
 
 resource "cloudstack_loadbalancer_rule" "foo" {
   name = "terraform-lb"
-  ipaddress = "${cloudstack_ipaddress.foo.ipaddress}"
+  ip_address = "${cloudstack_ipaddress.foo.ip_address}"
   algorithm = "roundrobin"
   network = "${cloudstack_network.foo.id}"
   public_port = 80
@@ -402,10 +365,10 @@ resource "cloudstack_loadbalancer_rule" "foo" {
 
 var testAccCloudStackLoadBalancerRule_vpc_update = fmt.Sprintf(`
 resource "cloudstack_vpc" "foobar" {
-    name = "terraform-vpc"
-    cidr = "%s"
-    vpc_offering = "%s"
-    zone = "%s"
+  name = "terraform-vpc"
+  cidr = "%s"
+  vpc_offering = "%s"
+  zone = "%s"
 }
 
 resource "cloudstack_network" "foo" {
@@ -427,7 +390,6 @@ resource "cloudstack_instance" "foobar1" {
   network = "${cloudstack_network.foo.name}"
   template = "%s"
   zone = "${cloudstack_network.foo.zone}"
-  user_data = "foobar\nfoo\nbar"
   expunge = true
 }
 
@@ -438,18 +400,17 @@ resource "cloudstack_instance" "foobar2" {
   network = "${cloudstack_network.foo.name}"
   template = "%s"
   zone = "${cloudstack_network.foo.zone}"
-  user_data = "foobar\nfoo\nbar"
   expunge = true
 }
 
 resource "cloudstack_loadbalancer_rule" "foo" {
   name = "terraform-lb-update"
-  ipaddress = "${cloudstack_ipaddress.foo.ipaddress}"
+  ip_address = "${cloudstack_ipaddress.foo.ip_address}"
   algorithm = "leastconn"
   network = "${cloudstack_network.foo.id}"
   public_port = 443
   private_port = 443
-  members = ["${cloudstack_instance.foobar2.id}", "${cloudstack_instance.foobar1.id}"]
+  members = ["${cloudstack_instance.foobar1.id}", "${cloudstack_instance.foobar2.id}"]
 }`,
 	CLOUDSTACK_VPC_CIDR_1,
 	CLOUDSTACK_VPC_OFFERING,

--- a/builtin/providers/cloudstack/resource_cloudstack_nic_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_nic_test.go
@@ -53,7 +53,7 @@ func TestAccCloudStackNIC_update(t *testing.T) {
 						"cloudstack_instance.foobar", "cloudstack_nic.foo", &nic),
 					testAccCheckCloudStackNICIPAddress(&nic),
 					resource.TestCheckResourceAttr(
-						"cloudstack_nic.foo", "ipaddress", CLOUDSTACK_2ND_NIC_IPADDRESS),
+						"cloudstack_nic.foo", "ip_address", CLOUDSTACK_2ND_NIC_IPADDRESS),
 				),
 			},
 		},
@@ -183,7 +183,7 @@ resource "cloudstack_instance" "foobar" {
 
 resource "cloudstack_nic" "foo" {
   network = "%s"
-  ipaddress = "%s"
+  ip_address = "%s"
   virtual_machine = "${cloudstack_instance.foobar.name}"
 }`,
 	CLOUDSTACK_SERVICE_OFFERING_1,

--- a/builtin/providers/cloudstack/resource_cloudstack_port_forward_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_port_forward_test.go
@@ -21,7 +21,7 @@ func TestAccCloudStackPortForward_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStackPortForwardsExist("cloudstack_port_forward.foo"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_port_forward.foo", "ipaddress", CLOUDSTACK_PUBLIC_IPADDRESS),
+						"cloudstack_port_forward.foo", "ip_address", CLOUDSTACK_PUBLIC_IPADDRESS),
 					resource.TestCheckResourceAttr(
 						"cloudstack_port_forward.foo", "forward.952396423.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
@@ -47,7 +47,7 @@ func TestAccCloudStackPortForward_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStackPortForwardsExist("cloudstack_port_forward.foo"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_port_forward.foo", "ipaddress", CLOUDSTACK_PUBLIC_IPADDRESS),
+						"cloudstack_port_forward.foo", "ip_address", CLOUDSTACK_PUBLIC_IPADDRESS),
 					resource.TestCheckResourceAttr(
 						"cloudstack_port_forward.foo", "forward.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -66,7 +66,7 @@ func TestAccCloudStackPortForward_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStackPortForwardsExist("cloudstack_port_forward.foo"),
 					resource.TestCheckResourceAttr(
-						"cloudstack_port_forward.foo", "ipaddress", CLOUDSTACK_PUBLIC_IPADDRESS),
+						"cloudstack_port_forward.foo", "ip_address", CLOUDSTACK_PUBLIC_IPADDRESS),
 					resource.TestCheckResourceAttr(
 						"cloudstack_port_forward.foo", "forward.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -161,7 +161,7 @@ resource "cloudstack_instance" "foobar" {
 }
 
 resource "cloudstack_port_forward" "foo" {
-  ipaddress = "%s"
+  ip_address = "%s"
 
   forward {
     protocol = "tcp"
@@ -187,7 +187,7 @@ resource "cloudstack_instance" "foobar" {
 }
 
 resource "cloudstack_port_forward" "foo" {
-  ipaddress = "%s"
+  ip_address = "%s"
 
   forward {
     protocol = "tcp"

--- a/builtin/providers/cloudstack/resource_cloudstack_secondary_ipaddress_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_secondary_ipaddress_test.go
@@ -43,7 +43,7 @@ func TestAccCloudStackSecondaryIPAddress_fixedIP(t *testing.T) {
 						"cloudstack_secondary_ipaddress.foo", &ip),
 					testAccCheckCloudStackSecondaryIPAddressAttributes(&ip),
 					resource.TestCheckResourceAttr(
-						"cloudstack_secondary_ipaddress.foo", "ipaddress", CLOUDSTACK_NETWORK_1_IPADDRESS1),
+						"cloudstack_secondary_ipaddress.foo", "ip_address", CLOUDSTACK_NETWORK_1_IPADDRESS1),
 				),
 			},
 		},
@@ -147,7 +147,7 @@ func testAccCheckCloudStackSecondaryIPAddressDestroy(s *terraform.State) error {
 		vm, count, err := cs.VirtualMachine.GetVirtualMachineByID(virtualmachineid)
 		if err != nil {
 			if count == 0 {
-				return fmt.Errorf("Instance not found")
+				return nil
 			}
 			return err
 		}
@@ -215,7 +215,7 @@ resource "cloudstack_instance" "foobar" {
 }
 
 resource "cloudstack_secondary_ipaddress" "foo" {
-	ipaddress = "%s"
+	ip_address = "%s"
 	virtual_machine = "${cloudstack_instance.foobar.id}"
 }`,
 	CLOUDSTACK_SERVICE_OFFERING_1,

--- a/builtin/providers/cloudstack/resources.go
+++ b/builtin/providers/cloudstack/resources.go
@@ -69,7 +69,7 @@ func retrieveID(cs *cloudstack.CloudStackClient, name, value string) (id string,
 		id, err = cs.Network.GetNetworkID(value)
 	case "zone":
 		id, err = cs.Zone.GetZoneID(value)
-	case "ipaddress":
+	case "ip_address":
 		p := cs.Address.NewListPublicIpAddressesParams()
 		p.SetIpaddress(value)
 		l, e := cs.Address.ListPublicIpAddresses(p)

--- a/website/source/docs/providers/cloudstack/r/firewall.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/firewall.html.markdown
@@ -14,7 +14,7 @@ Creates firewall rules for a given IP address.
 
 ```
 resource "cloudstack_firewall" "default" {
-  ipaddress = "192.168.0.1"
+  ip_address = "192.168.0.1"
 
   rule {
     cidr_list = ["10.0.0.0/8"]
@@ -28,8 +28,11 @@ resource "cloudstack_firewall" "default" {
 
 The following arguments are supported:
 
-* `ipaddress` - (Required) The IP address or ID for which to create the firewall
+* `ip_address` - (Required) The IP address or ID for which to create the firewall
     rules. Changing this forces a new resource to be created.
+
+* `ipaddress` - (Required, Deprecated) The IP address or ID for which to create
+    the firewall rules. Changing this forces a new resource to be created.
 
 * `managed` - (Optional) USE WITH CAUTION! If enabled all the firewall rules for
     this IP address will be managed by this resource. This means it will delete

--- a/website/source/docs/providers/cloudstack/r/instance.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/instance.html.markdown
@@ -37,8 +37,11 @@ The following arguments are supported:
 * `network` - (Optional) The name or ID of the network to connect this instance
     to. Changing this forces a new resource to be created.
 
-* `ipaddress` - (Optional) The IP address to assign to this instance. Changing
+* `ip_address` - (Optional) The IP address to assign to this instance. Changing
     this forces a new resource to be created.
+
+* `ipaddress` - (Optional, Deprecated) The IP address to assign to this instance.
+    Changing this forces a new resource to be created.
 
 * `template` - (Required) The name or ID of the template used for this
     instance. Changing this forces a new resource to be created.

--- a/website/source/docs/providers/cloudstack/r/ipaddress.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/ipaddress.html.markdown
@@ -38,4 +38,4 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the acquired and associated IP address.
-* `ipaddress` - The IP address that was acquired and associated.
+* `ip_address` - The IP address that was acquired and associated.

--- a/website/source/docs/providers/cloudstack/r/loadbalancer_rule.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/loadbalancer_rule.html.markdown
@@ -16,7 +16,7 @@ Creates a loadbalancer rule.
 resource "cloudstack_loadbalancer_rule" "default" {
   name = "loadbalancer-rule-1"
   description = "Loadbalancer rule 1"
-  ipaddress = "192.168.0.1"
+  ip_address = "192.168.0.1"
   algorithm = "roundrobin"
   private_port = 80
   public_port = 80
@@ -33,23 +33,31 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the load balancer rule.
 
-* `ipaddress` - (Required) Public ip address from where the network traffic will be load balanced from.
-    Changing this forces a new resource to be created.
+* `ip_address` - (Required) Public ip address from where the network traffic
+    will be load balanced from. Changing this forces a new resource to be
+    created.
 
-* `network` - (Optional) The guest network this rule will be created for. Required when public Ip address is
-    not associated with any Guest network yet (VPC case).
-
-* `algorithm` - (Required) Load balancer rule algorithm (source, roundrobin, leastconn).Changing this forces
-    a new resource to be created.
-
-* `private_port` - (Required) The private port of the private ip address/virtual machine where the network
-    traffic will be load balanced to. Changing this forces a new resource to be created.
-
-* `public_port` - (Required) The public port from where the network traffic will be load balanced from.
-    Changing this forces a new resource to be created.
-
-* `members` - (Required) List of instances to assign to the load balancer rule. Changing this forces a new
+* `ipaddress` - (Required, Deprecated) Public ip address from where the
+    network traffic will be load balanced from. Changing this forces a new
     resource to be created.
+
+* `network` - (Optional) The guest network this rule will be created for.
+    Required when public IP address is not associated with any Guest network
+    yet (VPC case).
+
+* `algorithm` - (Required) Load balancer rule algorithm (source, roundrobin,
+    leastconn). Changing this forces a new resource to be created.
+
+* `private_port` - (Required) The private port of the private IP address 
+    (virtual machine) where the network traffic will be load balanced to.
+    Changing this forces a new resource to be created.
+
+* `public_port` - (Required) The public port from where the network traffic
+    will be load balanced from. Changing this forces a new resource to be
+    created.
+
+* `members` - (Required) List of instances to assign to the load balancer rule.
+    Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/cloudstack/r/nic.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/nic.html.markdown
@@ -17,7 +17,7 @@ Basic usage:
 ```
 resource "cloudstack_nic" "test" {
     network = "network-2"
-    ipaddress = "192.168.1.1"
+    ip_address = "192.168.1.1"
     virtual_machine = "server-1"
 }
 ```
@@ -29,8 +29,11 @@ The following arguments are supported:
 * `network` - (Required) The name or ID of the network to plug the NIC into. Changing
     this forces a new resource to be created.
 
-* `ipaddress` - (Optional) The IP address to assign to the NIC. Changing this
+* `ip_address` - (Optional) The IP address to assign to the NIC. Changing this
     forces a new resource to be created.
+
+* `ipaddress` - (Optional, Deprecated) The IP address to assign to the NIC. Changing
+    this forces a new resource to be created.
 
 * `virtual_machine` - (Required) The name or ID of the virtual machine to which
     to attach the NIC. Changing this forces a new resource to be created.
@@ -40,4 +43,4 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the NIC.
-* `ipaddress` - The assigned IP address.
+* `ip_address` - The assigned IP address.

--- a/website/source/docs/providers/cloudstack/r/port_forward.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/port_forward.html.markdown
@@ -14,7 +14,7 @@ Creates port forwards.
 
 ```
 resource "cloudstack_port_forward" "default" {
-  ipaddress = "192.168.0.1"
+  ip_address = "192.168.0.1"
 
   forward {
     protocol = "tcp"
@@ -29,8 +29,11 @@ resource "cloudstack_port_forward" "default" {
 
 The following arguments are supported:
 
-* `ipaddress` - (Required) The IP address for which to create the port forwards.
+* `ip_address` - (Required) The IP address for which to create the port forwards.
     Changing this forces a new resource to be created.
+
+* `ipaddress` - (Required, Deprecated) The IP address for which to create the port
+    forwards. Changing this forces a new resource to be created.
 
 * `managed` - (Optional) USE WITH CAUTION! If enabled all the port forwards for
     this IP address will be managed by this resource. This means it will delete
@@ -54,4 +57,4 @@ The `forward` block supports:
 
 The following attributes are exported:
 
-* `ipaddress` - The IP address for which the port forwards are created.
+* `ip_address` - The IP address for which the port forwards are created.

--- a/website/source/docs/providers/cloudstack/r/secondary_ipaddress.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/secondary_ipaddress.html.markdown
@@ -22,9 +22,13 @@ resource "cloudstack_secondary_ipaddress" "default" {
 
 The following arguments are supported:
 
-* `ipaddress` - (Optional) The IP address to attach the to NIC. If not supplied
+* `ip_address` - (Optional) The IP address to attach the to NIC. If not supplied
  		an IP address will be selected randomly. Changing this forces a new resource
 		to be	created.
+
+* `ipaddress` - (Optional, Deprecated) The IP address to attach the to NIC. If
+    not supplied an IP address will be selected randomly. Changing this forces 
+    a new resource to be	created.
 
 * `nicid` - (Optional) The ID of the NIC to which you want to attach the
 		secondary IP address. Changing this forces a new resource to be

--- a/website/source/layouts/cloudstack.erb
+++ b/website/source/layouts/cloudstack.erb
@@ -65,6 +65,10 @@
                             <a href="/docs/providers/cloudstack/r/ssh_keypair.html">cloudstack_ssh_keypair</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-cloudstack-resource-static-nat") %>>
+                            <a href="/docs/providers/cloudstack/r/static_nat.html">cloudstack_static_nat</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-cloudstack-resource-template") %>>
                             <a href="/docs/providers/cloudstack/r/template.html">cloudstack_template</a>
                         </li>


### PR DESCRIPTION
It turns out all other providers use `ip_address` where the CloudStack
provider uses `ipaddress`. To make this more consistent this PR
deprecates `ipaddress` and adds `ip_address` where needed…