### PR TITLE
provider/aws: Allow empty S3 config in Cloudfront Origin

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -523,6 +523,15 @@ func expandOrigin(m map[string]interface{}) *cloudfront.Origin {
 			origin.S3OriginConfig = expandS3OriginConfig(s[0].(map[string]interface{}))
 		}
 	}
+
+	// if both custom and s3 origin are missing, add an empty s3 origin
+	// One or the other must be specified, but the S3 origin can be "empty"
+	if origin.S3OriginConfig == nil && origin.CustomOriginConfig == nil {
+		origin.S3OriginConfig = &cloudfront.S3OriginConfig{
+			OriginAccessIdentity: aws.String(""),
+		}
+	}
+
 	return origin
 }
 
@@ -540,7 +549,9 @@ func flattenOrigin(or *cloudfront.Origin) map[string]interface{} {
 		m["origin_path"] = *or.OriginPath
 	}
 	if or.S3OriginConfig != nil {
-		m["s3_origin_config"] = schema.NewSet(s3OriginConfigHash, []interface{}{flattenS3OriginConfig(or.S3OriginConfig)})
+		if or.S3OriginConfig.OriginAccessIdentity != nil && *or.S3OriginConfig.OriginAccessIdentity != "" {
+			m["s3_origin_config"] = schema.NewSet(s3OriginConfigHash, []interface{}{flattenS3OriginConfig(or.S3OriginConfig)})
+		}
 	}
 	return m
 }

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -195,7 +195,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 	origin {
 		domain_name = "${aws_s3_bucket.s3_bucket.id}"
 		origin_id = "myS3Origin"
-		s3_origin_config {}
 	}
 	enabled = true
 	default_root_object = "index.html"
@@ -303,7 +302,6 @@ resource "aws_cloudfront_distribution" "multi_origin_distribution" {
 	origin {
 		domain_name = "${aws_s3_bucket.s3_bucket.id}"
 		origin_id = "myS3Origin"
-		s3_origin_config {}
 	}
 	origin {
 		domain_name = "www.example.com"


### PR DESCRIPTION
If both custom and s3 origin are missing, add an empty s3 origin... one or the other must be specified, but the S3 origin can be "empty". Fixes https://github.com/hashicorp/terraform/issues/6422