### PR TITLE
Issue #2174 Check that InternetGateway exists before returning from creation

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -45,11 +45,6 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	d.SetId(*ig.InternetGatewayId)
 	log.Printf("[INFO] InternetGateway ID: %s", d.Id())
 
-	err = setTags(conn, d)
-	if err != nil {
-		return err
-	}
-
 	resource.Retry(5*time.Minute, func() *resource.RetryError {
 		igRaw, _, err := IGStateRefreshFunc(conn, d.Id())()
 		if igRaw != nil {
@@ -61,6 +56,11 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 			return resource.NonRetryableError(err)
 		}
 	})
+
+	err = setTags(conn, d)
+	if err != nil {
+		return err
+	}
 
 	// Attach the new gateway to the correct vpc
 	return resourceAwsInternetGatewayAttach(d, meta)


### PR DESCRIPTION
Fix #2174 some random InvalidInternetGatewayID.NotFound errors, seems to happen during attachment, right after creation

The errors look like

```
21:28:49 Initializing environment terraform
21:28:52 [vpc] aws_vpc.myvpc: Creating...
21:28:52 [vpc]   cidr_block:                 "" => "10.16.0.0/16"
21:28:52 [vpc]   default_network_acl_id:     "" => "<computed>"
21:28:52 [vpc]   default_security_group_id:  "" => "<computed>"
21:28:52 [vpc]   dhcp_options_id:            "" => "<computed>"
21:28:52 [vpc]   enable_classiclink:         "" => "<computed>"
21:28:52 [vpc]   enable_dns_hostnames:       "" => "1"
21:28:52 [vpc]   enable_dns_support:         "" => "1"
21:28:52 [vpc]   main_route_table_id:        "" => "<computed>"
21:28:52 [vpc]   tags.#:                     "" => "3"
21:28:52 [vpc]   tags.Name:                  "" => "myvpc-testing"
21:28:52 [vpc] aws_vpc.myvpc: Creation complete
21:28:52 [vpc] aws_internet_gateway.myvpc: Creating...
21:28:52 [vpc]   tags.#:                     "0" => "3"
21:28:52 [vpc]   tags.Name:                  "" => "myvpc-testing"
21:28:52 [vpc]   vpc_id:                     "" => "vpc-c7e1f3a3"
21:28:52 [vpc] aws_subnet.myvpc: Creating...
21:28:52 [vpc]   availability_zone:          "" => "<computed>"
21:28:52 [vpc]   cidr_block:                 "" => "10.16.0.0/16"
21:28:52 [vpc]   map_public_ip_on_launch:    "" => "1"
21:28:52 [vpc]   tags.#:                     "" => "3"
21:28:52 [vpc]   tags.Name:                  "" => "myvpc-testing"
21:28:52 [vpc]   vpc_id:                     "" => "vpc-c7e1f3a3"
21:28:52 [vpc] aws_subnet.myvpc: Creation complete
21:28:52 [vpc] Error applying plan:
21:28:52 [vpc] 
21:28:52 [vpc] 1 error(s) occurred:
21:28:52 [vpc] 
21:28:52 
[vpc] * aws_internet_gateway.myvpc: InvalidInternetGatewayID.NotFound: The internetGateway ID 'igw-748d0310' does not exist
21:28:52 [vpc]  status code: 400, request id: 
```
