### PR TITLE
Update CHANGELOG.md for AWS EIP change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.16 (Unreleased)
 
-Notes:
+BACKWARDS INCOMPATIBILITIES / NOTES:
 
  * provider/aws: `aws_eip` field `private_ip` is now a computed value, and cannot be set in your configuration. 
     Use `associate_with_private_ip` instead. See [GH-6521]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.6.16 (Unreleased)
 
+Notes:
+
+ * provider/aws: `aws_eip` field `private_ip` is now a computed value, and cannot be set in your configuration. 
+    Use `associate_with_private_ip` instead. See [GH-6521]
+
 FEATURES:
 
  * **New provider:** `librato` [GH-3371]


### PR DESCRIPTION
Adds a `Notes` item to the CHANGELOG noting the change in `aws_eip` field `private_ip`