### PR TITLE
Azure does not allow CDN ports to be 0

### DIFF
--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
@@ -145,6 +145,8 @@ resource "azurerm_cdn_endpoint" "test" {
     origin {
 	name = "acceptanceTestCdnOrigin1"
 	host_name = "www.example.com"
+	https_port = 443
+	http_port = 80
     }
 }
 `
@@ -170,6 +172,8 @@ resource "azurerm_cdn_endpoint" "test" {
     origin {
 	name = "acceptanceTestCdnOrigin2"
 	host_name = "www.example.com"
+	https_port = 443
+	http_port = 80
     }
 
     tags {
@@ -200,6 +204,8 @@ resource "azurerm_cdn_endpoint" "test" {
     origin {
 	name = "acceptanceTestCdnOrigin2"
 	host_name = "www.example.com"
+	https_port = 443
+	http_port = 80
     }
 
     tags {


### PR DESCRIPTION
The azure tests relating to cdn endpoints (TestAccAzureRMCdnEndpoint_basic etc) are breaking because ARM is not accepting port values of 0.  The following error is received:

statusCode:BadRequest
statusMessage:{"error":{"code":"BadRequest","message":"Invalid port \"0\". Port value must be a number between 1 and 65535."}}

This patch sets the ports for example.com to 443 and 80.