### PR TITLE
Fix docs for azurerm_virtual_machine and ssh_keys

### DIFF
--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -175,7 +175,7 @@ For more information on the different example configurations, please check out t
 `os_profile_linux_config` supports the following:
 
 * `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled.
-* `ssh_keys` - (Optional) Specifies a collection of `key_path` and `key_data` to be placed on the virtual machine.
+* `ssh_keys` - (Optional) Specifies a collection of `path` and `key_data` to be placed on the virtual machine.
 
 `os_profile_secrets` supports the following:
 


### PR DESCRIPTION
For `ssh_keys` in `os_profile_linux_config`, the docs specify `key_path`, but the code expects `path` - https://github.com/hashicorp/terraform/blob/453d38bafc4482fd86fd467c54b7346bfa727a76/builtin/providers/azurerm/resource_arm_virtual_machine.go#L284.