### PR TITLE
provider/fastly: Add Gzip rule support

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1173,7 +1173,7 @@
 		},
 		{
 			"ImportPath": "github.com/sethvargo/go-fastly",
-			"Rev": "382fee1e5e1adf3cc112fadf4f0a8a98e269ea3c"
+			"Rev": "b00964ba5a45ca385e9299c9803d6d2a8105d65b"
 		},
 		{
 			"ImportPath": "github.com/soniah/dnsmadeeasy",

--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -1,0 +1,147 @@
+package fastly
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	gofastly "github.com/sethvargo/go-fastly"
+)
+
+func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceV1GzipsConfig(name, domainName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1GzipsAttributes(&service, name, 2),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.#", "2"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.3704620722.extensions.#", "2"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.3704620722.content_types.#", "0"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.3820313126.content_types.#", "2"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.3820313126.extensions.#", "0"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccServiceV1GzipsConfig_update(name, domainName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1GzipsAttributes(&service, name, 1),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.#", "1"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.3694165387.extensions.#", "3"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.3694165387.content_types.#", "5"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1GzipsAttributes(service *gofastly.ServiceDetail, name string, gzipCount int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if service.Name != name {
+			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		gzipsList, err := conn.ListGzips(&gofastly.ListGzipsInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Gzips for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(gzipsList) != gzipCount {
+			return fmt.Errorf("Gzip count mismatch, expected (%d), got (%d)", gzipCount, len(gzipsList))
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1GzipsConfig(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  gzip {
+    name       = "gzip file types"
+    extensions = ["css", "js"]
+  }
+
+  gzip {
+    name          = "gzip extensions"
+    content_types = ["text/html", "text/css"]
+  }
+
+  force_destroy = true
+}`, name, domain)
+}
+
+func testAccServiceV1GzipsConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  gzip {
+    name       = "all"
+    extensions = ["css", "js", "html"]
+
+    content_types = [
+      "text/html",
+      "text/css",
+      "application/x-javascript",
+      "text/css",
+      "application/javascript",
+      "text/javascript",
+    ]
+  }
+
+  force_destroy = true
+}`, name, domain)
+}

--- a/vendor/github.com/sethvargo/go-fastly/Makefile
+++ b/vendor/github.com/sethvargo/go-fastly/Makefile
@@ -4,18 +4,18 @@ default: test
 
 # test runs the test suite and vets the code
 test: generate
-        go list $(TEST) | xargs -n1 go test -timeout=30s -parallel=8 $(TESTARGS)
+	go list $(TEST) | xargs -n1 go test -timeout=30s -parallel=12 $(TESTARGS)
 
 # updatedeps installs all the dependencies the library needs to run and build
 updatedeps:
-        go list ./... \
-                | xargs go list -f '{{ join .Deps "\n" }}{{ printf "\n" }}{{ join .TestImports "\n" }}' \
-                | grep -v github.com/sethvargo/go-fastly \
-                | xargs go get -f -u -v
+	go list ./... \
+		| xargs go list -f '{{ join .Deps "\n" }}{{ printf "\n" }}{{ join .TestImports "\n" }}' \
+		| grep -v github.com/sethvargo/go-fastly \
+		| xargs go get -f -u -v
 
 # generate runs `go generate` to build the dynamically generated source files
 generate:
-        find . -type f -name '.DS_Store' -delete
-        go generate ./...
+	find . -type f -name '.DS_Store' -delete
+	go generate ./...
 
 .PHONY: default bin dev dist test testrace updatedeps generate

--- a/vendor/github.com/sethvargo/go-fastly/backend.go
+++ b/vendor/github.com/sethvargo/go-fastly/backend.go
@@ -1,35 +1,36 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // Backend represents a backend response from the Fastly API.
 type Backend struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name                string   `mapstructure:"name"`
-        Address             string   `mapstructure:"address"`
-        Port                uint     `mapstructure:"port"`
-        ConnectTimeout      uint     `mapstructure:"connect_timeout"`
-        MaxConn             uint     `mapstructure:"max_conn"`
-        ErrorThreshold      uint     `mapstructure:"error_threshold"`
-        FirstByteTimeout    uint     `mapstructure:"first_byte_timeout"`
-        BetweenBytesTimeout uint     `mapstructure:"between_bytes_timeout"`
-        AutoLoadbalance     bool     `mapstructure:"auto_loadbalance"`
-        Weight              uint     `mapstructure:"weight"`
-        RequestCondition    string   `mapstructure:"request_condition"`
-        HealthCheck         string   `mapstructure:"healthcheck"`
-        UseSSL              bool     `mapstructure:"use_ssl"`
-        SSLCheckCert        bool     `mapstructure:"ssl_check_cert"`
-        SSLHostname         string   `mapstructure:"ssl_hostname"`
-        SSLCertHostname     string   `mapstructure:"ssl_cert_hostname"`
-        SSLSNIHostname      string   `mapstructure:"ssl_sni_hostname"`
-        MinTLSVersion       string   `mapstructure:"min_tls_version"`
-        MaxTLSVersion       string   `mapstructure:"max_tls_version"`
-        SSLCiphers          []string `mapstructure:"ssl_ciphers"`
+	Name                string   `mapstructure:"name"`
+	Address             string   `mapstructure:"address"`
+	Port                uint     `mapstructure:"port"`
+	ConnectTimeout      uint     `mapstructure:"connect_timeout"`
+	MaxConn             uint     `mapstructure:"max_conn"`
+	ErrorThreshold      uint     `mapstructure:"error_threshold"`
+	FirstByteTimeout    uint     `mapstructure:"first_byte_timeout"`
+	BetweenBytesTimeout uint     `mapstructure:"between_bytes_timeout"`
+	AutoLoadbalance     bool     `mapstructure:"auto_loadbalance"`
+	Weight              uint     `mapstructure:"weight"`
+	RequestCondition    string   `mapstructure:"request_condition"`
+	HealthCheck         string   `mapstructure:"healthcheck"`
+	Hostname            string   `mapstructure:"hostname"`
+	UseSSL              bool     `mapstructure:"use_ssl"`
+	SSLCheckCert        bool     `mapstructure:"ssl_check_cert"`
+	SSLHostname         string   `mapstructure:"ssl_hostname"`
+	SSLCertHostname     string   `mapstructure:"ssl_cert_hostname"`
+	SSLSNIHostname      string   `mapstructure:"ssl_sni_hostname"`
+	MinTLSVersion       string   `mapstructure:"min_tls_version"`
+	MaxTLSVersion       string   `mapstructure:"max_tls_version"`
+	SSLCiphers          []string `mapstructure:"ssl_ciphers"`
 }
 
 // backendsByName is a sortable list of backends.
@@ -39,228 +40,228 @@ type backendsByName []*Backend
 func (s backendsByName) Len() int      { return len(s) }
 func (s backendsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s backendsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListBackendsInput is used as input to the ListBackends function.
 type ListBackendsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListBackends returns the list of backends for the configuration version.
 func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var bs []*Backend
-        if err := decodeJSON(&bs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(backendsByName(bs))
-        return bs, nil
+	var bs []*Backend
+	if err := decodeJSON(&bs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(backendsByName(bs))
+	return bs, nil
 }
 
 // CreateBackendInput is used as input to the CreateBackend function.
 type CreateBackendInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name                string   `form:"name,omitempty"`
-        Address             string   `form:"address,omitempty"`
-        Port                uint     `form:"port,omitempty"`
-        ConnectTimeout      uint     `form:"connect_timeout,omitempty"`
-        MaxConn             uint     `form:"max_conn,omitempty"`
-        ErrorThreshold      uint     `form:"error_threshold,omitempty"`
-        FirstByteTimeout    uint     `form:"first_byte_timeout,omitempty"`
-        BetweenBytesTimeout uint     `form:"between_bytes_timeout,omitempty"`
-        AutoLoadbalance     bool     `form:"auto_loadbalance,omitempty"`
-        Weight              uint     `form:"weight,omitempty"`
-        RequestCondition    string   `form:"request_condition,omitempty"`
-        HealthCheck         string   `form:"healthcheck,omitempty"`
-        UseSSL              bool     `form:"use_ssl,omitempty"`
-        SSLCheckCert        bool     `form:"ssl_check_cert,omitempty"`
-        SSLHostname         string   `form:"ssl_hostname,omitempty"`
-        SSLCertHostname     string   `form:"ssl_cert_hostname,omitempty"`
-        SSLSNIHostname      string   `form:"ssl_sni_hostname,omitempty"`
-        MinTLSVersion       string   `form:"min_tls_version,omitempty"`
-        MaxTLSVersion       string   `form:"max_tls_version,omitempty"`
-        SSLCiphers          []string `form:"ssl_ciphers,omitempty"`
+	Name                string   `form:"name,omitempty"`
+	Address             string   `form:"address,omitempty"`
+	Port                uint     `form:"port,omitempty"`
+	ConnectTimeout      uint     `form:"connect_timeout,omitempty"`
+	MaxConn             uint     `form:"max_conn,omitempty"`
+	ErrorThreshold      uint     `form:"error_threshold,omitempty"`
+	FirstByteTimeout    uint     `form:"first_byte_timeout,omitempty"`
+	BetweenBytesTimeout uint     `form:"between_bytes_timeout,omitempty"`
+	AutoLoadbalance     bool     `form:"auto_loadbalance,omitempty"`
+	Weight              uint     `form:"weight,omitempty"`
+	RequestCondition    string   `form:"request_condition,omitempty"`
+	HealthCheck         string   `form:"healthcheck,omitempty"`
+	UseSSL              bool     `form:"use_ssl,omitempty"`
+	SSLCheckCert        bool     `form:"ssl_check_cert,omitempty"`
+	SSLHostname         string   `form:"ssl_hostname,omitempty"`
+	SSLCertHostname     string   `form:"ssl_cert_hostname,omitempty"`
+	SSLSNIHostname      string   `form:"ssl_sni_hostname,omitempty"`
+	MinTLSVersion       string   `form:"min_tls_version,omitempty"`
+	MaxTLSVersion       string   `form:"max_tls_version,omitempty"`
+	SSLCiphers          []string `form:"ssl_ciphers,omitempty"`
 }
 
 // CreateBackend creates a new Fastly backend.
 func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Backend
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Backend
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetBackendInput is used as input to the GetBackend function.
 type GetBackendInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the backend to fetch.
-        Name string
+	// Name is the name of the backend to fetch.
+	Name string
 }
 
 // GetBackend gets the backend configuration with the given parameters.
 func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Backend
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Backend
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateBackendInput is used as input to the UpdateBackend function.
 type UpdateBackendInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the backend to update.
-        Name string
+	// Name is the name of the backend to update.
+	Name string
 
-        NewName             string   `form:"name,omitempty"`
-        Address             string   `form:"address,omitempty"`
-        Port                uint     `form:"port,omitempty"`
-        ConnectTimeout      uint     `form:"connect_timeout,omitempty"`
-        MaxConn             uint     `form:"max_conn,omitempty"`
-        ErrorThreshold      uint     `form:"error_threshold,omitempty"`
-        FirstByteTimeout    uint     `form:"first_byte_timeout,omitempty"`
-        BetweenBytesTimeout uint     `form:"between_bytes_timeout,omitempty"`
-        AutoLoadbalance     bool     `form:"auto_loadbalance,omitempty"`
-        Weight              uint     `form:"weight,omitempty"`
-        RequestCondition    string   `form:"request_condition,omitempty"`
-        HealthCheck         string   `form:"healthcheck,omitempty"`
-        UseSSL              bool     `form:"use_ssl,omitempty"`
-        SSLCheckCert        bool     `form:"ssl_check_cert,omitempty"`
-        SSLHostname         string   `form:"ssl_hostname,omitempty"`
-        SSLCertHostname     string   `form:"ssl_cert_hostname,omitempty"`
-        SSLSNIHostname      string   `form:"ssl_sni_hostname,omitempty"`
-        MinTLSVersion       string   `form:"min_tls_version,omitempty"`
-        MaxTLSVersion       string   `form:"max_tls_version,omitempty"`
-        SSLCiphers          []string `form:"ssl_ciphers,omitempty"`
+	NewName             string   `form:"name,omitempty"`
+	Address             string   `form:"address,omitempty"`
+	Port                uint     `form:"port,omitempty"`
+	ConnectTimeout      uint     `form:"connect_timeout,omitempty"`
+	MaxConn             uint     `form:"max_conn,omitempty"`
+	ErrorThreshold      uint     `form:"error_threshold,omitempty"`
+	FirstByteTimeout    uint     `form:"first_byte_timeout,omitempty"`
+	BetweenBytesTimeout uint     `form:"between_bytes_timeout,omitempty"`
+	AutoLoadbalance     bool     `form:"auto_loadbalance,omitempty"`
+	Weight              uint     `form:"weight,omitempty"`
+	RequestCondition    string   `form:"request_condition,omitempty"`
+	HealthCheck         string   `form:"healthcheck,omitempty"`
+	UseSSL              bool     `form:"use_ssl,omitempty"`
+	SSLCheckCert        bool     `form:"ssl_check_cert,omitempty"`
+	SSLHostname         string   `form:"ssl_hostname,omitempty"`
+	SSLCertHostname     string   `form:"ssl_cert_hostname,omitempty"`
+	SSLSNIHostname      string   `form:"ssl_sni_hostname,omitempty"`
+	MinTLSVersion       string   `form:"min_tls_version,omitempty"`
+	MaxTLSVersion       string   `form:"max_tls_version,omitempty"`
+	SSLCiphers          []string `form:"ssl_ciphers,omitempty"`
 }
 
 // UpdateBackend updates a specific backend.
 func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Backend
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Backend
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteBackendInput is the input parameter to DeleteBackend.
 type DeleteBackendInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the backend to delete (required).
-        Name string
+	// Name is the name of the backend to delete (required).
+	Name string
 }
 
 // DeleteBackend deletes the given backend version.
 func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/billing.go
+++ b/vendor/github.com/sethvargo/go-fastly/billing.go
@@ -1,81 +1,81 @@
 package fastly
 
 import (
-        "fmt"
-        "time"
+	"fmt"
+	"time"
 )
 
 // Billing is the top-level representation of a billing response from the Fastly
 // API.
 type Billing struct {
-        InvoiceID string         `mapstructure:"invoice_id"`
-        StartTime *time.Time     `mapstructure:"start_time"`
-        EndTime   *time.Time     `mapstructure:"end_time"`
-        Status    *BillingStatus `mapstructure:"status"`
-        Total     *BillingTotal  `mapstructure:"total"`
+	InvoiceID string         `mapstructure:"invoice_id"`
+	StartTime *time.Time     `mapstructure:"start_time"`
+	EndTime   *time.Time     `mapstructure:"end_time"`
+	Status    *BillingStatus `mapstructure:"status"`
+	Total     *BillingTotal  `mapstructure:"total"`
 }
 
 // BillingStatus is a representation of the status of the bill from the Fastly
 // API.
 type BillingStatus struct {
-        InvoiceID string     `mapstructure:"invoice_id"`
-        Status    string     `mapstructure:"status"`
-        SentAt    *time.Time `mapstructure:"sent_at"`
+	InvoiceID string     `mapstructure:"invoice_id"`
+	Status    string     `mapstructure:"status"`
+	SentAt    *time.Time `mapstructure:"sent_at"`
 }
 
 // BillingTotal is a repsentation of the status of the usage for this bill from
 // the Fastly API.
 type BillingTotal struct {
-        PlanName           string          `mapstructure:"plan_name"`
-        PlanCode           string          `mapstructure:"plan_code"`
-        PlanMinimum        string          `mapstructure:"plan_minimum"`
-        Bandwidth          float64         `mapstructure:"bandwidth"`
-        BandwidthCost      float64         `mapstructure:"bandwidth_cost"`
-        Requests           uint64          `mapstructure:"requests"`
-        RequestsCost       float64         `mapstructure:"requests_cost"`
-        IncurredCost       float64         `mapstructure:"incurred_cost"`
-        Overage            float64         `mapstructure:"overage"`
-        Extras             []*BillingExtra `mapstructure:"extras"`
-        ExtrasCost         float64         `mapstructure:"extras_cost"`
-        CostBeforeDiscount float64         `mapstructure:"cost_before_discount"`
-        Discount           float64         `mapstructure:"discount"`
-        Cost               float64         `mapstructure:"cost"`
-        Terms              string          `mapstructure:"terms"`
+	PlanName           string          `mapstructure:"plan_name"`
+	PlanCode           string          `mapstructure:"plan_code"`
+	PlanMinimum        string          `mapstructure:"plan_minimum"`
+	Bandwidth          float64         `mapstructure:"bandwidth"`
+	BandwidthCost      float64         `mapstructure:"bandwidth_cost"`
+	Requests           uint64          `mapstructure:"requests"`
+	RequestsCost       float64         `mapstructure:"requests_cost"`
+	IncurredCost       float64         `mapstructure:"incurred_cost"`
+	Overage            float64         `mapstructure:"overage"`
+	Extras             []*BillingExtra `mapstructure:"extras"`
+	ExtrasCost         float64         `mapstructure:"extras_cost"`
+	CostBeforeDiscount float64         `mapstructure:"cost_before_discount"`
+	Discount           float64         `mapstructure:"discount"`
+	Cost               float64         `mapstructure:"cost"`
+	Terms              string          `mapstructure:"terms"`
 }
 
 // BillingExtra is a representation of extras (such as SSL addons) from the
 // Fastly API.
 type BillingExtra struct {
-        Name      string  `mapstructure:"name"`
-        Setup     float64 `mapstructure:"setup"`
-        Recurring float64 `mapstructure:"recurring"`
+	Name      string  `mapstructure:"name"`
+	Setup     float64 `mapstructure:"setup"`
+	Recurring float64 `mapstructure:"recurring"`
 }
 
 // GetBillingInput is used as input to the GetBilling function.
 type GetBillingInput struct {
-        Year  uint16
-        Month uint8
+	Year  uint16
+	Month uint8
 }
 
 // GetBilling returns the billing information for the current account.
 func (c *Client) GetBilling(i *GetBillingInput) (*Billing, error) {
-        if i.Year == 0 {
-                return nil, ErrMissingYear
-        }
+	if i.Year == 0 {
+		return nil, ErrMissingYear
+	}
 
-        if i.Month == 0 {
-                return nil, ErrMissingMonth
-        }
+	if i.Month == 0 {
+		return nil, ErrMissingMonth
+	}
 
-        path := fmt.Sprintf("/billing/year/%d/month/%02d", i.Year, i.Month)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/billing/year/%d/month/%02d", i.Year, i.Month)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Billing
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Billing
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/cache_setting.go
+++ b/vendor/github.com/sethvargo/go-fastly/cache_setting.go
@@ -1,19 +1,19 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 const (
-        // CacheSettingActionCache sets the cache to cache.
-        CacheSettingActionCache CacheSettingAction = "cache"
+	// CacheSettingActionCache sets the cache to cache.
+	CacheSettingActionCache CacheSettingAction = "cache"
 
-        // CacheSettingActionPass sets the cache to pass through.
-        CacheSettingActionPass CacheSettingAction = "pass"
+	// CacheSettingActionPass sets the cache to pass through.
+	CacheSettingActionPass CacheSettingAction = "pass"
 
-        // CacheSettingActionRestart sets the cache to restart the request.
-        CacheSettingActionRestart CacheSettingAction = "restart"
+	// CacheSettingActionRestart sets the cache to restart the request.
+	CacheSettingActionRestart CacheSettingAction = "restart"
 )
 
 // CacheSettingAction is the type of cache action.
@@ -21,14 +21,14 @@ type CacheSettingAction string
 
 // CacheSetting represents a response from Fastly's API for cache settings.
 type CacheSetting struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name           string             `mapstructure:"name"`
-        Action         CacheSettingAction `mapstructure:"action"`
-        TTL            uint               `mapstructure:"ttl"`
-        StaleTTL       uint               `mapstructure:"stale_ttl"`
-        CacheCondition string             `mapstructure:"cache_condition"`
+	Name           string             `mapstructure:"name"`
+	Action         CacheSettingAction `mapstructure:"action"`
+	TTL            uint               `mapstructure:"ttl"`
+	StaleTTL       uint               `mapstructure:"stale_ttl"`
+	CacheCondition string             `mapstructure:"cache_condition"`
 }
 
 // cacheSettingsByName is a sortable list of cache settings.
