### PR TITLE
[#4794] Don't Base64-encode EC2 userdata if it is already Base64 encoded

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -964,8 +964,16 @@ func buildAwsInstanceOpts(
 		Name: aws.String(d.Get("iam_instance_profile").(string)),
 	}
 
-	opts.UserData64 = aws.String(
-		base64.StdEncoding.EncodeToString([]byte(d.Get("user_data").(string))))
+	user_data := d.Get("user_data").(string)
+
+	// Check whether the user_data is already Base64 encoded; don't double-encode
+	_, base64DecodeError := base64.StdEncoding.DecodeString(user_data)
+
+	if base64DecodeError == nil {
+		opts.UserData64 = aws.String(user_data)
+	} else {
+		opts.UserData64 = aws.String(base64.StdEncoding.EncodeToString([]byte(user_data)))
+	}
 
 	// check for non-default Subnet, and cast it to a String
 	subnet, hasSubnet := d.GetOk("subnet_id")

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -825,6 +825,7 @@ resource "aws_instance" "foo" {
 	subnet_id = "${aws_subnet.foo.id}"
 	associate_public_ip_address = true
 	tenancy = "dedicated"
+	user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
 `
 


### PR DESCRIPTION
The user data may be Base64 encoded already - for example, if it has been generated by a template_cloudinit_config resource.

Partially resolves https://github.com/hashicorp/terraform/issues/4794