### PR TITLE
provider/triton: Recognize 404 for Firewall Rules

### DIFF
--- a/builtin/providers/triton/resource_firewall_rule.go
+++ b/builtin/providers/triton/resource_firewall_rule.go
@@ -2,6 +2,7 @@ package triton
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/gocommon/errors"
 	"github.com/joyent/gosdc/cloudapi"
 )
 
@@ -54,6 +55,9 @@ func resourceFirewallRuleExists(d *schema.ResourceData, meta interface{}) (bool,
 	client := meta.(*cloudapi.Client)
 
 	rule, err := client.GetFirewallRule(d.Id())
+	if errors.IsResourceNotFound(err) {
+		return false, nil
+	}
 
 	return rule != nil && err == nil, err
 }


### PR DESCRIPTION
This prevents a firewall rule deleted from underneath Terraform from causing a refresh to stall.