### PR TITLE
provider/aws: Improve error handling in IAM Server Certificates

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
+++ b/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
@@ -51,6 +51,41 @@ func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMServerCertificate_recreate(t *testing.T) {
+	var cert iam.ServerCertificate
+
+	testDestroyCert := func(*terraform.State) error {
+		// reach out and DELETE the Cert
+		conn := testAccProvider.Meta().(*AWSClient).iamconn
+		_, err := conn.DeleteServerCertificate(&iam.DeleteServerCertificateInput{
+			ServerCertificateName: cert.ServerCertificateMetadata.ServerCertificateName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error destorying cert in test: %s", err)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMServerCertConfig_random,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
+					testAccCheckAWSServerCertAttributes(&cert),
+					testDestroyCert,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckCertExists(n string, cert *iam.ServerCertificate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
+++ b/builtin/providers/aws/resource_aws_iam_server_certificate_test.go
@@ -51,7 +51,7 @@ func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 	})
 }
 
-func TestAccAWSIAMServerCertificate_recreate(t *testing.T) {
+func TestAccAWSIAMServerCertificate_disappears(t *testing.T) {
 	var cert iam.ServerCertificate
 
 	testDestroyCert := func(*terraform.State) error {
@@ -81,6 +81,10 @@ func TestAccAWSIAMServerCertificate_recreate(t *testing.T) {
 					testDestroyCert,
 				),
 				ExpectNonEmptyPlan: true,
+			},
+			// Follow up plan w/ empty config should be empty, since the Cert is gone
+			resource.TestStep{
+				Config: "",
 			},
 		},
 	})


### PR DESCRIPTION
This PR does 3 things:

- removes an IAM Server Cert from state if it's not found on `READ`, instead of throwing an error. This will correctly prompt to re-create if in a `plan`
- removes the cert from state if it's not found in a `DELETE` (API returns a `NoSuchEntity` error), instead of throwing an error locally and blocking progress
- Extends the timeout for retrying the delete if it's found to be in use. The cert can retain this "in use" status even after and ELB has stopped using it for a period greater than 1 minute. I was unable to reproduce it with a 3 minute timeout