### PR TITLE
Don't read back opsworks stack cookbooks source password

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -225,12 +225,12 @@ func resourceAwsOpsworksSetStackCustomCookbooksSource(d *schema.ResourceData, v 
 		if v.Username != nil {
 			m["username"] = *v.Username
 		}
-		if v.Password != nil {
-			m["password"] = *v.Password
-		}
 		if v.Revision != nil {
 			m["revision"] = *v.Revision
 		}
+		// v.Password will, on read, contain the placeholder string
+		// "*****FILTERED*****", so we ignore it on read and let persist
+		// the value already in the state.
 		nv = append(nv, m)
 	}
 

--- a/builtin/providers/aws/resource_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack_test.go
@@ -329,6 +329,8 @@ resource "aws_opsworks_stack" "tf-acc" {
     type = "git"
     revision = "master"
     url = "https://github.com/aws/opsworks-example-cookbooks.git"
+    username = "example"
+    password = "example"
   }
 resource "aws_iam_role" "opsworks_service" {
     name = "%s_opsworks_service"


### PR DESCRIPTION
As with several other sensitive values in Opsworks, the API returns a placeholder value rather than a nil. To avoid writing the placeholder value into the state we just skip updating the password on read, letting whatever value was in the state persist.

This means that Terraform can't detect configuration drift where someone has changed the password via some other means, but Terraform will still be able to recognize changes to the password made within Terraform itself due to the "last-written" value in the state.

This fixes #6192.