### PR TITLE
provider/aws: Fixes #5108 (launch_configuration failures)

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -328,6 +328,17 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	var blockDevices []*autoscaling.BlockDeviceMapping
 
+	// We'll use this to detect if we're declaring it incorrectly as an ebs_block_device.
+	rootDeviceName, err := fetchRootDeviceName(d.Get("image_id").(string), ec2conn)
+	if err != nil {
+		return err
+	}
+	if rootDeviceName == nil {
+		// We do this so the value is empty so we don't have to do nil checks later
+		var blank string
+		rootDeviceName = &blank
+	}
+
 	if v, ok := d.GetOk("ebs_block_device"); ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
@@ -354,6 +365,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
 				ebs.Iops = aws.Int64(int64(v))
+			}
+
+			if *aws.String(bd["device_name"].(string)) == *rootDeviceName {
+				return fmt.Errorf("Root device (%s) declared as an 'ebs_block_device'.  Use 'root_block_device' keyword.", *rootDeviceName)
 			}
 
 			blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
@@ -432,7 +447,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+	err = resource.Retry(30*time.Second, func() *resource.RetryError {
 		_, err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
@@ -584,12 +599,13 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 		if bdm.Ebs != nil && bdm.Ebs.Iops != nil {
 			bd["iops"] = *bdm.Ebs.Iops
 		}
-		if bdm.Ebs != nil && bdm.Ebs.Encrypted != nil {
-			bd["encrypted"] = *bdm.Ebs.Encrypted
-		}
+
 		if bdm.DeviceName != nil && *bdm.DeviceName == *rootDeviceName {
 			blockDevices["root"] = bd
 		} else {
+			if bdm.Ebs != nil && bdm.Ebs.Encrypted != nil {
+				bd["encrypted"] = *bdm.Ebs.Encrypted
+			}
 			if bdm.DeviceName != nil {
 				bd["device_name"] = *bdm.DeviceName
 			}


### PR DESCRIPTION
Fixes #5108  - `Invalid address to set: []string{"root_block_device", "0", "encrypted"}`

Fixes the problem where the root_block_device could cause an `apply` error by reading back an "encrypted" parameter that was meant for an ebs_block_device.  "encrypted" is not part of the root_block_device schema, since it can't be set explicitly.

Added a check in Create to fail when the root device is incorrectly specified as an ebs_block_device, as this causes continual refreshing due to mismatched state between root_block_device and ebs_block_device.

I wish I could make this trigger during `plan`, but it doesn't, only on `apply`.  I think that's an improvement over refresh-looping.

"encrypted" and "snapshot_id" should be guarded by `ConflictsWith`, but that doesn't appear to work on nested resources despite #1926.  I tried it and then reverted that when I saw no effect.

I think this PR as-is is an improvement over the current state of surprise failures.  Any advice about the two issues above would be greatly appreciated, though.  They're not blocking bugs, but would help prevent further surprises and questions.