### PR TITLE
[WIP] Grafana Provider, with Data Source and Dashboard resources

### DIFF
--- a/builtin/bins/provider-grafana/main.go
+++ b/builtin/bins/provider-grafana/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/grafana"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: grafana.Provider,
+	})
+}

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -1,0 +1,46 @@
+package grafana
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_URL", nil),
+				Description: "URL of the root of the target Grafana server.",
+			},
+			"auth": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
+				Description: "Credentials for accessing the Grafana API.",
+			},
+		},
+
+		ResourcesMap: map[string]*schema.Resource{
+			//"grafana_dashboard":                   ResourceDashboard(),
+			//"grafana_dashboard_config":            ResourceDashboardConfig(),
+			//"grafana_graph_panel_config":          ResourceGraphPanelConfig(),
+			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),
+			//"grafana_text_panel_config":           ResourceTextPanelConfig(),
+			//"grafana_dashboard_list_panel_config": ResourceDashboardListPanelConfig(),
+			//"grafana_data_source":                 ResourceDataSource(),
+		},
+
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	return gapi.New(
+		d.Get("auth").(string),
+		d.Get("url").(string),
+	)
+}

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -31,7 +31,7 @@ func Provider() terraform.ResourceProvider {
 			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),
 			//"grafana_text_panel_config":           ResourceTextPanelConfig(),
 			//"grafana_dashboard_list_panel_config": ResourceDashboardListPanelConfig(),
-			//"grafana_data_source":                 ResourceDataSource(),
+			"grafana_data_source":                 ResourceDataSource(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/grafana/provider.go
+++ b/builtin/providers/grafana/provider.go
@@ -25,7 +25,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			//"grafana_dashboard":                   ResourceDashboard(),
+			"grafana_dashboard":                   ResourceDashboard(),
 			//"grafana_dashboard_config":            ResourceDashboardConfig(),
 			//"grafana_graph_panel_config":          ResourceGraphPanelConfig(),
 			//"grafana_single_stat_panel_config":    ResourceSingleStatPanelConfig(),

--- a/builtin/providers/grafana/provider_test.go
+++ b/builtin/providers/grafana/provider_test.go
@@ -1,0 +1,54 @@
+package grafana
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// To run these acceptance tests, you will need a Grafana server.
+// Grafana can be downloaded here: http://grafana.org/download/
+//
+// The tests will need an API key to authenticate with the server. To create
+// one, use the menu for one of your installation's organizations (The
+// "Main Org." is fine if you've just done a fresh installation to run these
+// tests) to reach the "API Keys" admin page.
+//
+// Giving the API key the Admin role is the easiest way to ensure enough
+// access is granted to run all of the tests.
+//
+// Once you've created the API key, set the GRAFANA_URL and GRAFANA_AUTH
+// environment variables to the Grafana base URL and the API key respectively,
+// and then run:
+//    make testacc TEST=./builtin/providers/grafana
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"grafana": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("GRAFANA_URL"); v == "" {
+		t.Fatal("GRAFANA_URL must be set for acceptance tests")
+	}
+	if v := os.Getenv("GRAFANA_AUTH"); v == "" {
+		t.Fatal("GRAFANA_AUTH must be set for acceptance tests")
+	}
+}

