### PR TITLE
provider/aws: Update documentation to use t2.micro, provide Classic options

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -55,14 +55,18 @@ loads all of them.
 provider "aws" {
 	access_key = "ACCESS_KEY_HERE"
 	secret_key = "SECRET_KEY_HERE"
-	region = "us-east-1"
+  region     = "us-east-1"
 }
 
 resource "aws_instance" "example" {
-	ami = "ami-408c7f28"
-	instance_type = "t1.micro"
+  ami           = "ami-0d729a60"
+  instance_type = "t2.micro"
 }
 ```
+
+~> **Note**: The above configuation is designed to work on modern EC2 accounts,
+with access to a VPC. For EC2 Classic users, please `t1.micro` for
+`instance_type`, and `ami-408c7f28` for the `ami`.
 
 Replace the `ACCESS_KEY_HERE` and `SECRET_KEY_HERE` with your
 AWS access key and secret key, available from
@@ -95,7 +99,7 @@ Within the resource block itself is configuration for that
 resource. This is dependent on each resource provider and
 is fully documented within our
 [providers reference](/docs/providers/index.html). For our EC2 instance, we specify
-an AMI for Ubuntu, and request a "t1.micro" instance so we
+an AMI for Ubuntu, and request a "t2.micro" instance so we
 qualify under the free tier.
 
 ## Execution Plan
@@ -111,16 +115,24 @@ $ terraform plan
 ...
 
 + aws_instance.example
-    ami:               "" => "ami-408c7f28"
-    availability_zone: "" => "<computed>"
-    instance_type:     "" => "t1.micro"
-    key_name:          "" => "<computed>"
-    private_dns:       "" => "<computed>"
-    private_ip:        "" => "<computed>"
-    public_dns:        "" => "<computed>"
-    public_ip:         "" => "<computed>"
-    security_groups:   "" => "<computed>"
-    subnet_id:         "" => "<computed>"
+    ami:                      "ami-0d729a60"
+    availability_zone:        "<computed>"
+    ebs_block_device.#:       "<computed>"
+    ephemeral_block_device.#: "<computed>"
+    instance_state:           "<computed>"
+    instance_type:            "t2.micro"
+    key_name:                 "<computed>"
+    placement_group:          "<computed>"
+    private_dns:              "<computed>"
+    private_ip:               "<computed>"
+    public_dns:               "<computed>"
+    public_ip:                "<computed>"
+    root_block_device.#:      "<computed>"
+    security_groups.#:        "<computed>"
+    source_dest_check:        "true"
+    subnet_id:                "<computed>"
+    tenancy:                  "<computed>"
+    vpc_security_group_ids.#: "<computed>"
 ```
 
 `terraform plan` shows what changes Terraform will apply to
@@ -148,8 +160,12 @@ since Terraform waits for the EC2 instance to become available.
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-408c7f28"
-  instance_type: "" => "t1.micro"
+  ami:                      "" => "ami-0d729a60"
+  instance_type:            "" => "t2.micro"
+  [...]
+
+aws_instance.example: Still creating... (10s elapsed)
+aws_instance.example: Creation complete
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
@@ -171,18 +187,17 @@ You can inspect the state using `terraform show`:
 ```
 $ terraform show
 aws_instance.example:
-  id = i-e60900cd
-  ami = ami-408c7f28
-  availability_zone = us-east-1c
-  instance_type = t1.micro
-  key_name =
-  private_dns = domU-12-31-39-12-38-AB.compute-1.internal
-  private_ip = 10.200.59.89
-  public_dns = ec2-54-81-21-192.compute-1.amazonaws.com
-  public_ip = 54.81.21.192
-  security_groups.# = 1
-  security_groups.0 = default
-  subnet_id =
+  id = i-32cf65a8
+  ami = ami-0d729a60
+  availability_zone = us-east-1a
+  instance_state = running
+  instance_type = t2.micro
+  private_ip = 172.31.30.244
+  public_dns = ec2-52-90-212-55.compute-1.amazonaws.com
+  public_ip = 52.90.212.55
+  subnet_id = subnet-1497024d
+  vpc_security_group_ids.# = 1
+  vpc_security_group_ids.3348721628 = sg-67652003
 ```
 
 You can see that by creating our resource, we've also gathered

--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -53,8 +53,8 @@ loads all of them.
 
 ```
 provider "aws" {
-	access_key = "ACCESS_KEY_HERE"
-	secret_key = "SECRET_KEY_HERE"
+  access_key = "ACCESS_KEY_HERE"
+  secret_key = "SECRET_KEY_HERE"
   region     = "us-east-1"
 }
 

--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -64,8 +64,8 @@ resource "aws_instance" "example" {
 }
 ```
 
-~> **Note**: The above configuation is designed to work on modern EC2 accounts,
-with access to a VPC. For EC2 Classic users, please `t1.micro` for
+~> **Note**: The above configuation is designed to work on most EC2 accounts,
+with access to a default VPC. For EC2 Classic users, please use `t1.micro` for
 `instance_type`, and `ami-408c7f28` for the `ami`.
 
 Replace the `ACCESS_KEY_HERE` and `SECRET_KEY_HERE` with your

