### PR TITLE
provider/aws: Use ID in lookup for AWS KMS Aliases

### DIFF
--- a/builtin/providers/aws/resource_aws_kms_alias.go
+++ b/builtin/providers/aws/resource_aws_kms_alias.go
@@ -89,14 +89,13 @@ func resourceAwsKmsAliasCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kmsconn
-	name := d.Get("name").(string)
 
-	alias, err := findKmsAliasByName(conn, name, nil)
+	alias, err := findKmsAliasByName(conn, d.Id(), nil)
 	if err != nil {
 		return err
 	}
 	if alias == nil {
-		log.Printf("[DEBUG] Removing KMS Alias %q as it's already gone", name)
+		log.Printf("[DEBUG] Removing KMS Alias (%s) as it's already gone", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -138,17 +137,16 @@ func resourceAwsKmsAliasTargetUpdate(conn *kms.KMS, d *schema.ResourceData) erro
 
 func resourceAwsKmsAliasDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kmsconn
-	name := d.Get("name").(string)
 
 	req := &kms.DeleteAliasInput{
-		AliasName: aws.String(name),
+		AliasName: aws.String(d.Id()),
 	}
 	_, err := conn.DeleteAlias(req)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[DEBUG] KMS Alias: %s deleted.", name)
+	log.Printf("[DEBUG] KMS Alias: (%s) deleted.", d.Id())
 	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
Fixes a bug when using `name_prefix` in the AWS KMS Alias resource; we set the name generated as the ID, but then use the value from `d.Get("name")` for lookup. If we're using a prefix, this value is empty.

Fixes `TestAccAWSKmsAlias_basic` [here](https://travis-ci.org/hashicorp/terraform/jobs/125476425)