### PR TITLE
[WIP] provider/openstack: Remove Volume Support from Instances

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
@@ -41,137 +40,6 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccComputeV2Instance_volumeAttach(t *testing.T) {
-	var instance servers.Server
-	var volume volumes.Volume
-
-	var testAccComputeV2Instance_volumeAttach = fmt.Sprintf(`
-		resource "openstack_blockstorage_volume_v1" "myvol" {
-			name = "myvol"
-			size = 1
-		}
-
-		resource "openstack_compute_instance_v2" "foo" {
-			name = "terraform-test"
-			security_groups = ["default"]
-			volume {
-				volume_id = "${openstack_blockstorage_volume_v1.myvol.id}"
-			}
-		}`)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeV2Instance_volumeAttach,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
-					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
-					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume),
-				),
-			},
-		},
-	})
-}
-
-func TestAccComputeV2Instance_volumeAttachPostCreation(t *testing.T) {
-	var instance servers.Server
-	var volume volumes.Volume
-
-	var testAccComputeV2Instance_volumeAttachPostCreationInstance = fmt.Sprintf(`
-		resource "openstack_compute_instance_v2" "foo" {
-			name = "terraform-test"
-			security_groups = ["default"]
-		}`)
-
-	var testAccComputeV2Instance_volumeAttachPostCreationInstanceAndVolume = fmt.Sprintf(`
-		resource "openstack_blockstorage_volume_v1" "myvol" {
-			name = "myvol"
-			size = 1
-		}
-
-		resource "openstack_compute_instance_v2" "foo" {
-			name = "terraform-test"
-			security_groups = ["default"]
-			volume {
-				volume_id = "${openstack_blockstorage_volume_v1.myvol.id}"
-			}
-		}`)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeV2Instance_volumeAttachPostCreationInstance,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
-				),
-			},
-			resource.TestStep{
-				Config: testAccComputeV2Instance_volumeAttachPostCreationInstanceAndVolume,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
-					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
-					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume),
-				),
-			},
-		},
-	})
-}
-
-func TestAccComputeV2Instance_volumeDetachPostCreation(t *testing.T) {
-	var instance servers.Server
-	var volume volumes.Volume
-
-	var testAccComputeV2Instance_volumeDetachPostCreationInstanceAndVolume = fmt.Sprintf(`
-		resource "openstack_blockstorage_volume_v1" "myvol" {
-			name = "myvol"
-			size = 1
-		}
-
-		resource "openstack_compute_instance_v2" "foo" {
-			name = "terraform-test"
-			security_groups = ["default"]
-			volume {
-				volume_id = "${openstack_blockstorage_volume_v1.myvol.id}"
-			}
-		}`)
-
-	var testAccComputeV2Instance_volumeDetachPostCreationInstance = fmt.Sprintf(`
-		resource "openstack_compute_instance_v2" "foo" {
-			name = "terraform-test"
-			security_groups = ["default"]
-		}`)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeV2Instance_volumeDetachPostCreationInstanceAndVolume,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
-					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
-					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume),
-				),
-			},
-			resource.TestStep{
-				Config: testAccComputeV2Instance_volumeDetachPostCreationInstance,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeDoesNotExist(t, "openstack_blockstorage_volume_v1.myvol", &volume),
-					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
-					testAccCheckComputeV2InstanceVolumesDetached(&instance),
 				),
 			},
 		},
@@ -630,63 +498,6 @@ func testAccCheckComputeV2InstanceMetadata(
 		}
 
 		return fmt.Errorf("Metadata not found: %s", k)
