### PR TITLE
provider/openstack: Fix Disabling DHCP on Subnets

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
@@ -117,6 +117,8 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	enableDHCP := d.Get("enable_dhcp").(bool)
+
 	createOpts := subnets.CreateOpts{
 		NetworkID:       d.Get("network_id").(string),
 		CIDR:            d.Get("cidr").(string),
@@ -127,11 +129,7 @@ func resourceNetworkingSubnetV2Create(d *schema.ResourceData, meta interface{}) 
 		IPVersion:       d.Get("ip_version").(int),
 		DNSNameservers:  resourceSubnetDNSNameserversV2(d),
 		HostRoutes:      resourceSubnetHostRoutesV2(d),
-	}
-
-	if raw, ok := d.GetOk("enable_dhcp"); ok {
-		value := raw.(bool)
-		createOpts.EnableDHCP = &value
+		EnableDHCP:      &enableDHCP,
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -29,6 +29,26 @@ func TestAccNetworkingV2Subnet_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "name", "tf-test-subnet"),
 					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "gateway_ip", "192.168.199.1"),
+					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "enable_dhcp", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Subnet_enableDHCP(t *testing.T) {
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Subnet_enableDHCP,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists(t, "openstack_networking_subnet_v2.subnet_1", &subnet),
+					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "enable_dhcp", "true"),
 				),
 			},
 		},
@@ -90,28 +110,38 @@ func testAccCheckNetworkingV2SubnetExists(t *testing.T, n string, subnet *subnet
 
 var testAccNetworkingV2Subnet_basic = fmt.Sprintf(`
   resource "openstack_networking_network_v2" "network_1" {
-    region = "%s"
     name = "network_1"
     admin_state_up = "true"
   }
 
   resource "openstack_networking_subnet_v2" "subnet_1" {
-    region = "%s"
     network_id = "${openstack_networking_network_v2.network_1.id}"
     cidr = "192.168.199.0/24"
-  }`, OS_REGION_NAME, OS_REGION_NAME)
+  }`)
 
 var testAccNetworkingV2Subnet_update = fmt.Sprintf(`
   resource "openstack_networking_network_v2" "network_1" {
-    region = "%s"
     name = "network_1"
     admin_state_up = "true"
   }
 
   resource "openstack_networking_subnet_v2" "subnet_1" {
-    region = "%s"
     name = "tf-test-subnet"
     network_id = "${openstack_networking_network_v2.network_1.id}"
     cidr = "192.168.199.0/24"
     gateway_ip = "192.168.199.1"
-  }`, OS_REGION_NAME, OS_REGION_NAME)
+  }`)
+
+var testAccNetworkingV2Subnet_enableDHCP = fmt.Sprintf(`
+  resource "openstack_networking_network_v2" "network_1" {
+    name = "network_1"
+    admin_state_up = "true"
+  }
+
+  resource "openstack_networking_subnet_v2" "subnet_1" {
+    name = "tf-test-subnet"
+    network_id = "${openstack_networking_network_v2.network_1.id}"
+    cidr = "192.168.199.0/24"
+    gateway_ip = "192.168.199.1"
+    enable_dhcp = true
+  }`)


### PR DESCRIPTION
This commit fixes a bug where "false" was not correctly being passed to
the subnet creation and therefore enabling DHCP on all subnets.