### PR TITLE
Use schema funcs for reading values from the env

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -1,8 +1,6 @@
 package openstack
 
 import (
-	"os"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -14,12 +12,12 @@ func Provider() terraform.ResourceProvider {
 			"auth_url": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: envDefaultFunc("OS_AUTH_URL"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", nil),
 			},
 			"user_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFunc("OS_USERNAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_USERNAME", nil),
 			},
 			"user_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -34,27 +32,27 @@ func Provider() terraform.ResourceProvider {
 			"tenant_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFunc("OS_TENANT_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_TENANT_NAME", nil),
 			},
 			"password": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFunc("OS_PASSWORD"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_PASSWORD", nil),
 			},
 			"api_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_AUTH_TOKEN"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_TOKEN", ""),
 			},
 			"domain_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_DOMAIN_ID"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_ID", ""),
 			},
 			"domain_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_DOMAIN_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_DOMAIN_NAME", ""),
 			},
 			"insecure": &schema.Schema{
 				Type:     schema.TypeBool,
@@ -64,12 +62,12 @@ func Provider() terraform.ResourceProvider {
 			"endpoint_type": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_ENDPOINT_TYPE"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_ENDPOINT_TYPE", ""),
 			},
 			"cacert_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_CACERT"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_CACERT", ""),
 			},
 		},
 
@@ -121,21 +119,4 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	return &config, nil
-}
-
-func envDefaultFunc(k string) schema.SchemaDefaultFunc {
-	return func() (interface{}, error) {
-		if v := os.Getenv(k); v != "" {
-			return v, nil
-		}
-
-		return nil, nil
-	}
-}
-
-func envDefaultFuncAllowMissing(k string) schema.SchemaDefaultFunc {
-	return func() (interface{}, error) {
-		v := os.Getenv(k)
-		return v, nil
-	}
 }

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -26,7 +26,7 @@ func resourceBlockStorageVolumeV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"size": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
@@ -20,14 +20,14 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 
 			"pool": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_POOL_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_POOL_NAME", nil),
 			},
 
 			"address": &schema.Schema{

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -38,7 +38,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -62,14 +62,14 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Optional:    true,
 				ForceNew:    false,
 				Computed:    true,
-				DefaultFunc: envDefaultFunc("OS_FLAVOR_ID"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_ID", nil),
 			},
 			"flavor_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Computed:    true,
-				DefaultFunc: envDefaultFunc("OS_FLAVOR_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_NAME", nil),
 			},
 			"floating_ip": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_compute_keypair_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_keypair_v2.go
@@ -19,7 +19,7 @@ func resourceComputeKeypairV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
@@ -25,7 +25,7 @@ func resourceComputeSecGroupV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_servergroup_v2.go
@@ -20,7 +20,7 @@ func resourceComputeServerGroupV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
@@ -23,7 +23,7 @@ func resourceFWFirewallV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
@@ -22,7 +22,7 @@ func resourceFWPolicyV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
@@ -21,7 +21,7 @@ func resourceFWRuleV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_member_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_member_v1.go
@@ -24,7 +24,7 @@ func resourceLBMemberV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_monitor_v1.go
@@ -25,7 +25,7 @@ func resourceLBMonitorV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
@@ -28,7 +28,7 @@ func resourceLBPoolV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -66,7 +66,7 @@ func resourceLBPoolV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							ForceNew:    true,
-							DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+							DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 						},
 						"tenant_id": &schema.Schema{
 							Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_vip_v1.go
@@ -24,7 +24,7 @@ func resourceLBVipV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -26,7 +26,7 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"address": &schema.Schema{
 				Type:     schema.TypeString,
@@ -36,7 +36,7 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFunc("OS_POOL_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_POOL_NAME", nil),
 			},
 			"port_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_network_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2.go
@@ -25,7 +25,7 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -24,7 +24,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
@@ -24,7 +24,7 @@ func resourceNetworkingRouterInterfaceV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"router_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -24,7 +24,7 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
@@ -24,7 +24,7 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"network_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/builtin/providers/openstack/resource_openstack_objectstorage_container_v1.go
@@ -20,7 +20,7 @@ func resourceObjectStorageContainerV1() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				DefaultFunc: envDefaultFuncAllowMissing("OS_REGION_NAME"),
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/powerdns/provider.go
+++ b/builtin/providers/powerdns/provider.go
@@ -1,8 +1,6 @@
 package powerdns
 
 import (
-	"os"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -13,13 +11,13 @@ func Provider() terraform.ResourceProvider {
 			"api_key": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: envDefaultFunc("PDNS_API_KEY"),
+				DefaultFunc: schema.EnvDefaultFunc("PDNS_API_KEY", nil),
 				Description: "REST API authentication key",
 			},
 			"server_url": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: envDefaultFunc("PDNS_SERVER_URL"),
+				DefaultFunc: schema.EnvDefaultFunc("PDNS_SERVER_URL", nil),
 				Description: "Location of PowerDNS server",
 			},
 		},
@@ -39,14 +37,4 @@ func providerConfigure(data *schema.ResourceData) (interface{}, error) {
 	}
 
 	return config.Client()
-}
-
-func envDefaultFunc(k string) schema.SchemaDefaultFunc {
-	return func() (interface{}, error) {
-		if v := os.Getenv(k); v != "" {
-			return v, nil
-		}
-
-		return nil, nil
-	}
 }


### PR DESCRIPTION
These providers had their own implementation of "get an envvar", but we have a core function for this in the schema helper. 

The fact that no tests are changed is an indication that the behavior remains unchanged.