### PR TITLE
config: Add randomhex(n) interpolate func

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"crypto/md5"
+	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
@@ -46,6 +47,7 @@ func Funcs() map[string]ast.Function {
 		"lower":        interpolationFuncLower(),
 		"md5":          interpolationFuncMd5(),
 		"uuid":         interpolationFuncUUID(),
+		"randomhex":    interpolationFuncRandomHex(),
 		"replace":      interpolationFuncReplace(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
@@ -700,6 +702,25 @@ func interpolationFuncBase64Sha256() ast.Function {
 			shaSum := h.Sum(nil)
 			encoded := base64.StdEncoding.EncodeToString(shaSum[:])
 			return encoded, nil
+		},
+	}
+}
+
+func interpolationFuncRandomHex() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeInt},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			n := args[0].(int)
+			b := make([]byte, n)
+
+			_, err := rand.Read(b)
+			if err != nil {
+				return "", fmt.Errorf("failed to read random bytes: %v", err)
+			}
+
+			f := fmt.Sprintf("%%0%dx", n)
+			return fmt.Sprintf(f, b)[0:n], nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1017,6 +1017,44 @@ func TestInterpolateFuncUUID(t *testing.T) {
 	}
 }
 
+func TestInterpolateFuncRandomHex(t *testing.T) {
+	for i := 1; i <= 32; i++ {
+		ast, err := hil.Parse(fmt.Sprintf("${randomhex(%d)}", i))
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		out, _, err := hil.Eval(ast, langEvalConfig(nil))
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if len(out.(string)) != i {
+			t.Fatalf("Did not get string of length %d: %s", i, out.(string))
+		}
+	}
+
+	results := make(map[string]bool)
+
+	for i := 0; i < 100; i++ {
+		ast, err := hil.Parse("${randomhex(7)}")
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		out, _, err := hil.Eval(ast, langEvalConfig(nil))
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if results[out.(string)] {
+			t.Fatalf("Got unexpected duplicate string: %s", out)
+		}
+
+		results[out.(string)] = true
+	}
+}
+
 type testFunctionConfig struct {
 	Cases []testFunctionCase
 	Vars  map[string]ast.Variable


### PR DESCRIPTION
Adds a `randomhex` function for interpolations. Can be used to generate unique names or identifiers for resources.

```tf
output "4" { value = "${randomhex(4)}" }
output "7" { value = "${randomhex(7)}" }
output "32" { value = "${randomhex(32)}" }
output "security-group-name" { value = "myapp-${randomhex(7)}" }
```

```
$ terraform apply

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

    4                 = 7637
    7                 = b11f487
   32                 = 7eeedb14eb6faa1d4e311f08863682ac
  security-group-name = myapp-web-8ca2525
```