--- a/builtin/providers/grafana/resource_dashboard.go
+++ b/builtin/providers/grafana/resource_dashboard.go
@@ -1,0 +1,127 @@
+package grafana
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+)
+
+func ResourceDashboard() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDashboard,
+		Delete: DeleteDashboard,
+		Read:   ReadDashboard,
+
+		Schema: map[string]*schema.Schema{
+			"slug": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"config_json": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				StateFunc:    NormalizeDashboardConfigJSON,
+				ValidateFunc: ValidateDashboardConfigJSON,
+			},
+		},
+	}
+}
+
+func CreateDashboard(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	model := prepareDashboardModel(d.Get("config_json").(string))
+
+	resp, err := client.SaveDashboard(model, false)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resp.Slug)
+
+	return ReadDashboard(d, meta)
+}
+
+func ReadDashboard(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	slug := d.Id()
+
+	dashboard, err := client.Dashboard(slug)
+	if err != nil {
+		return err
+	}
+
+	configJSONBytes, err := json.Marshal(dashboard.Model)
+	if err != nil {
+		return err
+	}
+
+	configJSON := NormalizeDashboardConfigJSON(string(configJSONBytes))
+
+	d.SetId(dashboard.Meta.Slug)
+	d.Set("slug", dashboard.Meta.Slug)
+	d.Set("config_json", configJSON)
+
+	return nil
+}
+
+func DeleteDashboard(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	slug := d.Id()
+	return client.DeleteDashboard(slug)
+}
+
+func prepareDashboardModel(configJSON string) map[string]interface{} {
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		// The validate function should've taken care of this.
+		panic(fmt.Errorf("Invalid JSON got into prepare func"))
+	}
+
+	delete(configMap, "id")
+	configMap["version"] = 0
+
+	return configMap
+}
+
+func ValidateDashboardConfigJSON(configI interface{}, k string) ([]string, []error) {
+	configJSON := configI.(string)
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
+}
+
+func NormalizeDashboardConfigJSON(configI interface{}) string {
+	configJSON := configI.(string)
+
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		// The validate function should've taken care of this.
+		return ""
+	}
+
+	// Some properties are managed by this provider and are thus not
+	// significant when included in the JSON.
+	delete(configMap, "id")
+	delete(configMap, "version")
+
+	ret, err := json.Marshal(configMap)
+	if err != nil {
+		// Should never happen.
+		return configJSON
+	}
+
+	return string(ret)
+}

--- a/builtin/providers/grafana/resource_dashboard_test.go
+++ b/builtin/providers/grafana/resource_dashboard_test.go
@@ -1,0 +1,83 @@
+package grafana
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDashboard_basic(t *testing.T) {
+	var dashboard gapi.Dashboard
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDashboardCheckDestroy(&dashboard),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDashboardConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
+					resource.TestMatchResourceAttr(
+						"grafana_dashboard.test", "id", regexp.MustCompile(`terraform-acceptance-test.*`),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		client := testAccProvider.Meta().(*gapi.Client)
+		gotDashboard, err := client.Dashboard(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting dashboard: %s", err)
+		}
+
+		*dashboard = *gotDashboard
+
+		return nil
+	}
+}
+
+func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*gapi.Client)
+		_, err := client.Dashboard(dashboard.Meta.Slug)
+		if err == nil {
+			return fmt.Errorf("dashboard still exists")
+		}
+		return nil
+	}
+}
+
+// The "id" and "version" properties in the config below are there to test
+// that we correctly normalize them away. They are not actually used by this
+// resource, since it uses slugs for identification and never modifies an
+// existing dashboard.
+const testAccDashboardConfig_basic = `
+resource "grafana_dashboard" "test" {
+    config_json = <<EOT
+{
+    "title": "Terraform Acceptance Test",
+    "id": 12,
+    "version": "43"
+}
+EOT
+}
+`

