### PR TITLE
provider/aws: Set the state of `cross_zone_load_balancing` during the read func

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -362,6 +362,7 @@ func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("idle_timeout", lbAttrs.ConnectionSettings.IdleTimeout)
 	d.Set("connection_draining", lbAttrs.ConnectionDraining.Enabled)
 	d.Set("connection_draining_timeout", lbAttrs.ConnectionDraining.Timeout)
+	d.Set("cross_zone_load_balancing", lbAttrs.CrossZoneLoadBalancing.Enabled)
 	if lbAttrs.AccessLog != nil {
 		if err := d.Set("access_logs", flattenAccessLog(lbAttrs.AccessLog)); err != nil {
 			return err


### PR DESCRIPTION
Fixes #6291

Changes made manually to the ELB property were not being set and Terraform was reporting now changes to infra was to be made on refresh