### PR TITLE
provider/openstack: Enable DHCP By Default

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
@@ -85,7 +85,7 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
+				Default:  true,
 			},
 			"dns_nameservers": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -188,7 +188,6 @@ func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("tenant_id", s.TenantID)
 	d.Set("allocation_pools", s.AllocationPools)
 	d.Set("gateway_ip", s.GatewayIP)
-	d.Set("enable_dhcp", s.EnableDHCP)
 	d.Set("dns_nameservers", s.DNSNameservers)
 	d.Set("host_routes", s.HostRoutes)
 

--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -29,7 +29,7 @@ func TestAccNetworkingV2Subnet_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "name", "tf-test-subnet"),
 					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "gateway_ip", "192.168.199.1"),
-					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "enable_dhcp", "false"),
+					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "enable_dhcp", "true"),
 				),
 			},
 		},
@@ -49,6 +49,25 @@ func TestAccNetworkingV2Subnet_enableDHCP(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SubnetExists(t, "openstack_networking_subnet_v2.subnet_1", &subnet),
 					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "enable_dhcp", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Subnet_disableDHCP(t *testing.T) {
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Subnet_disableDHCP,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists(t, "openstack_networking_subnet_v2.subnet_1", &subnet),
+					resource.TestCheckResourceAttr("openstack_networking_subnet_v2.subnet_1", "enable_dhcp", "false"),
 				),
 			},
 		},
@@ -182,6 +201,19 @@ var testAccNetworkingV2Subnet_enableDHCP = fmt.Sprintf(`
     cidr = "192.168.199.0/24"
     gateway_ip = "192.168.199.1"
     enable_dhcp = true
+  }`)
+
+var testAccNetworkingV2Subnet_disableDHCP = fmt.Sprintf(`
+  resource "openstack_networking_network_v2" "network_1" {
+    name = "network_1"
+    admin_state_up = "true"
+  }
+
+  resource "openstack_networking_subnet_v2" "subnet_1" {
+    name = "tf-test-subnet"
+    network_id = "${openstack_networking_network_v2.network_1.id}"
+    cidr = "192.168.199.0/24"
+    enable_dhcp = false
   }`)
 
 var testAccNetworkingV2Subnet_noGateway = fmt.Sprintf(`

--- a/website/source/docs/providers/openstack/r/networking_subnet_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_subnet_v2.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `enable_dhcp` - (Optional) The administrative state of the network.
     Acceptable values are "true" and "false". Changing this value enables or
-    disables the DHCP capabilities of the existing subnet.
+    disables the DHCP capabilities of the existing subnet. Defaults to true.
 
 * `dns_nameservers` - (Optional) An array of DNS name server names used by hosts
     in this subnet. Changing this updates the DNS name servers for the existing


### PR DESCRIPTION
The openstack_networking_subnet_v2 resource was originally designed
to have DHCP disabled by default; however, a bug in the original
implementation caused DHCP to always be enabled and never be
disabled. This bug was fixed in #6052.

Recent discussions have shown that users prefer if DHCP is enabled
by default. This commit implements makes the change.

Fixes #6748