### PR TITLE
: core: Fix destroy w/module vars used in counts

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2706,6 +2706,92 @@ module.child:
 	}
 }
 
+func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
+	m := testModule(t, "apply-destroy-mod-var-and-count-nested")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	var state *State
+	var err error
+	{
+		ctx := testContext2(t, &ContextOpts{
+			Module: m,
+			Providers: map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		})
+
+		// First plan and apply a create operation
+		if _, err := ctx.Plan(); err != nil {
+			t.Fatalf("plan err: %s", err)
+		}
+
+		state, err = ctx.Apply()
+		if err != nil {
+			t.Fatalf("apply err: %s", err)
+		}
+	}
+
+	h := new(HookRecordApplyOrder)
+	h.Active = true
+
+	{
+		ctx := testContext2(t, &ContextOpts{
+			Destroy: true,
+			Module:  m,
+			State:   state,
+			Hooks:   []Hook{h},
+			Providers: map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		})
+
+		// First plan and apply a create operation
+		plan, err := ctx.Plan()
+		if err != nil {
+			t.Fatalf("destroy plan err: %s", err)
+		}
+
+		var buf bytes.Buffer
+		if err := WritePlan(plan, &buf); err != nil {
+			t.Fatalf("plan write err: %s", err)
+		}
+
+		planFromFile, err := ReadPlan(&buf)
+		if err != nil {
+			t.Fatalf("plan read err: %s", err)
+		}
+
+		ctx, err = planFromFile.Context(&ContextOpts{
+			Providers: map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		})
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		state, err = ctx.Apply()
+		if err != nil {
+			t.Fatalf("destroy apply err: %s", err)
+		}
+	}
+
+	//Test that things were destroyed
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(`
+<no state>
+module.child:
+  <no state>
+module.child.child2:
+  <no state>
+		`)
+	if actual != expected {
+		t.Fatalf("expected: \n%s\n\nbad: \n%s", expected, actual)
+	}
+}
+
 func TestContext2Apply_destroyOutputs(t *testing.T) {
 	m := testModule(t, "apply-destroy-outputs")
 	h := new(HookRecordApplyOrder)

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2622,6 +2622,90 @@ module.child:
 	}
 }
 
+func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
+	m := testModule(t, "apply-destroy-mod-var-and-count")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	var state *State
+	var err error
+	{
+		ctx := testContext2(t, &ContextOpts{
+			Module: m,
+			Providers: map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		})
+
+		// First plan and apply a create operation
+		if _, err := ctx.Plan(); err != nil {
+			t.Fatalf("plan err: %s", err)
+		}
+
+		state, err = ctx.Apply()
+		if err != nil {
+			t.Fatalf("apply err: %s", err)
+		}
+	}
+
+	h := new(HookRecordApplyOrder)
+	h.Active = true
+
+	{
+		ctx := testContext2(t, &ContextOpts{
+			Destroy: true,
+			Module:  m,
+			State:   state,
+			Hooks:   []Hook{h},
+			Providers: map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		})
+
+		// First plan and apply a create operation
+		plan, err := ctx.Plan()
+		if err != nil {
+			t.Fatalf("destroy plan err: %s", err)
+		}
+
+		var buf bytes.Buffer
+		if err := WritePlan(plan, &buf); err != nil {
+			t.Fatalf("plan write err: %s", err)
+		}
+
+		planFromFile, err := ReadPlan(&buf)
+		if err != nil {
+			t.Fatalf("plan read err: %s", err)
+		}
+
+		ctx, err = planFromFile.Context(&ContextOpts{
+			Providers: map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		})
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		state, err = ctx.Apply()
+		if err != nil {
+			t.Fatalf("destroy apply err: %s", err)
+		}
+	}
+
+	//Test that things were destroyed
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(`
+<no state>
+module.child:
+  <no state>
+		`)
+	if actual != expected {
+		t.Fatalf("expected: \n%s\n\nbad: \n%s", expected, actual)
+	}
+}
+
 func TestContext2Apply_destroyOutputs(t *testing.T) {
 	m := testModule(t, "apply-destroy-outputs")
 	h := new(HookRecordApplyOrder)

--- a/terraform/test-fixtures/apply-destroy-mod-var-and-count-nested/child/child2/main.tf
+++ b/terraform/test-fixtures/apply-destroy-mod-var-and-count-nested/child/child2/main.tf
@@ -1,0 +1,5 @@
+variable "mod_count_child2" { }
+
+resource "aws_instance" "foo" {
+  count = "${var.mod_count_child2}"
+}

--- a/terraform/test-fixtures/apply-destroy-mod-var-and-count-nested/child/main.tf
+++ b/terraform/test-fixtures/apply-destroy-mod-var-and-count-nested/child/main.tf
@@ -1,0 +1,8 @@
+variable "mod_count_child" { }
+
+module "child2" {
+  source    = "./child2"
+  mod_count_child2 = "${var.mod_count_child}"
+}
+
+resource "aws_instance" "foo" { }

--- a/terraform/test-fixtures/apply-destroy-mod-var-and-count-nested/main.tf
+++ b/terraform/test-fixtures/apply-destroy-mod-var-and-count-nested/main.tf
@@ -1,0 +1,9 @@
+variable "mod_count_root" {
+  type = "string"
+  default = "3"
+}
+
+module "child" {
+  source    = "./child"
+  mod_count_child = "${var.mod_count_root}"
+}

--- a/terraform/test-fixtures/apply-destroy-mod-var-and-count/child/main.tf
+++ b/terraform/test-fixtures/apply-destroy-mod-var-and-count/child/main.tf
@@ -1,0 +1,5 @@
+variable "mod_count" { }
+
+resource "aws_instance" "foo" {
+  count = "${var.mod_count}"
+}

--- a/terraform/test-fixtures/apply-destroy-mod-var-and-count/main.tf
+++ b/terraform/test-fixtures/apply-destroy-mod-var-and-count/main.tf
@@ -1,0 +1,4 @@
+module "child" {
+  source    = "./child"
+  mod_count = "3"
+}


### PR DESCRIPTION
_This is the same PR as #6723 but targeted at the 0.7 release rather than 0.6.17._

This PR combines the work of @phinze in #6704 and @vancluever on the paybyphone fork of Terraform.

First from @phinze:

A new problem was introduced by the prior fixes for destroy interpolation messages when resources depend on module variables with a count attribute, this makes the variable crucial for properly building the graph - even in destroys. So removing all module variables from the graph as noops was overzealous.

By borrowing the logic in DestroyEdgeInclude we are able to determine if we need to keep a given module variable relatively easily.

I'd like to overhaul the Destroy: true implementation so that it does not depend on config at all, but I want to continue for now with the targeted fixes that we can backport into the 0.6 series.

Then from @vancluever in paybyphone@c975906:

Building on b10564a, adding tweaks that allow the module var count search to act recursively, ensuring that a sitaution where something like var.top gets passed to module middle, as var.middle, and then to
module bottom, as var.bottom, which is then used in a resource count.