### PR TITLE
provider/aws: fix potential aws_route crash

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -375,7 +375,7 @@ func findResourceRoute(conn *ec2.EC2, rtbid string, cidr string) (*ec2.Route, er
 	}
 
 	for _, route := range (*resp.RouteTables[0]).Routes {
-		if *route.DestinationCidrBlock == cidr {
+		if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == cidr {
 			return route, nil
 		}
 	}


### PR DESCRIPTION
The "find route in table" helper code was not properly handling routes
with no destination CIDR block - like vpc_endpoint routes - so if one of
those routes would come up before the target route in the loop, we'd get
a crash.

Fixes #6337