### PR TITLE
provider/docker: don't crash with empty commands

### DIFF
--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -51,6 +51,11 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 
 	if v, ok := d.GetOk("command"); ok {
 		createOpts.Config.Cmd = stringListToStringSlice(v.([]interface{}))
+		for _, v := range createOpts.Config.Cmd {
+			if v == "" {
+				return fmt.Errorf("values for command may not be empty")
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("entrypoint"); ok {
@@ -269,6 +274,10 @@ func resourceDockerContainerDelete(d *schema.ResourceData, meta interface{}) err
 func stringListToStringSlice(stringList []interface{}) []string {
 	ret := []string{}
 	for _, v := range stringList {
+		if v == nil {
+			ret = append(ret, "")
+			continue
+		}
 		ret = append(ret, v.(string))
 	}
 	return ret


### PR DESCRIPTION
If any of the entries in `commands` on `docker_container` resources was empty, the assertion to string panic'd. Since we can't use ValidateFunc on list elements, we can only really check this at apply time. If any value is nil (resolves to empty string during conversion), we fail with an error prior to creating the container.

Fixes #6409.