### PR TITLE
Add support for the Base URL endpoint for GitHub Enterprise Support

### DIFF
--- a/builtin/providers/github/config.go
+++ b/builtin/providers/github/config.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"net/url"
+
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )
@@ -8,6 +10,7 @@ import (
 type Config struct {
 	Token        string
 	Organization string
+	BaseURL      string
 }
 
 type Organization struct {
@@ -25,5 +28,12 @@ func (c *Config) Client() (interface{}, error) {
 	tc := oauth2.NewClient(oauth2.NoContext, ts)
 
 	org.client = github.NewClient(tc)
+	if c.BaseURL != "" {
+		u, err := url.Parse(c.BaseURL)
+		if err != nil {
+			return nil, err
+		}
+		org.client.BaseURL = u
+	}
 	return &org, nil
 }

--- a/builtin/providers/github/provider.go
+++ b/builtin/providers/github/provider.go
@@ -23,6 +23,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("GITHUB_ORGANIZATION", nil),
 				Description: descriptions["organization"],
 			},
+			"base_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GITHUB_BASE_URL", ""),
+				Description: descriptions["base_url"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -43,6 +49,8 @@ func init() {
 		"token": "The OAuth token used to connect to GitHub.",
 
 		"organization": "The GitHub organization name to manage.",
+
+		"base_url": "The GitHub Base API URL",
 	}
 }
 
@@ -50,6 +58,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Token:        d.Get("token").(string),
 		Organization: d.Get("organization").(string),
+		BaseURL:      d.Get("base_url").(string),
 	}
 
 	return config.Client()

--- a/website/source/docs/providers/github/index.html.markdown
+++ b/website/source/docs/providers/github/index.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # GitHub Provider
 
-The GitHub provider is used to interact with GitHub organization resources. 
+The GitHub provider is used to interact with GitHub organization resources.
 
-The provider allows you to manage your GitHub organization's members and teams easily. 
+The provider allows you to manage your GitHub organization's members and teams easily.
 It needs to be configured with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
@@ -40,3 +40,7 @@ The following arguments are supported in the `provider` block:
 * `organization` - (Optional) This is the target GitHub organization to manage. The account
   corresponding to the token will need "owner" privileges for this organization. It must be provided, but
   it can also be sourced from the `GITHUB_ORGANIZATION` environment variable.
+
+* `base_url` - (Optional) This is the target GitHub base API endpoint. Providing a value is a
+  requirement when working with GitHub Enterprise.  It is optional to provide this value and
+  it can also be sourced from the `GITHUB_BASE_URL` environment variable.  The value must end with a slash.


### PR DESCRIPTION
Added logic to support changing the base API URL for GitHub.  Coded so that the value is only used when provided.  Updated documentation.

BaseURL is taken from https://github.com/google/go-github/blob/576fece59c05680a3862785c1f6522eefb6cb0aa/github/github.go#L81