### PR TITLE
provider/aws: Change to `aws_dynamodb_table` hash_key forces a new resource

### DIFF
--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -48,10 +48,12 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			"hash_key": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"range_key": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"write_capacity": &schema.Schema{
 				Type:     schema.TypeInt,
@@ -86,6 +88,7 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			"local_secondary_index": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -337,19 +340,6 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 
 	// Ensure table is active before trying to update
 	waitForTableToBeActive(d.Id(), meta)
-
-	// LSI can only be done at create-time, abort if it's been changed
-	if d.HasChange("local_secondary_index") {
-		return fmt.Errorf("Local secondary indexes can only be built at creation, you cannot update them!")
-	}
-
-	if d.HasChange("hash_key") {
-		return fmt.Errorf("Hash key can only be specified at creation, you cannot modify it.")
-	}
-
-	if d.HasChange("range_key") {
-		return fmt.Errorf("Range key can only be specified at creation, you cannot modify it.")
-	}
 
 	if d.HasChange("read_capacity") || d.HasChange("write_capacity") {
 		req := &dynamodb.UpdateTableInput{

--- a/website/source/docs/providers/aws/r/dynamodb_table.html.markdown
+++ b/website/source/docs/providers/aws/r/dynamodb_table.html.markdown
@@ -54,16 +54,16 @@ The following arguments are supported:
   within a region.
 * `read_capacity` - (Required) The number of read units for this table
 * `write_capacity` - (Required) The number of write units for this table
-* `hash_key` - (Required) The attribute to use as the hash key (the
+* `hash_key` - (Required, Forces new resource) The attribute to use as the hash key (the
   attribute must also be defined as an attribute record
-* `range_key` - (Optional) The attribute to use as the range key (must
+* `range_key` - (Optional, Forces new resource) The attribute to use as the range key (must
   also be defined)
 * `attribute` - Define an attribute, has two properties:
   * `name` - The name of the attribute
   * `type` - One of: S, N, or B for (S)tring, (N)umber or (B)inary data
 * `stream_enabled` - (Optional) Indicates whether Streams are to be enabled (true) or disabled (false).
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES.
-* `local_secondary_index` - (Optional) Describe an LSI on the table;
+* `local_secondary_index` - (Optional, Forces new resource) Describe an LSI on the table;
   these can only be allocated *at creation* so you cannot change this
 definition after you have created the resource.
 * `global_secondary_index` - (Optional) Describe a GSO for the table;


### PR DESCRIPTION
Fixes #6825

We had a line on the Update func that said:

```
Hash key can only be specified at creation, you cannot modify it.
```

The resource has now been changed to ForceNew on the hashkey

```
aws_dynamodb_table.demo-user-table: Refreshing state... (ID: Users)
aws_dynamodb_table.demo-user-table: Destroying...
aws_dynamodb_table.demo-user-table: Destruction complete
aws_dynamodb_table.demo-user-table: Creating...
aws_dynamodb_table.demo-user-table: Creation complete
```