### PR TITLE
provider/aws: Add agent_version argument to AWS_OPSWORKS_STACK

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -22,6 +22,11 @@ func resourceAwsOpsworksStack() *schema.Resource {
 		Delete: resourceAwsOpsworksStackDelete,
 
 		Schema: map[string]*schema.Schema{
+			"agent_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -265,6 +270,7 @@ func resourceAwsOpsworksStackRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	stack := resp.Stacks[0]
+	d.Set("agent_version", stack.AgentVersion)
 	d.Set("name", stack.Name)
 	d.Set("region", stack.Region)
 	d.Set("default_instance_profile_arn", stack.DefaultInstanceProfileArn)
@@ -396,6 +402,9 @@ func resourceAwsOpsworksStackUpdate(d *schema.ResourceData, meta interface{}) er
 		UseOpsworksSecurityGroups: aws.Bool(d.Get("use_opsworks_security_groups").(bool)),
 		Attributes:                make(map[string]*string),
 		CustomCookbooksSource:     resourceAwsOpsworksStackCustomCookbooksSource(d),
+	}
+	if v, ok := d.GetOk("agent_version"); ok {
+		req.AgentVersion = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("default_os"); ok {
 		req.DefaultOs = aws.String(v.(string))

--- a/website/source/docs/providers/aws/r/opsworks_stack.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_stack.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `service_role_arn` - (Required) The ARN of an IAM role that the OpsWorks service will act as.
 * `default_instance_profile_arn` - (Required) The ARN of an IAM Instance Profile that created instances
   will have by default.
+* `agent_version` - (Optional) If set to `"LATEST"`, OpsWorks will automatically install the latest version.
 * `berkshelf_version` - (Optional) If `manage_berkshelf` is enabled, the version of Berkshelf to use.
 * `color` - (Optional) Color to paint next to the stack's resources in the OpsWorks console.
 * `default_availability_zone` - (Optional) Name of the availability zone where instances will be created


### PR DESCRIPTION
This PR adds the omitted OpsWorks Agent version, used when creating Opsworks stacks.

`agent_version` is supported in AWS_OPSWORKS_INSTANCE, but AWS's api limits you to "INHERIT" or a static version number. The API default is to statically set the current version. Adding the `agent_version` argument to `aws_opsworks_stack` allows specifying "LATEST" so that the client can be automatically updated to the latest version.