### PR TITLE
provider/aws: VPC Peering: allow default peer account ID

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -241,17 +240,12 @@ func TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 		return nil
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if os.Getenv("AWS_ACCOUNT_ID") == "" {
-				t.Fatal("Error: Test TestAccAWSRouteTable_vpcPeering requires an Account ID in AWS_ACCOUNT_ID ")
-			}
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRouteTableVpcPeeringConfig(os.Getenv("AWS_ACCOUNT_ID")),
+				Config: testAccRouteTableVpcPeeringConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
 						"aws_route_table.foo", &v),
@@ -404,9 +398,8 @@ resource "aws_route_table" "foo" {
 `
 
 // VPC Peering connections are prefixed with pcx
-// This test requires an ENV var, AWS_ACCOUNT_ID, with a valid AWS Account ID
-func testAccRouteTableVpcPeeringConfig(acc string) string {
-	cfg := `resource "aws_vpc" "foo" {
+const testAccRouteTableVpcPeeringConfig = `
+resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 }
 
@@ -425,7 +418,6 @@ resource "aws_internet_gateway" "bar" {
 resource "aws_vpc_peering_connection" "foo" {
 		vpc_id = "${aws_vpc.foo.id}"
 		peer_vpc_id = "${aws_vpc.bar.id}"
-		peer_owner_id = "%s"
 		tags {
 			foo = "bar"
 		}
@@ -440,8 +432,6 @@ resource "aws_route_table" "foo" {
 	}
 }
 `
-	return fmt.Sprintf(cfg, acc)
-}
 
 const testAccRouteTableVgwRoutePropagationConfig = `
 resource "aws_vpc" "foo" {

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -25,10 +25,10 @@ func resourceAwsVpcPeeringConnection() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"peer_owner_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_ACCOUNT_ID", nil),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"peer_vpc_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -60,10 +60,14 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Create the vpc peering connection
 	createOpts := &ec2.CreateVpcPeeringConnectionInput{
-		PeerOwnerId: aws.String(d.Get("peer_owner_id").(string)),
-		PeerVpcId:   aws.String(d.Get("peer_vpc_id").(string)),
-		VpcId:       aws.String(d.Get("vpc_id").(string)),
+		PeerVpcId: aws.String(d.Get("peer_vpc_id").(string)),
+		VpcId:     aws.String(d.Get("vpc_id").(string)),
 	}
+
+	if v, ok := d.GetOk("peer_owner_id"); ok {
+		createOpts.PeerOwnerId = aws.String(v.(string))
+	}
+
 	log.Printf("[DEBUG] VPC Peering Create options: %#v", createOpts)
 
 	resp, err := conn.CreateVpcPeeringConnection(createOpts)

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"testing"
 
@@ -17,13 +16,7 @@ func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if os.Getenv("AWS_ACCOUNT_ID") == "" {
-				t.Fatal("AWS_ACCOUNT_ID must be set.")
-			}
-		},
-
+		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshName:   "aws_vpc_peering_connection.foo",
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -60,17 +53,10 @@ func TestAccAWSVPCPeeringConnection_plan(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if os.Getenv("AWS_ACCOUNT_ID") == "" {
-				t.Fatal("AWS_ACCOUNT_ID must be set.")
-			}
-		},
-
+		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshIgnore: []string{"auto_accept"},
-
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		Providers:       testAccProviders,
+		CheckDestroy:    testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccVpcPeeringConfig,
@@ -90,13 +76,7 @@ func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if os.Getenv("AWS_ACCOUNT_ID") == "" {
-				t.Fatal("AWS_ACCOUNT_ID must be set.")
-			}
-		},
-
+		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshName:   "aws_vpc_peering_connection.foo",
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -137,13 +117,7 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if os.Getenv("AWS_ACCOUNT_ID") == "" {
-				t.Fatal("AWS_ACCOUNT_ID must be set")
-			}
-		},
-
+		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshName:   "aws_vpc_peering_connection.foo",
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -280,7 +254,7 @@ func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VpcPeer
 			return err
 		}
 		if len(resp.VpcPeeringConnections) == 0 {
-			return fmt.Errorf("VPC Peering Connection could not be found.")
+			return fmt.Errorf("VPC Peering Connection could not be found")
 		}
 
 		*connection = *resp.VpcPeeringConnections[0]

--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -12,8 +12,6 @@ Provides an VPC Peering Connection resource.
 
 ## Example Usage
 
-Basic usage:
-
 ```
 resource "aws_vpc_peering_connection" "foo" {
     peer_owner_id = "${var.peer_owner_id}"
@@ -49,6 +47,9 @@ resource "aws_vpc_peering_connection" "foo" {
     peer_vpc_id = "${aws_vpc.bar.id}"
     vpc_id = "${aws_vpc.foo.id}"
 
+=======
+    
+>>>>>>> provider/aws: VPC Peering: allow default peer VPC ID
     auto_accept = true
 
     tags {
@@ -75,6 +76,7 @@ more information.
 The following arguments are supported:
 
 * `peer_owner_id` - (Required) The AWS account ID of the owner of the peer VPC.
+   Defaults to the account ID the [AWS provider][1] is currently connected to.
 * `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC Peering Connection.
 * `vpc_id` - (Required) The ID of the requester VPC.
 * `auto_accept` - (Optional) Accept the peering (you need to be the owner of both VPCs).
@@ -123,3 +125,5 @@ VPC Peering resources can be imported using the `vpc peering id`, e.g.
 ```
 $ terraform import aws_vpc_peering_connection.test_connection pcx-111aaa111
 ```
+
+[1]: /docs/providers/aws/index.html


### PR DESCRIPTION
Reference: #6396 

This is almost done, I've ran all acceptance tests save the one that requires a separate account and they pass. I just want to apply this on a local config first, just to make sure that diffs still work when you supply an account ID after the fact, and then I'll remove the WIP tag.
