### PR TITLE
provider/datadog Add test for no_data_timeframe.

### DIFF
--- a/builtin/providers/datadog/resource_datadog_monitor_test.go
+++ b/builtin/providers/datadog/resource_datadog_monitor_test.go
@@ -30,7 +30,7 @@ func TestAccDatadogMonitor_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "query", "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "notify_no_data", "true"),
+						"datadog_monitor.foo", "notify_no_data", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "renotify_interval", "60"),
 					resource.TestCheckResourceAttr(
@@ -70,7 +70,7 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "type", "metric alert"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "notify_no_data", "true"),
+						"datadog_monitor.foo", "notify_no_data", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "renotify_interval", "60"),
 					resource.TestCheckResourceAttr(
@@ -106,7 +106,9 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "type", "metric alert"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "notify_no_data", "false"),
+						"datadog_monitor.foo", "notify_no_data", "true"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "no_data_timeframe", "20"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "renotify_interval", "40"),
 					resource.TestCheckResourceAttr(
@@ -201,7 +203,7 @@ resource "datadog_monitor" "foo" {
 	critical = 2
   }
 
-  notify_no_data = true
+  notify_no_data = false
   renotify_interval = 60
 
   notify_audit = false
@@ -227,7 +229,8 @@ resource "datadog_monitor" "foo" {
 	critical = 3
   }
 
-  notify_no_data = false
+  notify_no_data = true
+  no_data_timeframe = 20
   renotify_interval = 40
   escalation_message = "the situation has escalated! @pagerduty"
   notify_audit = true


### PR DESCRIPTION
A bug related to `notify_no_data ` (https://github.com/hashicorp/terraform/issues/5645) was fixed by #6509, this just adds a test.