@@ -38,200 +38,200 @@ type cacheSettingsByName []*CacheSetting
 func (s cacheSettingsByName) Len() int      { return len(s) }
 func (s cacheSettingsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s cacheSettingsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListCacheSettingsInput is used as input to the ListCacheSettings function.
 type ListCacheSettingsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListCacheSettings returns the list of cache settings for the configuration
 // version.
 func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var cs []*CacheSetting
-        if err := decodeJSON(&cs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(cacheSettingsByName(cs))
-        return cs, nil
+	var cs []*CacheSetting
+	if err := decodeJSON(&cs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(cacheSettingsByName(cs))
+	return cs, nil
 }
 
 // CreateCacheSettingInput is used as input to the CreateCacheSetting function.
 type CreateCacheSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name           string             `form:"name,omitempty"`
-        Action         CacheSettingAction `form:"action,omitempty"`
-        TTL            uint               `form:"ttl,omitempty"`
-        StaleTTL       uint               `form:"stale_ttl,omitempty"`
-        CacheCondition string             `form:"cache_condition,omitempty"`
+	Name           string             `form:"name,omitempty"`
+	Action         CacheSettingAction `form:"action,omitempty"`
+	TTL            uint               `form:"ttl,omitempty"`
+	StaleTTL       uint               `form:"stale_ttl,omitempty"`
+	CacheCondition string             `form:"cache_condition,omitempty"`
 }
 
 // CreateCacheSetting creates a new Fastly cache setting.
 func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var cs *CacheSetting
-        if err := decodeJSON(&cs, resp.Body); err != nil {
-                return nil, err
-        }
-        return cs, nil
+	var cs *CacheSetting
+	if err := decodeJSON(&cs, resp.Body); err != nil {
+		return nil, err
+	}
+	return cs, nil
 }
 
 // GetCacheSettingInput is used as input to the GetCacheSetting function.
 type GetCacheSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the cache setting to fetch.
-        Name string
+	// Name is the name of the cache setting to fetch.
+	Name string
 }
 
 // GetCacheSetting gets the cache setting configuration with the given
 // parameters.
 func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var cs *CacheSetting
-        if err := decodeJSON(&cs, resp.Body); err != nil {
-                return nil, err
-        }
-        return cs, nil
+	var cs *CacheSetting
+	if err := decodeJSON(&cs, resp.Body); err != nil {
+		return nil, err
+	}
+	return cs, nil
 }
 
 // UpdateCacheSettingInput is used as input to the UpdateCacheSetting function.
 type UpdateCacheSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the cache setting to update.
-        Name string
+	// Name is the name of the cache setting to update.
+	Name string
 
-        NewName        string             `form:"name,omitempty"`
-        Action         CacheSettingAction `form:"action,omitempty"`
-        TTL            uint               `form:"ttl,omitempty"`
-        StateTTL       uint               `form:"stale_ttl,omitempty"`
-        CacheCondition string             `form:"cache_condition,omitempty"`
+	NewName        string             `form:"name,omitempty"`
+	Action         CacheSettingAction `form:"action,omitempty"`
+	TTL            uint               `form:"ttl,omitempty"`
+	StateTTL       uint               `form:"stale_ttl,omitempty"`
+	CacheCondition string             `form:"cache_condition,omitempty"`
 }
 
 // UpdateCacheSetting updates a specific cache setting.
 func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var cs *CacheSetting
-        if err := decodeJSON(&cs, resp.Body); err != nil {
-                return nil, err
-        }
-        return cs, nil
+	var cs *CacheSetting
+	if err := decodeJSON(&cs, resp.Body); err != nil {
+		return nil, err
+	}
+	return cs, nil
 }
 
 // DeleteCacheSettingInput is the input parameter to DeleteCacheSetting.
 type DeleteCacheSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the cache setting to delete (required).
-        Name string
+	// Name is the name of the cache setting to delete (required).
+	Name string
 }
 
 // DeleteCacheSetting deletes the given cache setting version.
 func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/client.go
+++ b/vendor/github.com/sethvargo/go-fastly/client.go
@@ -1,18 +1,18 @@
 package fastly
 
 import (
-        "encoding/json"
-        "fmt"
-        "io"
-        "net/http"
-        "net/url"
-        "os"
-        "runtime"
-        "strings"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
 
-        "github.com/ajg/form"
-        "github.com/hashicorp/go-cleanhttp"
-        "github.com/mitchellh/mapstructure"
+	"github.com/ajg/form"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/mitchellh/mapstructure"
 )
 
 // APIKeyEnvVar is the name of the environment variable where the Fastly API
@@ -30,37 +30,37 @@ const DefaultEndpoint = "https://api.fastly.com"
 var ProjectURL = "github.com/sethvargo/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "0.1"
+var ProjectVersion = "0.2"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",
-        ProjectVersion, ProjectURL, runtime.Version())
+	ProjectVersion, ProjectURL, runtime.Version())
 
 // Client is the main entrypoint to the Fastly golang API library.
 type Client struct {
-        // Address is the address of Fastly's API endpoint.
-        Address string
+	// Address is the address of Fastly's API endpoint.
+	Address string
 
-        // HTTPClient is the HTTP client to use. If one is not provided, a default
-        // client will be used.
-        HTTPClient *http.Client
+	// HTTPClient is the HTTP client to use. If one is not provided, a default
+	// client will be used.
+	HTTPClient *http.Client
 
-        // apiKey is the Fastly API key to authenticate requests.
-        apiKey string
+	// apiKey is the Fastly API key to authenticate requests.
+	apiKey string
 
-        // url is the parsed URL from Address
-        url *url.URL
+	// url is the parsed URL from Address
+	url *url.URL
 }
 
 // DefaultClient instantiates a new Fastly API client. This function requires
 // the environment variable `FASTLY_API_KEY` is set and contains a valid API key
 // to authenticate with Fastly.
 func DefaultClient() *Client {
-        client, err := NewClient(os.Getenv(APIKeyEnvVar))
-        if err != nil {
-                panic(err)
-        }
-        return client
+	client, err := NewClient(os.Getenv(APIKeyEnvVar))
+	if err != nil {
+		panic(err)
+	}
+	return client
 }
 
 // NewClient creates a new API client with the given key. Because Fastly allows
@@ -68,145 +68,145 @@ func DefaultClient() *Client {
 // token is not supplied. Attempts to make a request that requires an API key
 // will return a 403 response.
 func NewClient(key string) (*Client, error) {
-        client := &Client{apiKey: key}
-        return client.init()
+	client := &Client{apiKey: key}
+	return client.init()
 }
 
 func (c *Client) init() (*Client, error) {
-        if len(c.Address) == 0 {
-                c.Address = DefaultEndpoint
-        }
+	if len(c.Address) == 0 {
+		c.Address = DefaultEndpoint
+	}
 
-        u, err := url.Parse(c.Address)
-        if err != nil {
-                return nil, err
-        }
-        c.url = u
+	u, err := url.Parse(c.Address)
+	if err != nil {
+		return nil, err
+	}
+	c.url = u
 
-        if c.HTTPClient == nil {
-                c.HTTPClient = cleanhttp.DefaultClient()
-        }
+	if c.HTTPClient == nil {
+		c.HTTPClient = cleanhttp.DefaultClient()
+	}
 
-        return c, nil
+	return c, nil
 }
 
 // Get issues an HTTP GET request.
 func (c *Client) Get(p string, ro *RequestOptions) (*http.Response, error) {
-        return c.Request("GET", p, ro)
+	return c.Request("GET", p, ro)
 }
 
 // Head issues an HTTP HEAD request.
 func (c *Client) Head(p string, ro *RequestOptions) (*http.Response, error) {
-        return c.Request("HEAD", p, ro)
+	return c.Request("HEAD", p, ro)
 }
 
 // Post issues an HTTP POST request.
 func (c *Client) Post(p string, ro *RequestOptions) (*http.Response, error) {
-        return c.Request("POST", p, ro)
+	return c.Request("POST", p, ro)
 }
 
 // PostForm issues an HTTP POST request with the given interface form-encoded.
 func (c *Client) PostForm(p string, i interface{}, ro *RequestOptions) (*http.Response, error) {
-        return c.RequestForm("POST", p, i, ro)
+	return c.RequestForm("POST", p, i, ro)
 }
 
 // Put issues an HTTP PUT request.
 func (c *Client) Put(p string, ro *RequestOptions) (*http.Response, error) {
-        return c.Request("PUT", p, ro)
+	return c.Request("PUT", p, ro)
 }
 
 // PutForm issues an HTTP PUT request with the given interface form-encoded.
 func (c *Client) PutForm(p string, i interface{}, ro *RequestOptions) (*http.Response, error) {
-        return c.RequestForm("PUT", p, i, ro)
+	return c.RequestForm("PUT", p, i, ro)
 }
 
 // Delete issues an HTTP DELETE request.
 func (c *Client) Delete(p string, ro *RequestOptions) (*http.Response, error) {
-        return c.Request("DELETE", p, ro)
+	return c.Request("DELETE", p, ro)
 }
 
 // Request makes an HTTP request against the HTTPClient using the given verb,
 // Path, and request options.
 func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, error) {
-        req, err := c.RawRequest(verb, p, ro)
-        if err != nil {
-                return nil, err
-        }
+	req, err := c.RawRequest(verb, p, ro)
+	if err != nil {
+		return nil, err
+	}
 
-        resp, err := checkResp(c.HTTPClient.Do(req))
-        if err != nil {
-                return resp, err
-        }
+	resp, err := checkResp(c.HTTPClient.Do(req))
+	if err != nil {
+		return resp, err
+	}
 
-        return resp, nil
+	return resp, nil
 }
 
 // RequestForm makes an HTTP request with the given interface being encoded as
 // form data.
 func (c *Client) RequestForm(verb, p string, i interface{}, ro *RequestOptions) (*http.Response, error) {
-        values, err := form.EncodeToValues(i)
-        if err != nil {
-                return nil, err
-        }
+	values, err := form.EncodeToValues(i)
+	if err != nil {
+		return nil, err
+	}
 
-        if ro == nil {
-                ro = new(RequestOptions)
-        }
+	if ro == nil {
+		ro = new(RequestOptions)
+	}
 
-        if ro.Headers == nil {
-                ro.Headers = make(map[string]string)
-        }
-        ro.Headers["Content-Type"] = "application/x-www-form-urlencoded"
+	if ro.Headers == nil {
+		ro.Headers = make(map[string]string)
+	}
+	ro.Headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-        // There is a super-jank implementation in the form library where fields with
-        // a "dot" are replaced with "/.". That is then URL encoded and Fastly just
-        // dies. We fix that here.
-        body := strings.Replace(values.Encode(), "%5C.", ".", -1)
+	// There is a super-jank implementation in the form library where fields with
+	// a "dot" are replaced with "/.". That is then URL encoded and Fastly just
+	// dies. We fix that here.
+	body := strings.Replace(values.Encode(), "%5C.", ".", -1)
 
-        ro.Body = strings.NewReader(body)
-        ro.BodyLength = int64(len(body))
+	ro.Body = strings.NewReader(body)
+	ro.BodyLength = int64(len(body))
 
-        return c.Request(verb, p, ro)
+	return c.Request(verb, p, ro)
 }
 
 // checkResp wraps an HTTP request from the default client and verifies that the
 // request was successful. A non-200 request returns an error formatted to
 // included any validation problems or otherwise.
 func checkResp(resp *http.Response, err error) (*http.Response, error) {
-        // If the err is already there, there was an error higher up the chain, so
-        // just return that.
-        if err != nil {
-                return resp, err
-        }
+	// If the err is already there, there was an error higher up the chain, so
+	// just return that.
+	if err != nil {
+		return resp, err
+	}
 
-        switch resp.StatusCode {
-        case 200, 201, 202, 204, 205, 206:
-                return resp, nil
-        default:
-                return resp, NewHTTPError(resp)
-        }
+	switch resp.StatusCode {
+	case 200, 201, 202, 204, 205, 206:
+		return resp, nil
+	default:
+		return resp, NewHTTPError(resp)
+	}
 }
 
 // decodeJSON is used to decode an HTTP response body into an interface as JSON.
 func decodeJSON(out interface{}, body io.ReadCloser) error {
-        defer body.Close()
+	defer body.Close()
 
-        var parsed interface{}
-        dec := json.NewDecoder(body)
-        if err := dec.Decode(&parsed); err != nil {
-                return err
-        }
+	var parsed interface{}
+	dec := json.NewDecoder(body)
+	if err := dec.Decode(&parsed); err != nil {
+		return err
+	}
 
-        decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-                DecodeHook: mapstructure.ComposeDecodeHookFunc(
-                        mapToHTTPHeaderHookFunc(),
-                        stringToTimeHookFunc(),
-                ),
-                WeaklyTypedInput: true,
-                Result:           out,
-        })
-        if err != nil {
-                return err
-        }
-        return decoder.Decode(parsed)
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapToHTTPHeaderHookFunc(),
+			stringToTimeHookFunc(),
+		),
+		WeaklyTypedInput: true,
+		Result:           out,
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(parsed)
 }

--- a/vendor/github.com/sethvargo/go-fastly/condition.go
+++ b/vendor/github.com/sethvargo/go-fastly/condition.go
@@ -1,19 +1,19 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // Condition represents a condition response from the Fastly API.
 type Condition struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name      string `mapstructure:"name"`
-        Statement string `mapstructure:"statement"`
-        Type      string `mapstructure:"type"`
-        Priority  int    `mapstructure:"priority"`
+	Name      string `mapstructure:"name"`
+	Statement string `mapstructure:"statement"`
+	Type      string `mapstructure:"type"`
+	Priority  int    `mapstructure:"priority"`
 }
 
 // conditionsByName is a sortable list of conditions.
@@ -23,195 +23,195 @@ type conditionsByName []*Condition
 func (s conditionsByName) Len() int      { return len(s) }
 func (s conditionsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s conditionsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListConditionsInput is used as input to the ListConditions function.
 type ListConditionsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListConditions returns the list of conditions for the configuration version.
 func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var cs []*Condition
-        if err := decodeJSON(&cs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(conditionsByName(cs))
-        return cs, nil
+	var cs []*Condition
+	if err := decodeJSON(&cs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(conditionsByName(cs))
+	return cs, nil
 }
 
 // CreateConditionInput is used as input to the CreateCondition function.
 type CreateConditionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name      string `form:"name,omitempty"`
-        Statement string `form:"statement,omitempty"`
-        Type      string `form:"type,omitempty"`
-        Priority  int    `form:"priority,omitempty"`
+	Name      string `form:"name,omitempty"`
+	Statement string `form:"statement,omitempty"`
+	Type      string `form:"type,omitempty"`
+	Priority  int    `form:"priority,omitempty"`
 }
 
 // CreateCondition creates a new Fastly condition.
 func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var co *Condition
-        if err := decodeJSON(&co, resp.Body); err != nil {
-                return nil, err
-        }
-        return co, nil
+	var co *Condition
+	if err := decodeJSON(&co, resp.Body); err != nil {
+		return nil, err
+	}
+	return co, nil
 }
 
 // GetConditionInput is used as input to the GetCondition function.
 type GetConditionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the condition to fetch.
-        Name string
+	// Name is the name of the condition to fetch.
+	Name string
 }
 
 // GetCondition gets the condition configuration with the given parameters.
 func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var co *Condition
-        if err := decodeJSON(&co, resp.Body); err != nil {
-                return nil, err
-        }
-        return co, nil
+	var co *Condition
+	if err := decodeJSON(&co, resp.Body); err != nil {
+		return nil, err
+	}
+	return co, nil
 }
 
 // UpdateConditionInput is used as input to the UpdateCondition function.
 type UpdateConditionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the condition to update.
-        Name string
+	// Name is the name of the condition to update.
+	Name string
 
-        Statement string `form:"statement,omitempty"`
-        Type      string `form:"type,omitempty"`
-        Priority  int    `form:"priority,omitempty"`
+	Statement string `form:"statement,omitempty"`
+	Type      string `form:"type,omitempty"`
+	Priority  int    `form:"priority,omitempty"`
 }
 
 // UpdateCondition updates a specific condition.
 func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var co *Condition
-        if err := decodeJSON(&co, resp.Body); err != nil {
-                return nil, err
-        }
-        return co, nil
+	var co *Condition
+	if err := decodeJSON(&co, resp.Body); err != nil {
+		return nil, err
+	}
+	return co, nil
 }
 
 // DeleteConditionInput is the input parameter to DeleteCondition.
 type DeleteConditionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the condition to delete (required).
-        Name string
+	// Name is the name of the condition to delete (required).
+	Name string
 }
 
 // DeleteCondition deletes the given condition version.
 func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/content.go
+++ b/vendor/github.com/sethvargo/go-fastly/content.go
@@ -4,46 +4,46 @@ import "net/http"
 
 // EdgeCheck represents an edge check response from the Fastly API.
 type EdgeCheck struct {
-        Hash         string             `mapstructure:"hash"`
-        Server       string             `mapstructure:"server"`
-        ResponseTime float64            `mapstructure:"response_time"`
-        Request      *EdgeCheckRequest  `mapstructure:"request"`
-        Response     *EdgeCheckResponse `mapstructure:"response"`
+	Hash         string             `mapstructure:"hash"`
+	Server       string             `mapstructure:"server"`
+	ResponseTime float64            `mapstructure:"response_time"`
+	Request      *EdgeCheckRequest  `mapstructure:"request"`
+	Response     *EdgeCheckResponse `mapstructure:"response"`
 }
 
 // EdgeCheckRequest is the request part of an EdgeCheck response.
 type EdgeCheckRequest struct {
-        URL     string       `mapstructure:"url"`
-        Method  string       `mapstructure:"method"`
-        Headers *http.Header `mapstructure:"headers"`
+	URL     string       `mapstructure:"url"`
+	Method  string       `mapstructure:"method"`
+	Headers *http.Header `mapstructure:"headers"`
 }
 
 // EdgeCheckResponse is the response part of an EdgeCheck response.
 type EdgeCheckResponse struct {
-        Status  uint         `mapstructure:"status"`
-        Headers *http.Header `mapstructure:"headers"`
+	Status  uint         `mapstructure:"status"`
+	Headers *http.Header `mapstructure:"headers"`
 }
 
 // EdgeCheckInput is used as input to the EdgeCheck function.
 type EdgeCheckInput struct {
-        URL string `form:"url,omitempty"`
+	URL string `form:"url,omitempty"`
 }
 
 // EdgeCheck queries the edge cache for all of Fastly's servers for the given
 // URL.
 func (c *Client) EdgeCheck(i *EdgeCheckInput) ([]*EdgeCheck, error) {
-        resp, err := c.Get("/content/edge_check", &RequestOptions{
-                Params: map[string]string{
-                        "url": i.URL,
-                },
-        })
-        if err != nil {
-                return nil, err
-        }
+	resp, err := c.Get("/content/edge_check", &RequestOptions{
+		Params: map[string]string{
+			"url": i.URL,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
 
-        var e []*EdgeCheck
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e []*EdgeCheck
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/decode_hooks.go
+++ b/vendor/github.com/sethvargo/go-fastly/decode_hooks.go
@@ -1,64 +1,64 @@
 package fastly
 
 import (
-        "fmt"
-        "net/http"
-        "reflect"
-        "time"
+	"fmt"
+	"net/http"
+	"reflect"
+	"time"
 
-        "github.com/mitchellh/mapstructure"
+	"github.com/mitchellh/mapstructure"
 )
 
 // mapToHTTPHeaderHookFunc returns a function that converts maps into an
 // http.Header value.
 func mapToHTTPHeaderHookFunc() mapstructure.DecodeHookFunc {
-        return func(
-                f reflect.Type,
-                t reflect.Type,
-                data interface{}) (interface{}, error) {
-                if f.Kind() != reflect.Map {
-                        return data, nil
-                }
-                if t != reflect.TypeOf(new(http.Header)) {
-                        return data, nil
-                }
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.Map {
+			return data, nil
+		}
+		if t != reflect.TypeOf(new(http.Header)) {
+			return data, nil
+		}
 
-                typed, ok := data.(map[string]interface{})
-                if !ok {
-                        return nil, fmt.Errorf("cannot convert %T to http.Header", data)
-                }
+		typed, ok := data.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %T to http.Header", data)
+		}
 
-                n := map[string][]string{}
-                for k, v := range typed {
-                        switch v.(type) {
-                        case string:
-                                n[k] = []string{v.(string)}
-                        case []string:
-                                n[k] = v.([]string)
-                        default:
-                                return nil, fmt.Errorf("cannot convert %T to http.Header", v)
-                        }
-                }
+		n := map[string][]string{}
+		for k, v := range typed {
+			switch v.(type) {
+			case string:
+				n[k] = []string{v.(string)}
+			case []string:
+				n[k] = v.([]string)
+			default:
+				return nil, fmt.Errorf("cannot convert %T to http.Header", v)
+			}
+		}
 
-                return n, nil
-        }
+		return n, nil
+	}
 }
 
 // stringToTimeHookFunc returns a function that converts strings to a time.Time
 // value.
 func stringToTimeHookFunc() mapstructure.DecodeHookFunc {
-        return func(
-                f reflect.Type,
-                t reflect.Type,
-                data interface{}) (interface{}, error) {
-                if f.Kind() != reflect.String {
-                        return data, nil
-                }
-                if t != reflect.TypeOf(time.Now()) {
-                        return data, nil
-                }
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(time.Now()) {
+			return data, nil
+		}
 
-                // Convert it by parsing
-                return time.Parse(time.RFC3339, data.(string))
-        }
+		// Convert it by parsing
+		return time.Parse(time.RFC3339, data.(string))
+	}
 }

--- a/vendor/github.com/sethvargo/go-fastly/dictionary.go
+++ b/vendor/github.com/sethvargo/go-fastly/dictionary.go
@@ -1,18 +1,18 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // Dictionary represents a dictionary response from the Fastly API.
 type Dictionary struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        ID      string `mapstructure:"id"`
-        Name    string `mapstructure:"name"`
-        Address string `mapstructure:"address"`
+	ID      string `mapstructure:"id"`
+	Name    string `mapstructure:"name"`
+	Address string `mapstructure:"address"`
 }
 
 // dictionariesByName is a sortable list of dictionaries.
