### PR TITLE
providers/google: recreate Instance Group Manager when Instance Template is modified

### DIFF
--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -28,6 +28,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			"instance_template": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"name": &schema.Schema{


### PR DESCRIPTION
Fixes [#6234](https://github.com/hashicorp/terraform/issues/6234)