### PR TITLE
provider/aws: Support for Redshift Cluster encryption using a KMS key

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -154,6 +154,13 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"kms_key_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"elastic_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -244,6 +251,10 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		createOpts.Encrypted = aws.Bool(v.(bool))
 	}
 
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		createOpts.KmsKeyId = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("elastic_ip"); ok {
 		createOpts.ElasticIp = aws.String(v.(string))
 	}
@@ -311,6 +322,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("cluster_subnet_group_name", rsc.ClusterSubnetGroupName)
 	d.Set("availability_zone", rsc.AvailabilityZone)
 	d.Set("encrypted", rsc.Encrypted)
+	d.Set("kms_key_id", rsc.KmsKeyId)
 	d.Set("automated_snapshot_retention_period", rsc.AutomatedSnapshotRetentionPeriod)
 	d.Set("preferred_maintenance_window", rsc.PreferredMaintenanceWindow)
 	if rsc.Endpoint != nil && rsc.Endpoint.Address != nil {

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -6,7 +6,7 @@ sidebar_current: "docs-aws-resource-redshift-cluster"
 
 # aws\_redshift\_cluster
 
-Provides a Redshift Cluster Resource. 
+Provides a Redshift Cluster Resource.
 
 ## Example Usage
 
@@ -52,9 +52,10 @@ string.
 * `number_of_nodes` - (Optional) The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node. Default is 1.
 * `publicly_accessible` - (Optional) If true, the cluster can be accessed from a public network. Default is `true`.
 * `encrypted` - (Optional) If true , the data in the cluster is encrypted at rest.
+* `kms_key_id` - (Optional) The KMS key ID for the cluster.
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
 * `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is true.
-* `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.                                                                                                     
+* `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.
 
 ## Attributes Reference
 
@@ -77,5 +78,5 @@ The following attributes are exported:
 * `cluster_parameter_group_name` - The name of the parameter group to be associated with this cluster
 * `cluster_subnet_group_name` - The name of a cluster subnet group to be associated with this cluster
 * `cluster_public_key` - The public key for the cluster
-* `cluster_revision_number` - The specific revision number of the database in the cluster 
-	
+* `cluster_revision_number` - The specific revision number of the database in the cluster
+


### PR DESCRIPTION
Trivial change to support an Amazon or customer provided KMS key for encryption.

```
make test TEST=./builtin/providers/aws
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
2016/05/17 15:59:43 Generated command/internal_plugin_list.go
TF_ACC= go test ./builtin/providers/aws  -timeout=30s -parallel=4
ok    github.com/hashicorp/terraform/builtin/providers/aws  1.832s
```