### PR TITLE
provider/openstack: static routing entries for routers

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -1,9 +1,13 @@
 package openstack
 
 import (
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+// This is a global MutexKV for use within this plugin.
+var osMutexKV = mutexkv.NewMutexKV()
 
 // Provider returns a schema.Provider for OpenStack.
 func Provider() terraform.ResourceProvider {
@@ -96,6 +100,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_networking_port_v2":             resourceNetworkingPortV2(),
 			"openstack_networking_router_v2":           resourceNetworkingRouterV2(),
 			"openstack_networking_router_interface_v2": resourceNetworkingRouterInterfaceV2(),
+			"openstack_networking_router_route_v2":     resourceNetworkingRouterRouteV2(),
 			"openstack_objectstorage_container_v1":     resourceObjectStorageContainerV1(),
 		},
 

--- a/builtin/providers/openstack/resource_openstack_networking_router_route_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_route_v2.go
@@ -1,0 +1,214 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+)
+
+func resourceNetworkingRouterRouteV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkingRouterRouteV2Create,
+		Read:   resourceNetworkingRouterRouteV2Read,
+		Delete: resourceNetworkingRouterRouteV2Delete,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+			},
+			"router_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination_cidr": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"next_hop": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interface{}) error {
+
+	routerId := d.Get("router_id").(string)
+	osMutexKV.Lock(routerId)
+	defer osMutexKV.Unlock(routerId)
+
+	var destCidr string = d.Get("destination_cidr").(string)
+	var nextHop string = d.Get("next_hop").(string)
+
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	n, err := routers.Get(networkingClient, routerId).Extract()
+	if err != nil {
+		httpError, ok := err.(*gophercloud.UnexpectedResponseCodeError)
+		if !ok {
+			return fmt.Errorf("Error retrieving OpenStack Neutron Router: %s", err)
+		}
+
+		if httpError.Actual == 404 {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving OpenStack Neutron Router: %s", err)
+	}
+
+	var updateOpts routers.UpdateOpts
+	var routeExists bool = false
+
+	var rts []routers.Route = n.Routes
+	for _, r := range rts {
+
+		if r.DestinationCIDR == destCidr && r.NextHop == nextHop {
+			routeExists = true
+			break
+		}
+	}
+
+	if !routeExists {
+
+		if destCidr != "" && nextHop != "" {
+			r := routers.Route{DestinationCIDR: destCidr, NextHop: nextHop}
+			log.Printf(
+				"[INFO] Adding route %s", r)
+			rts = append(rts, r)
+		}
+
+		updateOpts.Routes = rts
+
+		log.Printf("[DEBUG] Updating Router %s with options: %+v", routerId, updateOpts)
+
+		_, err = routers.Update(networkingClient, routerId, updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating OpenStack Neutron Router: %s", err)
+		}
+		d.SetId(fmt.Sprintf("%s-route-%s-%s", routerId, destCidr, nextHop))
+
+	} else {
+		log.Printf("[DEBUG] Router %s has route already", routerId)
+	}
+
+	return resourceNetworkingRouterRouteV2Read(d, meta)
+}
+
+func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{}) error {
+
+	routerId := d.Get("router_id").(string)
+
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	n, err := routers.Get(networkingClient, routerId).Extract()
+	if err != nil {
+		httpError, ok := err.(*gophercloud.UnexpectedResponseCodeError)
+		if !ok {
+			return fmt.Errorf("Error retrieving OpenStack Neutron Router: %s", err)
+		}
+
+		if httpError.Actual == 404 {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving OpenStack Neutron Router: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieved Router %s: %+v", routerId, n)
+
+	var destCidr string = d.Get("destination_cidr").(string)
+	var nextHop string = d.Get("next_hop").(string)
+
+	d.Set("next_hop", "")
+	d.Set("destination_cidr", "")
+
+	for _, r := range n.Routes {
+
+		if r.DestinationCIDR == destCidr && r.NextHop == nextHop {
+			d.Set("destination_cidr", destCidr)
+			d.Set("next_hop", nextHop)
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interface{}) error {
+
+	routerId := d.Get("router_id").(string)
+	osMutexKV.Lock(routerId)
+	defer osMutexKV.Unlock(routerId)
+
+	config := meta.(*Config)
+
+	networkingClient, err := config.networkingV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	n, err := routers.Get(networkingClient, routerId).Extract()
+	if err != nil {
+		httpError, ok := err.(*gophercloud.UnexpectedResponseCodeError)
+		if !ok {
+			return fmt.Errorf("Error retrieving OpenStack Neutron Router: %s", err)
+		}
+
+		if httpError.Actual == 404 {
+			return nil
+		}
+		return fmt.Errorf("Error retrieving OpenStack Neutron Router: %s", err)
+	}
+
+	var updateOpts routers.UpdateOpts
+
+	var destCidr string = d.Get("destination_cidr").(string)
+	var nextHop string = d.Get("next_hop").(string)
+
+	var oldRts []routers.Route = n.Routes
+	var newRts []routers.Route
+
+	for _, r := range oldRts {
+
+		if r.DestinationCIDR != destCidr || r.NextHop != nextHop {
+			newRts = append(newRts, r)
+		}
+	}
+
+	if len(oldRts) != len(newRts) {
+		r := routers.Route{DestinationCIDR: destCidr, NextHop: nextHop}
+		log.Printf(
+			"[INFO] Deleting route %s", r)
+		updateOpts.Routes = newRts
+
+		log.Printf("[DEBUG] Updating Router %s with options: %+v", routerId, updateOpts)
+
+		_, err = routers.Update(networkingClient, routerId, updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating OpenStack Neutron Router: %s", err)
+		}
+	} else {
+		return fmt.Errorf("Route did not exist already")
+	}
+
+	return nil
+}

--- a/builtin/providers/openstack/resource_openstack_networking_router_route_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_route_v2_test.go
@@ -1,0 +1,324 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/rackspace/gophercloud/openstack/networking/v2/networks"
+	"github.com/rackspace/gophercloud/openstack/networking/v2/subnets"
+)
+
+func TestAccNetworkingV2RouterRoute_basic(t *testing.T) {
+	var router routers.Router
+	var network [2]networks.Network
+	var subnet [2]subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2RouterRoute_create,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterExists(t, "openstack_networking_router_v2.router_1", &router),
+					testAccCheckNetworkingV2NetworkExists(t, "openstack_networking_network_v2.network_1", &network[0]),
+					testAccCheckNetworkingV2SubnetExists(t, "openstack_networking_subnet_v2.subnet_1", &subnet[0]),
+					testAccCheckNetworkingV2NetworkExists(t, "openstack_networking_network_v2.network_1", &network[1]),
+					testAccCheckNetworkingV2SubnetExists(t, "openstack_networking_subnet_v2.subnet_1", &subnet[1]),
+					testAccCheckNetworkingV2RouterInterfaceExists(t, "openstack_networking_router_interface_v2.int_1"),
+					testAccCheckNetworkingV2RouterInterfaceExists(t, "openstack_networking_router_interface_v2.int_2"),
+					testAccCheckNetworkingV2RouterRouteExists(t, "openstack_networking_router_route_v2.router_route_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2RouterRoute_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterRouteExists(t, "openstack_networking_router_route_v2.router_route_1"),
+					testAccCheckNetworkingV2RouterRouteExists(t, "openstack_networking_router_route_v2.router_route_2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkingV2RouterRoute_destroy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterRouteEmpty(t, "openstack_networking_router_v2.router_1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingV2RouterRouteEmpty(t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("(testAccCheckNetworkingV2RouterRouteExists) Error creating OpenStack networking client: %s", err)
+		}
+
+		router, err := routers.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if router.ID != rs.Primary.ID {
+			return fmt.Errorf("Router not found")
+		}
+
+		if len(router.Routes) != 0 {
+			return fmt.Errorf("Invalid number of route entries: %d", len(router.Routes))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkingV2RouterRouteExists(t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("(testAccCheckNetworkingV2RouterRouteExists) Error creating OpenStack networking client: %s", err)
+		}
+
+		router, err := routers.Get(networkingClient, rs.Primary.Attributes["router_id"]).Extract()
+		if err != nil {
+			return err
+		}
+
+		if router.ID != rs.Primary.Attributes["router_id"] {
+			return fmt.Errorf("Router for route not found")
+		}
+
+		var found bool = false
+		for _, r := range router.Routes {
+			if r.DestinationCIDR == rs.Primary.Attributes["destination_cidr"] && r.NextHop == rs.Primary.Attributes["next_hop"] {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("Could not find route for destination CIDR: %s, next hop: %s", rs.Primary.Attributes["destination_cidr"], rs.Primary.Attributes["next_hop"])
+		}
+
+		return nil
+	}
+}
+
+var testAccNetworkingV2RouterRoute_create = fmt.Sprintf(`
+	resource "openstack_networking_router_v2" "router_1" {
+		name = "router_1"
+		admin_state_up = "true"
+	}
+
+	resource "openstack_networking_network_v2" "network_1" {
+			name = "network_1"
+			admin_state_up = "true"
+	}
+
+	resource "openstack_networking_subnet_v2" "subnet_1" {
+			network_id = "${openstack_networking_network_v2.network_1.id}"
+			cidr = "192.168.199.0/24"
+			ip_version = 4
+	}
+
+        resource "openstack_networking_port_v2" "port_1" {
+                name = "port_1"
+                network_id = "${openstack_networking_network_v2.network_1.id}"
+                admin_state_up = "true"
+                fixed_ip {
+                        subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+                        ip_address = "192.168.199.1"
+                }
+        }
+
+        resource "openstack_networking_router_interface_v2" "int_1" {
+                        router_id = "${openstack_networking_router_v2.router_1.id}"
+                        port_id = "${openstack_networking_port_v2.port_1.id}"
+        }
+
+        resource "openstack_networking_network_v2" "network_2" {
+                        name = "network_2"
+                        admin_state_up = "true"
+        }
+
+        resource "openstack_networking_subnet_v2" "subnet_2" {
+                        network_id = "${openstack_networking_network_v2.network_2.id}"
+                        cidr = "192.168.200.0/24"
+                        ip_version = 4
+        }
+
+        resource "openstack_networking_port_v2" "port_2" {
+                name = "port_2"
+                network_id = "${openstack_networking_network_v2.network_2.id}"
+                admin_state_up = "true"
+                fixed_ip {
+                        subnet_id = "${openstack_networking_subnet_v2.subnet_2.id}"
+                        ip_address = "192.168.200.1"
+                }
+        }
+
+        resource "openstack_networking_router_interface_v2" "int_2" {
+                        router_id = "${openstack_networking_router_v2.router_1.id}"
+                        port_id = "${openstack_networking_port_v2.port_2.id}"
+        }
+
+	resource "openstack_networking_router_route_v2" "router_route_1" {
+			depends_on = ["openstack_networking_router_interface_v2.int_1"]
+			router_id = "${openstack_networking_router_v2.router_1.id}"
+
+			destination_cidr = "10.0.1.0/24"
+			next_hop = "192.168.199.254"
+	}`)
+
+var testAccNetworkingV2RouterRoute_update = fmt.Sprintf(`
+	resource "openstack_networking_router_v2" "router_1" {
+		name = "router_1"
+		admin_state_up = "true"
+	}
+
+	resource "openstack_networking_network_v2" "network_1" {
+			name = "network_1"
+			admin_state_up = "true"
+	}
+
+	resource "openstack_networking_subnet_v2" "subnet_1" {
+			network_id = "${openstack_networking_network_v2.network_1.id}"
+			cidr = "192.168.199.0/24"
+			ip_version = 4
+	}
+
+        resource "openstack_networking_port_v2" "port_1" {
+                name = "port_1"
+                network_id = "${openstack_networking_network_v2.network_1.id}"
+                admin_state_up = "true"
+                fixed_ip {
+                        subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+                        ip_address = "192.168.199.1"
+                }
+        }
+
+        resource "openstack_networking_router_interface_v2" "int_1" {
+                        router_id = "${openstack_networking_router_v2.router_1.id}"
+                        port_id = "${openstack_networking_port_v2.port_1.id}"
+        }
+
+        resource "openstack_networking_network_v2" "network_2" {
+                        name = "network_2"
+                        admin_state_up = "true"
+        }
+
+        resource "openstack_networking_subnet_v2" "subnet_2" {
+                        network_id = "${openstack_networking_network_v2.network_2.id}"
+                        cidr = "192.168.200.0/24"
+                        ip_version = 4
+        }
+
+        resource "openstack_networking_port_v2" "port_2" {
+                name = "port_2"
+                network_id = "${openstack_networking_network_v2.network_2.id}"
+                admin_state_up = "true"
+                fixed_ip {
+                        subnet_id = "${openstack_networking_subnet_v2.subnet_2.id}"
+                        ip_address = "192.168.200.1"
+                }
+        }
+
+        resource "openstack_networking_router_interface_v2" "int_2" {
+                        router_id = "${openstack_networking_router_v2.router_1.id}"
+                        port_id = "${openstack_networking_port_v2.port_2.id}"
+        }
+
+	resource "openstack_networking_router_route_v2" "router_route_1" {
+			depends_on = ["openstack_networking_router_interface_v2.int_1"]
+			router_id = "${openstack_networking_router_v2.router_1.id}"
+
+			destination_cidr = "10.0.1.0/24"
+			next_hop = "192.168.199.254"
+	}
+
+	resource "openstack_networking_router_route_v2" "router_route_2" {
+			depends_on = ["openstack_networking_router_interface_v2.int_2"]
+			router_id = "${openstack_networking_router_v2.router_1.id}"
+
+			destination_cidr = "10.0.2.0/24"
+			next_hop = "192.168.200.254"
+	}`)
+
+var testAccNetworkingV2RouterRoute_destroy = fmt.Sprintf(`
+	resource "openstack_networking_router_v2" "router_1" {
+		name = "router_1"
+		admin_state_up = "true"
+	}
+
+	resource "openstack_networking_network_v2" "network_1" {
+			name = "network_1"
+			admin_state_up = "true"
+	}
+
+	resource "openstack_networking_subnet_v2" "subnet_1" {
+			network_id = "${openstack_networking_network_v2.network_1.id}"
+			cidr = "192.168.199.0/24"
+			ip_version = 4
+	}
+
+        resource "openstack_networking_port_v2" "port_1" {
+                name = "port_1"
+                network_id = "${openstack_networking_network_v2.network_1.id}"
+                admin_state_up = "true"
+                fixed_ip {
+                        subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+                        ip_address = "192.168.199.1"
+                }
+        }
+
+        resource "openstack_networking_router_interface_v2" "int_1" {
+                        router_id = "${openstack_networking_router_v2.router_1.id}"
+                        port_id = "${openstack_networking_port_v2.port_1.id}"
+        }
+
+        resource "openstack_networking_network_v2" "network_2" {
+                        name = "network_2"
+                        admin_state_up = "true"
+        }
+
+        resource "openstack_networking_subnet_v2" "subnet_2" {
+                        network_id = "${openstack_networking_network_v2.network_2.id}"
+                        cidr = "192.168.200.0/24"
+                        ip_version = 4
+        }
+
+        resource "openstack_networking_port_v2" "port_2" {
+                name = "port_2"
+                network_id = "${openstack_networking_network_v2.network_2.id}"
+                admin_state_up = "true"
+                fixed_ip {
+                        subnet_id = "${openstack_networking_subnet_v2.subnet_2.id}"
+                        ip_address = "192.168.200.1"
+                }
+        }
+
+        resource "openstack_networking_router_interface_v2" "int_2" {
+                        router_id = "${openstack_networking_router_v2.router_1.id}"
+                        port_id = "${openstack_networking_port_v2.port_2.id}"
+	}`)

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -195,6 +195,10 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) error {
+	routerId := d.Id()
+	osMutexKV.Lock(routerId)
+	defer osMutexKV.Unlock(routerId)
+
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(d.Get("region").(string))
 	if err != nil {

--- a/website/source/docs/providers/openstack/r/networking_router_route_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_router_route_v2.html.markdown
@@ -1,0 +1,76 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_networking_router_route_v2"
+sidebar_current: "docs-openstack-resource-networking-router-route-v2"
+description: |-
+  Creates a routing entry on a OpenStack V2 router.
+---
+
+# openstack\_networking\_router_route_v2
+
+Creates a routing entry on a OpenStack V2 router.
+
+## Example Usage
+
+```
+resource "openstack_networking_router_v2" "router_1" {
+  name = "router_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+}
+
+resource "openstack_networking_router_interface_v2" "int_1" {
+  router_id = "${openstack_networking_router_v2.router_1.id}"
+  subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+
+resource "openstack_networking_router_route_v2" "router_route_1" {
+  depends_on = ["openstack_networking_router_interface_v2.int_1"]
+  router_id = "${openstack_networking_router_v2.router_1.id}"
+  destination_cidr = "10.0.1.0/24"
+  next_hop = "192.168.199.254"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the V2 networking client.
+    A networking client is needed to configure a routing entry on a router. If omitted, the
+    `OS_REGION_NAME` environment variable is used. Changing this creates a new
+    routing entry.
+
+* `router_id` - (Required) ID of the router this routing entry belongs to. Changing
+    this creates a new routing entry.
+
+* `destination_cidr` - (Required) CIDR block to match on the packet’s destination IP. Changing
+    this creates a new routing entry.
+
+* `next_hop` - (Required) IP address of the next hop gateway.  Changing
+    this creates a new routing entry.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `router_id` - See Argument Reference above.
+* `destination_cidr` - See Argument Reference above.
+* `next_hop` - See Argument Reference above.
+
+## Notes
+
+The `next_hop` IP address must be directly reachable from the router at the ``openstack_networking_router_route_v2``
+resource creation time.  You can ensure that by explicitly specifying a dependency on the ``openstack_networking_router_interface_v2``
+resource that connects the next hop to the router, as in the example above.


### PR DESCRIPTION
Hi,

This is an attempt at adding support to static routes for OpenStack router resources. The trick here is that the static route entries are not first class citizens in OpenStack, but instead are created as an update to the routers once they are already attached to the subnets with the next hops.

I worked around that by creating a ``openstack_networking_router_table_v2`` resource with a ``router_id`` argument, which specifies which router to apply the rules to. Here's the example I'm using for the acceptance tests:

```
        resource "openstack_networking_router_v2" "router_1" {
                name = "router_1"
                admin_state_up = "true"
        }

        resource "openstack_networking_network_v2" "network_1" {
                        name = "network_1"
                        admin_state_up = "true"
        }

        resource "openstack_networking_subnet_v2" "subnet_1" {
                        network_id = "${openstack_networking_network_v2.network_1.id}"
                        cidr = "192.168.199.0/24"
                        ip_version = 4
        }

        resource "openstack_networking_port_v2" "port_1" {
                name = "port_1"
                network_id = "${openstack_networking_network_v2.network_1.id}"
                admin_state_up = "true"
                fixed_ip {
                        subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
                        ip_address = "192.168.199.1"
                }
        }

        resource "openstack_networking_router_interface_v2" "int_1" {
                        router_id = "${openstack_networking_router_v2.router_1.id}"
                        port_id = "${openstack_networking_port_v2.port_1.id}"
        }

        resource "openstack_networking_network_v2" "network_2" {
                        name = "network_2"
                        admin_state_up = "true"
        }

        resource "openstack_networking_subnet_v2" "subnet_2" {
                        network_id = "${openstack_networking_network_v2.network_2.id}"
                        cidr = "192.168.200.0/24"
                        ip_version = 4
        }

        resource "openstack_networking_port_v2" "port_2" {
                name = "port_2"
                network_id = "${openstack_networking_network_v2.network_2.id}"
                admin_state_up = "true"
                fixed_ip {
                        subnet_id = "${openstack_networking_subnet_v2.subnet_2.id}"
                        ip_address = "192.168.200.1"
                }
        }

        resource "openstack_networking_router_interface_v2" "int_2" {
                        router_id = "${openstack_networking_router_v2.router_1.id}"
                        port_id = "${openstack_networking_port_v2.port_2.id}"
        }

        resource "openstack_networking_router_table_v2" "router_table_1" {
                        depends_on = ["openstack_networking_router_interface_v2.int_1", "openstack_networking_router_interface_v2.int_2"]
                        router_id = "${openstack_networking_router_v2.router_1.id}"

                        route {
                                destination_cidr = "10.0.1.0/24"
                                next_hop = "192.168.199.254"
                        }

                        route {
                                destination_cidr = "10.0.2.0/24"
                                next_hop = "192.168.200.254"
                        }
        }
```

That seems to work, except for the case in which two ``openstack_networking_router_table_v2`` resources try to configure the same router (through the same ``router_id``). I'd assume that setting resource IDs consistently related to the router would allow the detection of conflicting resources (as they would have the same ID), but it doesn't seem to be the case.

The problem I'm having with the acceptance tasks is that the CheckDestroy function is called only once the whole configuration is destroyed, which includes the router to which the route entries are attached, which is more than what I want to check the deletion for. Is there a way I can limit that the CheckDestroy function is called after the destroy of the ``openstack_networking_router_table_v2`` resource, but still before the destruction of the other resources?

I'm also open to implement it in a different way, but I'm not sure how to do it, due to the way the lifecycle of the routes need to be managed. For that reason, I still haven't written any documentation, but plan to do so.