### PR TITLE
Correct CloudFormation Stack Output docs

### DIFF
--- a/website/source/docs/providers/aws/r/cloudformation_stack.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudformation_stack.html.markdown
@@ -59,5 +59,5 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `arn` - A unique identifier of the stack.
+* `id` - A unique identifier of the stack.
 * `outputs` - A list of output structures.


### PR DESCRIPTION
I was trying to get a CloudFormation stack to output the ARN of the stack. Trying to define this output with `arn` (listed in the docs) didn't appear to be working;

```
output "cf_arn" {
  value = "${aws_cloudformation_stack.main.arn}"
}
```
```
terraform output -module=cloudformation-stack cf_arn

The output variable requested could not be found in the state
file. If you recently added this to your configuration, be
sure to run `terraform apply`, since the state won't be updated
with new output variables until that command is run.
```

Changing the output to use `id` appears to correct this;
```
output "cf_id" {
  value = "${aws_cloudformation_stack.main.id}"
}
```
```
terraform output -module=cloudformation-stack cf_id
arn:aws:cloudformation:us-east-1...
```
Updating the docs to reflect this.

Current docs: https://www.terraform.io/docs/providers/aws/r/cloudformation_stack.html