### PR TITLE
provider/fastly: Add support for Cache Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ BUG FIXES:
  * provider/vsphere: `gateway` and `ipv6_gateway` are now read from `vsphere_virtual_machine` resources [GH-6522]
  * provider/vsphere: `ipv*_gateway` parameters won't force a new `vsphere_virtual_machine` [GH-6635]
  * provider/azurerm: Normalizes `availability_set_id` casing to avoid spurious diffs in `azurerm_virtual_machine` [GH-6768]
+ * provider/azurerm: Fixes terraform crash when using SSH keys with `azurerm_virtual_machine` [GH-6766]
 
 ## 0.6.16 (May 9, 2016)
 

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -21,6 +21,9 @@ func resourceServiceV1() *schema.Resource {
 		Read:   resourceServiceV1Read,
 		Update: resourceServiceV1Update,
 		Delete: resourceServiceV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -193,42 +193,42 @@ func resourceServiceV1() *schema.Resource {
 				Optional: true,
 			},
 
-                        "cache_setting": &schema.Schema{
-                                Type:     schema.TypeSet,
-                                Optional: true,
-                                Elem: &schema.Resource{
-                                        Schema: map[string]*schema.Schema{
-                                                // required fields
-                                                "name": &schema.Schema{
-                                                        Type:        schema.TypeString,
-                                                        Required:    true,
-                                                        Description: "A name to refer to this Cache Setting",
-                                                },
-                                                "cache_condition": &schema.Schema{
-                                                        Type:        schema.TypeString,
-                                                        Required:    true,
-                                                        Description: "Condition to check if this Cache Setting applies",
-                                                },
-                                                "action": &schema.Schema{
-                                                        Type:        schema.TypeString,
-                                                        Optional:    true,
-                                                        Description: "Action to take",
-                                                },
-                                                // optional
-                                                "stale_ttl": &schema.Schema{
-                                                        Type:        schema.TypeInt,
-                                                        Optional:    true,
-                                                        Description: "Max 'Time To Live' for stale (unreachable) objects.",
-                                                        Default:     300,
-                                                },
-                                                "ttl": &schema.Schema{
-                                                        Type:        schema.TypeInt,
-                                                        Optional:    true,
-                                                        Description: "The 'Time To Live' for the object",
-                                                },
-                                        },
-                                },
-                        },
+			"cache_setting": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// required fields
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "A name to refer to this Cache Setting",
+						},
+						"cache_condition": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Condition to check if this Cache Setting applies",
+						},
+						"action": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Action to take",
+						},
+						// optional
+						"stale_ttl": &schema.Schema{
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Max 'Time To Live' for stale (unreachable) objects.",
+							Default:     300,
+						},
+						"ttl": &schema.Schema{
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The 'Time To Live' for the object",
+						},
+					},
+				},
+			},
 
 			"gzip": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -597,7 +597,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"s3logging",
 		"condition",
 		"request_setting",
-                "cache_setting",
+		"cache_setting",
 		"vcl",
 	} {
 		if d.HasChange(v) {
@@ -1337,21 +1337,21 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[WARN] Error setting VCLs for (%s): %s", d.Id(), err)
 		}
 
-                // refresh Cache Settings
-                log.Printf("[DEBUG] Refreshing Cache Settings for (%s)", d.Id())
-                cslList, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
-                        Service: d.Id(),
-                        Version: s.ActiveVersion.Number,
-                })
-                if err != nil {
-                        return fmt.Errorf("[ERR] Error looking up Cache Settings for (%s), version (%s): %s", d.Id(), s.ActiveVersion.Number, err)
-                }
+		// refresh Cache Settings
+		log.Printf("[DEBUG] Refreshing Cache Settings for (%s)", d.Id())
+		cslList, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
+			Service: d.Id(),
+			Version: s.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Cache Settings for (%s), version (%s): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
 
-                csl := flattenCacheSettings(cslList)
+		csl := flattenCacheSettings(cslList)
 
