### PR TITLE
core: fix provider config inheritence for deeply nested modules

### DIFF
--- a/terraform/test-fixtures/apply-module-grandchild-provider-inherit/child/grandchild/main.tf
+++ b/terraform/test-fixtures/apply-module-grandchild-provider-inherit/child/grandchild/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "foo" {}

--- a/terraform/test-fixtures/apply-module-grandchild-provider-inherit/child/main.tf
+++ b/terraform/test-fixtures/apply-module-grandchild-provider-inherit/child/main.tf
@@ -1,0 +1,3 @@
+module "grandchild" {
+  source = "./grandchild"
+}

--- a/terraform/test-fixtures/apply-module-grandchild-provider-inherit/main.tf
+++ b/terraform/test-fixtures/apply-module-grandchild-provider-inherit/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  value = "foo"
+}
+
+module "child" {
+  source = "./child"
+}


### PR DESCRIPTION
The flattening process was not properly drawing dependencies between provider
nodes in modules and their parent provider nodes.

Fixes #2832
Fixes #4443
Fixes #4865