### PR TITLE
fix aws instance read subnet eth0

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -488,7 +488,11 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("iam_instance_profile", iamInstanceProfileArnToName(instance.IamInstanceProfile))
 
 	if len(instance.NetworkInterfaces) > 0 {
-		d.Set("subnet_id", instance.NetworkInterfaces[0].SubnetId)
+		for _, ni := range instance.NetworkInterfaces {
+			if *ni.Attachment.DeviceIndex == 0 {
+				d.Set("subnet_id", ni.SubnetId)
+			}
+		}
 	} else {
 		d.Set("subnet_id", instance.SubnetId)
 	}


### PR DESCRIPTION
Reading the aws instance it was assumed that eth0 was the first in the list of network interfaces. This is true when there is only one interface, but if you attach multiple network interfaces with different subnets then you don't know which subnet of which ni is read.

With this fix I assume that the subnet you want is the one of the ni with device index 0. The ni upon creating the instance gets device index 0.