### PR TITLE
provider/aws: CloudTrail tests were failing as the names were not unique per test run

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail_test.go
@@ -372,7 +372,7 @@ func testAccCheckCloudTrailLoadTags(trail *cloudtrail.Trail, tags *[]*cloudtrail
 func testAccAWSCloudTrailConfig(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "foobar" {
-    name = "tf-trail-foobar"
+    name = "tf-trail-foobar-%d"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
 }
 
@@ -406,13 +406,13 @@ resource "aws_s3_bucket" "foo" {
 }
 POLICY
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfigModified(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "foobar" {
-    name = "tf-trail-foobar"
+    name = "tf-trail-foobar-%d"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     s3_key_prefix = "/prefix"
     include_global_service_events = false
@@ -449,13 +449,13 @@ resource "aws_s3_bucket" "foo" {
 }
 POLICY
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfigMultiRegion(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "foobar" {
-    name = "tf-trail-foobar"
+    name = "tf-trail-foobar-%d"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     is_multi_region_trail = true
 }
@@ -490,13 +490,13 @@ resource "aws_s3_bucket" "foo" {
 }
 POLICY
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfig_logValidation(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "foobar" {
-    name = "tf-acc-trail-log-validation-test"
+    name = "tf-acc-trail-log-validation-test-%d"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     is_multi_region_trail = true
     include_global_service_events = true
@@ -533,13 +533,13 @@ resource "aws_s3_bucket" "foo" {
 }
 POLICY
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfig_logValidationModified(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "foobar" {
-    name = "tf-acc-trail-log-validation-test"
+    name = "tf-acc-trail-log-validation-test-%d"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     include_global_service_events = true
 }
@@ -574,12 +574,12 @@ resource "aws_s3_bucket" "foo" {
 }
 POLICY
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 var testAccAWSCloudTrailConfig_tags_tpl = `
 resource "aws_cloudtrail" "foobar" {
-    name = "tf-acc-trail-log-validation-test"
+    name = "tf-acc-trail-log-validation-test-%d"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     %s
 }
@@ -621,7 +621,7 @@ func testAccAWSCloudTrailConfig_tags(cloudTrailRandInt int) string {
 		`tags {
 		Foo = "moo"
 		Pooh = "hi"
-	}`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+	}`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt int) string {
@@ -630,10 +630,10 @@ func testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt int) string {
 		Foo = "moo"
 		Pooh = "hi"
 		Moo = "boom"
-	}`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+	}`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfig_tagsModifiedAgain(cloudTrailRandInt int) string {
 	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl,
-		"", cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+		"", cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }


### PR DESCRIPTION
@catsby this one is more for you than anyone else :)

The output of the nightlies are as follows:

```
=== RUN   TestAccAWSCloudTrail_basic
--- FAIL: TestAccAWSCloudTrail_basic (13.81s)
	testing.go:172: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_cloudtrail.foobar: TrailAlreadyExistsException: Trail tf-trail-foobar already exists for customer: 187416307283
			status code: 400, request id: e06e3bb9-14dc-11e6-8cc3-cb3bd91387b4
=== RUN   TestAccAWSCloudTrail_enable_logging
Sun May 8 05:22:45 UTC 2016 - building ...
--- FAIL: TestAccAWSCloudTrail_enable_logging (13.00s)
	testing.go:172: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_cloudtrail.foobar: TrailAlreadyExistsException: Trail tf-trail-foobar already exists for customer: 187416307283
			status code: 400, request id: e85bf575-14dc-11e6-8cbd-5f296819d23f
=== RUN   TestAccAWSCloudTrail_is_multi_region
--- FAIL: TestAccAWSCloudTrail_is_multi_region (13.74s)
	testing.go:172: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_cloudtrail.foobar: TrailAlreadyExistsException: Trail tf-trail-foobar already exists for customer: 187416307283
			status code: 400, request id: f06155ba-14dc-11e6-8cbd-5f296819d23f
```

https://travis-ci.org/hashicorp/terraform/jobs/128604374#L360