### PR TITLE
new provider: dockerregistry

### DIFF
--- a/builtin/bins/provider-dockerregistry/main.go
+++ b/builtin/bins/provider-dockerregistry/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/dockerregistry"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: dockerregistry.Provider,
+	})
+}

--- a/builtin/providers/dockerregistry/dockerregistry.go
+++ b/builtin/providers/dockerregistry/dockerregistry.go
@@ -1,0 +1,109 @@
+package dockerregistry
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/meteor/docker-registry-client/registry"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Username to log in to Docker registry",
+				DefaultFunc: schema.EnvDefaultFunc("DOCKERREGISTRY_USERNAME", ""),
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Password to log in to Docker registry",
+				DefaultFunc: schema.EnvDefaultFunc("DOCKERREGISTRY_PASSWORD", ""),
+			},
+			"registry": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "https://registry-1.docker.io",
+				Description: "URL to Docker V2 registry",
+			},
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"dockerregistry_image": dataSourceImage(),
+		},
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func dataSourceImage() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true, // No Update command; we mutate Id
+				Description: "Name of the repository in the registry; eg, `mycompany/myproject` or `library/alpine`",
+			},
+			"tag": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true, // No Update command; we mutate Id
+				Description: "Tag to search for",
+			},
+		},
+
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			id, err := ensureImageExists(d, meta)
+			if err != nil {
+				return err
+			}
+			d.SetId(id)
+			return nil
+		},
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	registryURL := d.Get("registry").(string)
+	reg := &registry.Registry{
+		URL: registryURL,
+		Client: &http.Client{
+			Transport: registry.WrapTransport(http.DefaultTransport, registryURL,
+				d.Get("username").(string), d.Get("password").(string)),
+		},
+		Logf: registry.Quiet,
+	}
+	return reg, nil
+}
+
+func ensureImageExists(d *schema.ResourceData, meta interface{}) (string, error) {
+	reg := meta.(*registry.Registry)
+	repository := d.Get("repository").(string)
+	tag := d.Get("tag").(string)
+
+	serverTags, err := reg.Tags(repository)
+	if err != nil {
+		return "", fmt.Errorf("Error looking up tags for %s: %s", repository, err)
+	}
+
+	if !stringInSlice(tag, serverTags) {
+		return "", fmt.Errorf("Docker image %s:%s not found in registry", repository, tag)
+	}
+
+	return fmt.Sprintf("%s:%s", repository, tag), nil
+}
+
+// stringInSlice returns true if the string is an element of the slice.
+//
+// (It's great that Go makes it hard to ignore that this operation is O(n)!)
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/builtin/providers/dockerregistry/dockerregistry_test.go
+++ b/builtin/providers/dockerregistry/dockerregistry_test.go
@@ -1,0 +1,142 @@
+package dockerregistry
+
+// Note: to run the tests that actually talk to the registry, run:
+//
+// $ TF_ACC=1 go test -v github.com/hashicorp/terraform/builtin/providers/dockerregistry
+//
+// (Username and password are not necessary as it only reads a public
+// repository. No tests currently test auth.)
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"dockerregistry": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestAccDockerRegistry_good(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDockerRegistryConfigGood,
+				Check:  resource.TestCheckResourceAttr("data.dockerregistry_image.good", "id", "library/alpine:3.1"),
+			},
+		},
+	})
+}
+
+func TestAccDockerRegistry_missing_tag(t *testing.T) {
+	expectT := &expectOneErrorTestT{
+		ErrorPredicate: func(args ...interface{}) bool {
+			return len(args) == 1 && strings.Contains(args[0].(string),
+				"Docker image library/alpine:3.1-does-not-exist not found in registry")
+		},
+		WrappedT: t,
+	}
+	resource.Test(expectT, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDockerRegistryConfigMissingTag,
+			},
+		},
+	})
+	if !expectT.GotError {
+		t.Error("Did not get expected error")
+	}
+}
+
+func TestAccDockerRegistry_missing_repo(t *testing.T) {
+	expectT := &expectOneErrorTestT{
+		ErrorPredicate: func(args ...interface{}) bool {
+			if len(args) != 1 {
+				return false
+			}
+			e := args[0].(string)
+			// This is not the best error, but it's what the registry gives us.
+			return strings.Contains(e, "Error looking up tags for library/alpine-does-not-exist") &&
+				strings.Contains(e, "UNAUTHORIZED")
+		},
+		WrappedT: t,
+	}
+	resource.Test(expectT, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDockerRegistryConfigMissingRepo,
+			},
+		},
+	})
+	if !expectT.GotError {
+		t.Error("Did not get expected error")
+	}
+}
+
+const testAccDockerRegistryConfigGood = `
+data "dockerregistry_image" "good" {
+  repository = "library/alpine"
+  tag = "3.1"
+}
+`
+
+const testAccDockerRegistryConfigMissingTag = `
+data "dockerregistry_image" "bad" {
+  repository = "library/alpine"
+  tag = "3.1-does-not-exist"
+}
+`
+
+const testAccDockerRegistryConfigMissingRepo = `
+data "dockerregistry_image" "bad" {
+  repository = "library/alpine-does-not-exist"
+  tag = "3.1"
+}
+`
+
+// This implements the terraform TestT interface and expects to have Error
+// called on it exactly once. Skip is passed through.
+type expectOneErrorTestT struct {
+	ErrorPredicate func(args ...interface{}) bool
+	WrappedT       *testing.T
+	GotError       bool
+}
+
+func (t *expectOneErrorTestT) Fatal(args ...interface{}) {
+	t.WrappedT.Fatal(args...)
+}
+
+func (t *expectOneErrorTestT) Skip(args ...interface{}) {
+	t.WrappedT.Skip(args...)
+}
+
+func (t *expectOneErrorTestT) Error(args ...interface{}) {
+	if t.GotError {
+		t.WrappedT.Error("Got unexpected additional error:", fmt.Sprintln(args...))
+		return
+	}
+	if !t.ErrorPredicate(args...) {
+		t.WrappedT.Error("Got non-matching error:", fmt.Sprintln(args...))
+		return
+	}
+	t.GotError = true
+}

