### PR TITLE
provider/aws: Updating state when `aws_sns_topic_subscription` is missing

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
 )
 
@@ -155,6 +156,12 @@ func resourceAwsSnsTopicSubscriptionRead(d *schema.ResourceData, meta interface{
 		SubscriptionArn: aws.String(d.Id()),
 	})
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFound" {
+			log.Printf("[WARN] SNS Topic Subscription (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Fixes #6625

When an SNS topic subscription was created with TF and then removed via
the AWS Console, Terraform threw an error:

```
* aws_sns_topic_subscription.testme: NotFound: Subscription does not
* exist
    status code: 404, request id: a22e7ed7-3630-5a8a-b767-317ac1440e24
```

This PR will remove the topic subscription from state on a NotFound and
will then readd the subscripton