### PR TITLE
provider/cloudstack: list network ACLs with VPC IDs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1336,8 +1336,8 @@
 		},
 		{
 			"ImportPath": "github.com/xanzy/go-cloudstack/cloudstack",
-			"Comment": "2.0.0-2-gcfbfb48",
-			"Rev": "cfbfb481e04c131cb89df1c6141b082f2714bc29"
+			"Comment": "2.0.0-6-g5686bcd",
+			"Rev": "5686bcde5af20565d8c7a3f66b5441430ac54186"
 		},
 		{
 			"ImportPath": "github.com/xanzy/ssh-agent",

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/LoadBalancerService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/LoadBalancerService.go
@@ -2008,12 +2008,12 @@ func (s *LoadBalancerService) ListLoadBalancerRuleInstances(p *ListLoadBalancerR
 
 type ListLoadBalancerRuleInstancesResponse struct {
 	Count                     int                         `json:"count"`
-	LoadBalancerRuleInstances []*LoadBalancerRuleInstance `json:"loadbalancerruleinstance"`
+	LoadBalancerRuleInstances []*LoadBalancerRuleInstance `json:"lbrulevmidip"`
 }
 
 type LoadBalancerRuleInstance struct {
-	Lbvmipaddresses          []string `json:"lbvmipaddresses,omitempty"`
-	Loadbalancerruleinstance string   `json:"loadbalancerruleinstance,omitempty"`
+	Lbvmipaddresses          []string        `json:"lbvmipaddresses,omitempty"`
+	Loadbalancerruleinstance *VirtualMachine `json:"loadbalancerruleinstance,omitempty"`
 }
 
 type UpdateLoadBalancerRuleParams struct {

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/cloudstack.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/cloudstack.go
@@ -411,6 +411,26 @@ func WithProject(project string) OptionFunc {
 	}
 }
 
+// VPCIDSetter is an interface that every type that can set a vpc ID must implement
+type VPCIDSetter interface {
+	SetVpcid(string)
+}
+
+// WithVPCID takes a vpc ID and sets the `vpcid` parameter
+func WithVPCID(id string) OptionFunc {
+	return func(cs *CloudStackClient, p interface{}) error {
+		vs, ok := p.(VPCIDSetter)
+
+		if !ok || id == "" {
+			return nil
+		}
+
+		vs.SetVpcid(id)
+
+		return nil
+	}
+}
+
 type APIDiscoveryService struct {
 	cs *CloudStackClient
 }


### PR DESCRIPTION
Use a new option to list ACLs based on the ID and VPC ID. This fixes #6684