### PR TITLE
vSphere Disk image name

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -811,8 +811,15 @@ func addHardDisk(vm *object.VirtualMachine, size, iops int64, diskType string, d
 	}
 	log.Printf("[DEBUG] disk controller: %#v\n", controller)
 
-	// TODO Check if diskPath & datastore exist
-	disk := devices.CreateDisk(controller, fmt.Sprintf("[%v] %v", datastore.Name(), diskPath))
+	// If diskPath is not specified, pass empty string to CreateDisk()
+	var newDiskPath string
+	if diskPath == "" {
+		newDiskPath = ""
+	} else {
+		// TODO Check if diskPath & datastore exist
+		newDiskPath = fmt.Sprintf("[%v] %v", datastore.Name(), diskPath)
+	}
+	disk := devices.CreateDisk(controller, newDiskPath)
 	existing := devices.SelectByBackingInfo(disk.Backing)
 	log.Printf("[DEBUG] disk: %#v\n", disk)
 


### PR DESCRIPTION
We were passing in a disk path of `[datastore] `, which the createDisk
call would create a file named `.vmdk` on the datastore, which is not
the expected behavior.  This make sure that if the user did not pass in
a vmdk path, that we call CreateDisk with an empty string like it
expects.