### PR TITLE
provider/aws: Add CloudFront hosted_zone_id attribute

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -21,6 +21,10 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+// cloudFrontRoute53ZoneID defines the route 53 zone ID for CloudFront. This
+// is used to set the zone_id attribute.
+const cloudFrontRoute53ZoneID = "Z2FDTNDATAQYW2"
+
 // Assemble the *cloudfront.DistributionConfig variable. Calls out to various
 // expander functions to convert attributes and sub-attributes to the various
 // complex structures which are necessary to properly build the
@@ -87,6 +91,7 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 
 	d.Set("enabled", distributionConfig.Enabled)
 	d.Set("price_class", distributionConfig.PriceClass)
+	d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)
 
 	err = d.Set("default_cache_behavior", flattenDefaultCacheBehavior(distributionConfig.DefaultCacheBehavior))
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -454,6 +454,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"hosted_zone_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			// retain_on_delete is a non-API attribute that may help facilitate speedy
 			// deletion of a resoruce. It's mainly here for testing purposes, so
 			// enable at your own risk.

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -30,6 +30,11 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 					testAccCheckCloudFrontDistributionExistence(
 						"aws_cloudfront_distribution.s3_distribution",
 					),
+					resource.TestCheckResourceAttr(
+						"aws_cloudfront_distribution.s3_distribution",
+						"hosted_zone_id",
+						"Z2FDTNDATAQYW2",
+					),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -346,6 +346,10 @@ The following attributes are exported:
 
   * `etag` - The current version of the distribution's information. For example:
     `E2QWRUHAPOMQZL`.
+  
+  * `hosted_zone_id` - The CloudFront Route 53 zone ID that can be used to
+     route an [Alias Resource Record Set][7] to. This attribute is simply an
+     alias for the zone ID `Z2FDTNDATAQYW2`.
 
 
 [1]: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html
@@ -354,3 +358,4 @@ The following attributes are exported:
 [4]: http://www.iso.org/iso/country_codes/iso_3166_code_lists/country_names_and_code_elements.htm
 [5]: /docs/providers/aws/r/cloudfront_origin_access_identity.html
 [6]: https://aws.amazon.com/certificate-manager/
+[7]: http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html


### PR DESCRIPTION
Reference: #6489 

Back by popular demand ;)

This adds the `hosted_zone_id` attribute to the `aws_cloudfront_distribution` resource, which, at the time, is currently just an alias for `Z2FDTNDATAQYW2`. This ultimately makes using the resource more semantic, allowing an easy place to reference the zone ID from and also a natural dependency path.

Docs included, and test hooked into the first acceptance test.
