### PR TITLE
adding a * catchall for var interpolation

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -472,9 +472,14 @@ func interpolationFuncLookup(vs map[string]ast.Variable) ast.Function {
 			k := fmt.Sprintf("var.%s.%s", args[0].(string), args[1].(string))
 			v, ok := vs[k]
 			if !ok {
-				return "", fmt.Errorf(
-					"lookup in '%s' failed to find '%s'",
-					args[0].(string), args[1].(string))
+				k = fmt.Sprintf("var.%s.*", args[0].(string))
+				v, ok = vs[k]
+				
+				if !ok {
+					return "", fmt.Errorf(
+						"lookup in '%s' failed to find '%s'",
+						args[0].(string), args[1].(string))
+				}
 			}
 			if v.Type != ast.TypeString {
 				return "", fmt.Errorf(

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -474,7 +474,7 @@ func interpolationFuncLookup(vs map[string]ast.Variable) ast.Function {
 			if !ok {
 				k = fmt.Sprintf("var.%s.*", args[0].(string))
 				v, ok = vs[k]
-				
+
 				if !ok {
 					return "", fmt.Errorf(
 						"lookup in '%s' failed to find '%s'",


### PR DESCRIPTION
This adds the following functionality for #2312

```
variable "instance_type" {
  default = {
    prod = "m4.xlarge"
    "*" = "m4.large"
  }
}
```

It allows a catch all. The `*` needs to be quotes since terraform thinks its an invalid character. 

I tried to edit the test but my knowledge of test writing in go is bad at best. This passes all my tests that I tried. 