### PR TITLE
fix(aws): volume attachment only forcenew on name

### DIFF
--- a/builtin/providers/aws/resource_aws_volume_attachment.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment.go
@@ -17,6 +17,7 @@ import (
 func resourceAwsVolumeAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsVolumeAttachmentCreate,
+		Update: resourceAwsVolumeAttachmentUpdate,
 		Read:   resourceAwsVolumeAttachmentRead,
 		Delete: resourceAwsVolumeAttachmentDelete,
 
@@ -30,13 +31,11 @@ func resourceAwsVolumeAttachment() *schema.Resource {
 			"instance_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"volume_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"force_detach": &schema.Schema{
@@ -54,19 +53,9 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 	iID := d.Get("instance_id").(string)
 	vID := d.Get("volume_id").(string)
 
-	opts := &ec2.AttachVolumeInput{
-		Device:     aws.String(name),
-		InstanceId: aws.String(iID),
-		VolumeId:   aws.String(vID),
-	}
-
 	log.Printf("[DEBUG] Attaching Volume (%s) to Instance (%s)", vID, iID)
-	_, err := conn.AttachVolume(opts)
+	err := attach(conn, name, iID, vID)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			return fmt.Errorf("[WARN] Error attaching volume (%s) to instance (%s), message: \"%s\", code: \"%s\"",
-				vID, iID, awsErr.Message(), awsErr.Code())
-		}
 		return err
 	}
 
@@ -88,6 +77,25 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 
 	d.SetId(volumeAttachmentID(name, vID, iID))
 	return resourceAwsVolumeAttachmentRead(d, meta)
+}
+
+func attach(conn *ec2.EC2, name, iID, vID string) error {
+
+	opts := &ec2.AttachVolumeInput{
+		Device:     aws.String(name),
+		InstanceId: aws.String(iID),
+		VolumeId:   aws.String(vID),
+	}
+
+	_, err := conn.AttachVolume(opts)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			return fmt.Errorf("[WARN] Error attaching volume (%s) to instance (%s), message: \"%s\", code: \"%s\"",
+				vID, iID, awsErr.Message(), awsErr.Code())
+		}
+		return err
+	}
+	return nil
 }
 
 func volumeAttachmentStateRefreshFunc(conn *ec2.EC2, volumeID, instanceID string) resource.StateRefreshFunc {
@@ -123,6 +131,7 @@ func volumeAttachmentStateRefreshFunc(conn *ec2.EC2, volumeID, instanceID string
 		return 42, "detached", nil
 	}
 }
+
 func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
@@ -149,18 +158,36 @@ func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-
+	name := d.Get("device_name").(string)
 	vID := d.Get("volume_id").(string)
 	iID := d.Get("instance_id").(string)
+	force := d.Get("force_detach").(bool)
 
-	opts := &ec2.DetachVolumeInput{
-		Device:     aws.String(d.Get("device_name").(string)),
-		InstanceId: aws.String(iID),
-		VolumeId:   aws.String(vID),
-		Force:      aws.Bool(d.Get("force_detach").(bool)),
+	err := detach(conn, name, iID, vID, force)
+	if err != nil {
+		return err
 	}
 
+	err = waitForState(conn, vID, iID)
+
+	d.SetId("")
+	return err
+}
+
+func detach(conn *ec2.EC2, name, iID, vID string, force bool) error {
+	opts := &ec2.DetachVolumeInput{
+		Device:     aws.String(name),
+		InstanceId: aws.String(iID),
+		VolumeId:   aws.String(vID),
+		Force:      aws.Bool(force),
+	}
+
+	log.Printf("[DEBUG] Detaching Volume (%s) from Instance (%s)", vID, iID)
 	_, err := conn.DetachVolume(opts)
+	return err
+}
+
+func waitForState(conn *ec2.EC2, vID, iID string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"detaching"},
 		Target:     []string{"detached"},
@@ -170,14 +197,43 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 		MinTimeout: 3 * time.Second,
 	}
 
-	log.Printf("[DEBUG] Detaching Volume (%s) from Instance (%s)", vID, iID)
-	_, err = stateConf.WaitForState()
+	_, err := stateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for Volume (%s) to detach from Instance: %s",
 			vID, iID)
 	}
-	d.SetId("")
+
+	return err
+}
+
+func resourceAwsVolumeAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	d.Partial(true)
+	conn := meta.(*AWSClient).ec2conn
+	name_old, name := d.GetChange("device_name")
+	iID_old, iID := d.GetChange("instance_id")
+	vID_old, vID := d.GetChange("volume_id")
+	force := d.Get("force_detach").(bool)
+
+	fmt.Printf("Moving volume from vol %s as dev %s on %s to %s as dev %s on %s",
+		vID_old, name_old, iID_old, vID, name, iID)
+	err := detach(conn, name_old.(string), iID_old.(string), vID_old.(string), force)
+	if err != nil {
+		return err
+	}
+
+	err = waitForState(conn, vID.(string), iID.(string))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("attaching %s onto %s from volume %s", name, iID, vID)
+	err = attach(conn, name.(string), iID.(string), vID.(string))
+	if err != nil {
+		return err
+	}
+
+	d.Partial(false)
 	return nil
 }
 


### PR DESCRIPTION
This is for #5240 

I'm being heavily affected by this and I found the only recourse was to sort of break convention.
## Summary

The aws_volume_attachment resource currently assumes creation and deletion whenever you alter its count. The reason for this is that the diff shows a change when it compares the calculated values for the volume or instance id ( usually something like"${element(aws_instance.foo.*.id, count.index)}" ).

Rather than waiting to see if the calculation actually changes an identifier (and usually it won't if you are just adding another instance and volume), the attachment immediately goes to delete/create .
## Example

Given a tfstate were `terraform apply` just succeeded for the following resources :

```
variable "dracula" { default = "2" }

resource "aws_volume_attachment" "foo_att" {
  count = "${var.dracula}"
  device_name = "/dev/sdh"
  volume_id = "${aws_ebs_volume.example.id}"
  instance_id = "${aws_instance.web.id}"
}

resource "aws_instance" "foo" {
  count = "${var.dracula}"
  ami = "ami-21f78e11"
  availability_zone = "us-west-2a"
  instance_type = "t1.micro"
}

resource "aws_ebs_volume" "v" {
  count = "${var.dracula}"
  availability_zone = "us-west-2a"
  size = 1
}
```

If I change dracula to be "3"

We expect for `terraform apply` to just make another instance, another volume, then attach the two.

Instead, the first two volume attachments are destroyed. Then recreated. then the expected behavior starts.
## The fix

Presently, I'm unaware of why the 'diff' functions built-in to terraform do not identify that no change has occurred.

Instead of trying to dig into the graph and unearth the failure to check for changes, I merely alter the schema. Instead of forcing new resources on changes to instance id and/or volume id, I just allow them to update the resource.

This fixes the issue, and only has the 'code smell' of being a little less than honest (because the 'Update' just does a delete/create)
## Closing thoughts

I think this is an acceptable fix because the nature of volume attachments does not follow that of a true resource. As it is... terraform has to 'invent' an id for the resource since aws doesn't really worry about one. The attachment behaves more akin to a 'pointer', essentially binding two resources to one another. As such, the Update really doesn't make much of a difference, since whether you forcenew or not... it doesn't change the fact that attachments aren't really modeled well in terraform.

This isn't a reflection of terraform... merely an observation of how aws has made volume attachments.... difficult to idempotentize [ pull request for adding that word to webster is forthcoming ]
