### PR TITLE
A simplifed load balancer resource for AzureRM

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -81,7 +81,6 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_sql_firewall_rule": resourceArmSqlFirewallRule(),
 			"azurerm_sql_server":        resourceArmSqlServer(),
 			"azurerm_simple_lb":         resourceArmSimpleLb(),
->>>>>>> A simplifed load balancer resource for AzureRM
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -80,6 +80,8 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_sql_database":      resourceArmSqlDatabase(),
 			"azurerm_sql_firewall_rule": resourceArmSqlFirewallRule(),
 			"azurerm_sql_server":        resourceArmSqlServer(),
+			"azurerm_simple_lb":         resourceArmSimpleLb(),
+>>>>>>> A simplifed load balancer resource for AzureRM
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -328,6 +328,12 @@ func resourceArmNetworkInterfaceIpConfigurationHash(v interface{}) int {
 	if m["public_ip_address_id"] != nil {
 		buf.WriteString(fmt.Sprintf("%s-", m["public_ip_address_id"].(string)))
 	}
+	if m["load_balancer_backend_address_pools_ids"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["load_balancer_backend_address_pools_ids"].(*schema.Set).GoString()))
+	}
+	if m["load_balancer_inbound_nat_rules_ids"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["load_balancer_inbound_nat_rules_ids"].(*schema.Set).GoString()))
+	}
 
 	return hashcode.String(buf.String())
 }

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -1,0 +1,501 @@
+package azurerm
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+// resourceArmLoadBalancer returns the *schema.Resource
+// associated to load balancer resources on ARM.
+func resourceArmSimpleLb() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmSimpleLbCreate,
+		Read:   resourceArmSimpleLbRead,
+		Update: resourceArmSimpleLbUpdate,
+		Delete: resourceArmSimpleLbDelete,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"backend_pool_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"probe_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"frontend_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"location": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+			"frontend_private_ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"frontend_allocation_method": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateAllocationMethod,
+			},
+			"frontend_subnet": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"frontend_public_ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"probe_protocol": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateProtocolType,
+			},
+			"probe_port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"probe_interval": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"probe_number_of_probes": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"probe_request_path": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"rule_protocol": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateProtocolType,
+			},
+			"rule_load_distribution": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateLoadDistribution,
+			},
+			"rule_frontend_port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"rule_backend_port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+		},
+	}
+}
+
+func validateAllocationMethod(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	allocations := map[string]bool{
+		"static":  true,
+		"dynamic": true,
+	}
+
+	if !allocations[value] {
+		errors = append(errors, fmt.Errorf("Allocation method can only be Static or Dynamic"))
+	}
+	return
+}
+
+func validateProtocolType(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	allocations := map[string]bool{
+		"tcp": true,
+		"udp": true,
+	}
+
+	if !allocations[value] {
+		errors = append(errors, fmt.Errorf("Protocol can only be tcp or udp"))
+	}
+	return
+}
+
+func validateLoadDistribution(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	allocations := map[string]bool{
+		"default":          true,
+		"sourceip":         true,
+		"sourceipprotocol": true,
+	}
+
+	if !allocations[value] {
+		errors = append(errors, fmt.Errorf("Load Distribution can only be default, sourceIp, or sourceIpProtocol"))
+	}
+	return
+}
+
+func pullOutLbRules(d *schema.ResourceData) (*[]network.LoadBalancingRule, error) {
+	log.Printf("[resourceArmSimpleLb] pullOutLbRules[enter]")
+	defer log.Printf("[resourceArmSimpleLb] pullOutLbRules[exit]")
+
+	backendPoolId := d.Get("backend_pool_id").(string)
+	frontendIpId := d.Get("frontend_id").(string)
+	probeId := d.Get("probe_id").(string)
+
+	backendPoolRef := network.SubResource{ID: &backendPoolId}
+	frontendIpRef := network.SubResource{ID: &frontendIpId}
+	probeRef := network.SubResource{ID: &probeId}
+
+	returnRules := []network.LoadBalancingRule{}
+
+	ruleName := fmt.Sprintf("%srule", d.Get("name").(string))
+	ruleProtocol := network.TransportProtocol(d.Get("rule_protocol").(string))
+	ruleFrontendPort := d.Get("rule_frontend_port").(int)
+	ruleBackendPort := d.Get("rule_backend_port").(int)
+	ruleLoadDistributionS := d.Get("rule_load_distribution").(string)
+	if ruleLoadDistributionS == "" {
+		ruleLoadDistributionS = "Default"
+	}
+
+	rulesProps := network.LoadBalancingRulePropertiesFormat{
+		FrontendIPConfiguration: &frontendIpRef,
+		BackendAddressPool:      &backendPoolRef,
+		BackendPort:             &ruleBackendPort,
+		FrontendPort:            &ruleFrontendPort,
+		Protocol:                ruleProtocol,
+		LoadDistribution:        network.LoadDistribution(ruleLoadDistributionS),
+		Probe:                   &probeRef,
+	}
+
+	ruleType := network.LoadBalancingRule{
+		Name:       &ruleName,
+		Properties: &rulesProps,
+	}
+
+	returnRules = append(returnRules, ruleType)
+
+	return &returnRules, nil
+}
+
+func pullOutProbes(d *schema.ResourceData) (*[]network.Probe, error) {
+	log.Printf("[resourceArmSimpleLb] pullOutProbes[enter]")
+	defer log.Printf("[resourceArmSimpleLb] pullOutProbes[exit]")
+
+	returnRules := []network.Probe{}
+
+	probeName := fmt.Sprintf("%sprobe", d.Get("name").(string))
+
+	probeProtocol := network.ProbeProtocol(d.Get("probe_protocol").(string))
+	probePort := d.Get("probe_port").(int)
+	probeInterval := d.Get("probe_interval").(int)
+	probeNumberOfProbes := d.Get("probe_number_of_probes").(int)
+	probeRequestPath := d.Get("probe_request_path").(string)
+
+	probeProps := network.ProbePropertiesFormat{
+		Protocol:          probeProtocol,
+		Port:              &probePort,
+		IntervalInSeconds: &probeInterval,
+		NumberOfProbes:    &probeNumberOfProbes,
+	}
+	if probeRequestPath != "" {
+		probeProps.RequestPath = &probeRequestPath
+	}
+	probe := network.Probe{
+		Name:       &probeName,
+		Properties: &probeProps,
+	}
+
+	returnRules = append(returnRules, probe)
+	return &returnRules, nil
+}
+
+func pullOutFrontEndIps(d *schema.ResourceData) (*[]network.FrontendIPConfiguration, error) {
+	log.Printf("[resourceArmSimpleLb] pullOutFrontEndIps[enter]")
+	defer log.Printf("[resourceArmSimpleLb] pullOutFrontEndIps[exit]")
+
+	returnRules := []network.FrontendIPConfiguration{}
+
+	frontedIpName := fmt.Sprintf("%sfrontendip", d.Get("name").(string))
+	frontedIpAllocationMethod := network.IPAllocationMethod(d.Get("frontend_allocation_method").(string))
+	frontedIpSubnet := d.Get("frontend_subnet").(string)
+	frontedIpPublicIpAddress := d.Get("frontend_public_ip_address").(string)
+	frontedIpPrivateIpAddress := d.Get("frontend_private_ip_address").(string)
+
+	if frontedIpSubnet == "" && frontedIpPublicIpAddress == "" {
+		var logMsg = fmt.Sprintf("[ERROR] Either a subnet of a public ip address must be provided")
+		log.Printf("[resourceArmSimpleLb] %s", logMsg)
+		return nil, fmt.Errorf(logMsg)
+	}
+
+	if frontedIpPrivateIpAddress == "" && frontedIpAllocationMethod == network.Static {
+		var logMsg = fmt.Sprintf("An private IP address must be provided if static allocation is used.")
+		log.Printf("[resourceArmSimpleLb] %s", logMsg)
+		return nil, fmt.Errorf(logMsg)
+	}
+
+	ipProps := network.FrontendIPConfigurationPropertiesFormat{
+		PrivateIPAllocationMethod: frontedIpAllocationMethod}
+
+	if frontedIpSubnet != "" {
+		subnet := network.Subnet{ID: &frontedIpSubnet}
+		ipProps.Subnet = &subnet
+	}
+	if frontedIpPublicIpAddress != "" {
+		pubIp := network.PublicIPAddress{ID: &frontedIpPublicIpAddress}
+		ipProps.PublicIPAddress = &pubIp
+	}
+	if frontedIpPrivateIpAddress != "" {
+		ipProps.PrivateIPAddress = &frontedIpPrivateIpAddress
+	}
+
+	frontendIpConf := network.FrontendIPConfiguration{Name: &frontedIpName, Properties: &ipProps}
+	returnRules = append(returnRules, frontendIpConf)
+	return &returnRules, nil
+}
+
+func resourceArmSimpleLbCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbCreate[enter]")
+	defer log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbCreate[exit]")
+
+	lbClient := meta.(*ArmClient).loadBalancerClient
+
+	// first; fetch a bunch of fields:
+	typ := d.Get("type").(string)
+	name := d.Get("name").(string)
+	location := d.Get("location").(string)
+	resGrp := d.Get("resource_group_name").(string)
+
+	loadBalancer := network.LoadBalancer{
+		Name:       &name,
+		Type:       &typ,
+		Location:   &location,
+		Properties: &network.LoadBalancerPropertiesFormat{},
+	}
+
+	fipconfs, err := pullOutFrontEndIps(d)
+	if err != nil {
+		return err
+	}
+	loadBalancer.Properties.FrontendIPConfigurations = fipconfs
+	probes, err := pullOutProbes(d)
+	if err != nil {
+		return err
+	}
+	loadBalancer.Properties.Probes = probes
+
+	new_backend_pool_name := fmt.Sprintf("%sbackendpool", name)
+	backendpool := network.BackendAddressPool{Name: &new_backend_pool_name}
+	backendPoolConfs := []network.BackendAddressPool{}
+	backendPoolConfs = append(backendPoolConfs, backendpool)
+	loadBalancer.Properties.BackendAddressPools = &backendPoolConfs
+
+	resp, err := lbClient.CreateOrUpdate(resGrp, name, loadBalancer)
+	if err != nil {
+		log.Printf("[resourceArmSimpleLb] ERROR LB got status %s", err.Error())
+		return fmt.Errorf("Error issuing Azure ARM creation request for load balancer '%s': %s", name, err)
+	}
+	log.Printf("[resourceArmSimpleLb] Create LB got status %d", resp.StatusCode)
+
+	d.SetId(*resp.ID)
+	err = iResourceArmSimpleLbRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[resourceArmSimpleLb] We have the IDs now updating to set rules")
+	loadBalancer.Properties.LoadBalancingRules, err = pullOutLbRules(d)
+	if err != nil {
+		return err
+	}
+	resp, err = lbClient.CreateOrUpdate(resGrp, name, loadBalancer)
+	if err != nil {
+		log.Printf("[resourceArmSimpleLb] ERROR LB got status %s", err.Error())
+		return fmt.Errorf("Error issuing Azure ARM creation request for load balancer '%s': %s", name, err)
+	}
+
+	return iResourceArmSimpleLbRead(d, meta)
+}
+
+func flattenAzureRmFrontendIp(frontenIpArray []network.FrontendIPConfiguration, d *schema.ResourceData) error {
+	log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[enter]")
+	defer log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[exit]")
+
+	if len(frontenIpArray) < 1 {
+		return nil
+	}
+	if len(frontenIpArray) > 1 {
+		log.Printf("[WARN] More than 1 frontend ip was found.  The simpleLB resource will just use the first one.")
+	}
+
+	frontenIp := frontenIpArray[0]
+
+	if frontenIp.Properties.PrivateIPAddress != nil {
+		d.Set("frontend_private_ip_address", *frontenIp.Properties.PrivateIPAddress)
+	}
+	d.Set("frontend_allocation_method", string(frontenIp.Properties.PrivateIPAllocationMethod))
+	if frontenIp.Properties.Subnet != nil {
+		d.Set("frontend_subnet", *frontenIp.Properties.Subnet.ID)
+	}
+	if frontenIp.Properties.PublicIPAddress != nil {
+		d.Set("frontend_public_ip_address", *frontenIp.Properties.PublicIPAddress.ID)
+	}
+
+	return nil
+}
+
+func flattenAzureRmLoadBalancerRules(loadBalancingRuleArray []network.LoadBalancingRule, d *schema.ResourceData) error {
+	log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[enter]")
+	defer log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[exit]")
+
+	if len(loadBalancingRuleArray) < 1 {
+		return nil
+	}
+	if len(loadBalancingRuleArray) > 1 {
+		log.Printf("[WARN] More than 1 load balancing rule was found.  The simpleLB resource will just use the first one.")
+	}
+
+	loadBalancingRule := loadBalancingRuleArray[0]
+	d.Set("rule_protocol", string(loadBalancingRule.Properties.Protocol))
+	d.Set("rule_load_distribution", string(loadBalancingRule.Properties.LoadDistribution))
+	d.Set("rule_frontend_port", *loadBalancingRule.Properties.FrontendPort)
+	d.Set("rule_backend_port", *loadBalancingRule.Properties.BackendPort)
+
+	return nil
+}
+
+func flattenAzureRmProbe(probeArray []network.Probe, d *schema.ResourceData) error {
+	log.Printf("[resourceArmSimpleLb] flattenAzureRmProbe[enter]")
+	defer log.Printf("[resourceArmSimpleLb] flattenAzureRmProbe[exit]")
+
+	if len(probeArray) < 1 {
+		return nil
+	}
+	if len(probeArray) > 1 {
+		log.Printf("[WARN] More than 1 load balancing rule was found.  The simpleLB resource will just use the first one.")
+	}
+
+	probe := probeArray[0]
+
+	d.Set("probe_protocol", string(probe.Properties.Protocol))
+	d.Set("probe_port", *probe.Properties.Port)
+	d.Set("probe_interval", *probe.Properties.IntervalInSeconds)
+	d.Set("probe_number_of_probes", *probe.Properties.NumberOfProbes)
+	if probe.Properties.RequestPath != nil {
+		d.Set("probe_request_path", *probe.Properties.RequestPath)
+	}
+
+	return nil
+}
+
+func resourceArmSimpleLbUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbUpdate[enter]")
+	defer log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbUpdate[exit]")
+
+	return resourceArmSimpleLbCreate(d, meta)
+}
+
+func resourceArmSimpleLbDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbDelete[enter]")
+	defer log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbDelete[exit]")
+
+	lbClient := meta.(*ArmClient).loadBalancerClient
+
+	name := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+
+	log.Printf("[INFO] Issuing deletion request to Azure ARM for load balancer '%s'.", name)
+
+	resp, err := lbClient.Delete(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error issuing Azure ARM delete request for load balancer '%s': %s", name, err)
+	}
+
+	log.Printf("[resourceArmSimpleLb] delete response %d %s", resp.StatusCode, resp.Status)
+
+	return nil
+}
+
+// resourceArmLoadBalancerRead goes ahead and reads the state of the corresponding ARM load balancer.
+func iResourceArmSimpleLbRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[resourceArmSimpleLb] iResourceArmSimpleLbRead[enter]")
+	defer log.Printf("[resourceArmSimpleLb] iResourceArmSimpleLbRead[exit]")
+
+	lbClient := meta.(*ArmClient).loadBalancerClient
+
+	name := d.Get("name").(string)
+	resGrp := d.Get("resource_group_name").(string)
+
+	log.Printf("[INFO] Issuing read request of load balancer '%s' off Azure.", name)
+
+	loadBalancer, err := lbClient.Get(resGrp, name, "")
+	if err != nil {
+		return fmt.Errorf("Error reading the state of the load balancer off Azure: %s", err)
+	}
+
+	log.Printf("[INFO] Succesfully retrieved details for load balancer '%s'.", *loadBalancer.Name)
+
+	fip := loadBalancer.Properties.FrontendIPConfigurations
+
+	d.Set("location", loadBalancer.Location)
+	d.Set("type", loadBalancer.Type)
+
+	err = flattenAzureRmFrontendIp(*fip, d)
+	if err != nil {
+		return err
+	}
+	err = flattenAzureRmProbe(*loadBalancer.Properties.Probes, d)
+	if err != nil {
+		return err
+	}
+	if loadBalancer.Properties.BackendAddressPools == nil || len(*loadBalancer.Properties.BackendAddressPools) != 1 {
+		return fmt.Errorf("There must be exactly 1 backend pool to use this resource")
+	}
+	d.Set("backend_pool_id", (*loadBalancer.Properties.BackendAddressPools)[0].ID)
+	if loadBalancer.Properties.Probes == nil || len(*loadBalancer.Properties.Probes) != 1 {
+		return fmt.Errorf("There must be exactly 1 probe to use this resource")
+	}
+	d.Set("probe_id", (*loadBalancer.Properties.Probes)[0].ID)
+	if loadBalancer.Properties.FrontendIPConfigurations == nil || len(*loadBalancer.Properties.FrontendIPConfigurations) != 1 {
+		return fmt.Errorf("There must be exactly 1 probe to use this resource")
+	}
+	d.Set("frontend_id", (*loadBalancer.Properties.FrontendIPConfigurations)[0].ID)
+	err = flattenAzureRmLoadBalancerRules(*loadBalancer.Properties.LoadBalancingRules, d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// resourceArmLoadBalancerRead goes ahead and reads the state of the corresponding ARM load balancer.
+func resourceArmSimpleLbRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbRead[enter]")
+	defer log.Printf("[resourceArmSimpleLb] resourceArmSimpleLbRead[exit]")
+
+	return iResourceArmSimpleLbRead(d, meta)
+}

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -153,6 +153,7 @@ func resourceArmSimpleLb() *schema.Resource {
 				},
 				Set: resourceARMLoadBalancerRuleHash,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -387,12 +388,14 @@ func resourceArmSimpleLbCreate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGrp := d.Get("resource_group_name").(string)
