### PR TITLE
ultradns_tcpool: add

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -202,7 +202,8 @@
 		},
 		{
 			"ImportPath": "github.com/Ensighten/udnssdk",
-			"Rev": "0290933f5e8afd933f2823fce32bf2847e6ea603"
+			"Comment": "v1.0.0",
+			"Rev": "b212803286841a85cb68ae87a6a4f506a7e23bbd"
 		},
 		{
 			"ImportPath": "github.com/ajg/form",

--- a/builtin/providers/ultradns/common.go
+++ b/builtin/providers/ultradns/common.go
@@ -1,0 +1,46 @@
+package ultradns
+
+import (
+	"fmt"
+
+	"github.com/Ensighten/udnssdk"
+)
+
+// Conversion helper functions
+type rRSetResource struct {
+	OwnerName string
+	RRType    string
+	RData     []string
+	TTL       int
+	Profile   *udnssdk.StringProfile
+	Zone      string
+}
+
+// profileAttrSchemaMap is a map from each ultradns_tcpool attribute name onto its respective ProfileSchema URI
+var profileAttrSchemaMap = map[string]udnssdk.ProfileSchema{
+	"dirpool_profile": udnssdk.DirPoolSchema,
+	"rdpool_profile":  udnssdk.RDPoolSchema,
+	"sbpool_profile":  udnssdk.SBPoolSchema,
+	"tcpool_profile":  udnssdk.TCPoolSchema,
+}
+
+func (r rRSetResource) RRSetKey() udnssdk.RRSetKey {
+	return udnssdk.RRSetKey{
+		Zone: r.Zone,
+		Type: r.RRType,
+		Name: r.OwnerName,
+	}
+}
+
+func (r rRSetResource) RRSet() udnssdk.RRSet {
+	return udnssdk.RRSet{
+		OwnerName: r.OwnerName,
+		RRType:    r.RRType,
+		RData:     r.RData,
+		TTL:       r.TTL,
+	}
+}
+
+func (r rRSetResource) ID() string {
+	return fmt.Sprintf("%s.%s", r.OwnerName, r.Zone)
+}

--- a/builtin/providers/ultradns/common.go
+++ b/builtin/providers/ultradns/common.go
@@ -12,7 +12,7 @@ type rRSetResource struct {
 	RRType    string
 	RData     []string
 	TTL       int
-	Profile   *udnssdk.StringProfile
+	Profile   udnssdk.RawProfile
 	Zone      string
 }
 
@@ -38,6 +38,7 @@ func (r rRSetResource) RRSet() udnssdk.RRSet {
 		RRType:    r.RRType,
 		RData:     r.RData,
 		TTL:       r.TTL,
+		Profile:   r.Profile,
 	}
 }
 

--- a/builtin/providers/ultradns/provider.go
+++ b/builtin/providers/ultradns/provider.go
@@ -34,6 +34,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"ultradns_record": resourceUltraDNSRecord(),
+			"ultradns_tcpool": resourceUltradnsTcpool(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/ultradns/provider.go
+++ b/builtin/providers/ultradns/provider.go
@@ -1,6 +1,7 @@
 package ultradns
 
 import (
+	"github.com/Ensighten/udnssdk"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -24,9 +25,10 @@ func Provider() terraform.ResourceProvider {
 			},
 			"baseurl": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ULTRADNS_BASEURL", nil),
-				Description: "UltraDNS Base Url(defaults to testing)",
+				Default:     udnssdk.DefaultLiveBaseURL,
+				Description: "UltraDNS Base URL",
 			},
 		},
 

--- a/builtin/providers/ultradns/resource_ultradns_record.go
+++ b/builtin/providers/ultradns/resource_ultradns_record.go
@@ -10,17 +10,10 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-type rRSetResource struct {
-	OwnerName string
-	RRType    string
-	RData     []string
-	TTL       int
-	Profile   *udnssdk.StringProfile
-	Zone      string
-}
-
 func newRRSetResource(d *schema.ResourceData) (rRSetResource, error) {
 	r := rRSetResource{}
+
+	// TODO: return error if required attributes aren't ok
 
 	if attr, ok := d.GetOk("name"); ok {
 		r.OwnerName = attr.(string)
@@ -47,27 +40,6 @@ func newRRSetResource(d *schema.ResourceData) (rRSetResource, error) {
 	}
 
 	return r, nil
-}
-
-func (r rRSetResource) RRSetKey() udnssdk.RRSetKey {
-	return udnssdk.RRSetKey{
-		Zone: r.Zone,
-		Type: r.RRType,
-		Name: r.OwnerName,
-	}
-}
-
-func (r rRSetResource) RRSet() udnssdk.RRSet {
-	return udnssdk.RRSet{
-		OwnerName: r.OwnerName,
-		RRType:    r.RRType,
-		RData:     r.RData,
-		TTL:       r.TTL,
-	}
-}
-
-func (r rRSetResource) ID() string {
-	return fmt.Sprintf("%s.%s", r.OwnerName, r.Zone)
 }
 
 func populateResourceDataFromRRSet(r udnssdk.RRSet, d *schema.ResourceData) error {
@@ -136,6 +108,8 @@ func resourceUltraDNSRecord() *schema.Resource {
 	}
 }
 
+// CRUD Operations
+
 func resourceUltraDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*udnssdk.Client)
 
