### PR TITLE
state/remote tests: bump timeout to work around failing test [maint-0.6]

### DIFF
--- a/state/remote/atlas_test.go
+++ b/state/remote/atlas_test.go
@@ -159,8 +159,8 @@ func TestAtlasClient_UnresolvableConflict(t *testing.T) {
 	select {
 	case <-doneCh:
 		// OK
-	case <-time.After(50 * time.Millisecond):
-		t.Fatalf("Timed out after 50ms, probably because retrying infinitely.")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("Timed out after 500ms, probably because retrying infinitely.")
 	}
 }
 


### PR DESCRIPTION
It seems that the 50ms timeout has become too tight for this assertion.

Ideally we'd rework the test to not be time based, but that is a battle
for another day! :)