### PR TITLE
provider/triton: Change the triton tests to run against joyent us-west-1

### DIFF
--- a/builtin/providers/triton/resource_machine_test.go
+++ b/builtin/providers/triton/resource_machine_test.go
@@ -117,8 +117,8 @@ func TestAccTritonMachine_firewall(t *testing.T) {
 
 func TestAccTritonMachine_metadata(t *testing.T) {
 	machineName := fmt.Sprintf("acctest-%d", acctest.RandInt())
-	basic := fmt.Sprintf(testAccTritonMachine_basic, machineName)
-	add_metadata := fmt.Sprintf(testAccTritonMachine_basic, machineName)
+	basic := fmt.Sprintf(testAccTritonMachine_metadata_1, machineName)
+	add_metadata := fmt.Sprintf(testAccTritonMachine_metadata_1, machineName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -144,10 +144,14 @@ func TestAccTritonMachine_metadata(t *testing.T) {
 }
 
 var testAccTritonMachine_basic = `
+provider "triton" {
+  url = "https://us-west-1.api.joyentcloud.com"
+}
+
 resource "triton_machine" "test" {
   name = "%s"
-  package = "t4-standard-128M"
-  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+  package = "g3-standard-0.25-smartos"
+  image = "c20b4b7c-e1a6-11e5-9a4d-ef590901732e"
 
   tags = {
 	test = "hello!"
@@ -156,29 +160,41 @@ resource "triton_machine" "test" {
 `
 
 var testAccTritonMachine_firewall_0 = `
+provider "triton" {
+  url = "https://us-west-1.api.joyentcloud.com"
+}
+
 resource "triton_machine" "test" {
   name = "%s"
-  package = "t4-standard-128M"
-  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+  package = "g3-standard-0.25-smartos"
+  image = "c20b4b7c-e1a6-11e5-9a4d-ef590901732e"
 
 	firewall_enabled = 0
 }
 `
 var testAccTritonMachine_firewall_1 = `
+provider "triton" {
+  url = "https://us-west-1.api.joyentcloud.com"
+}
+
 resource "triton_machine" "test" {
   name = "%s"
-  package = "t4-standard-128M"
-  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+  package = "g3-standard-0.25-smartos"
+  image = "c20b4b7c-e1a6-11e5-9a4d-ef590901732e"
 
 	firewall_enabled = 1
 }
 `
 
 var testAccTritonMachine_metadata_1 = `
+provider "triton" {
+  url = "https://us-west-1.api.joyentcloud.com"
+}
+
 resource "triton_machine" "test" {
   name = "%s"
-  package = "t4-standard-128M"
-  image = "eb9fc1ea-e19a-11e5-bb27-8b954d8c125c"
+  package = "g3-standard-0.25-smartos"
+  image = "c20b4b7c-e1a6-11e5-9a4d-ef590901732e"
 
   user_data = "hello"
 


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/triton TESTARGS='-run=TestAccTritonMachine' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/triton -v -run=TestAccTritonMachine -timeout 120m
=== RUN   TestAccTritonMachine_basic
--- PASS: TestAccTritonMachine_basic (195.93s)
=== RUN   TestAccTritonMachine_firewall
--- PASS: TestAccTritonMachine_firewall (230.09s)
=== RUN   TestAccTritonMachine_metadata
--- PASS: TestAccTritonMachine_metadata (200.02s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/triton	624.370s
```