### PR TITLE
provider/aws: Remove Network ACL from state if not found

### DIFF
--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -169,6 +169,13 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok {
+			if ec2err.Code() == "InvalidNetworkAclID.NotFound" {
+				log.Printf("[DEBUG] Network ACL (%s) not found", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
 		return err
 	}
 	if resp == nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/5392 by removing the Network ACL if it's not found. 