### PR TITLE
provider/docker: add option to keep local image on destroy

### DIFF
--- a/builtin/providers/docker/resource_docker_image.go
+++ b/builtin/providers/docker/resource_docker_image.go
@@ -26,6 +26,11 @@ func resourceDockerImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"keep_locally": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }

--- a/builtin/providers/docker/resource_docker_image_funcs.go
+++ b/builtin/providers/docker/resource_docker_image_funcs.go
@@ -63,6 +63,11 @@ func searchLocalImages(data Data, imageName string) *dc.APIImages {
 
 func removeImage(d *schema.ResourceData, client *dc.Client) error {
 	var data Data
+
+	if keepLocally := d.Get("keep_locally").(bool); keepLocally {
+		return nil
+	}
+
 	if err := fetchLocalImages(&data, client); err != nil {
 		return err
 	}

--- a/website/source/docs/providers/docker/r/image.html.markdown
+++ b/website/source/docs/providers/docker/r/image.html.markdown
@@ -33,6 +33,9 @@ The following arguments are supported:
   always be updated on the host to the latest. If this is false, as long as an
   image is downloaded with the correct tag, it won't be redownloaded if
   there is a newer image.
+* `keep_locally` - (Optional, boolean) If true, then the Docker image won't be
+  deleted on destroy operation. If this is false, it will delete the image from
+  the docker local storage on destroy operation.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Working with many docker container, I need to keep some local images even if I want to destroy the container, I want to keep the image locally. So I added the option `keep_locally`.