### PR TITLE
provider/aws: Renaming `option_settings` attribute to `setting`. Added test to verify that settings are applied to template.

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template.go
@@ -132,7 +132,7 @@ func resourceAwsElasticBeanstalkConfigurationTemplateUpdate(d *schema.ResourceDa
 		}
 	}
 
-	if d.HasChange("option_settings") {
+	if d.HasChange("setting") {
 		if err := resourceAwsElasticBeanstalkConfigurationTemplateOptionSettingsUpdate(conn, d); err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ func resourceAwsElasticBeanstalkConfigurationTemplateDescriptionUpdate(conn *ela
 }
 
 func resourceAwsElasticBeanstalkConfigurationTemplateOptionSettingsUpdate(conn *elasticbeanstalk.ElasticBeanstalk, d *schema.ResourceData) error {
-	if d.HasChange("option_settings") {
+	if d.HasChange("setting") {
 		_, err := conn.ValidateConfigurationSettings(&elasticbeanstalk.ValidateConfigurationSettingsInput{
 			ApplicationName: aws.String(d.Get("application").(string)),
 			TemplateName:    aws.String(d.Get("name").(string)),
@@ -162,7 +162,7 @@ func resourceAwsElasticBeanstalkConfigurationTemplateOptionSettingsUpdate(conn *
 			return err
 		}
 
-		o, n := d.GetChange("option_settings")
+		o, n := d.GetChange("setting")
 		if o == nil {
 			o = new(schema.Set)
 		}
@@ -211,7 +211,7 @@ func resourceAwsElasticBeanstalkConfigurationTemplateDelete(d *schema.ResourceDa
 }
 
 func gatherOptionSettings(d *schema.ResourceData) []*elasticbeanstalk.ConfigurationOptionSetting {
-	optionSettingsSet, ok := d.Get("option_settings").(*schema.Set)
+	optionSettingsSet, ok := d.Get("setting").(*schema.Set)
 	if !ok || optionSettingsSet == nil {
 		optionSettingsSet = new(schema.Set)
 	}

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
@@ -48,6 +48,28 @@ func TestAccAWSBeanstalkConfigurationTemplate_VPC(t *testing.T) {
 	})
 }
 
+func TestAccAWSBeanstalkConfigurationTemplate_Setting(t *testing.T) {
+	var config elasticbeanstalk.ConfigurationSettingsDescription
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkConfigurationTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBeanstalkConfigurationTemplateConfig_Setting(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBeanstalkConfigurationTemplateExists("aws_elastic_beanstalk_configuration_template.tf_template", &config),
+					resource.TestCheckResourceAttr(
+						"aws_elastic_beanstalk_configuration_template.tf_template", "setting.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_elastic_beanstalk_configuration_template.tf_template", "setting.4112217815.value", "m1.small"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBeanstalkConfigurationTemplateDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).elasticbeanstalkconn
 
@@ -174,6 +196,29 @@ resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
     name      = "Subnets"
     value     = "${aws_subnet.main.id}"
   }
+}
+`, name, name)
+}
+
+func testAccBeanstalkConfigurationTemplateConfig_Setting(name string) string {
+	return fmt.Sprintf(`
+resource "aws_elastic_beanstalk_application" "tftest" {
+  name        = "tf-test-%s"
+  description = "tf-test-desc"
+}
+
+resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
+  name        = "tf-test-%s"
+  application = "${aws_elastic_beanstalk_application.tftest.name}"
+
+  solution_stack_name = "64bit Amazon Linux running Python"
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "InstanceType"
+    value     = "m1.small"
+  }
+
 }
 `, name, name)
 }


### PR DESCRIPTION
This updates the remaining uses of `option_settings` to `setting`. Also added test to verify settings are being set.

#6035

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkConfigurationTemplate -timeout 120m
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_basic
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_basic (15.32s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_VPC
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_VPC (18.59s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_Setting
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_Setting (13.11s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	47.023s
```