### PR TITLE
command/fmt: Improve documentation for -diff and defaults

### DIFF
--- a/command/fmt.go
+++ b/command/fmt.go
@@ -83,7 +83,7 @@ Options:
 
   -write           Write result to source file instead of STDOUT (disabled if using STDIN)
 
-  -diff            Display diffs instead of rewriting files
+  -diff            Display diffs of formatting changes
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/fmt.go
+++ b/command/fmt.go
@@ -79,11 +79,11 @@ Usage: terraform fmt [options] [DIR]
 
 Options:
 
-  -list            List files whose formatting differs (disabled if using STDIN)
+  -list=true       List files whose formatting differs (always false if using STDIN)
 
-  -write           Write result to source file instead of STDOUT (disabled if using STDIN)
+  -write=true      Write result to source file instead of STDOUT (always false if using STDIN)
 
-  -diff            Display diffs of formatting changes
+  -diff=false      Display diffs of formatting changes
 
 `
 	return strings.TrimSpace(helpText)

--- a/website/source/docs/commands/fmt.html.markdown
+++ b/website/source/docs/commands/fmt.html.markdown
@@ -25,4 +25,4 @@ The command-line flags are all optional. The list of available flags are:
 * `-list=true` - List files whose formatting differs (disabled if using STDIN)
 * `-write=true` - Write result to source file instead of STDOUT (disabled if
     using STDIN)
-* `-diff=false` - Display diffs instead of rewriting files
+* `-diff=false` - Display diffs of formatting changes


### PR DESCRIPTION
#### Document -diff doesn't disable -write

As noted in hashicorp/terraform#6343, this description misleadingly suggested that the `-diff` option disables the `-write` option.

This isn't the case and because of the default options (described in c753390) the behaviour of `terraform fmt -diff` is actually the same as `terraform fmt -write -list -diff`.

Replace the "instead of rewriting" description to clarify that.

Documentation in hcl/fmtcmd is corrected in hashicorp/hcl#117 but it's not really necessary to bump the dependency version.

#### Show flag defaults in help text

These were documented on the website but not in the `-help` text. This should help to clarify that you need to pass `-list=false -write=false -diff` if you only want to see diffs.

Accordingly I've replaced the word "disabled" with "always false" in the STDIN special cases so that it matches the terminology used in the defaults and better indicates that it is overridden.

NB: The 3x duplicated defaults and documentation makes me feel uneasy once again. I'm not sure how to solve that, though