### PR TITLE
provider/aws: Extends the `aws_elasticache_cluster` validation

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -33,14 +33,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 					// with non-converging diffs.
 					return strings.ToLower(val.(string))
 				},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if (len(value) < 1) || (len(value) > 20) {
-						errors = append(errors, fmt.Errorf(
-							"%q must contain from 1 to 20 alphanumeric characters or hyphens", k))
-					}
-					return
-				},
+				ValidateFunc: validateElastiCacheClusterId,
 			},
 			"configuration_endpoint": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -31,6 +31,31 @@ func validateRdsId(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+func validateElastiCacheClusterId(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if (len(value) < 1) || (len(value) > 20) {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain from 1 to 20 alphanumeric characters or hyphens", k))
+	}
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	return
+}
+
 func validateASGScheduleTimestamp(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := time.Parse(awsAutoscalingScheduleTimeLayout, value)

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -480,3 +480,43 @@ func TestValidateIntegerInRange(t *testing.T) {
 		}
 	}
 }
+
+func TestResourceAWSElastiCacheClusterIdValidation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting",
+			ErrCount: 1,
+		},
+		{
+			Value:    "t.sting",
+			ErrCount: 1,
+		},
+		{
+			Value:    "t--sting",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1testing",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing-",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(65),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateElastiCacheClusterId(tc.Value, "aws_elasticache_cluster_cluster_id")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the ElastiCache Cluster cluster_id to trigger a validation error")
+		}
+	}
+}


### PR DESCRIPTION
The validation as part of #6330 was only for length. This PR adds the
rules for alphanumeric, not having -- within, not ending with a - and
that the id must start with a letter.

The PR also adds tests for these rules