### PR TITLE
[WIP] aws: Use new STS endpoint to validate creds

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -180,7 +180,7 @@ func (c *Config) Client() (interface{}, error) {
 		log.Println("[INFO] Initializing STS connection")
 		client.stsconn = sts.New(sess)
 
-		err = c.ValidateCredentials(client.iamconn)
+		err = c.ValidateCredentials(client.stsconn)
 		if err != nil {
 			errs = append(errs, err)
 			return nil, &multierror.Error{Errors: errs}
@@ -331,24 +331,8 @@ func (c *Config) ValidateRegion() error {
 }
 
 // Validate credentials early and fail before we do any graph walking.
-// In the case of an IAM role/profile with insuffecient privileges, fail
-// silently
-func (c *Config) ValidateCredentials(iamconn *iam.IAM) error {
-	_, err := iamconn.GetUser(nil)
-
-	if awsErr, ok := err.(awserr.Error); ok {
-		if awsErr.Code() == "AccessDenied" || awsErr.Code() == "ValidationError" {
-			log.Printf("[WARN] AccessDenied Error with iam.GetUser, assuming IAM role")
-			// User may be an IAM instance profile, or otherwise IAM role without the
-			// GetUser permissions, so fail silently
-			return nil
-		}
-
-		if awsErr.Code() == "SignatureDoesNotMatch" {
-			return fmt.Errorf("Failed authenticating with AWS: please verify credentials")
-		}
-	}
-
+func (c *Config) ValidateCredentials(stsconn *sts.STS) error {
+	_, err := stsconn.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	return err
 }
 


### PR DESCRIPTION
We were historically using `iam:GetUser` API for validating credentials, which however doesn't work on EC2 instances with IAM instance profiles (assumed roles) nor with other assumed roles for humans (via  SAML/OpenID). In addition to that any credentials generated via `sts:GetFederationToken` cannot call any STS or IAM endpoints.

We originally avoided the mentioned limitations just by silently ignoring certain error codes coming from `iam:GetUser`. We don't have to do this anymore since the new STS endpoint was introduced (`sts:GetCallerIdentity`).

I was originally afraid that it will be yet another half-working method for validation with dozens of exceptions across different environments - e.g. STS can be disabled per regions. It however looks like the `sts:GetCallerIdentity` can be used even when explicitly denied via IAM policy (`Deny` for `sts:*`) and in region which has STS disabled. It can also be used (surprisingly) on EC2 instances. 🎉 

**WIP:** I approached AWS support as I want them to confirm that the inability to "disable" this API endpoint is intention and not a bug which would be fixed later on. I'm currently awaiting response from them.

Fixes #6523