### PR TITLE
Added Group attribute to cloudstack instance resource

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_instance.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance.go
@@ -94,11 +94,11 @@ func resourceCloudStackInstance() *schema.Resource {
 				Default:  false,
 			},
 
-                        "group": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                Computed: true,
-                        },
+			"group": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -199,10 +199,10 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 		p.SetUserdata(ud)
 	}
 
-        // If there is a group supplied, add it to the parameter struct
-        if group, ok := d.GetOk("group"); ok {
-                p.SetGroup(group.(string))
-        }
+	// If there is a group supplied, add it to the parameter struct
+	if group, ok := d.GetOk("group"); ok {
+		p.SetGroup(group.(string))
+	}
 
 	// Create the new instance
 	r, err := cs.VirtualMachine.DeployVirtualMachine(p)

--- a/builtin/providers/cloudstack/resource_cloudstack_instance.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance.go
@@ -93,6 +93,12 @@ func resourceCloudStackInstance() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+                        "group": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Computed: true,
+                        },
 		},
 	}
 }
@@ -192,6 +198,11 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 
 		p.SetUserdata(ud)
 	}
+
+        // If there is a group supplied, add it to the parameter struct
+        if group, ok := d.GetOk("group"); ok {
+                p.SetGroup(group.(string))
+        }
 
 	// Create the new instance
 	r, err := cs.VirtualMachine.DeployVirtualMachine(p)

--- a/website/source/docs/providers/cloudstack/r/instance.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/instance.html.markdown
@@ -31,6 +31,8 @@ The following arguments are supported:
 
 * `display_name` - (Optional) The display name of the instance.
 
+* `group` - (Optional) The group name of the instance.
+
 * `service_offering` - (Required) The name or ID of the service offering used
     for this instance.
 


### PR DESCRIPTION
In our Cloudstack environment we make use of the group attribute. I noticed it was missing from the Terraform resource yet exists in the go-cloudstack library Terraform is using. This is simply an attribute addition so that the group may be specified in Terraform.