@@ -144,14 +118,14 @@ func resourceUltraDNSRecordCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	log.Printf("[INFO] ultradns_record create: %#v", r.RRSet())
+	log.Printf("[INFO] ultradns_record create: %+v", r)
 	_, err = client.RRSets.Create(r.RRSetKey(), r.RRSet())
 	if err != nil {
-		return fmt.Errorf("Failed to create UltraDNS RRSet: %s", err)
+		return fmt.Errorf("ultradns_record create failed: %v", err)
 	}
 
 	d.SetId(r.ID())
-	log.Printf("[INFO] ultradns_record.id: %s", d.Id())
+	log.Printf("[INFO] ultradns_record.id: %v", d.Id())
 
 	return resourceUltraDNSRecordRead(d, meta)
 }
@@ -174,10 +148,10 @@ func resourceUltraDNSRecordRead(d *schema.ResourceData, meta interface{}) error 
 					d.SetId("")
 					return nil
 				}
-				return fmt.Errorf("ultradns_record not found: %s", err)
+				return fmt.Errorf("ultradns_record not found: %v", err)
 			}
 		}
-		return fmt.Errorf("ultradns_record not found: %s", err)
+		return fmt.Errorf("ultradns_record not found: %v", err)
 	}
 	rec := rrsets[0]
 	return populateResourceDataFromRRSet(rec, d)
@@ -191,10 +165,10 @@ func resourceUltraDNSRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	log.Printf("[INFO] ultradns_record update: %#v", r.RRSet())
+	log.Printf("[INFO] ultradns_record update: %+v", r)
 	_, err = client.RRSets.Update(r.RRSetKey(), r.RRSet())
 	if err != nil {
-		return fmt.Errorf("ultradns_record update failed: %s", err)
+		return fmt.Errorf("ultradns_record update failed: %v", err)
 	}
 
 	return resourceUltraDNSRecordRead(d, meta)
@@ -208,11 +182,13 @@ func resourceUltraDNSRecordDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	log.Printf("[INFO] ultradns_record delete: %#v", r.RRSet())
+	log.Printf("[INFO] ultradns_record delete: %+v", r)
 	_, err = client.RRSets.Delete(r.RRSetKey())
 	if err != nil {
-		return fmt.Errorf("ultradns_record delete failed: %s", err)
+		return fmt.Errorf("ultradns_record delete failed: %v", err)
 	}
 
 	return nil
 }
+
+// Conversion helper functions

--- a/builtin/providers/ultradns/resource_ultradns_record_test.go
+++ b/builtin/providers/ultradns/resource_ultradns_record_test.go
@@ -2,7 +2,6 @@ package ultradns
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/Ensighten/udnssdk"
@@ -12,7 +11,8 @@ import (
 
 func TestAccUltraDNSRecord_Basic(t *testing.T) {
 	var record udnssdk.RRSet
-	domain := os.Getenv("ULTRADNS_DOMAIN")
+	// domain := os.Getenv("ULTRADNS_DOMAIN")
+	domain := "ultradns.phinze.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,14 +22,14 @@ func TestAccUltraDNSRecord_Basic(t *testing.T) {
 			resource.TestStep{
 				Config: fmt.Sprintf(testAccCheckUltraDNSRecordConfigBasic, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUltraDNSRecordExists("ultradns_record.foobar", &record),
+					testAccCheckUltraDNSRecordExists("ultradns_record.basic", &record),
 					testAccCheckUltraDNSRecordAttributes(&record),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "name", "terraform"),
+						"ultradns_record.basic", "name", "basic"),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "zone", domain),
+						"ultradns_record.basic", "zone", domain),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "rdata.0", "192.168.0.10"),
+						"ultradns_record.basic", "rdata.0", "192.168.0.10"),
 				),
 			},
 		},
@@ -38,7 +38,7 @@ func TestAccUltraDNSRecord_Basic(t *testing.T) {
 
 func TestAccUltraDNSRecord_Updated(t *testing.T) {
 	var record udnssdk.RRSet
-	domain := os.Getenv("ULTRADNS_DOMAIN")
+	domain := "ultradns.phinze.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -48,27 +48,27 @@ func TestAccUltraDNSRecord_Updated(t *testing.T) {
 			resource.TestStep{
 				Config: fmt.Sprintf(testAccCheckUltraDNSRecordConfigBasic, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUltraDNSRecordExists("ultradns_record.foobar", &record),
+					testAccCheckUltraDNSRecordExists("ultradns_record.basic", &record),
 					testAccCheckUltraDNSRecordAttributes(&record),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "name", "terraform"),
+						"ultradns_record.basic", "name", "basic"),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "zone", domain),
+						"ultradns_record.basic", "zone", domain),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "rdata.0", "192.168.0.10"),
+						"ultradns_record.basic", "rdata.0", "192.168.0.10"),
 				),
 			},
 			resource.TestStep{
 				Config: fmt.Sprintf(testAccCheckUltraDNSRecordConfigNewValue, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUltraDNSRecordExists("ultradns_record.foobar", &record),
+					testAccCheckUltraDNSRecordExists("ultradns_record.basic", &record),
 					testAccCheckUltraDNSRecordAttributesUpdated(&record),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "name", "terraform"),
+						"ultradns_record.basic", "name", "basic"),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "zone", domain),
+						"ultradns_record.basic", "zone", domain),
 					resource.TestCheckResourceAttr(
-						"ultradns_record.foobar", "rdata.0", "192.168.0.11"),
+						"ultradns_record.basic", "rdata.0", "192.168.0.11"),
 				),
 			},
 		},
