### PR TITLE
provider/aws: Add aws_availability_zones source

### DIFF
--- a/builtin/providers/aws/data_source_availability_zones.go
+++ b/builtin/providers/aws/data_source_availability_zones.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsAvailabilityZonesRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	log.Printf("[DEBUG] Reading availability zones")
+	d.SetId(time.Now().UTC().String())
+
+	req := &ec2.DescribeAvailabilityZonesInput{DryRun: aws.Bool(false)}
+	azresp, err := conn.DescribeAvailabilityZones(req)
+	if err != nil {
+		return fmt.Errorf("Error listing availability zones: %s", err)
+	}
+
+	raw := make([]string, len(azresp.AvailabilityZones))
+	for i, v := range azresp.AvailabilityZones {
+		raw[i] = *v.ZoneName
+	}
+
+	sort.Strings(raw)
+
+	if err := d.Set("instance", raw); err != nil {
+		return fmt.Errorf("[WARN] Error setting availability zones")
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -110,6 +110,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"aws_availability_zones": dataSourceAwsAvailabilityZones(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"aws_ami":                                      resourceAwsAmi(),
 			"aws_ami_copy":                                 resourceAwsAmiCopy(),

--- a/website/source/docs/providers/aws/d/availability_zones.html.markdown
+++ b/website/source/docs/providers/aws/d/availability_zones.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "aws"
+page_title: "AWS: aws_availability_zones"
+sidebar_current: "docs-aws-datasource-availability-zones"
+description: |-
+    Provides a list of availability zones which can be used by an AWS account
+---
+
+# aws\_availability\_zones
+
+The Availability Zones data source allows access to the list of AWS
+Availability Zones which can be accessed by an AWS account within the region
+configured in the provider.
+
+## Example Usage
+
+```
+# Declare the data source
+data "aws_availability_zones" "zones" {}
+
+# Create a subnet in each availability zone
+resource "aws_subnet" "public" {
+    count = "${length(data.aws_availability_zones.zones.instance)}"
+    
+    availability_zone = "${data.aws_availability_zones.zones.instance[count.index]}"
+
+    # Other properties...
+}
+```
+
+## Argument Reference
+
+There are no arguments for this data source.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `instance` - A list of the availability zone names available to the account.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -10,6 +10,15 @@
                     <a href="/docs/providers/aws/index.html">AWS Provider</a>
                 </li>
 
+                <li<%= sidebar_current(/^docs-aws-datasource/) %>
+                <a href="#">Data Sources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-datasource-availability-zones") %>>
+                            <a href="/docs/providers/aws/d/availability_zones.html">aws_availability_zones</a>
+                        </li>
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current(/^docs-aws-resource-api-gateway/) %>>
                     <a href="#">API Gateway Resources</a>
                     <ul class="nav nav-visible">


### PR DESCRIPTION
This pull request adds a data source with a single list, `available`, in the schema. The list is populated with the availability zones to which an account has access within the region for which the AWS provider is configured. The list is sorted alphabetically so should remain in a predictable order.