### PR TITLE
Retry AWS commands that may fail and increase insufficient timeouts

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -201,7 +201,7 @@ func resourceAwsInternetGatewayAttach(d *schema.ResourceData, meta interface{}) 
 		Pending: []string{"detached", "attaching"},
 		Target:  []string{"available"},
 		Refresh: IGAttachStateRefreshFunc(conn, d.Id(), "available"),
-		Timeout: 2 * time.Minute,
+		Timeout: 4 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -2,9 +2,13 @@ package aws
 
 import (
 	"log"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -28,25 +32,47 @@ func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 
 		// Set tags
 		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %#v from %s", remove, d.Id())
-			_, err := conn.DeleteTags(&ec2.DeleteTagsInput{
-				Resources: []*string{aws.String(d.Id())},
-				Tags:      remove,
+			err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+				log.Printf("[DEBUG] Removing tags: %#v from %s", remove, d.Id())
+				_, err := conn.DeleteTags(&ec2.DeleteTagsInput{
+					Resources: []*string{aws.String(d.Id())},
+					Tags:      remove,
+				})
+				if err != nil {
+					ec2err, ok := err.(awserr.Error)
+					if ok && strings.Contains(ec2err.Code(), ".NotFound") {
+						return resource.RetryableError(err) // retry
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
 			})
 			if err != nil {
 				return err
 			}
 		}
+
 		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %s for %s", create, d.Id())
-			_, err := conn.CreateTags(&ec2.CreateTagsInput{
-				Resources: []*string{aws.String(d.Id())},
-				Tags:      create,
+			err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+				log.Printf("[DEBUG] Creating tags: %s for %s", create, d.Id())
+				_, err := conn.CreateTags(&ec2.CreateTagsInput{
+					Resources: []*string{aws.String(d.Id())},
+					Tags:      create,
+				})
+				if err != nil {
+					ec2err, ok := err.(awserr.Error)
+					if ok && strings.Contains(ec2err.Code(), ".NotFound") {
+						return resource.RetryableError(err) // retry
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
 			})
 			if err != nil {
 				return err
 			}
 		}
+
 	}
 
 	return nil


### PR DESCRIPTION
AWS is lately experiencing increasing flakiness, or "eventual consistency",
that forces to retry a lot of operations.
Describing the resources until they show as available is not even enough
as a following call to eg. setTags will fail because the resource doesn't
exist.

I have added more debug logging but could be removed