### PR TITLE
Move GCP projece attribute onto resources, inherit from provider

### DIFF
--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -33,8 +33,8 @@ func Provider() terraform.ResourceProvider {
 
 			"project": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    false,
-				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_PROJECT", nil),
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_PROJECT", ""),
 			},
 
 			"region": &schema.Schema{
@@ -157,4 +157,32 @@ func getRegionFromZone(zone string) string {
 		return region
 	}
 	return ""
+}
+
+// getRegion reads the "region" field from the given resource data and falls
+// back to the provider's value if not given. If the provider's value is not
+// given, an error is returned.
+func getRegion(d *schema.ResourceData, config *Config) (string, error) {
+	res, ok := d.GetOk("region")
+	if !ok {
+		if config.Region != "" {
+			return config.Region, nil
+		}
+		return "", fmt.Errorf("%q: required field is not set", "region")
+	}
+	return res.(string), nil
+}
+
+// getProject reads the "project" field from the given resource data and falls
+// back to the provider's value if not given. If the provider's value is not
+// given, an error is returned.
+func getProject(d *schema.ResourceData, config *Config) (string, error) {
+	res, ok := d.GetOk("project")
+	if !ok {
+		if config.Project != "" {
+			return config.Project, nil
+		}
+		return "", fmt.Errorf("%q: required field is not set", "project")
+	}
+	return res.(string), nil
 }

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -33,7 +33,7 @@ func Provider() terraform.ResourceProvider {
 
 			"project": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Required:    false,
 				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_PROJECT", nil),
 			},
 
