### PR TITLE
provider/azure: Randomize DNS Server acctest names

### DIFF
--- a/builtin/providers/azure/resource_azure_dns_server_test.go
+++ b/builtin/providers/azure/resource_azure_dns_server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/management"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -12,16 +13,20 @@ import (
 func TestAccAzureDnsServerBasic(t *testing.T) {
 	name := "azure_dns_server.foo"
 
+	random := acctest.RandInt()
+	config := testAccAzureDnsServerBasic(random)
+	serverName := fmt.Sprintf("tf-dns-server-%d", random)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAzureDnsServerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureDnsServerBasic,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzureDnsServerExists(name),
-					resource.TestCheckResourceAttr(name, "name", "terraform-dns-server"),
+					resource.TestCheckResourceAttr(name, "name", serverName),
 					resource.TestCheckResourceAttr(name, "dns_address", "8.8.8.8"),
 				),
 			},
@@ -32,25 +37,30 @@ func TestAccAzureDnsServerBasic(t *testing.T) {
 func TestAccAzureDnsServerUpdate(t *testing.T) {
 	name := "azure_dns_server.foo"
 
+	random := acctest.RandInt()
+	basicConfig := testAccAzureDnsServerBasic(random)
+	updateConfig := testAccAzureDnsServerUpdate(random)
+	serverName := fmt.Sprintf("tf-dns-server-%d", random)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAzureDnsServerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureDnsServerBasic,
+				Config: basicConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzureDnsServerExists(name),
-					resource.TestCheckResourceAttr(name, "name", "terraform-dns-server"),
+					resource.TestCheckResourceAttr(name, "name", serverName),
 					resource.TestCheckResourceAttr(name, "dns_address", "8.8.8.8"),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccAzureDnsServerUpdate,
+				Config: updateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzureDnsServerExists(name),
-					resource.TestCheckResourceAttr(name, "name", "terraform-dns-server"),
+					resource.TestCheckResourceAttr(name, "name", serverName),
 					resource.TestCheckResourceAttr(name, "dns_address", "8.8.4.4"),
 				),
 			},
@@ -116,16 +126,20 @@ func testAccCheckAzureDnsServerDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAzureDnsServerBasic = `
+func testAccAzureDnsServerBasic(random int) string {
+	return fmt.Sprintf(`
 resource "azure_dns_server" "foo" {
-    name = "terraform-dns-server"
+    name = "tf-dns-server-%d"
     dns_address = "8.8.8.8"
 }
-`
+`, random)
+}
 
-const testAccAzureDnsServerUpdate = `
+func testAccAzureDnsServerUpdate(random int) string {
+	return fmt.Sprintf(`
 resource "azure_dns_server" "foo" {
-    name = "terraform-dns-server"
+    name = "tf-dns-server-%d"
     dns_address = "8.8.4.4"
 }
-`
+`, random)
+}


### PR DESCRIPTION
This commit should fix the following acceptance test failures:

```
=== RUN   TestAccAzureDnsServerBasic
--- FAIL: TestAccAzureDnsServerBasic (2.17s)
	testing.go:172: Step 0 error: Error applying: 1 error(s) occurred:

        * azure_dns_server.foo: Failed issuing update to network configuration: Error response from Azure. Code: BadRequest, Message: Multiple DNS servers specified with the same name 'terraform-dns-server'.
=== RUN   TestAccAzureDnsServerUpdate
--- FAIL: TestAccAzureDnsServerUpdate (2.04s)
        testing.go:172: Step 0 error: Error applying: 1 error(s) occurred:

        * azure_dns_server.foo: Failed issuing update to network configuration: Error response from Azure. Code: BadRequest, Message: Multiple DNS servers specified with the same name 'terraform-dns-server'.
```