### PR TITLE
Fixes an vet error.

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -391,8 +391,8 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	if vL, ok := d.GetOk("block_device"); ok {
 		blockDevices := resourceInstanceBlockDevicesV2(d, vL.([]interface{}))
 		createOpts = &bootfromvolume.CreateOptsExt{
-			createOpts,
-			blockDevices,
+			CreateOptsBuilder: createOpts,
+			BlockDevice:       blockDevices,
 		}
 	}
 


### PR DESCRIPTION
The head of master currently breaks when running make with the error below.  This PR fixes that:

go tool vet -all .
builtin/providers/openstack/resource_openstack_compute_instance_v2.go:393: github.com/hashicorp/terraform/vendor/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/bootfromvolume.CreateOptsExt composite literal uses unkeyed fields

Vet found suspicious constructs. Please check the reported constructs
and fix them if necessary before submitting the code for review.
make: *** [vet] Error 1