@@ -22,185 +22,185 @@ type dictionariesByName []*Dictionary
 func (s dictionariesByName) Len() int      { return len(s) }
 func (s dictionariesByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s dictionariesByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListDictionariesInput is used as input to the ListDictionaries function.
 type ListDictionariesInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListDictionaries returns the list of dictionaries for the configuration version.
 func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var bs []*Dictionary
-        if err := decodeJSON(&bs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(dictionariesByName(bs))
-        return bs, nil
+	var bs []*Dictionary
+	if err := decodeJSON(&bs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(dictionariesByName(bs))
+	return bs, nil
 }
 
 // CreateDictionaryInput is used as input to the CreateDictionary function.
 type CreateDictionaryInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name string `form:"name,omitempty"`
+	Name string `form:"name,omitempty"`
 }
 
 // CreateDictionary creates a new Fastly dictionary.
 func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Dictionary
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Dictionary
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetDictionaryInput is used as input to the GetDictionary function.
 type GetDictionaryInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the dictionary to fetch.
-        Name string
+	// Name is the name of the dictionary to fetch.
+	Name string
 }
 
 // GetDictionary gets the dictionary configuration with the given parameters.
 func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Dictionary
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Dictionary
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateDictionaryInput is used as input to the UpdateDictionary function.
 type UpdateDictionaryInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the dictionary to update.
-        Name string
+	// Name is the name of the dictionary to update.
+	Name string
 
-        NewName string `form:"name,omitempty"`
+	NewName string `form:"name,omitempty"`
 }
 
 // UpdateDictionary updates a specific dictionary.
 func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Dictionary
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Dictionary
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteDictionaryInput is the input parameter to DeleteDictionary.
 type DeleteDictionaryInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the dictionary to delete (required).
-        Name string
+	// Name is the name of the dictionary to delete (required).
+	Name string
 }
 
 // DeleteDictionary deletes the given dictionary version.
 func (c *Client) DeleteDictionary(i *DeleteDictionaryInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
-        _, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	_, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        // Unlike other endpoints, the dictionary endpoint does not return a status
-        // response - it just returns a 200 OK.
-        return nil
+	// Unlike other endpoints, the dictionary endpoint does not return a status
+	// response - it just returns a 200 OK.
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/dictionary_item.go
+++ b/vendor/github.com/sethvargo/go-fastly/dictionary_item.go
@@ -1,17 +1,17 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // DictionaryItem represents a dictionary item response from the Fastly API.
 type DictionaryItem struct {
-        ServiceID    string `mapstructure:"service_id"`
-        DictionaryID string `mapstructure:"dictionary_id"`
+	ServiceID    string `mapstructure:"service_id"`
+	DictionaryID string `mapstructure:"dictionary_id"`
 
-        ItemKey   string `mapstructure:"item_key"`
-        ItemValue string `mapstructure:"item_value"`
+	ItemKey   string `mapstructure:"item_key"`
+	ItemValue string `mapstructure:"item_value"`
 }
 
 // dictionaryItemsByKey is a sortable list of dictionary items.
@@ -21,187 +21,187 @@ type dictionaryItemsByKey []*DictionaryItem
 func (s dictionaryItemsByKey) Len() int      { return len(s) }
 func (s dictionaryItemsByKey) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s dictionaryItemsByKey) Less(i, j int) bool {
-        return s[i].ItemKey < s[j].ItemKey
+	return s[i].ItemKey < s[j].ItemKey
 }
 
 // ListDictionaryItemsInput is used as input to the ListDictionaryItems function.
 type ListDictionaryItemsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Dictionary is the ID of the dictionary to retrieve items for (required).
-        Dictionary string
+	// Dictionary is the ID of the dictionary to retrieve items for (required).
+	Dictionary string
 }
 
 // ListDictionaryItems returns the list of dictionary items for the
 // configuration version.
 func (c *Client) ListDictionaryItems(i *ListDictionaryItemsInput) ([]*DictionaryItem, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Dictionary == "" {
-                return nil, ErrMissingDictionary
-        }
+	if i.Dictionary == "" {
+		return nil, ErrMissingDictionary
+	}
 
-        path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.Service, i.Dictionary)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.Service, i.Dictionary)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var bs []*DictionaryItem
-        if err := decodeJSON(&bs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(dictionaryItemsByKey(bs))
-        return bs, nil
+	var bs []*DictionaryItem
+	if err := decodeJSON(&bs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(dictionaryItemsByKey(bs))
+	return bs, nil
 }
 
 // CreateDictionaryItemInput is used as input to the CreateDictionaryItem function.
 type CreateDictionaryItemInput struct {
-        // Service is the ID of the service. Dictionary is the ID of the dictionary.
-        // Both fields are required.
-        Service    string
-        Dictionary string
+	// Service is the ID of the service. Dictionary is the ID of the dictionary.
+	// Both fields are required.
+	Service    string
+	Dictionary string
 
-        ItemKey   string `form:"item_key,omitempty"`
-        ItemValue string `form:"item_value,omitempty"`
+	ItemKey   string `form:"item_key,omitempty"`
+	ItemValue string `form:"item_value,omitempty"`
 }
 
 // CreateDictionaryItem creates a new Fastly dictionary item.
 func (c *Client) CreateDictionaryItem(i *CreateDictionaryItemInput) (*DictionaryItem, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Dictionary == "" {
-                return nil, ErrMissingDictionary
-        }
+	if i.Dictionary == "" {
+		return nil, ErrMissingDictionary
+	}
 
-        path := fmt.Sprintf("/service/%s/dictionary/%s/item", i.Service, i.Dictionary)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/dictionary/%s/item", i.Service, i.Dictionary)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *DictionaryItem
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *DictionaryItem
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetDictionaryItemInput is used as input to the GetDictionaryItem function.
 type GetDictionaryItemInput struct {
-        // Service is the ID of the service. Dictionary is the ID of the dictionary.
-        // Both fields are required.
-        Service    string
-        Dictionary string
+	// Service is the ID of the service. Dictionary is the ID of the dictionary.
+	// Both fields are required.
+	Service    string
+	Dictionary string
 
-        // ItemKey is the name of the dictionary item to fetch.
-        ItemKey string
+	// ItemKey is the name of the dictionary item to fetch.
+	ItemKey string
 }
 
 // GetDictionaryItem gets the dictionary item with the given parameters.
 func (c *Client) GetDictionaryItem(i *GetDictionaryItemInput) (*DictionaryItem, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Dictionary == "" {
-                return nil, ErrMissingDictionary
-        }
+	if i.Dictionary == "" {
+		return nil, ErrMissingDictionary
+	}
 
-        if i.ItemKey == "" {
-                return nil, ErrMissingItemKey
-        }
+	if i.ItemKey == "" {
+		return nil, ErrMissingItemKey
+	}
 
-        path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.Service, i.Dictionary, i.ItemKey)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.Service, i.Dictionary, i.ItemKey)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *DictionaryItem
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *DictionaryItem
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateDictionaryItemInput is used as input to the UpdateDictionaryItem function.
 type UpdateDictionaryItemInput struct {
-        // Service is the ID of the service. Dictionary is the ID of the dictionary.
-        // Both fields are required.
-        Service    string
-        Dictionary string
+	// Service is the ID of the service. Dictionary is the ID of the dictionary.
+	// Both fields are required.
+	Service    string
+	Dictionary string
 
-        // ItemKey is the name of the dictionary item to fetch.
-        ItemKey string
+	// ItemKey is the name of the dictionary item to fetch.
+	ItemKey string
 
-        ItemValue string `form:"item_value,omitempty"`
+	ItemValue string `form:"item_value,omitempty"`
 }
 
 // UpdateDictionaryItem updates a specific dictionary item.
 func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*DictionaryItem, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Dictionary == "" {
-                return nil, ErrMissingDictionary
-        }
+	if i.Dictionary == "" {
+		return nil, ErrMissingDictionary
+	}
 
-        if i.ItemKey == "" {
-                return nil, ErrMissingItemKey
-        }
+	if i.ItemKey == "" {
+		return nil, ErrMissingItemKey
+	}
 
-        path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.Service, i.Dictionary, i.ItemKey)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.Service, i.Dictionary, i.ItemKey)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *DictionaryItem
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *DictionaryItem
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteDictionaryItemInput is the input parameter to DeleteDictionaryItem.
 type DeleteDictionaryItemInput struct {
-        // Service is the ID of the service. Dictionary is the ID of the dictionary.
-        // Both fields are required.
-        Service    string
-        Dictionary string
+	// Service is the ID of the service. Dictionary is the ID of the dictionary.
+	// Both fields are required.
+	Service    string
+	Dictionary string
 
-        // ItemKey is the name of the dictionary item to delete.
-        ItemKey string
+	// ItemKey is the name of the dictionary item to delete.
+	ItemKey string
 }
 
 // DeleteDictionaryItem deletes the given dictionary item.
 func (c *Client) DeleteDictionaryItem(i *DeleteDictionaryItemInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Dictionary == "" {
-                return ErrMissingDictionary
-        }
+	if i.Dictionary == "" {
+		return ErrMissingDictionary
+	}
 
-        if i.ItemKey == "" {
-                return ErrMissingItemKey
-        }
+	if i.ItemKey == "" {
+		return ErrMissingItemKey
+	}
 
-        path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.Service, i.Dictionary, i.ItemKey)
-        _, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.Service, i.Dictionary, i.ItemKey)
+	_, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        // Unlike other endpoints, the dictionary endpoint does not return a status
-        // response - it just returns a 200 OK.
-        return nil
+	// Unlike other endpoints, the dictionary endpoint does not return a status
+	// response - it just returns a 200 OK.
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/diff.go
+++ b/vendor/github.com/sethvargo/go-fastly/diff.go
@@ -4,54 +4,54 @@ import "fmt"
 
 // Diff represents a diff of two versions as a response from the Fastly API.
 type Diff struct {
-        Format string `mapstructure:"format"`
-        From   string `mapstructure:"from"`
-        To     string `mapstructure:"to"`
-        Diff   string `mapstructure:"diff"`
+	Format string `mapstructure:"format"`
+	From   string `mapstructure:"from"`
+	To     string `mapstructure:"to"`
+	Diff   string `mapstructure:"diff"`
 }
 
 // GetDiffInput is used as input to the GetDiff function.
 type GetDiffInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // From is the version to diff from. This can either be a string indicating a
-        // positive number (e.g. "1") or a negative number from "-1" down ("-1" is the
-        // latest version).
-        From string
+	// From is the version to diff from. This can either be a string indicating a
+	// positive number (e.g. "1") or a negative number from "-1" down ("-1" is the
+	// latest version).
+	From string
 
-        // To is the version to diff up to. The same rules for From apply.
-        To string
+	// To is the version to diff up to. The same rules for From apply.
+	To string
 
-        // Format is an optional field to specify the format with which the diff will
-        // be returned. Acceptable values are "text" (default), "html", or
-        // "html_simple".
-        Format string
+	// Format is an optional field to specify the format with which the diff will
+	// be returned. Acceptable values are "text" (default), "html", or
+	// "html_simple".
+	Format string
 }
 
 // GetDiff returns the diff of the given versions.
 func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.From == "" {
-                return nil, ErrMissingFrom
-        }
+	if i.From == "" {
+		return nil, ErrMissingFrom
+	}
 
-        if i.To == "" {
-                return nil, ErrMissingTo
-        }
+	if i.To == "" {
+		return nil, ErrMissingTo
+	}
 
-        path := fmt.Sprintf("service/%s/diff/from/%s/to/%s", i.Service, i.From, i.To)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("service/%s/diff/from/%s/to/%s", i.Service, i.From, i.To)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var d *Diff
-        if err := decodeJSON(&d, resp.Body); err != nil {
-                return nil, err
-        }
-        return d, nil
+	var d *Diff
+	if err := decodeJSON(&d, resp.Body); err != nil {
+		return nil, err
+	}
+	return d, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/director.go
+++ b/vendor/github.com/sethvargo/go-fastly/director.go
@@ -1,22 +1,22 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 const (
-        // DirectorTypeRandom is a director that does random direction.
-        DirectorTypeRandom DirectorType = 1
+	// DirectorTypeRandom is a director that does random direction.
+	DirectorTypeRandom DirectorType = 1
 
-        // DirectorTypeRoundRobin is a director that does round-robin direction.
-        DirectorTypeRoundRobin DirectorType = 2
+	// DirectorTypeRoundRobin is a director that does round-robin direction.
+	DirectorTypeRoundRobin DirectorType = 2
 
-        // DirectorTypeHash is a director that does hash direction.
-        DirectorTypeHash DirectorType = 3
+	// DirectorTypeHash is a director that does hash direction.
+	DirectorTypeHash DirectorType = 3
 
-        // DirectorTypeClient is a director that does client direction.
-        DirectorTypeClient DirectorType = 4
+	// DirectorTypeClient is a director that does client direction.
+	DirectorTypeClient DirectorType = 4
 )
 
 // DirectorType is a type of director.
@@ -24,15 +24,15 @@ type DirectorType uint8
 
 // Director represents a director response from the Fastly API.
 type Director struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name     string       `mapstructure:"name"`
-        Comment  string       `mapstructure:"comment"`
-        Quorum   uint         `mapstructure:"quorum"`
-        Type     DirectorType `mapstructure:"type"`
-        Retries  uint         `mapstructure:"retries"`
-        Capacity uint         `mapstructure:"capacity"`
+	Name     string       `mapstructure:"name"`
+	Comment  string       `mapstructure:"comment"`
+	Quorum   uint         `mapstructure:"quorum"`
+	Type     DirectorType `mapstructure:"type"`
+	Retries  uint         `mapstructure:"retries"`
+	Capacity uint         `mapstructure:"capacity"`
 }
 
 // directorsByName is a sortable list of directors.
@@ -42,197 +42,197 @@ type directorsByName []*Director
 func (s directorsByName) Len() int      { return len(s) }
 func (s directorsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s directorsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListDirectorsInput is used as input to the ListDirectors function.
 type ListDirectorsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListDirectors returns the list of directors for the configuration version.
 func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ds []*Director
-        if err := decodeJSON(&ds, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(directorsByName(ds))
-        return ds, nil
+	var ds []*Director
+	if err := decodeJSON(&ds, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(directorsByName(ds))
+	return ds, nil
 }
 
 // CreateDirectorInput is used as input to the CreateDirector function.
 type CreateDirectorInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name    string       `form:"name,omitempty"`
-        Comment string       `form:"comment,omitempty"`
-        Quorum  uint         `form:"quorum,omitempty"`
-        Type    DirectorType `form:"type,omitempty"`
-        Retries uint         `form:"retries,omitempty"`
+	Name    string       `form:"name,omitempty"`
+	Comment string       `form:"comment,omitempty"`
+	Quorum  uint         `form:"quorum,omitempty"`
+	Type    DirectorType `form:"type,omitempty"`
+	Retries uint         `form:"retries,omitempty"`
 }
 
 // CreateDirector creates a new Fastly director.
 func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var d *Director
-        if err := decodeJSON(&d, resp.Body); err != nil {
-                return nil, err
-        }
-        return d, nil
+	var d *Director
+	if err := decodeJSON(&d, resp.Body); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 // GetDirectorInput is used as input to the GetDirector function.
 type GetDirectorInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the director to fetch.
-        Name string
+	// Name is the name of the director to fetch.
+	Name string
 }
 
 // GetDirector gets the director configuration with the given parameters.
 func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var d *Director
-        if err := decodeJSON(&d, resp.Body); err != nil {
-                return nil, err
-        }
-        return d, nil
+	var d *Director
+	if err := decodeJSON(&d, resp.Body); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 // UpdateDirectorInput is used as input to the UpdateDirector function.
 type UpdateDirectorInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the director to update.
-        Name string
+	// Name is the name of the director to update.
+	Name string
 
-        Comment string       `form:"comment,omitempty"`
-        Quorum  uint         `form:"quorum,omitempty"`
-        Type    DirectorType `form:"type,omitempty"`
-        Retries uint         `form:"retries,omitempty"`
+	Comment string       `form:"comment,omitempty"`
+	Quorum  uint         `form:"quorum,omitempty"`
+	Type    DirectorType `form:"type,omitempty"`
+	Retries uint         `form:"retries,omitempty"`
 }
 
 // UpdateDirector updates a specific director.
 func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var d *Director
-        if err := decodeJSON(&d, resp.Body); err != nil {
-                return nil, err
-        }
-        return d, nil
+	var d *Director
+	if err := decodeJSON(&d, resp.Body); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 // DeleteDirectorInput is the input parameter to DeleteDirector.
 type DeleteDirectorInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the director to delete (required).
-        Name string
+	// Name is the name of the director to delete (required).
+	Name string
 }
 
 // DeleteDirector deletes the given director version.
 func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/director_backend.go
+++ b/vendor/github.com/sethvargo/go-fastly/director_backend.go
@@ -1,161 +1,161 @@
 package fastly
 
 import (
-        "fmt"
-        "time"
+	"fmt"
+	"time"
 )
 
 // DirectorBackend is the relationship between a director and a backend in the
 // Fastly API.
 type DirectorBackend struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Director  string     `mapstructure:"director_name"`
-        Backend   string     `mapstructure:"backend_name"`
-        CreatedAt *time.Time `mapstructure:"created_at"`
-        UpdatedAt *time.Time `mapstructure:"updated_at"`
-        DeletedAt *time.Time `mapstructure:"deleted_at"`
+	Director  string     `mapstructure:"director_name"`
+	Backend   string     `mapstructure:"backend_name"`
+	CreatedAt *time.Time `mapstructure:"created_at"`
+	UpdatedAt *time.Time `mapstructure:"updated_at"`
+	DeletedAt *time.Time `mapstructure:"deleted_at"`
 }
 
 // CreateDirectorBackendInput is used as input to the CreateDirectorBackend
 // function.
 type CreateDirectorBackendInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Director is the name of the director (required).
-        Director string
+	// Director is the name of the director (required).
+	Director string
 
-        // Backend is the name of the backend (required).
-        Backend string
+	// Backend is the name of the backend (required).
+	Backend string
 }
 
 // CreateDirectorBackend creates a new Fastly backend.
 func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*DirectorBackend, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Director == "" {
-                return nil, ErrMissingDirector
-        }
+	if i.Director == "" {
+		return nil, ErrMissingDirector
+	}
 
-        if i.Backend == "" {
-                return nil, ErrMissingBackend
-        }
+	if i.Backend == "" {
+		return nil, ErrMissingBackend
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
-                i.Service, i.Version, i.Director, i.Backend)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+		i.Service, i.Version, i.Director, i.Backend)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *DirectorBackend
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *DirectorBackend
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetDirectorBackendInput is used as input to the GetDirectorBackend function.
 type GetDirectorBackendInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Director is the name of the director (required).
-        Director string
+	// Director is the name of the director (required).
+	Director string
 
-        // Backend is the name of the backend (required).
-        Backend string
+	// Backend is the name of the backend (required).
+	Backend string
 }
 
 // GetDirectorBackend gets the backend configuration with the given parameters.
 func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBackend, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Director == "" {
-                return nil, ErrMissingDirector
-        }
+	if i.Director == "" {
+		return nil, ErrMissingDirector
+	}
 
-        if i.Backend == "" {
-                return nil, ErrMissingBackend
-        }
+	if i.Backend == "" {
+		return nil, ErrMissingBackend
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
-                i.Service, i.Version, i.Director, i.Backend)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+		i.Service, i.Version, i.Director, i.Backend)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *DirectorBackend
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *DirectorBackend
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteDirectorBackendInput is the input parameter to DeleteDirectorBackend.
 type DeleteDirectorBackendInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Director is the name of the director (required).
-        Director string
+	// Director is the name of the director (required).
+	Director string
 
-        // Backend is the name of the backend (required).
-        Backend string
+	// Backend is the name of the backend (required).
+	Backend string
 }
 
 // DeleteDirectorBackend deletes the given backend version.
 func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Director == "" {
-                return ErrMissingDirector
-        }
+	if i.Director == "" {
+		return ErrMissingDirector
+	}
 
-        if i.Backend == "" {
-                return ErrMissingBackend
-        }
+	if i.Backend == "" {
+		return ErrMissingBackend
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
-                i.Service, i.Version, i.Director, i.Backend)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+		i.Service, i.Version, i.Director, i.Backend)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/domain.go
+++ b/vendor/github.com/sethvargo/go-fastly/domain.go
@@ -1,18 +1,18 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // Domain represents the the domain name Fastly will serve content for.
 type Domain struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name    string `mapstructure:"name"`
