### PR TITLE
add a height to svg in bnr to fix IE bug

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -187,6 +187,3 @@ PLATFORMS
 
 DEPENDENCIES
   middleman-hashicorp!
-
-BUNDLED WITH
-   1.11.2

--- a/website/source/assets/stylesheets/_announcement-bnr.scss
+++ b/website/source/assets/stylesheets/_announcement-bnr.scss
@@ -87,6 +87,7 @@ body{
 
     svg{
       width: 156px;
+      height: 18px;
       fill: $white;
       margin-right: 4px;
       margin-left: 3px;


### PR DESCRIPTION
A bug was found on consul's website (https://github.com/hashicorp/consul/issues/2017) that applied to the announcment bnr. Terraform.io uses the same markup so I'm submitting the same fix. 

Here's a screen cap of the issue on terraform.io. Nasty bug renders the header nav useless in IE.

<img width="994" alt="screen shot 2016-05-03 at 6 05 18 pm" src="https://cloud.githubusercontent.com/assets/438899/15003205/58e13c00-115e-11e6-9c3b-566fa700939b.png">

Verified the fix on the VM as well.