### PR TITLE
provider/openstack: Support client certificates

### DIFF
--- a/builtin/providers/openstack/config.go
+++ b/builtin/providers/openstack/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	Insecure         bool
 	EndpointType     string
 	CACertFile       string
+	ClientCertFile   string
+	ClientKeyFile    string
 
 	osClient *gophercloud.ProviderClient
 }
@@ -56,6 +58,7 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 
+	config := &tls.Config{}
 	if c.CACertFile != "" {
 
 		caCert, err := ioutil.ReadFile(c.CACertFile)
@@ -65,21 +68,23 @@ func (c *Config) loadAndValidate() error {
 
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
+		config.RootCAs = caCertPool
+	}
+	if c.Insecure {
+		config.InsecureSkipVerify = true
+	}
 
-		config := &tls.Config{
-			RootCAs: caCertPool,
+	if c.ClientCertFile != "" && c.ClientKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(c.ClientCertFile, c.ClientKeyFile)
+		if err != nil {
+			return err
 		}
 
-		transport := &http.Transport{TLSClientConfig: config}
-		client.HTTPClient.Transport = transport
+		config.Certificates = []tls.Certificate{cert}
+		config.BuildNameToCertificate()
 	}
-
-	if c.Insecure {
-		// Configure custom TLS settings.
-		config := &tls.Config{InsecureSkipVerify: true}
-		transport := &http.Transport{TLSClientConfig: config}
-		client.HTTPClient.Transport = transport
-	}
+	transport := &http.Transport{TLSClientConfig: config}
+	client.HTTPClient.Transport = transport
 
 	err = openstack.Authenticate(client, ao)
 	if err != nil {

--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -78,6 +78,16 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_CACERT", ""),
 			},
+			"cert": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_CERT", ""),
+			},
+			"key": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_KEY", ""),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -123,6 +133,8 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		Insecure:         d.Get("insecure").(bool),
 		EndpointType:     d.Get("endpoint_type").(string),
 		CACertFile:       d.Get("cacert_file").(string),
+		ClientCertFile:   d.Get("cert").(string),
+		ClientKeyFile:    d.Get("key").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/website/source/docs/providers/openstack/index.html.markdown
+++ b/website/source/docs/providers/openstack/index.html.markdown
@@ -76,6 +76,12 @@ The following arguments are supported:
 * `cacert_file` - (Optional) Specify a custom CA certificate when communicating
     over SSL. If omitted, the `OS_CACERT` environment variable is used.
 
+* `cert` - (Optional) Specify client certificate file for SSL client
+    authentication. If omitted the `OS_CERT` environment variable is used.
+
+* `key` - (Optional) Specify client private key file for SSL client
+    authentication. If omitted the `OS_KEY` environment variable is used.
+
 * `endpoint_type` - (Optional) Specify which type of endpoint to use from the
     service catalog. It can be set using the OS_ENDPOINT_TYPE environment
     variable. If not set, public endpoints is used.


### PR DESCRIPTION
Official OpenStack clients commonly[*] support specifying a client
certificate/key to enable SSL client authentication when communicating
with OpenStack services. This patch enables such feature in Terraform
with new parameters and environment variables:

* 'cert' provider parameter or OS_CERT env variable to specify client
   certificate file,
* 'key' provider parameter or OS_KEY env variable to specify client
   certificate private key file.

[*] keystoneclient, neutronclient, glanceclient, cinderclient, novaclient, heatclient support it; openstackclient, swiftclient support it but in trunk branch.
http://docs.openstack.org/releasenotes/python-openstackclient/unreleased.html