--- a/builtin/providers/grafana/resource_data_source.go
+++ b/builtin/providers/grafana/resource_data_source.go
@@ -1,0 +1,184 @@
+package grafana
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+)
+
+func ResourceDataSource() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateDataSource,
+		Update: UpdateDataSource,
+		Delete: DeleteDataSource,
+		Read:   ReadDataSource,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"is_default": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"basic_auth_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"basic_auth_username": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"basic_auth_password": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"username": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"database_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"access_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "proxy",
+			},
+		},
+	}
+}
+
+func CreateDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	dataSource, err := makeDataSource(d)
+	if err != nil {
+		return err
+	}
+
+	id, err := client.NewDataSource(dataSource)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(id, 10))
+
+	return ReadDataSource(d, meta)
+}
+
+func UpdateDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	dataSource, err := makeDataSource(d)
+	if err != nil {
+		return err
+	}
+
+	return client.UpdateDataSource(dataSource)
+}
+
+func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	idStr := d.Id()
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid id: %#v", idStr)
+	}
+
+	dataSource, err := client.DataSource(id)
+	if err != nil {
+		return err
+	}
+
+	d.Set("id", dataSource.Id)
+	d.Set("access_mode", dataSource.Access)
+	d.Set("basic_auth_enabled", dataSource.BasicAuth)
+	d.Set("basic_auth_username", dataSource.BasicAuthUser)
+	d.Set("basic_auth_password", dataSource.BasicAuthPassword)
+	d.Set("database_name", dataSource.Database)
+	d.Set("is_default", dataSource.IsDefault)
+	d.Set("name", dataSource.Name)
+	d.Set("password", dataSource.Password)
+	d.Set("type", dataSource.Type)
+	d.Set("url", dataSource.URL)
+	d.Set("username", dataSource.User)
+
+	return nil
+}
+
+func DeleteDataSource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+
+	idStr := d.Id()
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid id: %#v", idStr)
+	}
+
+	return client.DeleteDataSource(id)
+}
+
+func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {
+	idStr := d.Id()
+	var id int64
+	var err error
+	if idStr != "" {
+		id, err = strconv.ParseInt(idStr, 10, 64)
+	}
+
+	return &gapi.DataSource{
+		Id:                id,
+		Name:              d.Get("name").(string),
+		Type:              d.Get("type").(string),
+		URL:               d.Get("url").(string),
+		Access:            d.Get("access_mode").(string),
+		Database:          d.Get("database_name").(string),
+		User:              d.Get("username").(string),
+		Password:          d.Get("password").(string),
+		IsDefault:         d.Get("is_default").(bool),
+		BasicAuth:         d.Get("basic_auth_enabled").(bool),
+		BasicAuthUser:     d.Get("basic_auth_username").(string),
+		BasicAuthPassword: d.Get("basic_auth_password").(string),
+	}, err
+}

--- a/builtin/providers/grafana/resource_data_source_test.go
+++ b/builtin/providers/grafana/resource_data_source_test.go
@@ -1,0 +1,87 @@
+package grafana
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	gapi "github.com/apparentlymart/go-grafana-api"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSource_basic(t *testing.T) {
+	var dataSource gapi.DataSource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDataSourceCheckDestroy(&dataSource),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceCheckExists("grafana_data_source.test", &dataSource),
+					resource.TestCheckResourceAttr(
+						"grafana_data_source.test", "type", "influxdb",
+					),
+					resource.TestMatchResourceAttr(
+						"grafana_data_source.test", "id", regexp.MustCompile(`\d+`),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCheckExists(rn string, dataSource *gapi.DataSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("resource id is malformed")
+		}
+
+		client := testAccProvider.Meta().(*gapi.Client)
+		gotDataSource, err := client.DataSource(id)
+		if err != nil {
+			return fmt.Errorf("error getting data source: %s", err)
+		}
+
+		*dataSource = *gotDataSource
+
+		return nil
+	}
+}
+
+func testAccDataSourceCheckDestroy(dataSource *gapi.DataSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*gapi.Client)
+		_, err := client.DataSource(dataSource.Id)
+		if err == nil {
+			return fmt.Errorf("data source still exists")
+		}
+		return nil
+	}
+}
+
+const testAccDataSourceConfig_basic = `
+resource "grafana_data_source" "test" {
+    type = "influxdb"
+    name = "terraform-acc-test"
+    database_name = "terraform-acc-test"
+    url = "http://terraform-acc-test.invalid/"
+    username = "terraform_user"
+    password = "terraform_password"
+}
+`


### PR DESCRIPTION
A provider for Grafana, including data source and dashboard resources.

* [x] Provider
* [x] `grafana_data_source` resource.
* [x] `grafana_dashboard` resource.
* [ ] Documentation

Grafana uses a documented JSON-based format for importing and exporting dashboards and panels. It is expected that many users of this provider will design dashboards/panels interactively in the Grafana UI, export them as JSON, and then include them in a Terraform config via the `file(...)` function, and so the `grafana_dashboard` resource just accepts a raw JSON string for the dashboard configuration.

This was originally submitted as #3480, including some additional resources to generate dashboard JSON from within Terraform configuration. However, experience trying to implement and use those suggested they could do with some more thinking, so this is a simplified PR that includes just the physical data source and dashboard resources.