@@ -157,21 +157,23 @@ func testAccCheckUltraDNSRecordExists(n string, record *udnssdk.RRSet) resource.
 }
 
 const testAccCheckUltraDNSRecordConfigBasic = `
-resource "ultradns_record" "foobar" {
-	zone = "%s"
+resource "ultradns_record" "basic" {
+  zone = "%s"
 
-	name = "terraform"
-	rdata = [ "192.168.0.10" ]
-	type = "A"
-	ttl = 3600
-}`
+  name  = "basic"
+  rdata = ["192.168.0.10"]
+  type  = "A"
+  ttl   = 3600
+}
+`
 
 const testAccCheckUltraDNSRecordConfigNewValue = `
-resource "ultradns_record" "foobar" {
-	zone = "%s"
+resource "ultradns_record" "basic" {
+  zone = "%s"
+  name  = "basic"
 
-	name = "terraform"
-	rdata = [ "192.168.0.11" ]
-	type = "A"
-	ttl = 3600
-}`
+  rdata = ["192.168.0.11"]
+  type  = "A"
+  ttl   = 3600
+}
+`

--- a/builtin/providers/ultradns/resource_ultradns_tcpool.go
+++ b/builtin/providers/ultradns/resource_ultradns_tcpool.go
@@ -1,0 +1,332 @@
+package ultradns
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Ensighten/udnssdk"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceUltradnsTcpool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUltradnsTcpoolCreate,
+		Read:   resourceUltradnsTcpoolRead,
+		Update: resourceUltradnsTcpoolUpdate,
+		Delete: resourceUltradnsTcpoolDelete,
+
+		Schema: map[string]*schema.Schema{
+			// Required
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				// 0-255 char
+			},
+			"rdata": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				// Valid: len(rdataInfo) == len(rdata)
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required
+						"host": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						// Optional
+						"failover_delay": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+							// Valid: 0-30
+							// Units: Minutes
+						},
+						"priority": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1,
+						},
+						"run_probes": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"state": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "NORMAL",
+						},
+						"threshold": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1,
+						},
+						"weight": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  2,
+							// Valid: i%2 == 0 && 2 <= i <= 100
+						},
+					},
+				},
+			},
+			// Optional
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  3600,
+			},
+			"run_probes": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"act_on_probes": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"max_to_lb": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				// Valid: 0 <= i <= len(rdata)
+			},
+			"backup_record_rdata": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				// Valid: IPv4 address or CNAME
+			},
+			"backup_record_failover_delay": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				// Valid: 0-30
+				// Units: Minutes
+			},
+			// Computed
+			"hostname": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// CRUD Operations
+
+func resourceUltradnsTcpoolCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*udnssdk.Client)
+
+	r, err := newRRSetResourceFromTcpool(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] ultradns_tcpool create: %#v", r)
+	_, err = client.RRSets.Create(r.RRSetKey(), r.RRSet())
+	if err != nil {
+		return fmt.Errorf("create failed: %#v -> %v", r, err)
+	}
+
+	d.SetId(r.ID())
+	log.Printf("[INFO] ultradns_tcpool.id: %v", d.Id())
+
+	return resourceUltradnsTcpoolRead(d, meta)
+}
+
+func resourceUltradnsTcpoolRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*udnssdk.Client)
+
+	rr, err := newRRSetResourceFromTcpool(d)
+	if err != nil {
+		return err
+	}
+
+	rrsets, err := client.RRSets.Select(rr.RRSetKey())
+	if err != nil {
+		uderr, ok := err.(*udnssdk.ErrorResponseList)
+		if ok {
+			for _, resps := range uderr.Responses {
+				// 70002 means Records Not Found
+				if resps.ErrorCode == 70002 {
+					d.SetId("")
+					return nil
+				}
+				return fmt.Errorf("resource not found: %v", err)
+			}
+		}
+		return fmt.Errorf("resource not found: %v", err)
+	}
+
+	r := rrsets[0]
+
+	zone := d.Get("zone")
+	// ttl
+	d.Set("ttl", r.TTL)
+	// hostname
+	if r.OwnerName == "" {
+		d.Set("hostname", zone)
+	} else {
+		if strings.HasSuffix(r.OwnerName, ".") {
+			d.Set("hostname", r.OwnerName)
+		} else {
+			d.Set("hostname", fmt.Sprintf("%s.%s", r.OwnerName, zone))
+		}
+	}
+
+	// And now... the Profile!
+	if r.Profile == nil {
+		return fmt.Errorf("RRSet.profile missing: invalid TCPool schema in: %#v", r)
+	}
+	p, err := r.Profile.TCPoolProfile()
+	if err != nil {
+		return fmt.Errorf("RRSet.profile could not be unmarshalled: %v\n", err)
+	}
+
+	// Set simple values
+	d.Set("description", p.Description)
+	d.Set("run_probes", p.RunProbes)
+	d.Set("act_on_probes", p.ActOnProbes)
+	d.Set("max_to_lb", p.MaxToLB)
+	if p.BackupRecord != nil {
+		d.Set("backup_record_rdata", p.BackupRecord.RData)
+		d.Set("backup_record_failover_delay", p.BackupRecord.FailoverDelay)
+	}
+
+	// TODO: rigorously test this to see if we can remove the error handling
+	err = d.Set("rdata", flattenRData(r.RData, p.RDataInfo))
+	if err != nil {
+		return fmt.Errorf("rdata set failed: %#v", err)
+	}
+	return nil
+}
+
+func resourceUltradnsTcpoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*udnssdk.Client)
+
+	r, err := newRRSetResourceFromTcpool(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] ultradns_tcpool update: %+v", r)
+	_, err = client.RRSets.Update(r.RRSetKey(), r.RRSet())
+	if err != nil {
+		return fmt.Errorf("resource update failed: %v", err)
+	}
+
+	return resourceUltradnsTcpoolRead(d, meta)
+}
+
+func resourceUltradnsTcpoolDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*udnssdk.Client)
+
+	r, err := newRRSetResourceFromTcpool(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] ultradns_tcpool delete: %+v", r)
+	_, err = client.RRSets.Delete(r.RRSetKey())
+	if err != nil {
+		return fmt.Errorf("resource delete failed: %v", err)
+	}
+
+	return nil
+}
+
+// Resource Helpers
+
+func newRRSetResourceFromTcpool(d *schema.ResourceData) (rRSetResource, error) {
+	rDataRaw := d.Get("rdata").([]interface{})
+	r := rRSetResource{
+		// "The only valid rrtype value for SiteBacker or Traffic Controller pools is A"
+		// per https://portal.ultradns.com/static/docs/REST-API_User_Guide.pdf
+		RRType:    "A",
+		Zone:      d.Get("zone").(string),
+		OwnerName: d.Get("name").(string),
+		TTL:       d.Get("ttl").(int),
+		RData:     expandRdataHosts(rDataRaw),
+	}
+
+	profile := udnssdk.TCPoolProfile{
+		Context:     udnssdk.TCPoolSchema,
+		ActOnProbes: d.Get("act_on_probes").(bool),
+		Description: d.Get("description").(string),
+		MaxToLB:     d.Get("max_to_lb").(int),
+		RunProbes:   d.Get("run_probes").(bool),
+		RDataInfo:   expandRdataInfos(rDataRaw),
+	}
+
+	// Only send BackupRecord if present
+	br := d.Get("backup_record_rdata").(string)
+	if br != "" {
+		profile.BackupRecord = &udnssdk.BackupRecord{
+			RData:         d.Get("backup_record_rdata").(string),
+			FailoverDelay: d.Get("backup_record_failover_delay").(int),
+		}
+	}
+
+	rp, err := profile.RawProfile()
+	if err != nil {
+		return r, err
+	}
+	r.Profile = rp
+
+	return r, nil
+}
+
+func expandRdataHosts(configured []interface{}) []string {
+	hs := make([]string, 0, len(configured))
+	for _, rRaw := range configured {
+		data := rRaw.(map[string]interface{})
+		h := data["host"].(string)
+		hs = append(hs, h)
+	}
+	return hs
+}
+
+func expandRdataInfos(configured []interface{}) []udnssdk.SBRDataInfo {
+	rdataInfos := make([]udnssdk.SBRDataInfo, 0, len(configured))
+	for _, rRaw := range configured {
+		data := rRaw.(map[string]interface{})
+		r := udnssdk.SBRDataInfo{
+			FailoverDelay: data["failover_delay"].(int),
+			Priority:      data["priority"].(int),
+			RunProbes:     data["run_probes"].(bool),
+			State:         data["state"].(string),
+			Threshold:     data["threshold"].(int),
+			Weight:        data["weight"].(int),
+		}
+		rdataInfos = append(rdataInfos, r)
+	}
+	return rdataInfos
+}
+
+// collate and flatten RData and RDataInfo into []map[string]interface{}
+func flattenRData(rds []string, rdis []udnssdk.SBRDataInfo) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(rds))
+	for i, rdi := range rdis {
+		r := map[string]interface{}{
+			"host":           rds[i],
+			"failover_delay": rdi.FailoverDelay,
+			"priority":       rdi.Priority,
+			"run_probes":     rdi.RunProbes,
+			"state":          rdi.State,
+			"threshold":      rdi.Threshold,
+			"weight":         rdi.Weight,
+		}
+		result = append(result, r)
+	}
+	return result
+}