-        Comment string `mapstructure:"comment"`
-        Locked  bool   `mapstructure:"locked"`
+	Name    string `mapstructure:"name"`
+	Comment string `mapstructure:"comment"`
+	Locked  bool   `mapstructure:"locked"`
 }
 
 // domainsByName is a sortable list of backends.
@@ -22,190 +22,190 @@ type domainsByName []*Domain
 func (s domainsByName) Len() int      { return len(s) }
 func (s domainsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s domainsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListDomainsInput is used as input to the ListDomains function.
 type ListDomainsInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
-// ListDomains returns the list of domains for this account.
+// ListDomains returns the list of domains for this Service.
 func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ds []*Domain
-        if err := decodeJSON(&ds, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(domainsByName(ds))
-        return ds, nil
+	var ds []*Domain
+	if err := decodeJSON(&ds, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(domainsByName(ds))
+	return ds, nil
 }
 
 // CreateDomainInput is used as input to the CreateDomain function.
 type CreateDomainInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the domain that the service will respond to (required).
-        Name string `form:"name"`
+	// Name is the name of the domain that the service will respond to (required).
+	Name string `form:"name"`
 
-        // Comment is a personal, freeform descriptive note.
-        Comment string `form:"comment,omitempty"`
+	// Comment is a personal, freeform descriptive note.
+	Comment string `form:"comment,omitempty"`
 }
 
 // CreateDomain creates a new domain with the given information.
 func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var d *Domain
-        if err := decodeJSON(&d, resp.Body); err != nil {
-                return nil, err
-        }
-        return d, nil
+	var d *Domain
+	if err := decodeJSON(&d, resp.Body); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 // GetDomainInput is used as input to the GetDomain function.
 type GetDomainInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the domain to fetch.
-        Name string `form:"name"`
+	// Name is the name of the domain to fetch.
+	Name string `form:"name"`
 }
 
 // GetDomain retrieves information about the given domain name.
 func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var d *Domain
-        if err := decodeJSON(&d, resp.Body); err != nil {
-                return nil, err
-        }
-        return d, nil
+	var d *Domain
+	if err := decodeJSON(&d, resp.Body); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 // UpdateDomainInput is used as input to the UpdateDomain function.
 type UpdateDomainInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the domain that the service will respond to (required).
-        Name string
+	// Name is the name of the domain that the service will respond to (required).
+	Name string
 
-        // NewName is the updated name of the domain
-        NewName string `form:"name"`
+	// NewName is the updated name of the domain
+	NewName string `form:"name"`
 
-        // Comment is a personal, freeform descriptive note.
-        Comment string `form:"comment,omitempty"`
+	// Comment is a personal, freeform descriptive note.
+	Comment string `form:"comment,omitempty"`
 }
 
 // UpdateDomain updates a single domain for the current service. The only allowed
 // parameters are `Name` and `Comment`.
 func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var d *Domain
-        if err := decodeJSON(&d, resp.Body); err != nil {
-                return nil, err
-        }
-        return d, nil
+	var d *Domain
+	if err := decodeJSON(&d, resp.Body); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 // DeleteDomainInput is used as input to the DeleteDomain function.
 type DeleteDomainInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the domain that the service will respond to (required).
-        Name string `form:"name"`
+	// Name is the name of the domain that the service will respond to (required).
+	Name string `form:"name"`
 }
 
 // DeleteDomain removes a single domain by the given name.
 func (c *Client) DeleteDomain(i *DeleteDomainInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
-        _, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
-        return nil
+	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	_, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/errors.go
+++ b/vendor/github.com/sethvargo/go-fastly/errors.go
@@ -1,10 +1,10 @@
 package fastly
 
 import (
-        "bytes"
-        "errors"
-        "fmt"
-        "net/http"
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
 )
 
 // ErrMissingService is an error that is returned when an input struct requires
@@ -69,48 +69,48 @@ var _ error = (*HTTPError)(nil)
 // HTTPError is a custom error type that wraps an HTTP status code with some
 // helper functions.
 type HTTPError struct {
-        // StatusCode is the HTTP status code (2xx-5xx).
-        StatusCode int
+	// StatusCode is the HTTP status code (2xx-5xx).
+	StatusCode int
 
-        // Message and Detail are information returned by the Fastly API.
-        Message string `mapstructure:"msg"`
-        Detail  string `mapstructure:"detail"`
+	// Message and Detail are information returned by the Fastly API.
+	Message string `mapstructure:"msg"`
+	Detail  string `mapstructure:"detail"`
 }
 
 // NewHTTPError creates a new HTTP error from the given code.
 func NewHTTPError(resp *http.Response) *HTTPError {
-        var e *HTTPError
-        if resp.Body != nil {
-                decodeJSON(&e, resp.Body)
-        }
-        e.StatusCode = resp.StatusCode
-        return e
+	var e *HTTPError
+	if resp.Body != nil {
+		decodeJSON(&e, resp.Body)
+	}
+	e.StatusCode = resp.StatusCode
+	return e
 }
 
 // Error implements the error interface and returns the string representing the
 // error text that includes the status code and the corresponding status text.
 func (e *HTTPError) Error() string {
-        var r bytes.Buffer
-        fmt.Fprintf(&r, "%d - %s", e.StatusCode, http.StatusText(e.StatusCode))
+	var r bytes.Buffer
+	fmt.Fprintf(&r, "%d - %s", e.StatusCode, http.StatusText(e.StatusCode))
 
-        if e.Message != "" {
-                fmt.Fprintf(&r, "\nMessage: %s", e.Message)
-        }
+	if e.Message != "" {
+		fmt.Fprintf(&r, "\nMessage: %s", e.Message)
+	}
 
-        if e.Detail != "" {
-                fmt.Fprintf(&r, "\nDetail: %s", e.Detail)
-        }
+	if e.Detail != "" {
+		fmt.Fprintf(&r, "\nDetail: %s", e.Detail)
+	}
 
-        return r.String()
+	return r.String()
 }
 
 // String implements the stringer interface and returns the string representing
 // the string text that includes the status code and corresponding status text.
 func (e *HTTPError) String() string {
-        return e.Error()
+	return e.Error()
 }
 
 // IsNotFound returns true if the HTTP error code is a 404, false otherwise.
 func (e *HTTPError) IsNotFound() bool {
-        return e.StatusCode == 404
+	return e.StatusCode == 404
 }

--- a/vendor/github.com/sethvargo/go-fastly/fastly.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly.go
@@ -1,23 +1,23 @@
 package fastly
 
 import (
-        "bytes"
-        "encoding"
+	"bytes"
+	"encoding"
 )
 
 type statusResp struct {
-        Status string
-        Msg    string
+	Status string
+	Msg    string
 }
 
 func (t *statusResp) Ok() bool {
-        return t.Status == "ok"
+	return t.Status == "ok"
 }
 
 // Ensure Compatibool implements the proper interfaces.
 var (
-        _ encoding.TextMarshaler   = new(Compatibool)
-        _ encoding.TextUnmarshaler = new(Compatibool)
+	_ encoding.TextMarshaler   = new(Compatibool)
+	_ encoding.TextUnmarshaler = new(Compatibool)
 )
 
 // Compatibool is a boolean value that marshalls to 0/1 instead of true/false
@@ -26,16 +26,16 @@ type Compatibool bool
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (b Compatibool) MarshalText() ([]byte, error) {
-        if b {
-                return []byte("1"), nil
-        }
-        return []byte("0"), nil
+	if b {
+		return []byte("1"), nil
+	}
+	return []byte("0"), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (b Compatibool) UnmarshalText(t []byte) error {
-        if bytes.Equal(t, []byte("1")) {
-                b = Compatibool(true)
-        }
-        return nil
+	if bytes.Equal(t, []byte("1")) {
+		b = Compatibool(true)
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/ftp.go
+++ b/vendor/github.com/sethvargo/go-fastly/ftp.go
@@ -1,30 +1,30 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
-        "time"
+	"fmt"
+	"sort"
+	"time"
 )
 
 // FTP represents an FTP logging response from the Fastly API.
 type FTP struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name              string     `mapstructure:"name"`
-        Address           string     `mapstructure:"address"`
-        Port              uint       `mapstructure:"port"`
-        Username          string     `mapstructure:"user"`
-        Password          string     `mapstructure:"password"`
-        Directory         string     `mapstructure:"directory"`
-        Period            uint       `mapstructure:"period"`
-        GzipLevel         uint8      `mapstructure:"gzip_level"`
-        Format            string     `mapstructure:"format"`
-        ResponseCondition string     `mapstructure:"response_condition"`
-        TimestampFormat   string     `mapstructure:"timestamp_format"`
-        CreatedAt         *time.Time `mapstructure:"created_at"`
-        UpdatedAt         *time.Time `mapstructure:"updated_at"`
-        DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Name              string     `mapstructure:"name"`
+	Address           string     `mapstructure:"address"`
+	Port              uint       `mapstructure:"port"`
+	Username          string     `mapstructure:"user"`
+	Password          string     `mapstructure:"password"`
+	Path              string     `mapstructure:"path"`
+	Period            uint       `mapstructure:"period"`
+	GzipLevel         uint8      `mapstructure:"gzip_level"`
+	Format            string     `mapstructure:"format"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
 }
 
 // ftpsByName is a sortable list of ftps.
@@ -34,210 +34,210 @@ type ftpsByName []*FTP
 func (s ftpsByName) Len() int      { return len(s) }
 func (s ftpsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s ftpsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListFTPsInput is used as input to the ListFTPs function.
 type ListFTPsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListFTPs returns the list of ftps for the configuration version.
 func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ftps []*FTP
-        if err := decodeJSON(&ftps, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(ftpsByName(ftps))
-        return ftps, nil
+	var ftps []*FTP
+	if err := decodeJSON(&ftps, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(ftpsByName(ftps))
+	return ftps, nil
 }
 
 // CreateFTPInput is used as input to the CreateFTP function.
 type CreateFTPInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name              string `form:"name,omitempty"`
-        Address           string `form:"address,omitempty"`
-        Port              uint   `form:"port,omitempty"`
-        Username          string `form:"user,omitempty"`
-        Password          string `form:"password,omitempty"`
-        Directory         string `form:"directory,omitempty"`
-        Period            uint   `form:"period,omitempty"`
-        GzipLevel         uint8  `form:"gzip_level,omitempty"`
-        Format            string `form:"format,omitempty"`
-        ResponseCondition string `form:"response_condition,omitempty"`
-        TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Name              string `form:"name,omitempty"`
+	Address           string `form:"address,omitempty"`
+	Port              uint   `form:"port,omitempty"`
+	Username          string `form:"user,omitempty"`
+	Password          string `form:"password,omitempty"`
+	Path              string `form:"path,omitempty"`
+	Period            uint   `form:"period,omitempty"`
+	GzipLevel         uint8  `form:"gzip_level,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
+	TimestampFormat   string `form:"timestamp_format,omitempty"`
 }
 
 // CreateFTP creates a new Fastly FTP.
 func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ftp *FTP
-        if err := decodeJSON(&ftp, resp.Body); err != nil {
-                return nil, err
-        }
-        return ftp, nil
+	var ftp *FTP
+	if err := decodeJSON(&ftp, resp.Body); err != nil {
+		return nil, err
+	}
+	return ftp, nil
 }
 
 // GetFTPInput is used as input to the GetFTP function.
 type GetFTPInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the FTP to fetch.
-        Name string
+	// Name is the name of the FTP to fetch.
+	Name string
 }
 
 // GetFTP gets the FTP configuration with the given parameters.
 func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *FTP
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *FTP
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateFTPInput is used as input to the UpdateFTP function.
 type UpdateFTPInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the FTP to update.
-        Name string
+	// Name is the name of the FTP to update.
+	Name string
 
