### PR TITLE
Update cloudwatch_metric_alarm.html.markdown

### DIFF
--- a/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
@@ -77,3 +77,10 @@ The following arguments are supported:
 * `insufficient_data_actions` - (Optional) The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. Each action is specified as an Amazon Resource Number (ARN).
 * `ok_actions` - (Optional) The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Number (ARN).
 * `unit` - (Optional) The unit for the alarm's associated metric.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the health check
+


### PR DESCRIPTION
On creating CloudWatch metric alarms, I need to get the HealthCheckId dimension. Reference would be useful.

```
dimensions {
    "HealthCheckId" = "${aws_route53_health_check.foo.id}"
}
```