### PR TITLE
provider/fastly: Update Gzip handling with new go-fastly

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1177,7 +1177,7 @@
 		},
 		{
 			"ImportPath": "github.com/sethvargo/go-fastly",
-			"Rev": "b00964ba5a45ca385e9299c9803d6d2a8105d65b"
+			"Rev": "058f71c351c7fd4b7cf7e4604e827f9705a35ce0"
 		},
 		{
 			"ImportPath": "github.com/soniah/dnsmadeeasy",

--- a/vendor/github.com/sethvargo/go-fastly/gzip.go
+++ b/vendor/github.com/sethvargo/go-fastly/gzip.go
@@ -67,8 +67,8 @@ type CreateGzipInput struct {
 	Version string
 
 	Name           string `form:"name,omitempty"`
-	ContentTypes   string `form:"content_types,omitempty"`
-	Extensions     string `form:"extensions,omitempty"`
+	ContentTypes   string `form:"content_types"`
+	Extensions     string `form:"extensions"`
 	CacheCondition string `form:"cache_condition,omitempty"`
 }
 


### PR DESCRIPTION
sethvargo/go-fastly now handles the special case of `ContentTypes` and `Extensions`, regarding `omitempty`, because the Fastly API expects empty values if there are no content types or extensions...

This PR updates the vendored go-fastly and updates the code to remove the blemish. 

```
$ make testacc TEST=./builtin/providers/fastly TESTARGS="-run=TestAccFastlyServiceV1_gzips_basic"
==> Checking that code complies with gofmt requirements...
/Users/clint/Projects/Go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/fastly -v -run=TestAccFastlyServiceV1_gzips_basic -timeout 120m
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- PASS: TestAccFastlyServiceV1_gzips_basic (26.15s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/fastly	26.163s
```