### PR TITLE
deps: Update github.com/fsouza/go-dockerclient

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -561,75 +561,75 @@
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/opts",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/idtools",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/longpath",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/promise",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/stdcopy",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/go-units",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/hashicorp/go-cleanhttp",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/opencontainers/runc/libcontainer/user",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/golang.org/x/net/context",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient/external/golang.org/x/sys/unix",
-			"Rev": "02a8beb401b20e112cff3ea740545960b667eab1"
+			"Rev": "bf97c77db7c945cbcdbf09d56c6f87a66f54537b"
 		},
 		{
 			"ImportPath": "github.com/go-chef/chef",

--- a/vendor/github.com/fsouza/go-dockerclient/.travis.yml
+++ b/vendor/github.com/fsouza/go-dockerclient/.travis.yml
@@ -1,22 +1,27 @@
 language: go
 sudo: required
 go:
-  - 1.3.3
   - 1.4.2
   - 1.5.3
-  - 1.6rc1
+  - 1.6
   - tip
+os:
+  - linux
+  - osx
 env:
-  - GOARCH=amd64 DOCKER_VERSION=1.7.1
-  - GOARCH=386   DOCKER_VERSION=1.7.1
   - GOARCH=amd64 DOCKER_VERSION=1.8.3
   - GOARCH=386   DOCKER_VERSION=1.8.3
   - GOARCH=amd64 DOCKER_VERSION=1.9.1
   - GOARCH=386   DOCKER_VERSION=1.9.1
+  - GOARCH=amd64 DOCKER_VERSION=1.10.3
+  - GOARCH=386   DOCKER_VERSION=1.10.3
 install:
-  - make prepare_docker
+  - travis_retry travis-scripts/install.bash
 script:
-  - make test
-  - DOCKER_HOST=tcp://127.0.0.1:2375 make integration
+  - travis-scripts/run-tests.bash
 services:
   - docker
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip

--- a/vendor/github.com/fsouza/go-dockerclient/AUTHORS
+++ b/vendor/github.com/fsouza/go-dockerclient/AUTHORS
@@ -14,6 +14,7 @@ Ben Marini <ben@remind101.com>
 Ben McCann <benmccann.com>
 Ben Parees <bparees@redhat.com>
 Benno van den Berg <bennovandenberg@gmail.com>
+Bradley Cicenas <bradley.cicenas@gmail.com>
 Brendan Fosberry <brendan@codeship.com>
 Brian Lalor <blalor@bravo5.org>
 Brian P. Hamachek <brian@brianhama.com>
@@ -48,6 +49,8 @@ Fabio Rehm <fgrehm@gmail.com>
 Fatih Arslan <ftharsln@gmail.com>
 Flavia Missi <flaviamissi@gmail.com>
 Francisco Souza <f@souza.cc>
+Frank Groeneveld <frank@frankgroeneveld.nl>
+George Moura <gwmoura@gmail.com>
 Grégoire Delattre <gregoire.delattre@gmail.com>
 Guillermo Álvarez Fernández <guillermo@cientifico.net>
 Harry Zhang <harryzhang@zju.edu.cn>
@@ -84,7 +87,9 @@ Michael Schmatz <michaelschmatz@gmail.com>
 Michal Fojtik <mfojtik@redhat.com>
 Mike Dillon <mike.dillon@synctree.com>
 Mrunal Patel <mrunalp@gmail.com>
+Nate Jones <nate@endot.org>
 Nguyen Sy Thanh Son <sonnst@sigma-solutions.eu>
+Nicholas Van Wiggeren <nvanwiggeren@digitalocean.com>
 Nick Ethier <ncethier@gmail.com>
 Omeid Matten <public@omeid.me>
 Orivej Desh <orivej@gmx.fr>
@@ -98,9 +103,11 @@ Philippe Lafoucrière <philippe.lafoucriere@tech-angels.com>
 Rafe Colton <rafael.colton@gmail.com>
 Rob Miller <rob@kalistra.com>
 Robert Williamson <williamson.robert@gmail.com>
+Roman Khlystik <roman.khlystik@gmail.com>
 Salvador Gironès <salvadorgirones@gmail.com>
 Sam Rijs <srijs@airpost.net>
 Sami Wagiaalla <swagiaal@redhat.com>
+Samuel Archambault <sarchambault@lapresse.ca>
 Samuel Karp <skarp@amazon.com>
 Silas Sewell <silas@sewell.org>
 Simon Eskildsen <sirup@sirupsen.com>

--- a/vendor/github.com/fsouza/go-dockerclient/LICENSE
+++ b/vendor/github.com/fsouza/go-dockerclient/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, go-dockerclient authors
+Copyright (c) 2016, go-dockerclient authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/vendor/github.com/fsouza/go-dockerclient/Makefile
+++ b/vendor/github.com/fsouza/go-dockerclient/Makefile
@@ -11,8 +11,7 @@
 	cov \
 	clean
 
-SRCS = $(shell git ls-files '*.go' | grep -v '^external/')
-PKGS = ./. ./testing
+PKGS = . ./testing
 
 all: test
 
@@ -22,31 +21,29 @@ vendor:
 
 lint:
 	@ go get -v github.com/golang/lint/golint
-	$(foreach file,$(SRCS),golint $(file) || exit;)
+	@for file in $$(git ls-files '*.go' | grep -v 'external/'); do \
+		export output="$$(golint $${file} | grep -v 'type name will be used as docker.DockerInfo')"; \
+		[ -n "$${output}" ] && echo "$${output}" && export status=1; \
+	done; \
+	exit $${status:-0}
 
 vet:
-	@-go get -v golang.org/x/tools/cmd/vet
 	$(foreach pkg,$(PKGS),go vet $(pkg);)
 
 fmt:
-	gofmt -w $(SRCS)
+	gofmt -s -w $(PKGS)
 
 fmtcheck:
-	$(foreach file,$(SRCS),gofmt -d $(file);)
-
-prepare_docker:
-	sudo stop docker
-	sudo rm -rf /var/lib/docker
-	sudo rm -f `which docker`
-	sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-	echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee /etc/apt/sources.list.d/docker.list
-	sudo apt-get update
-	sudo apt-get install docker-engine=$(DOCKER_VERSION)-0~$(shell lsb_release -cs) -y --force-yes
+	@ export output=$$(gofmt -s -d $(PKGS)); \
+		[ -n "$${output}" ] && echo "$${output}" && export status=1; \
+		exit $${status:-0}
 
 pretest: lint vet fmtcheck
 
-test: pretest
+gotest:
 	$(foreach pkg,$(PKGS),go test $(pkg) || exit;)
+
+test: pretest gotest
 
 integration:
 	go test -tags docker_integration -run TestIntegration -v

--- a/vendor/github.com/fsouza/go-dockerclient/README.markdown
+++ b/vendor/github.com/fsouza/go-dockerclient/README.markdown
@@ -4,7 +4,7 @@
 [![GoDoc](https://img.shields.io/badge/api-Godoc-blue.svg?style=flat-square)](https://godoc.org/github.com/fsouza/go-dockerclient)
 
 This package presents a client for the Docker remote API. It also provides
-support for the extensions in the [Swarm API](https://docs.docker.com/swarm/api/swarm-api/).
+support for the extensions in the [Swarm API](https://docs.docker.com/swarm/swarm-api/).
 
 This package also provides support for docker's network API, which is a simple
 passthrough to the libnetwork remote API.  Note that docker's network API is

--- a/vendor/github.com/fsouza/go-dockerclient/auth.go
+++ b/vendor/github.com/fsouza/go-dockerclient/auth.go
@@ -82,10 +82,12 @@ func parseDockerConfig(r io.Reader) (map[string]dockerConfig, error) {
 	buf.ReadFrom(r)
 	byteData := buf.Bytes()
 
-	var confsWrapper map[string]map[string]dockerConfig
+	confsWrapper := struct {
+		Auths map[string]dockerConfig `json:"auths"`
+	}{}
 	if err := json.Unmarshal(byteData, &confsWrapper); err == nil {
-		if confs, ok := confsWrapper["auths"]; ok {
-			return confs, nil
+		if len(confsWrapper.Auths) > 0 {
+			return confsWrapper.Auths, nil
 		}
 	}
 

--- a/vendor/github.com/fsouza/go-dockerclient/client.go
+++ b/vendor/github.com/fsouza/go-dockerclient/client.go
@@ -555,6 +555,8 @@ type hijackOptions struct {
 	data           interface{}
 }
 
+// CloseWaiter is an interface with methods for closing the underlying resource
+// and then waiting for it to finish processing.
 type CloseWaiter interface {
 	io.Closer
 	Wait() error
@@ -587,7 +589,7 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (Close
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "plain/text")
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 	protocol := c.endpointURL.Scheme

--- a/vendor/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/chtimes_unix.go
+++ b/vendor/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/chtimes_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package system
+
+import (
+	"time"
+)
+
+//setCTime will set the create time on a file. On Unix, the create
+//time is updated as a side effect of setting the modified time, so
+//no action is required.
+func setCTime(path string, ctime time.Time) error {
+	return nil
+}

--- a/vendor/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/chtimes_windows.go
+++ b/vendor/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/chtimes_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package system
+
+import (
+	"syscall"
+	"time"
+)
+
+//setCTime will set the create time on a file. On Windows, this requires
+//calling SetFileTime and explicitly including the create time.
+func setCTime(path string, ctime time.Time) error {
+	ctimespec := syscall.NsecToTimespec(ctime.UnixNano())
+	pathp, e := syscall.UTF16PtrFromString(path)
+	if e != nil {
+		return e
+	}
+	h, e := syscall.CreateFile(pathp,
+		syscall.FILE_WRITE_ATTRIBUTES, syscall.FILE_SHARE_WRITE, nil,
+		syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if e != nil {
+		return e
+	}
+	defer syscall.Close(h)
+	c := syscall.NsecToFiletime(syscall.TimespecToNsec(ctimespec))
+	return syscall.SetFileTime(h, &c, nil, nil)
+}

--- a/vendor/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_openbsd.go
+++ b/vendor/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_openbsd.go
@@ -1,5 +1,3 @@
-// +build !linux,!windows,!freebsd,!solaris,!openbsd
-
 package system
 
 import (
@@ -13,5 +11,5 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
-		mtim: s.Mtimespec}, nil
+		mtim: s.Mtim}, nil
 }

--- a/vendor/github.com/fsouza/go-dockerclient/external/golang.org/x/net/context/context.go
+++ b/vendor/github.com/fsouza/go-dockerclient/external/golang.org/x/net/context/context.go
@@ -210,13 +210,13 @@ type CancelFunc func()
 // call cancel as soon as the operations running in this Context complete.
 func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
 	c := newCancelCtx(parent)
-	propagateCancel(parent, &c)
-	return &c, func() { c.cancel(true, Canceled) }
+	propagateCancel(parent, c)
+	return c, func() { c.cancel(true, Canceled) }
 }
 
 // newCancelCtx returns an initialized cancelCtx.
-func newCancelCtx(parent Context) cancelCtx {
-	return cancelCtx{
+func newCancelCtx(parent Context) *cancelCtx {
+	return &cancelCtx{
 		Context: parent,
 		done:    make(chan struct{}),
 	}
@@ -259,7 +259,7 @@ func parentCancelCtx(parent Context) (*cancelCtx, bool) {
 		case *cancelCtx:
 			return c, true
 		case *timerCtx:
-			return &c.cancelCtx, true
+			return c.cancelCtx, true
 		case *valueCtx:
 			parent = c.Context
 		default:
@@ -377,7 +377,7 @@ func WithDeadline(parent Context, deadline time.Time) (Context, CancelFunc) {
 // implement Done and Err.  It implements cancel by stopping its timer then
 // delegating to cancelCtx.cancel.
 type timerCtx struct {
-	cancelCtx
+	*cancelCtx
 	timer *time.Timer // Under cancelCtx.mu.
 
 	deadline time.Time

--- a/vendor/github.com/fsouza/go-dockerclient/misc.go
+++ b/vendor/github.com/fsouza/go-dockerclient/misc.go
@@ -4,7 +4,10 @@
 
 package docker
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // Version returns version information about the docker server.
 //
@@ -22,17 +25,81 @@ func (c *Client) Version() (*Env, error) {
 	return &env, nil
 }
 
+// DockerInfo contains information about the Docker server
+//
+// See https://goo.gl/bHUoz9 for more details.
+type DockerInfo struct {
+	ID                 string
+	Containers         int
+	ContainersRunning  int
+	ContainersPaused   int
+	ContainersStopped  int
+	Images             int
+	Driver             string
+	DriverStatus       [][2]string
+	SystemStatus       [][2]string
+	Plugins            PluginsInfo
+	MemoryLimit        bool
+	SwapLimit          bool
+	KernelMemory       bool
+	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
+	CPUCfsQuota        bool `json:"CpuCfsQuota"`
+	CPUShares          bool
+	CPUSet             bool
+	IPv4Forwarding     bool
+	BridgeNfIptables   bool
+	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`
+	Debug              bool
+	NFd                int
+	OomKillDisable     bool
+	NGoroutines        int
+	SystemTime         string
+	ExecutionDriver    string
+	LoggingDriver      string
+	CgroupDriver       string
+	NEventsListener    int
+	KernelVersion      string
+	OperatingSystem    string
+	OSType             string
+	Architecture       string
+	IndexServerAddress string
+	NCPU               int
+	MemTotal           int64
+	DockerRootDir      string
+	HTTPProxy          string `json:"HttpProxy"`
+	HTTPSProxy         string `json:"HttpsProxy"`
+	NoProxy            string
+	Name               string
+	Labels             []string
+	ExperimentalBuild  bool
+	ServerVersion      string
+	ClusterStore       string
+	ClusterAdvertise   string
+}
+
+// PluginsInfo is a struct with the plugins registered with the docker daemon
+//
+// for more information, see: https://goo.gl/bHUoz9
+type PluginsInfo struct {
+	// List of Volume plugins registered
+	Volume []string
+	// List of Network plugins registered
+	Network []string
+	// List of Authorization plugins registered
+	Authorization []string
+}
+
 // Info returns system-wide information about the Docker server.
 //
 // See https://goo.gl/ElTHi2 for more details.
-func (c *Client) Info() (*Env, error) {
+func (c *Client) Info() (*DockerInfo, error) {
 	resp, err := c.do("GET", "/info", doOptions{})
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	var info Env
-	if err := info.Decode(resp.Body); err != nil {
+	var info DockerInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
 		return nil, err
 	}
 	return &info, nil


### PR DESCRIPTION
This introduces the fix in fsouza/go-dockerclient#497, which in turn fixes fsouza/go-dockerclient#296. This allows Terraform to build fully on OpenBSD.