### PR TITLE
Remove TF_QUICKDEV environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dev: fmtcheck generate
 	@TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
 quickdev: generate
-	@TF_QUICKDEV=1 TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
+	@TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
 # Shorthand for quickly building the core of Terraform. Note that some
 # changes will require a rebuild of everything, in which case the dev


### PR DESCRIPTION
This environment variable doesn't seem to be used, the last usage was removed in 6fe27036650adc8bc9237d033dd9d18c517892a1.