### PR TITLE
Replace flatmaps with HIL-native maps

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -768,11 +768,11 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/hil",
-			"Rev": "0640fefa3817883b16b77bf760c4c3a6f2589545"
+			"Rev": "01dc167cd239b7ccab78a683b866536cd5904719"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/hil/ast",
-			"Rev": "0640fefa3817883b16b77bf760c4c3a6f2589545"
+			"Rev": "01dc167cd239b7ccab78a683b866536cd5904719"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/logutils",

--- a/builtin/providers/terraform/resource_state.go
+++ b/builtin/providers/terraform/resource_state.go
@@ -60,7 +60,7 @@ func resourceRemoteStateRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	var outputs map[string]string
+	var outputs map[string]interface{}
 	if !state.State().Empty() {
 		outputs = state.State().RootModule().Outputs
 	}

--- a/builtin/providers/tls/resource_cert_request_test.go
+++ b/builtin/providers/tls/resource_cert_request_test.go
@@ -50,7 +50,13 @@ EOT
                     }
                 `, testPrivateKey),
 				Check: func(s *terraform.State) error {
-					got := s.RootModule().Outputs["key_pem"]
+					gotUntyped := s.RootModule().Outputs["key_pem"]
+
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"key_pem\" is not a string")
+					}
+
 					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE REQUEST----") {
 						return fmt.Errorf("key is missing CSR PEM preamble")
 					}

--- a/builtin/providers/tls/resource_locally_signed_cert_test.go
+++ b/builtin/providers/tls/resource_locally_signed_cert_test.go
@@ -47,7 +47,11 @@ EOT
                     }
                 `, testCertRequest, testCACert, testCAPrivateKey),
 				Check: func(s *terraform.State) error {
-					got := s.RootModule().Outputs["cert_pem"]
+					gotUntyped := s.RootModule().Outputs["cert_pem"]
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"cert_pem\" is not a string")
+					}
 					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE----") {
 						return fmt.Errorf("key is missing cert PEM preamble")
 					}

--- a/builtin/providers/tls/resource_private_key_test.go
+++ b/builtin/providers/tls/resource_private_key_test.go
@@ -29,7 +29,12 @@ func TestPrivateKeyRSA(t *testing.T) {
                     }
                 `,
 				Check: func(s *terraform.State) error {
-					gotPrivate := s.RootModule().Outputs["private_key_pem"]
+					gotPrivateUntyped := s.RootModule().Outputs["private_key_pem"]
+					gotPrivate, ok := gotPrivateUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"private_key_pem\" is not a string")
+					}
+
 					if !strings.HasPrefix(gotPrivate, "-----BEGIN RSA PRIVATE KEY----") {
 						return fmt.Errorf("private key is missing RSA key PEM preamble")
 					}
@@ -37,12 +42,20 @@ func TestPrivateKeyRSA(t *testing.T) {
 						return fmt.Errorf("private key PEM looks too long for a 2048-bit key (got %v characters)", len(gotPrivate))
 					}
 
-					gotPublic := s.RootModule().Outputs["public_key_pem"]
+					gotPublicUntyped := s.RootModule().Outputs["public_key_pem"]
+					gotPublic, ok := gotPublicUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"public_key_pem\" is not a string")
+					}
 					if !strings.HasPrefix(gotPublic, "-----BEGIN PUBLIC KEY----") {
 						return fmt.Errorf("public key is missing public key PEM preamble")
 					}
 
-					gotPublicSSH := s.RootModule().Outputs["public_key_openssh"]
+					gotPublicSSHUntyped := s.RootModule().Outputs["public_key_openssh"]
+					gotPublicSSH, ok := gotPublicSSHUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"public_key_openssh\" is not a string")
+					}
 					if !strings.HasPrefix(gotPublicSSH, "ssh-rsa ") {
 						return fmt.Errorf("SSH public key is missing ssh-rsa prefix")
 					}
@@ -61,7 +74,11 @@ func TestPrivateKeyRSA(t *testing.T) {
                     }
                 `,
 				Check: func(s *terraform.State) error {
-					got := s.RootModule().Outputs["key_pem"]
+					gotUntyped := s.RootModule().Outputs["key_pem"]
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"key_pem\" is not a string")
+					}
 					if !strings.HasPrefix(got, "-----BEGIN RSA PRIVATE KEY----") {
 						return fmt.Errorf("key is missing RSA key PEM preamble")
 					}
@@ -95,12 +112,22 @@ func TestPrivateKeyECDSA(t *testing.T) {
                     }
                 `,
 				Check: func(s *terraform.State) error {
-					gotPrivate := s.RootModule().Outputs["private_key_pem"]
+					gotPrivateUntyped := s.RootModule().Outputs["private_key_pem"]
+					gotPrivate, ok := gotPrivateUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"private_key_pem\" is not a string")
+					}
+
 					if !strings.HasPrefix(gotPrivate, "-----BEGIN EC PRIVATE KEY----") {
 						return fmt.Errorf("Private key is missing EC key PEM preamble")
 					}
 
-					gotPublic := s.RootModule().Outputs["public_key_pem"]
+					gotPublicUntyped := s.RootModule().Outputs["public_key_pem"]
+					gotPublic, ok := gotPublicUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"public_key_pem\" is not a string")
+					}
+
 					if !strings.HasPrefix(gotPublic, "-----BEGIN PUBLIC KEY----") {
 						return fmt.Errorf("public key is missing public key PEM preamble")
 					}
@@ -130,17 +157,29 @@ func TestPrivateKeyECDSA(t *testing.T) {
                     }
                 `,
 				Check: func(s *terraform.State) error {
-					gotPrivate := s.RootModule().Outputs["private_key_pem"]
+					gotPrivateUntyped := s.RootModule().Outputs["private_key_pem"]
+					gotPrivate, ok := gotPrivateUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"private_key_pem\" is not a string")
+					}
 					if !strings.HasPrefix(gotPrivate, "-----BEGIN EC PRIVATE KEY----") {
 						return fmt.Errorf("Private key is missing EC key PEM preamble")
 					}
 
