### PR TITLE
core: honor "destroy" diffs for data resources

### DIFF
--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -810,6 +810,7 @@ func (n *graphNodeExpandedResource) dataResourceEvalNodes(resource *Resource, in
 				&EvalReadDataDiff{
 					Info:     info,
 					Config:   &config,
+					Previous: &diff,
 					Provider: &provider,
 					Output:   &diff,
 				},


### PR DESCRIPTION
Previously the `planDestroy` pass would correctly produce a destroy diff, but the "apply" pass would just ignore it and make a fresh diff, turning it back into a "create" because data resources are always eager to refresh.

Now we consider the previous diff when re-diffing during apply and so we can preserve the plan to destroy and then ultimately actually "destroy" the data resource (remove from the state) when we get to `ReadDataApply`.

This ensures that the state is left empty after `terraform destroy`; previously we would leave behind data resource states.
