### PR TITLE
provider/fastly: add support for custom VCL configuration

### DIFF
--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -86,6 +86,38 @@ resource "aws_s3_bucket" "website" {
 }
 ```
 
+Basic usage with [custom VCL](https://docs.fastly.com/guides/vcl/uploading-custom-vcl) (must be enabled on your Fastly account):
+
+```
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+    port    = 80
+  }
+
+  force_destroy = true
+
+  vcl {
+    name = "my_custom_main_vcl"
+    content = "${file("${path.module}/my_custom_main.vcl")}"
+    main = true
+  }
+
+  vcl {
+    name = "my_custom_library_vcl"
+    content = "${file("${path.module}/my_custom_library.vcl")}"
+  }
+}
+```
+
 **Note:** For an AWS S3 Bucket, the Backend address is
 `<domain>.s3-website-<region>.amazonaws.com`. The `default_host` attribute
 should be set to `<bucket_name>.s3-website-<region>.amazonaws.com`. See the
@@ -112,6 +144,9 @@ below
 order to destroy the Service, set `force_destroy` to `true`. Default `false`.
 * `s3logging` - (Optional) A set of S3 Buckets to send streaming logs too.
 Defined below
+* `vcl` - (Optional) A set of custom VCL configuration blocks. Note that the
+ability to upload custom VCL code is not enabled by default for new Fastly
+accounts (see the [Fastly documentation](https://docs.fastly.com/guides/vcl/uploading-custom-vcl) for details).
 
 
 The `domain` block supports:
@@ -204,6 +239,13 @@ compressed. Default `0`
 Apache Common Log format (`%h %l %u %t %r %>s`)
 * `timestamp_format` - (Optional) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
 
+The `vcl` block supports:
+
+* `name` - (Required) A unique name for this configuration block
+* `content` - (Required) The custom VCL code to upload.
+* `main` - (Optional) If `true`, use this block as the main configuration. If
+`false`, use this block as an includable library. Only a single VCL block can be
+marked as the main block. Default is `false`.
 
 ## Attributes Reference
 
@@ -216,6 +258,7 @@ The following attributes are exported:
 * `backend` – Set of Backends. See above for details
 * `header` – Set of Headers. See above for details
 * `s3logging` – Set of S3 Logging configurations. See above for details
+* `vcl` – Set of custom VCL configurations. See above for details
 * `default_host` – Default host specified
 * `default_ttl` - Default TTL
 * `force_destroy` - Force the destruction of the Service on delete


### PR DESCRIPTION
This PR adds a new `vcl` configuration block to support Fastly [custom VCL](https://docs.fastly.com/guides/vcl/uploading-custom-vcl). VCL is the [Varnish Configuration Language](https://www.varnish-cache.org/docs/2.1/tutorial/vcl.html), which is a compiled C-like DSL.

[Fastly's API model](https://docs.fastly.com/api/config#vcl) for custom VCL is that you have zero or more VCL files associated with your service, with one of them set as the "main" block. The main block needs to define some entrypoints that are invoked directly by the Varnish request handling flow, the other non-main blocks are available to include as libraries in the main block.

#### Usage
```hcl
resource "fastly_service_v1" "demo" {
  name = "demofastly"

  domain {
    name    = "demo.notexample.com"
    comment = "demo"
  }

  backend {
    address = "127.0.0.1"
    name    = "localhost"
    port    = 80
  }

  force_destroy = true

  vcl {
    name = "my_custom_main_vcl"
    content = "${file("${path.module}/my_custom_main.vcl")}"
    main = true
  }

  vcl {
    name = "my_custom_library_vcl"
    content = "${file("${path.module}/my_custom_library.vcl")}"
  }
}
```

#### Caveats
Fastly does not allow custom VCL by default on new accounts. I think it is only available on paid accounts if you request access and describe your planned use case. I noted this in the documentation, but because of this I didn't (yet) write any acceptance tests for this functionality.

I'm open to any other ideas about how to represent VCL in this provider.