### PR TITLE
core: Add support for marking outputs as sensitive

### DIFF
--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -886,6 +886,36 @@ func TestApply_stateNoExist(t *testing.T) {
 	}
 }
 
+func TestApply_sensitiveOutput(t *testing.T) {
+	statePath := testTempFile(t)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ApplyCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		testFixturePath("apply-sensitive-output"),
+	}
+
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.OutputWriter.String())
+	}
+
+	output := ui.OutputWriter.String()
+	if !strings.Contains(output, "notsensitive = Hello world") {
+		t.Fatalf("bad: output should contain 'notsensitive' output\n%s", output)
+	}
+	if !strings.Contains(output, "sensitive    = <sensitive>") {
+		t.Fatalf("bad: output should contain 'sensitive' output\n%s", output)
+	}
+}
+
 func TestApply_vars(t *testing.T) {
 	statePath := testTempFile(t)
 

--- a/command/output.go
+++ b/command/output.go
@@ -82,6 +82,7 @@ func (c *OutputCommand) Run(args []string) int {
 
 		for _, k := range ks {
 			v := mod.Outputs[k]
+
 			c.Ui.Output(fmt.Sprintf("%s = %s", k, v))
 		}
 		return 0

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -109,7 +109,7 @@ func (c *RefreshCommand) Run(args []string) int {
 		return 1
 	}
 
-	if outputs := outputsAsString(newState); outputs != "" {
+	if outputs := outputsAsString(newState, ctx.Module().Config().Outputs); outputs != "" {
 		c.Ui.Output(c.Colorize().Color(outputs))
 	}
 

--- a/command/test-fixtures/apply-sensitive-output/main.tf
+++ b/command/test-fixtures/apply-sensitive-output/main.tf
@@ -1,0 +1,12 @@
+variable "input" {
+  default = "Hello world"
+}
+
+output "notsensitive" {
+  value = "${var.input}"
+}
+
+output "sensitive" {
+  sensitive = true
+  value = "${var.input}"
+}

--- a/website/source/docs/configuration/outputs.html.md
+++ b/website/source/docs/configuration/outputs.html.md
@@ -76,8 +76,8 @@ displayed in place of their value.
 
 ### Limitations of Sensitive Outputs
 
-* the values of sensitive outputs are still stored in the Terraform
+* The values of sensitive outputs are still stored in the Terraform
   state, and available using the `terraform output` command, so cannot be
   relied on as a sole means of protecting values.
-* sensitivity is not tracked internally, so if the output is interpolated in
+* Sensitivity is not tracked internally, so if the output is interpolated in
   another module into a resource, the value will be displayed. 

--- a/website/source/docs/configuration/outputs.html.md
+++ b/website/source/docs/configuration/outputs.html.md
@@ -57,3 +57,27 @@ output NAME {
 	value = VALUE
 }
 ```
+
+## Sensitive Outputs
+
+Outputs can be marked as containing sensitive material by setting the
+`sensitive` attribute to `true`, like this:
+
+```
+output "sensitive" {
+    sensitive = true
+    value = VALUE 
+}
+```
+
+When outputs are displayed on-screen following a `terraform apply` or
+`terraform refresh`, sensitive outputs are redacted, with `<sensitive>`
+displayed in place of their value.
+
+### Limitations of Sensitive Outputs
+
+* the values of sensitive outputs are still stored in the Terraform
+  state, and available using the `terraform output` command, so cannot be
+  relied on as a sole means of protecting values.
+* sensitivity is not tracked internally, so if the output is interpolated in
+  another module into a resource, the value will be displayed. 


### PR DESCRIPTION
This pull request allows an output to be marked "sensitive", in which case the value is redacted in the post-refresh and post-apply list of outputs.


The configuration:

```tf
variable "input" {
    default = "Hello world"
}

output "notsensitive" {
    value = "${var.input}"
}

output "sensitive" {
    sensitive = true
    value = "${var.input}"
}
```

Would result in the output:

```
terraform apply

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

  notsensitive = Hello world
  sensitive    = <sensitive>
```

The `terraform output` command continues to display the value as before.


Note that sensitivity is not tracked internally, so if the output is interpolated in another module into a resource, the value will be displayed. The value is still present in the state.