-        NewName           string `form:"name,omitempty"`
-        Address           string `form:"address,omitempty"`
-        Port              uint   `form:"port,omitempty"`
-        Username          string `form:"user,omitempty"`
-        Password          string `form:"password,omitempty"`
-        Directory         string `form:"directory,omitempty"`
-        Period            uint   `form:"period,omitempty"`
-        GzipLevel         uint8  `form:"gzip_level,omitempty"`
-        Format            string `form:"format,omitempty"`
-        ResponseCondition string `form:"response_condition,omitempty"`
-        TimestampFormat   string `form:"timestamp_format,omitempty"`
+	NewName           string `form:"name,omitempty"`
+	Address           string `form:"address,omitempty"`
+	Port              uint   `form:"port,omitempty"`
+	Username          string `form:"user,omitempty"`
+	Password          string `form:"password,omitempty"`
+	Path              string `form:"path,omitempty"`
+	Period            uint   `form:"period,omitempty"`
+	GzipLevel         uint8  `form:"gzip_level,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
+	TimestampFormat   string `form:"timestamp_format,omitempty"`
 }
 
 // UpdateFTP updates a specific FTP.
 func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *FTP
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *FTP
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteFTPInput is the input parameter to DeleteFTP.
 type DeleteFTPInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the FTP to delete (required).
-        Name string
+	// Name is the name of the FTP to delete (required).
+	Name string
 }
 
 // DeleteFTP deletes the given FTP version.
 func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/gcs.go
+++ b/vendor/github.com/sethvargo/go-fastly/gcs.go
@@ -1,0 +1,236 @@
+package fastly
+
+import (
+	"fmt"
+	"sort"
+)
+
+// GCS represents an GCS logging response from the Fastly API.
+type GCS struct {
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
+
+	Name              string `mapstructure:"name"`
+	Bucket            string `mapstructure:"bucket_name"`
+	User              string `mapstructure:"user"`
+	SecretKey         string `mapstructure:"secret_key"`
+	Path              string `mapstructure:"path"`
+	Period            uint   `mapstructure:"period"`
+	GzipLevel         uint8  `mapstructure:"gzip_level"`
+	Format            string `mapstructure:"format"`
+	ResponseCondition string `mapstructure:"response_condition"`
+	TimestampFormat   string `mapstructure:"timestamp_format"`
+}
+
+// gcsesByName is a sortable list of gcses.
+type gcsesByName []*GCS
+
+// Len, Swap, and Less implement the sortable interface.
+func (s gcsesByName) Len() int      { return len(s) }
+func (s gcsesByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s gcsesByName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+// ListGCSsInput is used as input to the ListGCSs function.
+type ListGCSsInput struct {
+	// Service is the ID of the service (required).
+	Service string
+
+	// Version is the specific configuration version (required).
+	Version string
+}
+
+// ListGCSs returns the list of gcses for the configuration version.
+func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var gcses []*GCS
+	if err := decodeJSON(&gcses, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(gcsesByName(gcses))
+	return gcses, nil
+}
+
+// CreateGCSInput is used as input to the CreateGCS function.
+type CreateGCSInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	Name              string `form:"name,omitempty"`
+	Bucket            string `form:"bucket_name,omitempty"`
+	User              string `form:"user,omitempty"`
+	SecretKey         string `form:"secret_key,omitempty"`
+	Path              string `form:"path,omitempty"`
+	Period            uint   `form:"period,omitempty"`
+	GzipLevel         uint8  `form:"gzip_level,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
+	TimestampFormat   string `form:"timestamp_format,omitempty"`
+}
+
+// CreateGCS creates a new Fastly GCS.
+func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var gcs *GCS
+	if err := decodeJSON(&gcs, resp.Body); err != nil {
+		return nil, err
+	}
+	return gcs, nil
+}
+
+// GetGCSInput is used as input to the GetGCS function.
+type GetGCSInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	// Name is the name of the GCS to fetch.
+	Name string
+}
+
+// GetGCS gets the GCS configuration with the given parameters.
+func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var b *GCS
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdateGCSInput is used as input to the UpdateGCS function.
+type UpdateGCSInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	// Name is the name of the GCS to update.
+	Name string
+
+	NewName           string `form:"name,omitempty"`
+	Bucket            string `form:"bucket_name,omitempty"`
+	User              string `form:"user,omitempty"`
+	SecretKey         string `form:"secret_key,omitempty"`
+	Path              string `form:"path,omitempty"`
+	Period            uint   `form:"period,omitempty"`
+	GzipLevel         uint8  `form:"gzip_level,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
+	TimestampFormat   string `form:"timestamp_format,omitempty"`
+}
+
+// UpdateGCS updates a specific GCS.
+func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var b *GCS
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// DeleteGCSInput is the input parameter to DeleteGCS.
+type DeleteGCSInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	// Name is the name of the GCS to delete (required).
+	Name string
+}
+
+// DeleteGCS deletes the given GCS version.
+func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
+}

--- a/vendor/github.com/sethvargo/go-fastly/gzip.go
+++ b/vendor/github.com/sethvargo/go-fastly/gzip.go
@@ -1,0 +1,218 @@
+package fastly
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Gzip represents an Gzip logging response from the Fastly API.
+type Gzip struct {
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
+
+	Name           string `mapstructure:"name"`
+	ContentTypes   string `mapstructure:"content_types"`
+	Extensions     string `mapstructure:"extensions"`
+	CacheCondition string `mapstructure:"cache_condition"`
+}
+
+// gzipsByName is a sortable list of gzips.
+type gzipsByName []*Gzip
+
+// Len, Swap, and Less implement the sortable interface.
+func (s gzipsByName) Len() int      { return len(s) }
+func (s gzipsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s gzipsByName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+// ListGzipsInput is used as input to the ListGzips function.
+type ListGzipsInput struct {
+	// Service is the ID of the service (required).
+	Service string
+
+	// Version is the specific configuration version (required).
+	Version string
+}
+
+// ListGzips returns the list of gzips for the configuration version.
+func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/gzip", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var gzips []*Gzip
+	if err := decodeJSON(&gzips, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(gzipsByName(gzips))
+	return gzips, nil
+}
+
+// CreateGzipInput is used as input to the CreateGzip function.
+type CreateGzipInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	Name           string `form:"name,omitempty"`
+	ContentTypes   string `form:"content_types,omitempty"`
+	Extensions     string `form:"extensions,omitempty"`
+	CacheCondition string `form:"cache_condition,omitempty"`
+}
+
+// CreateGzip creates a new Fastly Gzip.
+func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/gzip", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var gzip *Gzip
+	if err := decodeJSON(&gzip, resp.Body); err != nil {
+		return nil, err
+	}
+	return gzip, nil
+}
+
+// GetGzipInput is used as input to the GetGzip function.
+type GetGzipInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	// Name is the name of the Gzip to fetch.
+	Name string
+}
+
+// GetGzip gets the Gzip configuration with the given parameters.
+func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var b *Gzip
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdateGzipInput is used as input to the UpdateGzip function.
+type UpdateGzipInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	// Name is the name of the Gzip to update.
+	Name string
+
+	NewName        string `form:"name,omitempty"`
+	ContentTypes   string `form:"content_types,omitempty"`
+	Extensions     string `form:"extensions,omitempty"`
+	CacheCondition string `form:"cache_condition,omitempty"`
+}
+
+// UpdateGzip updates a specific Gzip.
+func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var b *Gzip
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// DeleteGzipInput is the input parameter to DeleteGzip.
+type DeleteGzipInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
+
+	// Name is the name of the Gzip to delete (required).
+	Name string
+}
+
+// DeleteGzip deletes the given Gzip version.
+func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
+}

--- a/vendor/github.com/sethvargo/go-fastly/header.go
+++ b/vendor/github.com/sethvargo/go-fastly/header.go
@@ -1,48 +1,48 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 const (
-        // HeaderActionSet is a header action that sets or resets a header.
-        HeaderActionSet HeaderAction = "set"
+	// HeaderActionSet is a header action that sets or resets a header.
+	HeaderActionSet HeaderAction = "set"
 
-        // HeaderActionAppend is a header action that appends to an existing header.
-        HeaderActionAppend HeaderAction = "append"
+	// HeaderActionAppend is a header action that appends to an existing header.
+	HeaderActionAppend HeaderAction = "append"
 
-        // HeaderActionDelete is a header action that deletes a header.
-        HeaderActionDelete HeaderAction = "delete"
+	// HeaderActionDelete is a header action that deletes a header.
+	HeaderActionDelete HeaderAction = "delete"
 
-        // HeaderActionRegex is a header action that performs a single regex
-        // replacement on a header.
-        HeaderActionRegex HeaderAction = "regex"
+	// HeaderActionRegex is a header action that performs a single regex
+	// replacement on a header.
+	HeaderActionRegex HeaderAction = "regex"
 
-        // HeaderActionRegexRepeat is a header action that performs a global regex
-        // replacement on a header.
-        HeaderActionRegexRepeat HeaderAction = "regex_repeat"
+	// HeaderActionRegexRepeat is a header action that performs a global regex
+	// replacement on a header.
+	HeaderActionRegexRepeat HeaderAction = "regex_repeat"
 )
 
 // HeaderAction is a type of header action.
 type HeaderAction string
 
 const (
-        // HeaderTypeRequest is a header type that performs on the request before
-        // lookups.
-        HeaderTypeRequest HeaderType = "request"
+	// HeaderTypeRequest is a header type that performs on the request before
+	// lookups.
+	HeaderTypeRequest HeaderType = "request"
 
-        // HeaderTypeFetch is a header type that performs on the request to the origin
-        // server.
-        HeaderTypeFetch HeaderType = "fetch"
+	// HeaderTypeFetch is a header type that performs on the request to the origin
+	// server.
+	HeaderTypeFetch HeaderType = "fetch"
 
-        // HeaderTypeCache is a header type that performs on the response before it's
-        // store in the cache.
-        HeaderTypeCache HeaderType = "cache"
+	// HeaderTypeCache is a header type that performs on the response before it's
+	// store in the cache.
+	HeaderTypeCache HeaderType = "cache"
 
-        // HeaderTypeResponse is a header type that performs on the response before
-        // delivering to the client.
-        HeaderTypeResponse HeaderType = "response"
+	// HeaderTypeResponse is a header type that performs on the response before
+	// delivering to the client.
+	HeaderTypeResponse HeaderType = "response"
 )
 
 // HeaderType is a type of header.
@@ -50,21 +50,21 @@ type HeaderType string
 
 // Header represents a header response from the Fastly API.
 type Header struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name              string       `mapstructure:"name"`
-        Action            HeaderAction `mapstructure:"action"`
-        IgnoreIfSet       bool         `mapstructure:"ignore_if_set"`
-        Type              HeaderType   `mapstructure:"type"`
-        Destination       string       `mapstructure:"dst"`
-        Source            string       `mapstructure:"src"`
-        Regex             string       `mapstructure:"regex"`
-        Substitution      string       `mapstructure:"substitution"`
-        Priority          uint         `mapstructure:"priority"`
-        RequestCondition  string       `mapstructure:"request_condition"`
-        CacheCondition    string       `mapstructure:"cache_condition"`
-        ResponseCondition string       `mapstructure:"response_condition"`
+	Name              string       `mapstructure:"name"`
+	Action            HeaderAction `mapstructure:"action"`
+	IgnoreIfSet       bool         `mapstructure:"ignore_if_set"`
+	Type              HeaderType   `mapstructure:"type"`
+	Destination       string       `mapstructure:"dst"`
+	Source            string       `mapstructure:"src"`
+	Regex             string       `mapstructure:"regex"`
+	Substitution      string       `mapstructure:"substitution"`
+	Priority          uint         `mapstructure:"priority"`
+	RequestCondition  string       `mapstructure:"request_condition"`
+	CacheCondition    string       `mapstructure:"cache_condition"`
+	ResponseCondition string       `mapstructure:"response_condition"`
 }
 
 // headersByName is a sortable list of headers.
@@ -74,212 +74,212 @@ type headersByName []*Header
 func (s headersByName) Len() int      { return len(s) }
 func (s headersByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s headersByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListHeadersInput is used as input to the ListHeaders function.
 type ListHeadersInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListHeaders returns the list of headers for the configuration version.
 func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var bs []*Header
-        if err := decodeJSON(&bs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(headersByName(bs))
-        return bs, nil
+	var bs []*Header
+	if err := decodeJSON(&bs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(headersByName(bs))
+	return bs, nil
 }
 
 // CreateHeaderInput is used as input to the CreateHeader function.
 type CreateHeaderInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name              string       `form:"name,omitempty"`
-        Action            HeaderAction `form:"action,omitempty"`
-        IgnoreIfSet       bool         `form:"ignore_if_set,omitempty"`
-        Type              HeaderType   `form:"type,omitempty"`
-        Destination       string       `form:"dst,omitempty"`
-        Source            string       `form:"src,omitempty"`
-        Regex             string       `form:"regex,omitempty"`
-        Substitution      string       `form:"substitution,omitempty"`
-        Priority          uint         `form:"priority,omitempty"`
-        RequestCondition  string       `form:"request_condition,omitempty"`
-        CacheCondition    string       `form:"cache_condition,omitempty"`
-        ResponseCondition string       `form:"response_condition,omitempty"`
+	Name              string       `form:"name,omitempty"`
+	Action            HeaderAction `form:"action,omitempty"`
+	IgnoreIfSet       bool         `form:"ignore_if_set,omitempty"`
+	Type              HeaderType   `form:"type,omitempty"`
+	Destination       string       `form:"dst,omitempty"`
+	Source            string       `form:"src,omitempty"`
+	Regex             string       `form:"regex,omitempty"`
+	Substitution      string       `form:"substitution,omitempty"`
+	Priority          uint         `form:"priority,omitempty"`
+	RequestCondition  string       `form:"request_condition,omitempty"`
+	CacheCondition    string       `form:"cache_condition,omitempty"`
+	ResponseCondition string       `form:"response_condition,omitempty"`
 }
 
 // CreateHeader creates a new Fastly header.
 func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Header
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Header
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetHeaderInput is used as input to the GetHeader function.
 type GetHeaderInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the header to fetch.
-        Name string
+	// Name is the name of the header to fetch.
+	Name string
 }
 
 // GetHeader gets the header configuration with the given parameters.
 func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Header
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Header
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateHeaderInput is used as input to the UpdateHeader function.
 type UpdateHeaderInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the header to update.
-        Name string
+	// Name is the name of the header to update.
+	Name string
 
-        NewName           string       `form:"name,omitempty"`
-        Action            HeaderAction `form:"action,omitempty"`
-        IgnoreIfSet       bool         `form:"ignore_if_set,omitempty"`
-        Type              HeaderType   `form:"type,omitempty"`
-        Destination       string       `form:"dst,omitempty"`
-        Source            string       `form:"src,omitempty"`
-        Regex             string       `form:"regex,omitempty"`
-        Substitution      string       `form:"substitution,omitempty"`
-        Priority          uint         `form:"priority,omitempty"`
-        RequestCondition  string       `form:"request_condition,omitempty"`
-        CacheCondition    string       `form:"cache_condition,omitempty"`
-        ResponseCondition string       `form:"response_condition,omitempty"`
+	NewName           string       `form:"name,omitempty"`
+	Action            HeaderAction `form:"action,omitempty"`
+	IgnoreIfSet       bool         `form:"ignore_if_set,omitempty"`
+	Type              HeaderType   `form:"type,omitempty"`
+	Destination       string       `form:"dst,omitempty"`
+	Source            string       `form:"src,omitempty"`
+	Regex             string       `form:"regex,omitempty"`
+	Substitution      string       `form:"substitution,omitempty"`
+	Priority          uint         `form:"priority,omitempty"`
+	RequestCondition  string       `form:"request_condition,omitempty"`
+	CacheCondition    string       `form:"cache_condition,omitempty"`
+	ResponseCondition string       `form:"response_condition,omitempty"`
 }
 
 // UpdateHeader updates a specific header.
 func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Header
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Header
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteHeaderInput is the input parameter to DeleteHeader.
 type DeleteHeaderInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the header to delete (required).
-        Name string
+	// Name is the name of the header to delete (required).
+	Name string
 }
 
 // DeleteHeader deletes the given header version.
 func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/health_check.go
+++ b/vendor/github.com/sethvargo/go-fastly/health_check.go
@@ -1,26 +1,26 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // HealthCheck represents a health check response from the Fastly API.
 type HealthCheck struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name             string `mapstructure:"name"`
-        Method           string `mapstructure:"method"`
-        Host             string `mapstructure:"host"`
-        Path             string `mapstructure:"path"`
-        HTTPVersion      string `mapstructure:"http_version"`
-        Timeout          uint   `mapstructure:"timeout"`
-        CheckInterval    uint   `mapstructure:"check_interval"`
-        ExpectedResponse uint   `mapstructure:"expected_response"`
-        Window           uint   `mapstructure:"window"`
-        Threshold        uint   `mapstructure:"threshold"`
-        Initial          uint   `mapstructure:"initial"`
+	Name             string `mapstructure:"name"`
+	Method           string `mapstructure:"method"`
+	Host             string `mapstructure:"host"`
+	Path             string `mapstructure:"path"`
+	HTTPVersion      string `mapstructure:"http_version"`
+	Timeout          uint   `mapstructure:"timeout"`
+	CheckInterval    uint   `mapstructure:"check_interval"`
+	ExpectedResponse uint   `mapstructure:"expected_response"`
+	Window           uint   `mapstructure:"window"`
+	Threshold        uint   `mapstructure:"threshold"`
+	Initial          uint   `mapstructure:"initial"`
 }
 
 // healthChecksByName is a sortable list of health checks.
@@ -30,211 +30,211 @@ type healthChecksByName []*HealthCheck
 func (s healthChecksByName) Len() int      { return len(s) }
 func (s healthChecksByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s healthChecksByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListHealthChecksInput is used as input to the ListHealthChecks function.
 type ListHealthChecksInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListHealthChecks returns the list of health checks for the configuration
 // version.
 func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var hcs []*HealthCheck
-        if err := decodeJSON(&hcs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(healthChecksByName(hcs))
-        return hcs, nil
+	var hcs []*HealthCheck
+	if err := decodeJSON(&hcs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(healthChecksByName(hcs))
+	return hcs, nil
 }
 
 // CreateHealthCheckInput is used as input to the CreateHealthCheck function.
 type CreateHealthCheckInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name             string `form:"name,omitempty"`
-        Method           string `form:"method,omitempty"`
-        Host             string `form:"host,omitempty"`
-        Path             string `form:"path,omitempty"`
-        HTTPVersion      string `form:"http_version,omitempty"`
-        Timeout          uint   `form:"timeout,omitempty"`
-        CheckInterval    uint   `form:"check_interval,omitempty"`
-        ExpectedResponse uint   `form:"expected_response,omitempty"`
-        Window           uint   `form:"window,omitempty"`
-        Threshold        uint   `form:"threshold,omitempty"`
-        Initial          uint   `form:"initial,omitempty"`
+	Name             string `form:"name,omitempty"`
+	Method           string `form:"method,omitempty"`
+	Host             string `form:"host,omitempty"`
+	Path             string `form:"path,omitempty"`
+	HTTPVersion      string `form:"http_version,omitempty"`
+	Timeout          uint   `form:"timeout,omitempty"`
+	CheckInterval    uint   `form:"check_interval,omitempty"`
+	ExpectedResponse uint   `form:"expected_response,omitempty"`
+	Window           uint   `form:"window,omitempty"`
+	Threshold        uint   `form:"threshold,omitempty"`
+	Initial          uint   `form:"initial,omitempty"`
 }
 
 // CreateHealthCheck creates a new Fastly health check.
 func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var h *HealthCheck
-        if err := decodeJSON(&h, resp.Body); err != nil {
-                return nil, err
-        }
-        return h, nil
+	var h *HealthCheck
+	if err := decodeJSON(&h, resp.Body); err != nil {
+		return nil, err
+	}
+	return h, nil
 }
 
 // GetHealthCheckInput is used as input to the GetHealthCheck function.
 type GetHealthCheckInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the health check to fetch.
-        Name string
+	// Name is the name of the health check to fetch.
+	Name string
 }
 
 // GetHealthCheck gets the health check configuration with the given parameters.
 func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var h *HealthCheck
-        if err := decodeJSON(&h, resp.Body); err != nil {
-                return nil, err
-        }
-        return h, nil
+	var h *HealthCheck
+	if err := decodeJSON(&h, resp.Body); err != nil {
+		return nil, err
+	}
+	return h, nil
 }
 
 // UpdateHealthCheckInput is used as input to the UpdateHealthCheck function.
 type UpdateHealthCheckInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the health check to update.
-        Name string
+	// Name is the name of the health check to update.
+	Name string
 
-        NewName          string `form:"name,omitempty"`
-        Method           string `form:"method,omitempty"`
-        Host             string `form:"host,omitempty"`
-        Path             string `form:"path,omitempty"`
-        HTTPVersion      string `form:"http_version,omitempty"`
-        Timeout          uint   `form:"timeout,omitempty"`
-        CheckInterval    uint   `form:"check_interval,omitempty"`
-        ExpectedResponse uint   `form:"expected_response,omitempty"`
-        Window           uint   `form:"window,omitempty"`
-        Threshold        uint   `form:"threshold,omitempty"`
-        Initial          uint   `form:"initial,omitempty"`
+	NewName          string `form:"name,omitempty"`
+	Method           string `form:"method,omitempty"`
+	Host             string `form:"host,omitempty"`
+	Path             string `form:"path,omitempty"`
+	HTTPVersion      string `form:"http_version,omitempty"`
+	Timeout          uint   `form:"timeout,omitempty"`
+	CheckInterval    uint   `form:"check_interval,omitempty"`
+	ExpectedResponse uint   `form:"expected_response,omitempty"`
+	Window           uint   `form:"window,omitempty"`
+	Threshold        uint   `form:"threshold,omitempty"`
+	Initial          uint   `form:"initial,omitempty"`
 }
 
 // UpdateHealthCheck updates a specific health check.
 func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var h *HealthCheck
-        if err := decodeJSON(&h, resp.Body); err != nil {
-                return nil, err
-        }
-        return h, nil
+	var h *HealthCheck
+	if err := decodeJSON(&h, resp.Body); err != nil {
+		return nil, err
+	}
+	return h, nil
 }
 
 // DeleteHealthCheckInput is the input parameter to DeleteHealthCheck.
 type DeleteHealthCheckInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the health check to delete (required).
-        Name string
+	// Name is the name of the health check to delete (required).
+	Name string
 }
 
 // DeleteHealthCheck deletes the given health check.
 func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/ip.go
+++ b/vendor/github.com/sethvargo/go-fastly/ip.go
@@ -5,14 +5,14 @@ type IPAddrs []string
 
 // IPs returns the list of public IP addresses for Fastly's network.
 func (c *Client) IPs() (IPAddrs, error) {
-        resp, err := c.Get("/public-ip-list", nil)
-        if err != nil {
-                return nil, err
-        }
+	resp, err := c.Get("/public-ip-list", nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var m map[string][]string
-        if err := decodeJSON(&m, resp.Body); err != nil {
-                return nil, err
-        }
-        return IPAddrs(m["addresses"]), nil
+	var m map[string][]string
+	if err := decodeJSON(&m, resp.Body); err != nil {
+		return nil, err
+	}
+	return IPAddrs(m["addresses"]), nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/logentries.go
+++ b/vendor/github.com/sethvargo/go-fastly/logentries.go
@@ -1,25 +1,25 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
-        "time"
+	"fmt"
+	"sort"
+	"time"
 )
 
 // Logentries represents a logentries response from the Fastly API.
 type Logentries struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name              string     `mapstructure:"name"`
-        Port              uint       `mapstructure:"port"`
-        UseTLS            bool       `mapstructure:"use_tls"`
-        Token             string     `mapstructure:"token"`
-        Format            string     `mapstructure:"format"`
-        ResponseCondition string     `mapstructure:"response_condition"`
-        CreatedAt         *time.Time `mapstructure:"created_at"`
-        UpdatedAt         *time.Time `mapstructure:"updated_at"`
-        DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Name              string     `mapstructure:"name"`
+	Port              uint       `mapstructure:"port"`
+	UseTLS            bool       `mapstructure:"use_tls"`
+	Token             string     `mapstructure:"token"`
+	Format            string     `mapstructure:"format"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
 }
 
 // logentriesByName is a sortable list of logentries.
@@ -29,200 +29,200 @@ type logentriesByName []*Logentries
 func (s logentriesByName) Len() int      { return len(s) }
 func (s logentriesByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s logentriesByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListLogentriesInput is used as input to the ListLogentries function.
 type ListLogentriesInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListLogentries returns the list of logentries for the configuration version.
 func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ls []*Logentries
-        if err := decodeJSON(&ls, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(logentriesByName(ls))
-        return ls, nil
+	var ls []*Logentries
+	if err := decodeJSON(&ls, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(logentriesByName(ls))
+	return ls, nil
 }
 
 // CreateLogentriesInput is used as input to the CreateLogentries function.
 type CreateLogentriesInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name              string      `form:"name,omitempty"`
-        Port              uint        `form:"port,omitempty"`
-        UseTLS            Compatibool `form:"use_tls,omitempty"`
-        Token             string      `form:"token,omitempty"`
-        Format            string      `form:"format,omitempty"`
-        ResponseCondition string      `form:"response_condition,omitempty"`
+	Name              string      `form:"name,omitempty"`
+	Port              uint        `form:"port,omitempty"`
+	UseTLS            Compatibool `form:"use_tls,omitempty"`
+	Token             string      `form:"token,omitempty"`
+	Format            string      `form:"format,omitempty"`
+	ResponseCondition string      `form:"response_condition,omitempty"`
 }
 
 // CreateLogentries creates a new Fastly logentries.
 func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var l *Logentries
-        if err := decodeJSON(&l, resp.Body); err != nil {
-                return nil, err
-        }
-        return l, nil
+	var l *Logentries
+	if err := decodeJSON(&l, resp.Body); err != nil {
+		return nil, err
+	}
+	return l, nil
 }
 
 // GetLogentriesInput is used as input to the GetLogentries function.
 type GetLogentriesInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the logentries to fetch.
-        Name string
+	// Name is the name of the logentries to fetch.
+	Name string
 }
 
 // GetLogentries gets the logentries configuration with the given parameters.
 func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var l *Logentries
-        if err := decodeJSON(&l, resp.Body); err != nil {
-                return nil, err
-        }
-        return l, nil
+	var l *Logentries
+	if err := decodeJSON(&l, resp.Body); err != nil {
+		return nil, err
+	}
+	return l, nil
 }
 
 // UpdateLogentriesInput is used as input to the UpdateLogentries function.
 type UpdateLogentriesInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the logentries to update.
-        Name string
+	// Name is the name of the logentries to update.
+	Name string
 
-        NewName           string      `form:"name,omitempty"`
-        Port              uint        `form:"port,omitempty"`
-        UseTLS            Compatibool `form:"use_tls,omitempty"`
-        Token             string      `form:"token,omitempty"`
-        Format            string      `form:"format,omitempty"`
-        ResponseCondition string      `form:"response_condition,omitempty"`
+	NewName           string      `form:"name,omitempty"`
+	Port              uint        `form:"port,omitempty"`
+	UseTLS            Compatibool `form:"use_tls,omitempty"`
+	Token             string      `form:"token,omitempty"`
+	Format            string      `form:"format,omitempty"`
+	ResponseCondition string      `form:"response_condition,omitempty"`
 }
 
 // UpdateLogentries updates a specific logentries.
 func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var l *Logentries
-        if err := decodeJSON(&l, resp.Body); err != nil {
-                return nil, err
-        }
-        return l, nil
+	var l *Logentries
+	if err := decodeJSON(&l, resp.Body); err != nil {
+		return nil, err
+	}
+	return l, nil
 }
 
 // DeleteLogentriesInput is the input parameter to DeleteLogentries.
 type DeleteLogentriesInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the logentries to delete (required).
-        Name string
+	// Name is the name of the logentries to delete (required).
+	Name string
 }
 
 // DeleteLogentries deletes the given logentries version.
 func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/papertrail.go
+++ b/vendor/github.com/sethvargo/go-fastly/papertrail.go
@@ -1,24 +1,24 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
-        "time"
+	"fmt"
+	"sort"
+	"time"
 )
 
 // Papertrail represents a papertrail response from the Fastly API.
 type Papertrail struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name              string     `mapstructure:"name"`
