### PR TITLE
[WIP] provider/aws: Availability Zone helper resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -130,6 +130,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_autoscaling_notification":                 resourceAwsAutoscalingNotification(),
 			"aws_autoscaling_policy":                       resourceAwsAutoscalingPolicy(),
 			"aws_autoscaling_schedule":                     resourceAwsAutoscalingSchedule(),
+			"aws_availability_zones":                       resourceAwsAvailabilityZones(),
 			"aws_cloudformation_stack":                     resourceAwsCloudFormationStack(),
 			"aws_cloudfront_distribution":                  resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":        resourceAwsCloudFrontOriginAccessIdentity(),

--- a/builtin/providers/aws/resource_aws_availability_zones.go
+++ b/builtin/providers/aws/resource_aws_availability_zones.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAZCreate,
+		Read:   resourceAwsAZRead,
+		//Update: resourceAwsAZUpdate,
+		//Delete: resourceAwsAZDelete,
+
+		Schema: map[string]*schema.Schema{
+			"availability_zones": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceAwsAZCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAwsAZRead(d, meta)
+}
+
+func resourceAwsAZRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	req := &ec2.DescribeAvailabilityZonesInput{DryRun: aws.Bool(false)}
+	azresp, err := conn.DescribeAvailabilityZones(req)
+	if err != nil {
+		return fmt.Errorf("Error listing availability zones: %s", err)
+	}
+	azl := make([]string, 0, len(azresp.AvailabilityZones))
+	for _, v := range azresp.AvailabilityZones {
+		azl = append(*v.ZoneName)
+	}
+	azErr := d.Set("availability_zones", azl)
+	if azErr != nil {
+		return fmt.Errorf("[WARN] Error setting availability zones")
+	}
+	return nil
+}


### PR DESCRIPTION
This resource reads the availability zones available to your account and provides a way of passing them to other resources/modules.

Example config:
```
resource "aws_availability_zones" "test" {
  name = "test"
}
output "az1" {
  value = "${element(aws_availability_zones.test.availability_zones, 0)}"
}
```

I'm looking for feedback on whether other people think this would be valuable, and hopefully guidance on how to test this better.

I'm thinking that it could save people time/lines of configuration when it comes to modules and other resources you might want 1 or more of across all your availability zones.