### PR TITLE
core: Fix interp error msgs on module vars during destroy

### DIFF
--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -297,6 +297,12 @@ func (n *GraphNodeConfigResource) Noop(opts *NoopOpts) bool {
 		return true
 	}
 
+	// If the whole module is being destroyed, then the resource nodes in that
+	// module are irrelevant - we only need to keep the destroy nodes.
+	if opts.ModDiff != nil && opts.ModDiff.Destroy == true {
+		return true
+	}
+
 	// Grab the ID which is the prefix (in the case count > 0 at some point)
 	prefix := n.Resource.Id()
 

--- a/terraform/test-fixtures/apply-destroy-module-with-attrs/child/main.tf
+++ b/terraform/test-fixtures/apply-destroy-module-with-attrs/child/main.tf
@@ -1,0 +1,5 @@
+variable "vpc_id" {}
+
+resource "aws_instance" "child" {
+  vpc_id = "${var.vpc_id}"
+}

--- a/terraform/test-fixtures/apply-destroy-module-with-attrs/main.tf
+++ b/terraform/test-fixtures/apply-destroy-module-with-attrs/main.tf
@@ -1,0 +1,6 @@
+resource "aws_instance" "vpc"   { }
+
+module "child" {
+  source = "./child"
+  vpc_id = "${aws_instance.vpc.id}"
+}


### PR DESCRIPTION
Wow this one was tricky!

This bug presents itself only when using planfiles, because when doing a
straight `terraform apply` the interpolations are left in place from the
Plan graph walk and paper over the issue. (This detail is what made it
so hard to reproduce initially.)

Basically, graph nodes for module variables are visited during the apply
walk and attempt to interpolate. During a destroy walk, no attributes
are interpolated from resource nodes, so these interpolations fail.

This scenario is supposed to be handled by the `PruneNoopTransformer` -
in fact it's described as the example use case in the comment above it!

So the bug had to do with the actual behavor of the Noop transformer.
The resource nodes were not properly reporting themselves as Noops
during a destroy, so they were being left in the graph.

This in turn triggered the module variable nodes to see that they had
another node depending on them, so they also reported that they could
not be pruned.

Therefore we had two nodes in the graph that were effectively noops but
were being visited anyways. The module variable nodes were already graph
leaves, which is why this error presented itself as just stray messages
instead of actual failure to destroy.

Fixes #5440
Fixes #5708
Fixes #4988
Fixes #3268