### PR TITLE
[WIP] provider/aws: Allow `aws_db_instance` to update db identifier

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -87,7 +87,6 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ForceNew:     true,
 				ValidateFunc: validateRdsId,
 			},
 
@@ -753,13 +752,19 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 
 	d.Partial(true)
 
+	applyImmediately := d.Get("apply_immediately").(bool)
 	req := &rds.ModifyDBInstanceInput{
-		ApplyImmediately:     aws.Bool(d.Get("apply_immediately").(bool)),
+		ApplyImmediately:     aws.Bool(applyImmediately),
 		DBInstanceIdentifier: aws.String(d.Id()),
 	}
 	d.SetPartial("apply_immediately")
 
 	requestUpdate := false
+	if d.HasChange("identifier") {
+		d.SetPartial("identifier")
+		req.NewDBInstanceIdentifier = aws.String(d.Get("identifier").(string))
+		requestUpdate = true
+	}
 	if d.HasChange("allocated_storage") {
 		d.SetPartial("allocated_storage")
 		req.AllocatedStorage = aws.Int64(int64(d.Get("allocated_storage").(int)))
@@ -880,6 +885,11 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		_, err := conn.ModifyDBInstance(req)
 		if err != nil {
 			return fmt.Errorf("Error modifying DB Instance %s: %s", d.Id(), err)
+		}
+		if applyImmediately {
+			//we will **ONLY** change the identifier state if we have applied
+			//immediately AND no error has occured
+			d.SetId(d.Get("identifier").(string))
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -129,6 +129,34 @@ func TestAccAWSDBInstance_enhancedMonitoring(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_updateidentifier(t *testing.T) {
+	var v rds.DBInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBInstanceIdentifier,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_instance.bar", "identifier", "myidentity1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSDBInstanceIdentifierUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_instance.bar", "identifier", "myidentity100"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSDBInstanceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
@@ -373,8 +401,8 @@ resource "aws_db_instance" "bar" {
 	username = "foo"
 
 
-	# Maintenance Window is stored in lower case in the API, though not strictly 
-	# documented. Terraform will downcase this to match (as opposed to throw a 
+	# Maintenance Window is stored in lower case in the API, though not strictly
+	# documented. Terraform will downcase this to match (as opposed to throw a
 	# validation error).
 	maintenance_window = "Fri:09:00-Fri:09:30"
 
@@ -400,7 +428,7 @@ func testAccReplicaInstanceConfig(val int) string {
 
 		parameter_group_name = "default.mysql5.6"
 	}
-	
+
 	resource "aws_db_instance" "replica" {
 		identifier = "tf-replica-db-%d"
 		backup_retention_period = 0
@@ -522,3 +550,35 @@ resource "aws_db_instance" "enhanced_monitoring" {
 	skip_final_snapshot = true
 }
 `
+
+var testAccAWSDBInstanceIdentifier = `
+resource "aws_db_instance" "bar" {
+	allocated_storage = 10
+	engine = "MySQL"
+	engine_version = "5.6.21"
+	instance_class = "db.t1.micro"
+	name = "baz"
+	password = "barbarbarbar"
+	username = "foo"
+	identifier = "myidentity1"
+
+	maintenance_window = "Fri:09:00-Fri:09:30"
+	backup_retention_period = 0
+	parameter_group_name = "default.mysql5.6"
+}`
+
+var testAccAWSDBInstanceIdentifierUpdated = `
+resource "aws_db_instance" "bar" {
+	allocated_storage = 10
+	engine = "MySQL"
+	engine_version = "5.6.21"
+	instance_class = "db.t1.micro"
+	name = "baz"
+	password = "barbarbarbar"
+	username = "foo"
+	identifier = "myidentity100"
+
+	maintenance_window = "Fri:09:00-Fri:09:30"
+	backup_retention_period = 0
+	parameter_group_name = "default.mysql5.6"
+}`


### PR DESCRIPTION
This fixes #6080 

The first tests pass:

```
TF_LOG=DEBUG make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBInstance_updateidentifier' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBInstance_updateidentifier -timeout 120m
=== RUN   TestAccAWSDBInstance_updateidentifier
--- PASS: TestAccAWSDBInstance_updateidentifier (1345.16s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1345.182s
```

Just waiting to verify that the existing tests also pass...