### PR TITLE
Allow running tests when AWS_PROFILE is set, needed for STS users

### DIFF
--- a/builtin/providers/aws/auth_helpers_test.go
+++ b/builtin/providers/aws/auth_helpers_test.go
@@ -483,7 +483,7 @@ func unsetEnv(t *testing.T) func() {
 		t.Fatalf("Error unsetting env var AWS_SESSION_TOKEN: %s", err)
 	}
 	if err := os.Unsetenv("AWS_PROFILE"); err != nil {
-		t.Fatalf("Error unsetting env var AWS_TOKEN: %s", err)
+		t.Fatalf("Error unsetting env var AWS_PROFILE: %s", err)
 	}
 	if err := os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE"); err != nil {
 		t.Fatalf("Error unsetting env var AWS_SHARED_CREDENTIALS_FILE: %s", err)
@@ -635,7 +635,7 @@ func getEnv() *currentEnv {
 		Key:           os.Getenv("AWS_ACCESS_KEY_ID"),
 		Secret:        os.Getenv("AWS_SECRET_ACCESS_KEY"),
 		Token:         os.Getenv("AWS_SESSION_TOKEN"),
-		Profile:       os.Getenv("AWS_TOKEN"),
+		Profile:       os.Getenv("AWS_PROFILE"),
 		CredsFilename: os.Getenv("AWS_SHARED_CREDENTIALS_FILE"),
 	}
 }

--- a/builtin/providers/aws/provider_test.go
+++ b/builtin/providers/aws/provider_test.go
@@ -30,11 +30,13 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("AWS_ACCESS_KEY_ID"); v == "" {
-		t.Fatal("AWS_ACCESS_KEY_ID must be set for acceptance tests")
-	}
-	if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v == "" {
-		t.Fatal("AWS_SECRET_ACCESS_KEY must be set for acceptance tests")
+	if v := os.Getenv("AWS_PROFILE"); v == "" {
+		if v := os.Getenv("AWS_ACCESS_KEY_ID"); v == "" {
+			t.Fatal("AWS_ACCESS_KEY_ID must be set for acceptance tests")
+		}
+		if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v == "" {
+			t.Fatal("AWS_SECRET_ACCESS_KEY must be set for acceptance tests")
+		}
 	}
 	if v := os.Getenv("AWS_DEFAULT_REGION"); v == "" {
 		log.Println("[INFO] Test: Using us-west-2 as test region")


### PR DESCRIPTION
I don't have a great understanding of how the testing system is set up, I just now learned how to run the acceptance tests with `testacc` and `TEST=./builtin/providers/aws` :)

A full test without `TESTARGS` will start to throw errors of no valid credentials, but with this patch you can at least test individual resources.