### PR TITLE
website: docs for azurerm custom images

### DIFF
--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -142,7 +142,7 @@ For more information on the different example configurations, please check out t
 * `vhd_uri` - (Required) Specifies the vhd uri.
 * `create_option` - (Required) Specifies how the virtual machine should be created. Possible values are `attach` and `FromImage`.
 * `caching` - (Optional) Specifies the caching requirements.
-* `image_uri` - (Optional) Specifies the image_uri in the form publisherName:offer:skus:version.
+* `image_uri` - (Optional) Specifies the image_uri in the form publisherName:offer:skus:version. `image_uri` can also specify the [VHD uri](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-deploy-templates/#create-a-custom-vm-image) of a custom VM image to clone. When cloning a custom disk image the `os_type` documented below becomes required.
 * `os_type` - (Optional) Specifies the operating system Type, valid values are windows, linux.
 
 `storage_data_disk` supports the following:


### PR DESCRIPTION
Adds docs on booting custom images with the azurerm_virtual_machine
resource; this was previously undocumented.