### PR TITLE
provider/aws: Require cookies for Cloudfront Distributions

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -358,7 +358,7 @@ func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues
 	fv := &cloudfront.ForwardedValues{
 		QueryString: aws.Bool(m["query_string"].(bool)),
 	}
-	if v, ok := m["cookies"]; ok {
+	if v, ok := m["cookies"]; ok && v.(*schema.Set).Len() > 0 {
 		fv.Cookies = expandCookiePreference(v.(*schema.Set).List()[0].(map[string]interface{}))
 	}
 	if v, ok := m["headers"]; ok {
@@ -385,7 +385,7 @@ func forwardedValuesHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%t-", m["query_string"].(bool)))
-	if d, ok := m["cookies"]; ok {
+	if d, ok := m["cookies"]; ok && d.(*schema.Set).Len() > 0 {
 		buf.WriteString(fmt.Sprintf("%d-", cookiePreferenceHash(d.(*schema.Set).List()[0].(map[string]interface{}))))
 	}
 	if d, ok := m["headers"]; ok {

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -58,7 +58,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"cookies": &schema.Schema{
 										Type:     schema.TypeSet,
-										Optional: true,
+										Required: true,
 										Set:      cookiePreferenceHash,
 										MaxItems: 1,
 										Elem: &schema.Resource{

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -186,7 +186,7 @@ of several sub-resources - these resources are laid out below.
 
 ##### Forwarded Values Arguments
 
-  * `cookies` (Optional) - The [forwarded values cookies](#cookies-arguments)
+  * `cookies` (Required) - The [forwarded values cookies](#cookies-arguments)
     that specifies how CloudFront handles cookies (maximum one).
 
   * `headers` (Optional) - Specifies the Headers, if any, that you want
@@ -200,7 +200,8 @@ of several sub-resources - these resources are laid out below.
 
   * `forward` (Required) - Specifies whether you want CloudFront to forward
     cookies to the origin that is associated with this cache behavior. You can
-    specify `all`, `none` or `whitelist`.
+    specify `all`, `none` or `whitelist`. If `whitelist`, you must include the
+    subsequent `whitelisted_names`
 
   * `whitelisted_names` (Optional) - If you have specified `whitelist` to
     `forward`, the whitelisted cookies that you want CloudFront to forward to


### PR DESCRIPTION
A `cookies` value must be sent for CloudFront distributions, even if `none`. The docs are hard to parse but there's a request example that shows the cookies in there and other fields mentioned as not optional, plus you get an error message if you send nothing... 

- http://docs.aws.amazon.com/AmazonCloudFront/latest/APIReference/CreateDistribution.html

This PR fixes the panic reported in https://github.com/hashicorp/terraform/issues/6425 as well, by guarding against a `*schema.Set` that contains just `nil`, in the event that they did not specify a `cookies` block. 

I think there's a core bug there as well, I can report that when this is merged, in that a required field inside a required field inside an optional field of a Resource will not error on plan if omitted