### PR TITLE
provider/aws: fix Elastic Beanstalk `cname_prefix`

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -371,7 +371,7 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 	}
 
 	if tier == "WebServer" {
-		beanstalkCnamePrefixRegexp := regexp.MustCompile(`(^[^.]+).\w{2}-\w{4}-\d.elasticbeanstalk.com$`)
+		beanstalkCnamePrefixRegexp := regexp.MustCompile(`(^[^.]+).\w{2}-\w{4,9}-\d.elasticbeanstalk.com$`)
 		var cnamePrefix string
 		cnamePrefixMatch := beanstalkCnamePrefixRegexp.FindStringSubmatch(*env.CNAME)
 


### PR DESCRIPTION
Fixes an issue where the `cname_prefix` attribute isn't correctly read
in some regions.

Previously environments in some regions would have recurring plans if the `cname_prefix` attribute was used. Running `terraform plan` after a `terraform apply` has this diff

```
-/+ aws_elastic_beanstalk_environment.default
    all_settings.#:          "94" => "<computed>"
    application:             "tf-test-cname-output" => "tf-test-cname-output"
    autoscaling_groups.#:    "1" => "<computed>"
    cname:                   "tf-test-cname-output-env.fvixezmt3v.ap-southeast-2.elasticbeanstalk.com" => "<computed>"
    cname_prefix:            "" => "region-prefix" (forces new resource)
    instances.#:             "1" => "<computed>"
    launch_configurations.#: "1" => "<computed>"
    load_balancers.#:        "1" => "<computed>"
    name:                    "tf-test-cname-output-env" => "tf-test-cname-output-env"
    queues.#:                "0" => "<computed>"
    setting.#:               "0" => "<computed>"
    solution_stack_name:     "64bit Amazon Linux running Python" => "64bit Amazon Linux running Python"
    tier:                    "WebServer" => "WebServer"
    triggers.#:              "0" => "<computed>"
    wait_for_ready_timeout:  "10m" => "10m"
```

Tests
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkEnv_basic -timeout 120m
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (395.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	395.018s
```

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkEnv_cname_prefix -timeout 120m
=== RUN   TestAccAWSBeanstalkEnv_cname_prefix
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (344.87s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	344.891s
```