### PR TITLE
provider/triton: fixed triton key_material documentation

### DIFF
--- a/website/source/docs/providers/triton/index.html.markdown
+++ b/website/source/docs/providers/triton/index.html.markdown
@@ -30,6 +30,6 @@ provider "triton" {
 The following arguments are supported in the `provider` block:
 
 * `account` - (Required) This is the name of the Triton account. It can also be provided via the `SDC_ACCOUNT` environment variable.
-* `key_material` - (Required) This is the path to the private key of an SSH key associated with the Triton account to be used.
+* `key_material` - (Required) This is the private key of an SSH key associated with the Triton account to be used.
 * `key_id` - (Required) This is the fingerprint of the public key matching the key specified in `key_path`. It can be obtained via the command `ssh-keygen -l -E md5 -f /path/to/key`
 * `url` - (Optional) This is the URL to the Triton API endpoint. It is required if using a private installation of Triton. The default is to use the Joyent public cloud.


### PR DESCRIPTION
Completely fixes #6211 

[d72bb52](https://github.com/hashicorp/terraform/commit/d72bb52ad4d70908378a5da0dc7d945a9d0c8a88) partially fixed the ticket but missed the explanation for key_material. 