### PR TITLE
[WIP] Add Triton CNS tag support.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -928,7 +928,7 @@
 		},
 		{
 			"ImportPath": "github.com/joyent/gosdc/cloudapi",
-			"Rev": "0697a5c4f39a71a4f9e3b154380b47dbfcc3da6e"
+			"Rev": "042c6e9de2b48a646d310e70cc0050c83fe18200"
 		},
 		{
 			"ImportPath": "github.com/joyent/gosign/auth",

--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -229,18 +229,13 @@ func resourceMachineCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	tags := map[string]string{}
-	for k, v := range d.Get("tags").(map[string]interface{}) {
-		tags[k] = v.(string)
-	}
-
 	machine, err := client.CreateMachine(cloudapi.CreateMachineOpts{
 		Name:            d.Get("name").(string),
 		Package:         d.Get("package").(string),
 		Image:           d.Get("image").(string),
 		Networks:        networks,
 		Metadata:        metadata,
-		Tags:            tags,
+		Tags:            tagsToTritonTags(d.Get("tags").(map[string]interface{})),
 		FirewallEnabled: d.Get("firewall_enabled").(bool),
 	})
 	if err != nil {
@@ -291,7 +286,7 @@ func resourceMachineRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("memory", machine.Memory)
 	d.Set("disk", machine.Disk)
 	d.Set("ips", machine.IPs)
-	d.Set("tags", machine.Tags)
+	d.Set("tags", tagsFromTritonTags(machine.Tags))
 	d.Set("created", machine.Created)
 	d.Set("updated", machine.Updated)
 	d.Set("package", machine.Package)
@@ -356,10 +351,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("tags") {
-		tags := map[string]string{}
-		for k, v := range d.Get("tags").(map[string]interface{}) {
-			tags[k] = v.(string)
-		}
+		tags := tagsToTritonTags(d.Get("tags").(map[string]interface{}))
 
 		var err error
 		if len(tags) == 0 {

--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -25,6 +25,7 @@ var (
 		"user_script":          "user-script",
 		"user_data":            "user-data",
 		"administrator_pw":     "administrator-pw",
+		"triton_cns_status":    "triton.cns.status",
 	}
 )
 
@@ -166,6 +167,12 @@ func resourceMachine() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
+			},
+			"triton_cns_status": {
+				Description: "up/down flag to control Triton's CNS",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "up",
 			},
 
 			// computed resources from metadata

--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -174,6 +174,14 @@ func resourceMachine() *schema.Resource {
 				Optional:    true,
 				Default:     "up",
 			},
+			"domain_names": {
+				Description: "list of domain names from Triton's CNS",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 
 			// computed resources from metadata
 			"root_authorized_keys": {
@@ -300,6 +308,7 @@ func resourceMachineRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("image", machine.Image)
 	d.Set("primaryip", machine.PrimaryIP)
 	d.Set("firewall_enabled", machine.FirewallEnabled)
+	d.Set("domain_names", machine.DomainNames)
 
 	// create and update NICs
 	var (

--- a/builtin/providers/triton/triton_tags.go
+++ b/builtin/providers/triton/triton_tags.go
@@ -1,0 +1,51 @@
+package triton
+
+import (
+	"strings"
+)
+
+var (
+	tritonTags = []string{
+		"triton.cns.disable",
+		"triton.cns.services",
+		"triton.cns.reverse_ptr",
+	}
+
+	fromTritonMap = map[string]string{}
+	toTritonMap   = map[string]string{}
+)
+
+func init() {
+	for _, tritonTag := range tritonTags {
+		// Transform: _ -> __ followed by . -> _
+		// Inverse:   _ -> . followed by .. -> _
+		terTag := strings.Replace(strings.Replace(tritonTag, "_", "__", -1),
+			".", "_", -1)
+		fromTritonMap[tritonTag] = terTag
+		toTritonMap[terTag] = tritonTag
+	}
+}
+
+// Returns Terraform's tags from Triton's machine tags
+func tagsFromTritonTags(tritonTags map[string]string) map[string]string {
+	tags := make(map[string]string)
+	for k, v := range tritonTags {
+		if new_k, ok := fromTritonMap[k]; ok {
+			k = new_k
+		}
+		tags[k] = v
+	}
+	return tags
+}
+
+// Returns Triton's machine tags from Terraform tags
+func tagsToTritonTags(tags map[string]interface{}) map[string]string {
+	tritonTags := make(map[string]string)
+	for k, v := range tags {
+		if new_k, ok := toTritonMap[k]; ok {
+			k = new_k
+		}
+		tritonTags[k] = v.(string)
+	}
+	return tritonTags
+}

--- a/builtin/providers/triton/triton_tags.go
+++ b/builtin/providers/triton/triton_tags.go
@@ -6,7 +6,8 @@ import (
 
 var (
 	tritonTags = []string{
-		"triton.cns.disable",
+		// TODO: add cns.disable when joyent/gosdc#31 is fixed.
+		//"triton.cns.disable",
 		"triton.cns.services",
 		"triton.cns.reverse_ptr",
 	}

--- a/builtin/providers/triton/triton_tags_test.go
+++ b/builtin/providers/triton/triton_tags_test.go
@@ -1,0 +1,3 @@
+package triton
+
+import ()

--- a/builtin/providers/triton/triton_tags_test.go
+++ b/builtin/providers/triton/triton_tags_test.go
@@ -1,3 +1,86 @@
 package triton
 
-import ()
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccTritonTags_basic(t *testing.T) {
+	machineName := fmt.Sprintf("acctest-%d", acctest.RandInt())
+	step_0 := fmt.Sprintf(testAccTritonTags_basic_0, machineName)
+	step_10 := fmt.Sprintf(testAccTritonTags_basic_10, machineName)
+
+	machine := "triton_machine.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTritonMachineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: step_0,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonMachineExists(machine),
+					resource.TestCheckResourceAttr(machine,
+						"triton_cns_status",
+						"up",
+					),
+					resource.TestCheckResourceAttr(machine,
+						"tags.triton_cns_services",
+						"bastion",
+					),
+					resource.TestCheckResourceAttr(machine,
+						"tags.triton_cns_reverse__ptr",
+						"www.joyent.com",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: step_10,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						time.Sleep(10 * time.Second)
+						return nil
+					},
+					resource.TestCheckResourceAttr(machine,
+						"triton_cns_status",
+						"down",
+					),
+				),
+			},
+		},
+	})
+}
+
+var testAccTritonTags_basic_0 = `
+resource "triton_machine" "test" {
+  name = "%s"
+  package = "t4-standard-128M"
+  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+
+  tags = {
+    triton_cns_services = "bastion"
+    triton_cns_reverse__ptr = "www.joyent.com"
+  }
+}
+`
+
+var testAccTritonTags_basic_10 = `
+resource "triton_machine" "test" {
+  name = "%s"
+  package = "t4-standard-128M"
+  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+
+	triton_cns_status = "down"
+
+  tags = {
+    triton_cns_services = "bastion"
+    triton_cns_reverse__ptr = "www.joyent.com"
+  }
+}
+`

--- a/vendor/github.com/joyent/gosdc/cloudapi/machines.go
+++ b/vendor/github.com/joyent/gosdc/cloudapi/machines.go
@@ -30,6 +30,7 @@ type Machine struct {
 	PrimaryIP       string            // The primary (public) IP address for the machine
 	Networks        []string          // The network IDs for the machine
 	FirewallEnabled bool              `json:"firewall_enabled"` // whether or not the firewall is enabled
+	DomainNames     []string          `json:"dns_names"` // The domain names of this machine
 }
 
 // Equals compares two machines. Ignores state and timestamps.


### PR DESCRIPTION
The code does an invertible transformation of the Triton CNS tags
effectively mapping `_ -> __` followed by `. -> _`.

Suggested modification to address hashicorp/terraform#5836.