### PR TITLE
provider/aws: Bump Cloudfront dependency to 1.1.15, matching the rest of AWS

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -367,8 +367,8 @@
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"Comment": "v1.1.14",
-			"Rev": "6876e9922ff299adf36e43e04c94820077968b3b"
+			"Comment": "v1.1.15",
+			"Rev": "e7cf1e5986499eea7d4a87868f1eb578c8f2045a"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudtrail",


### PR DESCRIPTION
Should fix #6464 by bringing Cloudfront up to 1.1.15, inline with the rest of the AWS dependencies 