### PR TITLE
provider/vSphere Disk Controller Type

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -125,13 +125,17 @@ func TestAccVSphereVirtualMachine_diskInitType(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.thin", "memory", "4096"),
 					resource.TestCheckResourceAttr(
-						"vsphere_virtual_machine.thin", "disk.#", "2"),
+						"vsphere_virtual_machine.thin", "disk.#", "3"),
 					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.thin", "disk.0.template", template),
 					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.thin", "disk.0.type", "thin"),
 					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.thin", "disk.1.type", "eager_zeroed"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.thin", "disk.1.controller_type", "scsi"),
+					resource.TestCheckResourceAttr(
+						"vsphere_virtual_machine.thin", "disk.2.controller_type", "ide"),
 					resource.TestCheckResourceAttr(
 						"vsphere_virtual_machine.thin", "network_interface.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -968,6 +972,11 @@ resource "vsphere_virtual_machine" "thin" {
     disk {
         size = 1
         iops = 500
+		controller_type = "scsi"
+    }
+	disk {
+        size = 1
+		controller_type = "ide"
     }
 }
 `

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -117,6 +117,7 @@ The `disk` block supports:
 * `type` - (Optional) 'eager_zeroed' (the default), or 'thin' are supported options.
 * `vmdk` - (Required if template and size not provided) Path to a vmdk in a vSphere datastore.
 * `bootable` - (Optional) Set to 'true' if a vmdk was given and it should attempt to boot after creation.
+* `controller_type` = (Optional) Controller type to attach the disk to.  'scsi' (the default), or 'ide' are supported options.
 
 <a id="cdrom"></a>
 ## CDROM


### PR DESCRIPTION
Gives the user the ability to specify the controller type they would
like to connect their disk to.  Supported options are scsi and ide.