### PR TITLE
provider/vsphere: Add support for memory reservation

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -62,6 +62,8 @@ func TestAccVSphereVirtualMachine_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.foo", "memory", "4096"),
 					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.foo", "memory_reservation", "4096"),
+					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.foo", "disk.#", "2"),
 					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.foo", "disk.0.template", template),
@@ -632,6 +634,7 @@ resource "vsphere_virtual_machine" "foo" {
 %s
     vcpu = 2
     memory = 4096
+    memory_reservation = 4096
     gateway = "%s"
     network_interface {
         label = "%s"

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `name` - (Required) The virtual machine name
 * `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual machine
 * `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual machine
+* `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve physical memory resource; defaults to 0 (means not to reserve)
 * `datacenter` - (Optional) The name of a Datacenter in which to launch the virtual machine
 * `cluster` - (Optional) Name of a Cluster in which to launch the virtual machine
 * `resource_pool` (Optional) The name of a Resource Pool in which to launch the virtual machine


### PR DESCRIPTION
This PR adds memory reservation support for `vsphere_virtual_machine` resource. I'd like to submit again, https://github.com/hashicorp/terraform/pull/4138.