### PR TITLE
provider/clc: Fix clc_server password argument as Optional.

### DIFF
--- a/builtin/providers/clc/resource_clc_server.go
+++ b/builtin/providers/clc/resource_clc_server.go
@@ -44,15 +44,14 @@ func resourceCLCServer() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			// optional
 			"password": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
-			// optional
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "",
 			},
 			"type": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
The `clc_server` resource doc's list `password` as *optional* [1], however the resource provider has it marked as a *Required* [2].

This PR switches the `password` field to an *Optional* field. 

I did look at adding additional tests for this, however the `password` value isn't returned by the resource, therefore I couldn't see an easy way to validate. Happy to revisit if I've missed something. 

cc @ack 

[1] https://github.com/hashicorp/terraform/blob/master/website/source/docs/providers/clc/r/server.html.markdown
[2] https://github.com/hashicorp/terraform/blob/master/builtin/providers/clc/resource_clc_server.go#L47-L49