### PR TITLE
provider/google: Provide valid config in acctest

### DIFF
--- a/builtin/providers/google/resource_storage_bucket_test.go
+++ b/builtin/providers/google/resource_storage_bucket_test.go
@@ -117,7 +117,7 @@ func TestAccStorageForceDestroy(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: "",
+				Config: testGoogleStorageBucketsReaderCustomAttributes("idontexist"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStorageBucketMissing(bucketName),
 				),


### PR DESCRIPTION
The changes to allow for testing ID-only refresh conflict with passing in "" as Config for tests. In this case we instead construct a config with a known-non-existent bucket name.

Previously we were seeing a test failure:

```
=== RUN   TestAccStorageForceDestroy
Created object bucketDestroyTestFile at location https://www.googleapis.com/storage/v1/b/tf-test-acl-bucket-8793874647999722819/o/bucketDestroyTestFile
--- FAIL: TestAccStorageForceDestroy (8.20s)
    testing.go:239: Step 2 error: unknown test mode for step. Please see TestStep docs
        
        resource.TestStep{ResourceName:"", PreConfig:(func())(nil), Config:"", Check:(resource.TestCheckFunc)(0x61eb10), Destroy:false, ExpectNonEmptyPlan:false, ImportState:false, ImportStateId:"", ImportStateCheck:(resource.ImportStateCheckFunc)(nil), ImportStateVerify:false, ImportStateVerifyIgnore:[]string(nil)}
FAIL
```