### PR TITLE
Normalizes availability_set_id to lowercase to avoid spurious diffs

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
@@ -69,6 +70,9 @@ func resourceArmVirtualMachine() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				StateFunc: func(id interface{}) string {
+					return strings.ToLower(id.(string))
+				},
 			},
 
 			"license_type": &schema.Schema{
@@ -480,7 +484,7 @@ func resourceArmVirtualMachineRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if resp.Properties.AvailabilitySet != nil {
-		d.Set("availability_set_id", resp.Properties.AvailabilitySet.ID)
+		d.Set("availability_set_id", strings.ToLower(*resp.Properties.AvailabilitySet.ID))
 	}
 
 	d.Set("vm_size", resp.Properties.HardwareProfile.VMSize)


### PR DESCRIPTION
Azure RM seems to return uppercased availability set ids from the API, which causes spurious diffs if the case used in the definition is anything else than uppercase. This normalizes the id to lowercase.