### PR TITLE
Update URL displayed to plugins documentation when Terraform warns you are running a locally compiled plugin.

### DIFF
--- a/config.go
+++ b/config.go
@@ -125,7 +125,7 @@ func (c *Config) Discover(ui cli.Ui) error {
 		if path, found := c.Providers[name]; found {
 			ui.Warn(fmt.Sprintf("[WARN] %s overrides an internal plugin for %s-provider.\n"+
 				"  If you did not expect to see this message you will need to remove the old plugin.\n"+
-				"  See https://www.terraform.io/docs/internals/internal-plugins.html", path, name))
+				"  See https://www.terraform.io/docs/plugins/index.html", path, name))
 		} else {
 
 			cmd, err := command.BuildPluginCommandString("provider", name)
@@ -139,7 +139,7 @@ func (c *Config) Discover(ui cli.Ui) error {
 		if path, found := c.Provisioners[name]; found {
 			ui.Warn(fmt.Sprintf("[WARN] %s overrides an internal plugin for %s-provisioner.\n"+
 				"  If you did not expect to see this message you will need to remove the old plugin.\n"+
-				"  See https://www.terraform.io/docs/internals/internal-plugins.html", path, name))
+				"  See https://www.terraform.io/docs/plugins/index.html", path, name))
 		} else {
 			cmd, err := command.BuildPluginCommandString("provisioner", name)
 			if err != nil {


### PR DESCRIPTION
Currently when running a locally compiled plugin for development purposes, Terraform will warn you with the following example message:
```
jrasell@jrasell:~$ terraform
[WARN] /Users/rasellj/Documents/go/bin/terraform-provider-aws overrides an internal plugin for aws-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
```

However, the URL displayed returns '404 Not Found':
```
jrasell@jrasell:~$ curl https://www.terraform.io/docs/internals/internal-plugins.html
<html>
<head><title>404 Not Found</title></head>
<body>
<h1>404 Not Found</h1>
<ul>
<li>Code: NoSuchKey</li>
<li>Message: The specified key does not exist.</li>
<li>Key: terraform/latest/docs/internals/internal-plugins.html</li>
<li>RequestId: DEC9767313BAD68E</li>
<li>HostId: zzorRnEw7EDFJ7yuEocIr1oc0NxJHLnRxgGWOjhnUCQAdLhXfg1xu5AAqMIkGDxb</li>
</ul>
<hr/>
</body>
</html>
```

This commit therefore updates the URL displayed to the existing page 'https://www.terraform.io/docs/plugins/index.html' which seemed most appropriate to me. If this is incorrect please let me know.

Regards,
jrasell