### PR TITLE
provider/aws: Added migration for `tier` attribute in aws_elastic_beanstalk_environment resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -43,6 +43,9 @@ func resourceAwsElasticBeanstalkEnvironment() *schema.Resource {
 		Update: resourceAwsElasticBeanstalkEnvironmentUpdate,
 		Delete: resourceAwsElasticBeanstalkEnvironmentDelete,
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsElasticBeanstalkEnvironmentMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_migrate.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_migrate.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsElasticBeanstalkEnvironmentMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Elastic Beanstalk Environment State v0; migrating to v1")
+		return migrateBeanstalkEnvironmentStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateBeanstalkEnvironmentStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty Elastic Beanstalk Environment State; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	if is.Attributes["tier"] == "" {
+		is.Attributes["tier"] = "WebServer"
+	}
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_migrate_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSElasticBeanstalkEnvironmentMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0_1_web": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"tier": "",
+			},
+			Expected: map[string]string{
+				"tier": "WebServer",
+			},
+		},
+		"v0_1_web_explicit": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"tier": "WebServer",
+			},
+			Expected: map[string]string{
+				"tier": "WebServer",
+			},
+		},
+		"v0_1_worker": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"tier": "Worker",
+			},
+			Expected: map[string]string{
+				"tier": "Worker",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "e-abcde12345",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsElasticBeanstalkEnvironmentMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+	}
+}


### PR DESCRIPTION
Adds migration for `tier` attribute. For #6164.

```
=== RUN   TestAWSElasticBeanstalkEnvironmentMigrateState
2016/04/13 14:17:09 [INFO] Found AWS Elastic Beanstalk Environment State v0; migrating to v1
2016/04/13 14:17:09 [DEBUG] Attributes before migration: map[string]string{"tier":""}
2016/04/13 14:17:09 [DEBUG] Attributes after migration: map[string]string{"tier":"WebServer"}
2016/04/13 14:17:09 [INFO] Found AWS Elastic Beanstalk Environment State v0; migrating to v1
2016/04/13 14:17:09 [DEBUG] Attributes before migration: map[string]string{"tier":"WebServer"}
2016/04/13 14:17:09 [DEBUG] Attributes after migration: map[string]string{"tier":"WebServer"}
2016/04/13 14:17:09 [INFO] Found AWS Elastic Beanstalk Environment State v0; migrating to v1
2016/04/13 14:17:09 [DEBUG] Attributes before migration: map[string]string{"tier":"Worker"}
2016/04/13 14:17:09 [DEBUG] Attributes after migration: map[string]string{"tier":"Worker"}
--- PASS: TestAWSElasticBeanstalkEnvironmentMigrateState (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.006s
```

I also tested this with the tf document and older Terraform version from #6164