### PR TITLE
Give Schema.DefaultFunc a context to retrieve data from the provider

### DIFF
--- a/builtin/providers/azure/resource_azure_storage_blob.go
+++ b/builtin/providers/azure/resource_azure_storage_blob.go
@@ -33,7 +33,7 @@ func resourceAzureStorageBlob() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
-				DefaultFunc: func() (interface{}, error) {
+				DefaultFunc: func(c *schema.DefaultFuncContext) (interface{}, error) {
 					return int64(0), nil
 				},
 			},

--- a/builtin/providers/chef/provider.go
+++ b/builtin/providers/chef/provider.go
@@ -69,7 +69,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return chefc.NewClient(config)
 }
 
-func providerPrivateKeyEnvDefault() (interface{}, error) {
+func providerPrivateKeyEnvDefault(c *schema.DefaultFuncContext) (interface{}, error) {
 	if fn := os.Getenv("CHEF_PRIVATE_KEY_FILE"); fn != "" {
 		contents, err := ioutil.ReadFile(fn)
 		if err != nil {

--- a/builtin/providers/dme/provider.go
+++ b/builtin/providers/dme/provider.go
@@ -40,7 +40,7 @@ func Provider() terraform.ResourceProvider {
 }
 
 func envDefaultFunc(k string) schema.SchemaDefaultFunc {
-	return func() (interface{}, error) {
+	return func(c *schema.DefaultFuncContext) (interface{}, error) {
 		if v := os.Getenv(k); v != "" {
 			if v == "true" {
 				return true, nil

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -17,6 +17,7 @@ import (
 type ConfigFieldReader struct {
 	Config *terraform.ResourceConfig
 	Schema map[string]*Schema
+	PCR    *ProviderConfigResult
 
 	indexMaps map[string]map[string]int
 	once      sync.Once
@@ -168,7 +169,7 @@ func (r *ConfigFieldReader) readPrimitive(
 	if !ok {
 		// Nothing in config, but we might still have a default from the schema
 		var err error
-		raw, err = schema.DefaultValue()
+		raw, err = schema.DefaultValue(r.PCR)
 		if err != nil {
 			return FieldReadResult{}, fmt.Errorf("%s, error loading default: %s", k, err)
 		}

--- a/helper/schema/field_reader_config_test.go
+++ b/helper/schema/field_reader_config_test.go
@@ -18,6 +18,8 @@ func TestConfigFieldReader(t *testing.T) {
 		return &ConfigFieldReader{
 			Schema: s,
 
+			PCR: &ProviderConfigResult{},
+
 			Config: testConfig(t, map[string]interface{}{
 				"bool":   true,
 				"float":  3.1415,
@@ -57,7 +59,7 @@ func TestConfigFieldReader_DefaultHandling(t *testing.T) {
 		},
 		"strWithDefaultFunc": &Schema{
 			Type: TypeString,
-			DefaultFunc: func() (interface{}, error) {
+			DefaultFunc: func(i *DefaultFuncContext) (interface{}, error) {
 				return "FuncDefault", nil
 			},
 		},
@@ -119,6 +121,7 @@ func TestConfigFieldReader_DefaultHandling(t *testing.T) {
 		r := &ConfigFieldReader{
 			Schema: schema,
 			Config: tc.Config,
+			PCR:    &ProviderConfigResult{},
 		}
 		out, err := r.ReadField(tc.Addr)
 		if err != nil != tc.Err {

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -19,6 +19,7 @@ import (
 type ResourceData struct {
 	// Settable (internally)
 	schema map[string]*Schema
+	pcr    *ProviderConfigResult
 	config *terraform.ResourceConfig
 	state  *terraform.InstanceState
 	diff   *terraform.InstanceDiff
@@ -308,6 +309,7 @@ func (d *ResourceData) init() {
 		readers["config"] = &ConfigFieldReader{
 			Schema: d.schema,
 			Config: d.config,
+			PCR:    d.pcr,
 		}
 	}
 	if d.diff != nil {

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -13,6 +13,7 @@ func TestResourceDataGet(t *testing.T) {
 		Schema map[string]*Schema
 		State  *terraform.InstanceState
 		Diff   *terraform.InstanceDiff
+		PCR    *ProviderConfigResult
 		Key    string
 		Value  interface{}
 	}{
@@ -735,7 +736,7 @@ func TestResourceDataGet(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
+		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff, tc.PCR)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -756,6 +757,7 @@ func TestResourceDataGetChange(t *testing.T) {
 		Schema   map[string]*Schema
 		State    *terraform.InstanceState
 		Diff     *terraform.InstanceDiff
+		PCR      *ProviderConfigResult
 		Key      string
 		OldValue interface{}
 		NewValue interface{}
@@ -822,7 +824,7 @@ func TestResourceDataGetChange(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
+		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff, tc.PCR)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -842,6 +844,7 @@ func TestResourceDataGetOk(t *testing.T) {
 		Schema map[string]*Schema
 		State  *terraform.InstanceState
 		Diff   *terraform.InstanceDiff
+		PCR    *ProviderConfigResult
 		Key    string
 		Value  interface{}
 		Ok     bool
@@ -1061,7 +1064,7 @@ func TestResourceDataGetOk(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
+		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff, tc.PCR)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1085,6 +1088,7 @@ func TestResourceDataHasChange(t *testing.T) {
 		Schema map[string]*Schema
 		State  *terraform.InstanceState
 		Diff   *terraform.InstanceDiff
+		PCR    *ProviderConfigResult
 		Key    string
 		Change bool
 	}{
@@ -1236,7 +1240,7 @@ func TestResourceDataHasChange(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
+		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff, tc.PCR)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1255,6 +1259,7 @@ func TestResourceDataSet(t *testing.T) {
 		Schema   map[string]*Schema
 		State    *terraform.InstanceState
 		Diff     *terraform.InstanceDiff
+		PCR      *ProviderConfigResult
 		Key      string
 		Value    interface{}
 		Err      bool
@@ -1730,7 +1735,7 @@ func TestResourceDataSet(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
+		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff, tc.PCR)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1760,6 +1765,7 @@ func TestResourceDataState(t *testing.T) {
 		Schema  map[string]*Schema
 		State   *terraform.InstanceState
 		Diff    *terraform.InstanceDiff
+		PCR     *ProviderConfigResult
 		Set     map[string]interface{}
 		Result  *terraform.InstanceState
 		Partial []string
@@ -2839,7 +2845,7 @@ func TestResourceDataState(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
+		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff, tc.PCR)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -37,7 +37,8 @@ func TestResourceApply_create(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Apply(s, d, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -86,7 +87,8 @@ func TestResourceApply_destroy(t *testing.T) {
 		Destroy: true,
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Apply(s, d, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -148,7 +150,8 @@ func TestResourceApply_destroyCreate(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Apply(s, d, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -199,7 +202,8 @@ func TestResourceApply_destroyPartial(t *testing.T) {
 		Destroy: true,
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Apply(s, d, &pcr)
 	if err == nil {
 		t.Fatal("should error")
 	}
@@ -250,7 +254,8 @@ func TestResourceApply_update(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Apply(s, d, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -295,7 +300,8 @@ func TestResourceApply_updateNoCallback(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Apply(s, d, &pcr)
 	if err == nil {
 		t.Fatal("should error")
 	}
@@ -347,7 +353,8 @@ func TestResourceApply_isNewResource(t *testing.T) {
 	// positive test
 	var s *terraform.InstanceState = nil
 
-	actual, err := r.Apply(s, d, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Apply(s, d, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -374,7 +381,7 @@ func TestResourceApply_isNewResource(t *testing.T) {
 		},
 	}
 
-	actual, err = r.Apply(s, d, nil)
+	actual, err = r.Apply(s, d, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -469,7 +476,7 @@ func TestResourceRefresh(t *testing.T) {
 
 	r.Read = func(d *ResourceData, m interface{}) error {
 		if m != 42 {
-			return fmt.Errorf("meta not passed")
+			return fmt.Errorf("meta not passed: %#v", m)
 		}
 
 		return d.Set("foo", d.Get("foo").(int)+1)
@@ -493,7 +500,7 @@ func TestResourceRefresh(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(s, &ProviderConfigResult{Meta: 42})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -523,7 +530,7 @@ func TestResourceRefresh_blankId(t *testing.T) {
 		Attributes: map[string]string{},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(s, &ProviderConfigResult{Meta: 42})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -554,7 +561,7 @@ func TestResourceRefresh_delete(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(s, &ProviderConfigResult{Meta: 42})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -589,7 +596,7 @@ func TestResourceRefresh_existsError(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(s, &ProviderConfigResult{Meta: 42})
 	if err == nil {
 		t.Fatalf("should error")
 	}
@@ -623,7 +630,7 @@ func TestResourceRefresh_noExists(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(s, &ProviderConfigResult{Meta: 42})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -684,7 +691,7 @@ func TestResourceRefresh_needsMigration(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(s, &ProviderConfigResult{Meta: 42})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -738,7 +745,8 @@ func TestResourceRefresh_noMigrationNeeded(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Refresh(s, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -790,7 +798,8 @@ func TestResourceRefresh_stateSchemaVersionUnset(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, nil)
+	var pcr ProviderConfigResult
+	actual, err := r.Refresh(s, &pcr)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -841,7 +850,8 @@ func TestResourceRefresh_migrateStateErr(t *testing.T) {
 		},
 	}
 
-	_, err := r.Refresh(s, nil)
+	var pcr ProviderConfigResult
+	_, err := r.Refresh(s, &pcr)
 	if err == nil {
 		t.Fatal("expected error, but got none!")
 	}


### PR DESCRIPTION
At present, there is no way to provide context to `Schema.DefaultFunc`, since the function takes no parameters and there exists no context at the time the function is defined.

This PR aims to fix that issue by introducing a new `ProviderConfigResult` and `DefaultFuncContext`. The `Configure()` function for Provider currently has this notion of "meta", which is an arbitrary interface that we pass down to other functions. The original version of this PR allowed access to meta, but after discussion internally, we determined there is also a desire to get the original values expressed in the provider as well as the meta result. A good example here is something like dnsimple. The configure func for dnsimple_record creates a client, but that client only exposes a subset of the fields actually configured in the provider. So it was decided to expose both the original value and the meta (which is arbitrary).

One issue encountered (which is also heavily documented) is Terraform's multi-phase evaluation. During the "validation" phase, the provider has not yet been configured. This means the `DefaultFuncContext` has no `ProviderData` or `Meta`. Iff plugin authors choose to adopt this pattern, they will need to be aware of this fact. There are examples in the godoc for `DefaultFunc` and `DefaultFuncContext`.

So what does this actually look like? As a plugin developer, I can now specify attributes that depend on the values from my provider configuration (or anywhere really). For example, given:

```hcl
provider "aws" {
  region = "us-east-1"
}
```

A plugin author for something in that provider could author a schema field like this:

```go
Schema: map[string]*schema.Schema{
  "region": &schema.Schema{
    Type:     schema.TypeString,
    Required: true
    DefaultFunc: func(c *schema.DefaultFuncContext) (interface{}, error) {
      if c.ProviderData == nil {
        return "<computed>", nil
      }
      return c.ProviderData.Get("region").(string), nil
    }
  },
}
```

This allows resource's attributes to "inherit" from a provider value, but also be overridden by the user at the resource level. There are considerations plugin authors must take with respect to "Required" attributes, but they are documented heavily in the godoc.

This is a breaking API change for plugin developers who are currently using `DefaultFunc`, as the method signature has now changed to include a struct. After talking with @phinze we decided the breaking change was okay because it's easy to communicate and serves the greater good. This change does not affect Terraform _users_, and plugins complied agains the old helper/schema will continue to work.

/cc @phinze @jen20 