### PR TITLE
provider/aws: Redshift Cluster not allowing 0 for automated_snapshot_retention_period

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -197,15 +197,16 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[INFO] Building Redshift Cluster Options")
 	createOpts := &redshift.CreateClusterInput{
-		ClusterIdentifier:   aws.String(d.Get("cluster_identifier").(string)),
-		Port:                aws.Int64(int64(d.Get("port").(int))),
-		MasterUserPassword:  aws.String(d.Get("master_password").(string)),
-		MasterUsername:      aws.String(d.Get("master_username").(string)),
-		ClusterVersion:      aws.String(d.Get("cluster_version").(string)),
-		NodeType:            aws.String(d.Get("node_type").(string)),
-		DBName:              aws.String(d.Get("database_name").(string)),
-		AllowVersionUpgrade: aws.Bool(d.Get("allow_version_upgrade").(bool)),
-		PubliclyAccessible:  aws.Bool(d.Get("publicly_accessible").(bool)),
+		ClusterIdentifier:                aws.String(d.Get("cluster_identifier").(string)),
+		Port:                             aws.Int64(int64(d.Get("port").(int))),
+		MasterUserPassword:               aws.String(d.Get("master_password").(string)),
+		MasterUsername:                   aws.String(d.Get("master_username").(string)),
+		ClusterVersion:                   aws.String(d.Get("cluster_version").(string)),
+		NodeType:                         aws.String(d.Get("node_type").(string)),
+		DBName:                           aws.String(d.Get("database_name").(string)),
+		AllowVersionUpgrade:              aws.Bool(d.Get("allow_version_upgrade").(bool)),
+		PubliclyAccessible:               aws.Bool(d.Get("publicly_accessible").(bool)),
+		AutomatedSnapshotRetentionPeriod: aws.Int64(int64(d.Get("automated_snapshot_retention_period").(int))),
 	}
 
 	if v := d.Get("number_of_nodes").(int); v > 1 {
@@ -237,10 +238,6 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 
 	if v, ok := d.GetOk("cluster_parameter_group_name"); ok {
 		createOpts.ClusterParameterGroupName = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("automated_snapshot_retention_period"); ok {
-		createOpts.AutomatedSnapshotRetentionPeriod = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("encrypted"); ok {

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -43,7 +43,7 @@ string.
 * `preferred_maintenance_window` - (Optional) The weekly time range (in UTC) during which automated cluster maintenance can occur.
                                               Format: ddd:hh24:mi-ddd:hh24:mi
 * `cluster_parameter_group_name` - (Optional) The name of the parameter group to be associated with this cluster.
-* `automated_snapshot_retention_period` - (Optional) The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with create-cluster-snapshot.
+* `automated_snapshot_retention_period` - (Optional) The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with create-cluster-snapshot. Default is 1.
 * `port` - (Optional) The port number on which the cluster accepts incoming connections.
                       The cluster is accessible only via the JDBC and ODBC connection strings. Part of the connection string requires the port on which the cluster will listen for incoming connections. Default port is 5439.
 * `cluster_version` - (Optional) The version of the Amazon Redshift engine software that you want to deploy on the cluster.


### PR DESCRIPTION
The default value for `automated_snapshot_retention_period` is 1.
Therefore, it can be included in the `CreateClusterInput` without
needing to check that it is set.

This was actually stopping people from setting the value to 0 (disabling
the snapshots) as there is an issue in `d.GetOk()` evaluating 0 for int

Also, documented that  the Default is actually 1 here