### PR TITLE
provider/azurerm: Add support for exporting the `azurerm_storage_account` access keys

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_account.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account.go
@@ -90,6 +90,16 @@ func resourceArmStorageAccount() *schema.Resource {
 				Computed: true,
 			},
 
+			"primary_access_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"secondary_access_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -208,6 +218,13 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error reading the state of AzureRM Storage Account %q: %s", name, err)
 	}
 
+	keys, err := client.ListKeys(resGroup, name)
+	if err != nil {
+		return err
+	}
+
+	d.Set("primary_access_key", keys.Key1)
+	d.Set("secondary_access_key", keys.Key2)
 	d.Set("location", resp.Location)
 	d.Set("account_type", resp.Properties.AccountType)
 	d.Set("primary_location", resp.Properties.PrimaryLocation)

--- a/website/source/docs/providers/azurerm/r/storage_account.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_account.html.markdown
@@ -70,3 +70,5 @@ The following attributes are exported in addition to the arguments listed above:
 * `primary_table_endpoint` - The endpoint URL for table storage in the primary location.
 * `secondary_table_endpoint` - The endpoint URL for table storage in the secondary location.
 * `primary_file_endpoint` - The endpoint URL for file storage in the primary location.
+* `primary_access_key` - The primary access key for the storage account
+* `secondary_access_key` - The secondary access key for the storage account


### PR DESCRIPTION
Fixes #6739 

Please note that we do NOT have the ability to manage the access keys -
we are just getting the keys that the account creates for us. To manage
the keys, you would need to use the azure portal still