### PR TITLE
provider/openstack allow floating ip to target a specific tenant

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -43,6 +43,12 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"tenant_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -64,6 +70,7 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 	createOpts := floatingips.CreateOpts{
 		FloatingNetworkID: poolID,
 		PortID:            d.Get("port_id").(string),
+		TenantID:          d.Get("tenant_id").(string),
 	}
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	floatingIP, err := floatingips.Create(networkingClient, createOpts).Extract()
@@ -107,6 +114,7 @@ func resourceNetworkFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error retrieving floating IP pool name: %s", err)
 	}
 	d.Set("pool", poolName)
+	d.Set("tenant_id", floatingIP.TenantID)
 
 	return nil
 }

--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -35,8 +35,13 @@ The following arguments are supported:
 * `pool` - (Required) The name of the pool from which to obtain the floating
     IP. Changing this creates a new floating IP.
 
-* `port_id` - ID of an existing port with at least one IP address to associate with
-this floating IP.
+* `port_id` - (Optional) ID of an existing port with at least one IP address to
+    associate with this floating IP.
+
+* `tenant_id` - (Optional) The target tenant ID in which to allocate the floating
+    IP, if you specify this together with a port_id, make sure the target port
+    belongs to the same tenant. Changing this creates a new floating IP (which
+    may or may not have a different address)
 
 ## Attributes Reference
 
@@ -46,3 +51,4 @@ The following attributes are exported:
 * `pool` - See Argument Reference above.
 * `address` - The actual floating IP address itself.
 * `port_id` - ID of associated port.
+* `tenant_id` - the ID of the tenant in which to create the floating IP.


### PR DESCRIPTION
Gophercloud library supports specifying a tenant_id in the Create function.

This patch extends the floatingip schema to allow a cloud admin to specify a tenant_id.
Major use cases:
* Q&A for neutron
* managed service where the tenants are not allowed to allocate floating IP addresses themselves due to scarcity or resources or organisational security constraints

The patch also adds relevant documentation information.