--- a/builtin/providers/ultradns/resource_ultradns_tcpool_test.go
+++ b/builtin/providers/ultradns/resource_ultradns_tcpool_test.go
@@ -1,0 +1,173 @@
+package ultradns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Ensighten/udnssdk"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccUltradnsTcpool(t *testing.T) {
+	var record udnssdk.RRSet
+	domain := "ultradns.phinze.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUltradnsTcpoolDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckUltraDNSRecordTcpoolMinimal, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUltraDNSRecordExists("ultradns_tcpool.minimal", &record),
+					// Specified
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "name", "tcpool-minimal"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "zone", domain),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "ttl", "300"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "rdata.0.host", "192.168.0.10"),
+					// Defaults
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "act_on_probes", "true"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "description", "Minimal TC Pool"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "max_to_lb", "0"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "run_probes", "true"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "rdata.0.failover_delay", "0"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "rdata.0.priority", "1"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "rdata.0.run_probes", "true"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "rdata.0.state", "NORMAL"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "rdata.0.threshold", "1"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "rdata.0.weight", "2"),
+					// Generated
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "id", "tcpool-minimal.ultradns.phinze.com"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.minimal", "hostname", "tcpool-minimal.ultradns.phinze.com."),
+				),
+			},
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckUltraDNSRecordTcpoolMaximal, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUltraDNSRecordExists("ultradns_tcpool.maximal", &record),
+					// Specified
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "name", "tcpool-maximal"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "zone", domain),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "ttl", "300"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "description", "traffic controller pool with all settings tuned"),
+
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "act_on_probes", "false"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "max_to_lb", "2"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "run_probes", "false"),
+
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.0.host", "192.168.0.10"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.0.failover_delay", "30"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.0.priority", "1"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.0.run_probes", "true"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.0.state", "ACTIVE"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.0.threshold", "1"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.0.weight", "2"),
+
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.1.host", "192.168.0.11"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.1.failover_delay", "30"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.1.priority", "2"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.1.run_probes", "true"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.1.state", "INACTIVE"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.1.threshold", "1"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.1.weight", "4"),
+
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.2.host", "192.168.0.12"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.2.failover_delay", "30"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.2.priority", "3"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.2.run_probes", "false"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.2.state", "NORMAL"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.2.threshold", "1"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "rdata.2.weight", "8"),
+					// Generated
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "id", "tcpool-maximal.ultradns.phinze.com"),
+					resource.TestCheckResourceAttr("ultradns_tcpool.maximal", "hostname", "tcpool-maximal.ultradns.phinze.com."),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckUltradnsTcpoolDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*udnssdk.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ultradns_tcpool" {
+			continue
+		}
+
+		k := udnssdk.RRSetKey{
+			Zone: rs.Primary.Attributes["zone"],
+			Name: rs.Primary.Attributes["name"],
+			Type: rs.Primary.Attributes["type"],
+		}
+
+		_, err := client.RRSets.Select(k)
+
+		if err == nil {
+			return fmt.Errorf("Record still exists")
+		}
+	}
+
+	return nil
+}
+
+const testAccCheckUltraDNSRecordTcpoolMinimal = `
+resource "ultradns_tcpool" "minimal" {
+  zone        = "%s"
+  name        = "tcpool-minimal"
+  ttl         = 300
+  description = "Minimal TC Pool"
+
+  rdata {
+    host = "192.168.0.10"
+  }
+}
+`
+
+const testAccCheckUltraDNSRecordTcpoolMaximal = `
+resource "ultradns_tcpool" "maximal" {
+  zone        = "%s"
+  name        = "tcpool-maximal"
+  ttl         = 300
+  description = "traffic controller pool with all settings tuned"
+
+  act_on_probes = false
+  max_to_lb     = 2
+  run_probes    = false
+
+  rdata {
+    host           = "192.168.0.10"
+    failover_delay = 30
+    priority       = 1
+    run_probes     = true
+    state          = "ACTIVE"
+    threshold      = 1
+    weight         = 2
+  }
+
+  rdata {
+    host           = "192.168.0.11"
+    failover_delay = 30
+    priority       = 2
+    run_probes     = true
+    state          = "INACTIVE"
+    threshold      = 1
+    weight         = 4
+  }
+
+  rdata {
+    host           = "192.168.0.12"
+    failover_delay = 30
+    priority       = 3
+    run_probes     = false
+    state          = "NORMAL"
+    threshold      = 1
+    weight         = 8
+  }
+
+  backup_record_rdata          = "192.168.0.11"
+  backup_record_failover_delay = 30
+}
+`

