### PR TITLE
provider/aws: Fix Read of AWS CloudWatch Log when Update was called

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -117,14 +117,18 @@ func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{
 			}
 			log.Printf("[DEBUG] Setting retention for CloudWatch Log Group: %q: %s", name, input)
 			_, err = conn.PutRetentionPolicy(&input)
+			if err != nil {
+				return err
+			}
 		} else {
 			log.Printf("[DEBUG] Deleting retention for CloudWatch Log Group: %q", name)
 			_, err = conn.DeleteRetentionPolicy(&cloudwatchlogs.DeleteRetentionPolicyInput{
 				LogGroupName: aws.String(name),
 			})
+			if err != nil {
+				return err
+			}
 		}
-
-		return err
 	}
 
 	return resourceAwsCloudWatchLogGroupRead(d, meta)


### PR DESCRIPTION
Fixes #6169

The Update func was hitting a return err and when the err was empty, it
was skipping over the subsequent read func

```
ake testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudWatchLogGroup' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudWatchLogGroup -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (14.64s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (23.51s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (18.58s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	56.747s
```