--- a/vendor/github.com/meteor/docker-registry-client/LICENSE.md
+++ b/vendor/github.com/meteor/docker-registry-client/LICENSE.md
@@ -1,0 +1,26 @@
+Copyright (c) 2015, Salesforce.com, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be
+    used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/meteor/docker-registry-client/registry/authchallenge.go
+++ b/vendor/github.com/meteor/docker-registry-client/registry/authchallenge.go
@@ -1,0 +1,150 @@
+package registry
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Octet types from RFC 2616.
+type octetType byte
+
+// AuthorizationChallenge carries information
+// from a WWW-Authenticate response header.
+type AuthorizationChallenge struct {
+	Scheme     string
+	Parameters map[string]string
+}
+
+var octetTypes [256]octetType
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+func parseAuthHeader(header http.Header) []*AuthorizationChallenge {
+	var challenges []*AuthorizationChallenge
+	for _, h := range header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		v, p := parseValueAndParams(h)
+		if v != "" {
+			challenges = append(challenges, &AuthorizationChallenge{Scheme: v, Parameters: p})
+		}
+	}
+	return challenges
+}
+
+func parseValueAndParams(header string) (value string, params map[string]string) {
+	params = make(map[string]string)
+	value, s := expectToken(header)
+	if value == "" {
+		return
+	}
+	value = strings.ToLower(value)
+	s = "," + skipSpace(s)
+	for strings.HasPrefix(s, ",") {
+		var pkey string
+		pkey, s = expectToken(skipSpace(s[1:]))
+		if pkey == "" {
+			return
+		}
+		if !strings.HasPrefix(s, "=") {
+			return
+		}
+		var pvalue string
+		pvalue, s = expectTokenOrQuoted(s[1:])
+		if pvalue == "" {
+			return
+		}
+		pkey = strings.ToLower(pkey)
+		params[pkey] = pvalue
+		s = skipSpace(s)
+	}
+	return
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectToken(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isToken == 0 {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectTokenOrQuoted(s string) (value string, rest string) {
+	if !strings.HasPrefix(s, "\"") {
+		return expectToken(s)
+	}
+	s = s[1:]
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return s[:i], s[i+1:]
+		case '\\':
+			p := make([]byte, len(s)-1)
+			j := copy(p, s[:i])
+			escape := true
+			for i = i + i; i < len(s); i++ {
+				b := s[i]
+				switch {
+				case escape:
+					escape = false
+					p[j] = b
+					j++
+				case b == '\\':
+					escape = true
+				case b == '"':
+					return string(p[:j]), s[i+1:]
+				default:
+					p[j] = b
+					j++
+				}
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}

--- a/vendor/github.com/meteor/docker-registry-client/registry/basictransport.go
+++ b/vendor/github.com/meteor/docker-registry-client/registry/basictransport.go
@@ -1,0 +1,23 @@
+package registry
+
+import (
+	"net/http"
+	"strings"
+)
+
+type BasicTransport struct {
+	Transport http.RoundTripper
+	URL       string
+	Username  string
+	Password  string
+}
+
+func (t *BasicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasPrefix(req.URL.String(), t.URL) {
+		if t.Username != "" || t.Password != "" {
+			req.SetBasicAuth(t.Username, t.Password)
+		}
+	}
+	resp, err := t.Transport.RoundTrip(req)
+	return resp, err
+}

--- a/vendor/github.com/meteor/docker-registry-client/registry/errortransport.go
+++ b/vendor/github.com/meteor/docker-registry-client/registry/errortransport.go
@@ -1,0 +1,44 @@
+package registry
+
+import(
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type HttpStatusError struct {
+	Response *http.Response
+	Body     []byte           // Copied from `Response.Body` to avoid problems with unclosed bodies later. Nobody calls `err.Response.Body.Close()`, ever.
+}
+
+func (err *HttpStatusError) Error() string {
+	return fmt.Sprintf("http: non-successful response (status=%v body=%q)", err.Response.StatusCode, err.Body)
+}
+
+var _ error = &HttpStatusError{}
+
+type ErrorTransport struct {
+	Transport http.RoundTripper
+}
+
+func (t *ErrorTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	resp, err := t.Transport.RoundTrip(request)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("http: failed to read response body (status=%v, err=%q)", resp.StatusCode, err)
+		}
+
+		return nil, &HttpStatusError {
+			Response: resp,
+			Body: body,
+		}
+	}
+
+	return resp, err
+}

--- a/vendor/github.com/meteor/docker-registry-client/registry/json.go
+++ b/vendor/github.com/meteor/docker-registry-client/registry/json.go
@@ -1,0 +1,23 @@
+package registry
+
+import (
+	"encoding/json"
+)
+
+func (registry *Registry) getJson(url string, response interface{}) error {
+	resp, err := registry.Client.Get(url)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/meteor/docker-registry-client/registry/registry.go
+++ b/vendor/github.com/meteor/docker-registry-client/registry/registry.go
@@ -1,0 +1,120 @@
+package registry
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type LogfCallback func(format string, args... interface{})
+
+/*
+ * Discard log messages silently.
+ */
+func Quiet(format string, args... interface{}) {
+	/* discard logs */
+}
+
+/*
+ * Pass log messages along to Go's "log" module.
+ */
+func Log(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+type Registry struct {
+	URL    string
+	Client *http.Client
+	Logf   LogfCallback
+}
+
+/*
+ * Create a new Registry with the given URL and credentials, then Ping()s it
+ * before returning it to verify that the registry is available.
+ *
+ * You can, alternately, construct a Registry manually by populating the fields.
+ * This passes http.DefaultTransport to WrapTransport when creating the
+ * http.Client.
+ */
+func New(registryUrl, username, password string) (*Registry, error) {
+	transport := http.DefaultTransport
+
+	return newFromTransport(registryUrl, username, password, transport, Log)
+}
+
+/*
+ * Create a new Registry, as with New, using an http.Transport that disables
+ * SSL certificate verification.
+ */
+func NewInsecure(registryUrl, username, password string) (*Registry, error) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	return newFromTransport(registryUrl, username, password, transport, Log)
+}
+
+/*
+ * Given an existing http.RoundTripper such as http.DefaultTransport, build the
+ * transport stack necessary to authenticate to the Docker registry API. This
+ * adds in support for OAuth bearer tokens and HTTP Basic auth, and sets up
+ * error handling this library relies on.
+ */
+func WrapTransport(transport http.RoundTripper, url, username, password string) http.RoundTripper {
+	tokenTransport := &TokenTransport{
+		Transport: transport,
+		Username:  username,
+		Password:  password,
+	}
+	basicAuthTransport := &BasicTransport{
+		Transport: tokenTransport,
+		URL:       url,
+		Username:  username,
+		Password:  password,
+	}
+	errorTransport := &ErrorTransport{
+		Transport: basicAuthTransport,
+	}
+	return errorTransport
+}
+
+func newFromTransport(registryUrl, username, password string, transport http.RoundTripper, logf LogfCallback) (*Registry, error) {
+	url := strings.TrimSuffix(registryUrl, "/")
+	transport = WrapTransport(transport, url, username, password)
+	registry := &Registry{
+		URL: url,
+		Client: &http.Client{
+			Transport: transport,
+		},
+		Logf: logf,
+	}
+
+	if err := registry.Ping(); err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (r *Registry) url(pathTemplate string, args ...interface{}) string {
+	pathSuffix := fmt.Sprintf(pathTemplate, args...)
+	url := fmt.Sprintf("%s%s", r.URL, pathSuffix)
+	return url
+}
+
+func (r *Registry) Ping() error {
+	url := r.url("/v2/")
+	r.Logf("registry.ping url=%s", url)
+	resp, err := r.Client.Get(url)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+
+	}
+	return err
+}

--- a/vendor/github.com/meteor/docker-registry-client/registry/tags.go
+++ b/vendor/github.com/meteor/docker-registry-client/registry/tags.go
@@ -1,0 +1,17 @@
+package registry
+
+type tagsResponse struct {
+	Tags []string `json:"tags"`
+}
+
+func (registry *Registry) Tags(repository string) ([]string, error) {
+	url := registry.url("/v2/%s/tags/list", repository)
+	registry.Logf("registry.tags url=%s repository=%s", url, repository)
+
+	var response tagsResponse
+	if err := registry.getJson(url, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Tags, nil
+}

--- a/vendor/github.com/meteor/docker-registry-client/registry/tokentransport.go
+++ b/vendor/github.com/meteor/docker-registry-client/registry/tokentransport.go
@@ -1,0 +1,125 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type TokenTransport struct {
+	Transport http.RoundTripper
+	Username  string
+	Password  string
+}
+
+func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.Transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if authService := isTokenDemand(resp); authService != nil {
+		resp, err = t.authAndRetry(authService, req)
+	}
+	return resp, err
+}
+
+type authToken struct {
+	Token string `json:"token"`
+}
+
+func (t *TokenTransport) authAndRetry(authService *authService, req *http.Request) (*http.Response, error) {
+	token, authResp, err := t.auth(authService)
+	if err != nil {
+		return authResp, err
+	}
+
+	retryResp, err := t.retry(req, token)
+	return retryResp, err
+}
+
+func (t *TokenTransport) auth(authService *authService) (string, *http.Response, error) {
+	authReq, err := authService.Request(t.Username, t.Password)
+	if err != nil {
+		return "", nil, err
+	}
+
+	client := http.Client{
+		Transport: t.Transport,
+	}
+
+	response, err := client.Do(authReq)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return "", response, err
+	}
+	defer response.Body.Close()
+
+	var authToken authToken
+	decoder := json.NewDecoder(response.Body)
+	err = decoder.Decode(&authToken)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return authToken.Token, nil, nil
+}
+
+func (t *TokenTransport) retry(req *http.Request, token string) (*http.Response, error) {
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	resp, err := t.Transport.RoundTrip(req)
+	return resp, err
+}
+
+type authService struct {
+	Realm   string
+	Service string
+	Scope   string
+}
+
+func (authService *authService) Request(username, password string) (*http.Request, error) {
+	url, err := url.Parse(authService.Realm)
+	if err != nil {
+		return nil, err
+	}
+
+	q := url.Query()
+	q.Set("service", authService.Service)
+	q.Set("scope", authService.Scope)
+	url.RawQuery = q.Encode()
+
+	request, err := http.NewRequest("GET", url.String(), nil)
+
+	if username != "" || password != "" {
+		request.SetBasicAuth(username, password)
+	}
+
+	return request, err
+}
+
+func isTokenDemand(resp *http.Response) *authService {
+	if resp == nil {
+		return nil
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return nil
+	}
+	return parseOauthHeader(resp)
+}
+
+func parseOauthHeader(resp *http.Response) *authService {
+	challenges := parseAuthHeader(resp.Header)
+	for _, challenge := range challenges {
+		if challenge.Scheme == "bearer" {
+			return &authService{
+				Realm:   challenge.Parameters["realm"],
+				Service: challenge.Parameters["service"],
+				Scope:   challenge.Parameters["scope"],
+			}
+		}
+	}
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1440,6 +1440,12 @@
 			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
 		},
 		{
+			"checksumSHA1": "uFGtM7zj0Q9fZPnnKlHTOJ9G5FA=",
+			"path": "github.com/meteor/docker-registry-client/registry",
+			"revision": "c92c2b37bee5e2332df0aa2608ebf020cf86c0da",
+			"revisionTime": "2016-04-05T21:33:58Z"
+		},
+		{
 			"checksumSHA1": "7niW29CvYceZ6zbia6b/LT+yD/M=",
 			"path": "github.com/mitchellh/cli",
 			"revision": "fcf521421aa29bde1d93b6920dfce826d7932208",


### PR DESCRIPTION
(Initial draft. This commit does not include doc updates, and all of the
code is in a single file instead of being split into provider/resource
files as is the terraform standard. It also uses the V1 API rather than
the V2 API mostly because it is simpler to implement, but it might be
better to use the V2 API (eg, Amazon ECR only implements V1).)

Unlike the 'docker' provider, which talks to your local Docker daemon to
read and write your local image stores, the 'dockerregistry' provider
talks to a Docker Registry V1 server and confirms that the named
repository/tag exists.

It is a read-only provider: it doesn't push to the registry; it just
helps you assert that the docker tag push via your build process
actually exists before creating other configuration that uses it.
