### PR TITLE
Vsphere windows support

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -136,7 +136,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"linkedClone": &schema.Schema{
+			"linked_clone": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -374,7 +374,7 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		vm.timeZone = v.(string)
 	}
 
-	if v, ok := d.GetOk("linkedClone"); ok {
+	if v, ok := d.GetOk("linked_clone"); ok {
 		vm.linkedClone = v.(bool)
 	}
 

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -60,7 +60,6 @@ type virtualMachine struct {
 	cluster               string
 	resourcePool          string
 	datastore             string
-	linkedClone           bool
 	vcpu                  int
 	memoryMb              int64
 	template              string
@@ -71,6 +70,7 @@ type virtualMachine struct {
 	timeZone              string
 	dnsSuffixes           []string
 	dnsServers            []string
+	linkedClone           bool
 	windowsOptionalConfig windowsOptConfig
 	customConfigurations  map[string](types.AnyType)
 }

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -1275,6 +1275,9 @@ func (vm *virtualMachine) deployVirtualMachine(c *govmomi.Client) error {
 	var identity_options types.BaseCustomizationIdentitySettings
 	if strings.HasPrefix(template_mo.Config.GuestId, "win") {
 		var timeZone int
+		if vm.timeZone == "Etc/UTC" {
+			vm.timeZone = "085"
+		}
 		timeZone, err := strconv.Atoi(vm.timeZone)
 		if err != nil {
 			return fmt.Errorf("Error converting TimeZone: %s", err)

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for details
 * `boot_delay` - (Optional) Time in seconds to wait for machine network to be ready.
 * `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
-* `linkedClone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
+* `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
 
 The `network_interface` block supports:

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -41,12 +41,14 @@ The following arguments are supported:
 * `resource_pool` (Optional) The name of a Resource Pool in which to launch the virtual machine
 * `gateway` - (Optional) Gateway IP address to use for all network interfaces
 * `domain` - (Optional) A FQDN for the virtual machine; defaults to "vsphere.local"
-* `time_zone` - (Optional) The [time zone](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/timezone.html) to set on the virtual machine. Defaults to "Etc/UTC"
+* `time_zone` - (Optional) The [Linux](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/timezone.html) or [Windows](https://msdn.microsoft.com/en-us/library/ms912391.aspx) time zone to set on the virtual machine. Defaults to "Etc/UTC"
 * `dns_suffixes` - (Optional) List of name resolution suffixes for the virtual network adapter
 * `dns_servers` - (Optional) List of DNS servers for the virtual network adapter; defaults to 8.8.8.8, 8.8.4.4
 * `network_interface` - (Required) Configures virtual network interfaces; see [Network Interfaces](#network-interfaces) below for details.
 * `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for details
 * `boot_delay` - (Optional) Time in seconds to wait for machine network to be ready.
+* `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
+* `linkedClone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
 
 The `network_interface` block supports:
@@ -61,6 +63,13 @@ removed in a future version:
 * `ip_address` - __Deprecated, please use `ipv4_address` instead_.
 * `subnet_mask` - __Deprecated, please use `ipv4_prefix_length` instead_.
 
+The `windows_opt_config` block supports:
+
+* `product_key` - (Optional) Serial number for new installation of Windows. This serial number is ignored if the original guest operating system was installed using a volume-licensed CD.
+* `admin_password` - (Optional) The password for the new `administrator` account. Omit for passwordless admin (using `""` does not work).
+* `domain` - (Optional) Domain that the new machine will be placed into. If `domain`, `domain_user`, and `domain_user_password` are not all set, all three will be ignored.
+* `domain_user` - (Optional) User that is a member of the specified domain.
+* `domain_user_password` - (Optional) Password for domain user, in plain text.
 
 The `disk` block supports:
 


### PR DESCRIPTION
Initial support for cloning of windows machines in Vsphere. Not all Vsphere windows features are implemented. This checks if the vsphere OS name starts with ["win"](https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html), and makes a windows clone config if it does, and a linux clone config otherwise. Without this change, creating clones of windows machines fails. fixes #5490 