-        Address           string     `mapstructure:"address"`
-        Port              uint       `mapstructure:"port"`
-        Format            string     `mapstructure:"format"`
-        ResponseCondition string     `mapstructure:"response_condition"`
-        CreatedAt         *time.Time `mapstructure:"created_at"`
-        UpdatedAt         *time.Time `mapstructure:"updated_at"`
-        DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Name              string     `mapstructure:"name"`
+	Address           string     `mapstructure:"address"`
+	Port              uint       `mapstructure:"port"`
+	Format            string     `mapstructure:"format"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
 }
 
 // papertrailsByName is a sortable list of papertrails.
@@ -28,204 +28,204 @@ type papertrailsByName []*Papertrail
 func (s papertrailsByName) Len() int      { return len(s) }
 func (s papertrailsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s papertrailsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListPapertrailsInput is used as input to the ListPapertrails function.
 type ListPapertrailsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListPapertrails returns the list of papertrails for the configuration version.
 func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ps []*Papertrail
-        if err := decodeJSON(&ps, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(papertrailsByName(ps))
-        return ps, nil
+	var ps []*Papertrail
+	if err := decodeJSON(&ps, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(papertrailsByName(ps))
+	return ps, nil
 }
 
 // CreatePapertrailInput is used as input to the CreatePapertrail function.
 type CreatePapertrailInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name              string     `form:"name,omitempty"`
-        Address           string     `form:"address,omitempty"`
-        Port              uint       `form:"port,omitempty"`
-        Format            string     `form:"format,omitempty"`
-        ResponseCondition string     `form:"response_condition,omitempty"`
-        CreatedAt         *time.Time `form:"created_at,omitempty"`
-        UpdatedAt         *time.Time `form:"updated_at,omitempty"`
-        DeletedAt         *time.Time `form:"deleted_at,omitempty"`
+	Name              string     `form:"name,omitempty"`
+	Address           string     `form:"address,omitempty"`
+	Port              uint       `form:"port,omitempty"`
+	Format            string     `form:"format,omitempty"`
+	ResponseCondition string     `form:"response_condition,omitempty"`
+	CreatedAt         *time.Time `form:"created_at,omitempty"`
+	UpdatedAt         *time.Time `form:"updated_at,omitempty"`
+	DeletedAt         *time.Time `form:"deleted_at,omitempty"`
 }
 
 // CreatePapertrail creates a new Fastly papertrail.
 func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var p *Papertrail
-        if err := decodeJSON(&p, resp.Body); err != nil {
-                return nil, err
-        }
-        return p, nil
+	var p *Papertrail
+	if err := decodeJSON(&p, resp.Body); err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
 // GetPapertrailInput is used as input to the GetPapertrail function.
 type GetPapertrailInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the papertrail to fetch.
-        Name string
+	// Name is the name of the papertrail to fetch.
+	Name string
 }
 
 // GetPapertrail gets the papertrail configuration with the given parameters.
 func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var p *Papertrail
-        if err := decodeJSON(&p, resp.Body); err != nil {
-                return nil, err
-        }
-        return p, nil
+	var p *Papertrail
+	if err := decodeJSON(&p, resp.Body); err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
 // UpdatePapertrailInput is used as input to the UpdatePapertrail function.
 type UpdatePapertrailInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the papertrail to update.
-        Name string
+	// Name is the name of the papertrail to update.
+	Name string
 
-        NewName           string     `form:"name,omitempty"`
-        Address           string     `form:"address,omitempty"`
-        Port              uint       `form:"port,omitempty"`
-        Format            string     `form:"format,omitempty"`
-        ResponseCondition string     `form:"response_condition,omitempty"`
-        CreatedAt         *time.Time `form:"created_at,omitempty"`
-        UpdatedAt         *time.Time `form:"updated_at,omitempty"`
-        DeletedAt         *time.Time `form:"deleted_at,omitempty"`
+	NewName           string     `form:"name,omitempty"`
+	Address           string     `form:"address,omitempty"`
+	Port              uint       `form:"port,omitempty"`
+	Format            string     `form:"format,omitempty"`
+	ResponseCondition string     `form:"response_condition,omitempty"`
+	CreatedAt         *time.Time `form:"created_at,omitempty"`
+	UpdatedAt         *time.Time `form:"updated_at,omitempty"`
+	DeletedAt         *time.Time `form:"deleted_at,omitempty"`
 }
 
 // UpdatePapertrail updates a specific papertrail.
 func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var p *Papertrail
-        if err := decodeJSON(&p, resp.Body); err != nil {
-                return nil, err
-        }
-        return p, nil
+	var p *Papertrail
+	if err := decodeJSON(&p, resp.Body); err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
 // DeletePapertrailInput is the input parameter to DeletePapertrail.
 type DeletePapertrailInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the papertrail to delete (required).
-        Name string
+	// Name is the name of the papertrail to delete (required).
+	Name string
 }
 
 // DeletePapertrail deletes the given papertrail version.
 func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/purge.go
+++ b/vendor/github.com/sethvargo/go-fastly/purge.go
@@ -4,127 +4,127 @@ import "fmt"
 
 // Purge is a response from a purge request.
 type Purge struct {
-        // Status is the status of the purge, usually "ok".
-        Status string `mapstructure:"status"`
+	// Status is the status of the purge, usually "ok".
+	Status string `mapstructure:"status"`
 
-        // ID is the unique ID of the purge request.
-        ID string `mapstructure:"id"`
+	// ID is the unique ID of the purge request.
+	ID string `mapstructure:"id"`
 }
 
 // PurgeInput is used as input to the Purge function.
 type PurgeInput struct {
-        // URL is the URL to purge (required).
-        URL string
+	// URL is the URL to purge (required).
+	URL string
 
-        // Soft performs a soft purge.
-        Soft bool
+	// Soft performs a soft purge.
+	Soft bool
 }
 
 // Purge instantly purges an individual URL.
 func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
-        if i.URL == "" {
-                return nil, ErrMissingURL
-        }
+	if i.URL == "" {
+		return nil, ErrMissingURL
+	}
 
-        req, err := c.RawRequest("PURGE", i.URL, nil)
-        if err != nil {
-                return nil, err
-        }
+	req, err := c.RawRequest("PURGE", i.URL, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        if i.Soft {
-                req.Header.Set("Fastly-Soft-Purge", "1")
-        }
+	if i.Soft {
+		req.Header.Set("Fastly-Soft-Purge", "1")
+	}
 
-        resp, err := checkResp(c.HTTPClient.Do(req))
-        if err != nil {
-                return nil, err
-        }
+	resp, err := checkResp(c.HTTPClient.Do(req))
+	if err != nil {
+		return nil, err
+	}
 
-        var r *Purge
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return nil, err
-        }
-        return r, nil
+	var r *Purge
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
 // PurgeKeyInput is used as input to the Purge function.
 type PurgeKeyInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Key is the key to purge (required).
-        Key string
+	// Key is the key to purge (required).
+	Key string
 
-        // Soft performs a soft purge.
-        Soft bool
+	// Soft performs a soft purge.
+	Soft bool
 }
 
 // PurgeKey instantly purges a particular service of items tagged with a key.
 func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Key == "" {
-                return nil, ErrMissingKey
-        }
+	if i.Key == "" {
+		return nil, ErrMissingKey
+	}
 
-        path := fmt.Sprintf("/service/%s/purge/%s", i.Service, i.Key)
-        req, err := c.RawRequest("POST", path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/purge/%s", i.Service, i.Key)
+	req, err := c.RawRequest("POST", path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        if i.Soft {
-                req.Header.Set("Fastly-Soft-Purge", "1")
-        }
+	if i.Soft {
+		req.Header.Set("Fastly-Soft-Purge", "1")
+	}
 
-        resp, err := checkResp(c.HTTPClient.Do(req))
-        if err != nil {
-                return nil, err
-        }
+	resp, err := checkResp(c.HTTPClient.Do(req))
+	if err != nil {
+		return nil, err
+	}
 
-        var r *Purge
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return nil, err
-        }
-        return r, nil
+	var r *Purge
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
 // PurgeAllInput is used as input to the Purge function.
 type PurgeAllInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Soft performs a soft purge.
-        Soft bool
+	// Soft performs a soft purge.
+	Soft bool
 }
 
 // PurgeAll instantly purges everything from a service.
 func (c *Client) PurgeAll(i *PurgeAllInput) (*Purge, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        path := fmt.Sprintf("/service/%s/purge_all", i.Service)
-        req, err := c.RawRequest("POST", path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/purge_all", i.Service)
+	req, err := c.RawRequest("POST", path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        if i.Soft {
-                req.Header.Set("Fastly-Soft-Purge", "1")
-        }
+	if i.Soft {
+		req.Header.Set("Fastly-Soft-Purge", "1")
+	}
 
-        resp, err := checkResp(c.HTTPClient.Do(req))
-        if err != nil {
-                return nil, err
-        }
+	resp, err := checkResp(c.HTTPClient.Do(req))
+	if err != nil {
+		return nil, err
+	}
 
-        var r *Purge
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return nil, err
-        }
-        return r, nil
+	var r *Purge
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return nil, err
+	}
+	return r, nil
 
 }

--- a/vendor/github.com/sethvargo/go-fastly/request.go
+++ b/vendor/github.com/sethvargo/go-fastly/request.go
@@ -1,68 +1,68 @@
 package fastly
 
 import (
-        "io"
-        "net/http"
-        "net/url"
-        "path"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
 )
 
 // RequestOptions is the list of options to pass to the request.
 type RequestOptions struct {
-        // Params is a map of key-value pairs that will be added to the Request.
-        Params map[string]string
+	// Params is a map of key-value pairs that will be added to the Request.
+	Params map[string]string
 
-        // Headers is a map of key-value pairs that will be added to the Request.
-        Headers map[string]string
+	// Headers is a map of key-value pairs that will be added to the Request.
+	Headers map[string]string
 
-        // Body is an io.Reader object that will be streamed or uploaded with the
-        // Request. BodyLength is the final size of the Body.
-        Body       io.Reader
-        BodyLength int64
+	// Body is an io.Reader object that will be streamed or uploaded with the
+	// Request. BodyLength is the final size of the Body.
+	Body       io.Reader
+	BodyLength int64
 }
 
 // RawRequest accepts a verb, URL, and RequestOptions struct and returns the
 // constructed http.Request and any errors that occurred
 func (c *Client) RawRequest(verb, p string, ro *RequestOptions) (*http.Request, error) {
-        // Ensure we have request options.
-        if ro == nil {
-                ro = new(RequestOptions)
-        }
+	// Ensure we have request options.
+	if ro == nil {
+		ro = new(RequestOptions)
+	}
 
-        // Append the path to the URL.
-        u := *c.url
-        u.Path = path.Join(c.url.Path, p)
+	// Append the path to the URL.
+	u := *c.url
+	u.Path = path.Join(c.url.Path, p)
 
-        // Add the token and other params.
-        var params = make(url.Values)
-        for k, v := range ro.Params {
-                params.Add(k, v)
-        }
-        u.RawQuery = params.Encode()
+	// Add the token and other params.
+	var params = make(url.Values)
+	for k, v := range ro.Params {
+		params.Add(k, v)
+	}
+	u.RawQuery = params.Encode()
 
-        // Create the request object.
-        request, err := http.NewRequest(verb, u.String(), ro.Body)
-        if err != nil {
-                return nil, err
-        }
+	// Create the request object.
+	request, err := http.NewRequest(verb, u.String(), ro.Body)
+	if err != nil {
+		return nil, err
+	}
 
-        // Set the API key.
-        if len(c.apiKey) > 0 {
-                request.Header.Set(APIKeyHeader, c.apiKey)
-        }
+	// Set the API key.
+	if len(c.apiKey) > 0 {
+		request.Header.Set(APIKeyHeader, c.apiKey)
+	}
 
-        // Set the User-Agent.
-        request.Header.Set("User-Agent", UserAgent)
+	// Set the User-Agent.
+	request.Header.Set("User-Agent", UserAgent)
 
-        // Add any custom headers.
-        for k, v := range ro.Headers {
-                request.Header.Add(k, v)
-        }
+	// Add any custom headers.
+	for k, v := range ro.Headers {
+		request.Header.Add(k, v)
+	}
 
-        // Add Content-Length if we have it.
-        if ro.BodyLength > 0 {
-                request.ContentLength = ro.BodyLength
-        }
+	// Add Content-Length if we have it.
+	if ro.BodyLength > 0 {
+		request.ContentLength = ro.BodyLength
+	}
 
-        return request, nil
+	return request, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/request_setting.go
+++ b/vendor/github.com/sethvargo/go-fastly/request_setting.go
@@ -1,37 +1,37 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 const (
-        // RequestSettingActionLookup sets request handling to lookup via the cache.
-        RequestSettingActionLookup RequestSettingAction = "lookup"
+	// RequestSettingActionLookup sets request handling to lookup via the cache.
+	RequestSettingActionLookup RequestSettingAction = "lookup"
 
-        // RequestSettingActionPass sets request handling to pass the cache.
-        RequestSettingActionPass RequestSettingAction = "pass"
+	// RequestSettingActionPass sets request handling to pass the cache.
+	RequestSettingActionPass RequestSettingAction = "pass"
 )
 
 // RequestSettingAction is a type of request setting action.
 type RequestSettingAction string
 
 const (
-        // RequestSettingXFFClear clears any X-Forwarded-For headers.
-        RequestSettingXFFClear RequestSettingXFF = "clear"
+	// RequestSettingXFFClear clears any X-Forwarded-For headers.
+	RequestSettingXFFClear RequestSettingXFF = "clear"
 
-        // RequestSettingXFFLeave leaves any X-Forwarded-For headers untouched.
-        RequestSettingXFFLeave RequestSettingXFF = "leave"
+	// RequestSettingXFFLeave leaves any X-Forwarded-For headers untouched.
+	RequestSettingXFFLeave RequestSettingXFF = "leave"
 
-        // RequestSettingXFFAppend adds Fastly X-Forwarded-For headers.
-        RequestSettingXFFAppend RequestSettingXFF = "append"
+	// RequestSettingXFFAppend adds Fastly X-Forwarded-For headers.
+	RequestSettingXFFAppend RequestSettingXFF = "append"
 
-        // RequestSettingXFFAppendAll appends all Fastly X-Forwarded-For headers.
-        RequestSettingXFFAppendAll RequestSettingXFF = "append_all"
+	// RequestSettingXFFAppendAll appends all Fastly X-Forwarded-For headers.
+	RequestSettingXFFAppendAll RequestSettingXFF = "append_all"
 
-        // RequestSettingXFFOverwrite clears any X-Forwarded-For headers and replaces
-        // with Fastly ones.
-        RequestSettingXFFOverwrite RequestSettingXFF = "overwrite"
+	// RequestSettingXFFOverwrite clears any X-Forwarded-For headers and replaces
+	// with Fastly ones.
+	RequestSettingXFFOverwrite RequestSettingXFF = "overwrite"
 )
 
 // RequestSettingXFF is a type of X-Forwarded-For value to set.
@@ -39,21 +39,21 @@ type RequestSettingXFF string
 
 // RequestSetting represents a request setting response from the Fastly API.
 type RequestSetting struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name             string               `mapstructure:"name"`
-        ForceMiss        bool                 `mapstructure:"force_miss"`
-        ForceSSL         bool                 `mapstructure:"force_ssl"`
-        Action           RequestSettingAction `mapstructure:"action"`
-        BypassBusyWait   bool                 `mapstructure:"bypass_busy_wait"`
-        MaxStaleAge      uint                 `mapstructure:"max_stale_age"`
-        HashKeys         string               `mapstructure:"hash_keys"`
-        XForwardedFor    RequestSettingXFF    `mapstructure:"xff"`
-        TimerSupport     bool                 `mapstructure:"timer_support"`
-        GeoHeaders       bool                 `mapstructure:"geo_headers"`
-        DefaultHost      string               `mapstructure:"default_host"`
-        RequestCondition string               `mapstructure:"request_condition"`
+	Name             string               `mapstructure:"name"`
+	ForceMiss        bool                 `mapstructure:"force_miss"`
+	ForceSSL         bool                 `mapstructure:"force_ssl"`
+	Action           RequestSettingAction `mapstructure:"action"`
+	BypassBusyWait   bool                 `mapstructure:"bypass_busy_wait"`
+	MaxStaleAge      uint                 `mapstructure:"max_stale_age"`
+	HashKeys         string               `mapstructure:"hash_keys"`
+	XForwardedFor    RequestSettingXFF    `mapstructure:"xff"`
+	TimerSupport     bool                 `mapstructure:"timer_support"`
+	GeoHeaders       bool                 `mapstructure:"geo_headers"`
+	DefaultHost      string               `mapstructure:"default_host"`
+	RequestCondition string               `mapstructure:"request_condition"`
 }
 
 // requestSettingsByName is a sortable list of request settings.
@@ -63,217 +63,217 @@ type requestSettingsByName []*RequestSetting
 func (s requestSettingsByName) Len() int      { return len(s) }
 func (s requestSettingsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s requestSettingsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListRequestSettingsInput is used as input to the ListRequestSettings
 // function.
 type ListRequestSettingsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListRequestSettings returns the list of request settings for the
 // configuration version.
 func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var bs []*RequestSetting
-        if err := decodeJSON(&bs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(requestSettingsByName(bs))
-        return bs, nil
+	var bs []*RequestSetting
+	if err := decodeJSON(&bs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(requestSettingsByName(bs))
+	return bs, nil
 }
 
 // CreateRequestSettingInput is used as input to the CreateRequestSetting
 // function.
 type CreateRequestSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name             string               `form:"name,omitempty"`
-        ForceMiss        Compatibool          `form:"force_miss,omitempty"`
-        ForceSSL         Compatibool          `form:"force_ssl,omitempty"`
-        Action           RequestSettingAction `form:"action,omitempty"`
-        BypassBusyWait   Compatibool          `form:"bypass_busy_wait,omitempty"`
-        MaxStaleAge      uint                 `form:"max_stale_age,omitempty"`
-        HashKeys         string               `form:"hash_keys,omitempty"`
-        XForwardedFor    RequestSettingXFF    `form:"xff,omitempty"`
-        TimerSupport     Compatibool          `form:"timer_support,omitempty"`
-        GeoHeaders       Compatibool          `form:"geo_headers,omitempty"`
-        DefaultHost      string               `form:"default_host,omitempty"`
-        RequestCondition string               `form:"request_condition,omitempty"`
+	Name             string               `form:"name,omitempty"`
+	ForceMiss        Compatibool          `form:"force_miss,omitempty"`
+	ForceSSL         Compatibool          `form:"force_ssl,omitempty"`
+	Action           RequestSettingAction `form:"action,omitempty"`
+	BypassBusyWait   Compatibool          `form:"bypass_busy_wait,omitempty"`
+	MaxStaleAge      uint                 `form:"max_stale_age,omitempty"`
+	HashKeys         string               `form:"hash_keys,omitempty"`
+	XForwardedFor    RequestSettingXFF    `form:"xff,omitempty"`
+	TimerSupport     Compatibool          `form:"timer_support,omitempty"`
+	GeoHeaders       Compatibool          `form:"geo_headers,omitempty"`
+	DefaultHost      string               `form:"default_host,omitempty"`
+	RequestCondition string               `form:"request_condition,omitempty"`
 }
 
 // CreateRequestSetting creates a new Fastly request settings.
 func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *RequestSetting
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *RequestSetting
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetRequestSettingInput is used as input to the GetRequestSetting function.
 type GetRequestSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the request settings to fetch.
-        Name string
+	// Name is the name of the request settings to fetch.
+	Name string
 }
 
 // GetRequestSetting gets the request settings configuration with the given
 // parameters.
 func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *RequestSetting
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *RequestSetting
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateRequestSettingInput is used as input to the UpdateRequestSetting
 // function.
 type UpdateRequestSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the request settings to update.
-        Name string
+	// Name is the name of the request settings to update.
+	Name string
 
-        NewName          string               `form:"name,omitempty"`
-        ForceMiss        Compatibool          `form:"force_miss,omitempty"`
-        ForceSSL         Compatibool          `form:"force_ssl,omitempty"`
-        Action           RequestSettingAction `form:"action,omitempty"`
-        BypassBusyWait   Compatibool          `form:"bypass_busy_wait,omitempty"`
-        MaxStaleAge      uint                 `form:"max_stale_age,omitempty"`
-        HashKeys         string               `form:"hash_keys,omitempty"`
-        XForwardedFor    RequestSettingXFF    `form:"xff,omitempty"`
-        TimerSupport     Compatibool          `form:"timer_support,omitempty"`
-        GeoHeaders       Compatibool          `form:"geo_headers,omitempty"`
-        DefaultHost      string               `form:"default_host,omitempty"`
-        RequestCondition string               `form:"request_condition,omitempty"`
+	NewName          string               `form:"name,omitempty"`
+	ForceMiss        Compatibool          `form:"force_miss,omitempty"`
+	ForceSSL         Compatibool          `form:"force_ssl,omitempty"`
+	Action           RequestSettingAction `form:"action,omitempty"`
+	BypassBusyWait   Compatibool          `form:"bypass_busy_wait,omitempty"`
+	MaxStaleAge      uint                 `form:"max_stale_age,omitempty"`
+	HashKeys         string               `form:"hash_keys,omitempty"`
+	XForwardedFor    RequestSettingXFF    `form:"xff,omitempty"`
+	TimerSupport     Compatibool          `form:"timer_support,omitempty"`
+	GeoHeaders       Compatibool          `form:"geo_headers,omitempty"`
+	DefaultHost      string               `form:"default_host,omitempty"`
+	RequestCondition string               `form:"request_condition,omitempty"`
 }
 
 // UpdateRequestSetting updates a specific request settings.
 func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSetting, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *RequestSetting
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *RequestSetting
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteRequestSettingInput is the input parameter to DeleteRequestSetting.
 type DeleteRequestSettingInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the request settings to delete (required).
-        Name string
+	// Name is the name of the request settings to delete (required).
+	Name string
 }
 
 // DeleteRequestSetting deletes the given request settings version.
 func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/response_object.go
+++ b/vendor/github.com/sethvargo/go-fastly/response_object.go
@@ -1,22 +1,22 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // ResponseObject represents a response object response from the Fastly API.
 type ResponseObject struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name             string `mapstructure:"name"`
-        Status           uint   `mapstructure:"status"`
-        Response         string `mapstructure:"response"`
-        Content          string `mapstructure:"content"`
-        ContentType      string `mapstructure:"content_type"`
-        RequestCondition string `mapstructure:"request_condition"`
-        CacheCondition   string `mapstructure:"cache_condition"`
+	Name             string `mapstructure:"name"`
+	Status           uint   `mapstructure:"status"`
+	Response         string `mapstructure:"response"`
+	Content          string `mapstructure:"content"`
+	ContentType      string `mapstructure:"content_type"`
+	RequestCondition string `mapstructure:"request_condition"`
+	CacheCondition   string `mapstructure:"cache_condition"`
 }
 
 // responseObjectsByName is a sortable list of response objects.
@@ -26,207 +26,207 @@ type responseObjectsByName []*ResponseObject
 func (s responseObjectsByName) Len() int      { return len(s) }
 func (s responseObjectsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s responseObjectsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListResponseObjectsInput is used as input to the ListResponseObjects
 // function.
 type ListResponseObjectsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListResponseObjects returns the list of response objects for the
 // configuration version.
 func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseObject, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var bs []*ResponseObject
-        if err := decodeJSON(&bs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(responseObjectsByName(bs))
-        return bs, nil
+	var bs []*ResponseObject
+	if err := decodeJSON(&bs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(responseObjectsByName(bs))
+	return bs, nil
 }
 
 // CreateResponseObjectInput is used as input to the CreateResponseObject
 // function.
 type CreateResponseObjectInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name             string `form:"name,omitempty"`
-        Status           uint   `form:"status,omitempty"`
-        Response         string `form:"response,omitempty"`
-        Content          string `form:"content,omitempty"`
-        ContentType      string `form:"content_type,omitempty"`
-        RequestCondition string `form:"request_condition,omitempty"`
-        CacheCondition   string `form:"cache_condition,omitempty"`
+	Name             string `form:"name,omitempty"`
+	Status           uint   `form:"status,omitempty"`
+	Response         string `form:"response,omitempty"`
+	Content          string `form:"content,omitempty"`
+	ContentType      string `form:"content_type,omitempty"`
+	RequestCondition string `form:"request_condition,omitempty"`
+	CacheCondition   string `form:"cache_condition,omitempty"`
 }
 
 // CreateResponseObject creates a new Fastly response object.
 func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseObject, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *ResponseObject
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *ResponseObject
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetResponseObjectInput is used as input to the GetResponseObject function.
 type GetResponseObjectInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the response object to fetch.
-        Name string
+	// Name is the name of the response object to fetch.
+	Name string
 }
 
 // GetResponseObject gets the response object configuration with the given
 // parameters.
 func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *ResponseObject
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *ResponseObject
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateResponseObjectInput is used as input to the UpdateResponseObject
 // function.
 type UpdateResponseObjectInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the response object to update.
-        Name string
+	// Name is the name of the response object to update.
+	Name string
 
-        NewName          string `form:"name,omitempty"`
-        Status           uint   `form:"status,omitempty"`
-        Response         string `form:"response,omitempty"`
-        Content          string `form:"content,omitempty"`
-        ContentType      string `form:"content_type,omitempty"`
-        RequestCondition string `form:"request_condition,omitempty"`
-        CacheCondition   string `form:"cache_condition,omitempty"`
+	NewName          string `form:"name,omitempty"`
+	Status           uint   `form:"status,omitempty"`
+	Response         string `form:"response,omitempty"`
+	Content          string `form:"content,omitempty"`
+	ContentType      string `form:"content_type,omitempty"`
+	RequestCondition string `form:"request_condition,omitempty"`
+	CacheCondition   string `form:"cache_condition,omitempty"`
 }
 
 // UpdateResponseObject updates a specific response object.
 func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseObject, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *ResponseObject
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *ResponseObject
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteResponseObjectInput is the input parameter to DeleteResponseObject.
 type DeleteResponseObjectInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the response object to delete (required).
-        Name string
+	// Name is the name of the response object to delete (required).
+	Name string
 }
 
 // DeleteResponseObject deletes the given response object version.
 func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/s3.go
+++ b/vendor/github.com/sethvargo/go-fastly/s3.go
@@ -1,29 +1,29 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
-        "time"
+	"fmt"
+	"sort"
+	"time"
 )
 
 // S3 represents a S3 response from the Fastly API.
 type S3 struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name              string     `mapstructure:"name"`
-        BucketName        string     `mapstructure:"bucket_name"`
-        AccessKey         string     `mapstructure:"access_key"`
-        SecretKey         string     `mapstructure:"secret_key"`
-        Path              string     `mapstructure:"path"`
-        Period            uint       `mapstructure:"period"`
-        GzipLevel         uint       `mapstructure:"gzip_level"`
-        Format            string     `mapstructure:"format"`
-        ResponseCondition string     `mapstructure:"response_condition"`
-        TimestampFormat   string     `mapstructure:"timestamp_format"`
-        CreatedAt         *time.Time `mapstructure:"created_at"`
-        UpdatedAt         *time.Time `mapstructure:"updated_at"`
-        DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Name              string     `mapstructure:"name"`
+	BucketName        string     `mapstructure:"bucket_name"`
+	AccessKey         string     `mapstructure:"access_key"`
+	SecretKey         string     `mapstructure:"secret_key"`
+	Path              string     `mapstructure:"path"`
+	Period            uint       `mapstructure:"period"`
+	GzipLevel         uint       `mapstructure:"gzip_level"`
+	Format            string     `mapstructure:"format"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
 }
 
 // s3sByName is a sortable list of S3s.
