### PR TITLE
provider/openstack: Remove Floating IP Support From Instances

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
 )
 
@@ -12,7 +13,7 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceComputeFloatingIPV2Create,
 		Read:   resourceComputeFloatingIPV2Read,
-		Update: nil,
+		Update: resourceComputeFloatingIPV2Update,
 		Delete: resourceComputeFloatingIPV2Delete,
 
 		Schema: map[string]*schema.Schema{
@@ -37,12 +38,12 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 
 			"fixed_ip": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 
 			"instance_id": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 		},
 	}
@@ -66,6 +67,36 @@ func resourceComputeFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 
 	d.SetId(newFip.ID)
 
+	// With the Floating IP created, if an Instance and Fixed IP were specified,
+	// attach the Floating IP to the instance.
+
+	// But first, ensure both an instance and fixed IP were specified.
+	missingAttachInfo := false
+	fixedIP := d.Get("fixed_ip").(string)
+	instanceID := d.Get("instance_id").(string)
+
+	// Is there an easier way to do this that I'm overlooking?
+	if fixedIP != "" && instanceID == "" {
+		missingAttachInfo = true
+	}
+
+	if instanceID != "" && fixedIP == "" {
+		missingAttachInfo = true
+	}
+
+	if missingAttachInfo {
+		return fmt.Errorf("Both a Fixed IP and Instance ID are required for Floating IP association")
+	}
+
+	if instanceID != "" && fixedIP != "" {
+		log.Printf("[DEBUG] Attempting to associate %s to instance %s on fixed IP %s", newFip.IP, instanceID, fixedIP)
+		if err := associateFloatingIPToInstance(computeClient, newFip.IP, instanceID, fixedIP); err != nil {
+			return fmt.Errorf("Error associating Floating IP %s to Instance %s on Fixed IP %s", newFip.IP, instanceID, fixedIP)
+		}
+	} else {
+		log.Printf("[DEBUG] Neither an instance ID nor a Fixed IP were specified. Not attaching.")
+	}
+
 	return resourceComputeFloatingIPV2Read(d, meta)
 }
 
@@ -84,9 +115,62 @@ func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Retrieved Floating IP %s: %+v", d.Id(), fip)
 
 	d.Set("pool", fip.Pool)
-	d.Set("instance_id", fip.InstanceID)
 	d.Set("address", fip.IP)
-	d.Set("fixed_ip", fip.FixedIP)
+
+	return nil
+}
+
+func resourceComputeFloatingIPV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	fip, err := floatingip.Get(computeClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "floating ip")
+	}
+
+	changeOccurred := false
+	newInstanceID := fip.InstanceID
+	oldInstanceID := fip.InstanceID
+	newFixedIP := fip.FixedIP
+	oldFixedIP := fip.FixedIP
+
+	if d.HasChange("instance_id") {
+		o, n := d.GetChange("instance_id")
+		oldInstanceID = o.(string)
+		newInstanceID = n.(string)
+		changeOccurred = true
+	}
+
+	if d.HasChange("fixed_ip") {
+		o, n := d.GetChange("fixed_ip")
+		oldFixedIP = o.(string)
+		newFixedIP = n.(string)
+		changeOccurred = true
+	}
+
+	if changeOccurred {
+		// Disassociate the IP from the instance
+		if oldInstanceID != "" && oldFixedIP != "" {
+			log.Printf("[DEBUG] Attempting to disassociate %s from instance %s on fixed IP %s", fip.IP, oldInstanceID, oldFixedIP)
+			if err := disassociateFloatingIPFromInstance(computeClient, fip.IP, oldInstanceID, oldFixedIP); err != nil {
+				return fmt.Errorf("Error disassociating Floating IP %s from Instance %s on Fixed IP %s", fip.IP, oldInstanceID, oldFixedIP)
+			}
+		}
+
+		// Associate the IP to the new information
+		if newInstanceID != "" && newFixedIP != "" {
+			log.Printf("[DEBUG] Attempting to associate %s to instance %s on fixed IP %s", fip.IP, oldInstanceID, oldFixedIP)
+
+			if err := associateFloatingIPToInstance(computeClient, fip.IP, newInstanceID, newFixedIP); err != nil {
+				return fmt.Errorf("Error associating Floating IP %s to Instance %s on Fixed IP %s", fip.IP, newInstanceID, newFixedIP)
+			}
+		}
+
+	}
 
 	return nil
 }
