### PR TITLE
provider/aws: Make 'stage_name' required in api_gateway_deployment

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_deployment.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_deployment.go
@@ -28,7 +28,7 @@ func resourceAwsApiGatewayDeployment() *schema.Resource {
 
 			"stage_name": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 

--- a/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
@@ -50,7 +50,7 @@ resource "aws_api_gateway_deployment" "MyDemoDeployment" {
 The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
-* `stage_name` - (Optional) The name of the stage
+* `stage_name` - (Required) The name of the stage
 * `description` - (Optional) The description of the deployment
 * `stage_description` - (Optional) The description of the stage
 * `variables` - (Optional) A map that defines variables for the stage


### PR DESCRIPTION
Currently the `stage_name` variable under the `aws_api_gateway_deployment` resource is listed as optional. However, when running a terraform apply on a configuration which omits the `stage_name` variable the following exception is raised from the AWS API:  

```
aws_api_gateway_deployment.jrasell-test-terraform: Error creating API Gateway Deployment: BadRequestException: Stage name must be non-empty
        status code: 400, request id: 934b9e58-1e8c-11e6-b1af-15e92240819e
```

```
Terraform v0.6.16
```
This request therefore updates the variable `stage_name` to be required.
The associated documentation as also been updated the reflect this.