### PR TITLE
provider/aws: Updating CloudFront distribution to correct LoggingConfig

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -124,12 +124,16 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 			return err
 		}
 	}
+
 	if distributionConfig.Logging != nil && *distributionConfig.Logging.Enabled {
 		err = d.Set("logging_config", flattenLoggingConfig(distributionConfig.Logging))
-		if err != nil {
-			return err
-		}
+	} else {
+		err = d.Set("logging_config", schema.NewSet(loggingConfigHash, []interface{}{}))
 	}
+	if err != nil {
+		return err
+	}
+
 	if distributionConfig.Aliases != nil {
 		err = d.Set("aliases", flattenAliases(distributionConfig.Aliases))
 		if err != nil {


### PR DESCRIPTION
- Addresses the issue when local state file has logging_config populated and the user
  disables the configuration via the UI (or in this case an
  application of the TF config).  This will now properly set the
  logging_config during the read operation and identify the state as
  diverging

Fixes #6390