### PR TITLE
provider/aws: normalize json policy for sns topic policy attribute

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -56,7 +56,9 @@ func resourceAwsSnsTopic() *schema.Resource {
 						log.Printf("[WARN] Error compacting JSON for Policy in SNS Topic")
 						return ""
 					}
-					return buffer.String()
+					value := normalizeJson(buffer.String())
+					log.Printf("[DEBUG] topic policy before save: %s", value)
+					return value
 				},
 			},
 			"delivery_policy": &schema.Schema{
@@ -183,9 +185,14 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 				// Some of the fetched attributes are stateful properties such as
 				// the number of subscriptions, the owner, etc. skip those
 				if resource.Schema[iKey] != nil {
-					value := *attrmap[oKey]
+					var value string
+					if iKey == "policy" {
+						value = normalizeJson(*attrmap[oKey])
+					} else {
+						value = *attrmap[oKey]
+					}
 					log.Printf("[DEBUG] Reading %s => %s -> %s", iKey, oKey, value)
-					d.Set(iKey, *attrmap[oKey])
+					d.Set(iKey, value)
 				}
 			}
 		}

--- a/builtin/providers/aws/resource_aws_sns_topic_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_test.go
@@ -128,8 +128,6 @@ resource "aws_sns_topic" "test_topic" {
   name = "example"
   policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Id": "Policy1445931846145",
   "Statement": [
     {
       "Sid": "Stmt1445931846145",
@@ -140,7 +138,9 @@ resource "aws_sns_topic" "test_topic" {
       "Action": "sns:Publish",
       "Resource": "arn:aws:sns:us-west-2::example"
     }
-  ]
+  ],
+  "Version": "2012-10-17",
+  "Id": "Policy1445931846145"
 }
 EOF
 }


### PR DESCRIPTION
Summary
------

For the policy attribute of the resource aws_sns_topic,  AWS returns the policy
in JSON format with the fields in a different order.
If we store and compare the values without normalizing, terraform
will unnecesary trigger and update of the resource.

To avoid that, we must add a normalization function in the StateFunc of
the policy attribute and also when we read the attribute from AWS.

Details
------

Given a manifest like this:

```
resource "aws_sns_topic" "CloudTrailWatch" {
  name = "CloudTrailWatch"
  policy = "${template_file.cloudtrailwatch_sns_permissions.rendered}"
}

resource "template_file" "cloudtrailwatch_sns_permissions" {
  template = <<EOF
{
   "Statement" : [
      {
         "Effect" : "Allow",
         "Resource" : "arn:aws:sns:${region}:${account_id}:CloudTrailWatch",
         "Condition" : {
            "StringEquals" : {
               "AWS:SourceOwner" : "${account_id}"
            }
         },
         "Action" : [
            "SNS:Subscribe",
            "SNS:ListSubscriptionsByTopic",
            "SNS:DeleteTopic",
            "SNS:GetTopicAttributes",
            "SNS:Publish",
            "SNS:RemovePermission",
            "SNS:AddPermission",
            "SNS:Receive",
            "SNS:SetTopicAttributes"
         ],
         "Sid" : "__default_statement_ID",
         "Principal" : {
            "AWS" : "*"
         }
      },
      {
         "Action" : "sns:Publish",
         "Principal" : {
            "Service" : "events.amazonaws.com"
         },
         "Sid" : "AWSEvents_cloudtrail-manipulation_SendToSNS",
         "Effect" : "Allow",
         "Resource" : "arn:aws:sns:${region}:${account_id}:CloudTrailWatch"
      }
   ],
   "Version" : "2012-10-17",
   "Id" : "__default_policy_ID"
}
EOF
  vars {
    account_id = "1234567890"
    region = "us-east-1"
  }
}

```

It will trigger update resource every time you run it:

```
$ terraform apply -target aws_sns_topic.CloudTrailWatch
provider.aws.region
  The region where AWS operations will take place. Examples
  are us-east-1, us-west-2, etc.

  Default: us-east-1
  Enter a value:

template_file.cloudtrailwatch_sns_permissions: Refreshing state... (ID: 88f56cab9e1a2b98a6751da9e316615e9e9dbf9e23b339063563e2e864570bf2)
aws_sns_topic.CloudTrailWatch: Refreshing state... (ID: arn:aws:sns:us-east-1:736306583401:CloudTrailWatch)
aws_sns_topic.CloudTrailWatch: Modifying...
  policy: "{\"Version\":\"2012-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:DeleteTopic\",\"SNS:GetTopicAttributes\",\"SNS:Publish\",\"SNS:RemovePermission\",\"SNS:AddPermission\",\"SNS:Receive\",\"SNS:SetTopicAttributes\"],\"Resource\":\"arn:aws:sns:eu-west-1:736306583401:CloudTrailWatch\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"736306583401\"}}},{\"Sid\":\"AWSEvents_cloudtrail-manipulation_SendToSNS\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"sns:Publish\",\"Resource\":\"arn:aws:sns:eu-west-1:736306583401:CloudTrailWatch\"}]}" => "{\"Statement\":[{\"Effect\":\"Allow\",\"Resource\":\"arn:aws:sns:eu-west-1:736306583401:CloudTrailWatch\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"736306583401\"}},\"Action\":[\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:DeleteTopic\",\"SNS:GetTopicAttributes\",\"SNS:Publish\",\"SNS:RemovePermission\",\"SNS:AddPermission\",\"SNS:Receive\",\"SNS:SetTopicAttributes\"],\"Sid\":\"__default_statement_ID\",\"Principal\":{\"AWS\":\"*\"}},{\"Action\":\"sns:Publish\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Sid\":\"AWSEvents_cloudtrail-manipulation_SendToSNS\",\"Effect\":\"Allow\",\"Resource\":\"arn:aws:sns:eu-west-1:736306583401:CloudTrailWatch\"}],\"Version\":\"2012-10-17\",\"Id\":\"__default_policy_ID\"}"
aws_sns_topic.CloudTrailWatch: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate

Outputs:

  CloudTrailWatch_arn = arn:aws:sns:us-east-1:1234567890:CloudTrailWatch
```

Expected result
---------------

Only applies changes if required.