### PR TITLE
provider/openstack: Fix admin_state_up on openstack_lb_member_v1

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_member_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_member_v1.go
@@ -75,7 +75,7 @@ func resourceLBMemberV1Create(d *schema.ResourceData, meta interface{}) error {
 		ProtocolPort: d.Get("port").(int),
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] OpenStack LB Member Create Options: %#v", createOpts)
 	m, err := members.Create(networkingClient, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack LB member: %s", err)
@@ -86,7 +86,7 @@ func resourceLBMemberV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
-		Target:     []string{"ACTIVE"},
+		Target:     []string{"ACTIVE", "INACTIVE"},
 		Refresh:    waitForLBMemberActive(networkingClient, m.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,
@@ -99,6 +99,17 @@ func resourceLBMemberV1Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(m.ID)
+
+	// Due to the way Gophercloud is currently set up, AdminStateUp must be set post-create
+	updateOpts := members.UpdateOpts{
+		AdminStateUp: d.Get("admin_state_up").(bool),
+	}
+
+	log.Printf("[DEBUG] OpenStack LB Member Update Options: %#v", createOpts)
+	m, err = members.Update(networkingClient, m.ID, updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating OpenStack LB member: %s", err)
+	}
 
 	return resourceLBMemberV1Read(d, meta)
 }

--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1_test.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1_test.go
@@ -237,19 +237,21 @@ var testAccLBV1Pool_fullstack = fmt.Sprintf(`
 		pool_id = "${openstack_lb_pool_v1.pool_1.id}"
 		address = "${openstack_compute_instance_v2.instance_1.access_ip_v4}"
 		port = 80
+		admin_state_up = true
 	}
 
 	resource "openstack_lb_member_v1" "member_2" {
 		pool_id = "${openstack_lb_pool_v1.pool_1.id}"
 		address = "${openstack_compute_instance_v2.instance_2.access_ip_v4}"
 		port = 80
+		admin_state_up = true
 	}
 
 	resource "openstack_lb_vip_v1" "vip_1" {
-                name = "vip_1"
-                subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
-                protocol = "TCP"
-                port = 80
-                pool_id = "${openstack_lb_pool_v1.pool_1.id}"
-                admin_state_up = true
+		name = "vip_1"
+		subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+		protocol = "TCP"
+		port = 80
+		pool_id = "${openstack_lb_pool_v1.pool_1.id}"
+		admin_state_up = true
 	}`)


### PR DESCRIPTION
admin_state_up was never being passed to a load balancing member
during creation.

(Not sure how this passed acceptance testing the other day, but OpenStack Mitaka clearly pointed it out today)