### PR TITLE
Document custom_json argument in opsworks_stack doc

### DIFF
--- a/website/source/docs/providers/aws/r/opsworks_stack.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_stack.html.markdown
@@ -18,6 +18,13 @@ resource "aws_opsworks_stack" "main" {
     region = "us-west-1"
     service_role_arn = "${aws_iam_role.opsworks.arn}"
     default_instance_profile_arn = "${aws_iam_instance_profile.opsworks.arn}"
+    custom_json = <<EOT
+{
+ "foobar": {
+    "version": "1.0.0"
+  }
+}
+EOT
 }
 ```
 
@@ -38,6 +45,7 @@ The following arguments are supported:
 * `configuration_manager_version` - (Optional) Version of the configuratino manager to use. Defaults to "11.4".
 * `custom_cookbooks_source` - (Optional) When `use_custom_cookbooks` is set, provide this sub-object as
   described below.
+* `custom_json` - (Optional) User defined JSON passed to "Chef". Use a "here doc" for multiline JSON.
 * `default_os` - (Optional) Name of OS that will be installed on instances by default.
 * `default_root_device_type` - (Optional) Name of the type of root device instances will have by default.
 * `default_ssh_key_name` - (Optional) Name of the SSH keypair that instances will have by default.


### PR DESCRIPTION
This adds documentation for the custom_json argument and appends an example.