### PR TITLE
provider/aws: Update S3 Bucket Object docs for KMS Key

### DIFF
--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -23,6 +23,27 @@ resource "aws_s3_bucket_object" "object" {
 }
 ```
 
+### Encrypting with KMS Key
+
+```
+resource "aws_kms_key" "examplekms" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 7
+}
+
+resource "aws_s3_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_object" "examplebucket_object" {
+  key        = "someobject"
+  bucket     = "${aws_s3_bucket.examplebucket.bucket}"
+  source     = "index.html"
+  kms_key_id = "${aws_kms_key.examplekms.arn}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -31,13 +52,17 @@ The following arguments are supported:
 * `key` - (Required) The name of the object once it is in the bucket.
 * `source` - (Required) The path to the source file being uploaded to the bucket.
 * `content` - (Required unless `source` given) The literal content being uploaded to the bucket.
-* `cache_control` - (Optional) Specifies caching behavior along the request/reply chain Read [w3c cache_control](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) for futher details.
+* `cache_control` - (Optional) Specifies caching behavior along the request/reply chain Read [w3c cache_control](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) for further details.
 * `content_disposition` - (Optional) Specifies presentational information for the object. Read [wc3 content_disposition](http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) for further information.
 * `content_encoding` - (Optional) Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [w3c content encoding](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11) for further information.
 * `content_language` - (Optional) The language the content is in e.g. en-US or en-GB.
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
-* `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`
-* `kms_key_id` - (Optional) Specifies the AWS KMS key ID to use for object encryption.
+* `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`. 
+This attribute is not compatible with `kms_key_id`
+* `kms_key_id` - (Optional) Specifies the AWS KMS Key ID to use for object encryption. 
+This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
+use the exported `arn` attribute:  
+      `kms_key_id = "${aws_kms_key.foo.arn}"`
 
 Either `source` or `content` must be provided to specify the bucket content.
 These two arguments are mutually-exclusive.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/6172 with the power of documentation!

Currently our docs for S3 Bucket Object KMS support say this:

    * `kms_key_id` - (Optional) Specifies the AWS KMS key ID to use for object encryption

In _Terraform_ terms, this is typically the _id_: `${aws_kms_key.foo.id}`. 
In _AWS_ terms, this is... really the _arn_: `${aws_kms_key.foo.arn}`

For creating a bucket object AWS will accept both the unique/random bits at the end of the arn, or the full arn itself as the "ID". Unfortunately when we do a READ on the bucket object, the KMS Key _ID_ will be the full ARN. So users that specify the _id_ will get a reoccurring plan after, as it wants to swap out the ARN it read for the ID is has. 

This PR updates the documentation to clarify that you need to use the exported ARN attribute of a KMS Key resource. 