-                if err := d.Set("cache_setting", csl); err != nil {
-                        log.Printf("[WARN] Error setting Cache Settings for (%s): %s", d.Id(), err)
-                }
+		if err := d.Set("cache_setting", csl); err != nil {
+			log.Printf("[WARN] Error setting Cache Settings for (%s): %s", d.Id(), err)
+		}
 
 	} else {
 		log.Printf("[DEBUG] Active Version for Service (%s) is empty, no state to refresh", d.Id())
@@ -1719,28 +1719,28 @@ func buildRequestSetting(requestSettingMap interface{}) (*gofastly.CreateRequest
 }
 
 func flattenCacheSettings(csList []*gofastly.CacheSetting) []map[string]interface{} {
-        var csl []map[string]interface{}
-        for _, cl := range csList {
-                // Convert Cache Settings to a map for saving to state.
-                clMap := map[string]interface{}{
-                        "name":            cl.Name,
-                        "action":          cl.Action,
-                        "cache_condition": cl.CacheCondition,
-                        "stale_ttl":       cl.StaleTTL,
-                        "ttl":             cl.TTL,
-                }
+	var csl []map[string]interface{}
+	for _, cl := range csList {
+		// Convert Cache Settings to a map for saving to state.
+		clMap := map[string]interface{}{
+			"name":            cl.Name,
+			"action":          cl.Action,
+			"cache_condition": cl.CacheCondition,
+			"stale_ttl":       cl.StaleTTL,
+			"ttl":             cl.TTL,
+		}
 
-                // prune any empty values that come from the default string value in structs
-                for k, v := range clMap {
-                        if v == "" {
-                                delete(clMap, k)
-                        }
-                }
+		// prune any empty values that come from the default string value in structs
+		for k, v := range clMap {
+			if v == "" {
+				delete(clMap, k)
+			}
+		}
 
-                csl = append(csl, clMap)
-        }
+		csl = append(csl, clMap)
+	}
 
-        return csl
+	return csl
 }
 
 func flattenVCLs(vclList []*gofastly.VCL) []map[string]interface{} {

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -193,6 +193,43 @@ func resourceServiceV1() *schema.Resource {
 				Optional: true,
 			},
 
+                        "cache_setting": &schema.Schema{
+                                Type:     schema.TypeSet,
+                                Optional: true,
+                                Elem: &schema.Resource{
+                                        Schema: map[string]*schema.Schema{
+                                                // required fields
+                                                "name": &schema.Schema{
+                                                        Type:        schema.TypeString,
+                                                        Required:    true,
+                                                        Description: "A name to refer to this Cache Setting",
+                                                },
+                                                "cache_condition": &schema.Schema{
+                                                        Type:        schema.TypeString,
+                                                        Required:    true,
+                                                        Description: "Condition to check if this Cache Setting applies",
+                                                },
+                                                "action": &schema.Schema{
+                                                        Type:        schema.TypeString,
+                                                        Optional:    true,
+                                                        Description: "Action to take",
+                                                },
+                                                // optional
+                                                "stale_ttl": &schema.Schema{
+                                                        Type:        schema.TypeInt,
+                                                        Optional:    true,
+                                                        Description: "Max 'Time To Live' for stale (unreachable) objects.",
+                                                        Default:     300,
+                                                },
+                                                "ttl": &schema.Schema{
+                                                        Type:        schema.TypeInt,
+                                                        Optional:    true,
+                                                        Description: "The 'Time To Live' for the object",
+                                                },
+                                        },
+                                },
+                        },
+
 			"gzip": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -560,6 +597,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"s3logging",
 		"condition",
 		"request_setting",
+                "cache_setting",
 		"vcl",
 	} {
 		if d.HasChange(v) {
@@ -1282,6 +1320,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("request_setting", rl); err != nil {
 			log.Printf("[WARN] Error setting Request Settings for (%s): %s", d.Id(), err)
 		}
+
 		// refresh VCLs
 		log.Printf("[DEBUG] Refreshing VCLs for (%s)", d.Id())
 		vclList, err := conn.ListVCLs(&gofastly.ListVCLsInput{
@@ -1297,6 +1336,22 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("vcl", vl); err != nil {
 			log.Printf("[WARN] Error setting VCLs for (%s): %s", d.Id(), err)
 		}
+
+                // refresh Cache Settings
+                log.Printf("[DEBUG] Refreshing Cache Settings for (%s)", d.Id())
+                cslList, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
+                        Service: d.Id(),
+                        Version: s.ActiveVersion.Number,
+                })
+                if err != nil {
+                        return fmt.Errorf("[ERR] Error looking up Cache Settings for (%s), version (%s): %s", d.Id(), s.ActiveVersion.Number, err)
+                }
+
+                csl := flattenCacheSettings(cslList)
+
+                if err := d.Set("cache_setting", csl); err != nil {
+                        log.Printf("[WARN] Error setting Cache Settings for (%s): %s", d.Id(), err)
+                }
 
 	} else {
 		log.Printf("[DEBUG] Active Version for Service (%s) is empty, no state to refresh", d.Id())
@@ -1662,6 +1717,32 @@ func buildRequestSetting(requestSettingMap interface{}) (*gofastly.CreateRequest
 
 	return &opts, nil
 }
+
+func flattenCacheSettings(csList []*gofastly.CacheSetting) []map[string]interface{} {
+        var csl []map[string]interface{}
+        for _, cl := range csList {
+                // Convert Cache Settings to a map for saving to state.
+                clMap := map[string]interface{}{
+                        "name":            cl.Name,
+                        "action":          cl.Action,
+                        "cache_condition": cl.CacheCondition,
+                        "stale_ttl":       cl.StaleTTL,
+                        "ttl":             cl.TTL,
+                }
+
+                // prune any empty values that come from the default string value in structs
+                for k, v := range clMap {
+                        if v == "" {
+                                delete(clMap, k)
+                        }
+                }
+
+                csl = append(csl, clMap)
+        }
+
+        return csl
+}
+
 func flattenVCLs(vclList []*gofastly.VCL) []map[string]interface{} {
 	var vl []map[string]interface{}
 	for _, vcl := range vclList {

--- a/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -1,0 +1,128 @@
+package fastly
+
+import (
+        "fmt"
+        "reflect"
+        "testing"
+
+        "github.com/hashicorp/terraform/helper/acctest"
+        "github.com/hashicorp/terraform/helper/resource"
+        "github.com/hashicorp/terraform/terraform"
+        gofastly "github.com/sethvargo/go-fastly"
+)
+
+func TestAccFastlyServiceV1CacheSetting_basic(t *testing.T) {
+        var service gofastly.ServiceDetail
+        name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+        domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+
+        cq1 := gofastly.CacheSetting{
+                Name:           "alt_backend",
+                Action:         "pass",
+                StaleTTL:       uint(3600),
+                CacheCondition: "serve_alt_backend",
+        }
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckServiceV1Destroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccServiceV1CacheSetting(name, domainName1),
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+                                        testAccCheckFastlyServiceV1CacheSettingsAttributes(&service, []*gofastly.CacheSetting{&cq1}),
+                                        resource.TestCheckResourceAttr(
+                                                "fastly_service_v1.foo", "name", name),
+                                        resource.TestCheckResourceAttr(
+                                                "fastly_service_v1.foo", "cache_setting.#", "1"),
+                                        resource.TestCheckResourceAttr(
+                                                "fastly_service_v1.foo", "condition.#", "1"),
+                                ),
+                        },
+                },
+        })
+}
+
+func testAccCheckFastlyServiceV1CacheSettingsAttributes(service *gofastly.ServiceDetail, rqs []*gofastly.CacheSetting) resource.TestCheckFunc {
+        return func(s *terraform.State) error {
+
+                conn := testAccProvider.Meta().(*FastlyClient).conn
+                rqList, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
+                        Service: service.ID,
+                        Version: service.ActiveVersion.Number,
+                })
+
+                if err != nil {
+                        return fmt.Errorf("[ERR] Error looking up Request Setting for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+                }
+
+                if len(rqList) != len(rqs) {
+                        return fmt.Errorf("Request Setting List count mismatch, expected (%d), got (%d)", len(rqs), len(rqList))
+                }
+
+                var found int
+                for _, r := range rqs {
+                        for _, lr := range rqList {
+                                if r.Name == lr.Name {
+                                        // we don't know these things ahead of time, so populate them now
+                                        r.ServiceID = service.ID
+                                        r.Version = service.ActiveVersion.Number
+                                        if !reflect.DeepEqual(r, lr) {
+                                                return fmt.Errorf("Bad match Request Setting match, expected (%#v), got (%#v)", r, lr)
+                                        }
+                                        found++
+                                }
+                        }
+                }
+
+                if found != len(rqs) {
+                        return fmt.Errorf("Error matching Request Setting rules (%d/%d)", found, len(rqs))
+                }
+
+                return nil
+        }
+}
+
+func testAccServiceV1CacheSetting(name, domain string) string {
+        return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
+
+  backend {
+    address = "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com"
+    name    = "OtherAWSS3hosting"
+    port    = 80
+  }
+
+  condition {
+    name      = "serve_alt_backend"
+    type      = "REQUEST"
+    priority  = 10
+    statement = "req.url ~ \"^/alt/\""
+  }
+
+  cache_setting {
+    name            = "alt_backend"
+    stale_ttl       = 3600
+    cache_condition = "serve_alt_backend"
+    action          = "pass"
+  }
+
+  default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+
+  force_destroy = true
+}`, name, domain)
+}

--- a/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -1,92 +1,92 @@
 package fastly
 
 import (
-        "fmt"
-        "reflect"
-        "testing"
+	"fmt"
+	"reflect"
+	"testing"
 
-        "github.com/hashicorp/terraform/helper/acctest"
-        "github.com/hashicorp/terraform/helper/resource"
-        "github.com/hashicorp/terraform/terraform"
-        gofastly "github.com/sethvargo/go-fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	gofastly "github.com/sethvargo/go-fastly"
 )
 
 func TestAccFastlyServiceV1CacheSetting_basic(t *testing.T) {
-        var service gofastly.ServiceDetail
-        name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-        domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
-        cq1 := gofastly.CacheSetting{
-                Name:           "alt_backend",
-                Action:         "pass",
-                StaleTTL:       uint(3600),
-                CacheCondition: "serve_alt_backend",
-        }
+	cq1 := gofastly.CacheSetting{
+		Name:           "alt_backend",
+		Action:         "pass",
+		StaleTTL:       uint(3600),
+		CacheCondition: "serve_alt_backend",
+	}
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckServiceV1Destroy,
-                Steps: []resource.TestStep{
-                        resource.TestStep{
-                                Config: testAccServiceV1CacheSetting(name, domainName1),
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-                                        testAccCheckFastlyServiceV1CacheSettingsAttributes(&service, []*gofastly.CacheSetting{&cq1}),
-                                        resource.TestCheckResourceAttr(
-                                                "fastly_service_v1.foo", "name", name),
-                                        resource.TestCheckResourceAttr(
-                                                "fastly_service_v1.foo", "cache_setting.#", "1"),
-                                        resource.TestCheckResourceAttr(
-                                                "fastly_service_v1.foo", "condition.#", "1"),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceV1CacheSetting(name, domainName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1CacheSettingsAttributes(&service, []*gofastly.CacheSetting{&cq1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "cache_setting.#", "1"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "condition.#", "1"),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckFastlyServiceV1CacheSettingsAttributes(service *gofastly.ServiceDetail, rqs []*gofastly.CacheSetting) resource.TestCheckFunc {
-        return func(s *terraform.State) error {
+	return func(s *terraform.State) error {
 
-                conn := testAccProvider.Meta().(*FastlyClient).conn
-                rqList, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
-                        Service: service.ID,
-                        Version: service.ActiveVersion.Number,
-                })
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		rqList, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
 
-                if err != nil {
-                        return fmt.Errorf("[ERR] Error looking up Request Setting for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
-                }
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Request Setting for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+		}
 
-                if len(rqList) != len(rqs) {
-                        return fmt.Errorf("Request Setting List count mismatch, expected (%d), got (%d)", len(rqs), len(rqList))
-                }
+		if len(rqList) != len(rqs) {
+			return fmt.Errorf("Request Setting List count mismatch, expected (%d), got (%d)", len(rqs), len(rqList))
+		}
 
-                var found int
-                for _, r := range rqs {
-                        for _, lr := range rqList {
-                                if r.Name == lr.Name {
-                                        // we don't know these things ahead of time, so populate them now
-                                        r.ServiceID = service.ID
-                                        r.Version = service.ActiveVersion.Number
-                                        if !reflect.DeepEqual(r, lr) {
-                                                return fmt.Errorf("Bad match Request Setting match, expected (%#v), got (%#v)", r, lr)
-                                        }
-                                        found++
-                                }
-                        }
-                }
+		var found int
+		for _, r := range rqs {
+			for _, lr := range rqList {
+				if r.Name == lr.Name {
+					// we don't know these things ahead of time, so populate them now
+					r.ServiceID = service.ID
+					r.Version = service.ActiveVersion.Number
+					if !reflect.DeepEqual(r, lr) {
+						return fmt.Errorf("Bad match Request Setting match, expected (%#v), got (%#v)", r, lr)
+					}
+					found++
+				}
+			}
+		}
 
-                if found != len(rqs) {
-                        return fmt.Errorf("Error matching Request Setting rules (%d/%d)", found, len(rqs))
-                }
+		if found != len(rqs) {
+			return fmt.Errorf("Error matching Request Setting rules (%d/%d)", found, len(rqs))
+		}
 
-                return nil
-        }
+		return nil
+	}
 }
 
 func testAccServiceV1CacheSetting(name, domain string) string {
-        return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
 

--- a/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -109,7 +109,7 @@ resource "fastly_service_v1" "foo" {
 
   condition {
     name      = "serve_alt_backend"
-    type      = "REQUEST"
+    type      = "CACHE"
     priority  = 10
     statement = "req.url ~ \"^/alt/\""
   }

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -192,9 +192,10 @@ conditions execute. Lower numbers execute first
 The `cache_setting` block supports:
 
 * `name` - (Required) A unique name to label this Cache Setting
-* `action` - (Required) One of `N/A`, `Deliver`, `Pass` or `Restart`, as defined
+* `action` - (Required) One of `cache`, `pass`, or `restart`, as defined
 on Fastly's documenation under ["Caching action descriptions"](https://docs.fastly.com/guides/performance-tuning/controlling-caching#caching-action-descriptions)
-* `cache_condition` - (Required) Name of the condition used to test whether this settings object should be used
+* `cache_condition` - (Required) Name of the condition used to test whether this settings object should be used.
+This Condition must be of type `CACHE`
 * `stale_ttl` - (Optional) Max "Time To Live" for stale (unreachable) objects.
 Default `300`
 * `ttl` - (Optional) The "Time To Live" for the object

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -134,6 +134,8 @@ Service. Defined below
 Defined below
 * `condition` - (Optional) A set of conditions to add logic to any basic
 configuration object in this service. Defined below
+* `cache_setting` - (Optional) A set of Cache Settings, allowing you to override
+when an item is not to be cached based on an above `condition`. Defined below
 * `gzip` - (Required) A set of gzip rules to control automatic gzipping of
 content. Defined below
 * `header` - (Optional) A set of Headers to manipulate for each request. Defined
@@ -186,6 +188,16 @@ used in the `request_condition`, `response_condition`, or
 conditions execute. Lower numbers execute first
 * `type` - (Required) Type of the condition, either `REQUEST` (req), `RESPONSE`
 (req, resp), or `CACHE` (req, beresp)
+
+The `cache_setting` block supports:
+
+* `name` - (Required) A unique name to label this Cache Setting
+* `action` - (Required) One of `N/A`, `Deliver`, `Pass` or `Restart`, as defined
+on Fastly's documenation under ["Caching action descriptions"](https://docs.fastly.com/guides/performance-tuning/controlling-caching#caching-action-descriptions)
+* `cache_condition` - (Required) Name of the condition used to test whether this settings object should be used
+* `stale_ttl` - (Optional) Max "Time To Live" for stale (unreachable) objects.
+Default `300`
+* `ttl` - (Optional) The "Time To Live" for the object
 
 The `gzip` block supports:
 


### PR DESCRIPTION
Add support for using Cache Settings in Fastly:

- https://docs.fastly.com/guides/conditions/using-conditions#create-a-cache-settings-object-and-its-condition
- https://docs.fastly.com/api/config#cache_settings

```
TF_ACC=1 go test ./builtin/providers/fastly -v -run=TestAccFastlyService -timeout 120m
=== RUN   TestAccFastlyServiceV1CacheSetting_basic
--- PASS: TestAccFastlyServiceV1CacheSetting_basic (36.24s)
=== RUN   TestAccFastlyServiceV1_conditional_basic
--- PASS: TestAccFastlyServiceV1_conditional_basic (14.48s)
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- PASS: TestAccFastlyServiceV1_gzips_basic (33.62s)
=== RUN   TestAccFastlyServiceV1_headers_basic
--- PASS: TestAccFastlyServiceV1_headers_basic (33.37s)
=== RUN   TestAccFastlyServiceV1RequestSetting_basic
--- PASS: TestAccFastlyServiceV1RequestSetting_basic (15.22s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic
--- PASS: TestAccFastlyServiceV1_s3logging_basic (31.90s)
=== RUN   TestAccFastlyServiceV1_s3logging_s3_env
--- PASS: TestAccFastlyServiceV1_s3logging_s3_env (15.72s)
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (35.16s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (33.98s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (13.29s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (9.03s)
=== RUN   TestAccFastlyServiceV1_VCL_basic
--- PASS: TestAccFastlyServiceV1_VCL_basic (33.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/fastly	305.013s
```