### PR TITLE
provider/vsphere: wait for network enhanced

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -403,7 +403,6 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 					},
 				},
 			},
-
 		},
 	}
 }

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -404,11 +404,6 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 				},
 			},
 
-			"boot_delay": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
 		},
 	}
 }
@@ -711,32 +706,6 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	if _, ok := d.GetOk("network_interface.0.ipv4_address"); !ok {
-		if v, ok := d.GetOk("boot_delay"); ok {
-			stateConf := &resource.StateChangeConf{
-				Pending:    []string{"pending"},
-				Target:     []string{"active"},
-				Refresh:    waitForNetworkingActive(client, vm.datacenter, vm.Path()),
-				Timeout:    600 * time.Second,
-				Delay:      time.Duration(v.(int)) * time.Second,
-				MinTimeout: 2 * time.Second,
-			}
-
-			_, err := stateConf.WaitForState()
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if ip, ok := d.GetOk("network_interface.0.ipv4_address"); ok {
-		d.SetConnInfo(map[string]string{
-			"host": ip.(string),
-		})
-	} else {
-		log.Printf("[DEBUG] Could not get IP address for %s", d.Id())
-	}
-
 	d.SetId(vm.Path())
 	log.Printf("[INFO] Created virtual machine: %s", d.Id())
 
@@ -760,6 +729,12 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	}
 
 	var mvm mo.VirtualMachine
+
+	// wait for interfaces to appear
+	_, err = vm.WaitForNetIP(context.TODO())
+	if err != nil {
+		return err
+	}
 
 	collector := property.DefaultCollector(client.Client)
 	if err := collector.RetrieveOne(context.TODO(), vm.Reference(), []string{"guest", "summary", "datastore"}, &mvm); err != nil {
@@ -826,14 +801,10 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Invalid network interfaces to set: %#v", networkInterfaces)
 	}
 
-	ip, err := vm.WaitForIP(context.TODO())
-	if err != nil {
-		return err
-	}
 	log.Printf("[DEBUG] ip address: %v", ip)
 	d.SetConnInfo(map[string]string{
 		"type": "ssh",
-		"host": ip,
+		"host": networkInterfaces[0]["ipv4_address"],
 	})
 
 	var rootDatastore string
@@ -909,39 +880,6 @@ func resourceVSphereVirtualMachineDelete(d *schema.ResourceData, meta interface{
 
 	d.SetId("")
 	return nil
-}
-
-func waitForNetworkingActive(client *govmomi.Client, datacenter, name string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		dc, err := getDatacenter(client, datacenter)
-		if err != nil {
-			log.Printf("[ERROR] %#v", err)
-			return nil, "", err
-		}
-		finder := find.NewFinder(client.Client, true)
-		finder = finder.SetDatacenter(dc)
-
-		vm, err := finder.VirtualMachine(context.TODO(), name)
-		if err != nil {
-			log.Printf("[ERROR] %#v", err)
-			return nil, "", err
-		}
-
-		var mvm mo.VirtualMachine
-		collector := property.DefaultCollector(client.Client)
-		if err := collector.RetrieveOne(context.TODO(), vm.Reference(), []string{"summary"}, &mvm); err != nil {
-			log.Printf("[ERROR] %#v", err)
-			return nil, "", err
-		}
-
-		if mvm.Summary.Guest.IpAddress != "" {
-			log.Printf("[DEBUG] IP address with DHCP: %v", mvm.Summary.Guest.IpAddress)
-			return mvm.Summary, "active", err
-		} else {
-			log.Printf("[DEBUG] Waiting for IP address")
-			return nil, "pending", err
-		}
-	}
 }
 
 // addHardDisk adds a new Hard Disk to the VirtualMachine.
@@ -1757,12 +1695,6 @@ func (vm *virtualMachine) deployVirtualMachine(c *govmomi.Client) error {
 	log.Printf("[DEBUG] virtual machine config spec: %v", configSpec)
 
 	newVM.PowerOn(context.TODO())
-
-	ip, err := newVM.WaitForIP(context.TODO())
-	if err != nil {
-		return err
-	}
-	log.Printf("[DEBUG] ip address: %v", ip)
 
 	return nil
 }

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -6,9 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
@@ -730,7 +728,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	var mvm mo.VirtualMachine
 
 	// wait for interfaces to appear
-	_, err = vm.WaitForNetIP(context.TODO())
+	_, err = vm.WaitForNetIP(context.TODO(), true)
 	if err != nil {
 		return err
 	}
@@ -800,10 +798,10 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Invalid network interfaces to set: %#v", networkInterfaces)
 	}
 
-	log.Printf("[DEBUG] ip address: %v", ip)
+	log.Printf("[DEBUG] ip address: %v", networkInterfaces[0]["ipv4_address"].(string))
 	d.SetConnInfo(map[string]string{
 		"type": "ssh",
-		"host": networkInterfaces[0]["ipv4_address"],
+		"host": networkInterfaces[0]["ipv4_address"].(string),
 	})
 
 	var rootDatastore string

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -76,7 +76,6 @@ The following arguments are supported:
 * `network_interface` - (Required) Configures virtual network interfaces; see [Network Interfaces](#network-interfaces) below for details.
 * `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for details
 * `cdrom` - (Optional) Configures a CDROM device and mounts an image as its media; see [CDROM](#cdrom) below for more details.
-* `boot_delay` - (Optional) Time in seconds to wait for machine network to be ready.
 * `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
 * `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.


### PR DESCRIPTION
I did some changes to the "wait for network" logic to make it more flexible and add the feature to wait for `Guest.Net` (takes ~30s longer than `Summary.Guest.IpAddress` in our environment)
* `boot_delay` with default value
* added `network_wait_timeout` which was previously hard coded to 600s. Changed the check for `boot_delay` to `network_wait_timeout > 0`
* added `wait_for_network_interfaces` to make it possible to wait for `Guest.Net` (the network interfaces)
* added the necessary logic to `waitForNetworkingActive`

I tried not to change the behavior, so `wait_for_network_interfaces` is set to `false` and `boot_delay` to `0` by default.