### PR TITLE
provider/aws: Update paramter for DB Option Group

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -407,7 +407,7 @@ resource "aws_db_instance" "bar" {
 var testAccAWSDBInstanceConfigWithOptionGroup = fmt.Sprintf(`
 
 resource "aws_db_option_group" "bar" {
-	option_group_name = "option-group-test-terraform"
+	name = "option-group-test-terraform"
 	option_group_description = "Test option group for terraform"
 	engine_name = "mysql"
 	major_engine_version = "5.6"
@@ -426,7 +426,7 @@ resource "aws_db_instance" "bar" {
 	backup_retention_period = 0
 
 	parameter_group_name = "default.mysql5.6"
-	option_group_name = "${aws_db_option_group.bar.option_group_name}"
+	option_group_name = "${aws_db_option_group.bar.name}"
 }`, acctest.RandInt())
 
 func testAccReplicaInstanceConfig(val int) string {

--- a/website/source/docs/providers/aws/r/db_option_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_option_group.html.markdown
@@ -12,7 +12,7 @@ Provides an RDS DB option group resource.
 
 ```
 resource "aws_db_option_group" "bar" {
-  option_group_name = "option-group-test-terraform"
+  name = "option-group-test-terraform"
   option_group_description = "Terraform Option Group"
   engine_name = "sqlserver-ee"
   major_engine_version = "11.00"
@@ -33,7 +33,7 @@ resource "aws_db_option_group" "bar" {
 
 The following arguments are supported:
 
-* `option_group_name` - (Required) The name of the Option group to be created.
+* `name` - (Required) The name of the Option group to be created.
 * `option_group_description` - (Required) The description of the option group.
 * `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with..
 * `major_engine_version` - (Required) Specifies the major version of the engine that this option group should be associated with.


### PR DESCRIPTION
`aws_db_option_group` was recently added in https://github.com/hashicorp/terraform/pull/4401, however a test therein that was added to DB Instance used a presumably old parameter name `option_group_name` instead of just `name`, which caused said DB Instance test to fail. 

This updates the test there and I made sure the existing DB Option group ones pass as well:

```
Running..

==> Checking that code complies with gofmt requirements...
/Users/clint/Projects/Go/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBOptionGroup_ -timeout 120m
d=== RUN   TestAccAWSDBOptionGroup_basic
--- PASS: TestAccAWSDBOptionGroup_basic (9.43s)
=== RUN   TestAccAWSDBOptionGroup_sqlServerOptionsUpdate
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (18.16s)
=== RUN   TestAccAWSDBOptionGroup_multipleOptions
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (11.39s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	39.003s
Test:
```