### PR TITLE
Fixes terraform crash when using SSH keys with Azure VMs

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -923,9 +923,13 @@ func expandAzureRmVirtualMachineOsProfileLinuxConfig(d *schema.ResourceData) (*c
 	}
 
 	linuxKeys := linuxConfig["ssh_keys"].([]interface{})
-	sshPublicKeys := make([]compute.SSHPublicKey, 0, len(linuxKeys))
+	sshPublicKeys := []compute.SSHPublicKey{}
 	for _, key := range linuxKeys {
-		sshKey := key.(map[string]interface{})
+
+		sshKey, ok := key.(map[string]interface{})
+		if !ok {
+			continue
+		}
 		path := sshKey["path"].(string)
 		keyData := sshKey["key_data"].(string)
 


### PR DESCRIPTION
Existing code was inserting `nil` elements into the slice (by appending to a pre-allocated slice).
- Fixes the behavior to no longer insert `nil` elements
- Adds a guard to allow a transition from states generated by the previous code