### PR TITLE
Make the OpsWorks app_source SSH key write only

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_application.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application.go
@@ -466,9 +466,6 @@ func resourceAwsOpsworksSetApplicationSource(d *schema.ResourceData, v *opsworks
 		if v.Revision != nil {
 			m["revision"] = *v.Revision
 		}
-		if v.SshKey != nil {
-			m["ssh_key"] = *v.SshKey
-		}
 		nv = append(nv, m)
 	}
 


### PR DESCRIPTION
Similarly to https://github.com/hashicorp/terraform/pull/4241 prevent ssh_key in OpsWorks application app_source key from re-applying every time.