### PR TITLE
provider/fastly: fix the description for "weight" on fastly_service_v1.

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -147,7 +147,7 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     100,
-							Description: "How long to wait for the first bytes in milliseconds",
+							Description: "The portion of traffic to send to a specific origins. Each origin receives weight/total of the traffic.",
 						},
 					},
 				},

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -123,8 +123,7 @@ Default `1000`
 Default `200`
 * `port` - (Optional) The port number Backend responds on. Default `80`
 * `ssl_check_cert` - (Optional) Be strict on checking SSL certs. Default `true`
-* `weight` - (Optional) How long to wait for the first bytes in milliseconds.
-Default `100`
+* `weight` - (Optional) The [portion of traffic](https://docs.fastly.com/guides/performance-tuning/load-balancing-configuration.html#how-weight-affects-load-balancing) to send to this Backend. Each Backend receives `weight / total` of the traffic. Default `100`
 
 The `Header` block supports adding, removing, or modifying Request and Response
 headers. See Fastly's documentation on 


### PR DESCRIPTION
This description is essentially copied from the Fastly dashboard.