### PR TITLE
aws_instance BC between 0.6.14 and 0.6.15+ in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ BUG FIXES:
 
 ## 0.6.15 (April 22, 2016)
 
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
+ * `aws_instance` - if you still use `security_groups` field for SG IDs - i.e. inside VPC, this will generate diffs during `plan` and `apply` will **recreate** the resource. Terraform expects IDs (VPC SGs) inside `security_group_ids`.
+
 FEATURES:
 
  * **New command:** `terraform fmt` to automatically normalize config file style ([#4955](https://github.com/hashicorp/terraform/issues/4955))


### PR DESCRIPTION
Wondering why does terraform want to recreate my `aws_instance`s I dug deeper to find this commit https://github.com/hashicorp/terraform/commit/d85df6352621e172da0c3c2037f84a1e9a679694 which apparently introduced BC between `0.6.14` and `0.6.15`.

This made me realise I'm the bad guy 🙈  that is still using `security_groups` for VPC security groups, which I obviously shouldn't be doing.

I however think that user should know about this change in behaviour (previously this was silently ignored).

```
-/+ aws_instance.nat
...
    security_groups.#:           "0" => "1" (forces new resource)
    security_groups.1521004543:  "" => "sg-11be0033" (forces new resource)
...
```

cc @mitchellh ^