--- a/website/source/intro/getting-started/change.html.md
+++ b/website/source/intro/getting-started/change.html.md
@@ -28,13 +28,15 @@ resource in your configuration and change it to the following:
 
 ```
 resource "aws_instance" "example" {
-	ami = "ami-b8b061d0"
-	instance_type = "t1.micro"
+  ami           = "ami-13be557e"
+  instance_type = "t2.micro"
 }
 ```
 
-We've changed the AMI from being an Ubuntu 14.04 AMI to being
-an Ubuntu 12.04 AMI. Terraform configurations are meant to be
+~> **Note:** EC2 Classic users please use AMI `ami-2106ed4c` and type `t1.micro`
+
+We've changed the AMI from being an Ubuntu 14.04 LTS AMI to being
+an Ubuntu 16.04 LTS AMI. Terraform configurations are meant to be
 changed like this. You can also completely remove resources
 and Terraform will know to destroy the old one.
 
@@ -47,15 +49,18 @@ $ terraform plan
 ...
 
 -/+ aws_instance.example
-    ami:               "ami-408c7f28" => "ami-b8b061d0" (forces new resource)
-    availability_zone: "us-east-1c" => "<computed>"
-    key_name:          "" => "<computed>"
-    private_dns:       "domU-12-31-39-12-38-AB.compute-1.internal" => "<computed>"
-    private_ip:        "10.200.59.89" => "<computed>"
-    public_dns:        "ec2-54-81-21-192.compute-1.amazonaws.com" => "<computed>"
-    public_ip:         "54.81.21.192" => "<computed>"
-    security_groups:   "" => "<computed>"
-    subnet_id:         "" => "<computed>"
+    ami:                      "ami-0d729a60" => "ami-13be557e" (forces new resource)
+    availability_zone:        "us-east-1a" => "<computed>"
+    ebs_block_device.#:       "0" => "<computed>"
+    ephemeral_block_device.#: "0" => "<computed>"
+    instance_state:           "running" => "<computed>"
+    instance_type:            "t2.micro" => "t2.micro"
+    private_dns:              "ip-172-31-17-94.ec2.internal" => "<computed>"
+    private_ip:               "172.31.17.94" => "<computed>"
+    public_dns:               "ec2-54-82-183-4.compute-1.amazonaws.com" => "<computed>"
+    public_ip:                "54.82.183.4" => "<computed>"
+    subnet_id:                "subnet-1497024d" => "<computed>"
+    vpc_security_group_ids.#: "1" => "<computed>"
 ```
 
 The prefix "-/+" means that Terraform will destroy and recreate
@@ -77,11 +82,33 @@ the change.
 
 ```
 $ terraform apply
+aws_instance.example: Refreshing state... (ID: i-64c268fe)
 aws_instance.example: Destroying...
-aws_instance.example: Modifying...
-  ami: "ami-408c7f28" => "ami-b8b061d0"
+aws_instance.example: Destruction complete
+aws_instance.example: Creating...
+  ami:                      "" => "ami-13be557e"
+  availability_zone:        "" => "<computed>"
+  ebs_block_device.#:       "" => "<computed>"
+  ephemeral_block_device.#: "" => "<computed>"
+  instance_state:           "" => "<computed>"
+  instance_type:            "" => "t2.micro"
+  key_name:                 "" => "<computed>"
+  placement_group:          "" => "<computed>"
+  private_dns:              "" => "<computed>"
+  private_ip:               "" => "<computed>"
+  public_dns:               "" => "<computed>"
+  public_ip:                "" => "<computed>"
+  root_block_device.#:      "" => "<computed>"
+  security_groups.#:        "" => "<computed>"
+  source_dest_check:        "" => "true"
+  subnet_id:                "" => "<computed>"
+  tenancy:                  "" => "<computed>"
+  vpc_security_group_ids.#: "" => "<computed>"
+aws_instance.example: Still creating... (10s elapsed)
+aws_instance.example: Still creating... (20s elapsed)
+aws_instance.example: Creation complete
 
-Apply complete! Resources: 0 added, 1 changed, 1 destroyed.
+Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
 
 ...
 ```

--- a/website/source/intro/getting-started/dependencies.html.md
+++ b/website/source/intro/getting-started/dependencies.html.md
@@ -59,24 +59,35 @@ will look something like the following:
 
 ```
 $ terraform plan
-...
 
 + aws_eip.ip
-    instance:   "" => "${aws_instance.example.id}"
-    private_ip: "" => "<computed>"
-    public_ip:  "" => "<computed>"
+    allocation_id:     "<computed>"
+    association_id:    "<computed>"
+    domain:            "<computed>"
+    instance:          "${aws_instance.example.id}"
+    network_interface: "<computed>"
+    private_ip:        "<computed>"
+    public_ip:         "<computed>"
 
 + aws_instance.example
