### PR TITLE
Update EC2 example to modern AMI & instance

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -59,8 +59,8 @@ provider "aws" {
 }
 
 resource "aws_instance" "example" {
-	ami = "ami-408c7f28"
-	instance_type = "t1.micro"
+	ami = "ami-b0ac25c3"
+	instance_type = "t2.micro"
 }
 ```
 
@@ -111,9 +111,9 @@ $ terraform plan
 ...
 
 + aws_instance.example
-    ami:               "" => "ami-408c7f28"
+    ami:               "" => "ami-b0ac25c3"
     availability_zone: "" => "<computed>"
-    instance_type:     "" => "t1.micro"
+    instance_type:     "" => "t2.micro"
     key_name:          "" => "<computed>"
     private_dns:       "" => "<computed>"
     private_ip:        "" => "<computed>"
@@ -148,8 +148,8 @@ since Terraform waits for the EC2 instance to become available.
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-408c7f28"
-  instance_type: "" => "t1.micro"
+  ami:           "" => "ami-b0ac25c3"
+  instance_type: "" => "t2.micro"
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
@@ -172,7 +172,7 @@ You can inspect the state using `terraform show`:
 $ terraform show
 aws_instance.example:
   id = i-e60900cd
-  ami = ami-408c7f28
+  ami = ami-b0ac25c3
   availability_zone = us-east-1c
   instance_type = t1.micro
   key_name =


### PR DESCRIPTION
The current intro docs give an example config to get you going.

However, this uses and older `t1.micro` instance and deprecated AMI, so users following the guide will get the following error when running `terraform apply`:

```
Error launching source instance: InvalidParameterCombination: Non-Windows instances with a virtualization type of 'hvm' are currently not supported for this instance type.
```

This PR updates the example config to a `t2.micro` instance and the latest Amazon Linux AMI to make the guide easier to follow again.