-					gotPublic := s.RootModule().Outputs["public_key_pem"]
+					gotPublicUntyped := s.RootModule().Outputs["public_key_pem"]
+					gotPublic, ok := gotPublicUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"public_key_pem\" is not a string")
+					}
 					if !strings.HasPrefix(gotPublic, "-----BEGIN PUBLIC KEY----") {
 						return fmt.Errorf("public key is missing public key PEM preamble")
 					}
 
-					gotPublicSSH := s.RootModule().Outputs["public_key_openssh"]
+					gotPublicSSHUntyped := s.RootModule().Outputs["public_key_openssh"]
+					gotPublicSSH, ok := gotPublicSSHUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"public_key_openssh\" is not a string")
+					}
 					if !strings.HasPrefix(gotPublicSSH, "ecdsa-sha2-nistp256 ") {
 						return fmt.Errorf("P256 SSH public key is missing ecdsa prefix")
 					}

--- a/builtin/providers/tls/resource_self_signed_cert_test.go
+++ b/builtin/providers/tls/resource_self_signed_cert_test.go
@@ -60,7 +60,12 @@ EOT
                     }
                 `, testPrivateKey),
 				Check: func(s *terraform.State) error {
-					got := s.RootModule().Outputs["key_pem"]
+					gotUntyped := s.RootModule().Outputs["key_pem"]
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"public_key_openssh\" is not a string")
+					}
+
 					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE----") {
 						return fmt.Errorf("key is missing cert PEM preamble")
 					}

--- a/command/output.go
+++ b/command/output.go
@@ -97,7 +97,13 @@ func (c *OutputCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(v)
+	switch output := v.(type) {
+	case string:
+		c.Ui.Output(output)
+	default:
+		panic(fmt.Errorf("Unknown output type: %T", output))
+	}
+
 	return 0
 }
 

--- a/command/output.go
+++ b/command/output.go
@@ -1,9 +1,11 @@
 package command
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -27,7 +29,7 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) > 1 {
+	if len(args) > 2 {
 		c.Ui.Error(
 			"The output command expects exactly one argument with the name\n" +
 				"of an output variable or no arguments to show all outputs.\n")
@@ -38,6 +40,11 @@ func (c *OutputCommand) Run(args []string) int {
 	name := ""
 	if len(args) > 0 {
 		name = args[0]
+	}
+
+	index := ""
+	if len(args) > 1 {
+		index = args[1]
 	}
 
 	stateStore, err := c.Meta.State()
@@ -74,16 +81,7 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if name == "" {
-		ks := make([]string, 0, len(mod.Outputs))
-		for k, _ := range mod.Outputs {
-			ks = append(ks, k)
-		}
-		sort.Strings(ks)
-
-		for _, k := range ks {
-			v := mod.Outputs[k]
-			c.Ui.Output(fmt.Sprintf("%s = %s", k, v))
-		}
+		c.Ui.Output(outputsAsString(state))
 		return 0
 	}
 
@@ -100,11 +98,96 @@ func (c *OutputCommand) Run(args []string) int {
 	switch output := v.(type) {
 	case string:
 		c.Ui.Output(output)
+		return 0
+	case []interface{}:
+		if index == "" {
+			c.Ui.Output(formatListOutput("", "", output))
+			break
+		}
+
+		indexInt, err := strconv.Atoi(index)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"The index %q requested is not valid for the list output\n"+
+					"%q - indices must be numeric, and in the range 0-%d", index, name,
+				len(output)-1))
+			break
+		}
+
+		if indexInt < 0 || indexInt >= len(output) {
+			c.Ui.Error(fmt.Sprintf(
+				"The index %d requested is not valid for the list output\n"+
+					"%q - indices must be in the range 0-%d", indexInt, name,
+				len(output)-1))
+			break
+		}
+
+		c.Ui.Output(fmt.Sprintf("%s", output[indexInt]))
+		return 0
+	case map[string]interface{}:
+		if index == "" {
+			c.Ui.Output(formatMapOutput("", "", output))
+			break
+		}
+
+		if value, ok := output[index]; ok {
+			c.Ui.Output(fmt.Sprintf("%s", value))
+			return 0
+		} else {
+			return 1
+		}
 	default:
 		panic(fmt.Errorf("Unknown output type: %T", output))
 	}
 
 	return 0
+}
+
+func formatListOutput(indent, outputName string, outputList []interface{}) string {
+	keyIndent := ""
+
+	outputBuf := new(bytes.Buffer)
+	if outputName != "" {
+		outputBuf.WriteString(fmt.Sprintf("%s%s = [", indent, outputName))
+		keyIndent = "  "
+	}
+
+	for _, value := range outputList {
+		outputBuf.WriteString(fmt.Sprintf("\n%s%s%s", indent, keyIndent, value))
+	}
+
+	if outputName != "" {
+		outputBuf.WriteString(fmt.Sprintf("\n%s]", indent))
+	}
+
+	return strings.TrimPrefix(outputBuf.String(), "\n")
+}
+
+func formatMapOutput(indent, outputName string, outputMap map[string]interface{}) string {
+	ks := make([]string, 0, len(outputMap))
+	for k, _ := range outputMap {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+
+	keyIndent := ""
+
+	outputBuf := new(bytes.Buffer)
+	if outputName != "" {
+		outputBuf.WriteString(fmt.Sprintf("%s%s = {", indent, outputName))
+		keyIndent = "  "
+	}
+
+	for _, k := range ks {
+		v := outputMap[k]
+		outputBuf.WriteString(fmt.Sprintf("\n%s%s%s = %v", indent, keyIndent, k, v))
+	}
+
+	if outputName != "" {
+		outputBuf.WriteString(fmt.Sprintf("\n%s}", indent))
+	}
+
+	return strings.TrimPrefix(outputBuf.String(), "\n")
 }
 
 func (c *OutputCommand) Help() string {

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -16,7 +16,7 @@ func TestOutput(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
@@ -52,13 +52,13 @@ func TestModuleOutput(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
 			&terraform.ModuleState{
 				Path: []string{"root", "my_module"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"blah": "tastatur",
 				},
 			},
@@ -96,7 +96,7 @@ func TestMissingModuleOutput(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
@@ -129,7 +129,7 @@ func TestOutput_badVar(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
@@ -160,7 +160,7 @@ func TestOutput_blank(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo":  "bar",
 					"name": "john-doe",
 				},
@@ -253,7 +253,7 @@ func TestOutput_noVars(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path:    []string{"root"},
-				Outputs: map[string]string{},
+				Outputs: map[string]interface{}{},
 			},
 		},
 	}
@@ -282,7 +282,7 @@ func TestOutput_stateDefault(t *testing.T) {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -455,43 +454,6 @@ func TestProviderConfigName(t *testing.T) {
 	n := ProviderConfigName("aws_instance", pcs)
 	if n != "aws" {
 		t.Fatalf("bad: %s", n)
-	}
-}
-
-func TestVariableDefaultsMap(t *testing.T) {
-	cases := []struct {
-		Default interface{}
-		Output  map[string]string
-	}{
-		{
-			nil,
-			nil,
-		},
-
-		{
-			"foo",
-			map[string]string{"var.foo": "foo"},
-		},
-
-		{
-			map[interface{}]interface{}{
-				"foo": "bar",
-				"bar": "baz",
-			},
-			map[string]string{
-				"var.foo":     "foo",
-				"var.foo.foo": "bar",
-				"var.foo.bar": "baz",
-			},
-		},
-	}
-
-	for i, tc := range cases {
-		v := &Variable{Name: "foo", Default: tc.Default}
-		actual := v.DefaultsMap()
-		if !reflect.DeepEqual(actual, tc.Output) {
-			t.Fatalf("%d: bad: %#v", i, actual)
-		}
 	}
 }
 

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -672,28 +672,33 @@ func TestInterpolateFuncSplit(t *testing.T) {
 func TestInterpolateFuncLookup(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Vars: map[string]ast.Variable{
-			"var.foo.bar": ast.Variable{
-				Value: "baz",
-				Type:  ast.TypeString,
+			"var.foo": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "baz",
+					},
+				},
 			},
 		},
 		Cases: []testFunctionCase{
 			{
-				`${lookup("foo", "bar")}`,
+				`${lookup(var.foo, "bar")}`,
 				"baz",
 				false,
 			},
 
 			// Invalid key
 			{
-				`${lookup("foo", "baz")}`,
+				`${lookup(var.foo, "baz")}`,
 				nil,
 				true,
 			},
 
 			// Too many args
 			{
-				`${lookup("foo", "bar", "baz")}`,
+				`${lookup(var.foo, "bar", "baz")}`,
 				nil,
 				true,
 			},
@@ -704,13 +709,18 @@ func TestInterpolateFuncLookup(t *testing.T) {
 func TestInterpolateFuncKeys(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Vars: map[string]ast.Variable{
-			"var.foo.bar": ast.Variable{
-				Value: "baz",
-				Type:  ast.TypeString,
-			},
-			"var.foo.qux": ast.Variable{
-				Value: "quack",
-				Type:  ast.TypeString,
+			"var.foo": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: "baz",
+						Type:  ast.TypeString,
+					},
+					"qux": ast.Variable{
+						Value: "quack",
+						Type:  ast.TypeString,
+					},
+				},
 			},
 			"var.str": ast.Variable{
 				Value: "astring",
@@ -719,28 +729,28 @@ func TestInterpolateFuncKeys(t *testing.T) {
 		},
 		Cases: []testFunctionCase{
 			{
-				`${keys("foo")}`,
-				NewStringList([]string{"bar", "qux"}).String(),
+				`${keys(var.foo)}`,
+				[]interface{}{"bar", "qux"},
 				false,
 			},
 
 			// Invalid key
 			{
-				`${keys("not")}`,
+				`${keys(var.not)}`,
 				nil,
 				true,
 			},
 
 			// Too many args
 			{
-				`${keys("foo", "bar")}`,
+				`${keys(var.foo, "bar")}`,
 				nil,
 				true,
 			},
 
 			// Not a map
 			{
-				`${keys("str")}`,
+				`${keys(var.str)}`,
 				nil,
 				true,
 			},
@@ -751,13 +761,18 @@ func TestInterpolateFuncKeys(t *testing.T) {
 func TestInterpolateFuncValues(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Vars: map[string]ast.Variable{
-			"var.foo.bar": ast.Variable{
-				Value: "quack",
-				Type:  ast.TypeString,
-			},
-			"var.foo.qux": ast.Variable{
-				Value: "baz",
-				Type:  ast.TypeString,
+			"var.foo": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: "quack",
+						Type:  ast.TypeString,
+					},
+					"qux": ast.Variable{
+						Value: "baz",
+						Type:  ast.TypeString,
+					},
+				},
 			},
 			"var.str": ast.Variable{
 				Value: "astring",
@@ -766,28 +781,28 @@ func TestInterpolateFuncValues(t *testing.T) {
 		},
 		Cases: []testFunctionCase{
 			{
-				`${values("foo")}`,
-				NewStringList([]string{"quack", "baz"}).String(),
+				`${values(var.foo)}`,
+				[]interface{}{"quack", "baz"},
 				false,
 			},
 
 			// Invalid key
 			{
-				`${values("not")}`,
+				`${values(var.not)}`,
 				nil,
 				true,
 			},
 
 			// Too many args
 			{
-				`${values("foo", "bar")}`,
+				`${values(var.foo, "bar")}`,
 				nil,
 				true,
 			},
 
 			// Not a map
 			{
-				`${values("str")}`,
+				`${values(var.str)}`,
 				nil,
 				true,
 			},

--- a/config/interpolate_walk.go
+++ b/config/interpolate_walk.go
@@ -42,7 +42,7 @@ type interpolationWalker struct {
 //
 // If Replace is set to false in interpolationWalker, then the replace
 // value can be anything as it will have no effect.
-type interpolationWalkerFunc func(ast.Node) (string, error)
+type interpolationWalkerFunc func(ast.Node) (interface{}, error)
 
 // interpolationWalkerContextFunc is called by interpolationWalk if
 // ContextF is set. This receives both the interpolation and the location
@@ -150,8 +150,8 @@ func (w *interpolationWalker) Primitive(v reflect.Value) error {
 		// set if it is computed. This behavior is different if we're
 		// splitting (in a SliceElem) or not.
 		remove := false
-		if w.loc == reflectwalk.SliceElem && IsStringList(replaceVal) {
-			parts := StringList(replaceVal).Slice()
+		if w.loc == reflectwalk.SliceElem && IsStringList(replaceVal.(string)) {
+			parts := StringList(replaceVal.(string)).Slice()
 			for _, p := range parts {
 				if p == UnknownVariableValue {
 					remove = true

--- a/config/interpolate_walk_test.go
+++ b/config/interpolate_walk_test.go
@@ -89,7 +89,7 @@ func TestInterpolationWalker_detect(t *testing.T) {
 
 	for i, tc := range cases {
 		var actual []string
-		detectFn := func(root ast.Node) (string, error) {
+		detectFn := func(root ast.Node) (interface{}, error) {
 			actual = append(actual, fmt.Sprintf("%s", root))
 			return "", nil
 		}
@@ -175,7 +175,7 @@ func TestInterpolationWalker_replace(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		fn := func(ast.Node) (string, error) {
+		fn := func(ast.Node) (interface{}, error) {
 			return tc.Value, nil
 		}
 

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -108,7 +108,7 @@ func (r *RawConfig) Interpolate(vs map[string]ast.Variable) error {
 	defer r.lock.Unlock()
 
 	config := langEvalConfig(vs)
-	return r.interpolate(func(root ast.Node) (string, error) {
+	return r.interpolate(func(root ast.Node) (interface{}, error) {
 		// We detect the variables again and check if the value of any
 		// of the variables is the computed value. If it is, then we
 		// treat this entire value as computed.
@@ -137,7 +137,7 @@ func (r *RawConfig) Interpolate(vs map[string]ast.Variable) error {
 			return "", err
 		}
 
-		return result.Value.(string), nil
+		return result.Value, nil
 	})
 }
 
@@ -194,7 +194,7 @@ func (r *RawConfig) init() error {
 	r.Interpolations = nil
 	r.Variables = nil
 
-	fn := func(node ast.Node) (string, error) {
+	fn := func(node ast.Node) (interface{}, error) {
 		r.Interpolations = append(r.Interpolations, node)
 		vars, err := DetectVariables(node)
 		if err != nil {

--- a/state/remote/atlas_test.go
+++ b/state/remote/atlas_test.go
@@ -245,7 +245,7 @@ func (f *fakeAtlas) handler(resp http.ResponseWriter, req *http.Request) {
 // loads the state.
 var testStateModuleOrderChange = []byte(
 	`{
-    "version": 1,
+    "version": 2,
     "serial": 1,
     "modules": [
         {
@@ -276,7 +276,7 @@ var testStateModuleOrderChange = []byte(
 
 var testStateSimple = []byte(
 	`{
-    "version": 1,
+    "version": 2,
     "serial": 1,
     "modules": [
         {

--- a/state/testing.go
+++ b/state/testing.go
@@ -36,7 +36,7 @@ func TestState(t *testing.T, s interface{}) {
 	if ws, ok := s.(StateWriter); ok {
 		current.Modules = append(current.Modules, &terraform.ModuleState{
 			Path: []string{"root"},
-			Outputs: map[string]string{
+			Outputs: map[string]interface{}{
 				"bar": "baz",
 			},
 		})
@@ -94,7 +94,7 @@ func TestState(t *testing.T, s interface{}) {
 		current.Modules = []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path:    []string{"root", "somewhere"},
-				Outputs: map[string]string{"serialCheck": "true"},
+				Outputs: map[string]interface{}{"serialCheck": "true"},
 			},
 		}
 		if err := writer.WriteState(current); err != nil {
@@ -123,7 +123,7 @@ func TestStateInitial() *terraform.State {
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root", "child"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -969,7 +969,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 						},
 					},
 				},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"a_output": "a",
 				},
 			},
@@ -1438,7 +1438,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 		Modules: []*ModuleState{
 			&ModuleState{
 				Path: rootModulePath,
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 					"bar": "baz",
 				},

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -48,6 +48,45 @@ func TestContext2Apply(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
+	m := testModule(t, "apply-map-var-through-module")
+	p := testProvider("null")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"null": testProviderFuncFixed(p),
+		},
+	})
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(`<no state>
+Outputs:
+
+amis_from_module = {eu-west-1:ami-789012 eu-west-2:ami-989484 us-west-1:ami-123456 us-west-2:ami-456789 }
+
+module.test:
+  null_resource.noop:
+    ID = foo
+
+  Outputs:
+
+  amis_out = {eu-west-1:ami-789012 eu-west-2:ami-989484 us-west-1:ami-123456 us-west-2:ami-456789 }`)
+	if actual != expected {
+		t.Fatalf("expected: \n%s\n\ngot: \n%s\n", expected, actual)
+	}
+}
+
 func TestContext2Apply_providerAlias(t *testing.T) {
 	m := testModule(t, "apply-provider-alias")
 	p := testProvider("aws")
@@ -2978,7 +3017,7 @@ func TestContext2Apply_outputInvalid(t *testing.T) {
 	if err == nil {
 		t.Fatalf("err: %s", err)
 	}
-	if !strings.Contains(err.Error(), "is not a string") {
+	if !strings.Contains(err.Error(), "is not a valid type") {
 		t.Fatalf("err: %s", err)
 	}
 }
@@ -3056,7 +3095,7 @@ func TestContext2Apply_outputList(t *testing.T) {
 	actual := strings.TrimSpace(state.String())
 	expected := strings.TrimSpace(testTerraformApplyOutputListStr)
 	if actual != expected {
-		t.Fatalf("bad: \n%s", actual)
+		t.Fatalf("expected: \n%s\n\nbad: \n%s", expected, actual)
 	}
 }
 
@@ -3762,7 +3801,7 @@ func TestContext2Apply_vars(t *testing.T) {
 	actual := strings.TrimSpace(state.String())
 	expected := strings.TrimSpace(testTerraformApplyVarsStr)
 	if actual != expected {
-		t.Fatalf("bad: \n%s", actual)
+		t.Fatalf("expected: %s\n got:\n%s", expected, actual)
 	}
 }
 

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -45,7 +45,7 @@ func TestContext2Input(t *testing.T) {
 	actual := strings.TrimSpace(state.String())
 	expected := strings.TrimSpace(testTerraformInputVarsStr)
 	if actual != expected {
-		t.Fatalf("bad: \n%s", actual)
+		t.Fatalf("expected:\n%s\ngot:\n%s", expected, actual)
 	}
 }
 

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -452,7 +452,7 @@ func TestContext2Refresh_output(t *testing.T) {
 						},
 					},
 
-					Outputs: map[string]string{
+					Outputs: map[string]interface{}{
 						"foo": "foo",
 					},
 				},
@@ -738,7 +738,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 						},
 					},
 				},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"id":            "i-bcd234",
 					"grandchild_id": "i-cde345",
 				},
@@ -752,7 +752,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 						},
 					},
 				},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"id": "i-cde345",
 				},
 			},

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -68,7 +68,7 @@ type EvalContext interface {
 	// SetVariables sets the variables for the module within
 	// this context with the name n. This function call is additive:
 	// the second parameter is merged with any previous call.
-	SetVariables(string, map[string]string)
+	SetVariables(string, map[string]interface{})
 
 	// Diff returns the global diff as well as the lock that should
 	// be used to modify that diff.

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -23,7 +23,7 @@ type BuiltinEvalContext struct {
 	// as the Interpolater itself, it is protected by InterpolaterVarLock
 	// which must be locked during any access to the map.
 	Interpolater        *Interpolater
-	InterpolaterVars    map[string]map[string]string
+	InterpolaterVars    map[string]map[string]interface{}
 	InterpolaterVarLock *sync.Mutex
 
 	Hooks               []Hook
@@ -311,7 +311,7 @@ func (ctx *BuiltinEvalContext) Path() []string {
 	return ctx.PathValue
 }
 
-func (ctx *BuiltinEvalContext) SetVariables(n string, vs map[string]string) {
+func (ctx *BuiltinEvalContext) SetVariables(n string, vs map[string]interface{}) {
 	ctx.InterpolaterVarLock.Lock()
 	defer ctx.InterpolaterVarLock.Unlock()
 
@@ -322,7 +322,7 @@ func (ctx *BuiltinEvalContext) SetVariables(n string, vs map[string]string) {
 
 	vars := ctx.InterpolaterVars[key]
 	if vars == nil {
-		vars = make(map[string]string)
+		vars = make(map[string]interface{})
 		ctx.InterpolaterVars[key] = vars
 	}
 

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -74,7 +74,7 @@ type MockEvalContext struct {
 
 	SetVariablesCalled    bool
 	SetVariablesModule    string
-	SetVariablesVariables map[string]string
+	SetVariablesVariables map[string]interface{}
 
 	DiffCalled bool
 	DiffDiff   *Diff
@@ -183,7 +183,7 @@ func (c *MockEvalContext) Path() []string {
 	return c.PathPath
 }
 
-func (c *MockEvalContext) SetVariables(n string, vs map[string]string) {
+func (c *MockEvalContext) SetVariables(n string, vs map[string]interface{}) {
 	c.SetVariablesCalled = true
 	c.SetVariablesModule = n
 	c.SetVariablesVariables = vs

--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/mitchellh/mapstructure"
@@ -26,7 +25,7 @@ import (
 // use of the values since it is only valid to pass string values. The
 // structure is in place for extension of the type system, however.
 type EvalTypeCheckVariable struct {
-	Variables  map[string]string
+	Variables  map[string]interface{}
 	ModulePath []string
 	ModuleTree *module.Tree
 }
@@ -43,24 +42,40 @@ func (n *EvalTypeCheckVariable) Eval(ctx EvalContext) (interface{}, error) {
 		prototypes[variable.Name] = variable.Type()
 	}
 
+	// Only display a module in an error message if we are not in the root module
+	modulePathDescription := fmt.Sprintf(" in module %s", strings.Join(n.ModulePath[1:], "."))
+	if len(n.ModulePath) == 1 {
+		modulePathDescription = ""
+	}
+
 	for name, declaredType := range prototypes {
 		// This is only necessary when we _actually_ check. It is left as a reminder
 		// that at the current time we are dealing with a type system consisting only
 		// of strings and maps - where the only valid inter-module variable type is
 		// string.
-		// proposedValue := n.Variables[name]
+		proposedValue := n.Variables[name]
 
 		switch declaredType {
 		case config.VariableTypeString:
 			// This will need actual verification once we aren't dealing with
 			// a map[string]string but this is sufficient for now.
-			continue
-		default:
-			// Only display a module if we are not in the root module
-			modulePathDescription := fmt.Sprintf(" in module %s", strings.Join(n.ModulePath[1:], "."))
-			if len(n.ModulePath) == 1 {
-				modulePathDescription = ""
+			switch proposedValue.(type) {
+			case string:
+				continue
+			default:
+				return nil, fmt.Errorf("variable %s%s should be type %s, got %T",
+					name, modulePathDescription, declaredType.Printable(), proposedValue)
 			}
+			continue
+		case config.VariableTypeMap:
+			switch proposedValue.(type) {
+			case map[string]interface{}:
+				continue
+			default:
+				return nil, fmt.Errorf("variable %s%s should be type %s, got %T",
+					name, modulePathDescription, declaredType.Printable(), proposedValue)
+			}
+		default:
 			// This will need the actual type substituting when we have more than
 			// just strings and maps.
 			return nil, fmt.Errorf("variable %s%s should be type %s, got type string",
@@ -75,7 +90,7 @@ func (n *EvalTypeCheckVariable) Eval(ctx EvalContext) (interface{}, error) {
 // explicitly for interpolation later.
 type EvalSetVariables struct {
 	Module    *string
-	Variables map[string]string
+	Variables map[string]interface{}
 }
 
 // TODO: test
@@ -88,31 +103,43 @@ func (n *EvalSetVariables) Eval(ctx EvalContext) (interface{}, error) {
 // given configuration, and uses the final values as a way to set the
 // mapping.
 type EvalVariableBlock struct {
-	Config    **ResourceConfig
-	Variables map[string]string
+	Config         **ResourceConfig
+	VariableValues map[string]interface{}
 }
 
 // TODO: test
 func (n *EvalVariableBlock) Eval(ctx EvalContext) (interface{}, error) {
 	// Clear out the existing mapping
-	for k, _ := range n.Variables {
-		delete(n.Variables, k)
+	for k, _ := range n.VariableValues {
+		delete(n.VariableValues, k)
 	}
 
 	// Get our configuration
 	rc := *n.Config
 	for k, v := range rc.Config {
-		var vStr string
-		if err := mapstructure.WeakDecode(v, &vStr); err != nil {
-			return nil, errwrap.Wrapf(fmt.Sprintf(
-				"%s: error reading value: {{err}}", k), err)
+		var vString string
+		if err := mapstructure.WeakDecode(v, &vString); err == nil {
+			n.VariableValues[k] = vString
+			continue
 		}
 
-		n.Variables[k] = vStr
+		var vMap map[string]interface{}
+		if err := mapstructure.WeakDecode(v, &vMap); err == nil {
+			n.VariableValues[k] = vMap
+			continue
+		}
+
+		var vSlice []interface{}
+		if err := mapstructure.WeakDecode(v, &vSlice); err == nil {
+			n.VariableValues[k] = vSlice
+			continue
+		}
+
+		return nil, fmt.Errorf("Variable value for %s is not a string, list or map type", k)
 	}
 	for k, _ := range rc.Raw {
-		if _, ok := n.Variables[k]; !ok {
-			n.Variables[k] = config.UnknownVariableValue
+		if _, ok := n.VariableValues[k]; !ok {
+			n.VariableValues[k] = config.UnknownVariableValue
 		}
 	}
 

--- a/terraform/graph_config_node_module.go
+++ b/terraform/graph_config_node_module.go
@@ -69,7 +69,7 @@ func (n *GraphNodeConfigModule) Expand(b GraphBuilder) (GraphNodeSubgraph, error
 	return &graphNodeModuleExpanded{
 		Original:  n,
 		Graph:     graph,
-		Variables: make(map[string]string),
+		Variables: make(map[string]interface{}),
 	}, nil
 }
 
@@ -107,7 +107,7 @@ type graphNodeModuleExpanded struct {
 	// Variables is a map of the input variables. This reference should
 	// be shared with ModuleInputTransformer in order to create a connection
 	// where the variables are set properly.
-	Variables map[string]string
+	Variables map[string]interface{}
 }
 
 func (n *graphNodeModuleExpanded) Name() string {
@@ -147,8 +147,8 @@ func (n *graphNodeModuleExpanded) EvalTree() EvalNode {
 			},
 
 			&EvalVariableBlock{
-				Config:    &resourceConfig,
-				Variables: n.Variables,
+				Config:         &resourceConfig,
+				VariableValues: n.Variables,
 			},
 		},
 	}

--- a/terraform/graph_config_node_variable.go
+++ b/terraform/graph_config_node_variable.go
@@ -114,7 +114,7 @@ func (n *GraphNodeConfigVariable) EvalTree() EvalNode {
 	// Otherwise, interpolate the value of this variable and set it
 	// within the variables mapping.
 	var config *ResourceConfig
-	variables := make(map[string]string)
+	variables := make(map[string]interface{})
 	return &EvalSequence{
 		Nodes: []EvalNode{
 			&EvalInterpolate{
@@ -123,8 +123,8 @@ func (n *GraphNodeConfigVariable) EvalTree() EvalNode {
 			},
 
 			&EvalVariableBlock{
-				Config:    &config,
-				Variables: variables,
+				Config:         &config,
+				VariableValues: variables,
 			},
 
 			&EvalTypeCheckVariable{

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -27,7 +27,7 @@ type ContextGraphWalker struct {
 	once                sync.Once
 	contexts            map[string]*BuiltinEvalContext
 	contextLock         sync.Mutex
-	interpolaterVars    map[string]map[string]string
+	interpolaterVars    map[string]map[string]interface{}
 	interpolaterVarLock sync.Mutex
 	providerCache       map[string]ResourceProvider
 	providerConfigCache map[string]*ResourceConfig
@@ -49,7 +49,7 @@ func (w *ContextGraphWalker) EnterPath(path []string) EvalContext {
 	}
 
 	// Setup the variables for this interpolater
-	variables := make(map[string]string)
+	variables := make(map[string]interface{})
 	if len(path) <= 1 {
 		for k, v := range w.Context.variables {
 			variables[k] = v
@@ -81,12 +81,12 @@ func (w *ContextGraphWalker) EnterPath(path []string) EvalContext {
 		StateValue:          w.Context.state,
 		StateLock:           &w.Context.stateLock,
 		Interpolater: &Interpolater{
-			Operation:     w.Operation,
-			Module:        w.Context.module,
-			State:         w.Context.state,
-			StateLock:     &w.Context.stateLock,
-			Variables:     variables,
-			VariablesLock: &w.interpolaterVarLock,
+			Operation:          w.Operation,
+			Module:             w.Context.module,
+			State:              w.Context.state,
+			StateLock:          &w.Context.stateLock,
+			VariableValues:     variables,
+			VariableValuesLock: &w.interpolaterVarLock,
 		},
 		InterpolaterVars:    w.interpolaterVars,
 		InterpolaterVarLock: &w.interpolaterVarLock,
@@ -150,5 +150,5 @@ func (w *ContextGraphWalker) init() {
 	w.providerCache = make(map[string]ResourceProvider, 5)
 	w.providerConfigCache = make(map[string]*ResourceConfig, 5)
 	w.provisionerCache = make(map[string]ResourceProvisioner, 5)
-	w.interpolaterVars = make(map[string]map[string]string, 5)
+	w.interpolaterVars = make(map[string]map[string]interface{}, 5)
 }

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -67,7 +67,7 @@ func TestInterpolater_moduleVariable(t *testing.T) {
 			},
 			&ModuleState{
 				Path: []string{RootModuleName, "child"},
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 				},
 			},

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1324,18 +1324,18 @@ func (e *EphemeralState) deepcopy() *EphemeralState {
 func ReadState(src io.Reader) (*State, error) {
 	buf := bufio.NewReader(src)
 
-	// Check if this is a V1 format
+	// Check if this is a V0 format
 	start, err := buf.Peek(len(stateFormatMagic))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to check for magic bytes: %v", err)
 	}
 	if string(start) == stateFormatMagic {
 		// Read the old state
-		old, err := ReadStateV1(buf)
+		old, err := ReadStateV0(buf)
 		if err != nil {
 			return nil, err
 		}
-		return upgradeV1State(old)
+		return upgradeV0State(old)
 	}
 
 	// Otherwise, must be V2
@@ -1409,9 +1409,9 @@ func WriteState(d *State, dst io.Writer) error {
 	return nil
 }
 
-// upgradeV1State is used to upgrade a V1 state representation
+// upgradeV0State is used to upgrade a V0 state representation
 // into a proper State representation.
-func upgradeV1State(old *StateV1) (*State, error) {
+func upgradeV0State(old *StateV0) (*State, error) {
 	s := &State{}
 	s.init()
 

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -575,7 +575,7 @@ func (m *ModuleState) Equal(other *ModuleState) bool {
 		return false
 	}
 	for k, v := range m.Outputs {
-		if other.Outputs[k] != v {
+		if !reflect.DeepEqual(other.Outputs[k], v) {
 			return false
 		}
 	}
@@ -803,7 +803,27 @@ func (m *ModuleState) String() string {
 
 		for _, k := range ks {
 			v := m.Outputs[k]
-			buf.WriteString(fmt.Sprintf("%s = %s\n", k, v))
+			switch vTyped := v.(type) {
+			case string:
+				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+			case []interface{}:
+				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+			case map[string]interface{}:
+				var mapKeys []string
+				for key, _ := range vTyped {
+					mapKeys = append(mapKeys, key)
+				}
+				sort.Strings(mapKeys)
+
+				var mapBuf bytes.Buffer
+				mapBuf.WriteString("{")
+				for _, key := range mapKeys {
+					mapBuf.WriteString(fmt.Sprintf("%s:%s ", key, vTyped[key]))
+				}
+				mapBuf.WriteString("}")
+
+				buf.WriteString(fmt.Sprintf("%s = %s\n", k, mapBuf.String()))
+			}
 		}
 	}
 

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -1163,15 +1163,15 @@ func TestInstanceState_MergeDiff_nilDiff(t *testing.T) {
 }
 
 func TestReadUpgradeState(t *testing.T) {
-	state := &StateV1{
-		Resources: map[string]*ResourceStateV1{
-			"foo": &ResourceStateV1{
+	state := &StateV0{
+		Resources: map[string]*ResourceStateV0{
+			"foo": &ResourceStateV0{
 				ID: "bar",
 			},
 		},
 	}
 	buf := new(bytes.Buffer)
-	if err := testWriteStateV1(state, buf); err != nil {
+	if err := testWriteStateV0(state, buf); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1182,7 +1182,7 @@ func TestReadUpgradeState(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	upgraded, err := upgradeV1State(state)
+	upgraded, err := upgradeV0State(state)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1359,20 +1359,20 @@ func TestWriteStateTFVersion(t *testing.T) {
 	}
 }
 
-func TestUpgradeV1State(t *testing.T) {
-	old := &StateV1{
+func TestUpgradeV0State(t *testing.T) {
+	old := &StateV0{
 		Outputs: map[string]string{
 			"ip": "127.0.0.1",
 		},
-		Resources: map[string]*ResourceStateV1{
-			"foo": &ResourceStateV1{
+		Resources: map[string]*ResourceStateV0{
+			"foo": &ResourceStateV0{
 				Type: "test_resource",
 				ID:   "bar",
 				Attributes: map[string]string{
 					"key": "val",
 				},
 			},
-			"bar": &ResourceStateV1{
+			"bar": &ResourceStateV0{
 				Type: "test_resource",
 				ID:   "1234",
 				Attributes: map[string]string{
@@ -1384,7 +1384,7 @@ func TestUpgradeV1State(t *testing.T) {
 			"bar": struct{}{},
 		},
 	}
-	state, err := upgradeV1State(old)
+	state, err := upgradeV0State(old)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/terraform/state_v0_test.go
+++ b/terraform/state_v0_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/mitchellh/hashstructure"
 )
 
-func TestReadWriteStateV1(t *testing.T) {
-	state := &StateV1{
-		Resources: map[string]*ResourceStateV1{
-			"foo": &ResourceStateV1{
+func TestReadWriteStateV0(t *testing.T) {
+	state := &StateV0{
+		Resources: map[string]*ResourceStateV0{
+			"foo": &ResourceStateV0{
 				ID: "bar",
 				ConnInfo: map[string]string{
 					"type":     "ssh",
@@ -33,7 +33,7 @@ func TestReadWriteStateV1(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	if err := testWriteStateV1(state, buf); err != nil {
+	if err := testWriteStateV0(state, buf); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -47,7 +47,7 @@ func TestReadWriteStateV1(t *testing.T) {
 		t.Fatalf("structure changed during serialization!")
 	}
 
-	actual, err := ReadStateV1(buf)
+	actual, err := ReadStateV0(buf)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -75,9 +75,9 @@ func (s *sensitiveState) init() {
 	})
 }
 
-// testWriteStateV1 writes a state somewhere in a binary format.
+// testWriteStateV0 writes a state somewhere in a binary format.
 // Only for testing now
-func testWriteStateV1(d *StateV1, dst io.Writer) error {
+func testWriteStateV0(d *StateV0, dst io.Writer) error {
 	// Write the magic bytes so we can determine the file format later
 	n, err := dst.Write([]byte(stateFormatMagic))
 	if err != nil {

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -592,7 +592,7 @@ aws_instance.foo:
 
 Outputs:
 
-foo_num = bar,bar,bar
+foo_num = [bar,bar,bar]
 `
 
 const testTerraformApplyOutputMultiStr = `

--- a/terraform/test-fixtures/apply-map-var-through-module/amodule/main.tf
+++ b/terraform/test-fixtures/apply-map-var-through-module/amodule/main.tf
@@ -1,0 +1,9 @@
+variable "amis" {
+    type = "map"
+}
+
+resource "null_resource" "noop" {}
+
+output "amis_out" {
+    value = "${var.amis}"
+}

--- a/terraform/test-fixtures/apply-map-var-through-module/main.tf
+++ b/terraform/test-fixtures/apply-map-var-through-module/main.tf
@@ -1,0 +1,19 @@
+variable "amis_in" {
+    type = "map"
+    default = {
+        "us-west-1" = "ami-123456"
+        "us-west-2" = "ami-456789"
+        "eu-west-1" = "ami-789012"
+        "eu-west-2" = "ami-989484"
+    }
+}
+
+module "test" {
+    source = "./amodule"
+
+    amis = "${var.amis_in}"
+}
+
+output "amis_from_module" {
+    value = "${module.test.amis_out}"
+}

--- a/terraform/test-fixtures/apply-vars/main.tf
+++ b/terraform/test-fixtures/apply-vars/main.tf
@@ -19,5 +19,5 @@ resource "aws_instance" "foo" {
 resource "aws_instance" "bar" {
     foo = "${var.foo}"
     bar = "${lookup(var.amis, var.foo)}"
-    baz = "${var.amis.us-east-1}"
+    baz = "${var.amis["us-east-1"]}"
 }

--- a/terraform/transform_output_test.go
+++ b/terraform/transform_output_test.go
@@ -11,7 +11,7 @@ func TestAddOutputOrphanTransformer(t *testing.T) {
 		Modules: []*ModuleState{
 			&ModuleState{
 				Path: RootModulePath,
-				Outputs: map[string]string{
+				Outputs: map[string]interface{}{
 					"foo": "bar",
 					"bar": "baz",
 				},

--- a/vendor/github.com/hashicorp/hil/convert.go
+++ b/vendor/github.com/hashicorp/hil/convert.go
@@ -16,23 +16,6 @@ func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 		}, nil
 	}
 
-	var sliceVal []interface{}
-	if err := mapstructure.WeakDecode(input, &sliceVal); err == nil {
-		elements := make([]ast.Variable, len(sliceVal))
-		for i, element := range sliceVal {
-			varElement, err := InterfaceToVariable(element)
-			if err != nil {
-				return ast.Variable{}, err
-			}
-			elements[i] = varElement
-		}
-
-		return ast.Variable{
-			Type:  ast.TypeList,
-			Value: elements,
-		}, nil
-	}
-
 	var mapVal map[string]interface{}
 	if err := mapstructure.WeakDecode(input, &mapVal); err == nil {
 		elements := make(map[string]ast.Variable)
@@ -46,6 +29,23 @@ func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 
 		return ast.Variable{
 			Type:  ast.TypeMap,
+			Value: elements,
+		}, nil
+	}
+
+	var sliceVal []interface{}
+	if err := mapstructure.WeakDecode(input, &sliceVal); err == nil {
+		elements := make([]ast.Variable, len(sliceVal))
+		for i, element := range sliceVal {
+			varElement, err := InterfaceToVariable(element)
+			if err != nil {
+				return ast.Variable{}, err
+			}
+			elements[i] = varElement
+		}
+
+		return ast.Variable{
+			Type:  ast.TypeList,
 			Value: elements,
 		}, nil
 	}

--- a/website/source/intro/getting-started/variables.html.md
+++ b/website/source/intro/getting-started/variables.html.md
@@ -122,6 +122,7 @@ support for the "us-west-2" region as well:
 
 ```
 variable "amis" {
+    type = "map"
 	default = {
 		us-east-1 = "ami-b8b061d0"
 		us-west-2 = "ami-ef5e24df"
@@ -129,8 +130,8 @@ variable "amis" {
 }
 ```
 
-A variable becomes a mapping when it has a default value that is a
-map like above. There is no way to create a required map.
+A variable becomes a mapping when it has a type of "map" assigned, or has a
+default value that is a map like above.
 
 Then, replace the "aws\_instance" with the following:
 
@@ -148,7 +149,7 @@ variables is the key.
 
 While we don't use it in our example, it is worth noting that you
 can also do a static lookup of a mapping directly with
-`${var.amis.us-east-1}`.
+`${var.amis["us-east-1"]}`.
 
 <a id="assigning-mappings"></a>
 ## Assigning Mappings


### PR DESCRIPTION
This PR brings the following sections of work (some of which have already been reviewed) to the `dev-0.7` branch following some rebasing. The work is:

- Upgrade `github.com/hashicorp/hil/...`

- Renumber the original binary state of Terraform as v0 from v1 (already reviewed in #5844)

- Add support in a new V2 state for outputs of types other than strings (maps, lists) (already reviewed in #5841)

- Replace usage of the flatmap structure for map variables with native HIL maps. This also includes the work necessary to allow map variables to pass between modules.