@@ -101,6 +185,34 @@ func resourceComputeFloatingIPV2Delete(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Deleting Floating IP %s", d.Id())
 	if err := floatingip.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
 		return fmt.Errorf("Error deleting Floating IP: %s", err)
+	}
+
+	return nil
+}
+
+func associateFloatingIPToInstance(computeClient *gophercloud.ServiceClient, floatingIP string, instanceID string, fixedIP string) error {
+	associateOpts := floatingip.AssociateOpts{
+		ServerID:   instanceID,
+		FloatingIP: floatingIP,
+		FixedIP:    fixedIP,
+	}
+
+	if err := floatingip.AssociateInstance(computeClient, associateOpts).ExtractErr(); err != nil {
+		return fmt.Errorf("Error associating floating IP: %s", err)
+	}
+
+	return nil
+}
+
+func disassociateFloatingIPFromInstance(computeClient *gophercloud.ServiceClient, floatingIP string, instanceID string, fixedIP string) error {
+	associateOpts := floatingip.AssociateOpts{
+		ServerID:   instanceID,
+		FloatingIP: floatingIP,
+		FixedIP:    fixedIP,
+	}
+
+	if err := floatingip.DisassociateInstance(computeClient, associateOpts).ExtractErr(); err != nil {
+		return fmt.Errorf("Error disassociating floating IP: %s", err)
 	}
 
 	return nil

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
-	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/secgroups"
@@ -70,11 +69,6 @@ func resourceComputeInstanceV2() *schema.Resource {
 				ForceNew:    false,
 				Computed:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_NAME", nil),
-			},
-			"floating_ip": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
 			},
 			"user_data": &schema.Schema{
 				Type:     schema.TypeString,
@@ -132,11 +126,6 @@ func resourceComputeInstanceV2() *schema.Resource {
 							Computed: true,
 						},
 						"fixed_ip_v6": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"floating_ip": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
@@ -346,11 +335,6 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	// check if floating IP configuration is correct
-	if err := checkInstanceFloatingIPs(d); err != nil {
-		return err
-	}
-
 	// Build a list of networks with the information given upon creation.
 	// Error out if an invalid network configuration was used.
 	networkDetails, err := getInstanceNetworks(computeClient, d)
@@ -445,16 +429,6 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf(
 			"Error waiting for instance (%s) to become ready: %s",
 			server.ID, err)
-	}
-
-	// Now that the instance has been created, we need to do an early read on the
-	// networks in order to associate floating IPs
-	_, err = getInstanceNetworksAndAddresses(computeClient, d)
-
-	// If floating IPs were specified, associate them after the instance has launched.
-	err = associateFloatingIPsToInstance(computeClient, d)
-	if err != nil {
-		return err
 	}
 
 	// if volumes were specified, attach them after the instance has launched.
