### PR TITLE
provider/aws: Fix Lambda VPC integration (missing vpc_id field)

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -98,6 +98,10 @@ func resourceAwsLambdaFunction() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},
+						"vpc_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -249,7 +253,11 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("runtime", function.Runtime)
 	d.Set("timeout", function.Timeout)
 	if config := flattenLambdaVpcConfigResponse(function.VpcConfig); len(config) > 0 {
-		d.Set("vpc_config", config)
+		log.Printf("[INFO] Setting Lambda %s VPC config %#v from API", d.Id(), config)
+		err := d.Set("vpc_config", config)
+		if err != nil {
+			return fmt.Errorf("Failed setting vpc_config: %s", err)
+		}
 	}
 	d.Set("source_code_hash", function.CodeSha256)
 

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -51,6 +52,10 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 					testAccCheckAwsLambdaFunctionName(&conf, "example_lambda_name"),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":example_lambda_name"),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.security_group_ids.#", "1"),
+					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.vpc_id", regexp.MustCompile("^vpc-")),
 				),
 			},
 		},


### PR DESCRIPTION
I'm not sure whether this field wasn't there before and was added in later versions of SDK or whether it was just overlooked - I assume the latter since it was already part of `flattenLambdaVpcConfigResponse`.

The `vpc_config` field was never saved as `d.Set` was failing due to missing field in the schema and that was also triggering unnecessary updates.