### PR TITLE
provider/aws: Fix crash in ElastiCache param group

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -645,10 +645,12 @@ func flattenRedshiftParameters(list []*redshift.Parameter) []map[string]interfac
 func flattenElastiCacheParameters(list []*elasticache.Parameter) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
-		result = append(result, map[string]interface{}{
-			"name":  strings.ToLower(*i.ParameterName),
-			"value": strings.ToLower(*i.ParameterValue),
-		})
+		if i.ParameterValue != nil {
+			result = append(result, map[string]interface{}{
+				"name":  strings.ToLower(*i.ParameterName),
+				"value": strings.ToLower(*i.ParameterValue),
+			})
+		}
 	}
 	return result
 }


### PR DESCRIPTION
Fixes crash reported in https://github.com/hashicorp/terraform/issues/6466 

When you edit/save the defaults on the web UI (even without changing anything), you get a lot of parameters with default values added. One such parameter (`notify-keyspace-events`) is returned that has no value 😱 

```
{
  DataType: "string",
  Description: "The keyspace events for Redis to notify Pub/Sub clients about. By default all notifications are disabled",
  IsModifiable: true,
  MinimumEngineVersion: "2.8.6",
  ParameterName: "notify-keyspace-events",
  Source: "user"
},
```

This PR only sets parameters locally if there is a value found