@@ -33,208 +33,208 @@ type s3sByName []*S3
 func (s s3sByName) Len() int      { return len(s) }
 func (s s3sByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s s3sByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListS3sInput is used as input to the ListS3s function.
 type ListS3sInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListS3s returns the list of S3s for the configuration version.
 func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s3s []*S3
-        if err := decodeJSON(&s3s, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(s3sByName(s3s))
-        return s3s, nil
+	var s3s []*S3
+	if err := decodeJSON(&s3s, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(s3sByName(s3s))
+	return s3s, nil
 }
 
 // CreateS3Input is used as input to the CreateS3 function.
 type CreateS3Input struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name              string `form:"name,omitempty"`
-        BucketName        string `form:"bucket_name,omitempty"`
-        AccessKey         string `form:"access_key,omitempty"`
-        SecretKey         string `form:"secret_key,omitempty"`
-        Path              string `form:"path,omitempty"`
-        Period            uint   `form:"period,omitempty"`
-        GzipLevel         uint   `form:"gzip_level,omitempty"`
-        Format            string `form:"format,omitempty"`
-        ResponseCondition string `form:"response_condition,omitempty"`
-        TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Name              string `form:"name,omitempty"`
+	BucketName        string `form:"bucket_name,omitempty"`
+	AccessKey         string `form:"access_key,omitempty"`
+	SecretKey         string `form:"secret_key,omitempty"`
+	Path              string `form:"path,omitempty"`
+	Period            uint   `form:"period,omitempty"`
+	GzipLevel         uint   `form:"gzip_level,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
+	TimestampFormat   string `form:"timestamp_format,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.
 func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s3 *S3
-        if err := decodeJSON(&s3, resp.Body); err != nil {
-                return nil, err
-        }
-        return s3, nil
+	var s3 *S3
+	if err := decodeJSON(&s3, resp.Body); err != nil {
+		return nil, err
+	}
+	return s3, nil
 }
 
 // GetS3Input is used as input to the GetS3 function.
 type GetS3Input struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the S3 to fetch.
-        Name string
+	// Name is the name of the S3 to fetch.
+	Name string
 }
 
 // GetS3 gets the S3 configuration with the given parameters.
 func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s3 *S3
-        if err := decodeJSON(&s3, resp.Body); err != nil {
-                return nil, err
-        }
-        return s3, nil
+	var s3 *S3
+	if err := decodeJSON(&s3, resp.Body); err != nil {
+		return nil, err
+	}
+	return s3, nil
 }
 
 // UpdateS3Input is used as input to the UpdateS3 function.
 type UpdateS3Input struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the S3 to update.
-        Name string
+	// Name is the name of the S3 to update.
+	Name string
 
-        NewName           string `form:"name,omitempty"`
-        BucketName        string `form:"bucket_name,omitempty"`
-        AccessKey         string `form:"access_key,omitempty"`
-        SecretKey         string `form:"secret_key,omitempty"`
-        Path              string `form:"path,omitempty"`
-        Period            uint   `form:"period,omitempty"`
-        GzipLevel         uint   `form:"gzip_level,omitempty"`
-        Format            string `form:"format,omitempty"`
-        ResponseCondition string `form:"response_condition,omitempty"`
-        TimestampFormat   string `form:"timestamp_format,omitempty"`
+	NewName           string `form:"name,omitempty"`
+	BucketName        string `form:"bucket_name,omitempty"`
+	AccessKey         string `form:"access_key,omitempty"`
+	SecretKey         string `form:"secret_key,omitempty"`
+	Path              string `form:"path,omitempty"`
+	Period            uint   `form:"period,omitempty"`
+	GzipLevel         uint   `form:"gzip_level,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
+	TimestampFormat   string `form:"timestamp_format,omitempty"`
 }
 
 // UpdateS3 updates a specific S3.
 func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s3 *S3
-        if err := decodeJSON(&s3, resp.Body); err != nil {
-                return nil, err
-        }
-        return s3, nil
+	var s3 *S3
+	if err := decodeJSON(&s3, resp.Body); err != nil {
+		return nil, err
+	}
+	return s3, nil
 }
 
 // DeleteS3Input is the input parameter to DeleteS3.
 type DeleteS3Input struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the S3 to delete (required).
-        Name string
+	// Name is the name of the S3 to delete (required).
+	Name string
 }
 
 // DeleteS3 deletes the given S3 version.
 func (c *Client) DeleteS3(i *DeleteS3Input) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/service.go
+++ b/vendor/github.com/sethvargo/go-fastly/service.go
@@ -1,28 +1,31 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // Service represents a single service for the Fastly account.
 type Service struct {
-        ID            string     `mapstructure:"id"`
-        Name          string     `mapstructure:"name"`
-        Comment       string     `mapstructure:"comment"`
-        CustomerID    string     `mapstructure:"customer_id"`
-        ActiveVersion uint       `mapstructure:"version"`
-        Versions      []*Version `mapstructure:"versions"`
+	ID            string     `mapstructure:"id"`
+	Name          string     `mapstructure:"name"`
+	Comment       string     `mapstructure:"comment"`
+	CustomerID    string     `mapstructure:"customer_id"`
+	CreatedAt     string     `mapstructure:"created_at"`
+	UpdatedAt     string     `mapstructure:"updated_at"`
+	DeletedAt     string     `mapstructure:"deleted_at"`
+	ActiveVersion uint       `mapstructure:"version"`
+	Versions      []*Version `mapstructure:"versions"`
 }
 
 type ServiceDetail struct {
-        ID            string     `mapstructure:"id"`
-        Name          string     `mapstructure:"name"`
-        Comment       string     `mapstructure:"comment"`
-        CustomerID    string     `mapstructure:"customer_id"`
-        ActiveVersion Version    `mapstructure:"active_version"`
-        Version       Version    `mapstructure:"version"`
-        Versions      []*Version `mapstructure:"versions"`
+	ID            string     `mapstructure:"id"`
+	Name          string     `mapstructure:"name"`
+	Comment       string     `mapstructure:"comment"`
+	CustomerID    string     `mapstructure:"customer_id"`
+	ActiveVersion Version    `mapstructure:"active_version"`
+	Version       Version    `mapstructure:"version"`
+	Versions      []*Version `mapstructure:"versions"`
 }
 
 // servicesByName is a sortable list of services.
@@ -32,7 +35,7 @@ type servicesByName []*Service
 func (s servicesByName) Len() int      { return len(s) }
 func (s servicesByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s servicesByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListServicesInput is used as input to the ListServices function.
@@ -40,166 +43,166 @@ type ListServicesInput struct{}
 
 // ListServices returns the full list of services for the current account.
 func (c *Client) ListServices(i *ListServicesInput) ([]*Service, error) {
-        resp, err := c.Get("/service", nil)
-        if err != nil {
-                return nil, err
-        }
+	resp, err := c.Get("/service", nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s []*Service
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(servicesByName(s))
-        return s, nil
+	var s []*Service
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(servicesByName(s))
+	return s, nil
 }
 
 // CreateServiceInput is used as input to the CreateService function.
 type CreateServiceInput struct {
-        Name    string `form:"name,omitempty"`
-        Comment string `form:"comment,omitempty"`
+	Name    string `form:"name,omitempty"`
+	Comment string `form:"comment,omitempty"`
 }
 
 // CreateService creates a new service with the given information.
 func (c *Client) CreateService(i *CreateServiceInput) (*Service, error) {
-        resp, err := c.PostForm("/service", i, nil)
-        if err != nil {
-                return nil, err
-        }
+	resp, err := c.PostForm("/service", i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Service
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Service
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // GetServiceInput is used as input to the GetService function.
 type GetServiceInput struct {
-        ID string
+	ID string
 }
 
 // GetService retrieves the service information for the service with the given
 // id. If no service exists for the given id, the API returns a 400 response
 // (not a 404).
 func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
-        if i.ID == "" {
-                return nil, ErrMissingID
-        }
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
 
-        path := fmt.Sprintf("/service/%s", i.ID)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s", i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Service
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
+	var s *Service
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
 
-        return s, nil
+	return s, nil
 }
 
 // GetService retrieves the details for the service with the given id. If no
 // service exists for the given id, the API returns a 400 response (not a 404).
 func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
-        if i.ID == "" {
-                return nil, ErrMissingID
-        }
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
 
-        path := fmt.Sprintf("/service/%s/details", i.ID)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/details", i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *ServiceDetail
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
+	var s *ServiceDetail
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
 
-        return s, nil
+	return s, nil
 }
 
 // UpdateServiceInput is used as input to the UpdateService function.
 type UpdateServiceInput struct {
-        ID string
+	ID string
 
-        Name    string `form:"name,omitempty"`
-        Comment string `form:"comment,omitempty"`
+	Name    string `form:"name,omitempty"`
+	Comment string `form:"comment,omitempty"`
 }
 
 // UpdateService updates the service with the given input.
 func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
-        if i.ID == "" {
-                return nil, ErrMissingID
-        }
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
 
-        path := fmt.Sprintf("/service/%s", i.ID)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s", i.ID)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Service
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Service
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // DeleteServiceInput is used as input to the DeleteService function.
 type DeleteServiceInput struct {
-        ID string
+	ID string
 }
 
 // DeleteService updates the service with the given input.
 func (c *Client) DeleteService(i *DeleteServiceInput) error {
-        if i.ID == "" {
-                return ErrMissingID
-        }
+	if i.ID == "" {
+		return ErrMissingID
+	}
 
-        path := fmt.Sprintf("/service/%s", i.ID)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s", i.ID)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }
 
 // SearchServiceInput is used as input to the SearchService function.
 type SearchServiceInput struct {
-        Name string
+	Name string
 }
 
 // SearchService gets a specific service by name. If no service exists by that
 // name, the API returns a 400 response (not a 404).
 func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        resp, err := c.Get("/service/search", &RequestOptions{
-                Params: map[string]string{
-                        "name": i.Name,
-                },
-        })
-        if err != nil {
-                return nil, err
-        }
+	resp, err := c.Get("/service/search", &RequestOptions{
+		Params: map[string]string{
+			"name": i.Name,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Service
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
+	var s *Service
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
 
-        return s, nil
+	return s, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/settings.go
+++ b/vendor/github.com/sethvargo/go-fastly/settings.go
@@ -4,74 +4,74 @@ import "fmt"
 
 // Settings represents a backend response from the Fastly API.
 type Settings struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        DefaultTTL  uint   `mapstructure:"general.default_ttl"`
-        DefaultHost string `mapstructure:"general.default_host"`
+	DefaultTTL  uint   `mapstructure:"general.default_ttl"`
+	DefaultHost string `mapstructure:"general.default_host"`
 }
 
 // GetSettingsInput is used as input to the GetSettings function.
 type GetSettingsInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // GetSettings gets the backend configuration with the given parameters.
 func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Settings
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Settings
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateSettingsInput is used as input to the UpdateSettings function.
 type UpdateSettingsInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        DefaultTTL  uint   `form:"general.default_ttl,omitempty"`
-        DefaultHost string `form:"general.default_host,omitempty"`
+	DefaultTTL  uint   `form:"general.default_ttl,omitempty"`
+	DefaultHost string `form:"general.default_host,omitempty"`
 }
 
 // UpdateSettings updates a specific backend.
 func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Settings
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Settings
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/sumologic.go
+++ b/vendor/github.com/sethvargo/go-fastly/sumologic.go
@@ -1,24 +1,24 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
-        "time"
+	"fmt"
+	"sort"
+	"time"
 )
 
 // Sumologic represents a sumologic response from the Fastly API.
 type Sumologic struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name              string     `mapstructure:"name"`
-        Address           string     `mapstructure:"address"`
-        URL               string     `mapstructure:"url"`
-        Format            string     `mapstructure:"format"`
-        ResponseCondition string     `mapstructure:"response_condition"`
-        CreatedAt         *time.Time `mapstructure:"created_at"`
-        UpdatedAt         *time.Time `mapstructure:"updated_at"`
-        DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Name              string     `mapstructure:"name"`
+	Address           string     `mapstructure:"address"`
+	URL               string     `mapstructure:"url"`
+	Format            string     `mapstructure:"format"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
 }
 
 // sumologicsByName is a sortable list of sumologics.
@@ -28,198 +28,198 @@ type sumologicsByName []*Sumologic
 func (s sumologicsByName) Len() int      { return len(s) }
 func (s sumologicsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s sumologicsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListSumologicsInput is used as input to the ListSumologics function.
 type ListSumologicsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListSumologics returns the list of sumologics for the configuration version.
 func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ss []*Sumologic
-        if err := decodeJSON(&ss, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(sumologicsByName(ss))
-        return ss, nil
+	var ss []*Sumologic
+	if err := decodeJSON(&ss, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(sumologicsByName(ss))
+	return ss, nil
 }
 
 // CreateSumologicInput is used as input to the CreateSumologic function.
 type CreateSumologicInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name              string `form:"name,omitempty"`
-        Address           string `form:"address,omitempty"`
-        URL               string `form:"url,omitempty"`
-        Format            string `form:"format,omitempty"`
-        ResponseCondition string `form:"response_condition,omitempty"`
+	Name              string `form:"name,omitempty"`
+	Address           string `form:"address,omitempty"`
+	URL               string `form:"url,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
 }
 
 // CreateSumologic creates a new Fastly sumologic.
 func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Sumologic
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Sumologic
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // GetSumologicInput is used as input to the GetSumologic function.
 type GetSumologicInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the sumologic to fetch.
-        Name string
+	// Name is the name of the sumologic to fetch.
+	Name string
 }
 
 // GetSumologic gets the sumologic configuration with the given parameters.
 func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Sumologic
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Sumologic
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // UpdateSumologicInput is used as input to the UpdateSumologic function.
 type UpdateSumologicInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the sumologic to update.
-        Name string
+	// Name is the name of the sumologic to update.
+	Name string
 
-        NewName           string `form:"name,omitempty"`
-        Address           string `form:"address,omitempty"`
-        URL               string `form:"url,omitempty"`
-        Format            string `form:"format,omitempty"`
-        ResponseCondition string `form:"response_condition,omitempty"`
+	NewName           string `form:"name,omitempty"`
+	Address           string `form:"address,omitempty"`
+	URL               string `form:"url,omitempty"`
+	Format            string `form:"format,omitempty"`
+	ResponseCondition string `form:"response_condition,omitempty"`
 }
 
 // UpdateSumologic updates a specific sumologic.
 func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Sumologic
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Sumologic
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // DeleteSumologicInput is the input parameter to DeleteSumologic.
 type DeleteSumologicInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the sumologic to delete (required).
-        Name string
+	// Name is the name of the sumologic to delete (required).
+	Name string
 }
 
 // DeleteSumologic deletes the given sumologic version.
 func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/syslog.go
+++ b/vendor/github.com/sethvargo/go-fastly/syslog.go
@@ -1,27 +1,27 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
-        "time"
+	"fmt"
+	"sort"
+	"time"
 )
 
 // Syslog represents a syslog response from the Fastly API.
 type Syslog struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name              string     `mapstructure:"name"`
-        Address           string     `mapstructure:"address"`
-        Port              uint       `mapstructure:"port"`
-        UseTLS            bool       `mapstructure:"use_tls"`
-        TLSCACert         string     `mapstructure:"tls_ca_cert"`
-        Token             string     `mapstructure:"token"`
-        Format            string     `mapstructure:"format"`
-        ResponseCondition string     `mapstructure:"response_condition"`
-        CreatedAt         *time.Time `mapstructure:"created_at"`
-        UpdatedAt         *time.Time `mapstructure:"updated_at"`
-        DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Name              string     `mapstructure:"name"`
+	Address           string     `mapstructure:"address"`
+	Port              uint       `mapstructure:"port"`
+	UseTLS            bool       `mapstructure:"use_tls"`
+	TLSCACert         string     `mapstructure:"tls_ca_cert"`
+	Token             string     `mapstructure:"token"`
+	Format            string     `mapstructure:"format"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
 }
 
 // syslogsByName is a sortable list of syslogs.
@@ -31,204 +31,204 @@ type syslogsByName []*Syslog
 func (s syslogsByName) Len() int      { return len(s) }
 func (s syslogsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s syslogsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListSyslogsInput is used as input to the ListSyslogs function.
 type ListSyslogsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListSyslogs returns the list of syslogs for the configuration version.
 func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var ss []*Syslog
-        if err := decodeJSON(&ss, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(syslogsByName(ss))
-        return ss, nil
+	var ss []*Syslog
+	if err := decodeJSON(&ss, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(syslogsByName(ss))
+	return ss, nil
 }
 
 // CreateSyslogInput is used as input to the CreateSyslog function.
 type CreateSyslogInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name              string      `form:"name,omitempty"`
-        Address           string      `form:"address,omitempty"`
-        Port              uint        `form:"port,omitempty"`
-        UseTLS            Compatibool `form:"use_tls,omitempty"`
-        TLSCACert         string      `form:"tls_ca_cert,omitempty"`
-        Token             string      `form:"token,omitempty"`
-        Format            string      `form:"format,omitempty"`
-        ResponseCondition string      `form:"response_condition,omitempty"`
+	Name              string      `form:"name,omitempty"`
+	Address           string      `form:"address,omitempty"`
+	Port              uint        `form:"port,omitempty"`
+	UseTLS            Compatibool `form:"use_tls,omitempty"`
+	TLSCACert         string      `form:"tls_ca_cert,omitempty"`
+	Token             string      `form:"token,omitempty"`
+	Format            string      `form:"format,omitempty"`
+	ResponseCondition string      `form:"response_condition,omitempty"`
 }
 
 // CreateSyslog creates a new Fastly syslog.
 func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Syslog
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Syslog
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // GetSyslogInput is used as input to the GetSyslog function.
 type GetSyslogInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the syslog to fetch.
-        Name string
+	// Name is the name of the syslog to fetch.
+	Name string
 }
 
 // GetSyslog gets the syslog configuration with the given parameters.
 func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Syslog
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Syslog
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // UpdateSyslogInput is used as input to the UpdateSyslog function.
 type UpdateSyslogInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the syslog to update.
-        Name string
+	// Name is the name of the syslog to update.
+	Name string
 
-        NewName           string      `form:"name,omitempty"`
-        Address           string      `form:"address,omitempty"`
-        Port              uint        `form:"port,omitempty"`
-        UseTLS            Compatibool `form:"use_tls,omitempty"`
-        TLSCACert         string      `form:"tls_ca_cert,omitempty"`
-        Token             string      `form:"token,omitempty"`
-        Format            string      `form:"format,omitempty"`
-        ResponseCondition string      `form:"response_condition,omitempty"`
+	NewName           string      `form:"name,omitempty"`
+	Address           string      `form:"address,omitempty"`
+	Port              uint        `form:"port,omitempty"`
+	UseTLS            Compatibool `form:"use_tls,omitempty"`
+	TLSCACert         string      `form:"tls_ca_cert,omitempty"`
+	Token             string      `form:"token,omitempty"`
+	Format            string      `form:"format,omitempty"`
+	ResponseCondition string      `form:"response_condition,omitempty"`
 }
 
 // UpdateSyslog updates a specific syslog.
 func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var s *Syslog
