### PR TITLE
provider/aws: Add support for S3 Bucket Acceleration

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -293,6 +293,13 @@ func resourceAwsS3Bucket() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"acceleration_status": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateS3BucketAccelerationStatus,
+			},
 		},
 	}
 }
@@ -391,6 +398,12 @@ func resourceAwsS3BucketUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("lifecycle_rule") {
 		if err := resourceAwsS3BucketLifecycleUpdate(s3conn, d); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("acceleration_status") {
+		if err := resourceAwsS3BucketAccelerationUpdate(s3conn, d); err != nil {
 			return err
 		}
 	}
@@ -524,6 +537,16 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
+
+	//read the acceleration status
+	accelerate, err := s3conn.GetBucketAccelerateConfiguration(&s3.GetBucketAccelerateConfigurationInput{
+		Bucket: aws.String(d.Id()),
+	})
+	log.Printf("[DEBUG] S3 bucket: %s, read Acceleration: %v", d.Id(), accelerate)
+	if err != nil {
+		return err
+	}
+	d.Set("acceleration_status", accelerate.Status)
 
 	// Read the logging configuration
 	logging, err := s3conn.GetBucketLogging(&s3.GetBucketLoggingInput{
@@ -1095,6 +1118,26 @@ func resourceAwsS3BucketLoggingUpdate(s3conn *s3.S3, d *schema.ResourceData) err
 	return nil
 }
 
+func resourceAwsS3BucketAccelerationUpdate(s3conn *s3.S3, d *schema.ResourceData) error {
+	bucket := d.Get("bucket").(string)
+	enableAcceleration := d.Get("acceleration_status").(string)
+
+	i := &s3.PutBucketAccelerateConfigurationInput{
+		Bucket: aws.String(bucket),
+		AccelerateConfiguration: &s3.AccelerateConfiguration{
+			Status: aws.String(enableAcceleration),
+		},
+	}
+	log.Printf("[DEBUG] S3 put bucket acceleration: %#v", i)
+
+	_, err := s3conn.PutBucketAccelerateConfiguration(i)
+	if err != nil {
+		return fmt.Errorf("Error putting S3 acceleration: %s", err)
+	}
+
+	return nil
+}
+
 func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) error {
 	bucket := d.Get("bucket").(string)
 
@@ -1288,6 +1331,18 @@ func normalizeRegion(region string) string {
 	}
 
 	return region
+}
+
+func validateS3BucketAccelerationStatus(v interface{}, k string) (ws []string, errors []error) {
+	validTypes := map[string]struct{}{
+		"Enabled":   struct{}{},
+		"Suspended": struct{}{},
+	}
+
+	if _, ok := validTypes[v.(string)]; !ok {
+		errors = append(errors, fmt.Errorf("S3 Bucket Acceleration Status %q is invalid, must be %q or %q", v.(string), "Enabled", "Suspended"))
+	}
+	return
 }
 
 func expirationHash(v interface{}) int {

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -49,6 +49,34 @@ func TestAccAWSS3Bucket_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3Bucket_acceleration(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithAcceleration(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "acceleration_status", "Enabled"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfigWithoutAcceleration(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "acceleration_status", "Suspended"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3Bucket_Policy(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -792,6 +820,26 @@ resource "aws_s3_bucket" "bucket" {
 }]
 EOF
 	}
+}
+`, randInt)
+}
+
+func testAccAWSS3BucketConfigWithAcceleration(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+	acceleration_status = "Enabled"
+}
+`, randInt)
+}
+
+func testAccAWSS3BucketConfigWithoutAcceleration(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+	acceleration_status = "Suspended"
 }
 `, randInt)
 }

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -172,6 +172,7 @@ The following arguments are supported:
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 * `logging` - (Optional) A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 * `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+* `acceleration_status` - (Optional) Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
 
 The `website` object supports the following:
 


### PR DESCRIPTION
As requested in #6626, this adds support for S3 Bucket Transfer Accelection

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3Bucket_basic' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3Bucket_ -timeout 120m
=== RUN   TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_basic (47.14s)
=== RUN   TestAccAWSS3Bucket_acceleration
--- PASS: TestAccAWSS3Bucket_acceleration (100.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	101.941s
```