### PR TITLE
Don't assume dev platform was built

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -69,10 +69,12 @@ fi
 
 # Copy our OS/Arch to the bin/ directory
 DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
+if [[ -d "${DEV_PLATFORM}" ]]; then
+    for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
+        cp ${F} bin/
+        cp ${F} ${MAIN_GOPATH}/bin/
+    done
+fi
 
 if [ "${TF_DEV}x" = "x" ]; then
     # Zip and copy to the dist dir


### PR DESCRIPTION
build.sh assumes DEV_PLATFORM was built. Produces find error.
```
vagrant@terraform:/opt/gopath/src/github.com/hashicorp/terraform$ XC_OS="darwin" XC_ARCH="amd64" make bin
==> Checking that code complies with gofmt requirements...
/opt/gopath/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
2016/05/15 23:29:28 Generated command/internal_plugin_list.go
==> Removing old directory...
==> Building...
Number of parallel builds: 1

-->    darwin/amd64: github.com/hashicorp/terraform
find: `./pkg/linux_amd64': No such file or directory
==> Packaging...
--> darwin_amd64
  adding: terraform (deflated 81%)

==> Results:
total 0
```