### PR TITLE
provider/openstack: Enable Token Authentication

### DIFF
--- a/builtin/providers/openstack/config.go
+++ b/builtin/providers/openstack/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Username         string
 	UserID           string
 	Password         string
+	Token            string
 	APIKey           string
 	IdentityEndpoint string
 	TenantID         string
@@ -41,6 +42,7 @@ func (c *Config) loadAndValidate() error {
 		Username:         c.Username,
 		UserID:           c.UserID,
 		Password:         c.Password,
+		TokenID:          c.Token,
 		APIKey:           c.APIKey,
 		IdentityEndpoint: c.IdentityEndpoint,
 		TenantID:         c.TenantID,

--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -17,7 +17,7 @@ func Provider() terraform.ResourceProvider {
 			"user_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USERNAME", nil),
+				DefaultFunc: schema.EnvDefaultFunc("OS_USERNAME", ""),
 			},
 			"user_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -37,12 +37,17 @@ func Provider() terraform.ResourceProvider {
 			"password": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PASSWORD", nil),
+				DefaultFunc: schema.EnvDefaultFunc("OS_PASSWORD", ""),
+			},
+			"token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_TOKEN", ""),
 			},
 			"api_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_TOKEN", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_API_KEY", ""),
 			},
 			"domain_id": &schema.Schema{
 				Type:        schema.TypeString,
@@ -104,6 +109,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		Username:         d.Get("user_name").(string),
 		UserID:           d.Get("user_id").(string),
 		Password:         d.Get("password").(string),
+		Token:            d.Get("token").(string),
 		APIKey:           d.Get("api_key").(string),
 		TenantID:         d.Get("tenant_id").(string),
 		TenantName:       d.Get("tenant_name").(string),

--- a/website/source/docs/providers/openstack/index.html.markdown
+++ b/website/source/docs/providers/openstack/index.html.markdown
@@ -46,7 +46,18 @@ The following arguments are supported:
 * `password` - (Optional; Required if not using `api_key`) If omitted, the
     `OS_PASSWORD` environment variable is used.
 
-* `api_key` - (Optional; Required if not using `password`)
+* `token` - (Optional; Required if not using `user_name` and `password`)
+    A token is an expiring, temporary means of access issued via the
+    Keystone service. By specifying a token, you do not have to
+    specify a username/password combination, since the token was
+    already created by a username/password out of band of Terraform.
+    If ommitted, the `OS_AUTH_TOKEN` environment variable is used.
+
+* `api_key` - (Optional; Required if not using `password`) An API Key
+    is issued by a cloud provider as alternative password. Unless
+    your cloud provider has documentation referencing an API Key,
+    you can safely ignore this argument. If omitted, the `OS_API_KEY`
+    environment variable is used.
 
 * `domain_id` - (Optional) If omitted, the `OS_DOMAIN_ID` environment
     variable is used.


### PR DESCRIPTION
This commit enables the ability to authenticate to OpenStack by way
of a Keystone Token. Tokens can provide a way to use Terraform and
OpenStack with an expiring, temporary credential. The token will need
to be generated out of band from Terraform.

Fixes #5802 