### PR TITLE
provider/openstack: Implement fixed_ip on floating ip allocations

### DIFF
--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -67,4 +67,9 @@ func testAccPreCheck(t *testing.T) {
 	if v == "" {
 		t.Fatal("OS_NETWORK_ID must be set for acceptance tests")
 	}
+
+	v = os.Getenv("OS_EXTGW_ID")
+	if v == "" {
+		t.Fatal("OS_EXTGW_ID must be set for acceptance tests")
+	}
 }

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -49,6 +49,11 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"fixed_ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -71,6 +76,7 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 		FloatingNetworkID: poolID,
 		PortID:            d.Get("port_id").(string),
 		TenantID:          d.Get("tenant_id").(string),
+		FixedIP:           d.Get("fixed_ip").(string),
 	}
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	floatingIP, err := floatingips.Create(networkingClient, createOpts).Extract()
@@ -109,6 +115,7 @@ func resourceNetworkFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("address", floatingIP.FloatingIP)
 	d.Set("port_id", floatingIP.PortID)
+	d.Set("fixed_ip", floatingIP.FixedIP)
 	poolName, err := getNetworkName(d, meta, floatingIP.FloatingNetworkID)
 	if err != nil {
 		return fmt.Errorf("Error retrieving floating IP pool name: %s", err)

--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2_test.go
@@ -65,6 +65,67 @@ func TestAccNetworkingV2FloatingIP_attach(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2FloatingIP_fixedip_bind(t *testing.T) {
+	var fip floatingips.FloatingIP
+	var testAccNetworkingV2FloatingIP_fixedip_bind = fmt.Sprintf(`
+		resource "openstack_networking_network_v2" "network_1" {
+      name = "network_1"
+      admin_state_up = "true"
+    }
+
+    resource "openstack_networking_subnet_v2" "subnet_1" {
+      name = "subnet_1"
+      network_id = "${openstack_networking_network_v2.network_1.id}"
+      cidr = "192.168.199.0/24"
+      ip_version = 4
+    }
+
+    resource "openstack_networking_router_interface_v2" "router_interface_1" {
+      router_id = "${openstack_networking_router_v2.router_1.id}"
+      subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    }
+
+    resource "openstack_networking_router_v2" "router_1" {
+      name = "router_1"
+      external_gateway = "%s"
+    }
+
+    resource "openstack_networking_port_v2" "port_1" {
+      network_id = "${openstack_networking_subnet_v2.subnet_1.network_id}"
+      admin_state_up = "true"
+      fixed_ip {
+        subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+        ip_address = "192.168.199.10"
+      }
+      fixed_ip {
+        subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+        ip_address = "192.168.199.20"
+      }
+    }
+
+    resource "openstack_networking_floatingip_v2" "ip_1" {
+      pool = "%s"
+      port_id = "${openstack_networking_port_v2.port_1.id}"
+      fixed_ip = "${openstack_networking_port_v2.port_1.fixed_ip.1.ip_address}"
+    }`,
+		os.Getenv("OS_EXTGW_ID"), os.Getenv("OS_POOL_NAME"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2FloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2FloatingIP_fixedip_bind,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2FloatingIPExists(t, "openstack_networking_floatingip_v2.ip_1", &fip),
+					testAccCheckNetworkingV2FloatingIPBoundToCorrectIP(t, &fip, "192.168.199.20"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2FloatingIPDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -113,6 +174,16 @@ func testAccCheckNetworkingV2FloatingIPExists(t *testing.T, n string, kp *floati
 		}
 
 		*kp = *found
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkingV2FloatingIPBoundToCorrectIP(t *testing.T, fip *floatingips.FloatingIP, fixed_ip string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if fip.FixedIP != fixed_ip {
+			return fmt.Errorf("Floating ip associated with wrong fixed ip")
+		}
 
 		return nil
 	}

--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -43,6 +43,9 @@ The following arguments are supported:
     belongs to the same tenant. Changing this creates a new floating IP (which
     may or may not have a different address)
 
+* `fixed_ip` - Fixed IP of the port to associate with this floating IP. Required if
+the port has multiple fixed IPs.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -52,3 +55,4 @@ The following attributes are exported:
 * `address` - The actual floating IP address itself.
 * `port_id` - ID of associated port.
 * `tenant_id` - the ID of the tenant in which to create the floating IP.
+* `fixed_ip` - The fixed IP which the floating IP maps to.


### PR DESCRIPTION
When creating ports with multiple fixed addresses, you cannot assign a floating ip to it unless specifying which fixed address to map to. This PR adds functionality for specifying it.