### PR TITLE
provider/aws - CloudFront custom_error_response fixes for missing

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -719,12 +719,15 @@ func expandCustomErrorResponse(m map[string]interface{}) *cloudfront.CustomError
 	if v, ok := m["error_caching_min_ttl"]; ok {
 		er.ErrorCachingMinTTL = aws.Int64(int64(v.(int)))
 	}
-	if v, ok := m["response_code"]; ok {
+	if v, ok := m["response_code"]; ok && v.(int) != 0 {
 		er.ResponseCode = aws.String(strconv.Itoa(v.(int)))
+	} else {
+		er.ResponseCode = aws.String("")
 	}
 	if v, ok := m["response_page_path"]; ok {
 		er.ResponsePagePath = aws.String(v.(string))
 	}
+
 	return &er
 }
 

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -191,6 +191,13 @@ func customErrorResponsesConfFirst() map[string]interface{} {
 	return customErrorResponsesConf()[0].(map[string]interface{})
 }
 
+func customErrorResponseConfNoResponseCode() map[string]interface{} {
+	er := customErrorResponsesConf()[0].(map[string]interface{})
+	er["response_code"] = 0
+	er["response_page_path"] = ""
+	return er
+}
+
 func viewerCertificateConfSetCloudFrontDefault() map[string]interface{} {
 	return map[string]interface{}{
 		"acm_certificate_arn":            "",
@@ -756,6 +763,17 @@ func TestCloudFrontStructure_expandCustomErrorResponse(t *testing.T) {
 	}
 	if *er.ResponsePagePath != "/error-pages/404.html" {
 		t.Fatalf("Expected ResponsePagePath to be /error-pages/404.html, got %v", *er.ResponsePagePath)
+	}
+}
+
+func TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode(t *testing.T) {
+	data := customErrorResponseConfNoResponseCode()
+	er := expandCustomErrorResponse(data)
+	if *er.ResponseCode != "" {
+		t.Fatalf("Expected ResponseCode to be empty string, got %v", *er.ResponseCode)
+	}
+	if *er.ResponsePagePath != "" {
+		t.Fatalf("Expected ResponsePagePath to be empty string, got %v", *er.ResponsePagePath)
 	}
 }
 

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -396,7 +396,7 @@ variable rand_id {
 	default = %d
 }
 
-resource "aws_cloudfront_distribution" "no_optional_items" {
+resource "aws_cloudfront_distribution" "no_custom_error_responses" {
 	origin {
 		domain_name = "www.example.com"
 		origin_id = "myCustomOrigin"
@@ -447,7 +447,7 @@ variable rand_id {
 	default = %d
 }
 
-resource "aws_cloudfront_distribution" "no_custom_error_responses" {
+resource "aws_cloudfront_distribution" "no_optional_items" {
 	origin {
 		domain_name = "www.example.com"
 		origin_id = "myCustomOrigin"


### PR DESCRIPTION
- Omit custom_error_response response_* fields when not explicitly set via config for
SDK call
- Adding a test case to ensure that the response_error gets converted
to an empty string properly, versus "0". (Thanks @vancluever)

Fixes #6324 