### PR TITLE
provider/aws: Fix issue in upgrading AutoScaling Policy

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_policy.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_policy.go
@@ -126,7 +126,7 @@ func resourceAwsAutoscalingPolicyRead(d *schema.ResourceData, meta interface{}) 
 		return nil
 	}
 
-	log.Printf("[DEBUG] Read Scaling Policy: ASG: %s, SP: %s, Obj: %#v", d.Get("autoscaling_group_name"), d.Get("name"), p)
+	log.Printf("[DEBUG] Read Scaling Policy: ASG: %s, SP: %s, Obj: %s", d.Get("autoscaling_group_name"), d.Get("name"), p)
 
 	d.Set("adjustment_type", p.AdjustmentType)
 	d.Set("autoscaling_group_name", p.AutoScalingGroupName)
@@ -134,8 +134,12 @@ func resourceAwsAutoscalingPolicyRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("estimated_instance_warmup", p.EstimatedInstanceWarmup)
 	d.Set("metric_aggregation_type", p.MetricAggregationType)
 	d.Set("policy_type", p.PolicyType)
-	d.Set("min_adjustment_magnitude", p.MinAdjustmentMagnitude)
-	d.Set("min_adjustment_step", p.MinAdjustmentStep)
+	if p.MinAdjustmentMagnitude != nil {
+		d.Set("min_adjustment_magnitude", p.MinAdjustmentMagnitude)
+		d.Set("min_adjustment_step", 0)
+	} else {
+		d.Set("min_adjustment_step", p.MinAdjustmentStep)
+	}
 	d.Set("arn", p.PolicyARN)
 	d.Set("name", p.PolicyName)
 	d.Set("scaling_adjustment", p.ScalingAdjustment)
@@ -175,6 +179,7 @@ func resourceAwsAutoscalingPolicyDelete(d *schema.ResourceData, meta interface{}
 		AutoScalingGroupName: aws.String(d.Get("autoscaling_group_name").(string)),
 		PolicyName:           aws.String(d.Get("name").(string)),
 	}
+	log.Printf("[DEBUG] Deleting Autoscaling Policy opts: %s", params)
 	if _, err := autoscalingconn.DeletePolicy(&params); err != nil {
 		return fmt.Errorf("Autoscaling Scaling Policy: %s ", err)
 	}
@@ -225,10 +230,10 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 	}
 
 	if v, ok := d.GetOk("min_adjustment_magnitude"); ok {
+		// params.MinAdjustmentMagnitude = aws.Int64(int64(d.Get("min_adjustment_magnitude").(int)))
 		params.MinAdjustmentMagnitude = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := d.GetOk("min_adjustment_step"); ok {
+	} else if v, ok := d.GetOk("min_adjustment_step"); ok {
+		// params.MinAdjustmentStep = aws.Int64(int64(d.Get("min_adjustment_step").(int)))
 		params.MinAdjustmentStep = aws.Int64(int64(v.(int)))
 	}
 

--- a/builtin/providers/aws/resource_aws_autoscaling_policy.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_policy.go
@@ -61,7 +61,7 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 			"min_adjustment_step": &schema.Schema{
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Deprecated:    "Use min_adjustment_magnitude instead.",
+				Deprecated:    "Use min_adjustment_magnitude instead, otherwise you may see a perpetual diff on this resource.",
 				ConflictsWith: []string{"min_adjustment_magnitude"},
 			},
 			"scaling_adjustment": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_autoscaling_policy_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_policy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -35,6 +36,38 @@ func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "metric_aggregation_type", "Minimum"),
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "estimated_instance_warmup", "200"),
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "autoscaling_group_name", "terraform-test-foobar5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAutoscalingPolicy_upgrade(t *testing.T) {
+	var policy autoscaling.ScalingPolicy
+
+	name := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAutoscalingPolicyConfig_upgrade_614(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
+					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_step", "0"),
+					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_magnitude", "1"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+
+			resource.TestStep{
+				Config: testAccAWSAutoscalingPolicyConfig_upgrade_615(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
+					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_step", "0"),
+					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_magnitude", "1"),
 				),
 			},
 		},
@@ -137,3 +170,79 @@ resource "aws_autoscaling_policy" "foobar_step" {
 	autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
 }
 `)
+
+func testAccAWSAutoscalingPolicyConfig_upgrade_614(name string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+  name          = "tf-test-%s"
+  image_id      = "ami-21f78e11"
+  instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "foobar" {
+  availability_zones        = ["us-west-2a"]
+  name                      = "terraform-test-%s"
+  max_size                  = 5
+  min_size                  = 1
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  force_delete              = true
+  termination_policies      = ["OldestInstance"]
+  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key                 = "Foo"
+    value               = "foo-bar"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_policy" "foobar_simple" {
+  name                   = "foobar_simple_%s"
+  adjustment_type        = "PercentChangeInCapacity"
+  cooldown               = 300
+  policy_type            = "SimpleScaling"
+  scaling_adjustment     = 2
+  min_adjustment_step    = 1
+  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+}
+`, name, name, name)
+}
+
+func testAccAWSAutoscalingPolicyConfig_upgrade_615(name string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+  name          = "tf-test-%s"
+  image_id      = "ami-21f78e11"
+  instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "foobar" {
+  availability_zones        = ["us-west-2a"]
+  name                      = "terraform-test-%s"
+  max_size                  = 5
+  min_size                  = 1
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  force_delete              = true
+  termination_policies      = ["OldestInstance"]
+  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key                 = "Foo"
+    value               = "foo-bar"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_policy" "foobar_simple" {
+  name                     = "foobar_simple_%s"
+  adjustment_type          = "PercentChangeInCapacity"
+  cooldown                 = 300
+  policy_type              = "SimpleScaling"
+  scaling_adjustment       = 2
+  min_adjustment_magnitude = 1
+  autoscaling_group_name   = "${aws_autoscaling_group.foobar.name}"
+}
+`, name, name, name)
+}


### PR DESCRIPTION
Fixes an issue introduced with the addition of `min_adjustment_magnitude ` and  https://github.com/hashicorp/terraform/pull/4277 deprecation of `min_adjustment_step`. The upgrade path of swapping one for the other results in a reoccurring plan due to how we were handling zero values with `GetOk` (explained https://github.com/hashicorp/terraform/issues/6408#issuecomment-215887212). 

This PR addresses the issue by setting `min_adjustment_step` to `0` if `min_adjustment_magnitude ` is found. The upgrade plan should be silent now; using `min_adjustment_step` still results in the depreciation warning, `min_adjustment_magnitude` corrects the plan and returns no diffs.

Unfortunately the API will set the `MinAdjustmentMagnitude` and `MinAdjustmentStep` to be equal, so setting `MinAdjustmentStep` will result in a `MinAdjustmentMagnitude` value. Users will need to make this config swap, but with this PR the plan will be silent afterwards. 

Fixes https://github.com/hashicorp/terraform/issues/6408