-        if err := decodeJSON(&s, resp.Body); err != nil {
-                return nil, err
-        }
-        return s, nil
+	var s *Syslog
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // DeleteSyslogInput is the input parameter to DeleteSyslog.
 type DeleteSyslogInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the syslog to delete (required).
-        Name string
+	// Name is the name of the syslog to delete (required).
+	Name string
 }
 
 // DeleteSyslog deletes the given syslog version.
 func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/vcl.go
+++ b/vendor/github.com/sethvargo/go-fastly/vcl.go
@@ -1,18 +1,18 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // VCL represents a response about VCL from the Fastly API.
 type VCL struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name    string `mapstructure:"name"`
-        Main    bool   `mapstructure:"main"`
-        Content string `mapstructure:"content"`
+	Name    string `mapstructure:"name"`
+	Main    bool   `mapstructure:"main"`
+	Content string `mapstructure:"content"`
 }
 
 // vclsByName is a sortable list of VCLs.
@@ -22,261 +22,261 @@ type vclsByName []*VCL
 func (s vclsByName) Len() int      { return len(s) }
 func (s vclsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s vclsByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListVCLsInput is used as input to the ListVCLs function.
 type ListVCLsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the specific configuration version (required).
-        Version string
+	// Version is the specific configuration version (required).
+	Version string
 }
 
 // ListVCLs returns the list of VCLs for the configuration version.
 func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var vcls []*VCL
-        if err := decodeJSON(&vcls, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(vclsByName(vcls))
-        return vcls, nil
+	var vcls []*VCL
+	if err := decodeJSON(&vcls, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(vclsByName(vcls))
+	return vcls, nil
 }
 
 // GetVCLInput is used as input to the GetVCL function.
 type GetVCLInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the VCL to fetch.
-        Name string
+	// Name is the name of the VCL to fetch.
+	Name string
 }
 
 // GetVCL gets the VCL configuration with the given parameters.
 func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var vcl *VCL
-        if err := decodeJSON(&vcl, resp.Body); err != nil {
-                return nil, err
-        }
-        return vcl, nil
+	var vcl *VCL
+	if err := decodeJSON(&vcl, resp.Body); err != nil {
+		return nil, err
+	}
+	return vcl, nil
 }
 
 // GetGeneratedVCLInput is used as input to the GetGeneratedVCL function.
 type GetGeneratedVCLInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // GetGeneratedVCL gets the VCL configuration with the given parameters.
 func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/generated_vcl", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/generated_vcl", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var vcl *VCL
-        if err := decodeJSON(&vcl, resp.Body); err != nil {
-                return nil, err
-        }
-        return vcl, nil
+	var vcl *VCL
+	if err := decodeJSON(&vcl, resp.Body); err != nil {
+		return nil, err
+	}
+	return vcl, nil
 }
 
 // CreateVCLInput is used as input to the CreateVCL function.
 type CreateVCLInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name    string `form:"name,omitempty"`
-        Content string `form:"content,omitempty"`
+	Name    string `form:"name,omitempty"`
+	Content string `form:"content,omitempty"`
 }
 
 // CreateVCL creates a new Fastly VCL.
 func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var vcl *VCL
-        if err := decodeJSON(&vcl, resp.Body); err != nil {
-                return nil, err
-        }
-        return vcl, nil
+	var vcl *VCL
+	if err := decodeJSON(&vcl, resp.Body); err != nil {
+		return nil, err
+	}
+	return vcl, nil
 }
 
 // UpdateVCLInput is used as input to the UpdateVCL function.
 type UpdateVCLInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the VCL to update (required).
-        Name string
+	// Name is the name of the VCL to update (required).
+	Name string
 
-        NewName string `form:"name,omitempty"`
-        Content string `form:"content,omitempty"`
+	NewName string `form:"name,omitempty"`
+	Content string `form:"content,omitempty"`
 }
 
 // UpdateVCL creates a new Fastly VCL.
 func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var vcl *VCL
-        if err := decodeJSON(&vcl, resp.Body); err != nil {
-                return nil, err
-        }
-        return vcl, nil
+	var vcl *VCL
+	if err := decodeJSON(&vcl, resp.Body); err != nil {
+		return nil, err
+	}
+	return vcl, nil
 }
 
 // ActivateVCLInput is used as input to the ActivateVCL function.
 type ActivateVCLInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the VCL to mark as main (required).
-        Name string
+	// Name is the name of the VCL to mark as main (required).
+	Name string
 }
 
 // ActivateVCL creates a new Fastly VCL.
 func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/vcl/%s/main", i.Service, i.Version, i.Name)
-        resp, err := c.Put(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s/main", i.Service, i.Version, i.Name)
+	resp, err := c.Put(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var vcl *VCL
-        if err := decodeJSON(&vcl, resp.Body); err != nil {
-                return nil, err
-        }
-        return vcl, nil
+	var vcl *VCL
+	if err := decodeJSON(&vcl, resp.Body); err != nil {
+		return nil, err
+	}
+	return vcl, nil
 }
 
 // DeleteVCLInput is the input parameter to DeleteVCL.
 type DeleteVCLInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the VCL to delete (required).
-        Name string
+	// Name is the name of the VCL to delete (required).
+	Name string
 }
 
 // DeleteVCL deletes the given VCL version.
 func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/version.go
+++ b/vendor/github.com/sethvargo/go-fastly/version.go
@@ -1,20 +1,20 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // Version represents a distinct configuration version.
 type Version struct {
-        Number    string     `mapstructure:"number"`
-        Comment   string     `mapstructure:"comment"`
-        ServiceID string     `mapstructure:"service_id"`
-        Active    bool       `mapstructure:"active"`
-        Locked    bool       `mapstructure:"locked"`
-        Deployed  bool       `mapstructure:"deployed"`
-        Staging   bool       `mapstructure:"staging"`
-        Testing   bool       `mapstructure:"testing"`
+	Number    string     `mapstructure:"number"`
+	Comment   string     `mapstructure:"comment"`
+	ServiceID string     `mapstructure:"service_id"`
+	Active    bool       `mapstructure:"active"`
+	Locked    bool       `mapstructure:"locked"`
+	Deployed  bool       `mapstructure:"deployed"`
+	Staging   bool       `mapstructure:"staging"`
+	Testing   bool       `mapstructure:"testing"`
 }
 
 // versionsByNumber is a sortable list of versions. This is used by the version
@@ -25,65 +25,65 @@ type versionsByNumber []*Version
 func (s versionsByNumber) Len() int      { return len(s) }
 func (s versionsByNumber) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s versionsByNumber) Less(i, j int) bool {
-        return s[i].Number < s[j].Number
+	return s[i].Number < s[j].Number
 }
 
 // ListVersionsInput is the input to the ListVersions function.
 type ListVersionsInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 }
 
 // ListVersions returns the full list of all versions of the given service.
 func (c *Client) ListVersions(i *ListVersionsInput) ([]*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        path := fmt.Sprintf("/service/%s/version", i.Service)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version", i.Service)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e []*Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Sort(versionsByNumber(e))
+	var e []*Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Sort(versionsByNumber(e))
 
-        return e, nil
+	return e, nil
 }
 
 // LatestVersionInput is the input to the LatestVersion function.
 type LatestVersionInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 }
 
 // LatestVersion fetches the latest version. If there are no versions, this
 // function will return nil (but not an error).
 func (c *Client) LatestVersion(i *LatestVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        list, err := c.ListVersions(&ListVersionsInput{Service: i.Service})
-        if err != nil {
-                return nil, err
-        }
-        if len(list) < 1 {
-                return nil, nil
-        }
+	list, err := c.ListVersions(&ListVersionsInput{Service: i.Service})
+	if err != nil {
+		return nil, err
+	}
+	if len(list) < 1 {
+		return nil, nil
+	}
 
-        e := list[len(list)-1]
-        return e, nil
+	e := list[len(list)-1]
+	return e, nil
 }
 
 // CreateVersionInput is the input to the CreateVersion function.
 type CreateVersionInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 }
 
 // CreateVersion constructs a new version. There are no request parameters, but
@@ -91,245 +91,245 @@ type CreateVersionInput struct {
 // preferred in almost all scenarios, since `Create()` creates a _blank_
 // configuration where `Clone()` builds off of an existing configuration.
 func (c *Client) CreateVersion(i *CreateVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        path := fmt.Sprintf("/service/%s/version", i.Service)
-        resp, err := c.Post(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version", i.Service)
+	resp, err := c.Post(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e *Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e *Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }
 
 // GetVersionInput is the input to the GetVersion function.
 type GetVersionInput struct {
-        // Service is the ID of the service (required).
-        Service string
+	// Service is the ID of the service (required).
+	Service string
 
-        // Version is the version number to fetch (required).
-        Version string
+	// Version is the version number to fetch (required).
+	Version string
 }
 
 // GetVersion fetches a version with the given information.
 func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e *Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e *Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }
 
 // UpdateVersionInput is the input to the UpdateVersion function.
 type UpdateVersionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Comment string `form:"comment,omitempty"`
+	Comment string `form:"comment,omitempty"`
 }
 
 // UpdateVersion updates the given version
 func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e *Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e *Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }
 
 // ActivateVersionInput is the input to the ActivateVersion function.
 type ActivateVersionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // ActivateVersion activates the given version.
 func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/activate", i.Service, i.Version)
-        resp, err := c.Put(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/activate", i.Service, i.Version)
+	resp, err := c.Put(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e *Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e *Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }
 
 // DeactivateVersionInput is the input to the DeactivateVersion function.
 type DeactivateVersionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // DeactivateVersion deactivates the given version.
 func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/deactivate", i.Service, i.Version)
-        resp, err := c.Put(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/deactivate", i.Service, i.Version)
+	resp, err := c.Put(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e *Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e *Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }
 
 // CloneVersionInput is the input to the CloneVersion function.
 type CloneVersionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // CloneVersion creates a clone of the version with and returns a new
 // configuration version with all the same configuration options, but an
 // incremented number.
 func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/clone", i.Service, i.Version)
-        resp, err := c.Put(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/clone", i.Service, i.Version)
+	resp, err := c.Put(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e *Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e *Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }
 
 // ValidateVersionInput is the input to the ValidateVersion function.
 type ValidateVersionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // ValidateVersion validates if the given version is okay.
 func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) {
-        var msg string
+	var msg string
 
-        if i.Service == "" {
-                return false, msg, ErrMissingService
-        }
+	if i.Service == "" {
+		return false, msg, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return false, msg, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return false, msg, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/validate", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return false, msg, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/validate", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return false, msg, err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return false, msg, err
-        }
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return false, msg, err
+	}
 
-        msg = r.Msg
-        return r.Ok(), msg, nil
+	msg = r.Msg
+	return r.Ok(), msg, nil
 }
 
 // LockVersionInput is the input to the LockVersion function.
 type LockVersionInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // LockVersion locks the specified version.
 func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/lock", i.Service, i.Version)
-        resp, err := c.Put(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/lock", i.Service, i.Version)
+	resp, err := c.Put(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var e *Version
-        if err := decodeJSON(&e, resp.Body); err != nil {
-                return nil, err
-        }
-        return e, nil
+	var e *Version
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/wordpress.go
+++ b/vendor/github.com/sethvargo/go-fastly/wordpress.go
@@ -1,18 +1,18 @@
 package fastly
 
 import (
-        "fmt"
-        "sort"
+	"fmt"
+	"sort"
 )
 
 // Wordpress represents a wordpress response from the Fastly API.
 type Wordpress struct {
-        ServiceID string `mapstructure:"service_id"`
-        Version   string `mapstructure:"version"`
+	ServiceID string `mapstructure:"service_id"`
+	Version   string `mapstructure:"version"`
 
-        Name    string `mapstructure:"name"`
-        Path    string `mapstructure:"path"`
-        Comment string `mapstructure:"comment"`
+	Name    string `mapstructure:"name"`
+	Path    string `mapstructure:"path"`
+	Comment string `mapstructure:"comment"`
 }
 
 // wordpressesByName is a sortable list of wordpresses.
@@ -22,193 +22,193 @@ type wordpressesByName []*Wordpress
 func (s wordpressesByName) Len() int      { return len(s) }
 func (s wordpressesByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s wordpressesByName) Less(i, j int) bool {
-        return s[i].Name < s[j].Name
+	return s[i].Name < s[j].Name
 }
 
 // ListWordpressesInput is used as input to the ListWordpresses function.
 type ListWordpressesInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 }
 
 // ListWordpresses returns the list of wordpresses for the configuration version.
 func (c *Client) ListWordpresses(i *ListWordpressesInput) ([]*Wordpress, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var bs []*Wordpress
-        if err := decodeJSON(&bs, resp.Body); err != nil {
-                return nil, err
-        }
-        sort.Stable(wordpressesByName(bs))
-        return bs, nil
+	var bs []*Wordpress
+	if err := decodeJSON(&bs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(wordpressesByName(bs))
+	return bs, nil
 }
 
 // CreateWordpressInput is used as input to the CreateWordpress function.
 type CreateWordpressInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        Name    string `form:"name,omitempty"`
-        Path    string `form:"path,omitempty"`
-        Comment string `form:"comment,omitempty"`
+	Name    string `form:"name,omitempty"`
+	Path    string `form:"path,omitempty"`
+	Comment string `form:"comment,omitempty"`
 }
 
 // CreateWordpress creates a new Fastly wordpress.
 func (c *Client) CreateWordpress(i *CreateWordpressInput) (*Wordpress, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
-        resp, err := c.PostForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Wordpress
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Wordpress
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetWordpressInput is used as input to the GetWordpress function.
 type GetWordpressInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the wordpress to fetch.
-        Name string
+	// Name is the name of the wordpress to fetch.
+	Name string
 }
 
 // GetWordpress gets the wordpress configuration with the given parameters.
 func (c *Client) GetWordpress(i *GetWordpressInput) (*Wordpress, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Get(path, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Wordpress
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Wordpress
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // UpdateWordpressInput is used as input to the UpdateWordpress function.
 type UpdateWordpressInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the wordpress to update.
-        Name string
+	// Name is the name of the wordpress to update.
+	Name string
 
-        NewName string `form:"name,omitempty"`
-        Path    string `form:"path,omitempty"`
-        Comment string `form:"comment,omitempty"`
+	NewName string `form:"name,omitempty"`
+	Path    string `form:"path,omitempty"`
+	Comment string `form:"comment,omitempty"`
 }
 
 // UpdateWordpress updates a specific wordpress.
 func (c *Client) UpdateWordpress(i *UpdateWordpressInput) (*Wordpress, error) {
-        if i.Service == "" {
-                return nil, ErrMissingService
-        }
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
 
-        if i.Version == "" {
-                return nil, ErrMissingVersion
-        }
+	if i.Version == "" {
+		return nil, ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return nil, ErrMissingName
-        }
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
-        resp, err := c.PutForm(path, i, nil)
-        if err != nil {
-                return nil, err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
 
-        var b *Wordpress
-        if err := decodeJSON(&b, resp.Body); err != nil {
-                return nil, err
-        }
-        return b, nil
+	var b *Wordpress
+	if err := decodeJSON(&b, resp.Body); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // DeleteWordpressInput is the input parameter to DeleteWordpress.
 type DeleteWordpressInput struct {
-        // Service is the ID of the service. Version is the specific configuration
-        // version. Both fields are required.
-        Service string
-        Version string
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version string
 
-        // Name is the name of the wordpress to delete (required).
-        Name string
+	// Name is the name of the wordpress to delete (required).
+	Name string
 }
 
 // DeleteWordpress deletes the given wordpress version.
 func (c *Client) DeleteWordpress(i *DeleteWordpressInput) error {
-        if i.Service == "" {
-                return ErrMissingService
-        }
+	if i.Service == "" {
+		return ErrMissingService
+	}
 
-        if i.Version == "" {
-                return ErrMissingVersion
-        }
+	if i.Version == "" {
+		return ErrMissingVersion
+	}
 
-        if i.Name == "" {
-                return ErrMissingName
-        }
+	if i.Name == "" {
+		return ErrMissingName
+	}
 
-        path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
-        resp, err := c.Delete(path, nil)
-        if err != nil {
-                return err
-        }
+	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
 
-        var r *statusResp
-        if err := decodeJSON(&r, resp.Body); err != nil {
-                return err
-        }
-        if !r.Ok() {
-                return fmt.Errorf("Not Ok")
-        }
-        return nil
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
 }

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -64,6 +64,12 @@ resource "fastly_service_v1" "demo" {
     name        = "remove x-amz-request-id"
   }
 
+  gzip {
+    name          = "file extensions and content types"
+    extensions    = ["css", "js"]
+    content_types = ["text/html", "text/css"]
+  }
+
   default_host = "${aws_s3_bucket.website.name}.s3-website-us-west-2.amazonaws.com"
 
   force_destroy = true
@@ -94,6 +100,8 @@ The following arguments are supported:
 Service. Defined below.
 * `backend` - (Required) A set of Backends to service requests from your Domains.
 Defined below.
+* `gzip` - (Required) A set of gzip rules to control automatic gzipping of
+content. Defined below.
 * `header` - (Optional) A set of Headers to manipulate for each request. Defined
 below.
 * `default_host` - (Optional) The default hostname
@@ -125,6 +133,15 @@ Default `200`
 * `ssl_check_cert` - (Optional) Be strict on checking SSL certs. Default `true`
 * `weight` - (Optional) How long to wait for the first bytes in milliseconds.
 Default `100`
+
+The `gzip` block supports:
+
+* `name` - (Required) A unique name
+* `content_types` - (Optional) content-type for each type of content you wish to 
+have dynamically gzipped. Ex: `["text/html", "text/css"]`
+* `extensions` - (Optional) File extensions for each file type to dynamically 
+gzip. Ex: `["css", "js"]`
+
 
 The `Header` block supports adding, removing, or modifying Request and Response
 headers. See Fastly's documentation on 


### PR DESCRIPTION
Provides new attribute `gzip`, a set of gzip rules to apply to file types or extensions, or both. 

I've opened a support case with Fastly regarding their handling of empty `extensions` and `content_types` parameters. Right now, if you send only one, the other will come back with a set of default values. Ex, sending just extension `css` will return a rule with just the `css` extension, but a default list of `content_types`... 

For now we work around this while I wait to hear what they say about that, e.g. is it a bug that will be fixed or just how things work, and we can work around that when we hear back.