### PR TITLE
Capitalize the H in GitHub

### DIFF
--- a/website/source/docs/providers/github/index.html.markdown
+++ b/website/source/docs/providers/github/index.html.markdown
@@ -1,16 +1,16 @@
 ---
 layout: "github"
-page_title: "Provider: Github"
+page_title: "Provider: GitHub"
 sidebar_current: "docs-github-index"
 description: |-
-  The Github provider is used to interact with Github organization resources.
+  The GitHub provider is used to interact with GitHub organization resources.
 ---
 
-# Github Provider
+# GitHub Provider
 
-The Github provider is used to interact with Github organization resources. 
+The GitHub provider is used to interact with GitHub organization resources. 
 
-The provider allows you to manage your Github organization's members and teams easily. 
+The provider allows you to manage your GitHub organization's members and teams easily. 
 It needs to be configured with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
@@ -18,7 +18,7 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```
-# Configure the Github Provider
+# Configure the GitHub Provider
 provider "github" {
     token = "${var.github_token}"
     organization = "${var.github_organization}"
@@ -34,9 +34,9 @@ resource "github_membership" "membership_for_user_x" {
 
 The following arguments are supported in the `provider` block:
 
-* `token` - (Optional) This is the Github personal access token. It must be provided, but
+* `token` - (Optional) This is the GitHub personal access token. It must be provided, but
   it can also be sourced from the `GITHUB_TOKEN` environment variable.
 
-* `organization` - (Optional) This is the target Github organization to manage. The account
+* `organization` - (Optional) This is the target GitHub organization to manage. The account
   corresponding to the token will need "owner" privileges for this organization. It must be provided, but
   it can also be sourced from the `GITHUB_ORGANIZATION` environment variable.

--- a/website/source/docs/providers/github/r/membership.html.markdown
+++ b/website/source/docs/providers/github/r/membership.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "github"
-page_title: "Github: github_membership"
+page_title: "GitHub: github_membership"
 sidebar_current: "docs-github-resource-membership"
 description: |-
-  Provides a Github membership resource.
+  Provides a GitHub membership resource.
 ---
 
 # github\_membership
 
-Provides a Github membership resource.
+Provides a GitHub membership resource.
 
 This resource allows you to add/remove users from your organization. When applied,
 an invitation will be sent to the user to become part of the organization. When

--- a/website/source/docs/providers/github/r/team.html.markdown
+++ b/website/source/docs/providers/github/r/team.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "github"
-page_title: "Github: github_team"
+page_title: "GitHub: github_team"
 sidebar_current: "docs-github-resource-team"
 description: |-
-  Provides a Github team resource.
+  Provides a GitHub team resource.
 ---
 
 # github\_team
 
-Provides a Github team resource.
+Provides a GitHub team resource.
 
 This resource allows you to add/remove teams from your organization. When applied,
 a new team will be created. When destroyed, that team will be removed.

--- a/website/source/docs/providers/github/r/team_membership.html.markdown
+++ b/website/source/docs/providers/github/r/team_membership.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "github"
-page_title: "Github: github_team_membership"
+page_title: "GitHub: github_team_membership"
 sidebar_current: "docs-github-resource-team-membership"
 description: |-
-  Provides a Github team membership resource.
+  Provides a GitHub team membership resource.
 ---
 
 # github\_team_membership
 
-Provides a Github team membership resource.
+Provides a GitHub team membership resource.
 
 This resource allows you to add/remove users from teams in your organization. When applied,
 the user will be added to the team. If the user hasn't accepted their invitation to the 
@@ -40,7 +40,7 @@ resource "github_team_membership" "some_team_membership" {
 
 The following arguments are supported:
 
-* `team_id` - (Required) The Github team id
+* `team_id` - (Required) The GitHub team id
 * `username` - (Required) The user to add to the team.
 * `role` - (Optional) The role of the user within the team. 
             Must be one of `member` or `maintainer`. Defaults to `member`.

--- a/website/source/docs/providers/github/r/team_repository.html.markdown
+++ b/website/source/docs/providers/github/r/team_repository.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "github"
-page_title: "Github: github_team_repository"
+page_title: "GitHub: github_team_repository"
 sidebar_current: "docs-github-resource-team-repository"
 description: |-
-  Provides a Github team repository resource.
+  Provides a GitHub team repository resource.
 ---
 
 # github\_team_repository
 
-Provides a Github team repository resource.
+Provides a GitHub team repository resource.
 
 This resource allows you to add/remove repositories from teams in your organization. When applied,
 the repository will be added to the team. When destroyed, the repository will be removed from the team.
@@ -33,7 +33,7 @@ resource "github_team_repository" "some_team_repo" {
 
 The following arguments are supported:
 
-* `team_id` - (Required) The Github team id
+* `team_id` - (Required) The GitHub team id
 * `repository` - (Required) The repository to add to the team.
 * `permission` - (Optional) The permissions of team members regarding the repository. 
                   Must be one of `pull`, `push`, or `admin`. Defaults to `pull`.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -194,7 +194,7 @@
 					</li>
 
 					<li<%= sidebar_current("docs-providers-github") %>>
-					<a href="/docs/providers/github/index.html">Github</a>
+					<a href="/docs/providers/github/index.html">GitHub</a>
 					</li>
 
 					<li<%= sidebar_current("docs-providers-fastly") %>>

--- a/website/source/layouts/github.erb
+++ b/website/source/layouts/github.erb
@@ -7,7 +7,7 @@
 				</li>
 
 				<li<%= sidebar_current("docs-github-index") %>>
-				<a href="/docs/providers/github/index.html">Github Provider</a>
+				<a href="/docs/providers/github/index.html">GitHub Provider</a>
 				</li>
 
 				<li<%= sidebar_current(/^docs-github-resource/) %>>


### PR DESCRIPTION
GitHub really doesn't like when you make the H lowercase, it violates their brand guidelines and they won't help promote anything that doesn't use the capital H.