+	tags := d.Get("tags").(map[string]interface{})
 
 	loadBalancer := network.LoadBalancer{
 		Name:       &name,
 		Type:       &typ,
 		Location:   &location,
 		Properties: &network.LoadBalancerPropertiesFormat{},
+		Tags:       expandTags(tags),
 	}
 
 	fipconfs, err := pullOutFrontEndIps(d)
@@ -603,6 +606,8 @@ func iResourceArmSimpleLbRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	flattenAndSetTags(d, loadBalancer.Tags)
+
 	return nil
 }
 

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -70,6 +70,9 @@ func resourceArmSimpleLb() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateAllocationMethod,
 				ForceNew:     true,
+				StateFunc: func(id interface{}) string {
+					return strings.ToLower(id.(string))
+				},
 			},
 			"frontend_subnet": &schema.Schema{
 				Type:     schema.TypeString,
@@ -462,7 +465,7 @@ func flattenAzureRmFrontendIp(frontenIpArray []network.FrontendIPConfiguration, 
 	if frontenIp.Properties.PrivateIPAddress != nil {
 		d.Set("frontend_private_ip_address", *frontenIp.Properties.PrivateIPAddress)
 	}
-	d.Set("frontend_allocation_method", string(frontenIp.Properties.PrivateIPAllocationMethod))
+	d.Set("frontend_allocation_method", strings.ToLower(string(frontenIp.Properties.PrivateIPAllocationMethod)))
 	if frontenIp.Properties.Subnet != nil {
 		d.Set("frontend_subnet", *frontenIp.Properties.Subnet.ID)
 	}

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -332,40 +332,40 @@ func pullOutFrontEndIps(d *schema.ResourceData) (*[]network.FrontendIPConfigurat
 
 	returnRules := []network.FrontendIPConfiguration{}
 
-	frontedIpName := fmt.Sprintf("%sfrontendip", d.Get("name").(string))
-	frontedIpAllocationMethod := network.IPAllocationMethod(d.Get("frontend_allocation_method").(string))
-	frontedIpSubnet := d.Get("frontend_subnet").(string)
-	frontedIpPublicIpAddress := d.Get("frontend_public_ip_address").(string)
-	frontedIpPrivateIpAddress := d.Get("frontend_private_ip_address").(string)
+	frontendIpName := fmt.Sprintf("%sfrontendip", d.Get("name").(string))
+	frontendIpAllocationMethod := network.IPAllocationMethod(d.Get("frontend_allocation_method").(string))
+	frontendIpSubnet := d.Get("frontend_subnet").(string)
+	frontendIpPublicIpAddress := d.Get("frontend_public_ip_address").(string)
+	frontendIpPrivateIpAddress := d.Get("frontend_private_ip_address").(string)
 
-	if frontedIpSubnet == "" && frontedIpPublicIpAddress == "" {
+	if frontendIpSubnet == "" && frontendIpPublicIpAddress == "" {
 		var logMsg = fmt.Sprintf("[ERROR] Either a subnet of a public ip address must be provided")
 		log.Printf("[resourceArmSimpleLb] %s", logMsg)
 		return nil, fmt.Errorf(logMsg)
 	}
 
-	if frontedIpPrivateIpAddress == "" && frontedIpAllocationMethod == network.Static {
+	if frontendIpPrivateIpAddress == "" && frontendIpAllocationMethod == network.Static {
 		var logMsg = fmt.Sprintf("An private IP address must be provided if static allocation is used.")
 		log.Printf("[resourceArmSimpleLb] %s", logMsg)
 		return nil, fmt.Errorf(logMsg)
 	}
 
 	ipProps := network.FrontendIPConfigurationPropertiesFormat{
-		PrivateIPAllocationMethod: frontedIpAllocationMethod}
+		PrivateIPAllocationMethod: frontendIpAllocationMethod}
 
-	if frontedIpSubnet != "" {
-		subnet := network.Subnet{ID: &frontedIpSubnet}
+	if frontendIpSubnet != "" {
+		subnet := network.Subnet{ID: &frontendIpSubnet}
 		ipProps.Subnet = &subnet
 	}
-	if frontedIpPublicIpAddress != "" {
-		pubIp := network.PublicIPAddress{ID: &frontedIpPublicIpAddress}
+	if frontendIpPublicIpAddress != "" {
+		pubIp := network.PublicIPAddress{ID: &frontendIpPublicIpAddress}
 		ipProps.PublicIPAddress = &pubIp
 	}
-	if frontedIpPrivateIpAddress != "" {
-		ipProps.PrivateIPAddress = &frontedIpPrivateIpAddress
+	if frontendIpPrivateIpAddress != "" {
+		ipProps.PrivateIPAddress = &frontendIpPrivateIpAddress
 	}
 
-	frontendIpConf := network.FrontendIPConfiguration{Name: &frontedIpName, Properties: &ipProps}
+	frontendIpConf := network.FrontendIPConfiguration{Name: &frontendIpName, Properties: &ipProps}
 	returnRules = append(returnRules, frontendIpConf)
 	return &returnRules, nil
 }
@@ -402,10 +402,10 @@ func resourceArmSimpleLbCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	loadBalancer.Properties.Probes = probes
 
-	new_backend_pool_name := fmt.Sprintf("%sbackendpool", name)
-	backendpool := network.BackendAddressPool{Name: &new_backend_pool_name}
+	newBackendPoolName := fmt.Sprintf("%sbackendpool", name)
+	backendPool := network.BackendAddressPool{Name: &newBackendPoolName}
 	backendPoolConfs := []network.BackendAddressPool{}
-	backendPoolConfs = append(backendPoolConfs, backendpool)
+	backendPoolConfs = append(backendPoolConfs, backendPool)
 	loadBalancer.Properties.BackendAddressPools = &backendPoolConfs
 	loadBalancer.Properties.LoadBalancingRules = &[]network.LoadBalancingRule{}
 
@@ -449,28 +449,28 @@ func resourceArmSimpleLbCreate(d *schema.ResourceData, meta interface{}) error {
 	return flattenAllOfLb(respLb, d, meta)
 }
 
-func flattenAzureRmFrontendIp(frontenIpArray []network.FrontendIPConfiguration, d *schema.ResourceData) error {
+func flattenAzureRmFrontendIp(frontendIpArray []network.FrontendIPConfiguration, d *schema.ResourceData) error {
 	log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[enter]")
 	defer log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[exit]")
 
-	if len(frontenIpArray) < 1 {
+	if len(frontendIpArray) < 1 {
 		return nil
 	}
-	if len(frontenIpArray) > 1 {
+	if len(frontendIpArray) > 1 {
 		log.Printf("[WARN] More than 1 frontend ip was found.  The simpleLB resource will just use the first one.")
 	}
 
-	frontenIp := frontenIpArray[0]
+	frontendIp := frontendIpArray[0]
 
-	if frontenIp.Properties.PrivateIPAddress != nil {
-		d.Set("frontend_private_ip_address", *frontenIp.Properties.PrivateIPAddress)
+	if frontendIp.Properties.PrivateIPAddress != nil {
+		d.Set("frontend_private_ip_address", *frontendIp.Properties.PrivateIPAddress)
 	}
-	d.Set("frontend_allocation_method", strings.ToLower(string(frontenIp.Properties.PrivateIPAllocationMethod)))
-	if frontenIp.Properties.Subnet != nil {
-		d.Set("frontend_subnet", *frontenIp.Properties.Subnet.ID)
+	d.Set("frontend_allocation_method", strings.ToLower(string(frontendIp.Properties.PrivateIPAllocationMethod)))
+	if frontendIp.Properties.Subnet != nil {
+		d.Set("frontend_subnet", *frontendIp.Properties.Subnet.ID)
 	}
-	if frontenIp.Properties.PublicIPAddress != nil {
-		d.Set("frontend_public_ip_address", *frontenIp.Properties.PublicIPAddress.ID)
+	if frontendIp.Properties.PublicIPAddress != nil {
+		d.Set("frontend_public_ip_address", *frontendIp.Properties.PublicIPAddress.ID)
 	}
 
 	return nil
@@ -570,10 +570,10 @@ func resourceArmSimpleLbUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	loadBalancer.Properties.Probes = probes
 
-	new_backend_pool_name := fmt.Sprintf("%sbackendpool", name)
-	backendpool := network.BackendAddressPool{Name: &new_backend_pool_name}
+	newBackendPoolName := fmt.Sprintf("%sbackendpool", name)
+	backendPool := network.BackendAddressPool{Name: &newBackendPoolName}
 	backendPoolConfs := []network.BackendAddressPool{}
-	backendPoolConfs = append(backendPoolConfs, backendpool)
+	backendPoolConfs = append(backendPoolConfs, backendPool)
 	loadBalancer.Properties.BackendAddressPools = &backendPoolConfs
 	loadBalancer.Properties.LoadBalancingRules = &[]network.LoadBalancingRule{}
 
@@ -684,7 +684,7 @@ func flattenAllOfLb(loadBalancer network.LoadBalancer, d *schema.ResourceData, m
 	}
 	d.Set("backend_pool_id", (*loadBalancer.Properties.BackendAddressPools)[0].ID)
 	if loadBalancer.Properties.FrontendIPConfigurations == nil || len(*loadBalancer.Properties.FrontendIPConfigurations) != 1 {
-		return fmt.Errorf("There must be exactly 1 fronted to use this resource")
+		return fmt.Errorf("There must be exactly 1 frontend to use this resource")
 	}
 	d.Set("frontend_id", (*loadBalancer.Properties.FrontendIPConfigurations)[0].ID)
 	err = flattenAzureRmLoadBalancerRules(loadBalancer, d)

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -625,6 +625,10 @@ func resourceArmSimpleLbRead(d *schema.ResourceData, meta interface{}) error {
 
 	loadBalancer, err := lbClient.Get(resGrp, name, "")
 	if err != nil {
+		if loadBalancer.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading the state of the load balancer off Azure: %s", err)
 	}
 

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -63,6 +63,7 @@ func resourceArmSimpleLb() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"frontend_allocation_method": &schema.Schema{
 				Type:         schema.TypeString,

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -445,7 +445,7 @@ func resourceArmSimpleLbCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[resourceArmSimpleLb] ERROR LB retrieving load balancer %s", err.Error())
 		return fmt.Errorf("Error issuing Azure ARM get request for load balancer '%s': %s", name, err)
 	}
-
+	log.Printf("XXXXXX 2 %s", respLb.Tags)
 	return flattenAllOfLb(respLb, d, meta)
 }
 
@@ -610,6 +610,12 @@ func resourceArmSimpleLbUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[resourceArmSimpleLb] Set the rules on the LB.  Provision State %s", *respLb.Properties.ProvisioningState)
 
+	respLb, err = lbClient.Get(resGrp, name, "")
+	if err != nil {
+		log.Printf("[resourceArmSimpleLb] ERROR LB retrieving load balancer %s", err.Error())
+		return fmt.Errorf("Error issuing Azure ARM get request for load balancer '%s': %s", name, err)
+	}
+	log.Printf("XXXXXX 3 %s", respLb.Tags)
 	return flattenAllOfLb(respLb, d, meta)
 }
 
@@ -655,7 +661,7 @@ func resourceArmSimpleLbRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		return fmt.Errorf("Error reading the state of the load balancer off Azure: %s", err)
 	}
-
+	log.Printf("XXXXXX 1 %s", loadBalancer.Tags)
 	return flattenAllOfLb(loadBalancer, d, meta)
 }
 

--- a/builtin/providers/azurerm/resource_arm_simple_lb_test.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb_test.go
@@ -8,29 +8,72 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"regexp"
 )
 
-func TestAccAzureSimpleLB_basic(t *testing.T) {
+func TestAccARMSimpleLB_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureSimpleLB_min, ri, ri)
+	config := fmt.Sprintf(testAccAzureSimpleLB_basic, ri, ri)
+
+	justBeThere := regexp.MustCompile(".*")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureSimpleRMLBDestroy,
+		CheckDestroy: testCheckARMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					resource.TestMatchResourceAttr("azurerm_simple_lb.test", "frontend_id", justBeThere),
+					resource.TestMatchResourceAttr("azurerm_simple_lb.test", "backend_pool_id", justBeThere),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureSimpleLBExists(name string) resource.TestCheckFunc {
+func TestAccARMSimpleLB_updateTage(t *testing.T) {
+
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureSimpleLB_tags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureSimpleLB_updateTags, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_simple_lb.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_simple_lb.test", "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_simple_lb.test", "tags.cost_center", "MSFT"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_simple_lb.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_simple_lb.test", "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckARMSimpleLBExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[name]
@@ -59,7 +102,7 @@ func testCheckAzureSimpleLBExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureSimpleRMLBDestroy(s *terraform.State) error {
+func testCheckARMSimpleRMLBDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
 
 	for _, rs := range s.RootModule().Resources {
@@ -84,7 +127,7 @@ func testCheckAzureSimpleRMLBDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureSimpleLB_min = `
+var testAccAzureSimpleLB_basic = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -119,6 +162,94 @@ resource "azurerm_simple_lb" "test" {
 	backend_port = 22
 	name = "rule1"
 	probe_name = "testProbe1"
+    }
+}
+`
+
+var testAccAzureSimpleLB_tags = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestlbrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "simplelbip"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_simple_lb" "test" {
+    name = "acctestlb%d"
+    location = "West US"
+    type = "Microsoft.Network/loadBalancers"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    frontend_allocation_method = "Dynamic"
+    frontend_public_ip_address = "${azurerm_public_ip.test.id}"
+
+    probe {
+        name = "testProbe1"
+        protocol = "Tcp"
+        port = 22
+        interval = 5
+        number_of_probes = 16
+    }
+    rule {
+	protocol = "Tcp"
+	load_distribution = "Default"
+	frontend_port = 22
+	backend_port = 22
+	name = "rule1"
+	probe_name = "testProbe1"
+    }
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureSimpleLB_updateTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestlbrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "simplelbip"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_simple_lb" "test" {
+    name = "acctestlb%d"
+    location = "West US"
+    type = "Microsoft.Network/loadBalancers"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    frontend_allocation_method = "Dynamic"
+    frontend_public_ip_address = "${azurerm_public_ip.test.id}"
+
+    probe {
+        name = "testProbe1"
+        protocol = "Tcp"
+        port = 22
+        interval = 5
+        number_of_probes = 16
+    }
+    rule {
+	protocol = "Tcp"
+	load_distribution = "Default"
+	frontend_port = 22
+	backend_port = 22
+	name = "rule1"
+	probe_name = "testProbe1"
+    }
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
     }
 }
 `

--- a/builtin/providers/azurerm/resource_arm_simple_lb_test.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb_test.go
@@ -1,0 +1,116 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureSimpleLB_basic(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureSimpleLB_min, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureSimpleRMLBDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureSimpleLBExists("azurerm_simple_lb.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureSimpleLBExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
+
+		resp, err := conn.Get(resourceGroup, name, "")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on loadBalancerClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Load Balancer %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureSimpleRMLBDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_load_balancer" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(resourceGroup, name, "")
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Load balancer still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+var testAccAzureSimpleLB_min = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestlbrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "simplelbip"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_simple_lb" "test" {
+    name = "acctestlb%d"
+    location = "West US"
+    type = "Microsoft.Network/loadBalancers"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    frontend_allocation_method = "Dynamic"
+    frontend_public_ip_address = "${azurerm_public_ip.test.id}"
+    probe_protocol = "Tcp"
+    probe_port = 22
+    probe_interval = 5
+    probe_number_of_probes = 16
+    rule_protocol = "Tcp"
+    rule_load_distribution = "Default"
+    rule_frontend_port = 22
+    rule_backend_port = 22
+}
+`

--- a/builtin/providers/azurerm/resource_arm_simple_lb_test.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb_test.go
@@ -104,13 +104,21 @@ resource "azurerm_simple_lb" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     frontend_allocation_method = "Dynamic"
     frontend_public_ip_address = "${azurerm_public_ip.test.id}"
-    probe_protocol = "Tcp"
-    probe_port = 22
-    probe_interval = 5
-    probe_number_of_probes = 16
-    rule_protocol = "Tcp"
-    rule_load_distribution = "Default"
-    rule_frontend_port = 22
-    rule_backend_port = 22
+
+    probe {
+        name = "testProbe1"
+        protocol = "Tcp"
+        port = 22
+        interval = 5
+        number_of_probes = 16
+    }
+    rule {
+	protocol = "Tcp"
+	load_distribution = "Default"
+	frontend_port = 22
+	backend_port = 22
+	name = "rule1"
+	probe_name = "testProbe1"
+    }
 }
 `

--- a/builtin/providers/azurerm/resource_arm_simple_lb_test.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb_test.go
@@ -12,22 +12,22 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccARMSimpleLB_basic(t *testing.T) {
+func TestAccAzureRMSimpleLB_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureSimpleLB_basic, ri, ri, ri)
+	config := fmt.Sprintf(testAccAzureRMSimpleLB_basic, ri, ri, ri)
 
 	justBeThere := regexp.MustCompile(".*")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestMatchResourceAttr("azurerm_simple_lb.test", "frontend_id", justBeThere),
 					resource.TestMatchResourceAttr("azurerm_simple_lb.test", "backend_pool_id", justBeThere),
 				),
@@ -36,21 +36,21 @@ func TestAccARMSimpleLB_basic(t *testing.T) {
 	})
 }
 
-func TestAccARMSimpleLB_updateTag(t *testing.T) {
+func TestAccAzureRMSimpleLB_updateTag(t *testing.T) {
 
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureSimpleLB_tags, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureSimpleLB_updateTags, ri, ri, ri)
+	preConfig := fmt.Sprintf(testAccAzureRMSimpleLB_tags, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSimpleLB_updateTags, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -63,7 +63,7 @@ func TestAccARMSimpleLB_updateTag(t *testing.T) {
 			resource.TestStep{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -74,21 +74,21 @@ func TestAccARMSimpleLB_updateTag(t *testing.T) {
 	})
 }
 
-func TestAccARMSimpleLB_updateProbe(t *testing.T) {
+func TestAccAzureRMSimpleLB_updateProbe(t *testing.T) {
 
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureSimpleLB_probe, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureSimpleLB_probeUpdate, ri, ri, ri)
+	preConfig := fmt.Sprintf(testAccAzureRMSimpleLB_probe, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSimpleLB_probeUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "probe.#", "2"),
 				),
@@ -97,7 +97,7 @@ func TestAccARMSimpleLB_updateProbe(t *testing.T) {
 			resource.TestStep{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "probe.#", "1"),
 				),
@@ -113,11 +113,11 @@ func TestAccAzureRMSimpleLB_dynamicFrontEndIPAddress(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check:  testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+				Check:  testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 			},
 			{
 				Config: config,
@@ -128,7 +128,7 @@ func TestAccAzureRMSimpleLB_dynamicFrontEndIPAddress(t *testing.T) {
 	})
 }
 
-func testCheckARMSimpleLBExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSimpleLBExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[name]
@@ -157,7 +157,7 @@ func testCheckARMSimpleLBExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckARMSimpleRMLBDestroy(s *terraform.State) error {
+func testCheckAzureRMSimpleRMLBDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
 
 	for _, rs := range s.RootModule().Resources {
@@ -182,7 +182,7 @@ func testCheckARMSimpleRMLBDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureSimpleLB_basic = `
+var testAccAzureRMSimpleLB_basic = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -221,7 +221,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_tags = `
+var testAccAzureRMSimpleLB_tags = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -265,7 +265,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_updateTags = `
+var testAccAzureRMSimpleLB_updateTags = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -308,7 +308,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_probe = `
+var testAccAzureRMSimpleLB_probe = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -363,7 +363,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_probeUpdate = `
+var testAccAzureRMSimpleLB_probeUpdate = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"

--- a/builtin/providers/azurerm/resource_arm_simple_lb_test.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb_test.go
@@ -52,7 +52,7 @@ func TestAccAzureRMSimpleLB_updateTag(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
-						"azurerm_simple_lb.test", "tags.#", "2"),
+						"azurerm_simple_lb.test", "tags.%", "2"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "tags.environment", "Production"),
 					resource.TestCheckResourceAttr(
@@ -65,7 +65,7 @@ func TestAccAzureRMSimpleLB_updateTag(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
-						"azurerm_simple_lb.test", "tags.#", "1"),
+						"azurerm_simple_lb.test", "tags.%", "1"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "tags.environment", "staging"),
 				),

--- a/builtin/providers/azurerm/util.go
+++ b/builtin/providers/azurerm/util.go
@@ -1,0 +1,24 @@
+package azurerm
+
+import "strings"
+
+func String(value interface{}) *string {
+	s := value.(string)
+	return &s
+}
+
+func Int(value interface{}) *int {
+	i := value.(int)
+	return &i
+}
+
+func isOneOf(haystack []string, needle interface{}) bool {
+	n := strings.ToLower(needle.(string))
+	for _, h := range haystack {
+		if h == n {
+			return true
+		}
+	}
+
+	return false
+}

--- a/builtin/providers/azurerm/util.go
+++ b/builtin/providers/azurerm/util.go
@@ -12,6 +12,12 @@ func Int(value interface{}) *int {
 	return &i
 }
 
+func Int32(value interface{}) *int32 {
+	i := value.(int)
+	i32 := int32(i)
+	return &i32
+}
+
 func isOneOf(haystack []string, needle interface{}) bool {
 	n := strings.ToLower(needle.(string))
 	for _, h := range haystack {


### PR DESCRIPTION
This commit adds a resource for the ARM load balancer.  The ARM LB is
quite complicated and has many different configuration options.  Instead
of trying to implement them all in a potential confusing user experience
this resources exposes the most common uses.  With it a load balancer can
be configured on a single public IP or subnet which can route to a single
backend pool according to one load balancing rule and 1 probe.

This could be expanded to support more features of the LB or live along side of a more sophisticated load balancer implementation as an easy to use option.