### PR TITLE
Fix spacing in Triton resources sidebar.

### DIFF
--- a/website/source/layouts/triton.erb
+++ b/website/source/layouts/triton.erb
@@ -17,15 +17,9 @@
                         <li<%= sidebar_current("docs-triton-resource-firewall-rule") %>>
                             <a href="/docs/providers/triton/r/triton_firewall_rule.html">triton_firewall_rule</a>
                         </li>
-                    </ul>
-
-                    <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-triton-resource-key") %>>
                             <a href="/docs/providers/triton/r/triton_key.html">triton_key</a>
                         </li>
-                    </ul>
-                    
-                    <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-triton-resource-machine") %>>
                             <a href="/docs/providers/triton/r/triton_machine.html">triton_machine</a>
                         </li>


### PR DESCRIPTION
This change makes the spacing of the Triton resources sidebar consistent with other providers.

![image](https://cloud.githubusercontent.com/assets/293763/14645317/044f6bc6-060a-11e6-8722-03b704239548.png)
