### PR TITLE
provider/aws: `aws_codedeploy_deployment_group` Panics when setting `on_premises_instance_tag_filter`

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -177,7 +177,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 	if attr, ok := d.GetOk("autoscaling_groups"); ok {
 		input.AutoScalingGroups = expandStringList(attr.(*schema.Set).List())
 	}
-	if attr, ok := d.GetOk("on_premises_instance_tag_filters"); ok {
+	if attr, ok := d.GetOk("on_premises_instance_tag_filter"); ok {
 		onPremFilters := buildOnPremTagFilters(attr.(*schema.Set).List())
 		input.OnPremisesInstanceTagFilters = onPremFilters
 	}
@@ -331,9 +331,15 @@ func buildOnPremTagFilters(configured []interface{}) []*codedeploy.TagFilter {
 		var filter codedeploy.TagFilter
 		m := raw.(map[string]interface{})
 
-		filter.Key = aws.String(m["key"].(string))
-		filter.Type = aws.String(m["type"].(string))
-		filter.Value = aws.String(m["value"].(string))
+		if v, ok := m["key"]; ok {
+			filter.Key = aws.String(v.(string))
+		}
+		if v, ok := m["type"]; ok {
+			filter.Type = aws.String(v.(string))
+		}
+		if v, ok := m["value"]; ok {
+			filter.Value = aws.String(v.(string))
+		}
 
 		filters = append(filters, &filter)
 	}
@@ -400,13 +406,13 @@ func onPremisesTagFiltersToMap(list []*codedeploy.TagFilter) []map[string]string
 	result := make([]map[string]string, 0, len(list))
 	for _, tf := range list {
 		l := make(map[string]string)
-		if *tf.Key != "" {
+		if tf.Key != nil && *tf.Key != "" {
 			l["key"] = *tf.Key
 		}
-		if *tf.Value != "" {
+		if tf.Value != nil && *tf.Value != "" {
 			l["value"] = *tf.Value
 		}
-		if *tf.Type != "" {
+		if tf.Type != nil && *tf.Type != "" {
 			l["type"] = *tf.Type
 		}
 		result = append(result, l)


### PR DESCRIPTION
Fixes #6593 

When setting `on_premises_instance_tag_filter`, Terraform was not
pushing the changes on the cReate (due to a spelling mistake). A second
apply would push the tags and then cause a panic. Terraform was building
a ec2.Tagfilter struct without checking for optional values. When the
TagFilter was being dereferenced, it caused a panic

Basic and new test not affected (to prove with and without this on_premises_tag`

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCodeDeployDeploymentGroup -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (98.84s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (41.09s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	139.107s
```