-	}
-}
-
-func testAccCheckComputeV2InstanceVolumeAttachment(
-	instance *servers.Server, volume *volumes.Volume) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		var attachments []volumeattach.VolumeAttachment
-
-		config := testAccProvider.Meta().(*Config)
-		computeClient, err := config.computeV2Client(OS_REGION_NAME)
-		if err != nil {
-			return err
-		}
-		err = volumeattach.List(computeClient, instance.ID).EachPage(func(page pagination.Page) (bool, error) {
-			actual, err := volumeattach.ExtractVolumeAttachments(page)
-			if err != nil {
-				return false, fmt.Errorf("Unable to lookup attachment: %s", err)
-			}
-
-			attachments = actual
-			return true, nil
-		})
-
-		for _, attachment := range attachments {
-			if attachment.VolumeID == volume.ID {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("Volume not found: %s", volume.ID)
-	}
-}
-
-func testAccCheckComputeV2InstanceVolumesDetached(instance *servers.Server) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		var attachments []volumeattach.VolumeAttachment
-
-		config := testAccProvider.Meta().(*Config)
-		computeClient, err := config.computeV2Client(OS_REGION_NAME)
-		if err != nil {
-			return err
-		}
-		err = volumeattach.List(computeClient, instance.ID).EachPage(func(page pagination.Page) (bool, error) {
-			actual, err := volumeattach.ExtractVolumeAttachments(page)
-			if err != nil {
-				return false, fmt.Errorf("Unable to lookup attachment: %s", err)
-			}
-
-			attachments = actual
-			return true, nil
-		})
-
-		if len(attachments) > 0 {
-			return fmt.Errorf("Volumes are still attached.")
-		}
-
-		return nil
 	}
 }
 

--- a/website/source/docs/providers/openstack/r/blockstorage_volume_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/blockstorage_volume_v1.html.markdown
@@ -56,6 +56,16 @@ The following arguments are supported:
 * `volume_type` - (Optional) The type of volume to create.
     Changing this creates a new volume.
 
+* `attachment` - (Optional) Attach the volume to an instance. See the description
+    below.
+
+The `attachment` block supports:
+
+* `instance_id` - (Optional - Required if attaching to an Instance) The ID of
+    the instance to attach the volume to.
+
+* `device` - (Optional) The device to attach the volume as (ex: `/dev/vdc`).
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -35,11 +35,6 @@ resource "openstack_compute_instance_v2" "basic" {
 ### Instance With Attached Volume
 
 ```
-resource "openstack_blockstorage_volume_v1" "myvol" {
-  name = "myvol"
-  size = 1
-}
-
 resource "openstack_compute_instance_v2" "volume-attached" {
   name = "volume-attached"
   image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
@@ -50,9 +45,14 @@ resource "openstack_compute_instance_v2" "volume-attached" {
   network {
     name = "my_network"
   }
+}
 
-  volume {
-    volume_id = "${openstack_blockstorage_volume_v1.myvol.id}"
+resource "openstack_blockstorage_volume_v1" "myvol" {
+  name = "myvol"
+  size = 1
+
+  attachment {
+    instance_id = "${openstack_compute_instance_v2.volume-attached.id}"
   }
 }
 ```
@@ -254,9 +254,6 @@ The following arguments are supported:
     You can specify multiple block devices which will create an instance with
     multiple ephemeral (local) disks.
 
-* `volume` - (Optional) Attach an existing volume to the instance. The volume
-    structure is described below.
-
 * `scheduler_hints` - (Optional) Provide the Nova scheduler with hints on how
     the instance should be launched. The available hints are described below.
 
@@ -300,14 +297,6 @@ The `block_device` block supports:
 
 * `destination_type` - (Optional) The type that gets created. Possible values
     are "volume" and "local".
-
-The `volume` block supports:
-
-* `volume_id` - (Required) The UUID of the volume to attach.
-
-* `device` - (Optional) The device that the volume will be attached as. For
-    example:  `/dev/vdc`. Omit this option to allow the volume to be
-    auto-assigned a device.
 
 The `scheduler_hints` block supports:
 


### PR DESCRIPTION
This commit removes volume management from the openstack_compute_instance_v2
resource and moves all functionality into the openstack_blockstorage_volume_v1
resource. Attaching and detaching volumes is now handled in the volume
resource.

Booting from a volume is still handled in the instance resource.