### PR TITLE
Add default description

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_api_key.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_api_key.go
@@ -28,7 +28,8 @@ func resourceAwsApiGatewayApiKey() *schema.Resource {
 
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"enabled": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_api_gateway_api_key_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_api_key_test.go
@@ -28,7 +28,7 @@ func TestAccAWSAPIGatewayApiKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_api_key.test", "name", "foo"),
 					resource.TestCheckResourceAttr(
-						"aws_api_gateway_api_key.test", "description", "bar"),
+						"aws_api_gateway_api_key.test", "description", "Managed by Terraform"),
 				),
 			},
 		},
@@ -165,7 +165,6 @@ resource "aws_api_gateway_deployment" "test" {
 
 resource "aws_api_gateway_api_key" "test" {
   name = "foo"
-  description = "bar"
   enabled = true
 
   stage_key {

--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -41,8 +41,9 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"parameter": &schema.Schema{
 				Type:     schema.TypeSet,

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -34,7 +34,7 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "description", "Test parameter group for terraform"),
+						"aws_db_parameter_group.bar", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "parameter.1708034931.name", "character_set_results"),
 					resource.TestCheckResourceAttr(
@@ -108,8 +108,6 @@ func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 						"aws_db_parameter_group.bar", "name", groupName),
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "family", "mysql5.6"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "description", "Test parameter group for terraform"),
 				),
 			},
 		},