-    ami:               "" => "ami-b8b061d0"
-    availability_zone: "" => "<computed>"
-    instance_type:     "" => "t1.micro"
-    key_name:          "" => "<computed>"
-    private_dns:       "" => "<computed>"
-    private_ip:        "" => "<computed>"
-    public_dns:        "" => "<computed>"
-    public_ip:         "" => "<computed>"
-    security_groups:   "" => "<computed>"
-    subnet_id:         "" => "<computed>"
+    ami:                      "ami-13be557e"
+    availability_zone:        "<computed>"
+    ebs_block_device.#:       "<computed>"
+    ephemeral_block_device.#: "<computed>"
+    instance_state:           "<computed>"
+    instance_type:            "t2.micro"
+    key_name:                 "<computed>"
+    placement_group:          "<computed>"
+    private_dns:              "<computed>"
+    private_ip:               "<computed>"
+    public_dns:               "<computed>"
+    public_ip:                "<computed>"
+    root_block_device.#:      "<computed>"
+    security_groups.#:        "<computed>"
+    source_dest_check:        "true"
+    subnet_id:                "<computed>"
+    tenancy:                  "<computed>"
+    vpc_security_group_ids.#: "<computed>"
 ```
 
 Terraform will create two resources: the instance and the elastic
@@ -89,11 +100,22 @@ Next, run `terraform apply`. The output will look similar to the
 following:
 
 ```
+$ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-b8b061d0"
-  instance_type: "" => "t1.micro"
+  ami:                      "" => "ami-13be557e"
+  instance_type:            "" => "t2.micro"
+  [..]
+aws_instance.example: Still creating... (10s elapsed)
+aws_instance.example: Creation complete
 aws_eip.ip: Creating...
-  instance: "" => "i-0e737b25"
+  allocation_id:     "" => "<computed>"
+  association_id:    "" => "<computed>"
+  domain:            "" => "<computed>"
+  instance:          "" => "i-f3d77d69"
+  network_interface: "" => "<computed>"
+  private_ip:        "" => "<computed>"
+  public_ip:         "" => "<computed>"
+aws_eip.ip: Creation complete
 
 Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
 ```
@@ -144,8 +166,8 @@ created in parallel to everything else.
 
 ```
 resource "aws_instance" "another" {
-	ami = "ami-b8b061d0"
-	instance_type = "t1.micro"
+  ami           = "ami-13be557e"
+  instance_type = "t2.micro"
 }
 ```
 

--- a/website/source/intro/getting-started/provision.html.md
+++ b/website/source/intro/getting-started/provision.html.md
@@ -25,12 +25,12 @@ To define a provisioner, modify the resource block defining the
 
 ```
 resource "aws_instance" "example" {
-	ami = "ami-b8b061d0"
-	instance_type = "t1.micro"
+  ami           = "ami-13be557e"
+  instance_type = "t2.micro"
 
-	provisioner "local-exec" {
-		command = "echo ${aws_instance.example.public_ip} > file.txt"
-	}
+  provisioner "local-exec" {
+    command = "echo ${aws_instance.example.public_ip} > file.txt"
+  }
 }
 ```
 

--- a/website/source/intro/getting-started/provision.html.md
+++ b/website/source/intro/getting-started/provision.html.md
@@ -61,8 +61,8 @@ then run `apply`:
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-b8b061d0"
-  instance_type: "" => "t1.micro"
+  ami:           "" => "ami-13be557e"
+  instance_type: "" => "t2.micro"
 aws_eip.ip: Creating...
   instance: "" => "i-213f350a"
 

--- a/website/source/intro/getting-started/variables.html.md
+++ b/website/source/intro/getting-started/variables.html.md
@@ -124,8 +124,8 @@ support for the "us-west-2" region as well:
 variable "amis" {
     type = "map"
 	default = {
-		us-east-1 = "ami-b8b061d0"
-		us-west-2 = "ami-ef5e24df"
+		us-east-1 = "ami-13be557e"
+		us-west-2 = "ami-06b94666"
 	}
 }
 ```
@@ -138,7 +138,7 @@ Then, replace the "aws\_instance" with the following:
 ```
 resource "aws_instance" "example" {
 	ami = "${lookup(var.amis, var.region)}"
-	instance_type = "t1.micro"
+	instance_type = "t2.micro"
 }
 ```
 


### PR DESCRIPTION
This updates our Getting Started guide to use `t2.micro` instances and us-east-1 compatible AMIs for most users who are not on EC2 Classic. It also provides an alternative AMI that works for `t1.micro`.

On `Building`:
<img width="745" alt="screen shot 2016-05-20 at 4 17 02 pm" src="https://cloud.githubusercontent.com/assets/61721/15442377/55f9c8fe-1ea6-11e6-811f-5a18c1039d0c.png">


On `Change`:
![screen shot 2016-05-20 at 1 12 21 pm](https://cloud.githubusercontent.com/assets/61721/15437399/86c6f9e4-1e8c-11e6-9353-754abcf980e8.png)



Fixes: 
- https://github.com/hashicorp/terraform/pull/6793