### PR TITLE
core: restore data resource creation diffs

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -889,9 +889,25 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 	if _, ok := moduleDiff.Resources["aws_instance.foo"]; !ok {
 		t.Fatalf("missing diff for aws_instance.foo")
 	}
-	_, ok := moduleDiff.Resources["data.aws_vpc.bar"]
+	iDiff, ok := moduleDiff.Resources["data.aws_vpc.bar"]
 	if !ok {
 		t.Fatalf("missing diff for data.aws_vpc.bar")
+	}
+
+	expectedDiff := &InstanceDiff{
+		Attributes: map[string]*ResourceAttrDiff{
+			"id": {
+				NewComputed: true,
+				RequiresNew: true,
+				Type:        DiffAttrOutput,
+			},
+		},
+	}
+	if same, _ := expectedDiff.Same(iDiff); !same {
+		t.Fatalf(
+			"incorrect diff for data.aws_vpc.bar\ngot:  %#v\nwant: %#v",
+			iDiff, expectedDiff,
+		)
 	}
 }
 

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -864,6 +864,37 @@ func TestContext2Plan_computed(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_computedDataResource(t *testing.T) {
+	m := testModule(t, "plan-computed-data-resource")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if got := len(plan.Diff.Modules); got != 1 {
+		t.Fatalf("got %d modules; want 1", got)
+	}
+
+	moduleDiff := plan.Diff.Modules[0]
+
+	if _, ok := moduleDiff.Resources["aws_instance.foo"]; !ok {
+		t.Fatalf("missing diff for aws_instance.foo")
+	}
+	_, ok := moduleDiff.Resources["data.aws_vpc.bar"]
+	if !ok {
+		t.Fatalf("missing diff for data.aws_vpc.bar")
+	}
+}
+
 func TestContext2Plan_computedList(t *testing.T) {
 	m := testModule(t, "plan-computed-list")
 	p := testProvider("aws")

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -38,7 +38,8 @@ func (n *EvalReadDataDiff) Eval(ctx EvalContext) (interface{}, error) {
 		provider := *n.Provider
 		config := *n.Config
 
-		diff, err := provider.ReadDataDiff(n.Info, config)
+		var err error
+		diff, err = provider.ReadDataDiff(n.Info, config)
 		if err != nil {
 			return nil, err
 		}

--- a/terraform/test-fixtures/plan-computed-data-resource/main.tf
+++ b/terraform/test-fixtures/plan-computed-data-resource/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "foo" {
+  num     = "2"
+  compute = "foo"
+}
+
+data "aws_vpc" "bar" {
+  foo = "${aws_instance.foo.foo}"
+}


### PR DESCRIPTION
cd0c4522eed540baf40e13e7c7fdb1b2195ecb2a contained a bug where the creation diff for a data resource was put into a new local variable within the else block rather than into the diff variable in the parent scope, causing a null diff to always be produced.

This restores the expected behavior: a computed data resource appears in the diff, so it can then be fetched during the apply walk.

It also introduces a context test so this is less likely to get broken again.
