### PR TITLE
Add note about ports when rule is created for all protocols (#6130)

### DIFF
--- a/website/source/docs/providers/aws/r/network_acl_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl_rule.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 * `icmp_type` - (Optional) ICMP protocol: The ICMP type. Required if specifying ICMP for the protocol. e.g. -1
 * `icmp_code` - (Optional) ICMP protocol: The ICMP code. Required if specifying ICMP for the protocol. e.g. -1
 
+~> **NOTE:** If the value of `protocol` is `-1` or `all`, the `from_port` and `to_port` values will be ignored and the rule will apply to all ports.
+
 ~> Note: For more information on ICMP types and codes, see here: http://www.nthelp.com/icmp.html
 
 ## Attributes Reference


### PR DESCRIPTION
This PR adds a note letting users know that the `from_port` and `to_port` values are ignored if `protocol = "-1"`

See #6130 for more information.