### PR TITLE
provider/aws: Fix issue changing EIP Association

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -61,8 +61,12 @@ func resourceAwsEip() *schema.Resource {
 
 			"private_ip": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
+			},
+
+			"associate_with_private_ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}
@@ -190,7 +194,7 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 		// more unique ID conditionals
 		if domain == "vpc" {
 			var privateIpAddress *string
-			if v := d.Get("private_ip").(string); v != "" {
+			if v := d.Get("associate_with_private_ip").(string); v != "" {
 				privateIpAddress = aws.String(v)
 			}
 			assocOpts = &ec2.AssociateAddressInput{

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -189,9 +189,20 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// more unique ID conditionals
 		if domain == "vpc" {
+			// Track if our InstanceID has changed, to conditionally include the
+			// PrivateIP Address in the AssociateAddress change
+			var instanceChange bool
+			if d.HasChange("instance") {
+				instanceChange = true
+			}
 			var privateIpAddress *string
-			if v := d.Get("private_ip").(string); v != "" {
-				privateIpAddress = aws.String(v)
+			if !instanceChange {
+				if v := d.Get("private_ip").(string); v != "" {
+					// Do not include the Private IP address if the Instance has changed,
+					// as the private IP of the different Instance will not match the
+					// request
+					privateIpAddress = aws.String(v)
+				}
 			}
 			assocOpts = &ec2.AssociateAddressInput{
 				NetworkInterfaceId: aws.String(networkInterfaceId),

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -189,20 +189,9 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// more unique ID conditionals
 		if domain == "vpc" {
-			// Track if our InstanceID has changed, to conditionally include the
-			// PrivateIP Address in the AssociateAddress change
-			var instanceChange bool
-			if d.HasChange("instance") {
-				instanceChange = true
-			}
 			var privateIpAddress *string
-			if !instanceChange {
-				if v := d.Get("private_ip").(string); v != "" {
-					// Do not include the Private IP address if the Instance has changed,
-					// as the private IP of the different Instance will not match the
-					// request
-					privateIpAddress = aws.String(v)
-				}
+			if v := d.Get("private_ip").(string); v != "" {
+				privateIpAddress = aws.String(v)
 			}
 			assocOpts = &ec2.AssociateAddressInput{
 				NetworkInterfaceId: aws.String(networkInterfaceId),

--- a/builtin/providers/aws/resource_aws_eip_test.go
+++ b/builtin/providers/aws/resource_aws_eip_test.go
@@ -105,6 +105,38 @@ func TestAccAWSEIP_twoEIPsOneNetworkInterface(t *testing.T) {
 	})
 }
 
+// This test is an expansion of TestAccAWSEIP_instance, by testing the
+// associated Private EIPs of two instances
+func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
+	var one ec2.Address
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_eip.bar",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEIPInstanceConfig_associated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists("aws_eip.bar", &one),
+					testAccCheckAWSEIPAttributes(&one),
+					testAccCheckAWSEIPAssociated(&one),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAWSEIPInstanceConfig_associated_switch,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists("aws_eip.bar", &one),
+					testAccCheckAWSEIPAttributes(&one),
+					testAccCheckAWSEIPAssociated(&one),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -248,6 +280,149 @@ resource "aws_eip" "bar" {
 }
 `
 
+const testAccAWSEIPInstanceConfig_associated = `
+resource "aws_vpc" "default" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+
+  tags {
+    Name = "default"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.default.id}"
+
+  tags {
+    Name = "main"
+  }
+}
+
+resource "aws_subnet" "tf_test_subnet" {
+  vpc_id                  = "${aws_vpc.default.id}"
+  cidr_block              = "10.0.0.0/24"
+  map_public_ip_on_launch = true
+
+  depends_on = ["aws_internet_gateway.gw"]
+
+  tags {
+    Name = "tf_test_subnet"
+  }
+}
+
+resource "aws_instance" "foo" {
+  # us-west-2
+  ami           = "ami-5189a661"
+  instance_type = "t2.micro"
+
+  private_ip = "10.0.0.12"
+  subnet_id  = "${aws_subnet.tf_test_subnet.id}"
+
+  tags {
+    Name = "foo instance"
+  }
+}
+
+resource "aws_instance" "bar" {
+  # us-west-2
+
+  ami = "ami-5189a661"
+
+  instance_type = "t2.micro"
+
+  private_ip = "10.0.0.19"
+  subnet_id  = "${aws_subnet.tf_test_subnet.id}"
+
+  tags {
+    Name = "bar instance"
+  }
+}
+
+resource "aws_eip" "bar" {
+  vpc = true
+
+  instance                  = "${aws_instance.bar.id}"
+  associate_with_private_ip = "10.0.0.19"
+}
+`
+const testAccAWSEIPInstanceConfig_associated_switch = `
+resource "aws_vpc" "default" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+
+  tags {
+    Name = "default"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.default.id}"
+
+  tags {
+    Name = "main"
+  }
+}
+
+resource "aws_subnet" "tf_test_subnet" {
+  vpc_id                  = "${aws_vpc.default.id}"
+  cidr_block              = "10.0.0.0/24"
+  map_public_ip_on_launch = true
+
+  depends_on = ["aws_internet_gateway.gw"]
+
+  tags {
+    Name = "tf_test_subnet"
+  }
+}
+
+resource "aws_instance" "foo" {
+  # us-west-2
+  ami           = "ami-5189a661"
+  instance_type = "t2.micro"
+
+  private_ip = "10.0.0.12"
+  subnet_id  = "${aws_subnet.tf_test_subnet.id}"
+
+  tags {
+    Name = "foo instance"
+  }
+}
+
+resource "aws_instance" "bar" {
+  # us-west-2
+
+  ami = "ami-5189a661"
+
+  instance_type = "t2.micro"
+
+  private_ip = "10.0.0.19"
+  subnet_id  = "${aws_subnet.tf_test_subnet.id}"
+
+  tags {
+    Name = "bar instance"
+  }
+}
+
+resource "aws_eip" "bar" {
+  vpc = true
+
+  instance                  = "${aws_instance.foo.id}"
+  associate_with_private_ip = "10.0.0.12"
+}
+`
+
+const testAccAWSEIPInstanceConfig_associated_update = `
+resource "aws_instance" "bar" {
+	# us-west-2
+	ami = "ami-4fccb37f"
+	instance_type = "m1.small"
+}
+
+resource "aws_eip" "bar" {
+	instance = "${aws_instance.bar.id}"
+}
+`
+
 const testAccAWSEIPNetworkInterfaceConfig = `
 resource "aws_vpc" "bar" {
 	cidr_block = "10.0.0.0/24"
@@ -273,29 +448,34 @@ resource "aws_eip" "bar" {
 
 const testAccAWSEIPMultiNetworkInterfaceConfig = `
 resource "aws_vpc" "bar" {
-	cidr_block = "10.0.0.0/24"
+  cidr_block = "10.0.0.0/24"
 }
+
 resource "aws_internet_gateway" "bar" {
-	vpc_id = "${aws_vpc.bar.id}"
+  vpc_id = "${aws_vpc.bar.id}"
 }
+
 resource "aws_subnet" "bar" {
   vpc_id            = "${aws_vpc.bar.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.0.0/24"
 }
+
 resource "aws_network_interface" "bar" {
   subnet_id       = "${aws_subnet.bar.id}"
-	private_ips     = ["10.0.0.10", "10.0.0.11"]
-  security_groups = [ "${aws_vpc.bar.default_security_group_id}" ]
+  private_ips     = ["10.0.0.10", "10.0.0.11"]
+  security_groups = ["${aws_vpc.bar.default_security_group_id}"]
 }
+
 resource "aws_eip" "one" {
-	vpc               = "true"
-	network_interface = "${aws_network_interface.bar.id}"
-	private_ip        = "10.0.0.10"
+  vpc                       = "true"
+  network_interface         = "${aws_network_interface.bar.id}"
+  associate_with_private_ip = "10.0.0.10"
 }
+
 resource "aws_eip" "two" {
-	vpc               = "true"
-	network_interface = "${aws_network_interface.bar.id}"
-	private_ip        = "10.0.0.11"
+  vpc                       = "true"
+  network_interface         = "${aws_network_interface.bar.id}"
+  associate_with_private_ip = "10.0.0.11"
 }
 `

--- a/website/source/docs/providers/aws/r/eip.html.markdown
+++ b/website/source/docs/providers/aws/r/eip.html.markdown
@@ -25,18 +25,57 @@ Muliple EIPs associated with a single network interface:
 
 ```
 resource "aws_network_interface" "multi-ip" {
-  subnet_id       = "${aws_subnet.main.id}"
-	private_ips     = ["10.0.0.10", "10.0.0.11"]
+  subnet_id   = "${aws_subnet.main.id}"
+  private_ips = ["10.0.0.10", "10.0.0.11"]
 }
+
 resource "aws_eip" "one" {
-	vpc               = true
-	network_interface = "${aws_network_interface.multi-ip.id}"
-	private_ip        = "10.0.0.10"
+  vpc                       = true
+  network_interface         = "${aws_network_interface.multi-ip.id}"
+  associate_with_private_ip = "10.0.0.10"
 }
+
 resource "aws_eip" "two" {
-	vpc               = true
-	network_interface = "${aws_network_interface.multi-ip.id}"
-	private_ip        = "10.0.0.11"
+  vpc                       = true
+  network_interface         = "${aws_network_interface.multi-ip.id}"
+  associate_with_private_ip = "10.0.0.11"
+}
+```
+
+Attaching an EIP to an Instance with a pre-assigned private ip (VPC Only):
+
+```
+resource "aws_vpc" "default" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.default.id}"
+}
+
+resource "aws_subnet" "tf_test_subnet" {
+  vpc_id                  = "${aws_vpc.default.id}"
+  cidr_block              = "10.0.0.0/24"
+  map_public_ip_on_launch = true
+
+  depends_on = ["aws_internet_gateway.gw"]
+}
+
+resource "aws_instance" "foo" {
+  # us-west-2
+  ami           = "ami-5189a661"
+  instance_type = "t2.micro"
+
+  private_ip = "10.0.0.12"
+  subnet_id  = "${aws_subnet.tf_test_subnet.id}"
+}
+
+resource "aws_eip" "bar" {
+  vpc = true
+
+  instance                  = "${aws_instance.foo.id}"
+  associate_with_private_ip = "10.0.0.12"
 }
 ```
 
@@ -47,7 +86,7 @@ The following arguments are supported:
 * `vpc` - (Optional) Boolean if the EIP is in a VPC or not.
 * `instance` - (Optional) EC2 instance ID.
 * `network_interface` - (Optional) Network interface ID to associate with.
-* `private_ip` - (Optional) The primary or secondary private IP address to
+* `associate_with_private_ip` - (Optional) A user specified primary or secondary private IP address to
   associate with the Elastic IP address. If no private IP address is specified,
   the Elastic IP address is associated with the primary private IP address.
 
@@ -62,6 +101,8 @@ The following attributes are exported:
 
 * `id` - Contains the EIP allocation ID.
 * `private_ip` - Contains the private IP address (if in VPC).
+* `associate_with_private_ip` - Contains the user specified private IP address
+(if in VPC).
 * `public_ip` - Contains the public IP address.
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.


### PR DESCRIPTION
Fix issue when moving an EIP from one Instance to another. 
Currently, we provide the `PrivateIpAddress` in the `AssociateAddress` call, but we're sending the private IP of the current instance, not the instance we're targeting. Since `private_ip` is computed, on association we get the PrivateIp of the first Instance here, which incorrectly get's thrown in with the request. 

Fixes https://github.com/hashicorp/terraform/issues/6436 and failing test `TestAccAWSEIP_instance`


**Update**

Chatted with @phinze about the possible/likely conflict with https://github.com/hashicorp/terraform/pull/6070 and we've got a plan for going forward. I will re-work this PR and update soon

**More Update:**

I've implemented what @phinze and I discussed:

- remove `private_ip` as a user specified value: this value is once again computed and reflects the current private ip
- added `associate_with_private_ip`: this is a private IP you designate to associate the EIP with. 

Private IP is a computed attribute, meaning it will pick up it's value from the Instance or Network Interface that the EIP is associated with. The `associate_with_private_ip` allows the users to specify what value the EIP should take. Without distinguishing between the two cases, we're unable to move the EIP from Instance to Instance (see https://github.com/hashicorp/terraform/issues/6436 and `TestAccAWSEIP_instance` test)