@@ -258,7 +256,6 @@ func testAccAWSDBParameterGroupConfig(n string) string {
 resource "aws_db_parameter_group" "bar" {
 	name = "%s"
 	family = "mysql5.6"
-	description = "Test parameter group for terraform"
 	parameter {
 	  name = "character_set_server"
 	  value = "utf8"

--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -38,8 +38,9 @@ func resourceAwsDbSecurityGroup() *schema.Resource {
 
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"ingress": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_db_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_security_group_test.go
@@ -27,7 +27,7 @@ func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_security_group.bar", "name", "secgroup-terraform"),
 					resource.TestCheckResourceAttr(
-						"aws_db_security_group.bar", "description", "just cuz"),
+						"aws_db_security_group.bar", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
 						"aws_db_security_group.bar", "ingress.3363517775.cidr", "10.0.0.1/24"),
 					resource.TestCheckResourceAttr(
@@ -97,10 +97,6 @@ func testAccCheckAWSDBSecurityGroupAttributes(group *rds.DBSecurityGroup) resour
 			return fmt.Errorf("bad name: %#v", *group.DBSecurityGroupName)
 		}
 
-		if *group.DBSecurityGroupDescription != "just cuz" {
-			return fmt.Errorf("bad description: %#v", *group.DBSecurityGroupDescription)
-		}
-
 		return nil
 	}
 }
@@ -146,7 +142,6 @@ provider "aws" {
 
 resource "aws_db_security_group" "bar" {
     name = "secgroup-terraform"
-    description = "just cuz"
 
     ingress {
         cidr = "10.0.0.1/24"

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -37,7 +37,8 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"subnet_ids": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_db_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group_test.go
@@ -29,6 +29,10 @@ func TestAccAWSDBSubnetGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBSubnetGroupExists(
 						"aws_db_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_subnet_group.foo", "name", "foo"),
+					resource.TestCheckResourceAttr(
+						"aws_db_subnet_group.foo", "description", "Managed by Terraform"),
 					testCheck,
 				),
 			},
@@ -80,7 +84,7 @@ func TestAccAWSDBSubnetGroup_updateDescription(t *testing.T) {
 					testAccCheckDBSubnetGroupExists(
 						"aws_db_subnet_group.foo", &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_subnet_group.foo", "description", "foo description"),
+						"aws_db_subnet_group.foo", "description", "Managed by Terraform"),
 				),
 			},
 
@@ -213,7 +217,6 @@ resource "aws_subnet" "bar" {
 
 resource "aws_db_subnet_group" "foo" {
 	name = "foo"
-	description = "foo description"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 	tags {
 		Name = "tf-dbsubnet-group-test"

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
@@ -34,8 +34,9 @@ func resourceAwsElasticacheParameterGroup() *schema.Resource {
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"parameter": &schema.Schema{
 				Type:     schema.TypeSet,

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group_test.go
@@ -29,7 +29,7 @@ func TestAccAWSElasticacheParameterGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_parameter_group.bar", "family", "redis2.8"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_parameter_group.bar", "description", "Test parameter group for terraform"),
+						"aws_elasticache_parameter_group.bar", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_parameter_group.bar", "parameter.283487565.name", "appendonly"),
 					resource.TestCheckResourceAttr(
@@ -78,8 +78,6 @@ func TestAccAWSElasticacheParameterGroupOnly(t *testing.T) {
 						"aws_elasticache_parameter_group.bar", "name", "parameter-group-test-terraform"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_parameter_group.bar", "family", "redis2.8"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_parameter_group.bar", "description", "Test parameter group for terraform"),
 				),
 			},
 		},
@@ -177,7 +175,6 @@ const testAccAWSElasticacheParameterGroupConfig = `
 resource "aws_elasticache_parameter_group" "bar" {
 	name = "parameter-group-test-terraform"
 	family = "redis2.8"
-	description = "Test parameter group for terraform"
 	parameter {
 	  name = "appendonly"
 	  value = "yes"

--- a/builtin/providers/aws/resource_aws_elasticache_security_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_security_group.go
@@ -21,8 +21,9 @@ func resourceAwsElasticacheSecurityGroup() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_elasticache_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_security_group_test.go
@@ -22,6 +22,8 @@ func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
 				Config: testAccAWSElasticacheSecurityGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_security_group.bar", "description", "Managed by Terraform"),
 				),
 			},
 		},
@@ -78,7 +80,6 @@ provider "aws" {
 }
 resource "aws_security_group" "bar" {
     name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
     ingress {
         from_port = -1
         to_port = -1

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -23,7 +23,8 @@ func resourceAwsElasticacheSubnetGroup() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "Managed by Terraform",
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group_test.go
@@ -25,6 +25,8 @@ func TestAccAWSElasticacheSubnetGroup_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheSubnetGroupExists("aws_elasticache_subnet_group.bar", &csg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_subnet_group.bar", "description", "Managed by Terraform"),
 				),
 			},
 		},
@@ -160,7 +162,6 @@ resource "aws_elasticache_subnet_group" "bar" {
     // that we correctly handle the fact that the API
     // normalizes names to lowercase.
     name = "tf-TEST-cache-subnet-%03d"
-    description = "tf-test-cache-subnet-group-descr"
     subnet_ids = ["${aws_subnet.foo.id}"]
 }
 `

--- a/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
@@ -39,8 +39,9 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"parameter": &schema.Schema{
 				Type:     schema.TypeSet,

--- a/builtin/providers/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -124,7 +124,7 @@ func TestAccAWSDBClusterParameterGroupOnly(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster_parameter_group.bar", "family", "aurora5.6"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "description", "Test cluster parameter group for terraform"),
+						"aws_rds_cluster_parameter_group.bar", "description", "Managed by Terraform"),
 				),
 			},
 		},
@@ -214,10 +214,6 @@ func testAccCheckAWSDBClusterParameterGroupAttributes(v *rds.DBClusterParameterG
 
 		if *v.DBParameterGroupFamily != "aurora5.6" {
 			return fmt.Errorf("bad family: %#v", v.DBParameterGroupFamily)
-		}
-
-		if *v.Description != "Test cluster parameter group for terraform" {
-			return fmt.Errorf("bad description: %#v", v.Description)
 		}
 
 		return nil
@@ -355,6 +351,5 @@ const testAccAWSDBClusterParameterGroupOnlyConfig = `
 resource "aws_rds_cluster_parameter_group" "bar" {
   name        = "cluster-parameter-group-test-terraform"
   family      = "aurora5.6"
-  description = "Test cluster parameter group for terraform"
 }
 `

--- a/builtin/providers/aws/resource_aws_redshift_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_parameter_group.go
@@ -39,8 +39,9 @@ func resourceAwsRedshiftParameterGroup() *schema.Resource {
 
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"parameter": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_redshift_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_parameter_group_test.go
@@ -28,7 +28,7 @@ func TestAccAWSRedshiftParameterGroup_withParameters(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_redshift_parameter_group.bar", "family", "redshift-1.0"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "description", "Test parameter group for terraform"),
+						"aws_redshift_parameter_group.bar", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_parameter_group.bar", "parameter.490804664.name", "require_ssl"),
 					resource.TestCheckResourceAttr(
@@ -190,7 +190,6 @@ const testAccAWSRedshiftParameterGroupConfig = `
 resource "aws_redshift_parameter_group" "bar" {
 	name = "parameter-group-test-terraform"
 	family = "redshift-1.0"
-	description = "Test parameter group for terraform"
 	parameter {
 	  name = "require_ssl"
 	  value = "true"

--- a/builtin/providers/aws/resource_aws_redshift_security_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_security_group.go
@@ -32,8 +32,9 @@ func resourceAwsRedshiftSecurityGroup() *schema.Resource {
 
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"ingress": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_redshift_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_security_group_test.go
@@ -26,7 +26,7 @@ func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_redshift_security_group.bar", "name", "redshift-sg-terraform"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_security_group.bar", "description", "this is a description"),
+						"aws_redshift_security_group.bar", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_security_group.bar", "ingress.2735652665.cidr", "10.0.0.1/24"),
 					resource.TestCheckResourceAttr(
@@ -170,7 +170,6 @@ provider "aws" {
 
 resource "aws_redshift_security_group" "bar" {
     name = "redshift-sg-terraform"
-    description = "this is a description"
 
     ingress {
         cidr = "10.0.0.1/24"

--- a/builtin/providers/aws/resource_aws_redshift_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group.go
@@ -30,7 +30,8 @@ func resourceAwsRedshiftSubnetGroup() *schema.Resource {
 
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"subnet_ids": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_redshift_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group_test.go
@@ -25,6 +25,8 @@ func TestAccAWSRedshiftSubnetGroup_basic(t *testing.T) {
 					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_subnet_group.foo", "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_subnet_group.foo", "description", "Managed by Terraform"),
 				),
 			},
 		},
@@ -175,7 +177,6 @@ resource "aws_subnet" "bar" {
 
 resource "aws_redshift_subnet_group" "foo" {
 	name = "foo"
-	description = "foo description"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 }
 `
@@ -214,7 +215,6 @@ resource "aws_subnet" "foobar" {
 
 resource "aws_redshift_subnet_group" "foo" {
 	name = "foo"
-	description = "foo description"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}", "${aws_subnet.foobar.id}"]
 }
 `

--- a/website/source/docs/providers/aws/r/api_gateway_api_key.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_api_key.html.markdown
@@ -15,7 +15,6 @@ Provides an API Gateway API Key.
 ```
 resource "aws_api_gateway_rest_api" "MyDemoAPI" {
   name = "MyDemoAPI"
-  description = "This is my API for demonstration purposes"
 }
 
 resource "aws_api_gateway_api_key" "MyDemoApiKey" {
@@ -38,7 +37,7 @@ resource "aws_api_gateway_deployment" "MyDemoDeployment" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the API key
-* `description` - (Required) The API key description
+* `description` - (Optional) The API key description. Defaults to "Managed by Terraform".
 * `enabled` - (Optional) Specifies whether the API key can be used by callers. Defaults to `true`.
 * `stage_key` - (Optional) A list of stage keys associated with the API key - see below
 

--- a/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
@@ -14,7 +14,6 @@ Provides an RDS DB parameter group resource.
 resource "aws_db_parameter_group" "default" {
     name = "rds-pg"
     family = "mysql5.6"
-    description = "RDS default parameter group"
 
   	parameter {
    	  name = "character_set_server"
@@ -34,7 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DB parameter group.
 * `family` - (Required) The family of the DB parameter group.
-* `description` - (Required) The description of the DB parameter group.
+* `description` - (Optional) The description of the DB parameter group. Defaults to "Managed by Terraform".
 * `parameter` - (Optional) A list of DB parameters to apply.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/source/docs/providers/aws/r/db_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_security_group.html.markdown
@@ -18,7 +18,6 @@ attribute instead.
 ```
 resource "aws_db_security_group" "default" {
     name = "rds_sg"
-    description = "RDS default security group"
 
     ingress {
         cidr = "10.0.0.0/24"
@@ -31,7 +30,7 @@ resource "aws_db_security_group" "default" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the DB security group.
-* `description` - (Required) The description of the DB security group.
+* `description` - (Optional) The description of the DB security group. Defaults to "Managed by Terraform".
 * `ingress` - (Required) A list of ingress rules.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
@@ -15,7 +15,6 @@ Provides an RDS DB subnet group resource.
 ```
 resource "aws_db_subnet_group" "default" {
     name = "main"
-    description = "Our main group of subnets"
     subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
     tags {
         Name = "My DB subnet group"
@@ -28,7 +27,7 @@ resource "aws_db_subnet_group" "default" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the DB subnet group.
-* `description` - (Required) The description of the DB subnet group.
+* `description` - (Optional) The description of the DB subnet group. Defaults to "Managed by Terraform".
 * `subnet_ids` - (Required) A list of VPC subnet IDs.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/source/docs/providers/aws/r/elasticache_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_parameter_group.html.markdown
@@ -14,7 +14,6 @@ Provides an ElastiCache parameter group resource.
 resource "aws_elasticache_parameter_group" "default" {
     name = "cache-params"
     family = "redis2.8"
-    description = "Cache cluster default param group"
 
     parameter {
         name = "activerehashing"
@@ -34,7 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the ElastiCache parameter group.
 * `family` - (Required) The family of the ElastiCache parameter group.
-* `description` - (Required) The description of the ElastiCache parameter group.
+* `description` - (Optional) The description of the ElastiCache parameter group. Defaults to "Managed by Terraform".
 * `parameter` - (Optional) A list of ElastiCache parameters to apply.
 
 Parameter blocks support the following:

--- a/website/source/docs/providers/aws/r/elasticache_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_security_group.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws\_elasticache\_security\_<wbr>group
 
-Provides an ElastiCache Security Group to control access to one or more cache 
+Provides an ElastiCache Security Group to control access to one or more cache
 clusters.
 
 ~> **NOTE:** ElastiCache Security Groups are for use only when working with an
@@ -20,12 +20,10 @@ ElastiCache cluster **outside** of a VPC. If you are using a VPC, see the
 ```
 resource "aws_security_group" "bar" {
     name = "security-group"
-    description = "security group"
 }
 
 resource "aws_elasticache_security_group" "bar" {
     name = "elasticache-security-group"
-    description = "elasticache security group"
     security_group_names = ["${aws_security_group.bar.name}"]
 }
 ```
@@ -34,10 +32,9 @@ resource "aws_elasticache_security_group" "bar" {
 
 The following arguments are supported:
 
-* `description` – (Required) description for the cache security group
-* `name` – (Required) Name for the cache security group. This value is stored as 
-a lowercase string
-* `security_group_names` – (Required) List of EC2 security group names to be 
+* `name` – (Required) Name for the cache security group. This value is stored as a lowercase string.
+* `description` – (Optional) description for the cache security group. Defaults to "Managed by Terraform".
+* `security_group_names` – (Required) List of EC2 security group names to be
 authorized for ingress to the cache security group
 
 

--- a/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_subnet_group.html.markdown
@@ -35,7 +35,6 @@ resource "aws_subnet" "foo" {
 
 resource "aws_elasticache_subnet_group" "bar" {
     name = "tf-test-cache-subnet"
-    description = "tf-test-cache-subnet-group-descr"
     subnet_ids = ["${aws_subnet.foo.id}"]
 }
 ```
@@ -44,9 +43,8 @@ resource "aws_elasticache_subnet_group" "bar" {
 
 The following arguments are supported:
 
-* `description` – (Required) Description for the cache subnet group
-* `name` – (Required) Name for the cache subnet group. Elasticache converts
-  this name to lowercase.
+* `name` – (Required) Name for the cache subnet group. Elasticache converts this name to lowercase.
+* `description` – (Optional) Description for the cache subnet group. Defaults to "Managed by Terraform".
 * `subnet_ids` – (Required) List of VPC Subnet IDs for the cache subnet group
 
 ## Attributes Reference

--- a/website/source/docs/providers/aws/r/redshift_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_parameter_group.html.markdown
@@ -14,7 +14,6 @@ Provides a Redshift Cluster parameter group resource.
 resource "aws_redshift_parameter_group" "bar" {
 	name = "parameter-group-test-terraform"
 	family = "redshift-1.0"
-	description = "Test parameter group for terraform"
 	parameter {
 	  name = "require_ssl"
 	  value = "true"
@@ -36,7 +35,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Redshift parameter group.
 * `family` - (Required) The family of the Redshift parameter group.
-* `description` - (Required) The description of the Redshift parameter group.
+* `description` - (Optional) The description of the Redshift parameter group. Defaults to "Managed by Terraform".
 * `parameter` - (Optional) A list of Redshift parameters to apply.
 
 Parameter blocks support the following:

--- a/website/source/docs/providers/aws/r/redshift_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_security_group.html.markdown
@@ -15,7 +15,6 @@ Creates a new Amazon Redshift security group. You use security groups to control
 ```
 resource "aws_redshift_security_group" "default" {
     name = "redshift_sg"
-    description = "Redshift Example security group"
 
     ingress {
         cidr = "10.0.0.0/24"
@@ -28,7 +27,7 @@ resource "aws_redshift_security_group" "default" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Redshift security group.
-* `description` - (Required) The description of the Redshift security group.
+* `description` - (Optional) The description of the Redshift security group. Defaults to "Managed by Terraform".
 * `ingress` - (Optional) A list of ingress rules.
 
 Ingress blocks support the following:

--- a/website/source/docs/providers/aws/r/redshift_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_subnet_group.html.markdown
@@ -37,7 +37,6 @@ resource "aws_subnet" "bar" {
 
 resource "aws_redshift_subnet_group" "foo" {
 	name = "foo"
-	description = "foo description"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 }
 `
@@ -48,7 +47,7 @@ resource "aws_redshift_subnet_group" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Redshift Subnet group.
-* `description` - (Required) The description of the Redshift Subnet group.
+* `description` - (Optional) The description of the Redshift Subnet group. Defaults to "Managed by Terraform".
 * `subnet_ids` - (Optional) An array of VPC subnet IDs..
 
 ## Attributes Reference


### PR DESCRIPTION
Ref #6100. Set the default value for the `description` field to be "Managed by Terraform".

This is my first time contributing so let me know if anything else is required. I know that I need to update the documentation, and I plan to do that next. I wasn't sure about testing this change because I couldn't see any existing tests that verify the default values.