### PR TITLE
add `validate_credentials` option to provider-aws

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -108,6 +108,12 @@ func Provider() terraform.ResourceProvider {
 				Default:     false,
 				Description: descriptions["insecure"],
 			},
+			"validate_credentials": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: descriptions["validate_credentials"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -300,6 +306,9 @@ func init() {
 
 		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
 			"default value is `false`",
+
+		"validate_credentials": "Accounts credentials will be validated against IAM as well as allowed_account_ids and forbidden_account_ids.\n" +
+			"default value is `true`",
 	}
 }
 
@@ -333,6 +342,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if v, ok := d.GetOk("forbidden_account_ids"); ok {
 		config.ForbiddenAccountIds = v.(*schema.Set).List()
 	}
+
+	config.ValidateCredentialsAndAccountID = d.Get("validate_credentials").(bool)
 
 	return config.Client()
 }

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -30,7 +30,7 @@ resource "aws_instance" "web" {
 }
 ```
 
-## Authentication 
+## Authentication
 
 The AWS provider offers flexible means of providing credentials for
 authentication. The following methods are supported, in this order, and
@@ -46,7 +46,7 @@ explained below:
 Static credentials can be provided by adding an `access_key` and `secret_key` in-line in the
 aws provider block:
 
-Usage: 
+Usage:
 
 ```
 provider "aws" {
@@ -58,7 +58,7 @@ provider "aws" {
 
 ###Environment variables
 
-You can provide your credentials via `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, 
+You can provide your credentials via `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`,
 environment variables, representing your AWS Access Key and AWS Secret Key, respectively.
 `AWS_DEFAULT_REGION` and `AWS_SECURITY_TOKEN` are also used, if applicable:
 
@@ -69,7 +69,7 @@ provider "aws" {}
 Usage:
 
 ```
-$ export AWS_ACCESS_KEY_ID="anaccesskey" 
+$ export AWS_ACCESS_KEY_ID="anaccesskey"
 $ export AWS_SECRET_ACCESS_KEY="asecretkey"
 $ export AWS_DEFAULT_REGION="us-west-2"
 $ terraform plan
@@ -78,7 +78,7 @@ $ terraform plan
 ###Shared Credentials file
 
 You can use an AWS credentials file to specify your credentials. The default
-location is `$HOME/.aws/credentials` on Linux and OSX, or `"%USERPROFILE%\.aws\credentials"` 
+location is `$HOME/.aws/credentials` on Linux and OSX, or `"%USERPROFILE%\.aws\credentials"`
 for Windows users. If we fail to detect credentials inline, or in the
 environment, Terraform will check this location. You can optionally specify a
 different location in the configuration by providing `shared_credentials_file`,
@@ -86,7 +86,7 @@ or in the environment with the `AWS_SHARED_CREDENTIALS_FILE` variable. This
 method also supports a `profile` configuration and matching `AWS_PROFILE`
 environment variable:
 
-Usage: 
+Usage:
 
 ```
 provider "aws" {
@@ -148,8 +148,13 @@ The following arguments are supported in the `provider` block:
   to prevent you mistakenly using a wrong one (and end up destroying live environment).
   Conflicts with `allowed_account_ids`.
 
-* `insecure` - (Optional) Optional) Explicitly allow the provider to
+* `insecure` - (Optional) Explicitly allow the provider to
   perform "insecure" SSL requests. If omitted, default value is `false`
+
+* `validate_credentials` - (Optional) Validate provided credentials via IAM as
+   well as allowed_account_ids and forbidden_account_ids. It is typically used
+   when using Terraform to create infrastructure against local versions of AWS
+   services (e.g. DynamoDB Local). Default value is `true`.
 
 * `dynamodb_endpoint` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to


### PR DESCRIPTION
My dev team is planning to use Terraform to manage our AWS resources in all of our environments (Dev, Test, and Prod).

We develop 100% locally (fake_sqs and DynamoDB Local) and do not have access to AWS credentials. We'd like to use Terraform to stand up tables against DynamoDB Local (or any other local AWS service).

I added a `validate_credentials` option to the `provider-aws` Schema. It defaults to `true`. When set to `false` the credentials are not validated at all against IAM or the white / black list of account ids.

Since DynamoDB Local does not check the validity of the credentials we can create tables against it. 