### PR TITLE
Removed port_id from Supported Arguments

### DIFF
--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -35,9 +35,6 @@ The following arguments are supported:
 * `pool` - (Required) The name of the pool from which to obtain the floating
     IP. Changing this creates a new floating IP.
 
-* `port_id` - ID of an existing port with at least one IP address to associate with
-this floating IP.
-
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
When I attempted this:

```hcl
#
# Create the Floating IP for the VM
#
resource "openstack_compute_floatingip_v2" "lnhc-affiliation-search-ws-dev-fip" {
    region = ""
    pool = "risk-internal"
    port_id = "032df78d-3ad6-46e4-aa84-c2d4fdc35307"
}
```

I receive this error:

```bash
Errors:

  * openstack_compute_floatingip_v2.lnhc-affiliation-search-ws-dev-fip: : invalid or unknown key: port_id
```

Based on the code here https://github.com/hashicorp/terraform/blob/master/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go#L18 it looks like port_id is not an argument allowed to be passed in.