### PR TITLE
AWS ELB Listener: Clarify that ssl_certificate_id must be ARN

### DIFF
--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -96,7 +96,7 @@ Listeners support the following:
 * `lb_port` - (Required) The port to listen on for the load balancer
 * `lb_protocol` - (Required) The protocol to listen on. Valid values are `HTTP`,
   `HTTPS`, `TCP`, or `SSL`
-* `ssl_certificate_id` - (Optional) The id of an SSL certificate you have
+* `ssl_certificate_id` - (Optional) The ARN of an SSL certificate you have
 uploaded to AWS IAM. **Only valid when `lb_protocol` is either HTTPS or SSL**
 
 Health Check supports the following:


### PR DESCRIPTION
Just saying `id` is ambiguous, it could be interpreted as the resource ID which will fail with the follow error: `CertificateNotFound: Server Certificate not found for the key: <id>`. The AWS documentation states that the ssl certificate id parameter must be the ARN.