### PR TITLE
Reduce the size of the binaries

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,12 +35,18 @@ if ! which gox > /dev/null; then
     go get -u github.com/mitchellh/gox
 fi
 
+LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}"
+# In relase mode we don't want debug information in the binary
+if [[ -n "${TF_RELEASE}" ]]; then
+    LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -s -w"
+fi
+
 # Build!
 echo "==> Building..."
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
-    -ldflags "-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "${LD_FLAGS}" \
     -output "pkg/{{.OS}}_{{.Arch}}/terraform-{{.Dir}}" \
     $(go list ./... | grep -v /vendor/)
 


### PR DESCRIPTION
Introducing an `TF_RELEASE` variable to the build process.
When `TF_RELEASE` is set, the LD_FLAGS `-s -w` is applied. This will strip debug information from
the binaries.
The complete size of the binaries before change was 543 mb
After the change the complete size is 395
This is a decrease of __148 mb__
Numbers are taken from OSX.

This has not been tested on other platform then OSX, but since it's standard go build flags I don't foresee any issues with it. 