@@ -638,62 +612,6 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if d.HasChange("floating_ip") {
-		oldFIP, newFIP := d.GetChange("floating_ip")
-		log.Printf("[DEBUG] Old Floating IP: %v", oldFIP)
-		log.Printf("[DEBUG] New Floating IP: %v", newFIP)
-		if oldFIP.(string) != "" {
-			log.Printf("[DEBUG] Attempting to disassociate %s from %s", oldFIP, d.Id())
-			if err := disassociateFloatingIPFromInstance(computeClient, oldFIP.(string), d.Id(), ""); err != nil {
-				return fmt.Errorf("Error disassociating Floating IP during update: %s", err)
-			}
-		}
-
-		if newFIP.(string) != "" {
-			log.Printf("[DEBUG] Attempting to associate %s to %s", newFIP, d.Id())
-			if err := associateFloatingIPToInstance(computeClient, newFIP.(string), d.Id(), ""); err != nil {
-				return fmt.Errorf("Error associating Floating IP during update: %s", err)
-			}
-		}
-	}
-
-	if d.HasChange("network") {
-		oldNetworks, newNetworks := d.GetChange("network")
-		oldNetworkList := oldNetworks.([]interface{})
-		newNetworkList := newNetworks.([]interface{})
-		for i, oldNet := range oldNetworkList {
-			var oldFIP, newFIP string
-			var oldFixedIP, newFixedIP string
-
-			if oldNetRaw, ok := oldNet.(map[string]interface{}); ok {
-				oldFIP = oldNetRaw["floating_ip"].(string)
-				oldFixedIP = oldNetRaw["fixed_ip_v4"].(string)
-			}
-
-			if len(newNetworkList) > i {
-				if newNetRaw, ok := newNetworkList[i].(map[string]interface{}); ok {
-					newFIP = newNetRaw["floating_ip"].(string)
-					newFixedIP = newNetRaw["fixed_ip_v4"].(string)
-				}
-			}
-
-			// Only changes to the floating IP are supported
-			if oldFIP != "" && oldFIP != newFIP {
-				log.Printf("[DEBUG] Attempting to disassociate %s from %s", oldFIP, d.Id())
-				if err := disassociateFloatingIPFromInstance(computeClient, oldFIP, d.Id(), oldFixedIP); err != nil {
-					return fmt.Errorf("Error disassociating Floating IP during update: %s", err)
-				}
-			}
-
-			if newFIP != "" && oldFIP != newFIP {
-				log.Printf("[DEBUG] Attempting to associate %s to %s", newFIP, d.Id())
-				if err := associateFloatingIPToInstance(computeClient, newFIP, d.Id(), newFixedIP); err != nil {
-					return fmt.Errorf("Error associating Floating IP during update: %s", err)
-				}
-			}
-		}
-	}
-
 	if d.HasChange("volume") {
 		// ensure the volume configuration is correct
 		if err := checkVolumeConfig(d); err != nil {
@@ -854,8 +772,8 @@ func resourceInstanceSecGroupsV2(d *schema.ResourceData) []string {
 	return secgroups
 }
 
-// getInstanceNetworks collects instance network information from different sources
-// and aggregates it all together.
+// getInstanceNetworksAndAddresses collects instance network information
+// from different sources and aggregates it all together.
 func getInstanceNetworksAndAddresses(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) ([]map[string]interface{}, error) {
 	server, err := servers.Get(computeClient, d.Id()).Extract()
 
@@ -884,7 +802,6 @@ func getInstanceNetworksAndAddresses(computeClient *gophercloud.ServiceClient, d
 				"name":        netName,
 				"fixed_ip_v4": n["fixed_ip_v4"],
 				"fixed_ip_v6": n["fixed_ip_v6"],
-				"floating_ip": n["floating_ip"],
 				"mac":         n["mac"],
 			}
 		}
@@ -898,7 +815,6 @@ func getInstanceNetworksAndAddresses(computeClient *gophercloud.ServiceClient, d
 				"port":           networkDetails[i]["port"],
 				"fixed_ip_v4":    n["fixed_ip_v4"],
 				"fixed_ip_v6":    n["fixed_ip_v6"],
-				"floating_ip":    n["floating_ip"],
 				"mac":            n["mac"],
 				"access_network": networkDetails[i]["access_network"],
 			}
@@ -983,14 +899,11 @@ func getInstanceAddresses(addresses map[string]interface{}) map[string]map[strin
 		addrs[n] = make(map[string]interface{})
 		for _, element := range networkAddresses.([]interface{}) {
 			address := element.(map[string]interface{})
-			if address["OS-EXT-IPS:type"] == "floating" {
-				addrs[n]["floating_ip"] = address["addr"]
-			} else {
-				if address["version"].(float64) == 4 {
-					addrs[n]["fixed_ip_v4"] = address["addr"].(string)
-				} else {
-					addrs[n]["fixed_ip_v6"] = fmt.Sprintf("[%s]", address["addr"].(string))
-				}
+			if address["version"].(float64) == 4 && address["OS-EXT-IPS:type"] == "fixed" {
+				addrs[n]["fixed_ip_v4"] = address["addr"].(string)
+			}
+			if address["version"].(float64) == 6 && address["OS-EXT-IPS:type"] == "fixed" {
+				addrs[n]["fixed_ip_v6"] = fmt.Sprintf("[%s]", address["addr"].(string))
 			}
 			if mac, ok := address["OS-EXT-IPS-MAC:mac_addr"]; ok {
 				addrs[n]["mac"] = mac.(string)
@@ -1006,14 +919,8 @@ func getInstanceAddresses(addresses map[string]interface{}) map[string]map[strin
 func getInstanceAccessAddresses(d *schema.ResourceData, networks []map[string]interface{}) (string, string) {
 	var hostv4, hostv6 string
 
-	// Start with a global floating IP
-	floatingIP := d.Get("floating_ip").(string)
-	if floatingIP != "" {
-		hostv4 = floatingIP
-	}
-
 	// Loop through all networks
-	// If the network has a valid floating, fixed v4, or fixed v6 address
+	// If the network has a valid fixed v4, or fixed v6 address
 	// and hostv4 or hostv6 is not set, set hostv4/hostv6.
 	// If the network is an "access_network" overwrite hostv4/hostv6.
 	for _, n := range networks {
@@ -1029,12 +936,6 @@ func getInstanceAccessAddresses(d *schema.ResourceData, networks []map[string]in
 			}
 		}
 
-		if floatingIP, ok := n["floating_ip"].(string); ok && floatingIP != "" {
-			if hostv4 == "" || accessNetwork {
-				hostv4 = floatingIP
-			}
-		}
-
 		if fixedIPv6, ok := n["fixed_ip_v6"].(string); ok && fixedIPv6 != "" {
 			if hostv6 == "" || accessNetwork {
 				hostv6 = fixedIPv6
@@ -1045,81 +946,6 @@ func getInstanceAccessAddresses(d *schema.ResourceData, networks []map[string]in
 	log.Printf("[DEBUG] OpenStack Instance Network Access Addresses: %s, %s", hostv4, hostv6)
 
 	return hostv4, hostv6
-}
-
-func checkInstanceFloatingIPs(d *schema.ResourceData) error {
-	rawNetworks := d.Get("network").([]interface{})
-	floatingIP := d.Get("floating_ip").(string)
-
-	for _, raw := range rawNetworks {
-		if raw == nil {
-			continue
-		}
-
-		rawMap := raw.(map[string]interface{})
-
-		// Error if a floating IP was specified both globally and in the network block.
-		if floatingIP != "" && rawMap["floating_ip"] != "" {
-			return fmt.Errorf("Cannot specify a floating IP both globally and in a network block.")
-		}
-	}
-	return nil
-}
-
-func associateFloatingIPsToInstance(computeClient *gophercloud.ServiceClient, d *schema.ResourceData) error {
-	floatingIP := d.Get("floating_ip").(string)
-	rawNetworks := d.Get("network").([]interface{})
-	instanceID := d.Id()
-
-	if floatingIP != "" {
-		if err := associateFloatingIPToInstance(computeClient, floatingIP, instanceID, ""); err != nil {
-			return err
-		}
-	} else {
-		for _, raw := range rawNetworks {
-			if raw == nil {
-				continue
-			}
-
-			rawMap := raw.(map[string]interface{})
-			if rawMap["floating_ip"].(string) != "" {
-				floatingIP := rawMap["floating_ip"].(string)
-				fixedIP := rawMap["fixed_ip_v4"].(string)
-				if err := associateFloatingIPToInstance(computeClient, floatingIP, instanceID, fixedIP); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func associateFloatingIPToInstance(computeClient *gophercloud.ServiceClient, floatingIP string, instanceID string, fixedIP string) error {
-	associateOpts := floatingip.AssociateOpts{
-		ServerID:   instanceID,
-		FloatingIP: floatingIP,
-		FixedIP:    fixedIP,
-	}
-
-	if err := floatingip.AssociateInstance(computeClient, associateOpts).ExtractErr(); err != nil {
-		return fmt.Errorf("Error associating floating IP: %s", err)
-	}
-
-	return nil
-}
-
-func disassociateFloatingIPFromInstance(computeClient *gophercloud.ServiceClient, floatingIP string, instanceID string, fixedIP string) error {
-	associateOpts := floatingip.AssociateOpts{
-		ServerID:   instanceID,
-		FloatingIP: floatingIP,
-		FixedIP:    fixedIP,
-	}
-
-	if err := floatingip.DisassociateInstance(computeClient, associateOpts).ExtractErr(); err != nil {
-		return fmt.Errorf("Error disassociating floating IP: %s", err)
-	}
-
-	return nil
 }
 
 func resourceInstanceMetadataV2(d *schema.ResourceData) map[string]string {

--- a/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_floatingip_v2.html.markdown
@@ -15,10 +15,30 @@ but only networking floating IPs can be used with load balancers.
 
 ## Example Usage
 
+### Allocating a Floating IP
+
 ```
 resource "openstack_compute_floatingip_v2" "floatip_1" {
-  region = ""
   pool = "public"
+}
+```
+
+### Attaching a Floating IP to an Instance
+
+```
+resource "openstack_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+
+  network {
+    name = "my_network"
+  }
+}
+
+resource "openstack_compute_floatingip_v2" "floatip_1" {
+  pool = "public"
+  instance_id = "${openstack_compute_instance_v2.instance_1.id}"
+  fixed_ip = "${openstack_compute_instance_v2.instance_1.access_ip_v4}"
 }
 ```
 
@@ -35,6 +55,12 @@ The following arguments are supported:
 * `pool` - (Required) The name of the pool from which to obtain the floating
     IP. Changing this creates a new floating IP.
 
+* `instance_id` - (Optional; Required with `fixed_ip`) The ID of the instance
+    to attach the floating IP.
+
+* `fixed_ip` - (Optional; Required with `instance_id`) The Fixed IP of the
+    instance to attach the floating IP.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -42,5 +68,3 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `pool` - See Argument Reference above.
 * `address` - The actual floating IP address itself.
-* `fixed_ip` - The fixed IP address corresponding to the floating IP.
-* `instance_id` - UUID of the compute instance associated with the floating IP.

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -113,10 +113,6 @@ resource "openstack_compute_instance_v2" "boot-from-volume" {
 ### Instance With Multiple Networks
 
 ```
-resource "openstack_compute_floatingip_v2" "myip" {
-  pool = "my_pool"
-}
-
 resource "openstack_compute_instance_v2" "multi-net" {
   name = "multi-net"
   image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
@@ -130,7 +126,6 @@ resource "openstack_compute_instance_v2" "multi-net" {
 
   network {
     name = "my_second_network"
-    floating_ip = "${openstack_compute_floatingip_v2.myip.address}"
     # Terraform will use this network for provisioning
     access_network = true
   }
@@ -218,10 +213,6 @@ The following arguments are supported:
 * `flavor_name` - (Optional; Required if `flavor_id` is empty) The name of the
     desired flavor for the server. Changing this resizes the existing server.
 
-* `floating_ip` - (Optional) A *Compute* Floating IP that will be associated
-    with the Instance. The Floating IP must be provisioned already. See *Notes*
-    for more information about Floating IPs.
-
 * `user_data` - (Optional) The user data to provide when launching the instance.
     Changing this creates a new server.
 
@@ -277,10 +268,6 @@ The `network` block supports:
 
 * `fixed_ip_v4` - (Optional) Specifies a fixed IPv4 address to be used on this
     network.
-
-* `floating_ip` - (Optional) Specifies a floating IP address to be associated
-    with this network. Cannot be combined with a top-level floating IP. See
-    *Notes* for more information about Floating IPs.
 
 * `access_network` - (Optional) Specifies if this network should be used for
     provisioning access. Accepts true or false. Defaults to false.
@@ -354,26 +341,9 @@ The following attributes are exported:
     network.
 * `network/fixed_ip_v6` - The Fixed IPv6 address of the Instance on that
     network.
-* `network/floating_ip` - The Floating IP address of the Instance on that
-    network.
 * `network/mac` - The MAC address of the NIC on that network.
 
 ## Notes
-
-### Floating IPs
-
-Floating IPs can be associated in one of two ways:
-
-* You can specify a Floating IP address by using the top-level `floating_ip`
-attribute. This floating IP will be associated with either the network defined
-in the first `network` block or the default network if no `network` blocks are
-defined.
-
-* You can specify a Floating IP address by using the `floating_ip` attribute
-defined in the `network` block. Each `network` block can have its own floating
-IP address.
-
-Only one of the above methods can be used.
 
 ### Multiple Ephemeral Disks
 

--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -15,10 +15,33 @@ but only compute floating IPs can be used with compute instances.
 
 ## Example Usage
 
+### Allocating a Floating IP
+
 ```
 resource "openstack_networking_floatingip_v2" "floatip_1" {
-  region = ""
   pool = "public"
+}
+```
+
+### Attach a Floating IP to a Port or Instance
+
+```
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  network_id = "<network uuid>"
+  admin_state_up = "true"
+}
+
+resource "openstack_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+
+  network {
+    port = "${openstack_networking_port_v2.port_1.id}"
+  }
+}
+
+resource "openstack_networking_floatingip_v2" "fip_1" {
+  port_id = "${openstack_networking_port_v2.port_1.id}"
 }
 ```
 
@@ -36,13 +59,10 @@ The following arguments are supported:
     IP. Changing this creates a new floating IP.
 
 * `port_id` - ID of an existing port with at least one IP address to associate with
-this floating IP.
+    this floating IP.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `pool` - See Argument Reference above.
 * `address` - The actual floating IP address itself.
-* `port_id` - ID of associated port.


### PR DESCRIPTION
Inspired by @Fodoj's request to remove the top-level `floating_ip` instance attribute, I wanted to explore entirely removing Floating IPs from instances.

Management of Floating IPs from within instances has to account for several different use-cases which becomes very complicated over time. As can be seen from this patch, removing Floating IPs gets rid of quite a bit of code from the instance resource -- including the increasingly complicated Access IP logic.

Moving the association and disassociation of Floating IPs to the Floating IP resources keeps those actions in more of a natural area of Terraform. 

In addition, this solves issus such as #4118 for these two specific resources.

There are downsides, though:

1. This is a breaking change.
2. The instance will never know of the Floating IP. This kind of matches normal Floating IP behavior, since the operating system within the instance never knows about the Floating IP either -- just its local IPs.
3. All connection configuration must now be configured to use the Floating IP resource `openstack_compute_floatingip_v2.myip.address`.

I'm not 100% sure this is a good idea yet. This WIP PR is more of an exploration as well as polling others for input.

At the moment, this PR only accounts for `openstack_compute_floatingip_v2`. I will work on `openstack_networking_floatingip_v2` next.

Edit: `openstack_networking_floatingip_v2` is done.

Input on this PR is greatly appreciated.