### PR TITLE
provider/aws: Fix cloudtrail_tags config formatting in test

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail_test.go
@@ -617,23 +617,33 @@ POLICY
 `
 
 func testAccAWSCloudTrailConfig_tags(cloudTrailRandInt int) string {
-	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl,
-		`tags {
+	tagsString := `tags {
 		Foo = "moo"
 		Pooh = "hi"
-	}`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+	}`
+	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl,
+		cloudTrailRandInt,
+		tagsString,
+		cloudTrailRandInt,
+		cloudTrailRandInt,
+		cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt int) string {
-	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl,
-		`tags {
+	tagsString := `tags {
 		Foo = "moo"
 		Pooh = "hi"
 		Moo = "boom"
-	}`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+	}`
+	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl,
+		cloudTrailRandInt,
+		tagsString,
+		cloudTrailRandInt,
+		cloudTrailRandInt,
+		cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfig_tagsModifiedAgain(cloudTrailRandInt int) string {
 	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl,
-		"", cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+		cloudTrailRandInt, "", cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }


### PR DESCRIPTION
Fixes config parsing error in `TestAccAWSCloudTrail_tags` test