--- a/vendor/github.com/Ensighten/udnssdk/.travis.yml
+++ b/vendor/github.com/Ensighten/udnssdk/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go:
+- 1.6.2
+script: script/test

--- a/vendor/github.com/Ensighten/udnssdk/CHANGELOG.md
+++ b/vendor/github.com/Ensighten/udnssdk/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [1.0.0] - 2016-05-11
+### Added
+* Support for API endpoints for `RRSets`, `Accounts`,  `DirectionalPools`, Traffic Controller Pool `Probes`, `Events`, `Notifications` & `Alerts`
+* `Client` wraps common API access including OAuth, deferred tasks and retries
+
+[Unreleased]: https://github.com/Ensighten/udnssdk/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.0...v1.0.0

--- a/vendor/github.com/Ensighten/udnssdk/CONTRIBUTING.md
+++ b/vendor/github.com/Ensighten/udnssdk/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing
+
+Want to contribute? Up-to-date pointers should be at:
+<http://contributing.appspot.com/udnssdk>
+
+Got an idea? Something smell wrong? Cause you pain? Or lost seconds of
+your life you'll never get back?
+
+All contributions are welcome: ideas, patches, documentation, bug
+reports, complaints, and even something you drew up on a napkin.
+
+Programming is not a required skill. Whatever you've seen about open
+source and maintainers or community members saying "send patches or die":
+you will not see that here.
+
+It is more important to me that you are able to contribute. If you
+haven't got time to do anything else, just email me and I'll try to
+help: <joseph@josephholsten.com>.
+
+I promise to help guide this project with these principles:
+
+-   Community: If a newbie has a bad time, it's a bug.
+-   Software: Make it work, then make it right, then make it fast.
+-   Technology: If it doesn't do a thing today, we can make it do
+    it tomorrow.
+
+Here are some ways you can be part of the community:
+
+## Something not working? Found a Bug?
+
+Find something that doesn't feel quite right? Here are 5 steps to
+getting it fixed!
+
+### Check your version
+
+To make sure you're not wasting your time, you should be using the
+latest version before you file your bug. First of all, you should
+download the latest revision to be sure you are up to date. If you've
+done this and you still experience the bug, go ahead to the next step.
+
+### Search our [issues]
+
+Now that you have the latest version and still think you've found a bug,
+search through issues first to see if anyone else has already filed it.
+This step is very important! If you find that someone has filed your bug
+already, please go to the next step anyway, but instead of filing a new
+bug, comment on the one you've found. If you can't find your bug in
+issues, go to the next step.
+
+### Create a Github account https://github.com/join
+
+You will need to create a Github account to be able to report bugs (and
+to comment on them). If you have registered, proceed to the next step.
+
+### File the bug!
+
+Now you are ready to file a bug. The [Writing a Good Bug Report]
+document gives some tips about the most useful information to include in
+bug reports. The better your bug report, the higher the chance that your
+bug will be addressed (and possibly fixed) quickly!
+
+### What happens next?
+
+Once your bug is filed, you will receive email when it is updated at
+each stage in the bug life cycle. After the bug is considered fixed, you
+may be asked to download the latest revision and confirm that the fix
+works for you.
+
+## Submitting patches
+
+1.  [Fork the repository.]
+2.  [Create a topic branch.]
+3.  Add specs for your unimplemented feature or bug fix.
+4.  Run `script/test`. If your specs pass, return to step 3.
+5.  Implement your feature or bug fix.
+6.  Run `script/test`. If your specs fail, return to step 5.
+7.  Add, commit (say *why* the changes were made, we can look at the
+    diff to see *how* they were made.), and push your changes. For
+    documentation-only fixes, please add `[ci skip]` to your commit
+    message to avoid needless CI builds.
+8.  [Submit a patch.]
+
+## Setting up a local dev environment
+
+For those of you who do want to contribute with code, we've tried to
+make it easy to get started. You can install all dependencies and tools
+with:
+
+    script/bootstrap
+
+Good luck!
+
+## Style guide
+
+There are great style guides out there, we don't need to reinvent the
+wheel. Here are ones we like:
+
+-   `go`: https://code.google.com/p/go-wiki/wiki/CodeReviewComments
+-   `sh`: http://google.github.io/styleguide/shell.xml
+-   `ruby`: https://github.com/bbatsov/ruby-style-guide
+-   `python`: https://www.python.org/dev/peps/pep-0008/
+
+For some things, the best we've got is a decent formatting tool:
+
+-   `markdown`: `pandoc --to=markdown --reference-links --atx-headers --columns 72`
+-   `json`: `jq .`
+
+  [issues]: https://github.com/Ensighten/udnssdk/issues
+  [Writing a Good Bug Report]: http://www.webkit.org/quality/bugwriting.html
+  [Fork the repository.]: https://help.github.com/articles/fork-a-repo
+  [Create a topic branch.]: http://learn.github.com/p/branching.html
+  [Submit a patch.]: https://help.github.com/articles/using-pull-requests