@@ -122,7 +122,7 @@ func validateAccountFile(v interface{}, k string) (warnings []string, errors []e
 		errors = append(errors, fmt.Errorf("Error loading Account File: %s", err))
 	}
 	if wasPath {
-		warnings = append(warnings, `account_file was provided as a path instead of 
+		warnings = append(warnings, `account_file was provided as a path instead of
 as file contents. This support will be removed in the future. Please update
 your configuration to use ${file("filename.json")} instead.`)
 	}

--- a/builtin/providers/google/resource_compute_address.go
+++ b/builtin/providers/google/resource_compute_address.go
@@ -27,9 +27,10 @@ func resourceComputeAddress() *schema.Resource {
 				Computed: true,
 			},
 
-			"self_link": &schema.Schema{
+			"project": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"region": &schema.Schema{
@@ -38,10 +39,9 @@ func resourceComputeAddress() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"project": &schema.Schema{
+			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_address.go
+++ b/builtin/providers/google/resource_compute_address.go
@@ -37,26 +37,33 @@ func resourceComputeAddress() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-		},
-	}
-}
 
-func getOptionalRegion(d *schema.ResourceData, config *Config) string {
-	if res, ok := d.GetOk("region"); !ok {
-		return config.Region
-	} else {
-		return res.(string)
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
 	}
 }
 
 func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	region := getOptionalRegion(d, config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Build the address parameter
 	addr := &compute.Address{Name: d.Get("name").(string)}
 	op, err := config.clientCompute.Addresses.Insert(
-		config.Project, region, addr).Do()
+		project, region, addr).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating address: %s", err)
 	}
@@ -75,10 +82,18 @@ func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) erro
 func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	region := getOptionalRegion(d, config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	addr, err := config.clientCompute.Addresses.Get(
-		config.Project, region, d.Id()).Do()
+		project, region, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
@@ -100,11 +115,20 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 func resourceComputeAddressDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	region := getOptionalRegion(d, config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the address
 	log.Printf("[DEBUG] address delete request")
 	op, err := config.clientCompute.Addresses.Delete(
-		config.Project, region, d.Id()).Do()
+		project, region, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting address: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_autoscaler.go
+++ b/builtin/providers/google/resource_compute_autoscaler.go
@@ -115,12 +115,17 @@ func resourceComputeAutoscaler() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func buildAutoscaler(d *schema.ResourceData) (*compute.Autoscaler, error) {
-
 	// Build the parameter
 	scaler := &compute.Autoscaler{
 		Name:   d.Get("name").(string),
@@ -200,10 +205,15 @@ func buildAutoscaler(d *schema.ResourceData) (*compute.Autoscaler, error) {
 func resourceComputeAutoscalerCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Get the zone
 	log.Printf("[DEBUG] Loading zone: %s", d.Get("zone").(string))
 	zone, err := config.clientCompute.Zones.Get(
-		config.Project, d.Get("zone").(string)).Do()
+		project, d.Get("zone").(string)).Do()
 	if err != nil {
 		return fmt.Errorf(
 			"Error loading zone '%s': %s", d.Get("zone").(string), err)
@@ -215,7 +225,7 @@ func resourceComputeAutoscalerCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	op, err := config.clientCompute.Autoscalers.Insert(
-		config.Project, zone.Name, scaler).Do()
+		project, zone.Name, scaler).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating Autoscaler: %s", err)
 	}
@@ -234,9 +244,14 @@ func resourceComputeAutoscalerCreate(d *schema.ResourceData, meta interface{}) e
 func resourceComputeAutoscalerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("zone").(string)
 	scaler, err := config.clientCompute.Autoscalers.Get(
-		config.Project, zone, d.Id()).Do()
+		project, zone, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
@@ -257,6 +272,11 @@ func resourceComputeAutoscalerRead(d *schema.ResourceData, meta interface{}) err
 func resourceComputeAutoscalerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("zone").(string)
 
 	scaler, err := buildAutoscaler(d)
@@ -265,7 +285,7 @@ func resourceComputeAutoscalerUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	op, err := config.clientCompute.Autoscalers.Patch(
-		config.Project, zone, d.Id(), scaler).Do()
+		project, zone, d.Id(), scaler).Do()
 	if err != nil {
 		return fmt.Errorf("Error updating Autoscaler: %s", err)
 	}
@@ -284,9 +304,14 @@ func resourceComputeAutoscalerUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceComputeAutoscalerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("zone").(string)
 	op, err := config.clientCompute.Autoscalers.Delete(
-		config.Project, zone, d.Id()).Do()
+		project, zone, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting autoscaler: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_autoscaler.go
+++ b/builtin/providers/google/resource_compute_autoscaler.go
@@ -23,14 +23,15 @@ func resourceComputeAutoscaler() *schema.Resource {
 				Required: true,
 			},
 
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
 			"target": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+			},
+
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"autoscaling_policy": &schema.Schema{
@@ -105,21 +106,20 @@ func resourceComputeAutoscaler() *schema.Resource {
 				},
 			},
 
-			"zone": &schema.Schema{
+			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -20,10 +20,36 @@ func resourceComputeBackendService() *schema.Resource {
 		Delete: resourceComputeBackendServiceDelete,
 
 		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					re := `^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$`
+					if !regexp.MustCompile(re).MatchString(value) {
+						errors = append(errors, fmt.Errorf(
+							"%q (%q) doesn't match regexp %q", k, value, re))
+					}
+					return
+				},
+			},
+
+			"health_checks": &schema.Schema{
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+				Set:      schema.HashString,
+			},
+
 			"backend": &schema.Schema{
 				Type: schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"group": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"balancing_mode": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
@@ -35,10 +61,6 @@ func resourceComputeBackendService() *schema.Resource {
 							Default:  1,
 						},
 						"description": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"group": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -66,32 +88,9 @@ func resourceComputeBackendService() *schema.Resource {
 				Optional: true,
 			},
 
-			"region": &schema.Schema{
+			"fingerprint": &schema.Schema{
 				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-			},
-
-			"health_checks": &schema.Schema{
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Required: true,
-				Set:      schema.HashString,
-			},
-
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					re := `^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$`
-					if !regexp.MustCompile(re).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q (%q) doesn't match regexp %q", k, value, re))
-					}
-					return
-				},
+				Computed: true,
 			},
 
 			"port_name": &schema.Schema{
@@ -100,21 +99,22 @@ func resourceComputeBackendService() *schema.Resource {
 				Computed: true,
 			},
 
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"protocol": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"timeout_sec": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-
-			"fingerprint": &schema.Schema{
+			"region": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"self_link": &schema.Schema{
@@ -122,10 +122,10 @@ func resourceComputeBackendService() *schema.Resource {
 				Computed: true,
 			},
 
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
+			"timeout_sec": &schema.Schema{
+				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -56,6 +56,12 @@ func resourceComputeDisk() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -63,10 +69,15 @@ func resourceComputeDisk() *schema.Resource {
 func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Get the zone
 	log.Printf("[DEBUG] Loading zone: %s", d.Get("zone").(string))
 	zone, err := config.clientCompute.Zones.Get(
-		config.Project, d.Get("zone").(string)).Do()
+		project, d.Get("zone").(string)).Do()
 	if err != nil {
 		return fmt.Errorf(
 			"Error loading zone '%s': %s", d.Get("zone").(string), err)
@@ -107,7 +118,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 		snapshotName := v.(string)
 		log.Printf("[DEBUG] Loading snapshot: %s", snapshotName)
 		snapshotData, err := config.clientCompute.Snapshots.Get(
-			config.Project, snapshotName).Do()
+			project, snapshotName).Do()
 
 		if err != nil {
 			return fmt.Errorf(
@@ -119,7 +130,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	op, err := config.clientCompute.Disks.Insert(
-		config.Project, d.Get("zone").(string), disk).Do()
+		project, d.Get("zone").(string), disk).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating disk: %s", err)
 	}
@@ -137,8 +148,13 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	disk, err := config.clientCompute.Disks.Get(
-		config.Project, d.Get("zone").(string), d.Id()).Do()
+		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Disk %q because it's gone", d.Get("name").(string))
@@ -159,9 +175,14 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the disk
 	op, err := config.clientCompute.Disks.Delete(
-		config.Project, d.Get("zone").(string), d.Id()).Do()
+		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting disk: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -34,20 +34,14 @@ func resourceComputeDisk() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"size": &schema.Schema{
 				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"type": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"snapshot": &schema.Schema{
-				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -57,7 +51,13 @@ func resourceComputeDisk() *schema.Resource {
 				Computed: true,
 			},
 
-			"project": &schema.Schema{
+			"snapshot": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"type": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -83,6 +83,12 @@ func resourceComputeFirewall() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -113,13 +119,18 @@ func resourceComputeFirewallAllowHash(v interface{}) int {
 func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	firewall, err := resourceFirewall(d, meta)
 	if err != nil {
 		return err
 	}
 
 	op, err := config.clientCompute.Firewalls.Insert(
-		config.Project, firewall).Do()
+		project, firewall).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating firewall: %s", err)
 	}
@@ -138,8 +149,13 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	firewall, err := config.clientCompute.Firewalls.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
@@ -160,6 +176,11 @@ func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error
 func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	d.Partial(true)
 
 	firewall, err := resourceFirewall(d, meta)
@@ -168,7 +189,7 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	op, err := config.clientCompute.Firewalls.Update(
-		config.Project, d.Id(), firewall).Do()
+		project, d.Id(), firewall).Do()
 	if err != nil {
 		return fmt.Errorf("Error updating firewall: %s", err)
 	}
@@ -186,9 +207,14 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the firewall
 	op, err := config.clientCompute.Firewalls.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting firewall: %s", err)
 	}
@@ -207,9 +233,11 @@ func resourceFirewall(
 	meta interface{}) (*compute.Firewall, error) {
 	config := meta.(*Config)
 
+	project, _ := getProject(d, config)
+
 	// Look up the network to attach the firewall to
 	network, err := config.clientCompute.Networks.Get(
-		config.Project, d.Get("network").(string)).Do()
+		project, d.Get("network").(string)).Do()
 	if err != nil {
 		return nil, fmt.Errorf("Error reading network: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -26,11 +26,6 @@ func resourceComputeFirewall() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
 			"network": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -58,6 +53,22 @@ func resourceComputeFirewall() *schema.Resource {
 				Set: resourceComputeFirewallAllowHash,
 			},
 
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"source_ranges": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -77,17 +88,6 @@ func resourceComputeFirewall() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -49,12 +49,6 @@ func resourceComputeForwardingRule() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"region": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,6 +59,18 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Required: true,
 				ForceNew: false,
 			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -72,7 +78,15 @@ func resourceComputeForwardingRule() *schema.Resource {
 func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	region := getOptionalRegion(d, config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	frule := &compute.ForwardingRule{
 		IPAddress:   d.Get("ip_address").(string),
@@ -85,7 +99,7 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG] ForwardingRule insert request: %#v", frule)
 	op, err := config.clientCompute.ForwardingRules.Insert(
-		config.Project, region, frule).Do()
+		project, region, frule).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating ForwardingRule: %s", err)
 	}
@@ -104,7 +118,15 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 func resourceComputeForwardingRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	region := getOptionalRegion(d, config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	d.Partial(true)
 
@@ -112,7 +134,7 @@ func resourceComputeForwardingRuleUpdate(d *schema.ResourceData, meta interface{
 		target_name := d.Get("target").(string)
 		target_ref := &compute.TargetReference{Target: target_name}
 		op, err := config.clientCompute.ForwardingRules.SetTarget(
-			config.Project, region, d.Id(), target_ref).Do()
+			project, region, d.Id(), target_ref).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating target: %s", err)
 		}
@@ -133,10 +155,18 @@ func resourceComputeForwardingRuleUpdate(d *schema.ResourceData, meta interface{
 func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	region := getOptionalRegion(d, config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	frule, err := config.clientCompute.ForwardingRules.Get(
-		config.Project, region, d.Id()).Do()
+		project, region, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Forwarding Rule %q because it's gone", d.Get("name").(string))
@@ -159,12 +189,20 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 func resourceComputeForwardingRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	region := getOptionalRegion(d, config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Delete the ForwardingRule
 	log.Printf("[DEBUG] ForwardingRule delete request")
 	op, err := config.clientCompute.ForwardingRules.Delete(
-		config.Project, region, d.Id()).Do()
+		project, region, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting ForwardingRule: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -17,6 +17,24 @@ func resourceComputeForwardingRule() *schema.Resource {
 		Update: resourceComputeForwardingRuleUpdate,
 
 		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"target": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"ip_address": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -31,36 +49,7 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Computed: true,
 			},
 
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"port_range": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"target": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: false,
-			},
-
-			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -70,6 +59,17 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_global_address.go
+++ b/builtin/providers/google/resource_compute_global_address.go
@@ -27,15 +27,15 @@ func resourceComputeGlobalAddress() *schema.Resource {
 				Computed: true,
 			},
 
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_global_address.go
+++ b/builtin/providers/google/resource_compute_global_address.go
@@ -31,6 +31,12 @@ func resourceComputeGlobalAddress() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -38,10 +44,15 @@ func resourceComputeGlobalAddress() *schema.Resource {
 func resourceComputeGlobalAddressCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Build the address parameter
 	addr := &compute.Address{Name: d.Get("name").(string)}
 	op, err := config.clientCompute.GlobalAddresses.Insert(
-		config.Project, addr).Do()
+		project, addr).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating address: %s", err)
 	}
@@ -60,8 +71,13 @@ func resourceComputeGlobalAddressCreate(d *schema.ResourceData, meta interface{}
 func resourceComputeGlobalAddressRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	addr, err := config.clientCompute.GlobalAddresses.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Global Address %q because it's gone", d.Get("name").(string))
@@ -83,10 +99,15 @@ func resourceComputeGlobalAddressRead(d *schema.ResourceData, meta interface{}) 
 func resourceComputeGlobalAddressDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the address
 	log.Printf("[DEBUG] address delete request")
 	op, err := config.clientCompute.GlobalAddresses.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting address: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_global_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_global_forwarding_rule.go
@@ -17,6 +17,23 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 		Delete: resourceComputeGlobalForwardingRuleDelete,
 
 		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"target": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"ip_address": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -31,32 +48,16 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 				Computed: true,
 			},
 
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"port_range": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"self_link": &schema.Schema{
+			"project": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"target": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"region": &schema.Schema{
@@ -66,10 +67,9 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 				Deprecated: "Please remove this attribute (it was never used)",
 			},
 
-			"project": &schema.Schema{
+			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_global_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_global_forwarding_rule.go
@@ -49,12 +49,6 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"region": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -63,6 +57,13 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 			"target": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+			},
+
+			"region": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "Please remove this attribute (it was never used)",
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -73,12 +73,23 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 				Optional: true,
 				Default:  2,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceComputeHttpHealthCheckCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Build the parameter
 	hchk := &compute.HttpHealthCheck{
@@ -112,7 +123,7 @@ func resourceComputeHttpHealthCheckCreate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] HttpHealthCheck insert request: %#v", hchk)
 	op, err := config.clientCompute.HttpHealthChecks.Insert(
-		config.Project, hchk).Do()
+		project, hchk).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating HttpHealthCheck: %s", err)
 	}
@@ -130,6 +141,11 @@ func resourceComputeHttpHealthCheckCreate(d *schema.ResourceData, meta interface
 
 func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Build the parameter
 	hchk := &compute.HttpHealthCheck{
@@ -163,7 +179,7 @@ func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] HttpHealthCheck patch request: %#v", hchk)
 	op, err := config.clientCompute.HttpHealthChecks.Patch(
-		config.Project, hchk.Name, hchk).Do()
+		project, hchk.Name, hchk).Do()
 	if err != nil {
 		return fmt.Errorf("Error patching HttpHealthCheck: %s", err)
 	}
@@ -182,8 +198,13 @@ func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface
 func resourceComputeHttpHealthCheckRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	hchk, err := config.clientCompute.HttpHealthChecks.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
@@ -211,9 +232,14 @@ func resourceComputeHttpHealthCheckRead(d *schema.ResourceData, meta interface{}
 func resourceComputeHttpHealthCheckDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the HttpHealthCheck
 	op, err := config.clientCompute.HttpHealthChecks.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting HttpHealthCheck: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -17,6 +17,12 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 		Update: resourceComputeHttpHealthCheckUpdate,
 
 		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
 			"check_interval_sec": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -39,16 +45,16 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 				Optional: true,
 			},
 
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"port": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  80,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"request_path": &schema.Schema{
@@ -72,12 +78,6 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  2,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_https_health_check.go
+++ b/builtin/providers/google/resource_compute_https_health_check.go
@@ -17,6 +17,12 @@ func resourceComputeHttpsHealthCheck() *schema.Resource {
 		Update: resourceComputeHttpsHealthCheckUpdate,
 
 		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
 			"check_interval_sec": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -39,16 +45,16 @@ func resourceComputeHttpsHealthCheck() *schema.Resource {
 				Optional: true,
 			},
 
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"port": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  443,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"request_path": &schema.Schema{
@@ -72,12 +78,6 @@ func resourceComputeHttpsHealthCheck() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  2,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_https_health_check.go
+++ b/builtin/providers/google/resource_compute_https_health_check.go
@@ -73,12 +73,23 @@ func resourceComputeHttpsHealthCheck() *schema.Resource {
 				Optional: true,
 				Default:  2,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceComputeHttpsHealthCheckCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Build the parameter
 	hchk := &compute.HttpsHealthCheck{
@@ -112,7 +123,7 @@ func resourceComputeHttpsHealthCheckCreate(d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] HttpsHealthCheck insert request: %#v", hchk)
 	op, err := config.clientCompute.HttpsHealthChecks.Insert(
-		config.Project, hchk).Do()
+		project, hchk).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating HttpsHealthCheck: %s", err)
 	}
@@ -130,6 +141,11 @@ func resourceComputeHttpsHealthCheckCreate(d *schema.ResourceData, meta interfac
 
 func resourceComputeHttpsHealthCheckUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Build the parameter
 	hchk := &compute.HttpsHealthCheck{
@@ -163,7 +179,7 @@ func resourceComputeHttpsHealthCheckUpdate(d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] HttpsHealthCheck patch request: %#v", hchk)
 	op, err := config.clientCompute.HttpsHealthChecks.Patch(
-		config.Project, hchk.Name, hchk).Do()
+		project, hchk.Name, hchk).Do()
 	if err != nil {
 		return fmt.Errorf("Error patching HttpsHealthCheck: %s", err)
 	}
@@ -182,8 +198,13 @@ func resourceComputeHttpsHealthCheckUpdate(d *schema.ResourceData, meta interfac
 func resourceComputeHttpsHealthCheckRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	hchk, err := config.clientCompute.HttpsHealthChecks.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing HTTPS Health Check %q because it's gone", d.Get("name").(string))
@@ -211,9 +232,14 @@ func resourceComputeHttpsHealthCheckRead(d *schema.ResourceData, meta interface{
 func resourceComputeHttpsHealthCheckDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the HttpsHealthCheck
 	op, err := config.clientCompute.HttpsHealthChecks.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting HttpsHealthCheck: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -26,30 +26,6 @@ func resourceComputeInstance() *schema.Resource {
 		MigrateState:  resourceComputeInstanceMigrateState,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"machine_type": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"disk": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
@@ -101,6 +77,55 @@ func resourceComputeInstance() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			"machine_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"can_ip_forward": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"metadata": &schema.Schema{
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Elem:         schema.TypeString,
+				ValidateFunc: validateInstanceMetadata,
+			},
+
+			"metadata_startup_script": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"metadata_fingerprint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"network_interface": &schema.Schema{
@@ -189,24 +214,38 @@ func resourceComputeInstance() *schema.Resource {
 				},
 			},
 
-			"can_ip_forward": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
-
-			"metadata_startup_script": &schema.Schema{
+			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"metadata": &schema.Schema{
-				Type:         schema.TypeMap,
-				Optional:     true,
-				Elem:         schema.TypeString,
-				ValidateFunc: validateInstanceMetadata,
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"scheduling": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"on_host_maintenance": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"automatic_restart": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
+						"preemptible": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
 			},
 
 			"service_account": &schema.Schema{
@@ -237,29 +276,6 @@ func resourceComputeInstance() *schema.Resource {
 				},
 			},
 
-			"scheduling": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"on_host_maintenance": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"automatic_restart": &schema.Schema{
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-
-						"preemptible": &schema.Schema{
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-
 			"tags": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -267,25 +283,9 @@ func resourceComputeInstance() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
-			"metadata_fingerprint": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"tags_fingerprint": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -281,13 +281,24 @@ func resourceComputeInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func getInstance(config *Config, d *schema.ResourceData) (*compute.Instance, error) {
+	project, err := getProject(d, config)
+	if err != nil {
+		return nil, err
+	}
+
 	instance, err := config.clientCompute.Instances.Get(
-		config.Project, d.Get("zone").(string), d.Id()).Do()
+		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Instance %q because it's gone", d.Get("name").(string))
@@ -307,10 +318,15 @@ func getInstance(config *Config, d *schema.ResourceData) (*compute.Instance, err
 func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Get the zone
 	log.Printf("[DEBUG] Loading zone: %s", d.Get("zone").(string))
 	zone, err := config.clientCompute.Zones.Get(
-		config.Project, d.Get("zone").(string)).Do()
+		project, d.Get("zone").(string)).Do()
 	if err != nil {
 		return fmt.Errorf(
 			"Error loading zone '%s': %s", d.Get("zone").(string), err)
@@ -319,7 +335,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	// Get the machine type
 	log.Printf("[DEBUG] Loading machine type: %s", d.Get("machine_type").(string))
 	machineType, err := config.clientCompute.MachineTypes.Get(
-		config.Project, zone.Name, d.Get("machine_type").(string)).Do()
+		project, zone.Name, d.Get("machine_type").(string)).Do()
 	if err != nil {
 		return fmt.Errorf(
 			"Error loading machine type: %s",
@@ -345,7 +361,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		if v, ok := d.GetOk(prefix + ".disk"); ok {
 			diskName := v.(string)
 			diskData, err := config.clientCompute.Disks.Get(
-				config.Project, zone.Name, diskName).Do()
+				project, zone.Name, diskName).Do()
 			if err != nil {
 				return fmt.Errorf(
 					"Error loading disk '%s': %s",
@@ -423,7 +439,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			// Load up the name of this network
 			networkName := d.Get(prefix + ".source").(string)
 			network, err := config.clientCompute.Networks.Get(
-				config.Project, networkName).Do()
+				project, networkName).Do()
 			if err != nil {
 				return fmt.Errorf(
 					"Error loading network '%s': %s",
@@ -458,7 +474,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 				return fmt.Errorf("Cannot specify both network and subnetwork values.")
 			} else if networkName != "" {
 				network, err := config.clientCompute.Networks.Get(
-					config.Project, networkName).Do()
+					project, networkName).Do()
 				if err != nil {
 					return fmt.Errorf(
 						"Error referencing network '%s': %s",
@@ -468,7 +484,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			} else {
 				region := getRegionFromZone(d.Get("zone").(string))
 				subnetwork, err := config.clientCompute.Subnetworks.Get(
-					config.Project, region, subnetworkName).Do()
+					project, region, subnetworkName).Do()
 				if err != nil {
 					return fmt.Errorf(
 						"Error referencing subnetwork '%s' in region '%s': %s",
@@ -552,7 +568,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Requesting instance creation")
 	op, err := config.clientCompute.Instances.Insert(
-		config.Project, zone.Name, &instance).Do()
+		project, zone.Name, &instance).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating instance: %s", err)
 	}
@@ -724,6 +740,11 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("zone").(string)
 
 	instance, err := getInstance(config, d)
@@ -760,7 +781,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return fmt.Errorf("Error updating metadata: %s", err)
 			}
 			op, err := config.clientCompute.Instances.SetMetadata(
-				config.Project, zone, d.Id(), md).Do()
+				project, zone, d.Id(), md).Do()
 			if err != nil {
 				return fmt.Errorf("Error updating metadata: %s", err)
 			}
@@ -780,7 +801,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("tags") {
 		tags := resourceInstanceTags(d)
 		op, err := config.clientCompute.Instances.SetTags(
-			config.Project, zone, d.Id(), tags).Do()
+			project, zone, d.Id(), tags).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
@@ -809,7 +830,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			scheduling.OnHostMaintenance = val.(string)
 		}
 
-		op, err := config.clientCompute.Instances.SetScheduling(config.Project,
+		op, err := config.clientCompute.Instances.SetScheduling(project,
 			zone, d.Id(), scheduling).Do()
 
 		if err != nil {
@@ -854,7 +875,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				// Delete any accessConfig that currently exists in instNetworkInterface
 				for _, ac := range instNetworkInterface.AccessConfigs {
 					op, err := config.clientCompute.Instances.DeleteAccessConfig(
-						config.Project, zone, d.Id(), ac.Name, networkName).Do()
+						project, zone, d.Id(), ac.Name, networkName).Do()
 					if err != nil {
 						return fmt.Errorf("Error deleting old access_config: %s", err)
 					}
@@ -873,7 +894,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 						NatIP: d.Get(acPrefix + ".nat_ip").(string),
 					}
 					op, err := config.clientCompute.Instances.AddAccessConfig(
-						config.Project, zone, d.Id(), networkName, ac).Do()
+						project, zone, d.Id(), networkName, ac).Do()
 					if err != nil {
 						return fmt.Errorf("Error adding new access_config: %s", err)
 					}
@@ -895,9 +916,14 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("zone").(string)
 	log.Printf("[INFO] Requesting instance deletion: %s", d.Id())
-	op, err := config.clientCompute.Instances.Delete(config.Project, zone, d.Id()).Do()
+	op, err := config.clientCompute.Instances.Delete(project, zone, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting instance: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -75,6 +75,12 @@ func resourceComputeInstanceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -100,6 +106,11 @@ func validInstanceURLs(instanceUrls []string) bool {
 func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Build the parameter
 	instanceGroup := &compute.InstanceGroup{
 		Name: d.Get("name").(string),
@@ -116,7 +127,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] InstanceGroup insert request: %#v", instanceGroup)
 	op, err := config.clientCompute.InstanceGroups.Insert(
-		config.Project, d.Get("zone").(string), instanceGroup).Do()
+		project, d.Get("zone").(string), instanceGroup).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating InstanceGroup: %s", err)
 	}
@@ -142,7 +153,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 
 		log.Printf("[DEBUG] InstanceGroup add instances request: %#v", addInstanceReq)
 		op, err := config.clientCompute.InstanceGroups.AddInstances(
-			config.Project, d.Get("zone").(string), d.Id(), addInstanceReq).Do()
+			project, d.Get("zone").(string), d.Id(), addInstanceReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error adding instances to InstanceGroup: %s", err)
 		}
@@ -160,9 +171,14 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// retreive instance group
 	instanceGroup, err := config.clientCompute.InstanceGroups.Get(
-		config.Project, d.Get("zone").(string), d.Id()).Do()
+		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
@@ -177,7 +193,7 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 	// retreive instance group members
 	var memberUrls []string
 	members, err := config.clientCompute.InstanceGroups.ListInstances(
-		config.Project, d.Get("zone").(string), d.Id(), &compute.InstanceGroupsListInstancesRequest{
+		project, d.Get("zone").(string), d.Id(), &compute.InstanceGroupsListInstancesRequest{
 			InstanceState: "ALL",
 		}).Do()
 	if err != nil {
@@ -206,8 +222,13 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// refresh the state incase referenced instances have been removed earlier in the run
-	err := resourceComputeInstanceGroupRead(d, meta)
+	err = resourceComputeInstanceGroupRead(d, meta)
 	if err != nil {
 		return fmt.Errorf("Error reading InstanceGroup: %s", err)
 	}
@@ -237,7 +258,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 
 			log.Printf("[DEBUG] InstanceGroup remove instances request: %#v", removeReq)
 			removeOp, err := config.clientCompute.InstanceGroups.RemoveInstances(
-				config.Project, d.Get("zone").(string), d.Id(), removeReq).Do()
+				project, d.Get("zone").(string), d.Id(), removeReq).Do()
 			if err != nil {
 				return fmt.Errorf("Error removing instances from InstanceGroup: %s", err)
 			}
@@ -257,7 +278,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 
 			log.Printf("[DEBUG] InstanceGroup adding instances request: %#v", addReq)
 			addOp, err := config.clientCompute.InstanceGroups.AddInstances(
-				config.Project, d.Get("zone").(string), d.Id(), addReq).Do()
+				project, d.Get("zone").(string), d.Id(), addReq).Do()
 			if err != nil {
 				return fmt.Errorf("Error adding instances from InstanceGroup: %s", err)
 			}
@@ -281,7 +302,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 
 		log.Printf("[DEBUG] InstanceGroup updating named ports request: %#v", namedPortsReq)
 		op, err := config.clientCompute.InstanceGroups.SetNamedPorts(
-			config.Project, d.Get("zone").(string), d.Id(), namedPortsReq).Do()
+			project, d.Get("zone").(string), d.Id(), namedPortsReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating named ports for InstanceGroup: %s", err)
 		}
@@ -301,8 +322,13 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("zone").(string)
-	op, err := config.clientCompute.InstanceGroups.Delete(config.Project, zone, d.Id()).Do()
+	op, err := config.clientCompute.InstanceGroups.Delete(project, zone, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting InstanceGroup: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -25,10 +25,22 @@ func resourceComputeInstanceGroup() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"instances": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"named_port": &schema.Schema{
@@ -49,29 +61,7 @@ func resourceComputeInstanceGroup() *schema.Resource {
 				},
 			},
 
-			"instances": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
 			"network": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"size": &schema.Schema{
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
-			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -80,6 +70,16 @@ func resourceComputeInstanceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -100,6 +100,12 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -118,6 +124,11 @@ func getNamedPorts(nps []interface{}) []*compute.NamedPort {
 
 func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Get group size, default to 1 if not given
 	var target_size int64 = 1
@@ -157,7 +168,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 	log.Printf("[DEBUG] InstanceGroupManager insert request: %#v", manager)
 	op, err := config.clientCompute.InstanceGroupManagers.Insert(
-		config.Project, d.Get("zone").(string), manager).Do()
+		project, d.Get("zone").(string), manager).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating InstanceGroupManager: %s", err)
 	}
@@ -177,8 +188,13 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	manager, err := config.clientCompute.InstanceGroupManagers.Get(
-		config.Project, d.Get("zone").(string), d.Id()).Do()
+		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Instance Group Manager %q because it's gone", d.Get("name").(string))
@@ -203,6 +219,11 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	d.Partial(true)
 
 	// If target_pools changes then update
@@ -221,7 +242,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		op, err := config.clientCompute.InstanceGroupManagers.SetTargetPools(
-			config.Project, d.Get("zone").(string), d.Id(), setTargetPools).Do()
+			project, d.Get("zone").(string), d.Id(), setTargetPools).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
 		}
@@ -243,7 +264,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		op, err := config.clientCompute.InstanceGroupManagers.SetInstanceTemplate(
-			config.Project, d.Get("zone").(string), d.Id(), setInstanceTemplate).Do()
+			project, d.Get("zone").(string), d.Id(), setInstanceTemplate).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
 		}
@@ -256,7 +277,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		if d.Get("update_strategy").(string) == "RESTART" {
 			managedInstances, err := config.clientCompute.InstanceGroupManagers.ListManagedInstances(
-				config.Project, d.Get("zone").(string), d.Id()).Do()
+				project, d.Get("zone").(string), d.Id()).Do()
 
 			managedInstanceCount := len(managedInstances.ManagedInstances)
 			instances := make([]string, managedInstanceCount)
@@ -269,7 +290,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			op, err = config.clientCompute.InstanceGroupManagers.RecreateInstances(
-				config.Project, d.Get("zone").(string), d.Id(), recreateInstances).Do()
+				project, d.Get("zone").(string), d.Id(), recreateInstances).Do()
 
 			if err != nil {
 				return fmt.Errorf("Error restarting instance group managers instances: %s", err)
@@ -297,7 +318,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		// Make the request:
 		op, err := config.clientCompute.InstanceGroups.SetNamedPorts(
-			config.Project, d.Get("zone").(string), d.Id(), setNamedPorts).Do()
+			project, d.Get("zone").(string), d.Id(), setNamedPorts).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
 		}
@@ -318,7 +339,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			target_size := int64(v.(int))
 
 			op, err := config.clientCompute.InstanceGroupManagers.Resize(
-				config.Project, d.Get("zone").(string), d.Id(), target_size).Do()
+				project, d.Get("zone").(string), d.Id(), target_size).Do()
 			if err != nil {
 				return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
 			}
@@ -341,8 +362,13 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("zone").(string)
-	op, err := config.clientCompute.InstanceGroupManagers.Delete(config.Project, zone, d.Id()).Do()
+	op, err := config.clientCompute.InstanceGroupManagers.Delete(project, zone, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting instance group manager: %s", err)
 	}
@@ -358,7 +384,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 		}
 
 		instanceGroup, err := config.clientCompute.InstanceGroups.Get(
-			config.Project, d.Get("zone").(string), d.Id()).Do()
+			project, d.Get("zone").(string), d.Id()).Do()
 
 		if err != nil {
 			return fmt.Errorf("Error getting instance group size: %s", err)

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -19,7 +19,24 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 		Delete: resourceComputeInstanceGroupManagerDelete,
 
 		Schema: map[string]*schema.Schema{
+			"base_instance_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"instance_template": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
 			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -28,12 +45,6 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
-			},
-
-			"base_instance_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
 				ForceNew: true,
 			},
 
@@ -47,17 +58,11 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Computed: true,
 			},
 
-			"instance_template": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
 			"named_port": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-
 						"name": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
@@ -69,6 +74,17 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"update_strategy": &schema.Schema{
@@ -88,23 +104,6 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 				Optional: true,
-			},
-
-			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -16,37 +16,6 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 		Delete: resourceComputeInstanceTemplateDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"can_ip_forward": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
-
-			"instance_description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"machine_type": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"disk": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
@@ -123,10 +92,54 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 				},
 			},
 
+			"machine_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"automatic_restart": &schema.Schema{
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Default:    true,
+				ForceNew:   true,
+				Deprecated: "Please use `scheduling.automatic_restart` instead",
+			},
+
+			"can_ip_forward": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"instance_description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"metadata": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"metadata_fingerprint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"network_interface": &schema.Schema{
@@ -164,19 +177,23 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 				},
 			},
 
-			"automatic_restart": &schema.Schema{
-				Type:       schema.TypeBool,
-				Optional:   true,
-				Default:    true,
-				ForceNew:   true,
-				Deprecated: "Please use `scheduling.automatic_restart` instead",
-			},
-
 			"on_host_maintenance": &schema.Schema{
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
 				Deprecated: "Please use `scheduling.on_host_maintenance` instead",
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"scheduling": &schema.Schema{
@@ -205,6 +222,11 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"service_account": &schema.Schema{
@@ -242,31 +264,9 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
-			"metadata_fingerprint": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"tags_fingerprint": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"region": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_network.go
+++ b/builtin/providers/google/resource_compute_network.go
@@ -22,18 +22,6 @@ func resourceComputeNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"ipv4_range": &schema.Schema{
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
-				Deprecated: "Please use google_compute_subnetwork resources instead.",
-			},
-
-			"gateway_ipv4": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"auto_create_subnetworks": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -52,15 +40,27 @@ func resourceComputeNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"self_link": &schema.Schema{
+			"gateway_ipv4": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+
+			"ipv4_range": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "Please use google_compute_subnetwork resources instead.",
 			},
 
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_project_metadata.go
+++ b/builtin/providers/google/resource_compute_project_metadata.go
@@ -24,6 +24,12 @@ func resourceComputeProjectMetadata() *schema.Resource {
 				Type:     schema.TypeMap,
 				Required: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -31,12 +37,17 @@ func resourceComputeProjectMetadata() *schema.Resource {
 func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	projectID, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	createMD := func() error {
 		// Load project service
-		log.Printf("[DEBUG] Loading project service: %s", config.Project)
-		project, err := config.clientCompute.Projects.Get(config.Project).Do()
+		log.Printf("[DEBUG] Loading project service: %s", projectID)
+		project, err := config.clientCompute.Projects.Get(projectID).Do()
 		if err != nil {
-			return fmt.Errorf("Error loading project '%s': %s", config.Project, err)
+			return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 		}
 
 		md := project.CommonInstanceMetadata
@@ -45,7 +56,7 @@ func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface
 		// Ensure that we aren't overwriting entries that already exist
 		for _, kv := range md.Items {
 			if _, ok := newMDMap[kv.Key]; ok {
-				return fmt.Errorf("Error, key '%s' already exists in project '%s'", kv.Key, config.Project)
+				return fmt.Errorf("Error, key '%s' already exists in project '%s'", kv.Key, projectID)
 			}
 		}
 
@@ -58,7 +69,7 @@ func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface
 			})
 		}
 
-		op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(config.Project, md).Do()
+		op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(projectID, md).Do()
 
 		if err != nil {
 			return fmt.Errorf("SetCommonInstanceMetadata failed: %s", err)
@@ -69,7 +80,7 @@ func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface
 		return computeOperationWaitGlobal(config, op, "SetCommonMetadata")
 	}
 
-	err := MetadataRetryWrapper(createMD)
+	err = MetadataRetryWrapper(createMD)
 	if err != nil {
 		return err
 	}
@@ -80,9 +91,14 @@ func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface
 func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	projectID, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Load project service
-	log.Printf("[DEBUG] Loading project service: %s", config.Project)
-	project, err := config.clientCompute.Projects.Get(config.Project).Do()
+	log.Printf("[DEBUG] Loading project service: %s", projectID)
+	project, err := config.clientCompute.Projects.Get(projectID).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Project Metadata because it's gone")
@@ -92,7 +108,7 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return fmt.Errorf("Error loading project '%s': %s", config.Project, err)
+		return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 	}
 
 	md := project.CommonInstanceMetadata
@@ -109,22 +125,27 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 func resourceComputeProjectMetadataUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	projectID, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	if d.HasChange("metadata") {
 		o, n := d.GetChange("metadata")
 
 		updateMD := func() error {
 			// Load project service
-			log.Printf("[DEBUG] Loading project service: %s", config.Project)
-			project, err := config.clientCompute.Projects.Get(config.Project).Do()
+			log.Printf("[DEBUG] Loading project service: %s", projectID)
+			project, err := config.clientCompute.Projects.Get(projectID).Do()
 			if err != nil {
-				return fmt.Errorf("Error loading project '%s': %s", config.Project, err)
+				return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 			}
 
 			md := project.CommonInstanceMetadata
 
 			MetadataUpdate(o.(map[string]interface{}), n.(map[string]interface{}), md)
 
-			op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(config.Project, md).Do()
+			op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(projectID, md).Do()
 
 			if err != nil {
 				return fmt.Errorf("SetCommonInstanceMetadata failed: %s", err)
@@ -152,11 +173,16 @@ func resourceComputeProjectMetadataUpdate(d *schema.ResourceData, meta interface
 func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	// Load project service
-	log.Printf("[DEBUG] Loading project service: %s", config.Project)
-	project, err := config.clientCompute.Projects.Get(config.Project).Do()
+	projectID, err := getProject(d, config)
 	if err != nil {
-		return fmt.Errorf("Error loading project '%s': %s", config.Project, err)
+		return err
+	}
+
+	// Load project service
+	log.Printf("[DEBUG] Loading project service: %s", projectID)
+	project, err := config.clientCompute.Projects.Get(projectID).Do()
+	if err != nil {
+		return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 	}
 
 	md := project.CommonInstanceMetadata
@@ -164,7 +190,7 @@ func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface
 	// Remove all items
 	md.Items = nil
 
-	op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(config.Project, md).Do()
+	op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(projectID, md).Do()
 
 	log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
 

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -87,6 +87,12 @@ func resourceComputeRoute() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -94,9 +100,14 @@ func resourceComputeRoute() *schema.Resource {
 func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Look up the network to attach the route to
 	network, err := config.clientCompute.Networks.Get(
-		config.Project, d.Get("network").(string)).Do()
+		project, d.Get("network").(string)).Do()
 	if err != nil {
 		return fmt.Errorf("Error reading network: %s", err)
 	}
@@ -115,7 +126,7 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	if v, ok := d.GetOk("next_hop_instance"); ok {
 		nextInstance, err := config.clientCompute.Instances.Get(
-			config.Project,
+			project,
 			d.Get("next_hop_instance_zone").(string),
 			v.(string)).Do()
 		if err != nil {
@@ -148,7 +159,7 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	log.Printf("[DEBUG] Route insert request: %#v", route)
 	op, err := config.clientCompute.Routes.Insert(
-		config.Project, route).Do()
+		project, route).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating route: %s", err)
 	}
@@ -167,8 +178,13 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	route, err := config.clientCompute.Routes.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Route %q because it's gone", d.Get("name").(string))
@@ -190,9 +206,14 @@ func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 func resourceComputeRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the route
 	op, err := config.clientCompute.Routes.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting route: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -16,13 +16,13 @@ func resourceComputeRoute() *schema.Resource {
 		Delete: resourceComputeRouteDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"dest_range": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"dest_range": &schema.Schema{
+			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -34,7 +34,13 @@ func resourceComputeRoute() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"next_hop_ip": &schema.Schema{
+			"priority": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"next_hop_gateway": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -52,7 +58,7 @@ func resourceComputeRoute() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"next_hop_gateway": &schema.Schema{
+			"next_hop_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -69,10 +75,15 @@ func resourceComputeRoute() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"priority": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"tags": &schema.Schema{
@@ -81,17 +92,6 @@ func resourceComputeRoute() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_ssl_certificate.go
+++ b/builtin/providers/google/resource_compute_ssl_certificate.go
@@ -50,12 +50,23 @@ func resourceComputeSslCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceComputeSslCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Build the certificate parameter
 	cert := &compute.SslCertificate{
@@ -69,7 +80,7 @@ func resourceComputeSslCertificateCreate(d *schema.ResourceData, meta interface{
 	}
 
 	op, err := config.clientCompute.SslCertificates.Insert(
-		config.Project, cert).Do()
+		project, cert).Do()
 
 	if err != nil {
 		return fmt.Errorf("Error creating ssl certificate: %s", err)
@@ -88,8 +99,13 @@ func resourceComputeSslCertificateCreate(d *schema.ResourceData, meta interface{
 func resourceComputeSslCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	cert, err := config.clientCompute.SslCertificates.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing SSL Certificate %q because it's gone", d.Get("name").(string))
@@ -111,8 +127,13 @@ func resourceComputeSslCertificateRead(d *schema.ResourceData, meta interface{})
 func resourceComputeSslCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	op, err := config.clientCompute.SslCertificates.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting ssl certificate: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_ssl_certificate.go
+++ b/builtin/providers/google/resource_compute_ssl_certificate.go
@@ -17,19 +17,13 @@ func resourceComputeSslCertificate() *schema.Resource {
 		Delete: resourceComputeSslCertificateDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"certificate": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"certificate": &schema.Schema{
+			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -41,9 +35,10 @@ func resourceComputeSslCertificate() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"self_link": &schema.Schema{
+			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"id": &schema.Schema{
@@ -55,6 +50,11 @@ func resourceComputeSslCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_target_http_proxy.go
+++ b/builtin/providers/google/resource_compute_target_http_proxy.go
@@ -24,7 +24,23 @@ func resourceComputeTargetHttpProxy() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"url_map": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
 			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -33,22 +49,6 @@ func resourceComputeTargetHttpProxy() *schema.Resource {
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-
-			"id": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"url_map": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_target_http_proxy.go
+++ b/builtin/providers/google/resource_compute_target_http_proxy.go
@@ -44,12 +44,23 @@ func resourceComputeTargetHttpProxy() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceComputeTargetHttpProxyCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	proxy := &compute.TargetHttpProxy{
 		Name:   d.Get("name").(string),
@@ -62,7 +73,7 @@ func resourceComputeTargetHttpProxyCreate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] TargetHttpProxy insert request: %#v", proxy)
 	op, err := config.clientCompute.TargetHttpProxies.Insert(
-		config.Project, proxy).Do()
+		project, proxy).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating TargetHttpProxy: %s", err)
 	}
@@ -80,13 +91,18 @@ func resourceComputeTargetHttpProxyCreate(d *schema.ResourceData, meta interface
 func resourceComputeTargetHttpProxyUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	d.Partial(true)
 
 	if d.HasChange("url_map") {
 		url_map := d.Get("url_map").(string)
 		url_map_ref := &compute.UrlMapReference{UrlMap: url_map}
 		op, err := config.clientCompute.TargetHttpProxies.SetUrlMap(
-			config.Project, d.Id(), url_map_ref).Do()
+			project, d.Id(), url_map_ref).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating target: %s", err)
 		}
@@ -107,8 +123,13 @@ func resourceComputeTargetHttpProxyUpdate(d *schema.ResourceData, meta interface
 func resourceComputeTargetHttpProxyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	proxy, err := config.clientCompute.TargetHttpProxies.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Target HTTP Proxy %q because it's gone", d.Get("name").(string))
@@ -130,10 +151,15 @@ func resourceComputeTargetHttpProxyRead(d *schema.ResourceData, meta interface{}
 func resourceComputeTargetHttpProxyDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the TargetHttpProxy
 	log.Printf("[DEBUG] TargetHttpProxy delete request")
 	op, err := config.clientCompute.TargetHttpProxies.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting TargetHttpProxy: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_target_https_proxy.go
+++ b/builtin/providers/google/resource_compute_target_https_proxy.go
@@ -50,12 +50,23 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceComputeTargetHttpsProxyCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	_sslCertificates := d.Get("ssl_certificates").([]interface{})
 	sslCertificates := make([]string, len(_sslCertificates))
@@ -76,7 +87,7 @@ func resourceComputeTargetHttpsProxyCreate(d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] TargetHttpsProxy insert request: %#v", proxy)
 	op, err := config.clientCompute.TargetHttpsProxies.Insert(
-		config.Project, proxy).Do()
+		project, proxy).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating TargetHttpsProxy: %s", err)
 	}
@@ -94,13 +105,18 @@ func resourceComputeTargetHttpsProxyCreate(d *schema.ResourceData, meta interfac
 func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	d.Partial(true)
 
 	if d.HasChange("url_map") {
 		url_map := d.Get("url_map").(string)
 		url_map_ref := &compute.UrlMapReference{UrlMap: url_map}
 		op, err := config.clientCompute.TargetHttpsProxies.SetUrlMap(
-			config.Project, d.Id(), url_map_ref).Do()
+			project, d.Id(), url_map_ref).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating Target HTTPS proxy URL map: %s", err)
 		}
@@ -115,7 +131,7 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 
 	if d.HasChange("ssl_certificates") {
 		proxy, err := config.clientCompute.TargetHttpsProxies.Get(
-			config.Project, d.Id()).Do()
+			project, d.Id()).Do()
 
 		_old, _new := d.GetChange("ssl_certificates")
 		_oldCerts := _old.([]interface{})
@@ -161,7 +177,7 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 			SslCertificates: sslCertificates,
 		}
 		op, err := config.clientCompute.TargetHttpsProxies.SetSslCertificates(
-			config.Project, d.Id(), cert_ref).Do()
+			project, d.Id(), cert_ref).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating Target Https Proxy SSL Certificates: %s", err)
 		}
@@ -182,8 +198,13 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 func resourceComputeTargetHttpsProxyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	proxy, err := config.clientCompute.TargetHttpsProxies.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Target HTTPS Proxy %q because it's gone", d.Get("name").(string))
@@ -223,10 +244,15 @@ func resourceComputeTargetHttpsProxyRead(d *schema.ResourceData, meta interface{
 func resourceComputeTargetHttpsProxyDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Delete the TargetHttpsProxy
 	log.Printf("[DEBUG] TargetHttpsProxy delete request")
 	op, err := config.clientCompute.TargetHttpsProxies.Delete(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting TargetHttpsProxy: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_target_https_proxy.go
+++ b/builtin/providers/google/resource_compute_target_https_proxy.go
@@ -24,6 +24,17 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"ssl_certificates": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"url_map": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -38,17 +49,6 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 			"id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-
-			"url_map": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"ssl_certificates": &schema.Schema{
-				Type:     schema.TypeList,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"project": &schema.Schema{

--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -18,6 +18,12 @@ func resourceComputeTargetPool() *schema.Resource {
 		Update: resourceComputeTargetPoolUpdate,
 
 		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
 			"backup_pool": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -50,18 +56,7 @@ func resourceComputeTargetPool() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"session_affinity": &schema.Schema{
+			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -73,7 +68,12 @@ func resourceComputeTargetPool() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"project": &schema.Schema{
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"session_affinity": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,

--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -72,6 +72,12 @@ func resourceComputeTargetPool() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -85,11 +91,11 @@ func convertStringArr(ifaceArr []interface{}) []string {
 }
 
 // Healthchecks need to exist before being referred to from the target pool.
-func convertHealthChecks(config *Config, names []string) ([]string, error) {
+func convertHealthChecks(config *Config, project string, names []string) ([]string, error) {
 	urls := make([]string, len(names))
 	for i, name := range names {
 		// Look up the healthcheck
-		res, err := config.clientCompute.HttpHealthChecks.Get(config.Project, name).Do()
+		res, err := config.clientCompute.HttpHealthChecks.Get(project, name).Do()
 		if err != nil {
 			return nil, fmt.Errorf("Error reading HealthCheck: %s", err)
 		}
@@ -100,7 +106,7 @@ func convertHealthChecks(config *Config, names []string) ([]string, error) {
 
 // Instances do not need to exist yet, so we simply generate URLs.
 // Instances can be full URLS or zone/name
-func convertInstances(config *Config, names []string) ([]string, error) {
+func convertInstances(config *Config, project string, names []string) ([]string, error) {
 	urls := make([]string, len(names))
 	for i, name := range names {
 		if strings.HasPrefix(name, "https://www.googleapis.com/compute/v1/") {
@@ -112,7 +118,7 @@ func convertInstances(config *Config, names []string) ([]string, error) {
 			} else {
 				urls[i] = fmt.Sprintf(
 					"https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s",
-					config.Project, splitName[0], splitName[1])
+					project, splitName[0], splitName[1])
 			}
 		}
 	}
@@ -121,16 +127,25 @@ func convertInstances(config *Config, names []string) ([]string, error) {
 
 func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	region := getOptionalRegion(d, config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	hchkUrls, err := convertHealthChecks(
-		config, convertStringArr(d.Get("health_checks").([]interface{})))
+		config, project, convertStringArr(d.Get("health_checks").([]interface{})))
 	if err != nil {
 		return err
 	}
 
 	instanceUrls, err := convertInstances(
-		config, convertStringArr(d.Get("instances").([]interface{})))
+		config, project, convertStringArr(d.Get("instances").([]interface{})))
 	if err != nil {
 		return err
 	}
@@ -149,7 +164,7 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	log.Printf("[DEBUG] TargetPool insert request: %#v", tpool)
 	op, err := config.clientCompute.TargetPools.Insert(
-		config.Project, region, tpool).Do()
+		project, region, tpool).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating TargetPool: %s", err)
 	}
@@ -196,7 +211,16 @@ func calcAddRemove(from []string, to []string) ([]string, []string) {
 
 func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	region := getOptionalRegion(d, config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	d.Partial(true)
 
@@ -205,11 +229,11 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		from_, to_ := d.GetChange("health_checks")
 		from := convertStringArr(from_.([]interface{}))
 		to := convertStringArr(to_.([]interface{}))
-		fromUrls, err := convertHealthChecks(config, from)
+		fromUrls, err := convertHealthChecks(config, project, from)
 		if err != nil {
 			return err
 		}
-		toUrls, err := convertHealthChecks(config, to)
+		toUrls, err := convertHealthChecks(config, project, to)
 		if err != nil {
 			return err
 		}
@@ -222,7 +246,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			removeReq.HealthChecks[i] = &compute.HealthCheckReference{HealthCheck: v}
 		}
 		op, err := config.clientCompute.TargetPools.RemoveHealthCheck(
-			config.Project, region, d.Id(), removeReq).Do()
+			project, region, d.Id(), removeReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
@@ -238,7 +262,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			addReq.HealthChecks[i] = &compute.HealthCheckReference{HealthCheck: v}
 		}
 		op, err = config.clientCompute.TargetPools.AddHealthCheck(
-			config.Project, region, d.Id(), addReq).Do()
+			project, region, d.Id(), addReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
@@ -255,11 +279,11 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		from_, to_ := d.GetChange("instances")
 		from := convertStringArr(from_.([]interface{}))
 		to := convertStringArr(to_.([]interface{}))
-		fromUrls, err := convertInstances(config, from)
+		fromUrls, err := convertInstances(config, project, from)
 		if err != nil {
 			return err
 		}
-		toUrls, err := convertInstances(config, to)
+		toUrls, err := convertInstances(config, project, to)
 		if err != nil {
 			return err
 		}
@@ -272,7 +296,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			addReq.Instances[i] = &compute.InstanceReference{Instance: v}
 		}
 		op, err := config.clientCompute.TargetPools.AddInstance(
-			config.Project, region, d.Id(), addReq).Do()
+			project, region, d.Id(), addReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
@@ -288,7 +312,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			removeReq.Instances[i] = &compute.InstanceReference{Instance: v}
 		}
 		op, err = config.clientCompute.TargetPools.RemoveInstance(
-			config.Project, region, d.Id(), removeReq).Do()
+			project, region, d.Id(), removeReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
@@ -305,7 +329,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			Target: bpool_name,
 		}
 		op, err := config.clientCompute.TargetPools.SetBackup(
-			config.Project, region, d.Id(), tref).Do()
+			project, region, d.Id(), tref).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating backup_pool: %s", err)
 		}
@@ -324,10 +348,19 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	region := getOptionalRegion(d, config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	tpool, err := config.clientCompute.TargetPools.Get(
-		config.Project, region, d.Id()).Do()
+		project, region, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Target Pool %q because it's gone", d.Get("name").(string))
@@ -347,11 +380,20 @@ func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	region := getOptionalRegion(d, config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Delete the TargetPool
 	op, err := config.clientCompute.TargetPools.Delete(
-		config.Project, region, d.Id()).Do()
+		project, region, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting TargetPool: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_url_map.go
+++ b/builtin/providers/google/resource_compute_url_map.go
@@ -18,20 +18,15 @@ func resourceComputeUrlMap() *schema.Resource {
 		Delete: resourceComputeUrlMapDelete,
 
 		Schema: map[string]*schema.Schema{
+			"default_service": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-
-			"id": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"default_service": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
 			},
 
 			"description": &schema.Schema{
@@ -66,6 +61,11 @@ func resourceComputeUrlMap() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"path_matcher": &schema.Schema{
@@ -110,6 +110,12 @@ func resourceComputeUrlMap() *schema.Resource {
 				},
 			},
 
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -141,12 +147,6 @@ func resourceComputeUrlMap() *schema.Resource {
 						},
 					},
 				},
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_url_map.go
+++ b/builtin/providers/google/resource_compute_url_map.go
@@ -142,6 +142,12 @@ func resourceComputeUrlMap() *schema.Resource {
 					},
 				},
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -235,6 +241,11 @@ func createUrlMapTest(v interface{}) *compute.UrlMapTest {
 func resourceComputeUrlMapCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 	defaultService := d.Get("default_service").(string)
 
@@ -271,7 +282,7 @@ func resourceComputeUrlMapCreate(d *schema.ResourceData, meta interface{}) error
 		urlMap.Tests[i] = createUrlMapTest(v)
 	}
 
-	op, err := config.clientCompute.UrlMaps.Insert(config.Project, urlMap).Do()
+	op, err := config.clientCompute.UrlMaps.Insert(project, urlMap).Do()
 
 	if err != nil {
 		return fmt.Errorf("Error, failed to insert Url Map %s: %s", name, err)
@@ -289,9 +300,14 @@ func resourceComputeUrlMapCreate(d *schema.ResourceData, meta interface{}) error
 func resourceComputeUrlMapRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 
-	urlMap, err := config.clientCompute.UrlMaps.Get(config.Project, name).Do()
+	urlMap, err := config.clientCompute.UrlMaps.Get(project, name).Do()
 
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -425,8 +441,13 @@ func resourceComputeUrlMapRead(d *schema.ResourceData, meta interface{}) error {
 func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
-	urlMap, err := config.clientCompute.UrlMaps.Get(config.Project, name).Do()
+	urlMap, err := config.clientCompute.UrlMaps.Get(project, name).Do()
 	if err != nil {
 		return fmt.Errorf("Error, failed to get Url Map %s: %s", name, err)
 	}
@@ -624,7 +645,7 @@ func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error
 		urlMap.Tests = newTests
 	}
 
-	op, err := config.clientCompute.UrlMaps.Update(config.Project, urlMap.Name, urlMap).Do()
+	op, err := config.clientCompute.UrlMaps.Update(project, urlMap.Name, urlMap).Do()
 
 	if err != nil {
 		return fmt.Errorf("Error, failed to update Url Map %s: %s", name, err)
@@ -641,9 +662,15 @@ func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error
 
 func resourceComputeUrlMapDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 
-	op, err := config.clientCompute.UrlMaps.Delete(config.Project, name).Do()
+	op, err := config.clientCompute.UrlMaps.Delete(project, name).Do()
 
 	if err != nil {
 		return fmt.Errorf("Error, failed to delete Url Map %s: %s", name, err)

--- a/builtin/providers/google/resource_compute_vpn_gateway.go
+++ b/builtin/providers/google/resource_compute_vpn_gateway.go
@@ -34,14 +34,19 @@ func resourceComputeVpnGateway() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"self_link": &schema.Schema{
+			"project": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
 		},
 	}
@@ -50,10 +55,18 @@ func resourceComputeVpnGateway() *schema.Resource {
 func resourceComputeVpnGatewayCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 	network := d.Get("network").(string)
-	region := getOptionalRegion(d, config)
-	project := config.Project
 
 	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)
 
@@ -82,9 +95,17 @@ func resourceComputeVpnGatewayCreate(d *schema.ResourceData, meta interface{}) e
 func resourceComputeVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
-	region := getOptionalRegion(d, config)
-	project := config.Project
 
 	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)
 	vpnGateway, err := vpnGatewaysService.Get(project, region, name).Do()
@@ -110,9 +131,17 @@ func resourceComputeVpnGatewayRead(d *schema.ResourceData, meta interface{}) err
 func resourceComputeVpnGatewayDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
-	region := getOptionalRegion(d, config)
-	project := config.Project
 
 	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)
 

--- a/builtin/providers/google/resource_compute_vpn_gateway.go
+++ b/builtin/providers/google/resource_compute_vpn_gateway.go
@@ -24,29 +24,34 @@ func resourceComputeVpnGateway() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+
 			"network": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"self_link": &schema.Schema{
+
+			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"project": &schema.Schema{
+
+			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -31,11 +31,6 @@ func resourceComputeVpnTunnel() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"region": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 			"peer_ip": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -73,6 +68,16 @@ func resourceComputeVpnTunnel() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -80,13 +85,21 @@ func resourceComputeVpnTunnel() *schema.Resource {
 func resourceComputeVpnTunnelCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
-	region := getOptionalRegion(d, config)
 	peerIp := d.Get("peer_ip").(string)
 	sharedSecret := d.Get("shared_secret").(string)
 	targetVpnGateway := d.Get("target_vpn_gateway").(string)
 	ikeVersion := d.Get("ike_version").(int)
-	project := config.Project
 
 	if ikeVersion < 1 || ikeVersion > 2 {
 		return fmt.Errorf("Only IKE version 1 or 2 supported, not %d", ikeVersion)
@@ -132,9 +145,17 @@ func resourceComputeVpnTunnelCreate(d *schema.ResourceData, meta interface{}) er
 func resourceComputeVpnTunnelRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
-	region := getOptionalRegion(d, config)
-	project := config.Project
 
 	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)
 
@@ -162,9 +183,17 @@ func resourceComputeVpnTunnelRead(d *schema.ResourceData, meta interface{}) erro
 func resourceComputeVpnTunnelDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
-	region := getOptionalRegion(d, config)
-	project := config.Project
 
 	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)
 

--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -26,33 +26,44 @@ func resourceComputeVpnTunnel() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+
 			"peer_ip": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validatePeerAddr,
 			},
+
 			"shared_secret": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
 			"target_vpn_gateway": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"detailed_status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"ike_version": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  2,
 				ForceNew: true,
 			},
+
 			"local_traffic_selector": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -60,23 +71,22 @@ func resourceComputeVpnTunnel() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"detailed_status": &schema.Schema{
+
+			"project": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"project": &schema.Schema{
+
+			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -21,57 +21,9 @@ func resourceContainerCluster() *schema.Resource {
 		Delete: resourceContainerClusterDelete,
 
 		Schema: map[string]*schema.Schema{
-			"zone": &schema.Schema{
-				Type:     schema.TypeString,
+			"initial_node_count": &schema.Schema{
+				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
-			},
-
-			"node_version": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"cluster_ipv4_cidr": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					_, ipnet, err := net.ParseCIDR(value)
-
-					if err != nil || ipnet == nil || value != ipnet.String() {
-						errors = append(errors, fmt.Errorf(
-							"%q must contain a valid CIDR", k))
-					}
-					return
-				},
-			},
-
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"endpoint": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"logging_service": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"monitoring_service": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
 				ForceNew: true,
 			},
 
@@ -93,13 +45,11 @@ func resourceContainerCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-
 						"password": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
-
 						"username": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
@@ -134,6 +84,60 @@ func resourceContainerCluster() *schema.Resource {
 					}
 					return
 				},
+			},
+
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"cluster_ipv4_cidr": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					_, ipnet, err := net.ParseCIDR(value)
+
+					if err != nil || ipnet == nil || value != ipnet.String() {
+						errors = append(errors, fmt.Errorf(
+							"%q must contain a valid CIDR", k))
+					}
+					return
+				},
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"endpoint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"instance_group_urls": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"logging_service": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"monitoring_service": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"network": &schema.Schema{
@@ -184,16 +188,10 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-			"initial_node_count": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"instance_group_urls": &schema.Schema{
-				Type:     schema.TypeList,
+			"node_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"project": &schema.Schema{

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -195,12 +195,23 @@ func resourceContainerCluster() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	zoneName := d.Get("zone").(string)
 	clusterName := d.Get("name").(string)
@@ -273,7 +284,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	op, err := config.clientContainer.Projects.Zones.Clusters.Create(
-		config.Project, zoneName, req).Do()
+		project, zoneName, req).Do()
 	if err != nil {
 		return err
 	}
@@ -286,7 +297,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		MinTimeout: 3 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := config.clientContainer.Projects.Zones.Operations.Get(
-				config.Project, zoneName, op.Name).Do()
+				project, zoneName, op.Name).Do()
 			log.Printf("[DEBUG] Progress of creating GKE cluster %s: %s",
 				clusterName, resp.Status)
 			return resp, resp.Status, err
@@ -308,10 +319,15 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zoneName := d.Get("zone").(string)
 
 	cluster, err := config.clientContainer.Projects.Zones.Clusters.Get(
-		config.Project, zoneName, d.Get("name").(string)).Do()
+		project, zoneName, d.Get("name").(string)).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Container Cluster %q because it's gone", d.Get("name").(string))
@@ -355,6 +371,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zoneName := d.Get("zone").(string)
 	clusterName := d.Get("name").(string)
 	desiredNodeVersion := d.Get("node_version").(string)
@@ -365,7 +386,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		},
 	}
 	op, err := config.clientContainer.Projects.Zones.Clusters.Update(
-		config.Project, zoneName, clusterName, req).Do()
+		project, zoneName, clusterName, req).Do()
 	if err != nil {
 		return err
 	}
@@ -379,7 +400,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		Refresh: func() (interface{}, string, error) {
 			log.Printf("[DEBUG] Checking if GKE cluster %s is updated", clusterName)
 			resp, err := config.clientContainer.Projects.Zones.Operations.Get(
-				config.Project, zoneName, op.Name).Do()
+				project, zoneName, op.Name).Do()
 			log.Printf("[DEBUG] Progress of updating GKE cluster %s: %s",
 				clusterName, resp.Status)
 			return resp, resp.Status, err
@@ -400,12 +421,17 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zoneName := d.Get("zone").(string)
 	clusterName := d.Get("name").(string)
 
 	log.Printf("[DEBUG] Deleting GKE cluster %s", d.Get("name").(string))
 	op, err := config.clientContainer.Projects.Zones.Clusters.Delete(
-		config.Project, zoneName, clusterName).Do()
+		project, zoneName, clusterName).Do()
 	if err != nil {
 		return err
 	}
@@ -419,7 +445,7 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 		Refresh: func() (interface{}, string, error) {
 			log.Printf("[DEBUG] Checking if GKE cluster %s is deleted", clusterName)
 			resp, err := config.clientContainer.Projects.Zones.Operations.Get(
-				config.Project, zoneName, op.Name).Do()
+				project, zoneName, op.Name).Do()
 			log.Printf("[DEBUG] Progress of deleting GKE cluster %s: %s",
 				clusterName, resp.Status)
 			return resp, resp.Status, err

--- a/builtin/providers/google/resource_dns_managed_zone.go
+++ b/builtin/providers/google/resource_dns_managed_zone.go
@@ -44,12 +44,23 @@ func resourceDnsManagedZone() *schema.Resource {
 			},
 
 			// Google Cloud DNS ManagedZone resources do not have a SelfLink attribute.
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceDnsManagedZoneCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Build the parameter
 	zone := &dns.ManagedZone{
@@ -65,7 +76,7 @@ func resourceDnsManagedZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] DNS ManagedZone create request: %#v", zone)
-	zone, err := config.clientDns.ManagedZones.Create(config.Project, zone).Do()
+	zone, err = config.clientDns.ManagedZones.Create(project, zone).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating DNS ManagedZone: %s", err)
 	}
@@ -78,8 +89,13 @@ func resourceDnsManagedZoneCreate(d *schema.ResourceData, meta interface{}) erro
 func resourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone, err := config.clientDns.ManagedZones.Get(
-		config.Project, d.Id()).Do()
+		project, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing DNS Managed Zone %q because it's gone", d.Get("name").(string))
@@ -100,7 +116,12 @@ func resourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) error 
 func resourceDnsManagedZoneDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	err := config.clientDns.ManagedZones.Delete(config.Project, d.Id()).Do()
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	err = config.clientDns.ManagedZones.Delete(project, d.Id()).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting DNS ManagedZone: %s", err)
 	}

--- a/builtin/providers/google/resource_dns_managed_zone.go
+++ b/builtin/providers/google/resource_dns_managed_zone.go
@@ -16,13 +16,13 @@ func resourceDnsManagedZone() *schema.Resource {
 		Delete: resourceDnsManagedZoneDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"dns_name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"dns_name": &schema.Schema{
+			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,

--- a/builtin/providers/google/resource_dns_record_set.go
+++ b/builtin/providers/google/resource_dns_record_set.go
@@ -49,12 +49,23 @@ func resourceDnsRecordSet() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceDnsRecordSetCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	zone := d.Get("managed_zone").(string)
 
@@ -78,7 +89,7 @@ func resourceDnsRecordSetCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] DNS Record create request: %#v", chg)
-	chg, err := config.clientDns.Changes.Create(config.Project, zone, chg).Do()
+	chg, err = config.clientDns.Changes.Create(project, zone, chg).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating DNS RecordSet: %s", err)
 	}
@@ -88,7 +99,7 @@ func resourceDnsRecordSetCreate(d *schema.ResourceData, meta interface{}) error 
 	w := &DnsChangeWaiter{
 		Service:     config.clientDns,
 		Change:      chg,
-		Project:     config.Project,
+		Project:     project,
 		ManagedZone: zone,
 	}
 	state := w.Conf()
@@ -106,6 +117,11 @@ func resourceDnsRecordSetCreate(d *schema.ResourceData, meta interface{}) error 
 func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("managed_zone").(string)
 
 	// name and type are effectively the 'key'
@@ -113,7 +129,7 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	dnsType := d.Get("type").(string)
 
 	resp, err := config.clientDns.ResourceRecordSets.List(
-		config.Project, zone).Name(name).Type(dnsType).Do()
+		project, zone).Name(name).Type(dnsType).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing DNS Record Set %q because it's gone", d.Get("name").(string))
@@ -144,6 +160,11 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	zone := d.Get("managed_zone").(string)
 
 	rrdatasCount := d.Get("rrdatas.#").(int)
@@ -165,7 +186,7 @@ func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error 
 		chg.Deletions[0].Rrdatas[i] = d.Get(rrdata).(string)
 	}
 	log.Printf("[DEBUG] DNS Record delete request: %#v", chg)
-	chg, err := config.clientDns.Changes.Create(config.Project, zone, chg).Do()
+	chg, err = config.clientDns.Changes.Create(project, zone, chg).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting DNS RecordSet: %s", err)
 	}
@@ -173,7 +194,7 @@ func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error 
 	w := &DnsChangeWaiter{
 		Service:     config.clientDns,
 		Change:      chg,
-		Project:     config.Project,
+		Project:     project,
 		ManagedZone: zone,
 	}
 	state := w.Conf()

--- a/builtin/providers/google/resource_dns_record_set.go
+++ b/builtin/providers/google/resource_dns_record_set.go
@@ -17,26 +17,14 @@ func resourceDnsRecordSet() *schema.Resource {
 		Delete: resourceDnsRecordSetDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"managed_zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"type": &schema.Schema{
+			"name": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"ttl": &schema.Schema{
-				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
@@ -48,6 +36,18 @@ func resourceDnsRecordSet() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"project": &schema.Schema{

--- a/builtin/providers/google/resource_pubsub_subscription.go
+++ b/builtin/providers/google/resource_pubsub_subscription.go
@@ -20,8 +20,20 @@ func resourcePubsubSubscription() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"topic": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
 			"ack_deadline_seconds": &schema.Schema{
 				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -46,18 +58,6 @@ func resourcePubsubSubscription() *schema.Resource {
 						},
 					},
 				},
-			},
-
-			"topic": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_pubsub_subscription.go
+++ b/builtin/providers/google/resource_pubsub_subscription.go
@@ -53,6 +53,12 @@ func resourcePubsubSubscription() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -68,8 +74,13 @@ func cleanAdditionalArgs(args map[string]interface{}) map[string]string {
 func resourcePubsubSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	name := fmt.Sprintf("projects/%s/subscriptions/%s", config.Project, d.Get("name").(string))
-	computed_topic_name := fmt.Sprintf("projects/%s/topics/%s", config.Project, d.Get("topic").(string))
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("projects/%s/subscriptions/%s", project, d.Get("name").(string))
+	computed_topic_name := fmt.Sprintf("projects/%s/topics/%s", project, d.Get("topic").(string))
 
 	//  process optional parameters
 	var ackDeadlineSeconds int64

--- a/builtin/providers/google/resource_pubsub_topic.go
+++ b/builtin/providers/google/resource_pubsub_topic.go
@@ -19,6 +19,12 @@ func resourcePubsubTopic() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -26,7 +32,12 @@ func resourcePubsubTopic() *schema.Resource {
 func resourcePubsubTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	name := fmt.Sprintf("projects/%s/topics/%s", config.Project, d.Get("name").(string))
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("projects/%s/topics/%s", project, d.Get("name").(string))
 	topic := &pubsub.Topic{}
 
 	call := config.clientPubsub.Projects.Topics.Create(name, topic)

--- a/builtin/providers/google/resource_sql_database.go
+++ b/builtin/providers/google/resource_sql_database.go
@@ -22,19 +22,22 @@ func resourceSqlDatabase() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
 			"instance": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_sql_database.go
+++ b/builtin/providers/google/resource_sql_database.go
@@ -31,6 +31,11 @@ func resourceSqlDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -38,9 +43,13 @@ func resourceSqlDatabase() *schema.Resource {
 func resourceSqlDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	database_name := d.Get("name").(string)
 	instance_name := d.Get("instance").(string)
-	project := config.Project
 
 	db := &sqladmin.Database{
 		Name:     database_name,
@@ -69,9 +78,13 @@ func resourceSqlDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	database_name := d.Get("name").(string)
 	instance_name := d.Get("instance").(string)
-	project := config.Project
 
 	db, err := config.clientSqlAdmin.Databases.Get(project, instance_name,
 		database_name).Do()
@@ -99,9 +112,13 @@ func resourceSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 func resourceSqlDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	database_name := d.Get("name").(string)
 	instance_name := d.Get("instance").(string)
-	project := config.Project
 
 	op, err := config.clientSqlAdmin.Databases.Delete(project, instance_name,
 		database_name).Do()

--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -19,32 +19,12 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 		Delete: resourceSqlDatabaseInstanceDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"master_instance_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"database_version": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "MYSQL_5_5",
-				ForceNew: true,
-			},
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+
 			"settings": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
@@ -170,6 +150,14 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 					},
 				},
 			},
+
+			"database_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "MYSQL_5_5",
+				ForceNew: true,
+			},
+
 			"ip_address": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
@@ -187,6 +175,26 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 					},
 				},
 			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"master_instance_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"replica_configuration": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -246,10 +254,9 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 				},
 			},
 
-			"project": &schema.Schema{
+			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_sql_user.go
+++ b/builtin/providers/google/resource_sql_user.go
@@ -40,6 +40,12 @@ func resourceSqlUser() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -47,11 +53,15 @@ func resourceSqlUser() *schema.Resource {
 func resourceSqlUserCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 	instance := d.Get("instance").(string)
 	password := d.Get("password").(string)
 	host := d.Get("host").(string)
-	project := config.Project
 
 	user := &sqladmin.User{
 		Name:     name,
@@ -81,9 +91,13 @@ func resourceSqlUserCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 	instance := d.Get("instance").(string)
-	project := config.Project
 
 	users, err := config.clientSqlAdmin.Users.List(project, instance).Do()
 
@@ -122,11 +136,15 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	if d.HasChange("password") {
+		project, err := getProject(d, config)
+		if err != nil {
+			return err
+		}
+
 		name := d.Get("name").(string)
 		instance := d.Get("instance").(string)
 		host := d.Get("host").(string)
 		password := d.Get("password").(string)
-		project := config.Project
 
 		user := &sqladmin.User{
 			Name:     name,
@@ -159,10 +177,14 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceSqlUserDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 	instance := d.Get("instance").(string)
 	host := d.Get("host").(string)
-	project := config.Project
 
 	op, err := config.clientSqlAdmin.Users.Delete(project, instance, host, name).Do()
 

--- a/builtin/providers/google/resource_sql_user.go
+++ b/builtin/providers/google/resource_sql_user.go
@@ -18,17 +18,6 @@ func resourceSqlUser() *schema.Resource {
 		Delete: resourceSqlUserDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"password": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
 			"host": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -39,6 +28,17 @@ func resourceSqlUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
 			},
 
 			"project": &schema.Schema{

--- a/builtin/providers/google/resource_storage_bucket.go
+++ b/builtin/providers/google/resource_storage_bucket.go
@@ -24,23 +24,38 @@ func resourceStorageBucket() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"predefined_acl": &schema.Schema{
-				Type:       schema.TypeString,
-				Deprecated: "Please use resource \"storage_bucket_acl.predefined_acl\" instead.",
-				Optional:   true,
-				ForceNew:   true,
+
+			"force_destroy": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
+
 			"location": &schema.Schema{
 				Type:     schema.TypeString,
 				Default:  "US",
 				Optional: true,
 				ForceNew: true,
 			},
-			"force_destroy": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+
+			"predefined_acl": &schema.Schema{
+				Type:       schema.TypeString,
+				Deprecated: "Please use resource \"storage_bucket_acl.predefined_acl\" instead.",
+				Optional:   true,
+				ForceNew:   true,
 			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"website": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -56,15 +71,6 @@ func resourceStorageBucket() *schema.Resource {
 						},
 					},
 				},
-			},
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"project": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_storage_bucket.go
+++ b/builtin/providers/google/resource_storage_bucket.go
@@ -61,12 +61,22 @@ func resourceStorageBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
 
 func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
 
 	// Get the bucket and acl
 	bucket := d.Get("name").(string)
@@ -95,7 +105,7 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	call := config.clientStorage.Buckets.Insert(config.Project, sb)
+	call := config.clientStorage.Buckets.Insert(project, sb)
 	if v, ok := d.GetOk("predefined_acl"); ok {
 		call = call.PredefinedAcl(v.(string))
 	}

--- a/builtin/providers/google/resource_storage_bucket_acl.go
+++ b/builtin/providers/google/resource_storage_bucket_acl.go
@@ -24,19 +24,22 @@ func resourceStorageBucketAcl() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"default_acl": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"predefined_acl": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
+
 			"role_entity": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"default_acl": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_storage_bucket_object.go
+++ b/builtin/providers/google/resource_storage_bucket_object.go
@@ -32,18 +32,21 @@ func resourceStorageBucketObject() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"source": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"content"},
-			},
-
 			"content": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"source"},
+			},
+
+			"crc32c": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"md5hash": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"predefined_acl": &schema.Schema{
@@ -53,14 +56,11 @@ func resourceStorageBucketObject() *schema.Resource {
 				ForceNew:   true,
 			},
 
-			"md5hash": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"crc32c": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
+			"source": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"content"},
 			},
 		},
 	}

--- a/builtin/providers/google/resource_storage_object_acl.go
+++ b/builtin/providers/google/resource_storage_object_acl.go
@@ -23,20 +23,23 @@ func resourceStorageObjectAcl() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
 			"object": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"role_entity": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+
 			"predefined_acl": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"role_entity": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -42,11 +42,14 @@ The following keys can be used to configure the provider.
   can also be specified with the `GOOGLE_CREDENTIALS` or `GOOGLE_CLOUD_KEYFILE_JSON`
   shell environment variable, containing the contents of the credentials file.
 
-* `project` - (Required) The ID of the project to apply any resources to.  This
-  can also be specified with the `GOOGLE_PROJECT` shell environment variable.
-
 * `region` - (Required) The region to operate under. This can also be specified
   with the `GOOGLE_REGION` shell environment variable.
+
+* `project` - (Optional) The ID of the project to apply resources in. This
+  can also be specified with the `GOOGLE_PROJECT` shell environment variable.
+  If unspecified, users will need to specify the `project` attribute for
+  all resources. If specified, resources which do not depend on a project will
+  ignore this value.
 
 The following keys are supported for backwards compatibility, and may be
 removed in a future version:

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -16,17 +16,17 @@ Use the navigation to the left to read about the available resources.
 
 ## Example Usage
 
-```
-# Configure the Google Cloud provider
+```js
+// Configure the Google Cloud provider
 provider "google" {
   credentials = "${file("account.json")}"
   project     = "my-gce-project"
   region      = "us-central1"
 }
 
-# Create a new instance
+// Create a new instance
 resource "google_compute_instance" "default" {
-  ...
+  // ...
 }
 ```
 

--- a/website/source/docs/providers/google/r/compute_address.html.markdown
+++ b/website/source/docs/providers/google/r/compute_address.html.markdown
@@ -8,16 +8,16 @@ description: |-
 
 # google\_compute\_address
 
-Creates a static IP address resource for Google Compute Engine.  For more information see
+Creates a static IP address resource for Google Compute Engine. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instances-and-network) and
 [API](https://cloud.google.com/compute/docs/reference/latest/addresses).
 
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_address" "default" {
-	name = "test-address"
+  name = "test-address"
 }
 ```
 
@@ -27,14 +27,18 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
 * `region` - (Optional) The Region in which the created address should reside.
     If it is not provided, the provider region is used.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `address` - The IP address that was allocated.
 * `self_link` - The URI of the created resource.
-* `region` - The Region in which the created address does reside.

--- a/website/source/docs/providers/google/r/compute_autoscaler.html.markdown
+++ b/website/source/docs/providers/google/r/compute_autoscaler.html.markdown
@@ -12,7 +12,7 @@ A Compute Engine Autoscaler automatically adds or removes virtual machines from
 a managed instance group based on increases or decreases in load. This allows
 your applications to gracefully handle increases in traffic and reduces cost
 when the need for resources is lower. You just define the autoscaling policy and
-the autoscaler performs automatic scaling based on the measured load.  For more
+the autoscaler performs automatic scaling based on the measured load. For more
 information, see [the official
 documentation](https://cloud.google.com/compute/docs/autoscaler/) and
 [API](https://cloud.google.com/compute/docs/autoscaler/v1beta2/autoscalers)
@@ -20,54 +20,58 @@ documentation](https://cloud.google.com/compute/docs/autoscaler/) and
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_instance_template" "foobar" {
-    name = "foobar"
-    machine_type = "n1-standard-1"
-    can_ip_forward = false
-    tags = ["foo", "bar"]
+  name           = "foobar"
+  machine_type   = "n1-standard-1"
+  can_ip_forward = false
 
-    disk {
-        source_image = "debian-cloud/debian-7-wheezy-v20160301"
-    }
+  tags = ["foo", "bar"]
 
-    network_interface {
-        network = "default"
-    }
+  disk {
+    source_image = "debian-cloud/debian-7-wheezy-v20160301"
+  }
 
-    metadata {
-        foo = "bar"
-    }
+  network_interface {
+    network = "default"
+  }
 
-    service_account {
-        scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-    }
+  metadata {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
 }
 
 resource "google_compute_target_pool" "foobar" {
-    name = "foobar"
+  name = "foobar"
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
-    name = "foobar"
-    instance_template = "${google_compute_instance_template.foobar.self_link}"
-    target_pools = ["${google_compute_target_pool.foobar.self_link}"]
-    base_instance_name = "foobar"
-    zone = "us-central1-f"
+  name = "foobar"
+  zone = "us-central1-f"
+
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
+  base_instance_name = "foobar"
 }
 
 resource "google_compute_autoscaler" "foobar" {
-    name = "foobar"
-    zone = "us-central1-f"
-    target = "${google_compute_instance_group_manager.foobar.self_link}"
-    autoscaling_policy = {
-        max_replicas = 5
-        min_replicas = 1
-        cooldown_period = 60
-        cpu_utilization = {
-            target = 0.5
-        }
+  name   = "foobar"
+  zone   = "us-central1-f"
+  target = "${google_compute_instance_group_manager.foobar.self_link}"
+
+  autoscaling_policy = {
+    max_replicas    = 5
+    min_replicas    = 1
+    cooldown_period = 60
+
+    cpu_utilization {
+      target = 0.5
     }
+  }
 }
 ```
 
@@ -75,16 +79,23 @@ resource "google_compute_autoscaler" "foobar" {
 
 The following arguments are supported:
 
-* `description` - (Optional) An optional textual description of the instance
-group manager.
+* `name` - (Required) The name of the autoscaler.
 
 * `target` - (Required) The full URL to the instance group manager whose size we
   control.
 
-* `autoscaling_policy.` - (Required) The parameters of the autoscaling
-  algorithm.  Structure is documented below.
-
 * `zone` - (Required) The zone of the target.
+
+* `autoscaling_policy.` - (Required) The parameters of the autoscaling
+  algorithm. Structure is documented below.
+
+- - -
+
+* `description` - (Optional) An optional textual description of the instance
+    group manager.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 The `autoscaling_policy` block contains:
 
@@ -92,22 +103,22 @@ The `autoscaling_policy` block contains:
 
 * `min_replicas` - (Required) The group will never be smaller than this.
 
-* `cooldown_period` - (Optional) Period to wait between changes.  This should be
+* `cooldown_period` - (Optional) Period to wait between changes. This should be
   at least double the time your instances take to start up.
 
 * `cpu_utilization` - (Optional) A policy that scales when the cluster's average
-  CPU is above or below a given threshold.  Structure is documented below.
+  CPU is above or below a given threshold. Structure is documented below.
 
 * `metric` - (Optional) A policy that scales according to Google Cloud
   Monitoring metrics  Structure is documented below.
 
 * `load_balancing_utilization` - (Optional) A policy that scales when the load
-  reaches a proportion of a limit defined in the HTTP load balancer.  Structure
+  reaches a proportion of a limit defined in the HTTP load balancer. Structure
 is documented below.
 
 The `cpu_utilization` block contains:
 
-* `target` - The floating point threshold where CPU utilization should be.  E.g.
+* `target` - The floating point threshold where CPU utilization should be. E.g.
   for 50% one would specify 0.5.
 
 The `metric` block contains (more documentation
@@ -118,18 +129,19 @@ The `metric` block contains (more documentation
 
 * `type` - Either "cumulative", "delta", or "gauge".
 
-* `target` - The desired metric value per instance.  Must be a positive value.
+* `target` - The desired metric value per instance. Must be a positive value.
 
 The `load_balancing_utilization` block contains:
 
 * `target` - The floating point threshold where load balancing utilization
-  should be.  E.g. if the load balancer's `maxRatePerInstance` is 10 requests
+  should be. E.g. if the load balancer's `maxRatePerInstance` is 10 requests
   per second (RPS) then setting this to 0.5 would cause the group to be scaled
   such that each instance receives 5 RPS.
 
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
 * `self_link` - The URL of the created resource.

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -12,50 +12,49 @@ A Backend Service defines a group of virtual machines that will serve traffic fo
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_backend_service" "foobar" {
-    name = "blablah"
-    description = "Hello World 1234"
-    port_name = "http"
-    protocol = "HTTP"
-    timeout_sec = 10
-    region = "us-central1"
+  name        = "blablah"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
 
-    backend {
-        group = "${google_compute_instance_group_manager.foo.instance_group}"
-    }
+  backend {
+    group = "${google_compute_instance_group_manager.foo.instance_group}"
+  }
 
-    health_checks = ["${google_compute_http_health_check.default.self_link}"]
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
 }
 
 resource "google_compute_instance_group_manager" "foo" {
-    name = "terraform-test"
-    instance_template = "${google_compute_instance_template.foobar.self_link}"
-    base_instance_name = "foobar"
-    zone = "us-central1-f"
-    target_size = 1
+  name               = "terraform-test"
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  base_instance_name = "foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
 }
 
 resource "google_compute_instance_template" "foobar" {
-    name = "terraform-test"
-    machine_type = "n1-standard-1"
+  name         = "terraform-test"
+  machine_type = "n1-standard-1"
 
-    network_interface {
-        network = "default"
-    }
+  network_interface {
+    network = "default"
+  }
 
-    disk {
-        source_image = "debian-7-wheezy-v20160301"
-        auto_delete = true
-        boot = true
-    }
+  disk {
+    source_image = "debian-7-wheezy-v20160301"
+    auto_delete  = true
+    boot         = true
+  }
 }
 
 resource "google_compute_http_health_check" "default" {
-    name = "test"
-    request_path = "/"
-    check_interval_sec = 1
-    timeout_sec = 1
+  name               = "test"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
 }
 ```
 
@@ -64,31 +63,64 @@ resource "google_compute_http_health_check" "default" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the backend service.
+
 * `health_checks` - (Required) Specifies a list of HTTP health check objects
     for checking the health of the backend service.
+
+- - -
+
+* `backend` - (Optional) The list of backends that serve this BackendService.
+    See *Backend* below.
+
 * `description` - (Optional) The textual description for the backend service.
-* `backend` - (Optional) The list of backends that serve this BackendService. See *Backend* below.
-* `region` - (Optional) The region the service sits in. If not specified, the project region is used.
-* `port_name` - (Optional) The name of a service that has been added to
-	an instance group in this backend. See [related docs](https://cloud.google.com/compute/docs/instance-groups/#specifying_service_endpoints)
-    for details. Defaults to http.
-* `protocol` - (Optional) The protocol for incoming requests. Defaults to `HTTP`.
+
+* `port_name` - (Optional) The name of a service that has been added to an
+    instance group in this backend. See [related docs](https://cloud.google.com/compute/docs/instance-groups/#specifying_service_endpoints) for details. Defaults to http.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `protocol` - (Optional) The protocol for incoming requests. Defaults to
+    `HTTP`.
+
+* `region` - (Optional) The Region in which the created address should reside.
+    If it is not provided, the provider region is used.
+
 * `timeout_sec` - (Optional) The number of secs to wait for a backend to respond
-	to a request before considering the request failed. Defaults to `30`.
+    to a request before considering the request failed. Defaults to `30`.
+
 
 **Backend** supports the following attributes:
 
-* `group` - (Required) The name or URI of a Compute Engine instance group (`google_compute_instance_group_manager.xyz.instance_group`) that can receive traffic.
-* `balancing_mode` - (Optional) Defines the strategy for balancing load. Defaults to `UTILIZATION`
-* `capacity_scaler` - (Optional) A float in the range [0, 1.0] that scales the maximum parameters for the group (e.g., max rate). A value of 0.0 will cause no requests to be sent to the group (i.e., it adds the group in a drained state). The default is 1.0.
+* `group` - (Required) The name or URI of a Compute Engine instance group
+    (`google_compute_instance_group_manager.xyz.instance_group`) that can
+    receive traffic.
+
+* `balancing_mode` - (Optional) Defines the strategy for balancing load.
+    Defaults to `UTILIZATION`
+
+* `capacity_scaler` - (Optional) A float in the range [0, 1.0] that scales the
+    maximum parameters for the group (e.g., max rate). A value of 0.0 will cause
+    no requests to be sent to the group (i.e., it adds the group in a drained
+    state). The default is 1.0.
+
 * `description` - (Optional) Textual description for the backend.
-* `max_rate` - (Optional) Maximum requests per second (RPS) that the group can handle.
-* `max_rate_per_instance` - (Optional) The maximum per-instance requests per second (RPS).
-* `max_utilization` - (Optional) The target CPU utilization for the group as a float in the range [0.0, 1.0]. This flag can only be provided when the balancing mode is `UTILIZATION`. Defaults to `0.8`.
+
+* `max_rate` - (Optional) Maximum requests per second (RPS) that the group can
+    handle.
+
+* `max_rate_per_instance` - (Optional) The maximum per-instance requests per
+    second (RPS).
+
+* `max_utilization` - (Optional) The target CPU utilization for the group as a
+    float in the range [0.0, 1.0]. This flag can only be provided when the
+    balancing mode is `UTILIZATION`. Defaults to `0.8`.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
+* `fingerprint` - The fingerprint of the backend service.
+
 * `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_disk.html.markdown
+++ b/website/source/docs/providers/google/r/compute_disk.html.markdown
@@ -12,12 +12,12 @@ Creates a new persistent disk within GCE, based on another disk.
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_disk" "default" {
-	name = "test-disk"
-	type = "pd-ssd"
-	zone = "us-central1-a"
-	image = "debian7-wheezy"
+  name  = "test-disk"
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  image = "debian7-wheezy"
 }
 ```
 
@@ -30,22 +30,25 @@ The following arguments are supported:
 
 * `zone` - (Required) The zone where this disk will be available.
 
-* `image` - (Optional) The image from which to initialize this disk.  Either the full URL, a
-  contraction of the form "project/name", or just a name (in which case the current project is
-used).
+- - -
 
-* `snapshot` - (Optional) Name of snapshot from which to initialize this disk;
+* `image` - (Optional) The image from which to initialize this disk. Either the
+    full URL, a contraction of the form "project/name", or just a name (in which
+    case the current project is used).
 
-* `size` - (Optional) The size of the image in gigabytes. If not specified,
-    it will inherit the size of its base image.
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `size` - (Optional) The size of the image in gigabytes. If not specified, it
+    will inherit the size of its base image.
+
+* `snapshot` - (Optional) Name of snapshot from which to initialize this disk.
 
 * `type` - (Optional) The GCE disk type.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `zone` - The zone where the resource is located.
-* `image` - The name of the image the disk is based off of.
-* `size` - The size of the disk in gigabytes.
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_firewall.html.markdown
+++ b/website/source/docs/providers/google/r/compute_firewall.html.markdown
@@ -12,21 +12,21 @@ Manages a firewall resource within GCE.
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_firewall" "default" {
-	name = "test"
-	network = "${google_compute_network.other.name}"
+  name    = "test"
+  network = "${google_compute_network.other.name}"
 
-	allow {
-		protocol = "icmp"
-	}
+  allow {
+    protocol = "icmp"
+  }
 
-	allow {
-		protocol = "tcp"
-		ports = ["80", "8080", "1000-2000"]
-	}
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "8080", "1000-2000"]
+  }
 
-	source_tags = ["web"]
+  source_tags = ["web"]
 }
 ```
 
@@ -37,19 +37,24 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `description` - (Optional) Textual description field.
-
 * `network` - (Required) The name of the network to attach this firewall to.
 
 * `allow` - (Required) Can be specified multiple times for each allow
     rule. Each allow block supports fields documented below.
 
+- - -
+
+* `description` - (Optional) Textual description field.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
 * `source_ranges` - (Optional) A list of source CIDR ranges that this
    firewall applies to.
 
-* `source_tags` - (Optional) A list of source tags that this firewall applies to.
+* `source_tags` - (Optional) A list of source tags for this firewall.
 
-* `target_tags` - (Optional) A list of target tags that this firewall applies to.
+* `target_tags` - (Optional) A list of target tags for this firewall.
 
 The `allow` block supports:
 
@@ -60,9 +65,7 @@ The `allow` block supports:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `network` - The network that this resource is attached to.
-* `source_ranges` - The CIDR block ranges this firewall applies to.
-* `source_tags` - The tags that this firewall applies to.
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_forwarding_rule.html.markdown
+++ b/website/source/docs/providers/google/r/compute_forwarding_rule.html.markdown
@@ -8,18 +8,18 @@ description: |-
 
 # google\_compute\_forwarding\_rule
 
-Manages a Forwarding Rule within GCE.  This binds an ip and port range to a target pool.  For more
+Manages a Forwarding Rule within GCE. This binds an ip and port range to a target pool. For more
 information see [the official
 documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules) and
 [API](https://cloud.google.com/compute/docs/reference/latest/forwardingRules).
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_forwarding_rule" "default" {
-	name = "test"
-	target = "${google_compute_target_pool.default.self_link}"
-	port_range = "80"
+  name       = "test"
+  target     = "${google_compute_target_pool.default.self_link}"
+  port_range = "80"
 }
 ```
 
@@ -27,27 +27,33 @@ resource "google_compute_forwarding_rule" "default" {
 
 The following arguments are supported:
 
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+* `target` - (Required) URL of target pool.
+
+- - -
+
 * `description` - (Optional) Textual description field.
 
 * `ip_address` - (Optional) The static IP. (if not set, an ephemeral IP is
-used).
+    used).
 
-* `ip_protocol` - (Optional) The IP protocol to route, one of "TCP" "UDP" "AH" "ESP" or "SCTP". (default "TCP").
-
-* `name` - (Required) A unique name for the resource, required by GCE.  Changing
-  this forces a new resource to be created.
+* `ip_protocol` - (Optional) The IP protocol to route, one of "TCP" "UDP" "AH"
+    "ESP" or "SCTP". (default "TCP").
 
 * `port_range` - (Optional) A range e.g. "1024-2048" or a single port "1024"
-(defaults to all ports!).
+    (defaults to all ports!).
 
-* `target` - URL of target pool.
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The Region in which the created address should reside.
+    If it is not provided, the provider region is used.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `self_link` - The URL of the created resource.
-
-* `ip_address` - The IP address that was chosen (or specified).
-
-
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_global_address.html.markdown
+++ b/website/source/docs/providers/google/r/compute_global_address.html.markdown
@@ -15,9 +15,9 @@ Creates a static IP address resource global to a Google Compute Engine project. 
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_global_address" "default" {
-	name = "test-address"
+  name = "test-address"
 }
 ```
 
@@ -28,10 +28,16 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+is not provided, the provider project is used.
+
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `address` - The IP address that was allocated.
+* `address` - The assigned address.
+
 * `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_global_forwarding_rule.html.markdown
+++ b/website/source/docs/providers/google/r/compute_global_forwarding_rule.html.markdown
@@ -1,68 +1,67 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_global_forwarding_rule"
-sidebar_current: "docs-google-compute-global-forwarding_rule"
+sidebar_current: "docs-google-compute-global-forwarding-rule"
 description: |-
   Manages a Target Pool within GCE.
 ---
 
 # google\_compute\_global\_forwarding\_rule
 
-Manages a Global Forwarding Rule within GCE.  This binds an ip and port to a target HTTP(s) proxy.  For more
+Manages a Global Forwarding Rule within GCE. This binds an ip and port to a target HTTP(s) proxy. For more
 information see [the official
 documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules) and
 [API](https://cloud.google.com/compute/docs/reference/latest/globalForwardingRules).
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_global_forwarding_rule" "default" {
-    name = "test"
-    target = "${google_compute_target_http_proxy.default.self_link}"
-    port_range = "80"
+  name       = "test"
+  target     = "${google_compute_target_http_proxy.default.self_link}"
+  port_range = "80"
 }
 
 resource "google_compute_target_http_proxy" "default" {
-    name = "test-proxy"
-    description = "a description"
-    url_map = "${google_compute_url_map.default.self_link}"
+  name        = "test-proxy"
+  description = "a description"
+  url_map     = "${google_compute_url_map.default.self_link}"
 }
 
 resource "google_compute_url_map" "default" {
-    name = "url-map"
-    description = "a description"
+  name            = "url-map"
+  description     = "a description"
+  default_service = "${google_compute_backend_service.default.self_link}"
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
     default_service = "${google_compute_backend_service.default.self_link}"
-
-    host_rule {
-        hosts = ["mysite.com"]
-        path_matcher = "allpaths"
+    path_rule {
+      paths   = ["/*"]
+      service = "${google_compute_backend_service.default.self_link}"
     }
-
-    path_matcher {
-        default_service = "${google_compute_backend_service.default.self_link}"
-        name = "allpaths"
-        path_rule {
-            paths = ["/*"]
-            service = "${google_compute_backend_service.default.self_link}"
-        }
-    }
+  }
 }
 
 resource "google_compute_backend_service" "default" {
-    name = "default-backend"
-    port_name = "http"
-    protocol = "HTTP"
-    timeout_sec = 10
-    region = "us-central1"
+  name        = "default-backend"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
 
-    health_checks = ["${google_compute_http_health_check.default.self_link}"]
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
 }
 
 resource "google_compute_http_health_check" "default" {
-    name = "test"
-    request_path = "/"
-    check_interval_sec = 1
-    timeout_sec = 1
+  name               = "test"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
 }
 ```
 
@@ -70,24 +69,30 @@ resource "google_compute_http_health_check" "default" {
 
 The following arguments are supported:
 
-* `description` - (Optional) Textual description field.
-
-* `ip_address` - (Optional) The static IP. (if not set, an ephemeral IP is used).
-
-* `ip_protocol` - (Optional) The IP protocol to route, one of "TCP" "UDP" "AH" "ESP" or "SCTP". (default "TCP").
-
-* `name` - (Required) A unique name for the resource, required by GCE.  Changing
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
   this forces a new resource to be created.
 
-* `port_range` - (Optional) A range e.g. "1024-2048" or a single port "1024"
-  (defaults to all ports!).
+* `target` - (Required) URL of target HTTP or HTTPS proxy.
 
-* `target` - URL of target HTTP or HTTPS proxy.
+- - -
+
+* `description` - (Optional) Textual description field.
+
+* `ip_address` - (Optional) The static IP. (if not set, an ephemeral IP is
+    used).
+
+* `ip_protocol` - (Optional) The IP protocol to route, one of "TCP" "UDP" "AH"
+    "ESP" or "SCTP". (default "TCP").
+
+* `port_range` - (Optional) A range e.g. "1024-2048" or a single port "1024"
+    (defaults to all ports!).
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `self_link` - The URL of the created resource.
-
-* `ip_address` - The IP address that was chosen (or specified).
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_http_health_check.html.markdown
+++ b/website/source/docs/providers/google/r/compute_http_health_check.html.markdown
@@ -8,21 +8,22 @@ description: |-
 
 # google\_compute\_http\_health\_check
 
-Manages an HTTP health check within GCE.  This is used to monitor instances
-behind load balancers.  Timeouts or HTTP errors cause the instance to be
-removed from the pool.  For more information, see [the official
+Manages an HTTP health check within GCE. This is used to monitor instances
+behind load balancers. Timeouts or HTTP errors cause the instance to be
+removed from the pool. For more information, see [the official
 documentation](https://cloud.google.com/compute/docs/load-balancing/health-checks)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/httpHealthChecks).
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_http_health_check" "default" {
-	name = "test"
-    request_path = "/health_check"
-    check_interval_sec = 1
-    timeout_sec = 1
+  name         = "test"
+  request_path = "/health_check"
+
+  timeout_sec        = 1
+  check_interval_sec = 1
 }
 ```
 
@@ -30,7 +31,13 @@ resource "google_compute_http_health_check" "default" {
 
 The following arguments are supported:
 
-* `check_interval_sec` - (Optional) How often to poll each instance (default 5).
+* `name` - (Required) A unique name for the resource, required by GCE.
+    Changing this forces a new resource to be created.
+
+- - -
+
+* `check_interval_sec` - (Optional) The number of seconds between each poll of
+    the instance instance (default 5).
 
 * `description` - (Optional) Textual description field.
 
@@ -38,20 +45,22 @@ The following arguments are supported:
 
 * `host` - (Optional) HTTP host header field (default instance's public ip).
 
-* `name` - (Required) A unique name for the resource, required by GCE.
-    Changing this forces a new resource to be created.
-
 * `port` - (Optional) TCP port to connect to (default 80).
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 * `request_path` - (Optional) URL path to query (default /).
 
-* `timeout_sec` - (Optional) How long before declaring failure (default 5).
+* `timeout_sec` - (Optional) The number of seconds to wait before declaring
+    failure (default 5).
 
 * `unhealthy_threshold` - (Optional) Consecutive failures required (default 2).
 
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `self_link` - The URL of the created resource.
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_https_health_check.html.markdown
+++ b/website/source/docs/providers/google/r/compute_https_health_check.html.markdown
@@ -8,27 +8,33 @@ description: |-
 
 # google\_compute\_https\_health\_check
 
-Manages an HTTPS health check within GCE.  This is used to monitor instances
-behind load balancers.  Timeouts or HTTPS errors cause the instance to be
-removed from the pool.  For more information, see [the official
+Manages an HTTPS health check within GCE. This is used to monitor instances
+behind load balancers. Timeouts or HTTPS errors cause the instance to be
+removed from the pool. For more information, see [the official
 documentation](https://cloud.google.com/compute/docs/load-balancing/health-checks)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/httpsHealthChecks).
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_https_health_check" "default" {
-	name = "test"
-    request_path = "/health_check"
-    check_interval_sec = 1
-    timeout_sec = 1
+  name         = "test"
+  request_path = "/health_check"
+
+  timeout_sec        = 1
+  check_interval_sec = 1
 }
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+- - -
 
 * `check_interval_sec` - (Optional) How often to poll each instance (default 5).
 
@@ -38,10 +44,10 @@ The following arguments are supported:
 
 * `host` - (Optional) HTTPS host header field (default instance's public ip).
 
-* `name` - (Required) A unique name for the resource, required by GCE.
-    Changing this forces a new resource to be created.
-
 * `port` - (Optional) TCP port to connect to (default 443).
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 * `request_path` - (Optional) URL path to query (default /).
 

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # google\_compute\_instance
 
-Manages a VM instance resource within GCE.  For more information see
+Manages a VM instance resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instances)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/instances).
@@ -16,39 +16,40 @@ and
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_instance" "default" {
-	name = "test"
-	machine_type = "n1-standard-1"
-	zone = "us-central1-a"
-	tags = ["foo", "bar"]
+  name         = "test"
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
 
-	disk {
-		image = "debian-7-wheezy-v20160301"
-	}
+  tags = ["foo", "bar"]
 
-	// Local SSD disk
-	disk {
-		type = "local-ssd"
-		scratch = true
-	}
+  disk {
+    image = "debian-7-wheezy-v20160301"
+  }
 
-	network_interface {
-		network = "default"
-        access_config {
-            // Ephemeral IP
-        }
-	}
+  // Local SSD disk
+  disk {
+    type    = "local-ssd"
+    scratch = true
+  }
 
-	metadata {
-		foo = "bar"
-	}
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
 
-    metadata_startup_script = "echo hi > /test.txt"
+  metadata {
+    foo = "bar"
+  }
 
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-	}
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
 }
 ```
 
@@ -56,39 +57,48 @@ resource "google_compute_instance" "default" {
 
 The following arguments are supported:
 
+* `disk` - (Required) Disks to attach to the instance. This can be specified
+    multiple times for multiple disks. Structure is documented below.
+
+* `machine_type` - (Required) The machine type to create.To create a custom
+    machine type, value should be set as specified
+    [here](https://cloud.google.com/compute/docs/reference/latest/instances#machineType)
+
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `description` - (Optional) A brief description of this resource.
-
-* `machine_type` - (Required) The machine type to create.To create a custom machine type, value should be
-    set as specified [here](https://cloud.google.com/compute/docs/reference/latest/instances#machineType)
-
 * `zone` - (Required) The zone that the machine should be created in.
 
-* `disk` - (Required) Disks to attach to the instance. This can be specified
-    multiple times for multiple disks. Structure is documented below.
+- - -
 
 * `can_ip_forward` - (Optional) Whether to allow sending and receiving of
     packets with non-matching source or destination IPs.
     This defaults to false.
 
+* `description` - (Optional) A brief description of this resource.
+
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within the instance.
 
 * `metadata_startup_script` - (Optional) An alternative to using the
-  startup-script metadata key, except this one forces the instance to be
-  recreated (thus re-running the script) if it is changed.  This replaces the
-  startup-script metadata key on the created instance and thus the two mechanisms
-  are not allowed to be used simultaneously.
+    startup-script metadata key, except this one forces the instance to be
+    recreated (thus re-running the script) if it is changed. This replaces the
+    startup-script metadata key on the created instance and thus the two
+    mechanisms are not allowed to be used simultaneously.
 
-* `network_interface` - (Required) Networks to attach to the instance. This can be
-    specified multiple times for multiple networks, but GCE is currently limited
-    to just 1. Structure is documented below.
+* `network_interface` - (Required) Networks to attach to the instance. This can
+    be specified multiple times for multiple networks, but GCE is currently
+    limited to just 1. Structure is documented below.
 
-* `network` - (DEPRECATED, Required) Networks to attach to the instance. This can be
-    specified multiple times for multiple networks. Structure is documented
-    below.
+* `network` - (DEPRECATED, Required) Networks to attach to the instance. This
+    can be specified multiple times for multiple networks. Structure is
+    documented below.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `scheduling` - (Optional) The scheduling strategy to use. More details about
+    this configuration option are detailed below.
 
 * `service_account` - (Optional) Service account to attach to the instance.
 
@@ -98,14 +108,14 @@ The `disk` block supports: (Note that either disk or image is required, unless
 the type is "local-ssd", in which case scratch must be true).
 
 * `disk` - The name of the existing disk (such as those managed by
-  `google_compute_disk`) to attach.
+    `google_compute_disk`) to attach.
 
 * `image` - The image from which to initialize this
-    disk.  Either the full URL, a contraction of the form "project/name", or just
-    a name (in which case the current project is used).
+    disk. Either the full URL, a contraction of the form "project/name", or
+    just a name (in which case the current project is used).
 
 * `auto_delete` - (Optional) Whether or not the disk should be auto-deleted.
-    This defaults to true.  Leave true for local SSDs.
+    This defaults to true. Leave true for local SSDs.
 
 * `type` - (Optional) The GCE disk type, e.g. pd-standard, pd-ssd, or local-ssd.
 
@@ -113,7 +123,7 @@ the type is "local-ssd", in which case scratch must be true).
     persistent disk (required for local-ssd).
 
 * `size` - (Optional) The size of the image in gigabytes. If not specified, it
-    will inherit the size of its base image.  Do not specify for local SSDs as
+    will inherit the size of its base image. Do not specify for local SSDs as
     their size is fixed.
 
 * `device_name` - (Optional) Name with which attached disk will be accessible
@@ -121,34 +131,36 @@ the type is "local-ssd", in which case scratch must be true).
 
 The `network_interface` block supports:
 
-* `network` - (Optional) The name of the network to attach this interface to. Either
-    `network` or `subnetwork` must be provided.
+* `network` - (Optional) The name of the network to attach this interface to.
+    Either `network` or `subnetwork` must be provided.
 
-*  `subnetwork` - (Optional) the name of the subnetwork to attach this interface to. The subnetwork
-     must exist in the same region this instance will be created in. Either `network`
-     or `subnetwork` must be provided.
+*  `subnetwork` - (Optional) the name of the subnetwork to attach this interface
+    to. The subnetwork must exist in the same region this instance will be
+    created in. Either `network` or `subnetwork` must be provided.
 
-* `access_config` - (Optional) Access configurations, i.e. IPs via which this instance can be
-  accessed via the Internet.  Omit to ensure that the instance is not accessible from the Internet
-(this means that ssh provisioners will not work unless you are running Terraform can send traffic to
-the instance's network (e.g. via tunnel or because it is running on another cloud instance on that
-network).  This block can be repeated multiple times.  Structure documented below.
+* `access_config` - (Optional) Access configurations, i.e. IPs via which this
+    instance can be accessed via the Internet. Omit to ensure that the instance
+    is not accessible from the Internet (this means that ssh provisioners will
+    not work unless you are running Terraform can send traffic tothe instance's
+    network (e.g. via tunnel or because it is running on another cloud instance
+    on that network). This block can be repeated multiple times. Structure
+    documented below.
 
 The `access_config` block supports:
 
-* `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's network ip.  If not
-  given, one will be generated.
+* `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's
+    network ip. If not given, one will be generated.
 
 * `assigned_nat_ip` - (Optional) The IP address that is assigned to the
-  instance. If `nat_ip` is filled, it will appear here. If `nat_ip` is left
-  blank, the ephemeral assigned IP will appear here.
+    instance. If `nat_ip` is filled, it will appear here. If `nat_ip` is left
+    blank, the ephemeral assigned IP will appear here.
 
 (DEPRECATED) The `network` block supports:
 
 * `source` - (Required) The name of the network to attach this interface to.
 
 * `address` - (Optional) The IP address of a reserved IP address to assign
-     to this interface.
+    to this interface.
 
 The `service_account` block supports:
 
@@ -159,8 +171,8 @@ The `scheduling` block supports:
 
 * `preemptible` - (Optional) Is the instance preemptible.
 
-* `on_host_maintenance` - (Optional) Describes maintenance behavior for
-    the instance. Can be MIGRATE or TERMINATE, for more info, read
+* `on_host_maintenance` - (Optional) Describes maintenance behavior for the
+    instance. Can be MIGRATE or TERMINATE, for more info, read
     [here](https://cloud.google.com/compute/docs/instances/setting-instance-scheduling-options)
 
 * `automatic_restart` - (Optional) Specifies if the instance should be
@@ -168,8 +180,11 @@ The `scheduling` block supports:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `machine_type` - The type of machine.
-* `zone` - The zone the machine lives in.
+* `metadata_fingerprint` - The unique fingerprint of the metadata.
+
+* `self_link` - The URI of the created resource.
+
+* `tags_fingerprint` - The unique fingerprint of the tags.

--- a/website/source/docs/providers/google/r/compute_instance_group.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_group.html.markdown
@@ -10,38 +10,42 @@ description: |-
 
 The Google Compute Engine Instance Group API creates and manages pools
 of homogeneous Compute Engine virtual machine instances from a common instance
-template.  For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/unmanaged-groups)
+template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/unmanaged-groups)
 and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroups)
 
 ## Example Usage
 
 ### Empty instance group
-```
+```js
 resource "google_compute_instance_group" "test" {
-	name = "terraform-test"
-	description = "Terraform test instance group"
-	zone = "us-central1-a"
+  name        = "terraform-test"
+  description = "Terraform test instance group"
+  zone        = "us-central1-a"
 }
 ```
 
 ### With instances and named ports
-```
+```js
 resource "google_compute_instance_group" "webservers" {
-	name = "terraform-webservers"
-	description = "Terraform test instance group"
-	instances = [
-		"${google_compute_instance.test.self_link}",
-		"${google_compute_instance.test2.self_link}"
-	]
-	named_port {
-		name = "http"
-		port = "8080"
-	}
-	named_port {
-		name = "https"
-		port = "8443"
-	}
-	zone = "us-central1-a"
+  name        = "terraform-webservers"
+  description = "Terraform test instance group"
+
+  instances = [
+    "${google_compute_instance.test.self_link}",
+    "${google_compute_instance.test2.self_link}"
+  ]
+
+  named_port {
+    name = "http"
+    port = "8080"
+  }
+
+  named_port {
+    name = "https"
+    port = "8443"
+  }
+
+  zone = "us-central1-a"
 }
 ```
 
@@ -50,32 +54,40 @@ resource "google_compute_instance_group" "webservers" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the instance group. Must be 1-63
-characters long and comply with [RFC1035](https://www.ietf.org/rfc/rfc1035.txt).
-Supported characters include lowercase letters, numbers, and hyphens.
-
-* `description` - (Optional) An optional textual description of the instance
-  group.
-
-* `instances` - (Optional) List of instances in the group. They should be given as
-  self_link URLs. When adding instances they must all be in the same network and
-  zone as the instance group.
-
-* `named_port` - (Optional) Named ports are key:value pairs that represent a
-  service name and the port number that the service runs on. The key:value pairs
-  are simple metadata that the Load Balancing service can use. This can specified
-  multiple times
+    characters long and comply with
+    [RFC1035](https://www.ietf.org/rfc/rfc1035.txt). Supported characters
+    include lowercase letters, numbers, and hyphens.
 
 * `zone` - (Required) The zone that this instance group should be created in.
 
+- - -
+
+* `description` - (Optional) An optional textual description of the instance
+    group.
+
+* `instances` - (Optional) List of instances in the group. They should be given
+    as self_link URLs. When adding instances they must all be in the same
+    network and zone as the instance group.
+
+* `named_port` - (Optional) The named port configuration. See the section below
+    for details on configuration.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
 The `named_port` block supports:
 
-* `name` - The name which the port will be mapped to.
-* `port` - The port number to map the name to.
+* `name` - (Required) The name which the port will be mapped to.
+
+* `port` - (Required) The port number to map the name to.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
 * `network` - The network the instance group is in.
+
+* `self_link` - The URI of the created resource.
+
 * `size` - The number of instances in the group.
-* `self_link` - The URL of the created resource.

--- a/website/source/docs/providers/google/r/compute_instance_group_manager.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_group_manager.html.markdown
@@ -10,27 +10,28 @@ description: |-
 
 The Google Compute Engine Instance Group Manager API creates and manages pools
 of homogeneous Compute Engine virtual machine instances from a common instance
-template.  For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/manager)
+template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/manager)
 and [API](https://cloud.google.com/compute/docs/instance-groups/manager/v1beta2/instanceGroupManagers)
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_instance_group_manager" "foobar" {
-	description = "Terraform test instance group manager"
-	name = "terraform-test"
-	instance_template = "${google_compute_instance_template.foobar.self_link}"
-	update_strategy= "NONE"
-	target_pools = ["${google_compute_target_pool.foobar.self_link}"]
-	base_instance_name = "foobar"
-	zone = "us-central1-a"
-	target_size = 2
+  name        = "terraform-test"
+  description = "Terraform test instance group manager"
 
-	named_port {
-		name = "customHTTP"
-		port = 8888
-	}
+  base_instance_name = "foobar"
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  update_strategy    = "NONE"
+  zone               = "us-central1-a"
 
+  target_pools = ["${google_compute_target_pool.foobar.self_link}"]
+  target_size  = 2
+
+  named_port {
+    name = "customHTTP"
+    port = 8888
+  }
 }
 ```
 
@@ -39,35 +40,47 @@ resource "google_compute_instance_group_manager" "foobar" {
 The following arguments are supported:
 
 * `base_instance_name` - (Required) The base instance name to use for
-instances in this group. The value must be a valid [RFC1035](https://www.ietf.org/rfc/rfc1035.txt) name.
-Supported characters are lowercase letters, numbers, and hyphens (-). Instances
-are named by appending a hyphen and a random four-character string to the base
-instance name.
-
-* `description` - (Optional) An optional textual description of the instance
-group manager.
+    instances in this group. The value must be a valid
+    [RFC1035](https://www.ietf.org/rfc/rfc1035.txt) name. Supported characters
+    are lowercase letters, numbers, and hyphens (-). Instances are named by
+    appending a hyphen and a random four-character string to the base instance
+    name.
 
 * `instance_template` - (Required) The full URL to an instance template from
-which all new instances will be created.
-
-* `update_strategy` - (Optional, Default `"RESTART"`) If the `instance_template` resource is
-modified, a value of `"NONE"` will prevent any of the managed instances from
-being restarted by Terraform. A value of `"RESTART"` will restart all of the
-instances at once. In the future, as the GCE API matures we will support
-`"ROLLING_UPDATE"` as well.
+    which all new instances will be created.
 
 * `name` - (Required) The name of the instance group manager. Must be 1-63
-characters long and comply with [RFC1035](https://www.ietf.org/rfc/rfc1035.txt).
-Supported characters include lowercase letters, numbers, and hyphens.
+    characters long and comply with
+    [RFC1035](https://www.ietf.org/rfc/rfc1035.txt). Supported characters
+    include lowercase letters, numbers, and hyphens.
 
-* `target_size` - (Optional) If not given at creation time, this defaults to 1.  Do not specify this
-  if you are managing the group with an autoscaler, as this will cause fighting.
+* `zone` - (Required) The zone that instances in this group should be created
+    in.
+
+- - -
+
+* `description` - (Optional) An optional textual description of the instance
+    group manager.
+
+* `named_port` - (Optional) The named port configuration. See the section below
+    for details on configuration.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `update_strategy` - (Optional, Default `"RESTART"`) If the `instance_template`
+    resource is modified, a value of `"NONE"` will prevent any of the managed
+    instances from being restarted by Terraform. A value of `"RESTART"` will
+    restart all of the instances at once. In the future, as the GCE API matures
+    we will support `"ROLLING_UPDATE"` as well.
+
+* `target_size` - (Optional) If not given at creation time, this defaults to 1.
+    Do not specify this if you are managing the group with an autoscaler, as
+    this will cause fighting.
 
 * `target_pools` - (Optional) The full URL of all target pools to which new
-instances in the group are added. Updating the target pools attribute does not
-affect existing instances.
-
-* `zone` - (Required) The zone that instances in this group should be created in.
+    instances in the group are added. Updating the target pools attribute does
+    not affect existing instances.
 
 The `named_port` block supports: (Include a `named_port` block for each named-port required).
 
@@ -77,7 +90,10 @@ The `named_port` block supports: (Include a `named_port` block for each named-po
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `fingerprint` - The fingerprint of the instance group manager.
 
 * `instance_group` - The full URL of the instance group created by the manager.
 

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # google\_compute\_instance\_template
 
-Manages a VM instance template resource within GCE.  For more information see
+Manages a VM instance template resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instance-templates)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/instanceTemplates).
@@ -17,42 +17,44 @@ and
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_instance_template" "foobar" {
-	name = "terraform-test"
-	description = "template description"
-	instance_description = "description assigned to instances"
-	machine_type = "n1-standard-1"
-	can_ip_forward = false
-	automatic_restart = true
-	on_host_maintenance = "MIGRATE"
-	tags = ["foo", "bar"]
+  name        = "terraform-test"
+  description = "template description"
 
-	# Create a new boot disk from an image
-	disk {
-		source_image = "debian-7-wheezy-v20160301"
-		auto_delete = true
-		boot = true
-	}
+  tags = ["foo", "bar"]
 
-	# Use an existing disk resource
-	disk {
-		source = "foo_existing_disk"
-		auto_delete = false
-		boot = false
-	}
+  instance_description = "description assigned to instances"
+  machine_type         = "n1-standard-1"
+  can_ip_forward       = false
+  automatic_restart    = true
+  on_host_maintenance  = "MIGRATE"
 
-	network_interface {
-		network = "default"
-	}
+  // Create a new boot disk from an image
+  disk {
+    source_image = "debian-7-wheezy-v20160301"
+    auto_delete = true
+    boot = true
+  }
 
-	metadata {
-		foo = "bar"
-	}
+  // Use an existing disk resource
+  disk {
+    source      = "foo_existing_disk"
+    auto_delete = false
+    boot        = false
+  }
 
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-	}
+  network_interface {
+    network = "default"
+  }
+
+  metadata {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
 }
 ```
 
@@ -62,128 +64,130 @@ Note that changing any field for this resource forces a new resource to be creat
 
 The following arguments are supported:
 
-* `name` - (Required) A unique name for the resource, required by GCE.
-
-* `description` - (Optional) A brief description of this resource.
-
-* `can_ip_forward` - (Optional) Whether to allow sending and receiving of
-	packets with non-matching source or destination IPs.
-	This defaults to false.
-
-* `instance_description` - (Optional) A brief description to use for instances
-	created from this template.
+* `disk` - (Required) Disks to attach to instances created from this template.
+    This can be specified multiple times for multiple disks. Structure is
+    documented below.
 
 * `machine_type` - (Required) The machine type to create.
 
-* `disk` - (Required) Disks to attach to instances created from this
-	template. This can be specified multiple times for multiple disks.
-	Structure is documented below.
+* `name` - (Required) A unique name for the resource, required by GCE.
+
+- - -
+
+* `can_ip_forward` - (Optional) Whether to allow sending and receiving of
+    packets with non-matching source or destination IPs. This defaults to false.
+
+* `description` - (Optional) A brief description of this resource.
+
+* `instance_description` - (Optional) A brief description to use for instances
+    created from this template.
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
-	within instances created from this template.
+    within instances created from this template.
 
-* `network_interface` - (Required) Networks to attach to instances created from this template.
- 	This can be specified multiple times for multiple networks. Structure is
-	documented below.
+* `network_interface` - (Required) Networks to attach to instances created from
+    this template. This can be specified multiple times for multiple networks.
+    Structure is documented below.
 
-* `region` - (Optional) An instance template is a global resource that is not bound to a zone
-    or a region. However, you can still specify some regional resources in an instance template,
-    which restricts the template to the region where that resource resides. For example, a
-    custom `subnetwork` resource is tied to a specific region.
-    Defaults to the region of the Provider if no value is given.
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
-* `automatic_restart` - (Optional, Deprecated - see `scheduling`)
-	Specifies whether the instance should be
-	automatically restarted if it is terminated by Compute Engine (not
-	terminated by a user).
-	This defaults to true.
+* `region` - (Optional) An instance template is a global resource that is not
+    bound to a zone or a region. However, you can still specify some regional
+    resources in an instance template, which restricts the template to the
+    region where that resource resides. For example, a custom `subnetwork`
+    resource is tied to a specific region. Defaults to the region of the
+    Provider if no value is given.
 
-* `on_host_maintenance` - (Optional, Deprecated - see `scheduling`)
-	Defines the maintenance behavior for this instance.
+* `scheduling` - (Optional) The scheduling strategy to use. More details about
+    this configuration option are detailed below.
 
 * `service_account` - (Optional) Service account to attach to the instance.
 
 * `tags` - (Optional) Tags to attach to the instance.
 
-
-
 The `disk` block supports:
 
 * `auto_delete` - (Optional) Whether or not the disk should be auto-deleted.
-	This defaults to true.
+    This defaults to true.
 
 * `boot` - (Optional) Indicates that this is a boot disk.
 
-* `device_name` - (Optional) A unique device name that is reflected into
-	the /dev/  tree of a Linux operating system running within the instance.
-	If not specified, the server chooses a default device name to apply to
-	this disk.
+* `device_name` - (Optional) A unique device name that is reflected into the
+    /dev/  tree of a Linux operating system running within the instance. If not
+    specified, the server chooses a default device name to apply to this disk.
 
 * `disk_name` - (Optional) Name of the disk. When not provided, this defaults
-	to the name of the instance.
+    to the name of the instance.
 
 * `source_image` - (Required if source not set) The name of the image to base
-	this disk off of.
+    this disk off of.
 
 * `interface` - (Optional) Specifies the disk interface to use for attaching
-	this disk.
+    this disk.
 
 * `mode` - (Optional) The mode in which to attach this disk, either READ_WRITE
-	or READ_ONLY. If you are attaching or creating a boot disk, this must
-	read-write mode.
+    or READ_ONLY. If you are attaching or creating a boot disk, this must
+    read-write mode.
 
 * `source` - (Required if source_image not set) The name of the disk (such as
-	those managed by `google_compute_disk`) to attach.
+    those managed by `google_compute_disk`) to attach.
 
 * `disk_type` - (Optional) The GCE disk type. Can be either `"pd-ssd"`,
-	`"local-ssd"`, or `"pd-standard"`.
+    `"local-ssd"`, or `"pd-standard"`.
 
-* `disk_size_gb` - (Optional) The size of the image in gigabytes. If not specified,
-	it will inherit the size of its base image.
+* `disk_size_gb` - (Optional) The size of the image in gigabytes. If not
+    specified, it will inherit the size of its base image.
 
 * `type` - (Optional) The type of GCE disk, can be either `"SCRATCH"` or
-	`"PERSISTENT"`.
+    `"PERSISTENT"`.
 
 The `network_interface` block supports:
 
-* `network` - (Optional) The name of the network to attach this interface to. Use `network`
-   attribute for Legacy or Auto subnetted networks and `subnetwork` for custom subnetted
-   networks.
+* `network` - (Optional) The name of the network to attach this interface to.
+    Use `network` attribute for Legacy or Auto subnetted networks and
+    `subnetwork` for custom subnetted networks.
 
-* `subnetwork` - (Optional) the name of the subnetwork to attach this interface to. The subnetwork
-   must exist in the same `region` this instance will be created in. Either `network`
-   or `subnetwork` must be provided.
+* `subnetwork` - (Optional) the name of the subnetwork to attach this interface
+    to. The subnetwork must exist in the same `region` this instance will be
+    created in. Either `network` or `subnetwork` must be provided.
 
-* `access_config` - (Optional) Access configurations, i.e. IPs via which this instance can be
-  accessed via the Internet.  Omit to ensure that the instance is not accessible from the Internet
-(this means that ssh provisioners will not work unless you are running Terraform can send traffic to
-the instance's network (e.g. via tunnel or because it is running on another cloud instance on that
-network).  This block can be repeated multiple times.  Structure documented below.
+* `access_config` - (Optional) Access configurations, i.e. IPs via which this
+    instance can be accessed via the Internet. Omit to ensure that the instance
+    is not accessible from the Internet (this means that ssh provisioners will
+    not work unless you are running Terraform can send traffic to the instance's
+    network (e.g. via tunnel or because it is running on another cloud instance
+    on that network). This block can be repeated multiple times. Structure documented below.
 
 The `access_config` block supports:
 
-* `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's network ip.  If not
-  given, one will be generated.
+* `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's
+    network ip. If not given, one will be generated.
 
 The `service_account` block supports:
 
 * `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
-	short names are supported.
+    short names are supported.
 
 The `scheduling` block supports:
 
 * `automatic_restart` - (Optional) Specifies whether the instance should be
-	automatically restarted if it is terminated by Compute Engine (not
-	terminated by a user).
-	This defaults to true.
+    automatically restarted if it is terminated by Compute Engine (not
+    terminated by a user). This defaults to true.
 
-* `on_host_maintenance` - (Optional) Defines the maintenance behavior for this instance.
+* `on_host_maintenance` - (Optional) Defines the maintenance behavior for this
+    instance.
 
-* `preemptible` - (Optional) Allows instance to be preempted. Read
-	more on this [here](https://cloud.google.com/compute/docs/instances/preemptible).
+* `preemptible` - (Optional) Allows instance to be preempted. Read more on this
+    [here](https://cloud.google.com/compute/docs/instances/preemptible).
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `self_link` - The URL of the created resource.
+* `metadata_fingerprint` - The unique fingerprint of the metadata.
+
+* `self_link` - The URI of the created resource.
+
+* `tags_fingerprint` - The unique fingerprint of the tags.

--- a/website/source/docs/providers/google/r/compute_network.html.markdown
+++ b/website/source/docs/providers/google/r/compute_network.html.markdown
@@ -12,10 +12,10 @@ Manages a network within GCE.
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_network" "default" {
-	name = "test"
-	ipv4_range = "10.0.0.0/16"
+  name       = "test"
+  ipv4_range = "10.0.0.0/16"
 }
 ```
 
@@ -26,23 +26,31 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `ipv4_range` - (Optional) The IPv4 address range that machines in this
-     network are assigned to, represented as a CIDR block. If not
-     set, an auto or custom subnetted network will be created, depending
-     on the value of `auto_create_subnetworks` attribute. This attribute
-     may not be used if `auto_create_subnets` is specified.
+- - -
 
-* `auto_create_subnetworks` - (Optional) If set to true, this network
-     will be created in auto subnet mode, and Google will create a
-     subnet for each region automatically.
-     If set to false, and `ipv4_range` is not set, a custom subnetted
-     network will be created that can support `google_compute_subnetwork`
-     resources. This attribute may not be used if `ipv4_range` is specified.
+* `auto_create_subnetworks` - (Optional) If set to true, this network will be
+    created in auto subnet mode, and Google will create a subnet for each region
+    automatically. If set to false, and `ipv4_range` is not set, a custom
+    subnetted network will be created that can support
+    `google_compute_subnetwork` resources. This attribute may not be used if
+    `ipv4_range` is specified.
+
+* `description` - (Optional) A brief description of this resource.
+
+* `ipv4_range` - (Optional) The IPv4 address range that machines in this network
+    are assigned to, represented as a CIDR block. If not set, an auto or custom
+    subnetted network will be created, depending on the value of  
+    `auto_create_subnetworks` attribute. This attribute may not be used if
+    `auto_create_subnets` is specified. This attribute is deprecated.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `ipv4_range` - The CIDR block of this network.
 * `gateway_ipv4` - The IPv4 address of the gateway.
+
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_project_metadata.html.markdown
+++ b/website/source/docs/providers/google/r/compute_project_metadata.html.markdown
@@ -12,13 +12,13 @@ Manages metadata common to all instances for a project in GCE.
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_project_metadata" "default" {
-    metadata {
-        foo = "bar"
-        fizz = "buzz"
-        13 = "42"
-    }
+  metadata {
+    foo  = "bar"
+    fizz = "buzz"
+    13   = "42"
+  }
 }
 ```
 
@@ -26,11 +26,14 @@ resource "google_compute_project_metadata" "default" {
 
 The following arguments are supported:
 
-* `metadata` - (Required) A series of key value pairs. Changing this resource updates
-    the GCE state.
+* `metadata` - (Required) A series of key value pairs. Changing this resource
+    updates the GCE state.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 ## Attributes Reference
 
-The following attributes are exported:
-
-* `metadata` - Common instance metadata.
+Only the arguments listed above are exposed as attributes.

--- a/website/source/docs/providers/google/r/compute_route.html.markdown
+++ b/website/source/docs/providers/google/r/compute_route.html.markdown
@@ -12,18 +12,18 @@ Manages a network route within GCE.
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_network" "foobar" {
-	name = "test"
-	ipv4_range = "10.0.0.0/16"
+  name       = "test"
+  ipv4_range = "10.0.0.0/16"
 }
 
 resource "google_compute_route" "foobar" {
-	name = "test"
-	dest_range = "15.0.0.0/24"
-	network = "${google_compute_network.foobar.name}"
-	next_hop_ip = "10.0.1.5"
-	priority = 100
+  name        = "test"
+  dest_range  = "15.0.0.0/24"
+  network     = "${google_compute_network.foobar.name}"
+  next_hop_ip = "10.0.1.5"
+  priority    = 100
 }
 ```
 
@@ -31,44 +31,43 @@ resource "google_compute_route" "foobar" {
 
 The following arguments are supported:
 
+* `dest_range` - (Required) The destination IPv4 address range that this
+    route applies to.
+
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `dest_range` - (Required) The destination IPv4 address range that this
-     route applies to.
-
 * `network` - (Required) The name of the network to attach this route to.
 
-* `next_hop_ip` - (Optional) The IP address of the next hop if this route
-    is matched.
+* `priority` - (Required) The priority of this route, used to break ties.
 
-* `next_hop_instance` - (Optional) The name of the VM instance to route to
-    if this route is matched.
-
-* `next_hop_instance_zone` - (Required when `next_hop_instance` is specified) The zone of the instance specified
-    in `next_hop_instance`.
+- - -
 
 * `next_hop_gateway` - (Optional) The name of the internet gateway to route
     to if this route is matched.
 
-* `next_hop_vpn_gateway` - (Optional) The name of the VPN to route to if this
+* `next_hop_instance` - (Optional) The name of the VM instance to route to
+    if this route is matched.
+
+* `next_hop_instance_zone` - (Required when `next_hop_instance` is specified)
+    The zone of the instance specified in `next_hop_instance`.
+
+* `next_hop_ip` - (Optional) The IP address of the next hop if this route
+    is matched.
+
+* `next_hop_vpn_tunnel` - (Optional) The name of the VPN to route to if this
     route is matched.
 
-* `priority` - (Required) The priority of this route, used to break ties.
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 * `tags` - (Optional) The tags that this route applies to.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `dest_range` - The destination CIDR block of this route.
-* `network` - The name of the network of this route.
-* `next_hop_ip` - The IP address of the next hop, if available.
-* `next_hop_instance` - The name of the instance of the next hop, if available.
-* `next_hop_instance_zone` - The zone of the next hop instance, if available.
-* `next_hop_gateway` - The name of the next hop gateway, if available.
 * `next_hop_network` - The name of the next hop network, if available.
-* `priority` - The priority of this route.
-* `tags` - The tags this route applies to.
+
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_ssl_certificate.html.markdown
+++ b/website/source/docs/providers/google/r/compute_ssl_certificate.html.markdown
@@ -16,12 +16,12 @@ For more information see
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_ssl_certificate" "default" {
-	name = "my-certificate"
-	description = "a description"
-	private_key = "${file("path/to/private.key")}"
-	certificate = "${file("path/to/certificate.crt")}"
+  name        = "my-certificate"
+  description = "a description"
+  private_key = "${file("path/to/private.key")}"
+  certificate = "${file("path/to/certificate.crt")}"
 }
 ```
 
@@ -29,19 +29,29 @@ resource "google_compute_ssl_certificate" "default" {
 
 The following arguments are supported:
 
+* `certificate` - (Required) A local certificate file in PEM format. The chain
+    may be at most 5 certs long, and must include at least one intermediate
+    cert. Changing this forces a new resource to be created.
+
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
-* `description` - (Optional) An optional description of this resource.
-    Changing this forces a new resource to be created.
+
 * `private_key` - (Required) Write only private key in PEM format.
     Changing this forces a new resource to be created.
-* `certificate` - (Required) A local certificate file in PEM format. The chain
-    may be at most 5 certs long, and must include at least one intermediate cert.
+
+- - -
+
+* `description` - (Optional) An optional description of this resource.
     Changing this forces a new resource to be created.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `id` - A unique ID for the certificated, assigned by GCE.
 
 * `self_link` - The URI of the created resource.
-* `id` - A unique ID assigned by GCE.

--- a/website/source/docs/providers/google/r/compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/r/compute_subnetwork.html.markdown
@@ -12,12 +12,12 @@ Manages a subnetwork within GCE.
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_subnetwork" "default-us-east1" {
-	name = "default-us-east1"
-	ip_cidr_range = "10.0.0.0/16"
-	network = "${google_compute_network.default.self_link}"
-	region = "us-east1"
+  name          = "default-us-east1"
+  ip_cidr_range = "10.0.0.0/16"
+  network       = "${google_compute_network.default.self_link}"
+  region        = "us-east1"
 }
 ```
 
@@ -25,23 +25,30 @@ resource "google_compute_subnetwork" "default-us-east1" {
 
 The following arguments are supported:
 
+* `ip_cidr_range` - (Required) The IP address range that machines in this
+    network are assigned to, represented as a CIDR block.
+
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
 * `network` - (Required) A link to the parent network of this subnetwork.
-     The parent network must have been created in custom subnet mode.
+    The parent network must have been created in custom subnet mode.
 
-* `ip_cidr_range` - (Required) The IP address range that machines in this
-     network are assigned to, represented as a CIDR block.
-
-* `region` - (Required) The region this subnetwork will be created in.
+- - -
 
 * `description` - (Optional) Description of this subnetwork.
 
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The region this subnetwork will be created in. If
+    unspecified, this defaults to the region configured in the provider.
+
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `ip_cidr_range` - The CIDR block of this network.
 * `gateway_address` - The IP address of the gateway.
+
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_target_http_proxy.html.markdown
+++ b/website/source/docs/providers/google/r/compute_target_http_proxy.html.markdown
@@ -16,48 +16,49 @@ documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_target_http_proxy" "default" {
-    name = "test-proxy"
-    description = "a description"
-    url_map = "${google_compute_url_map.default.self_link}"
+  name        = "test-proxy"
+  description = "a description"
+  url_map     = "${google_compute_url_map.default.self_link}"
 }
 
 resource "google_compute_url_map" "default" {
-    name = "url-map"
-    description = "a description"
+  name        = "url-map"
+  description = "a description"
+
+  default_service = "${google_compute_backend_service.default.self_link}"
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
     default_service = "${google_compute_backend_service.default.self_link}"
 
-    host_rule {
-        hosts = ["mysite.com"]
-        path_matcher = "allpaths"
+    path_rule {
+      paths = ["/*"]
+      service = "${google_compute_backend_service.default.self_link}"
     }
-
-    path_matcher {
-        default_service = "${google_compute_backend_service.default.self_link}"
-        name = "allpaths"
-        path_rule {
-            paths = ["/*"]
-            service = "${google_compute_backend_service.default.self_link}"
-        }
-    }
+  }
 }
 
 resource "google_compute_backend_service" "default" {
-    name = "default-backend"
-    port_name = "http"
-    protocol = "HTTP"
-    timeout_sec = 10
-    region = "us-central1"
+  name        = "default-backend"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
 
-    health_checks = ["${google_compute_http_health_check.default.self_link}"]
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
 }
 
 resource "google_compute_http_health_check" "default" {
-    name = "test"
-    request_path = "/"
-    check_interval_sec = 1
-    timeout_sec = 1
+  name               = "test"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
 }
 ```
 
@@ -65,16 +66,23 @@ resource "google_compute_http_health_check" "default" {
 
 The following arguments are supported:
 
-* `name` - (Required) A unique name for the resource, required by GCE.
-    Changing this forces a new resource to be created.
-* `description` - (Optional) A description of this resource.
-    Changing this forces a new resource to be created.
-* `url_map` - (Required) The URL of a URL Map resource that defines the
-    mapping from the URL to the BackendService.
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+* `url_map` - (Required) The URL of a URL Map resource that defines the mapping
+    from the URL to the BackendService.
+
+- - -
+
+* `description` - (Optional) A description of this resource. Changing this
+    forces a new resource to be created.
+
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `id` - A unique ID assigned by GCE.
 
 * `self_link` - The URI of the created resource.
-* `id` - A unique ID assigned by GCE.

--- a/website/source/docs/providers/google/r/compute_target_https_proxy.html.markdown
+++ b/website/source/docs/providers/google/r/compute_target_https_proxy.html.markdown
@@ -16,56 +16,57 @@ documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_target_https_proxy" "default" {
-    name = "test-proxy"
-    description = "a description"
-    url_map = "${google_compute_url_map.default.self_link}"
-    ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
+  name             = "test-proxy"
+  description      = "a description"
+  url_map          = "${google_compute_url_map.default.self_link}"
+  ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
 }
 
 resource "google_compute_ssl_certificate" "default" {
-    name = "my-certificate"
-    description = "a description"
-    private_key = "${file("path/to/private.key")}"
-    certificate = "${file("path/to/certificate.crt")}"
+  name        = "my-certificate"
+  description = "a description"
+  private_key = "${file("path/to/private.key")}"
+  certificate = "${file("path/to/certificate.crt")}"
 }
 
 resource "google_compute_url_map" "default" {
-    name = "url-map"
-    description = "a description"
+  name        = "url-map"
+  description = "a description"
+
+  default_service = "${google_compute_backend_service.default.self_link}"
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
     default_service = "${google_compute_backend_service.default.self_link}"
 
-    host_rule {
-        hosts = ["mysite.com"]
-        path_matcher = "allpaths"
+    path_rule {
+      paths = ["/*"]
+      service = "${google_compute_backend_service.default.self_link}"
     }
-
-    path_matcher {
-        default_service = "${google_compute_backend_service.default.self_link}"
-        name = "allpaths"
-        path_rule {
-            paths = ["/*"]
-            service = "${google_compute_backend_service.default.self_link}"
-        }
-    }
+  }
 }
 
 resource "google_compute_backend_service" "default" {
-    name = "default-backend"
-    port_name = "http"
-    protocol = "HTTP"
-    timeout_sec = 10
-    region = "us-central1"
+  name        = "default-backend"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
 
-    health_checks = ["${google_compute_http_health_check.default.self_link}"]
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
 }
 
 resource "google_compute_http_health_check" "default" {
-    name = "test"
-    request_path = "/"
-    check_interval_sec = 1
-    timeout_sec = 1
+  name               = "test"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
 }
 ```
 
@@ -73,19 +74,29 @@ resource "google_compute_http_health_check" "default" {
 
 The following arguments are supported:
 
-* `name` - (Required) A unique name for the resource, required by GCE.
-    Changing this forces a new resource to be created.
-* `description` - (Optional) A description of this resource.
-    Changing this forces a new resource to be created.
-* `url_map` - (Required) The URL of a URL Map resource that defines the
-    mapping from the URL to the BackendService.
-* `ssl_certificates` - (Required) The URLs of the SSL Certificate resources
-    that authenticate connections between users and load balancing. Currently
-    exactly one must be specified.
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+* `ssl_certificates` - (Required) The URLs of the SSL Certificate resources that
+    authenticate connections between users and load balancing. Currently exactly
+    one must be specified.
+
+* `url_map` - (Required) The URL of a URL Map resource that defines the mapping
+    from the URL to the BackendService.
+
+- - -
+
+* `description` - (Optional) A description of this resource. Changing this
+    forces a new resource to be created.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `id` - A unique ID assigned by GCE.
 
 * `self_link` - The URI of the created resource.
-* `id` - A unique ID assigned by GCE.

--- a/website/source/docs/providers/google/r/compute_target_pool.html.markdown
+++ b/website/source/docs/providers/google/r/compute_target_pool.html.markdown
@@ -8,8 +8,8 @@ description: |-
 
 # google\_compute\_target\_pool
 
-Manages a Target Pool within GCE.  This is a collection of instances used as
-target of a network load balancer (Forwarding Rule).  For more information see
+Manages a Target Pool within GCE. This is a collection of instances used as
+target of a network load balancer (Forwarding Rule). For more information see
 [the official
 documentation](https://cloud.google.com/compute/docs/load-balancing/network/target-pools)
 and [API](https://cloud.google.com/compute/docs/reference/latest/targetPools).
@@ -17,11 +17,18 @@ and [API](https://cloud.google.com/compute/docs/reference/latest/targetPools).
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_target_pool" "default" {
-    name = "test"
-    instances = [ "us-central1-a/myinstance1", "us-central1-b/myinstance2" ]
-    health_checks = [ "${google_compute_http_health_check.default.name}" ]
+  name = "test"
+
+  instances = [
+    "us-central1-a/myinstance1",
+    "us-central1-b/myinstance2",
+  ]
+
+  health_checks = [
+    "${google_compute_http_health_check.default.name}",
+  ]
 }
 ```
 
@@ -29,31 +36,40 @@ resource "google_compute_target_pool" "default" {
 
 The following arguments are supported:
 
-* `backup_pool` - (Optional) URL to the backup target pool.  Must also set
-  failover\_ratio.
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+- - -
+
+* `backup_pool` - (Optional) URL to the backup target pool. Must also set
+    failover\_ratio.
 
 * `description` - (Optional) Textual description field.
 
 * `failover_ratio` - (Optional) Ratio (0 to 1) of failed nodes before using the
-  backup pool (which must also be set).
+    backup pool (which must also be set).
 
 * `health_checks` - (Optional) List of zero or one healthcheck names.
 
-* `instances` - (Optional) List of instances in the pool.  They can be given as
-  URLs, or in the form of "zone/name".  Note that the instances need not exist
-  at the time of target pool creation, so there is no need to use the Terraform
-  interpolators to create a dependency on the instances from the target pool.
+* `instances` - (Optional) List of instances in the pool. They can be given as
+    URLs, or in the form of "zone/name". Note that the instances need not exist
+    at the time of target pool creation, so there is no need to use the
+    Terraform interpolators to create a dependency on the instances from the
+    target pool.
 
-* `name` - (Required) A unique name for the resource, required by GCE.  Changing
-  this forces a new resource to be created.
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
-* `session_affinity` - (Optional) How to distribute load.  Options are "NONE" (no affinity).  "CLIENT\_IP" (hash of the source/dest addresses / ports), and "CLIENT\_IP\_PROTO" also includes the protocol (default "NONE").
+* `region` - (Optional) Where the target pool resides. Defaults to project
+    region.
 
-* `region` - (Optional) Where the target pool resides. Defaults to project region.
+* `session_affinity` - (Optional) How to distribute load. Options are "NONE" (no
+    affinity). "CLIENT\_IP" (hash of the source/dest addresses / ports), and
+    "CLIENT\_IP\_PROTO" also includes the protocol (default "NONE").
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `self_link` - The URL of the created resource.
-
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_url_map.html.markdown
+++ b/website/source/docs/providers/google/r/compute_url_map.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_url_map"
-sidebar_current: "docs-google-resource-url-map"
+sidebar_current: "docs-google-compute-url-map"
 description: |-
   Manages a URL Map resource in GCE.
 ---
 
 # google\_compute\_url\_map
 
-Manages a URL Map resource within GCE.  For more information see
+Manages a URL Map resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/load-balancing/http/url-map)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/urlMaps).
@@ -16,63 +16,65 @@ and
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_url_map" "foobar" {
-    name = "urlmap"
-    description = "a description"
+  name        = "urlmap"
+  description = "a description"
+
+  default_service = "${google_compute_backend_service.home.self_link}"
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
     default_service = "${google_compute_backend_service.home.self_link}"
 
-    host_rule {
-        hosts = ["mysite.com"]
-        path_matcher = "allpaths"
+    path_rule {
+      paths   = ["/home"]
+      service = "${google_compute_backend_service.home.self_link}"
     }
 
-    path_matcher {
-        default_service = "${google_compute_backend_service.home.self_link}"
-        name = "allpaths"
-        path_rule {
-            paths = ["/home"]
-            service = "${google_compute_backend_service.home.self_link}"
-        }
-
-        path_rule {
-            paths = ["/login"]
-            service = "${google_compute_backend_service.login.self_link}"
-        }
+    path_rule {
+      paths   = ["/login"]
+      service = "${google_compute_backend_service.login.self_link}"
     }
+  }
 
-    test {
-        service = "${google_compute_backend_service.home.self_link}"
-        host = "hi.com"
-        path = "/home"
-    }
+  test {
+    service = "${google_compute_backend_service.home.self_link}"
+    host    = "hi.com"
+    path    = "/home"
+  }
 }
 
 resource "google_compute_backend_service" "login" {
-    name = "login-backend"
-    port_name = "http"
-    protocol = "HTTP"
-    timeout_sec = 10
-    region = "us-central1"
+  name        = "login-backend"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  region      = "us-central1"
 
-    health_checks = ["${google_compute_http_health_check.default.self_link}"]
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
 }
 
 resource "google_compute_backend_service" "home" {
-    name = "home-backend"
-    port_name = "http"
-    protocol = "HTTP"
-    timeout_sec = 10
-    region = "us-central1"
+  name        = "home-backend"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  region      = "us-central1"
 
-    health_checks = ["${google_compute_http_health_check.default.self_link}"]
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
 }
 
 resource "google_compute_http_health_check" "default" {
-    name = "test"
-    request_path = "/"
-    check_interval_sec = 1
-    timeout_sec = 1
+  name               = "test"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
 }
 ```
 
@@ -80,50 +82,62 @@ resource "google_compute_http_health_check" "default" {
 
 The following arguments are supported:
 
+* `default_service` - (Required) The URL of the backend service to use when none
+    of the given rules match. See the documentation for formatting the service
+    URL
+    [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#defaultService)
+
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
+- - -
+
 * `description` - (Optional) A brief description of this resource.
 
-* `default_service` - (Required) The URL of the backend service to use when none of the
-    given rules match. See the documentation for formatting the service URL
-    [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#defaultService)
+* `host_rule` - (Optional) A list of host rules. See below for configuration
+    options.
 
-The `host_rule` block supports: (Note that this block can be defined an arbitrary
-number of times.)
+* `path_matcher` - (Optional) A list of paths to match. See below for
+    configuration options.
 
-* `hosts` (Required) - A list of hosts to match against. See the documention
-    for formatting each host [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#hostRules.hosts)
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `test` - (Optional) The test to perform. See below for configuration options.
+
+The `host_rule` block supports: (This block can be defined multiple times).
+
+* `hosts` (Required) - A list of hosts to match against. See the documentation
+    for formatting each host
+    [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#hostRules.hosts)
 
 * `description` - (Optional) An optional description of the host rule.
 
 * `path_matcher` - (Required) The name of the `path_matcher` (defined below)
     to apply this host rule to.
 
-The `path_matcher` block supports: (Note that this block can be defined an arbitrary
-number of times.)
+The `path_matcher` block supports: (This block can be defined multiple times)
 
 * `default_service` - (Required) The URL for the backend service to use if none
-    of the given paths match. See the documentation for formatting the service URL
-    [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#pathMatcher.defaultService)
+    of the given paths match. See the documentation for formatting the service
+    URL [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#pathMatcher.defaultService)
 
-* `name` - (Required) The name of the `path_matcher` resource. Used by the `host_rule`
-    block above.
+* `name` - (Required) The name of the `path_matcher` resource. Used by the
+    `host_rule` block above.
 
 * `description` - (Optional) An optional description of the host rule.
 
-The `path_matcher.path_rule` sub-block supports: (Note that this block can be defined an arbitrary
-number of times.)
+The `path_matcher.path_rule` sub-block supports: (This block can be defined
+multiple times)
 
 * `paths` - (Required) The list of paths to match against. See the
     documentation for formatting these [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#pathMatchers.pathRules.paths)
 
 * `default_service` - (Required) The URL for the backend service to use if any
-    of the given paths match. See the documentation for formatting the service URL
-    [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#pathMatcher.defaultService)
+    of the given paths match. See the documentation for formatting the service
+    URL [here](https://cloud.google.com/compute/docs/reference/latest/urlMaps#pathMatcher.defaultService)
 
-The optional `test` block supports: (Note that this block can be defined an arbitary
-number of times.)
+The optional `test` block supports: (This block can be defined multiple times)
 
 * `service` - (Required) The service that should be matched by this test.
 
@@ -135,7 +149,11 @@ number of times.)
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `fingerprint` - The unique fingerprint for this resource.
 
 * `id` - The GCE assigned ID of the resource.
-* `self_link` - A GCE assigned link to the resource.
+
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_vpn_gateway.html.markdown
+++ b/website/source/docs/providers/google/r/compute_vpn_gateway.html.markdown
@@ -14,83 +14,91 @@ Manages a VPN Gateway in the GCE network. For more info, read the
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_network" "network1" {
-    name = "network1"
-    ipv4_range = "10.120.0.0/16"
+  name       = "network1"
+  ipv4_range = "10.120.0.0/16"
 }
 
 resource "google_compute_vpn_gateway" "target_gateway" {
-    name = "vpn1"
-    network = "${google_compute_network.network1.self_link}"
-    region = "${var.region}"
+  name    = "vpn1"
+  network = "${google_compute_network.network1.self_link}"
+  region  = "${var.region}"
 }
 
 resource "google_compute_address" "vpn_static_ip" {
-    name = "vpn-static-ip"
-    region = "${var.region}"
+  name   = "vpn-static-ip"
+  region = "${var.region}"
 }
 
 resource "google_compute_forwarding_rule" "fr_esp" {
-    name = "fr-esp"
-    region = "${var.region}"
-    ip_protocol = "ESP"
-    ip_address = "${google_compute_address.vpn_static_ip.address}"
-    target = "${google_compute_vpn_gateway.target_gateway.self_link}"
+  name        = "fr-esp"
+  region      = "${var.region}"
+  ip_protocol = "ESP"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
 }
 
 resource "google_compute_forwarding_rule" "fr_udp500" {
-    name = "fr-udp500"
-    region = "${var.region}"
-    ip_protocol = "UDP"
-    port_range = "500"
-    ip_address = "${google_compute_address.vpn_static_ip.address}"
-    target = "${google_compute_vpn_gateway.target_gateway.self_link}"
+  name        = "fr-udp500"
+  region      = "${var.region}"
+  ip_protocol = "UDP"
+  port_range  = "500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
 }
 
 resource "google_compute_forwarding_rule" "fr_udp4500" {
-    name = "fr-udp4500"
-    region = "${var.region}"
-    ip_protocol = "UDP"
-    port_range = "4500"
-    ip_address = "${google_compute_address.vpn_static_ip.address}"
-    target = "${google_compute_vpn_gateway.target_gateway.self_link}"
+  name        = "fr-udp4500"
+  region      = "${var.region}"
+  ip_protocol = "UDP"
+  port_range  = "4500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
 }
 
 resource "google_compute_vpn_tunnel" "tunnel1" {
-    name = "tunnel1"
-    region = "${var.region}"
-    peer_ip = "15.0.0.120"
-    shared_secret = "a secret message"
-    target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
-    depends_on = ["google_compute_forwarding_rule.fr_esp",
-        "google_compute_forwarding_rule.fr_udp500",
-        "google_compute_forwarding_rule.fr_udp4500"]
+  name          = "tunnel1"
+  region        = "${var.region}"
+  peer_ip       = "15.0.0.120"
+  shared_secret = "a secret message"
+
+  target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
+
+  depends_on = [
+    "google_compute_forwarding_rule.fr_esp",
+    "google_compute_forwarding_rule.fr_udp500",
+    "google_compute_forwarding_rule.fr_udp4500",
+  ]
 }
 
 resource "google_compute_route" "route1" {
-    name = "route1"
-    network = "${google_compute_network.network1.name}"
-    next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
-    dest_range = "15.0.0.0/24"
-    priority = 1000
-}
+  name       = "route1"
+  network    = "${google_compute_network.network1.name}"
+  dest_range = "15.0.0.0/24"
+  priority   = 1000
 
+  next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) A unique name for the resource, required by GCE.
-    Changing this forces a new resource to be created.
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+* `network` - (Required) A link to the network this VPN gateway is accepting
+    traffic for. Changing this forces a new resource to be created.
+
+- - -
 
 * `description` - (Optional) A description of the resource.
     Changing this forces a new resource to be created.
 
-* `network` - (Required) A link to the network this VPN gateway is accepting
-    traffic for.
-    Changing this forces a new resource to be created.
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 * `region` - (Optional) The region this gateway should sit in. If not specified,
     the project region will be used. Changing this forces a new resource to be
@@ -98,6 +106,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `self_link` - A GCE server assigned link to this resource.
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
+++ b/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
@@ -13,104 +13,109 @@ Manages a VPN Tunnel to the GCE network. For more info, read the
 
 ## Example Usage
 
-```
+```js
 resource "google_compute_network" "network1" {
-    name = "network1"
-    ipv4_range = "10.120.0.0/16"
+  name       = "network1"
+  ipv4_range = "10.120.0.0/16"
 }
 
 resource "google_compute_vpn_gateway" "target_gateway" {
-    name = "vpn1"
-    network = "${google_compute_network.network1.self_link}"
-    region = "${var.region}"
+  name    = "vpn1"
+  network = "${google_compute_network.network1.self_link}"
 }
 
 resource "google_compute_address" "vpn_static_ip" {
-    name = "vpn-static-ip"
-    region = "${var.region}"
+  name   = "vpn-static-ip"
 }
 
 resource "google_compute_forwarding_rule" "fr_esp" {
-    name = "fr-esp"
-    region = "${var.region}"
-    ip_protocol = "ESP"
-    ip_address = "${google_compute_address.vpn_static_ip.address}"
-    target = "${google_compute_vpn_gateway.target_gateway.self_link}"
+  name        = "fr-esp"
+  ip_protocol = "ESP"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
 }
 
 resource "google_compute_forwarding_rule" "fr_udp500" {
-    name = "fr-udp500"
-    region = "${var.region}"
-    ip_protocol = "UDP"
-    port_range = "500"
-    ip_address = "${google_compute_address.vpn_static_ip.address}"
-    target = "${google_compute_vpn_gateway.target_gateway.self_link}"
+  name        = "fr-udp500"
+  ip_protocol = "UDP"
+  port_range  = "500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
 }
 
 resource "google_compute_forwarding_rule" "fr_udp4500" {
-    name = "fr-udp4500"
-    region = "${var.region}"
-    ip_protocol = "UDP"
-    port_range = "4500"
-    ip_address = "${google_compute_address.vpn_static_ip.address}"
-    target = "${google_compute_vpn_gateway.target_gateway.self_link}"
+  name        = "fr-udp4500"
+  ip_protocol = "UDP"
+  port_range  = "4500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
 }
 
 resource "google_compute_vpn_tunnel" "tunnel1" {
-    name = "tunnel1"
-    region = "${var.region}"
-    peer_ip = "15.0.0.120"
-    shared_secret = "a secret message"
-    target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
-    depends_on = ["google_compute_forwarding_rule.fr_esp",
-        "google_compute_forwarding_rule.fr_udp500",
-        "google_compute_forwarding_rule.fr_udp4500"]
+  name          = "tunnel1"
+  peer_ip       = "15.0.0.120"
+  shared_secret = "a secret message"
+
+  target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
+
+  depends_on = [
+    "google_compute_forwarding_rule.fr_esp",
+    "google_compute_forwarding_rule.fr_udp500",
+    "google_compute_forwarding_rule.fr_udp4500",
+  ]
 }
 
 resource "google_compute_route" "route1" {
-    name = "route1"
-    network = "${google_compute_network.network1.name}"
-    next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
-    dest_range = "15.0.0.0/24"
-    priority = 1000
-}
+  name       = "route1"
+  network    = "${google_compute_network.network1.name}"
+  dest_range = "15.0.0.0/24"
+  priority   = 1000
 
+  next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) A unique name for the resource, required by GCE.
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+* `peer_ip` - (Required) The VPN gateway sitting outside of GCE. Changing this
+    forces a new resource to be created.
+
+* `shared_secret` - (Required) A passphrase shared between the two VPN gateways.
     Changing this forces a new resource to be created.
 
-* `description` - (Optional) A description of the resource.
-    Changing this forces a new resource to be created.
+* `target_vpn_gateway` - (Required) A link to the VPN gateway sitting inside
+    GCE. Changing this forces a new resource to be created.
 
-* `peer_ip` - (Required) The VPN gateway sitting outside of GCE.
-    Changing this forces a new resource to be created.
+- - -
+
+* `description` - (Optional) A description of the resource. Changing this forces
+    a new resource to be created.
+
+* `ike_version` - (Optional) Either version 1 or 2. Default is 2. Changing this
+    forces a new resource to be created.
+
+* `local_traffic_selector` - (Optional) Specifies which CIDR ranges are
+    announced to the VPN peer. Mandatory if the VPN gateway is attached to a
+    custom subnetted network. Refer to Google documentation for more
+    information.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 * `region` - (Optional) The region this tunnel should sit in. If not specified,
     the project region will be used. Changing this forces a new resource to be
     created.
 
-* `shared_secret` - (Required) A passphrase shared between the two VPN gateways.
-    Changing this forces a new resource to be created.
-
-* `target_vpn_gateway` - (Required) A link to the VPN gateway sitting inside GCE.
-    Changing this forces a new resource to be created.
-
-* `ike_version` - (Optional) Either version 1 or 2. Default is 2.
-    Changing this forces a new resource to be created.
-
-* `local_traffic_selector` - (Optional) Specifies which CIDR ranges are announced
-    to the VPN peer. Mandatory if the VPN gateway is attached to a custom subnetted
-    network. Refer to Google documentation for more information.
-
 ## Attributes Reference
 
-The following attributes are exported:
-
-* `self_link` - A GCE server assigned link to this resource.
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
 * `detailed_status` - Information about the status of the VPN tunnel.
+
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -8,64 +8,95 @@ description: |-
 
 # google\_container\_cluster
 
--> **Note:** Due to limitations of the API, all arguments except `node_version` are non-updateable (changing any will cause recreation of the whole cluster).
+!> **Warning:** Due to limitations of the API, all arguments except
+`node_version` are non-updateable. Changing any will cause recreation of the
+whole cluster!
 
 ## Example usage
 
-```
+```js
 resource "google_container_cluster" "primary" {
-    name = "marcellus-wallace"
-    zone = "us-central1-a"
-    initial_node_count = 3
+  name = "marcellus-wallace"
+  zone = "us-central1-a"
+  initial_node_count = 3
 
-    master_auth {
-        username = "mr.yoda"
-        password = "adoy.rm"
-    }
+  master_auth {
+    username = "mr.yoda"
+    password = "adoy.rm"
+  }
 
-    node_config {
-        oauth_scopes = [
-            "https://www.googleapis.com/auth/compute",
-            "https://www.googleapis.com/auth/devstorage.read_only",
-            "https://www.googleapis.com/auth/logging.write",
-            "https://www.googleapis.com/auth/monitoring"
-        ]
-    }
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring"
+    ]
+  }
 }
 ```
 
 ## Argument Reference
 
-* `name` - (Required) The name of the cluster, unique within the project and zone
+* `initial_node_count` - (Required) The number of nodes to create in this
+    cluster (not including the Kubernetes master).
+
+* `master_auth` - (Required) The authentication information for accessing the
+    Kubernetes master.
+
+* `name` - (Required) The name of the cluster, unique within the project and
+    zone.
+
 * `zone` - (Required) The zone that all resources should be created in.
-* `master_auth` - (Required) The authentication information for accessing the Kubernetes master
-* `initial_node_count` - (Required) The number of nodes to create in this cluster (not including the Kubernetes master)
-* `description` - (Optional) Description of the cluster
-* `node_version` - (Optional) The Kubernetes version on the nodes. Only valid for upgrading of existing cluster.
-  Defaults to latest version supported by the server.
-* `cluster_ipv4_cidr` - (Optional) The IP address range of the container pods in this cluster.
-  Default is an automatically assigned CIDR.
-* `logging_service` - (Optional) The logging service that the cluster should write logs to.
-  Available options include `logging.googleapis.com` and `none`. Defaults to `logging.googleapis.com`
-* `monitoring_service` - (Optional) The monitoring service that the cluster should write metrics to.
-  Available options include `monitoring.googleapis.com` and `none`. Defaults to `monitoring.googleapis.com`
-* `network` - (Optional) The name of the Google Compute Engine network to which the cluster is connected
-* `node_config` -  (Optional) The machine type and image to use for all nodes in this cluster
+
+- - -
+
+* `cluster_ipv4_cidr` - (Optional) The IP address range of the container pods in
+    this cluster. Default is an automatically assigned CIDR.
+
+* `description` - (Optional) Description of the cluster.
+
+* `logging_service` - (Optional) The logging service that the cluster should
+    write logs to. Available options include `logging.googleapis.com` and
+    `none`. Defaults to `logging.googleapis.com`
+
+* `monitoring_service` - (Optional) The monitoring service that the cluster
+    should write metrics to. Available options include
+    `monitoring.googleapis.com` and `none`. Defaults to
+    `monitoring.googleapis.com`
+
+* `network` - (Optional) The name of the Google Compute Engine network to which
+    the cluster is connected
+
+* `node_config` -  (Optional) The machine type and image to use for all nodes in
+    this cluster
+
+* `node_version` - (Optional) The Kubernetes version on the nodes. Only valid
+    for upgrading of existing cluster. Defaults to latest version supported by
+    the server.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 **Master Auth** supports the following arguments:
 
-* `password` - The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint
-* `username` - The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint
+* `password` - The password to use for HTTP basic authentication when accessing
+    the Kubernetes master endpoint
+
+* `username` - The username to use for HTTP basic authentication when accessing
+    the Kubernetes master endpoint
 
 **Node Config** supports the following arguments:
 
 * `machine_type` - (Optional) The name of a Google Compute Engine machine type.
-  Defaults to `n1-standard-1`.
-* `disk_size_gb` - (Optional) Size of the disk attached to each node, specified in GB.
-  The smallest allowed disk size is 10GB. Defaults to 100GB.
-* `oauth_scopes` - (Optional) The set of Google API scopes to be made available on all
-  of the node VMs under the "default" service account. The following scopes are necessary
-  to ensure the correct functioning of the cluster:
+    Defaults to `n1-standard-1`.
+
+* `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
+    in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
+
+* `oauth_scopes` - (Optional) The set of Google API scopes to be made available
+    on all of the node VMs under the "default" service account. The following
+    scopes are necessary to ensure the correct functioning of the cluster:
 
   * `https://www.googleapis.com/auth/compute`
   * `https://www.googleapis.com/auth/devstorage.read_only`
@@ -74,11 +105,19 @@ resource "google_container_cluster" "primary" {
 
 ## Attributes Reference
 
-* `master_auth.client_certificate` - Base64 encoded public certificate
-  used by clients to authenticate to the cluster endpoint.
-* `master_auth.client_key` - Base64 encoded private key used by clients
-  to authenticate to the cluster endpoint
-* `master_auth.cluster_ca_certificate` - Base64 encoded public certificate
-  that is the root of trust for the cluster
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
 * `endpoint` - The IP address of this cluster's Kubernetes master
-* `instance_group_urls` - List of instance group URLs which have been assigned to the cluster
+
+* `instance_group_urls` - List of instance group URLs which have been assigned
+    to the cluster
+
+* `master_auth.client_certificate` - Base64 encoded public certificate
+    used by clients to authenticate to the cluster endpoint.
+
+* `master_auth.client_key` - Base64 encoded private key used by clients
+    to authenticate to the cluster endpoint
+
+* `master_auth.cluster_ca_certificate` - Base64 encoded public certificate
+    that is the root of trust for the cluster

--- a/website/source/docs/providers/google/r/dns_managed_zone.markdown
+++ b/website/source/docs/providers/google/r/dns_managed_zone.markdown
@@ -12,11 +12,11 @@ Manages a zone within Google Cloud DNS.
 
 ## Example Usage
 
-```
+```js
 resource "google_dns_managed_zone" "prod" {
-    name = "prod-zone"
-    dns_name = "prod.mydomain.com."
-    description = "Production DNS zone"
+  name        = "prod-zone"
+  dns_name    = "prod.mydomain.com."
+  description = "Production DNS zone"
 }
 ```
 
@@ -24,19 +24,23 @@ resource "google_dns_managed_zone" "prod" {
 
 The following arguments are supported:
 
+* `dns_name` - (Required) The DNS name of this zone, e.g. "terraform.io".
+
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `dns_name` - (Required) The DNS name of this zone, e.g. "terraform.io".
+- - -
 
 * `description` - (Optional) A textual description field. Defaults to 'Managed by Terraform'.
 
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
-* `name` - The name of the resource.
-* `dns_name` - The DNS name of this zone.
 * `name_servers` - The list of nameservers that will be authoritative for this
-  domain.  Use NS records to redirect from your DNS provider to these names,
-thus making Google Cloud DNS authoritative for this zone.
+    domain. Use NS records to redirect from your DNS provider to these names,
+    thus making Google Cloud DNS authoritative for this zone.

--- a/website/source/docs/providers/google/r/dns_record_set.markdown
+++ b/website/source/docs/providers/google/r/dns_record_set.markdown
@@ -14,33 +14,34 @@ Manages a set of DNS records within Google Cloud DNS.
 
 This example is the common case of binding a DNS name to the ephemeral IP of a new instance:
 
-```
+```js
 resource "google_compute_instance" "frontend" {
-    name = "frontend"
-    machine_type = "g1-small"
-    zone = "us-central1-b"
+  name         = "frontend"
+  machine_type = "g1-small"
+  zone         = "us-central1-b"
 
-    disk {
-        image = "debian-7-wheezy-v20160301"
-    }
+  disk {
+    image = "debian-7-wheezy-v20160301"
+  }
 
-    network_interface {
-        network = "default"
-        access_config {
-        }
-    }
+  network_interface {
+    network = "default"
+    access_config {}
+  }
 }
 resource "google_dns_managed_zone" "prod" {
-    name = "prod-zone"
-    dns_name = "prod.mydomain.com."
+  name     = "prod-zone"
+  dns_name = "prod.mydomain.com."
 }
 
 resource "google_dns_record_set" "frontend" {
-    managed_zone = "${google_dns_managed_zone.prod.name}"
-    name = "frontend.${google_dns_managed_zone.prod.dns_name}"
-    type = "A"
-    ttl = 300
-    rrdatas = ["${google_compute_instance.frontend.network_interface.0.access_config.0.assigned_nat_ip}"]
+  name = "frontend.${google_dns_managed_zone.prod.dns_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = "${google_dns_managed_zone.prod.name}"
+
+  rrdatas = ["${google_compute_instance.frontend.network_interface.0.access_config.0.assigned_nat_ip}"]
 }
 ```
 
@@ -48,17 +49,23 @@ resource "google_dns_record_set" "frontend" {
 
 The following arguments are supported:
 
-* `managed_zone` - (Required) The name of the zone in which this record set will reside.
+* `managed_zone` - (Required) The name of the zone in which this record set will
+    reside.
 
 * `name` - (Required) The DNS name this record set will apply to.
 
-* `type` - (Required) The DNS record set type.
+* `rrdatas` - (Required) The string data for the records in this record set
+    whose meaning depends on the DNS type.
 
 * `ttl` - (Required) The time-to-live of this record set (seconds).
 
-* `rrdatas` - (Required) The string data for the records in this record set
-  whose meaning depends on the DNS type.
+* `type` - (Required) The DNS record set type.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
 
 ## Attributes Reference
 
-All arguments are available as attributes.
+Only the arguments listed above are exposed as attributes.

--- a/website/source/docs/providers/google/r/pubsub_subscription.html.markdown
+++ b/website/source/docs/providers/google/r/pubsub_subscription.html.markdown
@@ -8,24 +8,26 @@ description: |-
 
 # google\_pubsub\_subscripion
 
-Creates a subscription in Google's pubsub queueing system.  For more information see
+Creates a subscription in Google's pubsub queueing system. For more information see
 [the official documentation](https://cloud.google.com/pubsub/docs) and
 [API](https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions).
 
 
 ## Example Usage
 
-```
+```js
 resource "google_pubsub_subscription" "default" {
-    name = "default-subscription"
-    topic = "default-topic"
-    ack_deadline_seconds = 20
-    push_config {
-        endpoint = "https://example.com/push"
-        attributes {
-            x-goog-version = "v1"
-        }
+  name  = "default-subscription"
+  topic = "default-topic"
+
+  ack_deadline_seconds = 20
+
+  push_config {
+    endpoint = "https://example.com/push"
+    attributes {
+      x-goog-version = "v1"
     }
+  }
 }
 ```
 
@@ -39,9 +41,17 @@ The following arguments are supported:
 * `topic` - (Required) A topic to bind this subscription to, required by pubsub.
     Changing this forces a new resource to be created.
 
+- - -
+
 * `ack_deadline_seconds` - (Optional) The maximum number of seconds a
     subscriber has to acknowledge a received message, otherwise the message is
     redelivered. Changing this forces a new resource to be created.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `push_config` - (Optional) Block configuration for push options. More
+    configuration options are detailed below.
 
 The optional `push_config` block supports:
 
@@ -54,3 +64,7 @@ The optional `push_config` block supports:
     delivery. For more information, read [the API docs
     here](https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions#PushConfig.FIELDS.attributes).
     Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+Only the arguments listed above are exposed as attributes.

--- a/website/source/docs/providers/google/r/pubsub_topic.html.markdown
+++ b/website/source/docs/providers/google/r/pubsub_topic.html.markdown
@@ -8,16 +8,16 @@ description: |-
 
 # google\_pubsub\_topic
 
-Creates a topic in Google's pubsub queueing system.  For more information see
+Creates a topic in Google's pubsub queueing system. For more information see
 [the official documentation](https://cloud.google.com/pubsub/docs) and
 [API](https://cloud.google.com/pubsub/reference/rest/v1/projects.topics).
 
 
 ## Example Usage
 
-```
+```js
 resource "google_pubsub_topic" "default" {
-	name = "default-topic"
+  name = "default-topic"
 }
 ```
 
@@ -28,8 +28,11 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by pubsub.
     Changing this forces a new resource to be created.
 
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
 ## Attributes Reference
 
-The following attributes are exported:
-
-* `name` - The name of the resource.
+Only the arguments listed above are exposed as attributes.

--- a/website/source/docs/providers/google/r/sql_database.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database.html.markdown
@@ -14,20 +14,19 @@ Creates a new Google SQL Database on a Google SQL Database Instance. For more in
 
 Example creating a SQL Database.
 
-```
+```js
 resource "google_sql_database_instance" "master" {
-	name = "master-instance"
+  name = "master-instance"
 
-    settings {
-        tier = "D0"
-    }
+  settings {
+    tier = "D0"
+  }
 }
 
 resource "google_sql_database" "users" {
-	name = "image-store-bucket"
-	instance = "${google_sql_database_instance.master.name}"
+  name     = "image-store-bucket"
+  instance = "${google_sql_database_instance.master.name}"
 }
-
 ```
 
 ## Argument Reference
@@ -38,8 +37,14 @@ The following arguments are supported:
 
 * `instance` - (Required) The name of containing instance.
 
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
 * `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -14,13 +14,13 @@ Creates a new Google SQL Database Instance. For more information, see the [offic
 
 Example creating a SQL Database.
 
-```
+```js
 resource "google_sql_database_instance" "master" {
-    name = "master-instance"
+  name = "master-instance"
 
-    settings {
-        tier = "D0"
-    }
+  settings {
+    tier = "D0"
+  }
 }
 ```
 
@@ -28,42 +28,53 @@ resource "google_sql_database_instance" "master" {
 
 The following arguments are supported:
 
-* `name` - (Optional, Computed) The name of the instance. If the name is left
-  blank, Terraform will randomly generate one when the instance is first
-  created. This is done because after a name is used, it cannot be reused
-  for up to [two months](https://cloud.google.com/sql/docs/delete-instance).
-
 * `region` - (Required) The region the instance will sit in. Note, this does
-  not line up with the Google Compute Engine (GCE) regions - your options are
-  `us-central`, `asia-west1`, `europe-west1`, and `us-east1`.
+    not line up with the Google Compute Engine (GCE) regions - your options are
+    `us-central`, `asia-west1`, `europe-west1`, and `us-east1`.
 
-* `master_instance_name` - (Optional) The name of the instance that will act as
-  the master in the replication setup. Note, this requires the master to have
-  `binary_log_enabled` set, as well as existing backups.
+* `settings` - (Required) The settings to use for the database. The
+    configuration is detailed below.
+
+- - -
 
 * `database_version` - (Optional, Default: `MYSQL_5_5`) The MySQL version to
-  use. Can be either `MYSQL_5_5` or `MYSQL_5_6`.
+    use. Can be either `MYSQL_5_5` or `MYSQL_5_6`.
+
+* `name` - (Optional, Computed) The name of the instance. If the name is left
+    blank, Terraform will randomly generate one when the instance is first
+    created. This is done because after a name is used, it cannot be reused for
+    up to [two months](https://cloud.google.com/sql/docs/delete-instance).
+
+* `master_instance_name` - (Optional) The name of the instance that will act as
+    the master in the replication setup. Note, this requires the master to have
+    `binary_log_enabled` set, as well as existing backups.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `replica_configuration` - (Optional) The configuration for replication. The
+    configuration is detailed below.
 
 The required `settings` block supports:
 
 * `tier` - (Required) The machine tier to use. See
-  [pricing](https://cloud.google.com/sql/pricing) for more details and
-  supported versions.
+    [pricing](https://cloud.google.com/sql/pricing) for more details and
+    supported versions.
 
 * `activation_policy` - (Optional) This specifies when the instance should be
-  active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
+    active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
 
-* `authorized_gae_applications` - (Optional) A list of Google App Engine (GAE) project names that
-  are allowed to access this instance.
+* `authorized_gae_applications` - (Optional) A list of Google App Engine (GAE)
+    project names that are allowed to access this instance.
 
 * `crash_safe_replication` - (Optional) Specific to read instances, indicates
-  when crash-safe replication flags are enabled.
+    when crash-safe replication flags are enabled.
 
 * `pricing_plan` - (Optional) Pricing plan for this instance, can be one of
-  `PER_USE` or `PACKAGE`.
+    `PER_USE` or `PACKAGE`.
 
-* `replication_type` - (Optional) Replication type for this instance, can be one of
-  `ASYNCHRONOUS` or `SYNCHRONOUS`.
+* `replication_type` - (Optional) Replication type for this instance, can be one
+    of `ASYNCHRONOUS` or `SYNCHRONOUS`.
 
 The optional `settings.database_flags` sublist supports:
 
@@ -74,61 +85,60 @@ The optional `settings.database_flags` sublist supports:
 The optional `settings.backup_configuration` subblock supports:
 
 * `binary_log_enabled` - (Optional) True iff binary logging is enabled. If
-  `logging` is false, this must be as well.
+    `logging` is false, this must be as well.
 
 * `enabled` - (Optional) True iff backup configuration is enabled.
 
 * `start_time` - (Optional) `HH:MM` format time indicating when backup
-  configuration starts.
+    configuration starts.
 
 The optional `settings.ip_configuration` subblock supports:
 
 * `ipv4_enabled` - (Optional) True iff the instance should be assigned an IP
-  address.
+    address.
 
 * `require_ssl` - (Optional) True iff mysqld should default to `REQUIRE X509`
-  for users connecting over IP.
+    for users connecting over IP.
 
 The optional `settings.ip_configuration.authorized_networks[]` sublist supports:
 
-* `expiration_time` - (Optional) The [RFC
-  3339](https://tools.ietf.org/html/rfc3339) formatted date time string
-  indicating when this whitelist expires.
+* `expiration_time` - (Optional) The [RFC 3339](https://tools.ietf.org/html/rfc3339)
+  formatted date time string indicating when this whitelist expires.
 
 * `name` - (Optional) A name for this whitelist entry.
 
 * `value` - (Optional) A CIDR notation IPv4 or IPv6 address that is allowed to
-  access this instance. Must be set even if other two attributes are not for
-  the whitelist to become active.
+    access this instance. Must be set even if other two attributes are not for
+    the whitelist to become active.
 
 The optional `settings.location_preference` subblock supports:
 
 * `follow_gae_application` - (Optional) A GAE application whose zone to remain
-  in. Must be in the same region as this instance.
+    in. Must be in the same region as this instance.
 
 * `zone` - (Optional) The preferred compute engine
-  [zone](https://cloud.google.com/compute/docs/zones?hl=en).
+    [zone](https://cloud.google.com/compute/docs/zones?hl=en).
 
-The optional `replica_configuration` block must have
-`master_instance_name` set to work, cannot be updated, and supports:
+The optional `replica_configuration` block must have `master_instance_name` set
+to work, cannot be updated, and supports:
 
 * `ca_certificate` - (Optional) PEM representation of the trusted CA's x509
-  certificate.
+    certificate.
 
 * `client_certificate` - (Optional) PEM representation of the slave's x509
-  certificate.
+    certificate.
 
-* `client_key` - (Optional) PEM representation of the slave's private key.
-  The corresponding public key in encoded in the `client_certificate`.
+* `client_key` - (Optional) PEM representation of the slave's private key. The
+    corresponding public key in encoded in the `client_certificate`.
 
 * `connect_retry_interval` - (Optional, Default: 60) The number of seconds
-  between connect retries.
+    between connect retries.
 
 * `dump_file_path` - (Optional) Path to a SQL file in GCS from which slave
-  instances are created. Format is `gs://bucket/filename`.
+    instances are created. Format is `gs://bucket/filename`.
 
 * `master_heartbeat_period` - (Optional) Time in ms between replication
-  heartbeats.
+    heartbeats.
 
 * `password` - (Optional) Password for the replication connection.
 
@@ -137,22 +147,19 @@ The optional `replica_configuration` block must have
 * `username` - (Optional) Username for replication connection.
 
 * `verify_server_certificate` - (Optional) True iff the master's common name
-  value is checked during the SSL handshake.
+    value is checked during the SSL handshake.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `ip_address.ip_address` - The IPv4 address assigned.
+
+* `ip_address.time_to_retire` - The time this IP address will be retired, in RFC
+    3339 format.
 
 * `self_link` - The URI of the created resource.
 
-The `settings` block exports:
-
-* `version` - Used to make sure changes to the `settings` block are atomic.
-
-The `ip_address` block exports a list of IPv4 addresses assigned to this
-instance, with the following properties:
-
-* `ip_address` - The IPv4 address assigned.
-
-* `time_to_retire` - The time this IP address will be retired, in RFC 3339
-  format.
+* `settings.version` - Used to make sure changes to the `settings` block are
+    atomic.

--- a/website/source/docs/providers/google/r/sql_user.html.markdown
+++ b/website/source/docs/providers/google/r/sql_user.html.markdown
@@ -14,34 +14,42 @@ Creates a new Google SQL User on a Google SQL User Instance. For more informatio
 
 Example creating a SQL User.
 
-```
+```js
 resource "google_sql_database_instance" "master" {
-	name = "master-instance"
+  name = "master-instance"
 
-    settings {
-        tier = "D0"
-    }
+  settings {
+    tier = "D0"
+  }
 }
 
 resource "google_sql_user" "users" {
-	name = "me"
-	instance = "${google_sql_database_instance.master.name}"
-	host = "me.com"
+  name     = "me"
+  instance = "${google_sql_database_instance.master.name}"
+  host     = "me.com"
 }
-
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the user.
-  Changing this forces a new resource to be created.
-
 * `host` - (Required) The host the user can connect from. Can be an IP address.
-  Changing this forces a new resource to be created.
+    Changing this forces a new resource to be created.
+
+* `instance` - (Required) The name of the Cloud SQL instance. Changing this
+    forces a new resource to be created.
+
+* `name` - (Required) The name of the user. Changing this forces a new resource
+    to be created.
 
 * `password` - (Required) The users password. Can be updated.
 
-* `instance` - (Required) The name of the Cloud SQL instance.
-  Changing this forces a new resource to be created.
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+Only the arguments listed above are exposed as attributes.

--- a/website/source/docs/providers/google/r/storage_bucket.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket.html.markdown
@@ -15,16 +15,16 @@ Creates a new bucket in Google cloud storage service(GCS). Currently, it will no
 
 Example creating a private bucket in standard storage, in the EU region.
 
-```
+```js
 resource "google_storage_bucket" "image-store" {
-	name = "image-store-bucket"
-	location = "EU"
-    website {
-        main_page_suffix = "index.html"
-        not_found_page = "404.html"
-    }
-}
+  name     = "image-store-bucket"
+  location = "EU"
 
+  website {
+    main_page_suffix = "index.html"
+    not_found_page = "404.html"
+  }
+}
 ```
 
 ## Argument Reference
@@ -32,18 +32,35 @@ resource "google_storage_bucket" "image-store" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the bucket.
+
+- - -
+
+* `force_destroy` - (Optional, Default: false) When deleting a bucket, this
+    boolean option will delete all contained objects. If you try to delete a
+    bucket that contains objects, Terraform will fail that run.
+
+* `location` - (Optional, Default: 'US') The [GCS location](https://cloud.google.com/storage/docs/bucket-locations)
+
+
 * `predefined_acl` - (Optional, Deprecated) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Please switch
 to `google_storage_bucket_acl.predefined_acl`.
-* `location` - (Optional, Default: 'US') The [GCS location](https://cloud.google.com/storage/docs/bucket-locations)
-* `force_destroy` - (Optional, Default: false) When deleting a bucket, this boolean option will delete all contained objects. If you try to delete a bucket that contains objects, Terraform will fail that run.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `website` - (Optional) Configuration if the bucket acts as a website.
 
 The optional `website` block supports:
 
-* `main_page_suffix` - (Optional) Behaves as the bucket's directory index where missing objects are treated as potential directories.
-* `not_found_page` - (Optional) The custom object to return when a requested resource is not found.
+* `main_page_suffix` - (Optional) Behaves as the bucket's directory index where
+    missing objects are treated as potential directories.
+
+* `not_found_page` - (Optional) The custom object to return when a requested
+    resource is not found.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
 * `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
@@ -14,23 +14,34 @@ Creates a new bucket ACL in Google cloud storage service(GCS).
 
 Example creating an ACL on a bucket with one owner, and one reader.
 
-```
+```js
 resource "google_storage_bucket" "image-store" {
-	name = "image-store-bucket"
-	location = "EU"
+  name     = "image-store-bucket"
+  location = "EU"
 }
 
 resource "google_storage_bucket_acl" "image-store-acl" {
-    bucket = "${google_storage_bucket.image_store.name}"
-    role_entity = ["OWNER:user-my.email@gmail.com",
-        "READER:group-mygroup"]
-}
+  bucket = "${google_storage_bucket.image_store.name}"
 
+  role_entity = [
+    "OWNER:user-my.email@gmail.com",
+    "READER:group-mygroup",
+  ]
+}
 ```
 
 ## Argument Reference
 
 * `bucket` - (Required) The name of the bucket it applies to.
-* `predefined_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if both `role_entity` and `default_acl` are not.
+
+- - -
+
 * `default_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply to future buckets. Must be set both `role_entity` and `predefined_acl` are not.
+
+* `predefined_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if both `role_entity` and `default_acl` are not.
+
 * `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Bucket ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls)  for more details. Must be set if both `predefined_acl` and `default_acl` are not.
+
+## Attributes Reference
+
+Only the arguments listed above are exposed as attributes.

--- a/website/source/docs/providers/google/r/storage_bucket_object.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket_object.html.markdown
@@ -15,36 +15,39 @@ Creates a new object inside an exisiting bucket in Google cloud storage service 
 
 Example creating a public object in an existing `image-store` bucket.
 
-```
+```js
 resource "google_storage_bucket_object" "picture" {
-	name = "butterfly01"
-    source = "/images/nature/garden-tiger-moth.jpg"
-    bucket = "image-store"
+  name   = "butterfly01"
+  source = "/images/nature/garden-tiger-moth.jpg"
+  bucket = "image-store"
 }
-
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the object.
-
 * `bucket` - (Required) The name of the containing bucket.
 
-* `source` - (Optional) A path to the data you want to upload. Must be defined
-if `content` is not.
+* `name` - (Required) The name of the object.
+
+- - -
 
 * `content` - (Optional) Data as `string` to be uploaded. Must be defined if
-`source` is not.
+    `source` is not.
 
 * `predefined_acl` - (Optional, Deprecated) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) apply. Please switch
 to `google_storage_object_acl.predefined_acl`.
 
+
+* `source` - (Optional) A path to the data you want to upload. Must be defined
+    if `content` is not.
+
 ## Attributes Reference
 
-The following attributes are exported:
-
-* `md5hash` - (Computed) Base 64 MD5 hash of the uploaded data.
+In addition to the arguments listed above, the following computed attributes are
+exported:
 
 * `crc32c` - (Computed) Base 64 CRC32 hash of the uploaded data.
+
+* `md5hash` - (Computed) Base 64 MD5 hash of the uploaded data.

--- a/website/source/docs/providers/google/r/storage_object_acl.html.markdown
+++ b/website/source/docs/providers/google/r/storage_object_acl.html.markdown
@@ -14,30 +14,41 @@ Creates a new object ACL in Google cloud storage service (GCS)
 
 Create an object ACL with one owner and one reader.
 
-```
+```js
 resource "google_storage_bucket" "image-store" {
-	name = "image-store-bucket"
-	location = "EU"
+  name     = "image-store-bucket"
+  location = "EU"
 }
 
 resource "google_storage_bucket_object" "image" {
-	name = "image1"
-    bucket = "${google_storage_bucket.name}"
-    source = "image1.jpg"
+  name  = "image1"
+  bucket = "${google_storage_bucket.name}"
+  source = "image1.jpg"
 }
 
 resource "google_storage_object_acl" "image-store-acl" {
-    bucket = "${google_storage_bucket.image_store.name}"
-    object = "${google_storage_bucket_object.image_store.name}"
-    role_entity = ["OWNER:user-my.email@gmail.com",
-        "READER:group-mygroup"]
-}
+  bucket = "${google_storage_bucket.image_store.name}"
+  object = "${google_storage_bucket_object.image_store.name}"
 
+  role_entity = [
+    "OWNER:user-my.email@gmail.com",
+    "READER:group-mygroup",
+  ]
+}
 ```
 
 ## Argument Reference
 
 * `bucket` - (Required) The name of the bucket it applies to.
+
 * `object` - (Required) The name of the object it applies to.
+
+- - -
+
 * `predefined_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if `role_entity` is not.
+
 * `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Object ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls) for more details. Must be set if `predefined_acl` is not.
+
+## Attributes Reference
+
+Only the arguments listed above are exposed as attributes.


### PR DESCRIPTION
This commit uses the existing pattern in the provider for "region", but extends it to "project" as well. Currently the provider is heavily tied to a project. Some of the upcoming APIs (that we would like to leverage) do not require a project id. This PR decouples the provider configuration from the project configuration, but does so in a backwards-compatible way.

Highlight changes:

- provider/google.project: required => optional
- resource/google_*: +project attribute (with some exceptions)
- Updated all docs with the new resource

/cc @lwander @jen20 