### PR TITLE
provider/openstack: update doc sidebar link to router_route

### DIFF
--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -55,6 +55,9 @@
             <li<%= sidebar_current("docs-openstack-resource-networking-router-interface-v2") %>>
               <a href="/docs/providers/openstack/r/networking_router_interface_v2.html">openstack_networking_router_interface_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-networking-router-route-v2") %>>
+              <a href="/docs/providers/openstack/r/networking_router_route_v2.html">openstack_networking_router_route_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-networking-router-v2") %>>
               <a href="/docs/providers/openstack/r/networking_router_v2.html">openstack_networking_router_v2</a>
             </li>


### PR DESCRIPTION
I didn't know I needed to update the doc sidebar link page to include the new ``openstack_networking_router_route_v2`` resource on #6207. This fixes that.