--- a/vendor/github.com/Ensighten/udnssdk/LICENSE
+++ b/vendor/github.com/Ensighten/udnssdk/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015, 2016 Ensighten
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/Ensighten/udnssdk/readme.md
+++ b/vendor/github.com/Ensighten/udnssdk/readme.md
@@ -1,103 +1,81 @@
-# udnssdk - A ultradns SDK for GoLang
-## about
+# udnssdk - An UltraDNS SDK for Go
 
-This is a golang 'SDK' for UltraDNS that I copapasta'd from weppos/dnsimple.
-It seemed like an ideal donor since the use case is terraform.
+This is a golang SDK for the UltraDNS REST API. It's not feature complete, and currently is only known to be used for Terraform's `ultradns` provider.
 
-## How It works:
-    client := udnssdk.NewClient("username","password",udnssdk.DefaultTestBaseURL)
+Full API docs are available at [godoc](https://godoc.org/github.com/Ensighten/udnssdk)
 
-There is DefaultTestBaseURL and DefaultLiveBaseURL.
-When you call NewClient, it performs the 'oauth2' authorization step.
-The refresh token is saved, but not implemented.  It should ideally be an error
-condition triggering a reauth and retry.  But since Terraform is the use case, this won't be an issue.
+## Example
 
-### RRSet Declaration
+```go
+package main
 
-    type RRSet struct {
-      OwnerName string `json:"ownerName"`
-      RRType string `json:"rrtype"`
-      TTL int `json:"ttl"`
-      RData []string `json:"rdata"`
-    }
+import (
+	"fmt"
+	"log"
 
-###GetRRSets(DomainName, RecordName(leave blank for all), RecordType[A|CNAME|ANY])
-      rrsets, resp, err := client.Zones.GetRRSets("domain.com","","ANY")
-      rrsets, resp, err := client.Zones.GetRRSets("domain.com","www","ANY")
-      rrsets, resp, err := client.Zones.GetRRSets("domain.com","","MX")
-      rrsets, resp, err := client.Zones.GetRRSets("domain.com","www","SRV")
+	"github.com/Ensighten/udnssdk"
+)
 
+func main() {
+	client := udnssdk.NewClient("username", "password", udnssdk.DefaultTestBaseURL)
+	if client == nil {
+		log.Fatalf("Failed to create client")
+	}
 
+	fmt.Printf("---- Query RRSets\n")
+	rrsetkey := RRSetKey{
+		Zone: "domain.com",
+		Type: "ANY",
+		Name: "",
+	}
+	rrsets, err := client.RRSets.Select(rrsetkey)
+	if err != nil {
+		log.Fatalf(err)
+	}
+	fmt.Printf("%+v\n", rrsets)
 
+	fmt.Printf("---- Create RRSet\n")
+	rrsetkey = RRSetKey{
+		Zone: "domain.com",
+		Type: "A",
+		Name: "test",
+	}
+	rrset := udnssdk.RRSet{
+		OwnerName: r.Name,
+		RRType:    r.Type,
+		TTL:       300,
+		RData:     []string{"127.0.0.1"},
+	}
+	resp, err := client.RRSets.Create(rrsetkey, rrset)
+	if err != nil {
+		log.Fatalf(err)
+	}
+	fmt.Printf("Response: %+v\n", resp)
 
-###CreateRRSet(DomainName, RRSet)
-      rr1 := &udnssdk.RRSet{OwnerName: "test", RRType: "A", TTL: 300, RData: []string{"127.0.0.1"}}
-      resp2,err2 := client.Zones.CreateRRSet("ensighten.com",*rr1)
+	fmt.Printf("---- Update RRSet\n")
+	rrset = udnssdk.RRSet{
+		OwnerName: r.Name,
+		RRType:    r.Type,
+		TTL:       300,
+		RData:     []string{"127.0.0.2"},
+	}
+	resp, err := client.RRSets.Update(rrsetkey, rrset)
+	if err != nil {
+		log.Fatalf(err)
+	}
+	fmt.Printf("Response: %+v\n", resp)
 
-###UpdateRRSet(DomainName, RRSet)
-UpdateRRSet requires you to specify the complete RRSet for the update.  This implementation does not support PATCHing.
+	fmt.Printf("---- Delete RRSet\n")
+	resp, err := client.RRSets.Delete(rrsetkey)
+	if err != nil {
+		log.Fatalf(err)
+	}
+	fmt.Printf("Response: %+v\n", resp)
+}
+```
 
-    rr1 := &udnssdk.RRSet{OwnerName: "test", RRType: "A", TTL: 300, RData: []string{"192.168.1.1"}}
-    resp2,err2 := client.Zones.CreateRRSet("domain.com",*rr1)
+## Thanks
 
-###DeleteRRSet(DomainName, RRSet)
-Delete RRSet only uses the ownerName and RRType values from the RRSet object.
-
-    rr3 := &udnssdk.RRSet{OwnerName: "test", RRType: "A"} // This is permissible.
-    resp3,err3 := client.RRSets.DeleteRRSet("domain.com",*rr3)
-
-## Example Program
-
-        package main
-        // udnssdk - a golang sdk for the ultradns REST service.
-        // based on weppos/dnsimple
-
-        import (
-                "fmt"
-                "udnssdk"
-        )
-
-
-        func main() {
-          client := udnssdk.NewClient("username","password",udnssdk.DefaultTestBaseURL)
-          if client == nil {
-            fmt.Printf("Fail")
-          } else {
-            fmt.Printf("Win\n")
-            rrsets, resp, err := client.RRSets.GetRRSets("domain.com","test","ANY")
-            fmt.Printf("%+v\n",rrsets)
-            fmt.Printf("%+v\n",resp)
-            fmt.Printf("%+v\n",err)
-            fmt.Printf("------------------------\n")
-            fmt.Printf("---- Create RRSet\n")
-            rr1 := &udnssdk.RRSet{OwnerName: "test", RRType: "A", TTL: 300, RData: []string{"127.0.0.1}}
-            resp2,err2 := client.RRSets.CreateRRSet("domain.com",*rr1)
-            fmt.Printf("Resp2: %+v\n", resp2)
-            fmt.Printf("Err2: %+v\n", err2)
-            fmt.Printf("------------------------\n")
-            fmt.Printf("------------------------\n")
-            fmt.Printf("---- Update RRSet\n")
-            fmt.Printf("------------------------\n")
-            rr2 := &udnssdk.RRSet{OwnerName: "test", RRType: "A", TTL: 300, RData: []string{"127.0.0.2"}}
-            resp3, err3 := client.RRSets.UpdateRRSet("domain.com",*rr2)
-            fmt.Printf("Resp3: %+v\n", resp3)
-            fmt.Printf("Err3: %+v\n", err3)
-            fmt.Printf("------------------------\n")
-
-            fmt.Printf("------------------------\n")
-            fmt.Printf("---- Delete RRSet\n")
-            fmt.Printf("------------------------\n")
-            resp4,err4 := client.RRSets.DeleteRRSet("domain.com",*rr2)
-            fmt.Printf("Resp4: %+v\n", resp4)
-            fmt.Printf("Err4: %+v\n", err4)
-            fmt.Printf("------------------------\n")
-
-          }
-        }
-
-
-#thanks
-* [weppo's dnsimple go sdk @ github](https://github.com/weppos/go-dnsimple)
-* [pearkes dnsimple sdk (this one is used by terraform) @ github](https://github.com/pearkes/dnsimple)
-* [terraform](http://terraform.io)
-* [UltraDNS's various SDK's](https://github.com/ultradns)
+* Originally started as a modified version of [weppos/go-dnsimple](https://github.com/weppos/go-dnsimple)
+* Designed to add UltraDNS support to [terraform](http://terraform.io)
+* And for other languages, be sure to check out [UltraDNS's various SDKs](https://github.com/ultradns)

--- a/website/source/docs/providers/ultradns/r/tcpool.html.markdown
+++ b/website/source/docs/providers/ultradns/r/tcpool.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "ultradns"
+page_title: "UltraDNS: ultradns_tcpool"
+sidebar_current: "docs-ultradns-resource-tcpool"
+description: |-
+  Provides a UltraDNS Traffic Controller pool resource.
+---
+
+# ultradns\_record
+
+Provides a UltraDNS record resource.
+
+## Example Usage
+r.ultradns_domain}
+```
+# Create a Traffic Controller pool
+resource "ultradns_tcpool" "pool" {
+  zone        = "${var.ultradns_domain}"
+  name        = "terraform-tcpool"
+  ttl         = 300
+  description = "Minimal TC Pool"
+
+  rdata {
+    host = "192.168.0.10"
+  }
+}
+```
+
+## Argument Reference
+
+See [related part of UltraDNS Docs](https://restapi.ultradns.com/v1/docs#post-rrset) for details about valid values.
+
+The following arguments are supported:
+
+* `zone` - (Required) The domain to add the record to
+* `name` - (Required) The name of the record
+* `rdata` - (Required) a list of rdata blocks, one for each member in the pool. Record Data documented below.
+* `description` - (Required) Description of the Traffic Controller pool. Valid values are strings less than 256 characters.
+* `ttl` - (Optional) The TTL of the record. Default: `3600`.
+* `run_probes` - (Optional) Boolean to run probes for this pool. Default: `true`.
+* `act_on_probes` - (Optional) Boolean to enable and disable pool records when probes are run. Default: `true`.
+* `max_to_lb` - (Optional) Determines the number of records to balance between. Valid values are integers  `0` - `len(rdata)`. Default: `0`.
+* `backup_record_rdata` - (Optional) IPv4 address or CNAME for the backup record. Default: `nil`.
+* `backup_record_failover_delay` - (Optional) Time in minutes that Traffic Controller waits after detecting that the pool record has failed before activating primary records. Valid values are integers `0` - `30`. Default: `0`.
+
+Record Data blocks support the following:
+
+* `host` - (Required) IPv4 address or CNAME for the pool member.
+* `failover_delay` - (Optional) Time in minutes that Traffic Controller waits after detecting that the pool record has failed before activating secondary records. `0` will activate the secondary records immediately. Integer. Range: `0` - `30`. Default: `0`.
+* `priority` - (Optional) Indicates the serving preference for this pool record. Valid values are integers `1` or greater. Default: `1`.
+* `run_probes` - (Optional) Whether probes are run for this pool record. Boolean. Default: `true`.
+* `state` - (Optional) Current state of the pool record. String. Must be one of `"NORMAL"`, `"ACTIVE"`, or `"INACTIVE"`. Default: `"NORMAL"`.
+* `threshold` - (Optional) How many probes must agree before the record state is changed. Valid values are integers `1` - `len(probes)`. Default: `1`.
+* `weight` - (Optional) Traffic load to send to each server in the Traffic Controller pool. Valid values are integers `2` - `100`. Default: `2`
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The record ID
+* `hostname` - The FQDN of the record


### PR DESCRIPTION
This patchset is best reviewed a patch at a time, especially because it includes a large update to `github.com/Ensighten/udnssdk`. Inside, you'll find
- a few straightforward cleanup patches,
- the vendor update,
- a squashed implementation+test patch and
- a doc patch. 
