### PR TITLE
[WIP] Fixes Triton firewall_enabled bug with AccTest

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/hashicorp/terraform",
 	"GoVersion": "go1.6",
+	"GodepVersion": "v61",
 	"Packages": [
 		"./..."
 	],
@@ -842,7 +843,7 @@
 		},
 		{
 			"ImportPath": "github.com/joyent/gosdc/cloudapi",
-			"Rev": "d0f3bf74903550b93aa817695001d4607cc632f3"
+			"Rev": "15a29f7e5094f2dcd4d1d0ec1ee9da5d031d16e9"
 		},
 		{
 			"ImportPath": "github.com/joyent/gosign/auth",

--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -333,6 +333,19 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
+		err = waitFor(
+			func() (bool, error) {
+				machine, err := client.GetMachine(d.Id())
+				return machine.FirewallEnabled == d.Get("firewall_enabled").(bool), err
+			},
+			machineStateChangeCheckInterval,
+			machineStateChangeTimeout,
+		)
+
+		if err != nil {
+			return err
+		}
+
 		d.SetPartial("firewall_enabled")
 	}
 

--- a/builtin/providers/triton/resource_machine_test.go
+++ b/builtin/providers/triton/resource_machine_test.go
@@ -77,14 +77,71 @@ func testCheckTritonMachineDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccTritonMachine_firewall(t *testing.T) {
+	machineName := fmt.Sprintf("acctest-%d", acctest.RandInt())
+	disabled_config := fmt.Sprintf(testAccTritonMachine_firewall_0, machineName)
+	enabled_config := fmt.Sprintf(testAccTritonMachine_firewall_1, machineName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTritonMachineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: enabled_config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonMachineExists("triton_machine.test"),
+					resource.TestCheckResourceAttr(
+						"triton_machine.test", "firewall_enabled", "true"),
+				),
+			},
+			resource.TestStep{
+				Config: disabled_config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonMachineExists("triton_machine.test"),
+					resource.TestCheckResourceAttr(
+						"triton_machine.test", "firewall_enabled", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: enabled_config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonMachineExists("triton_machine.test"),
+					resource.TestCheckResourceAttr(
+						"triton_machine.test", "firewall_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 var testAccTritonMachine_basic = `
 resource "triton_machine" "test" {
   name = "%s"
-  package = "g3-standard-0.25-smartos"
-  image = "842e6fa6-6e9b-11e5-8402-1b490459e334"
+  package = "t4-standard-128M"
+  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
 
   tags = {
 	test = "hello!"
   }
+}
+`
+
+var testAccTritonMachine_firewall_0 = `
+resource "triton_machine" "test" {
+  name = "%s"
+  package = "t4-standard-128M"
+  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+
+	firewall_enabled = 0
+}
+`
+var testAccTritonMachine_firewall_1 = `
+resource "triton_machine" "test" {
+  name = "%s"
+  package = "t4-standard-128M"
+  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+
+	firewall_enabled = 1
 }
 `

--- a/vendor/github.com/joyent/gosdc/cloudapi/images.go
+++ b/vendor/github.com/joyent/gosdc/cloudapi/images.go
@@ -19,7 +19,7 @@ type Image struct {
 	Requirements map[string]interface{} // Minimum requirements for provisioning a machine with this image, e.g. 'password' indicates that a password must be provided
 	Homepage     string                 // URL for a web page including detailed information for this image (new in API version 7.0)
 	PublishedAt  string                 `json:"published_at"` // Time this image has been made publicly available (new in API version 7.0)
-	Public       string                 // Indicates if the image is publicly available (new in API version 7.1)
+	Public       bool                   // Indicates if the image is publicly available (new in API version 7.1)
 	State        string                 // Current image state. One of 'active', 'unactivated', 'disabled', 'creating', 'failed' (new in API version 7.1)
 	Tags         map[string]string      // A map of key/value pairs that allows clients to categorize images by any given criteria (new in API version 7.1)
 	EULA         string                 // URL of the End User License Agreement (EULA) for the image (new in API version 7.1)
@@ -44,14 +44,14 @@ type MantaLocation struct {
 // CreateImageFromMachineOpts represent the option that can be specified
 // when creating a new image from an existing machine.
 type CreateImageFromMachineOpts struct {
-	Machine     string            `json:"machine"`     // The machine UUID from which the image is to be created
-	Name        string            `json:"name"`        // Image name
-	Version     string            `json:"version"`     // Image version
-	Description string            `json:"description"` // Image description
-	Homepage    string            `json:"homepage"`    // URL for a web page including detailed information for this image
-	EULA        string            `json:"eula"`        // URL of the End User License Agreement (EULA) for the image
-	ACL         []string          `json:"acl"`         // An array of account UUIDs given access to a private image. The field is only relevant to private images
-	Tags        map[string]string `json:"tags"`        // A map of key/value pairs that allows clients to categorize images by any given criteria
+	Machine     string            `json:"machine"`               // The machine UUID from which the image is to be created
+	Name        string            `json:"name"`                  // Image name
+	Version     string            `json:"version"`               // Image version
+	Description string            `json:"description,omitempty"` // Image description
+	Homepage    string            `json:"homepage,omitempty"`    // URL for a web page including detailed information for this image
+	EULA        string            `json:"eula,omitempty"`        // URL of the End User License Agreement (EULA) for the image
+	ACL         []string          `json:"acl,omitempty"`         // An array of account UUIDs given access to a private image. The field is only relevant to private images
+	Tags        map[string]string `json:"tags,omitempty"`        // A map of key/value pairs that allows clients to categorize images by any given criteria
 }
 
 // ListImages provides a list of images available in the datacenter.

--- a/vendor/github.com/joyent/gosdc/cloudapi/machines.go
+++ b/vendor/github.com/joyent/gosdc/cloudapi/machines.go
@@ -29,7 +29,7 @@ type Machine struct {
 	Image           string            // The image id the machine was provisioned with
 	PrimaryIP       string            // The primary (public) IP address for the machine
 	Networks        []string          // The network IDs for the machine
-	FirewallEnabled bool              // whether or not the firewall is enabled
+	FirewallEnabled bool              `json:"firewall_enabled"` // whether or not the firewall is enabled
 }
 
 // Equals compares two machines. Ignores state and timestamps.


### PR DESCRIPTION
This is to close hashicorp/terraform#6109.

I am setting it to [WIP] because I am not sure what is the proper way of integrating the [PR#23](https://github.com/joyent/gosdc/pull/23)  to the vendor library . 

The tests passed when I checked
```
$ make testacc TEST=./builtin/providers/triton/ TESTARGS='-run=TestAccTritonMachine_firewall'
==> Checking that code complies with gofmt requirements...
/Users/sodre/go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/triton/ -v -run=TestAccTritonMachine_firewall -timeout 120m
=== RUN   TestAccTritonMachine_firewall
--- PASS: TestAccTritonMachine_firewall (116.74s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/triton	116.757s
$
``` 
