### PR TITLE
provider/aws: AWS API Gateway request parameters json

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -73,6 +74,11 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 				Optional: true,
 				Elem:     schema.TypeString,
 			},
+
+			"request_parameters_in_json": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -93,6 +99,13 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		templates[k] = v.(string)
 	}
 
+	parameters := make(map[string]string)
+	if v, ok := d.GetOk("request_parameters_in_json"); ok {
+		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
+			return fmt.Errorf("Error unmarshaling request_parameters_in_json: %s", err)
+		}
+	}
+
 	var credentials *string
 	if val, ok := d.GetOk("credentials"); ok {
 		credentials = aws.String(val.(string))
@@ -105,8 +118,8 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		Type:       aws.String(d.Get("type").(string)),
 		IntegrationHttpMethod: integrationHttpMethod,
 		Uri: uri,
-		// TODO implement once [GH-2143](https://github.com/hashicorp/terraform/issues/2143) has been implemented
-		RequestParameters:  nil,
+		// TODO reimplement once [GH-2143](https://github.com/hashicorp/terraform/issues/2143) has been implemented
+		RequestParameters:  aws.StringMap(parameters),
 		RequestTemplates:   aws.StringMap(templates),
 		Credentials:        credentials,
 		CacheNamespace:     nil,
@@ -149,6 +162,7 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 	d.Set("credentials", integration.Credentials)
 	d.Set("type", integration.Type)
 	d.Set("uri", integration.Uri)
+	d.Set("request_parameters_in_json", aws.StringValueMap(integration.RequestParameters))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_response.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_response.go
@@ -75,7 +75,7 @@ func resourceAwsApiGatewayIntegrationResponseCreate(d *schema.ResourceData, meta
 	parameters := make(map[string]string)
 	if v, ok := d.GetOk("response_parameters_in_json"); ok {
 		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
-			return fmt.Errorf("Error unmarshaling request_parameters_in_json: %s", err)
+			return fmt.Errorf("Error unmarshaling response_parameters_in_json: %s", err)
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
@@ -59,6 +59,9 @@ func testAccCheckAWSAPIGatewayMockIntegrationAttributes(conf *apigateway.Integra
 		if *conf.Type != "MOCK" {
 			return fmt.Errorf("Wrong Type: %q", *conf.Type)
 		}
+		if *conf.RequestParameters["integration.request.header.X-Authorization"] != "'updated'" {
+			return fmt.Errorf("wrong updated RequestParameters for header.X-Authorization")
+		}
 		return nil
 	}
 }
@@ -79,6 +82,9 @@ func testAccCheckAWSAPIGatewayIntegrationAttributes(conf *apigateway.Integration
 		}
 		if *conf.RequestTemplates["application/xml"] != "#set($inputRoot = $input.path('$'))\n{ }" {
 			return fmt.Errorf("wrong RequestTemplate for application/xml")
+		}
+		if *conf.RequestParameters["integration.request.header.X-Authorization"] != "'static'" {
+			return fmt.Errorf("wrong RequestParameters for header.X-Authorization")
 		}
 		return nil
 	}
@@ -178,6 +184,12 @@ resource "aws_api_gateway_integration" "test" {
     "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
+  request_parameters_in_json = <<PARAMS
+  {
+	  "integration.request.header.X-Authorization": "'static'"
+  }
+  PARAMS
+
   type = "HTTP"
   uri = "https://www.google.de"
   integration_http_method = "GET"
@@ -210,6 +222,12 @@ resource "aws_api_gateway_integration" "test" {
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
   resource_id = "${aws_api_gateway_resource.test.id}"
   http_method = "${aws_api_gateway_method.test.http_method}"
+
+  request_parameters_in_json = <<PARAMS
+  {
+	  "integration.request.header.X-Authorization": "'updated'"
+  }
+  PARAMS
 
   type = "MOCK"
 }

--- a/builtin/providers/aws/resource_aws_api_gateway_method.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method.go
@@ -141,7 +141,7 @@ func resourceAwsApiGatewayMethodUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("request_parameters_in_json") {
-		ops, err := expandApiGatewayMethodResponseParametersJSONOperations(d, "request_parameters_in_json", "requestParameters")
+		ops, err := expandApiGatewayMethodParametersJSONOperations(d, "request_parameters_in_json", "requestParameters")
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/aws/resource_aws_api_gateway_method.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -55,6 +56,11 @@ func resourceAwsApiGatewayMethod() *schema.Resource {
 				Optional: true,
 				Elem:     schema.TypeString,
 			},
+
+			"request_parameters_in_json": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -68,10 +74,9 @@ func resourceAwsApiGatewayMethodCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	parameters := make(map[string]bool)
-	if parameterData, ok := d.GetOk("request_parameters"); ok {
-		params := parameterData.(*schema.Set).List()
-		for k := range params {
-			parameters[params[k].(string)] = true
+	if v, ok := d.GetOk("request_parameters_in_json"); ok {
+		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
+			return fmt.Errorf("Error unmarshaling request_parameters_in_json: %s", err)
 		}
 	}
 
@@ -81,8 +86,8 @@ func resourceAwsApiGatewayMethodCreate(d *schema.ResourceData, meta interface{})
 		ResourceId:        aws.String(d.Get("resource_id").(string)),
 		RestApiId:         aws.String(d.Get("rest_api_id").(string)),
 		RequestModels:     aws.StringMap(models),
-		// TODO implement once [GH-2143](https://github.com/hashicorp/terraform/issues/2143) has been implemented
-		RequestParameters: nil,
+		// TODO reimplement once [GH-2143](https://github.com/hashicorp/terraform/issues/2143) has been implemented
+		RequestParameters: aws.BoolMap(parameters),
 		ApiKeyRequired:    aws.Bool(d.Get("api_key_required").(bool)),
 	})
 	if err != nil {
@@ -113,6 +118,7 @@ func resourceAwsApiGatewayMethodRead(d *schema.ResourceData, meta interface{}) e
 	}
 	log.Printf("[DEBUG] Received API Gateway Method: %s", out)
 	d.SetId(fmt.Sprintf("agm-%s-%s-%s", d.Get("rest_api_id").(string), d.Get("resource_id").(string), d.Get("http_method").(string)))
+	d.Set("request_parameters_in_json", aws.BoolValueMap(out.RequestParameters))
 
 	return nil
 }
@@ -132,6 +138,14 @@ func resourceAwsApiGatewayMethodUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("request_models") {
 		operations = append(operations, expandApiGatewayRequestResponseModelOperations(d, "request_models", "requestModels")...)
+	}
+
+	if d.HasChange("request_parameters_in_json") {
+		ops, err := expandApiGatewayMethodResponseParametersJSONOperations(d, "request_parameters_in_json", "requestParameters")
+		if err != nil {
+			return err
+		}
+		operations = append(operations, ops...)
 	}
 
 	method, err := conn.UpdateMethod(&apigateway.UpdateMethodInput{

--- a/builtin/providers/aws/resource_aws_api_gateway_method_response.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_response.go
@@ -130,7 +130,7 @@ func resourceAwsApiGatewayMethodResponseUpdate(d *schema.ResourceData, meta inte
 	}
 
 	if d.HasChange("response_parameters_in_json") {
-		ops, err := expandApiGatewayMethodResponseParametersJSONOperations(d, "response_parameters_in_json", "responseParameters")
+		ops, err := expandApiGatewayMethodParametersJSONOperations(d, "response_parameters_in_json", "responseParameters")
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/aws/resource_aws_api_gateway_method_response_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_response_test.go
@@ -184,11 +184,11 @@ resource "aws_api_gateway_method_response" "error" {
     "application/json" = "Error"
   }
 
-	response_parameters_in_json = <<PARAMS
-	{
-		"method.response.header.Content-Type": true
-	}
-	PARAMS
+  response_parameters_in_json = <<PARAMS
+  {
+    "method.response.header.Content-Type": true
+  }
+  PARAMS
 }
 `
 
@@ -224,11 +224,11 @@ resource "aws_api_gateway_method_response" "error" {
     "application/json" = "Empty"
   }
 
-	response_parameters_in_json = <<PARAMS
-	{
-		"method.response.header.Host": true
-	}
-	PARAMS
+  response_parameters_in_json = <<PARAMS
+  {
+    "method.response.header.Host": true
+  }
+  PARAMS
 
 }
 `

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -948,7 +948,7 @@ func expandApiGatewayRequestResponseModelOperations(d *schema.ResourceData, key 
 	return operations
 }
 
-func expandApiGatewayMethodResponseParametersJSONOperations(d *schema.ResourceData, key string, prefix string) ([]*apigateway.PatchOperation, error) {
+func expandApiGatewayMethodParametersJSONOperations(d *schema.ResourceData, key string, prefix string) ([]*apigateway.PatchOperation, error) {
 	operations := make([]*apigateway.PatchOperation, 0)
 
 	oldParameters, newParameters := d.GetChange(key)
@@ -956,12 +956,12 @@ func expandApiGatewayMethodResponseParametersJSONOperations(d *schema.ResourceDa
 	newParametersMap := make(map[string]interface{})
 
 	if err := json.Unmarshal([]byte(oldParameters.(string)), &oldParametersMap); err != nil {
-		err := fmt.Errorf("Error unmarshaling old response_parameters_in_json: %s", err)
+		err := fmt.Errorf("Error unmarshaling old %s: %s", key, err)
 		return operations, err
 	}
 
 	if err := json.Unmarshal([]byte(newParameters.(string)), &newParametersMap); err != nil {
-		err := fmt.Errorf("Error unmarshaling new response_parameters_in_json: %s", err)
+		err := fmt.Errorf("Error unmarshaling new %s: %s", key, err)
 		return operations, err
 	}
 

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -56,3 +56,6 @@ The following arguments are supported:
   Not all methods are compatible with all `AWS` integrations.
   e.g. Lambda function [can only be invoked](https://github.com/awslabs/aws-apigateway-importer/issues/9#issuecomment-129651005) via `POST`.
 * `request_templates` - (Optional) A map of the integration's request templates.
+* `request_parameters_in_json` - (Optional) A map written as a JSON string specifying
+  the request query string parameters and headers that should be passed to the
+  backend responder

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -44,3 +44,5 @@ The following arguments are supported:
 * `request_models` - (Optional) A map of the API models used for the request's content type
   where key is the content type (e.g. `application/json`)
   and value is either `Error`, `Empty` (built-in models) or `aws_api_gateway_model`'s `name`.
+* `request_parameters_in_json` - (Optional) A map written as a JSON string specifying
+  the request query string parameters and headers that should be passed to the integration


### PR DESCRIPTION
Add the ability to specify request parameters on API Gateway Method and Integration resources, which achieves parity with MethodResponse and IntegrationResponse resources and allows incoming headers and query string parameters to be passed to the backend controller.

This change is a straight extension of the work done in #6344.

