### PR TITLE
Add version_id attribute for aws_s3_bucket_object documentation

### DIFF
--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -73,3 +73,5 @@ The following attributes are exported
 
 * `id` - the `key` of the resource supplied above
 * `etag` - the ETag generated for the object (an MD5 sum of the object content).
+* `version_id` - A unique version ID value for the object, if bucket versioning
+is enabled.


### PR DESCRIPTION
I wanted to use the `s3_object_version` argument in the `aws_lambda_function` resource (https://www.terraform.io/docs/providers/aws/r/lambda_function.html#s3_object_version), but I could not find any documentation on how to retrieve the version ID of an S3 object in terraform.

I looked at the source code and discovered the `version_id` field from there and tested that it works as an attribute for the `aws_s3_bucket_object` resource. I could not see from the code directly is the `version_id` attribute correctly exported already or does it need some changes in the code still. Could you doublecheck that and if it is OK as it is, here is the small docs update to add the `version_id` attribute.