### PR TITLE
[WIP] rough changes that fix vsphere vm's on master

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -736,6 +736,13 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 	} else {
 		log.Printf("[DEBUG] Could not get IP address for %s", d.Id())
 	}
+	if ip, ok := d.GetOk("network_interface.1.ipv4_address"); ok {
+		d.SetConnInfo(map[string]string{
+			"host": ip.(string),
+		})
+	} else {
+		log.Printf("[DEBUG] Could not get IP address for %s", d.Id())
+	}
 
 	d.SetId(vm.Path())
 


### PR DESCRIPTION
I'm not sure if this should be merged in it's current form but I wanted to put this out there so people could see what I had to do to get vSphere vms working today.

Currently master pulls the network information too soon thus if anything wants to subsequently use the IP of the instance it fails. I believe this is documented in #6174 and this PR is a really rough fix for the problem. I solved this by adding in a loop that spins until the network information is not null. This probably needs a circuit breaker after some amount of time but it's effective.

I also am not sure if this would work at all with DHCP. It does work when all the addressing information is passed in statically. Furthermore, this fix (#6522) for pulling in the gateway routing information flat out didn't work for me (and I debugged it for hours) so I statically set the gateway based upon what's passed in from the configuration.

Hopefully someone finds this helpful. I'm going to use it as a stopgap for my purposes. 
