### PR TITLE
provider/azurerm: Add support for EnableIPForwarding to `azurerm_network_interface`

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -145,6 +145,12 @@ func resourceArmNetworkInterface() *schema.Resource {
 				Computed: true,
 			},
 
+			"enable_ip_forwarding": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -159,9 +165,12 @@ func resourceArmNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
+	enableIpForwarding := d.Get("enable_ip_forwarding").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
-	properties := network.InterfacePropertiesFormat{}
+	properties := network.InterfacePropertiesFormat{
+		EnableIPForwarding: &enableIpForwarding,
+	}
 
 	if v, ok := d.GetOk("network_security_group_id"); ok {
 		nsgId := v.(string)

--- a/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
@@ -26,6 +26,25 @@ func TestAccAzureRMNetworkInterface_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterfaceenableIPForwarding(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_ipForwarding,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_network_interface.test", "enable_ip_forwarding", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterface_withTags(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -167,6 +186,40 @@ resource "azurerm_network_interface" "test" {
     name = "acceptanceTestNetworkInterface1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+`
+
+var testAccAzureRMNetworkInterface_ipForwarding = `
+resource "azurerm_resource_group" "test" {
+    name = "acceptanceTestResourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acceptanceTestVirtualNetwork1"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "testsubnet"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acceptanceTestNetworkInterface1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    enable_ip_forwarding = true
 
     ip_configuration {
     	name = "testconfiguration1"

--- a/website/source/docs/providers/azurerm/r/network_interface.html.markdown
+++ b/website/source/docs/providers/azurerm/r/network_interface.html.markdown
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 * `internal_dns_name_label` - (Optional) Relative DNS name for this NIC used for internal communications between VMs in the same VNet
 
+* `enable_ip_forwarding` - (Optional) Enables IP Forwarding on the NIC. Defaults to `false`.
+
 * `dns_servers` - (Optional) List of DNS servers IP addresses to use for this NIC, overrides the VNet-level server list
 
 * `ip_configuration` - (Optional) Collection of ipConfigurations associated with this NIC. Each `ip_configuration` block supports fields documented below.


### PR DESCRIPTION
As requested in #6803

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMNetworkInterface' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMNetworkInterface -timeout 120m
=== RUN   TestAccAzureRMNetworkInterface_basic
--- PASS: TestAccAzureRMNetworkInterface_basic (109.66s)
=== RUN   TestAccAzureRMNetworkInterfaceenableIPForwarding
--- PASS: TestAccAzureRMNetworkInterfaceenableIPForwarding (96.85s)
=== RUN   TestAccAzureRMNetworkInterface_withTags
--- PASS: TestAccAzureRMNetworkInterface_withTags (161.35s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	367.883s
```