### PR TITLE
provider/aws: Opsworks Agent has a default, needs to be computed

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -25,6 +25,7 @@ func resourceAwsOpsworksStack() *schema.Resource {
 			"agent_version": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"id": &schema.Schema{


### PR DESCRIPTION
`agent_version` was introduced to Opsworks Stacks in https://github.com/hashicorp/terraform/pull/6493, however as an optional attribute that will have a default if not specified. This PR makes the attribute computed, if the user omits it. Fixes failing Acc tests:

```
--- FAIL: TestAccAWSOpsworksStackVpc (15.79s)
	testing.go:172: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_opsworks_stack.tf-acc
		  agent_version: "3437-20160504095744" => ""
		
		STATE:
```