### PR TITLE
provider/aws: Enhance Triggers for AWS CodeDeploy Event Notifications

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"sort"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -439,6 +440,19 @@ func resourceAwsCodeDeployTriggerConfigHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["trigger_name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["trigger_target_arn"].(string)))
+
+	if triggerEvents, ok := m["trigger_events"]; ok {
+		names := triggerEvents.(*schema.Set).List()
+		strings := make([]string, len(names))
+		for i, raw := range names {
+			strings[i] = raw.(string)
+		}
+		sort.Strings(strings)
+
+		for _, s := range strings {
+			buf.WriteString(fmt.Sprintf("%s-", s))
+		}
+	}
 	return hashcode.String(buf.String())
 }
 


### PR DESCRIPTION
This is a companion to https://github.com/hashicorp/terraform/pull/5599

This PR is required to ensure that updates to `trigger_configuration.trigger_events` are applied.

This commit enhances existing tests for Trigger Configurations by asserting that the changes to Trigger Events and Trigger Target ARN actually happen.

In order to ensure the `TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic` test passes, I had to include ALL `trigger_configuration` attributes in the hash function `resourceAwsSecurityGroupRuleHash`.

I mentioned in https://github.com/hashicorp/terraform/pull/5599 that I don't believe all attributes should need to be included in the hash. However, the following issues appear when this is not the case:

 * If `trigger_events` are not included in the hash, then updates to `trigger_events` do NOT happen, unless either the `trigger_target_arn` or `trigger_name` attributes also change.
 * If `trigger_target_arn` is not included in the hash, then terraform fails with a bang.

See https://github.com/hashicorp/terraform/pull/5599 for more information.

@stack72 

I feel this should be merged alongside #5599 . I would have included these changes in that PR but I was hoping for some clarification before doing so.