### PR TITLE
Adding privacy argument for GitHub teams for #6015

### DIFF
--- a/builtin/providers/github/resource_github_membership.go
+++ b/builtin/providers/github/resource_github_membership.go
@@ -22,7 +22,7 @@ func resourceGithubMembership() *schema.Resource {
 			"role": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateRoleValueFunc([]string{"member", "admin"}),
+				ValidateFunc: validateValueFunc([]string{"member", "admin"}),
 				Default:      "member",
 			},
 		},

--- a/builtin/providers/github/resource_github_team_membership.go
+++ b/builtin/providers/github/resource_github_team_membership.go
@@ -31,7 +31,7 @@ func resourceGithubTeamMembership() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "member",
-				ValidateFunc: validateRoleValueFunc([]string{"member", "maintainer"}),
+				ValidateFunc: validateValueFunc([]string{"member", "maintainer"}),
 			},
 		},
 	}

--- a/builtin/providers/github/resource_github_team_repository.go
+++ b/builtin/providers/github/resource_github_team_repository.go
@@ -33,7 +33,7 @@ func resourceGithubTeamRepository() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "pull",
-				ValidateFunc: validateRoleValueFunc([]string{"pull", "push", "admin"}),
+				ValidateFunc: validateValueFunc([]string{"pull", "push", "admin"}),
 			},
 		},
 	}

--- a/builtin/providers/github/resource_github_team_test.go
+++ b/builtin/providers/github/resource_github_team_test.go
@@ -97,6 +97,7 @@ const testAccGithubTeamConfig = `
 resource "github_team" "foo" {
 	name = "foo"
 	description = "Terraform acc test group"
+	privacy = "secret"
 }
 `
 
@@ -104,5 +105,6 @@ const testAccGithubTeamUpdateConfig = `
 resource "github_team" "foo" {
 	name = "foo2"
 	description = "Terraform acc test group - updated"
+	privacy = "closed"
 }
 `

--- a/builtin/providers/github/util.go
+++ b/builtin/providers/github/util.go
@@ -17,11 +17,11 @@ func fromGithubID(id *int) string {
 	return strconv.Itoa(*id)
 }
 
-func validateRoleValueFunc(roles []string) schema.SchemaValidateFunc {
+func validateValueFunc(values []string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (we []string, errors []error) {
 		value := v.(string)
 		valid := false
-		for _, role := range roles {
+		for _, role := range values {
 			if value == role {
 				valid = true
 				break
@@ -29,7 +29,7 @@ func validateRoleValueFunc(roles []string) schema.SchemaValidateFunc {
 		}
 
 		if !valid {
-			errors = append(errors, fmt.Errorf("%s is an invalid Github role type for %s", value, k))
+			errors = append(errors, fmt.Errorf("%s is an invalid value for argument %s", value, k))
 		}
 		return
 	}

--- a/builtin/providers/github/util_test.go
+++ b/builtin/providers/github/util_test.go
@@ -23,13 +23,13 @@ func TestAccGithubUtilRole_validation(t *testing.T) {
 		},
 	}
 
-	validationFunc := validateRoleValueFunc([]string{"valid_one", "valid_two"})
+	validationFunc := validateValueFunc([]string{"valid_one", "valid_two"})
 
 	for _, tc := range cases {
-		_, errors := validationFunc(tc.Value, "github_membership")
+		_, errors := validationFunc(tc.Value, "test_arg")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected github_membership to trigger a validation error")
+			t.Fatalf("Expected 1 validation error")
 		}
 	}
 }

--- a/website/source/docs/providers/github/r/team.html.markdown
+++ b/website/source/docs/providers/github/r/team.html.markdown
@@ -20,6 +20,7 @@ a new team will be created. When destroyed, that team will be removed.
 resource "github_team" "some_team" {
 	name = "some-team"
 	description = "Some cool team"
+	privacy = "closed"
 }
 ```
 
@@ -29,6 +30,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the team.
 * `description` - (Optional) A description of the team.
+* `privacy` - (Optional) The level of privacy for the team. Must be one of `secret` or `closed`.
+               Defaults to `secret`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Added the ability to set the `privacy` of a `github_team` resource so all teams won't automatically set to private.

* Added the privacy argument to github_team

* Refactored parameter validation to be general for any argument

* Updated testing