### PR TITLE
AWS IAM OpenID Connect provider

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
@@ -1,0 +1,125 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsIamOpenIDConnectProvider() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIamOpenIDConnectProviderCreate,
+		Read:   resourceAwsIamOpenIDConnectProviderRead,
+		Update: resourceAwsIamOpenIDConnectProviderUpdate,
+		Delete: resourceAwsIamOpenIDConnectProviderDelete,
+
+		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: false,
+				Required: true,
+				ForceNew: true,
+			},
+			"client-id-list": &schema.Schema{
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+			},
+			"thumbprint-list": &schema.Schema{
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Required: true,
+			},
+		},
+	}
+}
+
+func stringListToStringSlice(stringList []interface{}) []string {
+	ret := []string{}
+	for _, v := range stringList {
+		ret = append(ret, v.(string))
+	}
+	return ret
+}
+
+func resourceAwsIamOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	input := &iam.CreateOpenIDConnectProviderInput{
+		Url:            aws.String(d.Get("url").(string)),
+		ClientIDList:   aws.StringSlice(stringListToStringSlice(d.Get("client-id-list").([]interface{}))),
+		ThumbprintList: aws.StringSlice(stringListToStringSlice(d.Get("thumbprint-list").([]interface{}))),
+	}
+
+	out, err := iamconn.CreateOpenIDConnectProvider(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*out.OpenIDConnectProviderArn)
+
+	return resourceAwsIamOpenIDConnectProviderRead(d, meta)
+}
+
+func resourceAwsIamOpenIDConnectProviderRead(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	input := &iam.GetOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: aws.String(d.Id()),
+	}
+	out, err := iamconn.GetOpenIDConnectProvider(input)
+	if err != nil {
+		return err
+	}
+
+	d.Set("arn", d.Id())
+	d.Set("url", *out.Url)
+	d.Set("client-id-list", out.ClientIDList)
+	d.Set("thumbprint-list", out.ThumbprintList)
+
+	return nil
+}
+
+func resourceAwsIamOpenIDConnectProviderUpdate(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	if d.HasChange("thumbprint-list") {
+		input := &iam.UpdateOpenIDConnectProviderThumbprintInput{
+			OpenIDConnectProviderArn: aws.String(d.Id()),
+		}
+
+		_, err := iamconn.UpdateOpenIDConnectProviderThumbprint(input)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceAwsIamOpenIDConnectProviderRead(d, meta)
+}
+
+func resourceAwsIamOpenIDConnectProviderDelete(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	input := &iam.DeleteOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: aws.String(d.Id()),
+	}
+	_, err := iamconn.DeleteOpenIDConnectProvider(input)
+
+	if err != nil {
+		if err, ok := err.(awserr.Error); ok && err.Code() == "NotFound" {
+			return nil
+		}
+		return fmt.Errorf("Error deleting platform application %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider_test.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider_test.go
@@ -1,0 +1,90 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSIAMOpenIDConnectProvider_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMOpenIDConnectProviderDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMOpenIDConnectProviderConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMOpenIDConnectProvider("aws_iam_openid_connect_provider.goog"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIAMOpenIDConnectProviderDestroy(s *terraform.State) error {
+	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iam_openid_connect_provider" {
+			continue
+		}
+
+		input := &iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(rs.Primary.ID),
+		}
+		out, err := iamconn.GetOpenIDConnectProvider(input)
+		if err != nil {
+			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+				// none found, that's good
+				return nil
+			}
+			return fmt.Errorf("Error reading IAM OpenID Connect Provider, out: %s, err: %s", out, err)
+		}
+
+		if out != nil {
+			return fmt.Errorf("Found IAM OpenID Connect Provider, expected none: %s", out)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIAMOpenIDConnectProvider(id string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[id]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", id)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+		_, err := iamconn.GetOpenIDConnectProvider(&iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+const testAccIAMOpenIDConnectProviderConfig = `
+resource "aws_iam_openid_connect_provider" "goog" {
+  url="https://accounts.google.com"
+  client-id-list = [
+     "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.googleusercontent.com"
+  ]
+  thumbprint-list = []
+}
+`

--- a/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_openid_connect_provider"
+sidebar_current: "docs-aws-resource-iam-openid-connect-provider"
+description: |-
+  Provides an IAM OpenID Connect provider.
+---
+
+# aws\_iam\_openid\_connect\_provider
+
+Provides an IAM OpenID Connect provider.
+
+## Example Usage
+
+```
+resource "aws_iam_openid_connect_provider" "default" {
+    url = "https://accounts.google.com"
+    client-id-list = [
+     "266362248691-342342xasdasdasda-apps.googleusercontent.com"
+    ]
+    thumbprint-list = []
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `url` - (Required) The URL of the identity provider. Corresponds to the _iss_ claim.
+* `client-id-list` - (Required) A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)
+* `thumbprint-list` - (Required) A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s). 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The ARN assigned by AWS for this provider.


### PR DESCRIPTION
Basically a copy of the IAM SAML provider, with an additional 404 check on destruction.

http://docs.aws.amazon.com/cli/latest/reference/iam/create-open-id-connect-provider.html

Tests currently use a personal google account identity
