### PR TITLE
Set a log prefix for each plugin and remove go-dynect global log prefix

### DIFF
--- a/command/internal_plugin.go
+++ b/command/internal_plugin.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -40,6 +41,8 @@ func (c *InternalPluginCommand) Run(args []string) int {
 
 	pluginType := args[0]
 	pluginName := args[1]
+
+	log.SetPrefix(fmt.Sprintf("%s-%s (internal) ", pluginName, pluginType))
 
 	switch pluginType {
 	case "provider":

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 )
 
 func main() {
+	// Override global prefix set by go-dynect during init()
+	log.SetPrefix("")
 	os.Exit(realMain())
 }
 


### PR DESCRIPTION
For internal plugins we will now see a log entry like this:

    2016/04/25 15:28:29 [DEBUG] plugin: terraform: aws-provider (internal)

Also, logs will no longer be erroneously prefixed with go-dynect.