### PR TITLE
provider/vsphere: missing memory reservation in deployVirtualMachine

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -1553,6 +1553,9 @@ func (vm *virtualMachine) deployVirtualMachine(c *govmomi.Client) error {
 		NumCPUs:           vm.vcpu,
 		NumCoresPerSocket: 1,
 		MemoryMB:          vm.memoryMb,
+		MemoryAllocation: &types.ResourceAllocationInfo{
+			Reservation: vm.memoryAllocation.reservation,
+		},
 	}
 
 	log.Printf("[DEBUG] virtual machine config spec: %v", configSpec)


### PR DESCRIPTION
Fixes this one:
```
==> Checking that code complies with gofmt requirements...
/home/dpossmann/go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/vsphere -v -run=TestAccVSphereVirtualMachine_basic -timeout 120m
=== RUN   TestAccVSphereVirtualMachine_basic
--- FAIL: TestAccVSphereVirtualMachine_basic (77.07s)
        testing.go:172: Step 0 error: Check failed: Check 5/9 error: vsphere_virtual_machine.foo: Attribute 'memory_reservation' expected "4096", got "0"
FAIL
exit status 1
FAIL    github.com/hashicorp/terraform/builtin/providers/vsphere        77.082s
```