### PR TITLE
provider/aws: More randomization to our Acc tests

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -18,21 +19,23 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 	var group autoscaling.Group
 	var lc autoscaling.LaunchConfiguration
 
+	randName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAutoScalingGroupConfig,
+				Config: testAccAWSAutoScalingGroupConfig(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckAWSAutoScalingGroupHealthyCapacity(&group, 2),
-					testAccCheckAWSAutoScalingGroupAttributes(&group),
+					testAccCheckAWSAutoScalingGroupAttributes(&group, randName),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "availability_zones.2487133097", "us-west-2a"),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "name", "foobar3-terraform-test"),
+						"aws_autoscaling_group.bar", "name", randName),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "max_size", "5"),
 					resource.TestCheckResourceAttr(
@@ -53,7 +56,7 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAWSAutoScalingGroupConfigUpdate,
+				Config: testAccAWSAutoScalingGroupConfigUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.new", &lc),
@@ -139,13 +142,15 @@ func TestAccAWSAutoScalingGroup_terminationPolicies(t *testing.T) {
 func TestAccAWSAutoScalingGroup_tags(t *testing.T) {
 	var group autoscaling.Group
 
+	randName := fmt.Sprintf("tfautotags-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAutoScalingGroupConfig,
+				Config: testAccAWSAutoScalingGroupConfig(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckAutoscalingTags(&group.Tags, "Foo", map[string]interface{}{
@@ -156,7 +161,7 @@ func TestAccAWSAutoScalingGroup_tags(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAWSAutoScalingGroupConfigUpdate,
+				Config: testAccAWSAutoScalingGroupConfigUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckAutoscalingTagNotExists(&group.Tags, "Foo"),
@@ -217,7 +222,7 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: fmt.Sprintf(testAccAWSAutoScalingGroupConfigWithLoadBalancer),
+				Config: testAccAWSAutoScalingGroupConfigWithLoadBalancer,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(&group),
@@ -230,17 +235,18 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 func TestAccAWSAutoScalingGroup_withPlacementGroup(t *testing.T) {
 	var group autoscaling.Group
 
+	randName := fmt.Sprintf("tf_placement_test-%s", acctest.RandString(5))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAutoScalingGroupConfig_withPlacementGroup,
+				Config: testAccAWSAutoScalingGroupConfig_withPlacementGroup(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "placement_group", "tf_placement_test"),
+						"aws_autoscaling_group.bar", "placement_group", randName),
 				),
 			},
 		},
@@ -310,14 +316,14 @@ func testAccCheckAWSAutoScalingGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.Group) resource.TestCheckFunc {
+func testAccCheckAWSAutoScalingGroupAttributes(group *autoscaling.Group, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *group.AvailabilityZones[0] != "us-west-2a" {
 			return fmt.Errorf("Bad availability_zones: %#v", group.AvailabilityZones[0])
 		}
 
-		if *group.AutoScalingGroupName != "foobar3-terraform-test" {
-			return fmt.Errorf("Bad name: %s", *group.AutoScalingGroupName)
+		if *group.AutoScalingGroupName != name {
+			return fmt.Errorf("Bad Autoscaling Group name, expected (%s), got (%s)", name, *group.AutoScalingGroupName)
 		}
 
 		if *group.MaxSize != 5 {
@@ -539,20 +545,21 @@ resource "aws_autoscaling_group" "bar" {
 }
 `
 
-const testAccAWSAutoScalingGroupConfig = `
+func testAccAWSAutoScalingGroupConfig(name string) string {
+	return fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   image_id = "ami-21f78e11"
   instance_type = "t1.micro"
 }
 
 resource "aws_placement_group" "test" {
-  name = "test"
+  name = "%s"
   strategy = "cluster"
 }
 
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["us-west-2a"]
-  name = "foobar3-terraform-test"
+  name = "%s"
   max_size = 5
   min_size = 2
   health_check_type = "ELB"
@@ -568,9 +575,11 @@ resource "aws_autoscaling_group" "bar" {
     propagate_at_launch = true
   }
 }
-`
+`, name, name)
+}
 
-const testAccAWSAutoScalingGroupConfigUpdate = `
+func testAccAWSAutoScalingGroupConfigUpdate(name string) string {
+	return fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   image_id = "ami-21f78e11"
   instance_type = "t1.micro"
@@ -583,7 +592,7 @@ resource "aws_launch_configuration" "new" {
 
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["us-west-2a"]
-  name = "foobar3-terraform-test"
+  name = "%s"
   max_size = 5
   min_size = 2
   health_check_grace_period = 300
@@ -600,7 +609,8 @@ resource "aws_autoscaling_group" "bar" {
     propagate_at_launch = true
   }
 }
-`
+`, name)
+}
 
 const testAccAWSAutoScalingGroupConfigWithLoadBalancer = `
 resource "aws_vpc" "foo" {
@@ -668,7 +678,6 @@ resource "aws_launch_configuration" "foobar" {
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["${aws_subnet.foo.availability_zone}"]
 	vpc_zone_identifier = ["${aws_subnet.foo.id}"]
-  name = "foobar3-terraform-test"
   max_size = 2
   min_size = 2
   health_check_grace_period = 300
@@ -747,20 +756,21 @@ resource "aws_autoscaling_group" "bar" {
 }
 `
 
-const testAccAWSAutoScalingGroupConfig_withPlacementGroup = `
+func testAccAWSAutoScalingGroupConfig_withPlacementGroup(name string) string {
+	return fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   image_id = "ami-21f78e11"
   instance_type = "c3.large"
 }
 
 resource "aws_placement_group" "test" {
-  name = "tf_placement_test"
+  name = "%s"
   strategy = "cluster"
 }
 
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["us-west-2a"]
-  name = "foobar3-terraform-test"
+  name = "%s"
   max_size = 1
   min_size = 1
   health_check_grace_period = 300
@@ -778,7 +788,8 @@ resource "aws_autoscaling_group" "bar" {
     propagate_at_launch = true
   }
 }
-`
+`, name, name)
+}
 
 const testAccAWSAutoscalingMetricsCollectionConfig_allMetricsCollected = `
 resource "aws_launch_configuration" "foobar" {

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -17,18 +17,20 @@ import (
 func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 	var v rds.DBParameterGroup
 
+	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSDBParameterGroupConfig(acctest.RandInt()),
+				Config: testAccAWSDBParameterGroupConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
-					testAccCheckAWSDBParameterGroupAttributes(&v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", "parameter-group-test-terraform"),
+						"aws_db_parameter_group.bar", "name", groupName),
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(
@@ -50,12 +52,12 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSDBParameterGroupAddParametersConfig(acctest.RandInt()),
+				Config: testAccAWSDBParameterGroupAddParametersConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
-					testAccCheckAWSDBParameterGroupAttributes(&v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", "parameter-group-test-terraform"),
+						"aws_db_parameter_group.bar", "name", groupName),
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(
@@ -88,21 +90,22 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBParameterGroupOnly(t *testing.T) {
+func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 	var v rds.DBParameterGroup
 
+	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSDBParameterGroupOnlyConfig(acctest.RandInt()),
+				Config: testAccAWSDBParameterGroupOnlyConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
-					testAccCheckAWSDBParameterGroupAttributes(&v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", "parameter-group-test-terraform"),
+						"aws_db_parameter_group.bar", "name", groupName),
 					resource.TestCheckResourceAttr(
 						"aws_db_parameter_group.bar", "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(
@@ -187,11 +190,11 @@ func testAccCheckAWSDBParameterGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSDBParameterGroupAttributes(v *rds.DBParameterGroup) resource.TestCheckFunc {
+func testAccCheckAWSDBParameterGroupAttributes(v *rds.DBParameterGroup, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if *v.DBParameterGroupName != "parameter-group-test-terraform" {
-			return fmt.Errorf("bad name: %#v", v.DBParameterGroupName)
+		if *v.DBParameterGroupName != name {
+			return fmt.Errorf("Bad Parameter Group name, expected (%s), got (%s)", name, *v.DBParameterGroupName)
 		}
 
 		if *v.DBParameterGroupFamily != "mysql5.6" {
@@ -250,10 +253,10 @@ func randomString(strlen int) string {
 	return string(result)
 }
 
-func testAccAWSDBParameterGroupConfig(n int) string {
+func testAccAWSDBParameterGroupConfig(n string) string {
 	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "bar" {
-	name = "parameter-group-test-terraform-%d"
+	name = "%s"
 	family = "mysql5.6"
 	description = "Test parameter group for terraform"
 	parameter {
@@ -274,10 +277,10 @@ resource "aws_db_parameter_group" "bar" {
 }`, n)
 }
 
-func testAccAWSDBParameterGroupAddParametersConfig(n int) string {
+func testAccAWSDBParameterGroupAddParametersConfig(n string) string {
 	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "bar" {
-	name = "parameter-group-test-terraform-%d"
+	name = "%s"
 	family = "mysql5.6"
 	description = "Test parameter group for terraform"
 	parameter {
@@ -307,10 +310,10 @@ resource "aws_db_parameter_group" "bar" {
 }`, n)
 }
 
-func testAccAWSDBParameterGroupOnlyConfig(n int) string {
+func testAccAWSDBParameterGroupOnlyConfig(n string) string {
 	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "bar" {
-	name = "parameter-group-test-terraform-%d"
+	name = "%s"
 	family = "mysql5.6"
 	description = "Test parameter group for terraform"
 }`, n)


### PR DESCRIPTION
Introduces more randomization in the naming of resources in our nightly acceptance tests, to avoid false positive test failures due to name collisions. 