### PR TITLE
aws provider: normalize json of cloudwatch event_pattern before updating terraform

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
@@ -213,7 +213,7 @@ func buildPutRuleInputStruct(d *schema.ResourceData) *events.PutRuleInput {
 		input.Description = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("event_pattern"); ok {
-		input.EventPattern = aws.String(v.(string))
+		input.EventPattern = aws.String(normalizeJson(v.(string)))
 	}
 	if v, ok := d.GetOk("role_arn"); ok {
 		input.RoleArn = aws.String(v.(string))


### PR DESCRIPTION
Summary
----

Normalise the event_pattern of the aws_cloudwatch_event_rule resource
before uploading it to AWS.

AWS seems to accept a event_pattern with a JSON with new lines, but then
the rule does not seem to work. Creating the rule in the AWS console works,
but will setup the pattern  as a json without newlines or spaces, and
display a formatted JSON.


Detailed problem description
-----

Given a config like this:

```
resource "aws_cloudwatch_event_rule" "CloudTrail_inline" {
  name = "cloudtrail-manipulation-inline"
  description = "Capture tempering with CloudTrail settings - Inline"
  event_pattern = <<PATTERN
{
  "detail-type": [
    "AWS API Call via CloudTrail"
  ],
  "detail": {
    "eventSource": [
      "cloudtrail.amazonaws.com"
    ],
    "eventName": [
      "StopLogging",
      "UpdateTrail",
      "DeleteTrail"
    ]
  }
}
PATTERN
}
```

Terraform runs cleanly, and even in the interface you can see the rule created and everything fine. But **it does not work**.

But then, if you create it manually, it does work!

But I found the issue running aws cli:
```
$ aws events list-rules
{
    "Rules": [
        {
            "EventPattern": "{\"detail-type\":[\"AWS API Call via CloudTrail\"],\"detail\":{\"eventSource\":[\"cloudtrail.amazonaws.com\"],\"eventName\":[\"StopLogging\",\"UpdateTrail\",\"DeleteTrail\"]}}",
            "State": "DISABLED",
            "Name": "manually",
            "Arn": "arn:aws:events:us-east-1:736306583401:rule/manually",
            "Description": "manually"
        },
        {
            "EventPattern": "{\n  \"detail-type\": [\n    \"AWS API Call via CloudTrail\"\n  ],\n  \"detail\": {\n    \"eventSource\": [\n      \"cloudtrail.amazonaws.com\"\n    ],\n    \"eventName\": [\n      \"StopLogging\",\n      \"UpdateTrail\",\n      \"DeleteTrail\"\n    ]\n  }\n}\n",
            "State": "ENABLED",
            "Name": "cloudtrail-manipulation",
            "Arn": "arn:aws:events:us-east-1:736306583401:rule/cloudtrail-manipulation",
            "Description": "Capture tempering with CloudTrail settings"
        }
}
```

You can see that the rule created manually **has not newlines**.

But in the `terraform.tfstate`, the rule has no new lines:
```
$ grep event_pattern terraform.tfstate
                            "event_pattern": "{\"detail\":{\"eventName\":[\"StopLogging\",\"UpdateTrail\",\"DeleteTrail\"],\"eventSource\":[\"cloudtrail.amazonaws.com\"]},\"detail-type\":[\"AWS API Call via CloudTrail\"]}",
```

Expected result
---

It should work even with new lines, but I think that is a bug in AWS itself. We should file a bug if somebody can confirm that behaviour.

Meanwhile, I think terraform should send a json without new lines. as done in this PR.