### PR TITLE
Add project parameter to cloudstack_port_forward.

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
@@ -213,15 +213,8 @@ func resourceCloudStackPortForwardRead(d *schema.ResourceData, meta interface{})
 	p.SetIpaddressid(d.Id())
 	p.SetListall(true)
 
-	// If there is a project supplied, we retrieve and set the project id
-	if project, ok := d.GetOk("project"); ok {
-		// Retrieve the project ID
-		projectid, e := retrieveID(cs, "project", project.(string))
-		if e != nil {
-			return e.Error()
-		}
-		// Set the default project ID
-		p.SetProjectid(projectid)
+	if err := setProjectid(p, cs, d); err != nil {
+		return err
 	}
 
 	l, err := cs.Firewall.ListPortForwardingRules(p)

--- a/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
@@ -43,6 +43,12 @@ func resourceCloudStackPortForward() *schema.Resource {
 				Default:  false,
 			},
 
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"forward": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
@@ -206,6 +212,17 @@ func resourceCloudStackPortForwardRead(d *schema.ResourceData, meta interface{})
 	p := cs.Firewall.NewListPortForwardingRulesParams()
 	p.SetIpaddressid(d.Id())
 	p.SetListall(true)
+
+	// If there is a project supplied, we retrieve and set the project id
+	if project, ok := d.GetOk("project"); ok {
+		// Retrieve the project ID
+		projectid, e := retrieveID(cs, "project", project.(string))
+		if e != nil {
+			return e.Error()
+		}
+		// Set the default project ID
+		p.SetProjectid(projectid)
+	}
 
 	l, err := cs.Firewall.ListPortForwardingRules(p)
 	if err != nil {


### PR DESCRIPTION
- Add `project` parameter to `cloudstack_port_forward` resource. This is required for CS providers that require `projectid` parameters to always be passed in.
- Modify read operation to pass in `projectid` if defined.
- Related to #6069