### PR TITLE
provider/vsphere: fixed ipv6 test failure - changed ForceNew to Computed like ipv4

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -296,13 +296,13 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 						"ipv6_address": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
+							Computed: true,
 						},
 
 						"ipv6_prefix_length": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
-							ForceNew: true,
+							Computed: true,
 						},
 
 						"ipv6_gateway": &schema.Schema{


### PR DESCRIPTION
Problem was this:
```
--- FAIL: TestAccVSphereVirtualMachine_updateMemory (359.93s)
        testing.go:172: Step 0 error: After applying this step, the plan was not empty:

                DIFF:

                UPDATE: vsphere_virtual_machine.bar
                  network_interface.0.ipv6_address:       "fe80::250:56ff:fe8e:5c7e" => ""
                  network_interface.0.ipv6_prefix_length: "64" => "0"

                STATE:

                vsphere_virtual_machine.bar:
                  ID = terraform-test
                  cluster = dc1.boerse-go.de
                  datacenter = dc1
                  disk.# = 1
                  disk.0.bootable = false
                  disk.0.datastore = DS1
                  disk.0.iops = 0
                  disk.0.size = 0
                  disk.0.template = terraform-test-folder/centos-terraform-template
                  disk.0.type = eager_zeroed
                  disk.0.vmdk =
                  domain = vsphere.local
                  linked_clone = false
                  memory = 4096
                  memory_reservation = 0
                  name = terraform-test
                  network_interface.# = 1
                  network_interface.0.adapter_type =
                  network_interface.0.ip_address =
                  network_interface.0.ipv4_address = 10.30.8.38
                  network_interface.0.ipv4_gateway =
                  network_interface.0.ipv4_prefix_length = 23
                  network_interface.0.ipv6_address = fe80::250:56ff:fe8e:5c7e
                  network_interface.0.ipv6_gateway =
                  network_interface.0.ipv6_prefix_length = 64
                  network_interface.0.label = cld_tst1_access
                  network_interface.0.subnet_mask =
                  resource_pool = dc1.boerse-go.de/Resources/test_server
                  skip_customization = false
                  time_zone = Etc/UTC
                  vcpu = 2
FAIL
exit status 1
FAIL    github.com/hashicorp/terraform/builtin/providers/vsphere        359.939s
```

I changed the schema to the way it is with ipv4.