### PR TITLE
provider/vsphere: fix createWithExistingVmdk test

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -459,9 +459,7 @@ func TestAccVSphereVirtualMachine_createWithCdrom(t *testing.T) {
 
 func TestAccVSphereVirtualMachine_createWithExistingVmdk(t *testing.T) {
 	vmdk_path := os.Getenv("VSPHERE_VMDK_PATH")
-	gateway := os.Getenv("VSPHERE_IPV4_GATEWAY")
 	label := os.Getenv("VSPHERE_NETWORK_LABEL")
-	ip_address := os.Getenv("VSPHERE_IPV4_ADDRESS")
 
 	var vm virtualMachine
 	var locationOpt string
@@ -489,10 +487,7 @@ func TestAccVSphereVirtualMachine_createWithExistingVmdk(t *testing.T) {
 				Config: fmt.Sprintf(
 					testAccCheckVSphereVirtualMachineConfig_withExistingVmdk,
 					locationOpt,
-					gateway,
 					label,
-					ip_address,
-					gateway,
 					datastoreOpt,
 					vmdk_path,
 				),
@@ -1078,12 +1073,8 @@ resource "vsphere_virtual_machine" "with_existing_vmdk" {
 %s
     vcpu = 2
     memory = 4096
-    gateway = "%s"
     network_interface {
         label = "%s"
-        ipv4_address = "%s"
-        ipv4_prefix_length = 24
-        ipv4_gateway = "%s"
     }
     disk {
 %s


### PR DESCRIPTION
The createWithExistingVmdk test failed with an error for the network configuration since the the `createVirtualMachine` function doesn't set customization parameters (yet) and (IMO) this test doesn't have to check it.
```
TF_ACC=1 go test ./builtin/providers/vsphere -v -run=TestAccVSphereVirtualMachine_createWithExistingVmdk -timeout 120m
=== RUN   TestAccVSphereVirtualMachine_createWithExistingVmdk
--- FAIL: TestAccVSphereVirtualMachine_createWithExistingVmdk (65.40s)
        testing.go:234: Step 0 error: After applying this step, the plan was not empty:

                DIFF:

                UPDATE: vsphere_virtual_machine.with_existing_vmdk
                  network_interface.0.ipv4_address:       "10.30.8.82" => "10.30.8.250"
                  network_interface.0.ipv4_prefix_length: "23" => "24"

                STATE:

                vsphere_virtual_machine.with_existing_vmdk:
                  ID = terraform-test-with-existing-vmdk
                  cluster = dc1.boerse-go.de
                  datacenter = dc1
                  disk.# = 1
                  disk.0.bootable = true
                  disk.0.datastore = DS1
                  disk.0.iops = 0
                  disk.0.size = 0
                  disk.0.template = 
                  disk.0.type = eager_zeroed
                  disk.0.vmdk = terraform-unit-test/centos-terraform.vmdk
                  domain = vsphere.local
                  gateway = 10.30.8.1
                  linked_clone = false
                  memory = 4096
                  memory_reservation = 0
                  name = terraform-test-with-existing-vmdk
                  network_interface.# = 1
                  network_interface.0.adapter_type = 
                  network_interface.0.ip_address = 
                  network_interface.0.ipv4_address = 10.30.8.82
                  network_interface.0.ipv4_gateway = 10.30.8.1
                  network_interface.0.ipv4_prefix_length = 23
                  network_interface.0.ipv6_address = fe80::250:56ff:fe8e:5014
                  network_interface.0.ipv6_gateway = 
                  network_interface.0.ipv6_prefix_length = 64
                  network_interface.0.label = cld_tst1_access
                  network_interface.0.subnet_mask = 
                  resource_pool = dc1.boerse-go.de/Resources/test_server
                  skip_customization = false
                  time_zone = Etc/UTC
                  vcpu = 2
FAIL
exit status 1
FAIL    github.com/hashicorp/terraform/builtin/providers/vsphere        65.412s
```
Acceptance test after fix:
```
=== RUN   TestAccVSphereVirtualMachine_createWithExistingVmdk
--- PASS: TestAccVSphereVirtualMachine_createWithExistingVmdk (69.68s)
```
cc @chrislovecnm 