### PR TITLE
provider/aws: fix aws_security_group_rule refresh

### DIFF
--- a/builtin/providers/aws/import_aws_security_group.go
+++ b/builtin/providers/aws/import_aws_security_group.go
@@ -49,6 +49,9 @@ func resourceAwsSecurityGroupImportState(
 			d.SetType("aws_security_group_rule")
 			d.Set("security_group_id", sgId)
 			d.Set("type", ruleType)
+			// XXX If the rule contained more than one source security group, this
+			// will choose one of them. We actually need to create one rule for each
+			// source security group.
 			setFromIPPerm(d, sg, perm)
 			results = append(results, d)
 		}

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -240,7 +240,7 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Found rule for Security Group Rule (%s): %s", d.Id(), rule)
 
 	d.Set("type", ruleType)
-	setFromIPPerm(d, sg, rule)
+	setFromIPPerm(d, sg, p)
 	return nil
 }
 


### PR DESCRIPTION
When two rules differ only in source security group, EC2 APIs return
them as a single rule, but Terraform requires separate
aws_security_group_rule resources.

6bdab07174 changed Read to set source_security_group_id (and
cidr_blocks) from the rule returned from EC2 and chose the first
source_security_group_id arbitrarily, which is wrong.

Makes TestAccAWSSecurityGroupRule_PartialMatching_Source pass again.

Also adds a comment noting that there is a bug in the new resource
importing feature.

Fixes #6728.