### PR TITLE
provider/vsphere: read gateway information

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -799,13 +799,21 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		for _, v := range mvm.Guest.IpStack {
 			if v.IpRouteConfig != nil && v.IpRouteConfig.IpRoute != nil {
 				for _, route := range v.IpRouteConfig.IpRoute {
-					if route.Network == "0.0.0.0" && route.Gateway.Device != "" {
-						deviceID, err := strconv.Atoi(route.Gateway.Device)
-						if err != nil {
-							log.Printf("[WARN] error at processing device id %#v: %#v", route.Gateway.Device, err)
-						} else {
-							log.Printf("[DEBUG] gateway of device id %d: %s", deviceID, route.Gateway.IpAddress)
-							networkInterfaces[deviceID]["ipv4_gateway"] = route.Gateway.IpAddress
+					if route.Gateway.Device != "" {
+						gatewaySetting := ""
+						if route.Network == "::" {
+							gatewaySetting = "ipv6_gateway"
+						} else if route.Network == "0.0.0.0" {
+							gatewaySetting = "ipv4_gateway"
+						}
+						if gatewaySetting != "" {
+							deviceID, err := strconv.Atoi(route.Gateway.Device)
+							if err != nil {
+								log.Printf("[WARN] error at processing %s of device id %#v: %#v", gatewaySetting, route.Gateway.Device, err)
+							} else {
+								log.Printf("[DEBUG] %s of device id %d: %s", gatewaySetting, deviceID, route.Gateway.IpAddress)
+								networkInterfaces[deviceID][gatewaySetting] = route.Gateway.IpAddress
+							}
 						}
 					}
 				}

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -802,7 +802,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 					if route.Network == "0.0.0.0" && route.Gateway.Device != nil {
 						deviceID, err := strconv.Atoi(route.Gateway.Device)
 						if err != nil {
-							log.Printf("[DEBUG] error at processing device id %#v: %#v", route.Gateway.Device, err)
+							log.Printf("[WARN] error at processing device id %#v: %#v", route.Gateway.Device, err)
 						} else {
 							log.Printf("[DEBUG] gateway of device id %d: %s", deviceID, route.Gateway.IpAddress)
 							networkInterfaces[deviceID]["ipv4_gateway"] = route.Gateway.IpAddress

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -795,15 +795,19 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 			networkInterfaces = append(networkInterfaces, networkInterface)
 		}
 	}
-	for _, v := range mvm.Guest.IpStack {
-		for _, route := range v.IpRouteConfig.IpRoute {
-			if route.Network == "0.0.0.0" {
-				deviceID, err := strconv.Atoi(route.Gateway.Device)
-				if err != nil {
-					log.Printf("[DEBUG] error at processing device id %#v: %#v", route.Gateway.Device, err)
-				} else {
-					log.Printf("[DEBUG] gateway of device id %d: %s", deviceID, route.Gateway.IpAddress)
-					networkInterfaces[deviceID]["ipv4_gateway"] = route.Gateway.IpAddress
+	if mvm.Guest.IpStack != nil {
+		for _, v := range mvm.Guest.IpStack {
+			if v.IpRouteConfig != nil && v.IpRouteConfig.IpRoute != nil {
+				for _, route := range v.IpRouteConfig.IpRoute {
+					if route.Network == "0.0.0.0" && route.Gateway.Device != nil {
+						deviceID, err := strconv.Atoi(route.Gateway.Device)
+						if err != nil {
+							log.Printf("[DEBUG] error at processing device id %#v: %#v", route.Gateway.Device, err)
+						} else {
+							log.Printf("[DEBUG] gateway of device id %d: %s", deviceID, route.Gateway.IpAddress)
+							networkInterfaces[deviceID]["ipv4_gateway"] = route.Gateway.IpAddress
+						}
+					}
 				}
 			}
 		}

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -799,7 +799,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		for _, v := range mvm.Guest.IpStack {
 			if v.IpRouteConfig != nil && v.IpRouteConfig.IpRoute != nil {
 				for _, route := range v.IpRouteConfig.IpRoute {
-					if route.Network == "0.0.0.0" && route.Gateway.Device != nil {
+					if route.Network == "0.0.0.0" && route.Gateway.Device != "" {
 						deviceID, err := strconv.Atoi(route.Gateway.Device)
 						if err != nil {
 							log.Printf("[WARN] error at processing device id %#v: %#v", route.Gateway.Device, err)

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -795,6 +795,19 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 			networkInterfaces = append(networkInterfaces, networkInterface)
 		}
 	}
+	for _, v := range mvm.Guest.IpStack {
+		for _, route := range v.IpRouteConfig.IpRoute {
+			if route.Network == "0.0.0.0" {
+				deviceID, err := strconv.Atoi(route.Gateway.Device)
+				if err != nil {
+					log.Printf("[DEBUG] error at processing device id %#v: %#v", route.Gateway.Device, err)
+				} else {
+					log.Printf("[DEBUG] gateway of device id %d: %s", deviceID, route.Gateway.IpAddress)
+					networkInterfaces[deviceID]["ipv4_gateway"] = route.Gateway.IpAddress
+				}
+			}
+		}
+	}
 	log.Printf("[DEBUG] networkInterfaces: %#v", networkInterfaces)
 	err = d.Set("network_interface", networkInterfaces)
 	if err != nil {

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -50,6 +50,7 @@ func TestAccVSphereVirtualMachine_basic(t *testing.T) {
 					gateway,
 					label,
 					ip_address,
+					gateway,
 					datastoreOpt,
 					template,
 				),
@@ -111,6 +112,7 @@ func TestAccVSphereVirtualMachine_diskInitType(t *testing.T) {
 					gateway,
 					label,
 					ip_address,
+					gateway,
 					datastoreOpt,
 					template,
 				),
@@ -490,6 +492,7 @@ func TestAccVSphereVirtualMachine_createWithExistingVmdk(t *testing.T) {
 					gateway,
 					label,
 					ip_address,
+					gateway,
 					datastoreOpt,
 					vmdk_path,
 				),
@@ -935,6 +938,7 @@ resource "vsphere_virtual_machine" "foo" {
         label = "%s"
         ipv4_address = "%s"
         ipv4_prefix_length = 24
+        ipv4_gateway = "%s"
     }
     disk {
 %s
@@ -958,6 +962,7 @@ resource "vsphere_virtual_machine" "thin" {
         label = "%s"
         ipv4_address = "%s"
         ipv4_prefix_length = 24
+        ipv4_gateway = "%s"
     }
     disk {
 %s
@@ -1078,6 +1083,7 @@ resource "vsphere_virtual_machine" "with_existing_vmdk" {
         label = "%s"
         ipv4_address = "%s"
         ipv4_prefix_length = 24
+        ipv4_gateway = "%s"
     }
     disk {
 %s


### PR DESCRIPTION
The gateway was not read from the VM before and could have forced redeploying the VM when setting a static gateway.