### PR TITLE
provider/openstack: Allow subnets with no gateway

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -55,6 +55,44 @@ func TestAccNetworkingV2Subnet_enableDHCP(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Subnet_noGateway(t *testing.T) {
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Subnet_noGateway,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists(t, "openstack_networking_subnet_v2.subnet_1", &subnet),
+					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "gateway_ip", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Subnet_impliedGateway(t *testing.T) {
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Subnet_impliedGateway,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists(t, "openstack_networking_subnet_v2.subnet_1", &subnet),
+					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "gateway_ip", "192.168.199.1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2SubnetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -144,4 +182,27 @@ var testAccNetworkingV2Subnet_enableDHCP = fmt.Sprintf(`
     cidr = "192.168.199.0/24"
     gateway_ip = "192.168.199.1"
     enable_dhcp = true
+  }`)
+
+var testAccNetworkingV2Subnet_noGateway = fmt.Sprintf(`
+  resource "openstack_networking_network_v2" "network_1" {
+    name = "network_1"
+    admin_state_up = "true"
+  }
+  resource "openstack_networking_subnet_v2" "subnet_1" {
+    name = "tf-test-subnet"
+    network_id = "${openstack_networking_network_v2.network_1.id}"
+    cidr = "192.168.199.0/24"
+		no_gateway = true
+  }`)
+
+var testAccNetworkingV2Subnet_impliedGateway = fmt.Sprintf(`
+  resource "openstack_networking_network_v2" "network_1" {
+    name = "network_1"
+    admin_state_up = "true"
+  }
+  resource "openstack_networking_subnet_v2" "subnet_1" {
+    name = "tf-test-subnet"
+    network_id = "${openstack_networking_network_v2.network_1.id}"
+    cidr = "192.168.199.0/24"
   }`)

--- a/website/source/docs/providers/openstack/r/networking_subnet_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_subnet_v2.html.markdown
@@ -53,7 +53,12 @@ The following arguments are supported:
     documented below. Changing this creates a new subnet.
 
 * `gateway_ip` - (Optional)  Default gateway used by devices in this subnet.
-    Changing this updates the gateway IP of the existing subnet.
+    Leaving this blank and not setting `no_gateway` will cause a default
+    gateway of `.1` to be used. Changing this updates the gateway IP of the
+    existing subnet.
+
+* `no_gateway` - (Optional) Do not set a gateway IP on this subnet. Changing
+    this removes or adds a default gateway IP of the existing subnet.
 
 * `enable_dhcp` - (Optional) The administrative state of the network.
     Acceptable values are "true" and "false". Changing this value enables or


### PR DESCRIPTION
This commit adds a no_gateway attribute. When set, the subnet will
not have a gateway. This is different than not specifying a
gateway_ip since that will cause a default gateway of .1 to be used.
This behavior mirrors the OpenStack Neutron command-line tool.

Fixes #6031 

Waiting for https://github.com/rackspace/gophercloud/pull/553 to merge.