### PR TITLE
provider/vsphere: Setting to skip customization

### DIFF
--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -80,6 +80,7 @@ The following arguments are supported:
 * `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
 * `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
+* `skip_customization` - (Optional) skip virtual machine customization (useful if OS is not in the guest OS support matrix of VMware like "other3xLinux64Guest").
 
 The `network_interface` block supports:
 


### PR DESCRIPTION
We ran into the problem like described in  #3562.
We use a template with empty disks. After deploying it will boot with PXE into CoreOS. The CoreOS will load an install cloud-init and install to disk. After a reboot it is ready for ansible.
Since "other Linux ..." is not supported for customization, terraform failed and I found no setting to change it.
With this new setting (skip_customization) you are able to skip the customization part.