### PR TITLE
provider/aws: Refresh state on Directory Service not found

### DIFF
--- a/builtin/providers/aws/resource_aws_directory_service_directory.go
+++ b/builtin/providers/aws/resource_aws_directory_service_directory.go
@@ -401,6 +401,13 @@ func resourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta inter
 	out, err := dsconn.DescribeDirectories(&input)
 	if err != nil {
 		return err
+
+	}
+
+	if len(out.DirectoryDescriptions) == 0 {
+		log.Printf("[WARN] Directory %s not found", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	dir := out.DirectoryDescriptions[0]


### PR DESCRIPTION
Fixes #6292

When a directory service was not found, Terraform was panicking due to
`dir := out.DirectoryDescriptions[0]`. The AWS API doesn't throw an
Error in this case. IT just return s0 results. Therefore, we should
check for 0 results in the return and remove the directory from the
state