### PR TITLE
provider/aws: SQS use raw policy string if compact fails

### DIFF
--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -77,8 +77,8 @@ func resourceAwsSqsQueue() *schema.Resource {
 					jsonb := []byte(s)
 					buffer := new(bytes.Buffer)
 					if err := json.Compact(buffer, jsonb); err != nil {
-						log.Printf("[WARN] Error compacting JSON for Policy in SNS Queue")
-						return ""
+						log.Printf("[WARN] Error compacting JSON for Policy in SNS Queue, using raw string: %s", err)
+						return s
 					}
 					return buffer.String()
 				},


### PR DESCRIPTION
In a complicated policy setup, the initial `json.Compact` may fail if the `policy` uses the `lookup` interpolation function in Terraform. 

Given this (snippet):

```
variable "aws_region" {
  default = "us-west-2"
}

variable "devs" {
  default = "atlas-terraform-acctests,clint"
}

variable "aws_accts" {
  type = "map"

  default = {
    development = "***"
    management  = "***"
  }
}

resource "aws_sqs_queue" "queue" {
  name  = "${element(split(",", var.devs), count.index)}-queue"
  count = "${length(split(",", var.devs))}"

  policy = <<EOF
{
  "Version": "2012-10-17",
  "Id": "arn:aws:sqs:${var.aws_region}:${lookup(var.aws_accts, "development")}:${element(split(",", var.devs), count.index)}-queue/SQSDefaultPolicy",
  "Statement": [
    {
  [...]
}
EOF
}
```

The `policy` attribute of `aws_sqs_queue` calls `json.Compact` on the value, however due to the `lookup` call with `"` in it, the compaction will fail _on the first run_ if the `aws_sqs_queue` source does not yet exist (it's in the plan as well). Right now, a plan->apply will result in a **diffs don't match** error. A second run will apply successfully because the interpolations will succeed. 

Here, if the initial `json.Compact` fails, we simply use the raw string. 

Fixes https://github.com/hashicorp/terraform/issues/6705