### PR TITLE
JSON render format option to output command

### DIFF
--- a/command/output_test.go
+++ b/command/output_test.go
@@ -194,6 +194,46 @@ func TestOutput_blank(t *testing.T) {
 	}
 }
 
+func TestOutput_json(t *testing.T) {
+	originalState := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path: []string{"root"},
+				Outputs: map[string]string{
+					"foo":  "bar",
+					"name": "john-doe",
+				},
+			},
+		},
+	}
+
+	statePath := testStateFile(t, originalState)
+
+	ui := new(cli.MockUi)
+	c := &OutputCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-format", "json",
+		"",
+	}
+
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	expectedOutput := "{\"foo\":\"bar\",\"name\":\"john-doe\"}\n"
+	output := ui.OutputWriter.String()
+	if output != expectedOutput {
+		t.Fatalf("Expected output: %#v\ngiven: %#v", expectedOutput, output)
+	}
+}
+
 func TestOutput_manyArgs(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &OutputCommand{

--- a/website/source/docs/commands/output.html.markdown
+++ b/website/source/docs/commands/output.html.markdown
@@ -26,3 +26,6 @@ The command-line flags are all optional. The list of available flags are:
     a period-separated list. Example: "foo" would reference the module
     "foo" but "foo.bar" would reference the "bar" module in the "foo"
     module.
+* `-format=format_name` - The format to render the outputs in. Possible
+    options are "display" and "json". Default is "display"; a human readable
+    format. This option is only valid when no output name is specified. 


### PR DESCRIPTION
Hi,

This PR adds a format option to the output command. Valid formats are "display" and "json", with the default being "display"; the current renderer. Is this your preferred way to add a json format renderer? An alternative could be just to specify a --json flag or similar.