### PR TITLE
fix local-exec by using get instead of accessing Config directly

### DIFF
--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -27,7 +27,7 @@ func (p *ResourceProvisioner) Apply(
 	c *terraform.ResourceConfig) error {
 
 	// Get the command
-	commandRaw, ok := c.Config["command"]
+	commandRaw, ok := c.Get("command")
 	if !ok {
 		return fmt.Errorf("local-exec provisioner missing 'command'")
 	}


### PR DESCRIPTION
For some reason the ResourceConfig looked like:
```
&terraform.ResourceConfig{
    ComputedKeys:[]string{"command"},
    Raw:map[string]interface {}{
        "command":"echo ${k-0-master-ip} >> hello.ip.txt",
    },
    Config:map[string]interface {}{},
    raw:(*config.RawConfig)(nil),
}
```
So "command" field existed in Raw but not in Config. It is however accessible through Get.

Fixes #3254 but I'm not familar with the deserialization internals so I'm not sure why.