### PR TITLE
core: Another validate test for computed module var refs

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -776,3 +776,30 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 		t.Fatal("err:", e)
 	}
 }
+
+// When module vars reference something that is actually computed, this
+// shouldn't cause validation to fail.
+func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
+	input := new(MockUIInput)
+
+	m := testModule(t, "validate-computed-module-var-ref")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		UIInput: input,
+	})
+
+	w, e := ctx.Validate()
+	if w != nil {
+		t.Log("warnings:", w)
+	}
+	if e != nil {
+		t.Fatal("err:", e)
+	}
+}

--- a/terraform/test-fixtures/validate-computed-module-var-ref/dest/main.tf
+++ b/terraform/test-fixtures/validate-computed-module-var-ref/dest/main.tf
@@ -1,0 +1,5 @@
+variable "destin" { }
+
+resource "aws_instance" "dest" {
+  attr = "${var.destin}"
+}

--- a/terraform/test-fixtures/validate-computed-module-var-ref/main.tf
+++ b/terraform/test-fixtures/validate-computed-module-var-ref/main.tf
@@ -1,0 +1,8 @@
+module "source" {
+  source = "./source"
+}
+
+module "dest" {
+  source = "./dest"
+  destin = "${module.source.sourceout}"
+}

--- a/terraform/test-fixtures/validate-computed-module-var-ref/source/main.tf
+++ b/terraform/test-fixtures/validate-computed-module-var-ref/source/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "source" { }
+
+output "sourceout" { value = "${aws_instance.source.id}" }


### PR DESCRIPTION
I wanted to make sure this case was handled, and it is!

So here's an extra test for us.