### PR TITLE
aws/provider: Resolves DefaultOS and ConfigurationManager conflict

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -310,6 +310,10 @@ func resourceAwsOpsworksStackCreate(d *schema.ResourceData, meta interface{}) er
 		DefaultOs:                 aws.String(d.Get("default_os").(string)),
 		UseOpsworksSecurityGroups: aws.Bool(d.Get("use_opsworks_security_groups").(bool)),
 	}
+	req.ConfigurationManager = &opsworks.StackConfigurationManager{
+		Name:     aws.String(d.Get("configuration_manager_name").(string)),
+		Version:  aws.String(d.Get("configuration_manager_version").(string)),
+	}
 	inVpc := false
 	if vpcId, ok := d.GetOk("vpc_id"); ok {
 		req.VpcId = aws.String(vpcId.(string))


### PR DESCRIPTION
This resolves, allot: #5569 #5905 #5958 #6221 (and anything else that would otherwise be blocked by stack creation failing).