### PR TITLE
provider/aws: Fix `aws_redshift_cluster` number_of_nodes update

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -375,6 +375,7 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		} else {
 			req.ClusterType = aws.String("single-node")
 		}
+		req.NodeType = aws.String(d.Get("node_type").(string))
 	}
 
 	if d.HasChange("cluster_security_groups") {


### PR DESCRIPTION
Fixes #6274

Currently, the number of nodes was broken due to not passing the
node_type with the update. This PR adds the correct parameters and a
test to prove this works as expected

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftCluster_updateNodeCount' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftCluster_updateNodeCount -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_updateNodeCount
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (1926.88s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    1926.902s
```