### PR TITLE
Protect instance from autoscale in on aws_autoscaling_group

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -163,6 +163,12 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 				Default:  "1Minute",
 			},
 
+			"protect_from_scale_in": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"tag": autoscalingTagsSchema(),
 		},
 	}
@@ -185,6 +191,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	autoScalingGroupOpts.LaunchConfigurationName = aws.String(d.Get("launch_configuration").(string))
 	autoScalingGroupOpts.MinSize = aws.Int64(int64(d.Get("min_size").(int)))
 	autoScalingGroupOpts.MaxSize = aws.Int64(int64(d.Get("max_size").(int)))
+	autoScalingGroupOpts.NewInstancesProtectedFromScaleIn = aws.Bool(d.Get("protect_from_scale_in").(bool))
 
 	// Availability Zones are optional if VPC Zone Identifer(s) are specified
 	if v, ok := d.GetOk("availability_zones"); ok && v.(*schema.Set).Len() > 0 {
@@ -278,6 +285,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("name", g.AutoScalingGroupName)
 	d.Set("tag", autoscalingTagDescriptionsToSlice(g.Tags))
 	d.Set("vpc_zone_identifier", strings.Split(*g.VPCZoneIdentifier, ","))
+	d.Set("protect_from_scale_in", g.NewInstancesProtectedFromScaleIn)
 
 	// If no termination polices are explicitly configured and the upstream state
 	// is only using the "Default" policy, clear the state to make it consistent
@@ -306,6 +314,8 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 	opts := autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(d.Id()),
 	}
+
+	opts.NewInstancesProtectedFromScaleIn = aws.Bool(d.Get("protect_from_scale_in").(bool))
 
 	if d.HasChange("default_cooldown") {
 		opts.DefaultCooldown = aws.Int64(int64(d.Get("default_cooldown").(int)))

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -54,6 +54,8 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 						"aws_autoscaling_group.bar", "termination_policies.0", "OldestInstance"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "termination_policies.1", "ClosestToNextInstanceHour"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "protect_from_scale_in", "false"),
 				),
 			},
 
@@ -66,6 +68,8 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 						"aws_autoscaling_group.bar", "desired_capacity", "5"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "termination_policies.0", "ClosestToNextInstanceHour"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "protect_from_scale_in", "true"),
 					testLaunchConfigurationName("aws_autoscaling_group.bar", &lc),
 					testAccCheckAutoscalingTags(&group.Tags, "Bar", map[string]interface{}{
 						"value":               "bar-foo",
@@ -602,6 +606,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity = 5
   force_delete = true
   termination_policies = ["ClosestToNextInstanceHour"]
+  protect_from_scale_in = true
 
   launch_configuration = "${aws_launch_configuration.new.name}"
 

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -86,6 +86,9 @@ The following arguments are supported:
   on both create and update operations. (Takes precedence over
   `min_elb_capacity` behavior.)
   (See also [Waiting for Capacity](#waiting-for-capacity) below.)
+* `protect_from_scale_in` (Optional) Allows setting instance protection. The
+   autoscaling group will not select instances with this setting for terminination
+   during scale in events.
 
 Tags support the following:
 


### PR DESCRIPTION
Desired functionality: Ability to set Instance Protection to "Protect From Scale In" on an AWS auto scaling group.

I understand this change to be working through manual testing. I'm opening the PR for discussion and feedback.

1) I'm interested if supporting setting this option is compatible with the workflows used in Terraform and 
2) if this is compatible I'm interested in feedback on implementation and (lack of) testing.

Please let me know if there are any questions - Thanks!