### PR TITLE
provider/azurerm: `azurerm_network_interface` diffs didn't match during apply

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -328,7 +328,13 @@ func resourceArmNetworkInterfaceIpConfigurationHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+	if m["private_ip_address"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["private_ip_address"].(string)))
+	}
 	buf.WriteString(fmt.Sprintf("%s-", m["private_ip_address_allocation"].(string)))
+	if m["public_ip_address_id"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["public_ip_address_id"].(string)))
+	}
 
 	return hashcode.String(buf.String())
 }


### PR DESCRIPTION
Fixes #6776 

The IP Configuration block of `azurerm_network_interface` didn't have a
hash created in a way that changes to the optional params were being
picked up:

```
~ azurerm_network_interface.test
    ip_configuration.273485505.name:                                       "testconfiguration1" => ""
    ip_configuration.273485505.private_ip_address_allocation:              "dynamic" => ""
    ip_configuration.273485505.subnet_id:                                  "/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourceGroups/acctestrg/providers/Microsoft.Network/virtualNetworks/acctvn/subnets/acctsub" => ""
    ip_configuration.~273485505.load_balancer_backend_address_pools_ids.#: "" => "<computed>"
    ip_configuration.~273485505.load_balancer_inbound_nat_rules_ids.#:     "" => "<computed>"
    ip_configuration.~273485505.name:                                      "" => "testconfiguration1"
    ip_configuration.~273485505.private_ip_address:                        "" => "<computed>"
    ip_configuration.~273485505.private_ip_address_allocation:             "" => "dynamic"
    ip_configuration.~273485505.public_ip_address_id:                      "" => "${azurerm_public_ip.test.id}"
    ip_configuration.~273485505.subnet_id:                                 "" => "/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourceGroups/acctestrg/providers/Microsoft.Network/virtualNetworks/acctvn/subnets/acctsub"
```

This caused the following error:

```
Error applying plan:

1 error(s) occurred:

* azurerm_network_interface.test: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.

Please include the following information in your report:
```

Notice that the hash didn't change. This change adds the remaining optional params to the hash so that the hash id will change.

```
~ azurerm_network_interface.test
    ip_configuration.4255411321.load_balancer_backend_address_pools_ids.#: "" => "<computed>"
    ip_configuration.4255411321.load_balancer_inbound_nat_rules_ids.#:     "" => "<computed>"
    ip_configuration.4255411321.name:                                      "" => "testconfiguration1"
    ip_configuration.4255411321.private_ip_address:                        "" => "<computed>"
    ip_configuration.4255411321.private_ip_address_allocation:             "" => "dynamic"
    ip_configuration.4255411321.public_ip_address_id:                      "" => "/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourceGroups/acctestrg/providers/Microsoft.Network/publicIPAddresses/public-ip"
    ip_configuration.4255411321.subnet_id:                                 "" => "/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourceGroups/acctestrg/providers/Microsoft.Network/virtualNetworks/acctvn/subnets/acctsub"
    ip_configuration.966273186.name:                                       "testconfiguration1" => ""
    ip_configuration.966273186.private_ip_address_allocation:              "dynamic" => ""
    ip_configuration.966273186.subnet_id:                                  "/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourceGroups/acctestrg/providers/Microsoft.Network/virtualNetworks/acctvn/subnets/acctsub" => ""
```

This allows the Update to work as expected :)

```
azurerm_network_interface.test: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```