### PR TITLE
test if iam profile alread was destroyed by terraform

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -145,12 +145,18 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 	// Loop and remove this Role from any Profiles
 	if len(resp.InstanceProfiles) > 0 {
 		for _, i := range resp.InstanceProfiles {
-			_, err := iamconn.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
+			// Test if profile was already deleted by terraform
+			_, err := iamconn.GetInstanceProfile(&iam.GetInstanceProfileInput{
 				InstanceProfileName: i.InstanceProfileName,
-				RoleName:            aws.String(d.Id()),
 			})
 			if err != nil {
-				return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
+				_, err := iamconn.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
+					InstanceProfileName: i.InstanceProfileName,
+					RoleName:            aws.String(d.Id()),
+				})
+				if err != nil {
+					return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<h1>Summary</h1>
When terraform try to destroy an IAM role. It loops for every IAM Instance Profile attached and try to delete the attachment.
```
// Roles cannot be destroyed when attached to an existing Instance Profile
	resp, err := iamconn.ListInstanceProfilesForRole(&iam.ListInstanceProfilesForRoleInput{
		RoleName: aws.String(d.Id()),
	})
	if err != nil {
		return fmt.Errorf("Error listing Profiles for IAM Role (%s) when trying to delete: %s", d.Id(), err)
	}

	// Loop and remove this Role from any Profiles
	if len(resp.InstanceProfiles) > 0 {
		for _, i := range resp.InstanceProfiles {
			_, err := iamconn.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
				InstanceProfileName: i.InstanceProfileName,
				RoleName:            aws.String(d.Id()),
			})
			if err != nil {
				return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
			}
		}
	}
```
But here, if you create IAM Instance Profile by terraform it will be deleted before and cause exception here.

<h1>Fix</h1>
I check if IAM Instance profile still exists before removing the attachment.
```
	// Loop and remove this Role from any Profiles
	if len(resp.InstanceProfiles) > 0 {
		for _, i := range resp.InstanceProfiles {
			// Test if profile was already deleted by terraform
			_, err := iamconn.GetInstanceProfile(&iam.GetInstanceProfileInput{
				InstanceProfileName: i.InstanceProfileName,
			})
			if err != nil {
				_, err := iamconn.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
					InstanceProfileName: i.InstanceProfileName,
					RoleName:            aws.String(d.Id()),
				})
				if err != nil {
					return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
				}
			}
		}
	}
```

<h2>Note</h2>
You can also fix it using depends_on. But I guess it's a bug. Please let me know what you guys think.