### PR TITLE
provider/cloudstack: make replacing the ACL of a network update the network in place

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_network_acl.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_network_acl.go
@@ -117,7 +117,9 @@ func resourceCloudStackNetworkACLDelete(d *schema.ResourceData, meta interface{}
 	p := cs.NetworkACL.NewDeleteNetworkACLListParams(d.Id())
 
 	// Delete the network ACL list
-	_, err := cs.NetworkACL.DeleteNetworkACLList(p)
+	_, err := Retry(3, func() (interface{}, error) {
+		return cs.NetworkACL.DeleteNetworkACLList(p)
+	})
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/website/source/docs/providers/cloudstack/r/network.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/network.html.markdown
@@ -57,10 +57,9 @@ The following arguments are supported:
     for. Changing this forces a new resource to be created.
 
 * `acl_id` - (Optional) The network ACL ID that should be attached to the network.
-    Changing this forces a new resource to be created.
 
 * `aclid` - (Optional, Deprecated) The ID of a network ACL that should be attached
-    to the network. Changing this forces a new resource to be created.
+    to the network.
 
 * `project` - (Optional) The name or ID of the project to deploy this
     instance to. Changing this forces a new resource to be created.


### PR DESCRIPTION
This prevents having to recreate the whole network and fixes #6630