### PR TITLE
provider/openstack: Reassociate FIP on network changes

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -678,12 +678,14 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 			}
 
 			// Only changes to the floating IP are supported
-			if oldFIP != "" && newFIP != "" && oldFIP != newFIP {
+			if oldFIP != "" && oldFIP != newFIP {
 				log.Printf("[DEBUG] Attempting to disassociate %s from %s", oldFIP, d.Id())
 				if err := disassociateFloatingIPFromInstance(computeClient, oldFIP, d.Id(), oldFixedIP); err != nil {
 					return fmt.Errorf("Error disassociating Floating IP during update: %s", err)
 				}
+			}
 
+			if newFIP != "" && oldFIP != newFIP {
 				log.Printf("[DEBUG] Attempting to associate %s to %s", newFIP, d.Id())
 				if err := associateFloatingIPToInstance(computeClient, newFIP, d.Id(), newFixedIP); err != nil {
 					return fmt.Errorf("Error associating Floating IP during update: %s", err)
@@ -856,6 +858,7 @@ func resourceInstanceSecGroupsV2(d *schema.ResourceData) []string {
 // and aggregates it all together.
 func getInstanceNetworksAndAddresses(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) ([]map[string]interface{}, error) {
 	server, err := servers.Get(computeClient, d.Id()).Extract()
+
 	if err != nil {
 		return nil, CheckDeleted(d, err, "server")
 	}


### PR DESCRIPTION
Previously changes to floating ips of networks were not applied (though they were detected) during update. With this PR changes are applied: new FIPs are assoicated as expected.