### PR TITLE
core: Do not type check unset variables

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -660,6 +660,23 @@ func TestContext2Plan_moduleVarWrongTypeNested(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_moduleVarWithDefaultValue(t *testing.T) {
+	m := testModule(t, "plan-module-var-with-default-value")
+	p := testProvider("null")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"null": testProviderFuncFixed(p),
+		},
+	})
+
+	_, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+}
+
 func TestContext2Plan_moduleVarComputed(t *testing.T) {
 	m := testModule(t, "plan-module-var-computed")
 	p := testProvider("aws")

--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -48,7 +48,12 @@ func (n *EvalTypeCheckVariable) Eval(ctx EvalContext) (interface{}, error) {
 		// that at the current time we are dealing with a type system consisting only
 		// of strings and maps - where the only valid inter-module variable type is
 		// string.
-		// proposedValue := n.Variables[name]
+		_, ok := n.Variables[name]
+		if !ok {
+			// This means the default value should be used as no overriding value
+			// has been set. Therefore we should continue as no check is necessary.
+			continue
+		}
 
 		switch declaredType {
 		case config.VariableTypeString:

--- a/terraform/test-fixtures/plan-module-var-with-default-value/inner/main.tf
+++ b/terraform/test-fixtures/plan-module-var-with-default-value/inner/main.tf
@@ -1,0 +1,12 @@
+variable "im_a_string" {
+    type = "string"
+}
+
+variable "service_region_ami" {
+    type = "map"
+    default = {
+        us-east-1 = "ami-e4c9db8e"
+    }
+}
+
+resource "null_resource" "noop" {}

--- a/terraform/test-fixtures/plan-module-var-with-default-value/main.tf
+++ b/terraform/test-fixtures/plan-module-var-with-default-value/main.tf
@@ -1,0 +1,7 @@
+resource "null_resource" "noop" {}
+
+module "test" {
+    source = "./inner"
+
+    im_a_string = "hello"
+}


### PR DESCRIPTION
A consequnce of the work done in #6185 was that variables which were in a module but not set explicitly (i.e. the default value was relied upon) were marked as type errors. This was reported in #6230.

This commit adds a test case for this and a patch which fixes the issue.

Fixes #6230.