### PR TITLE
provider/aws: Implementing `vpc_peering_connection_accept`

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -260,6 +260,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_dhcp_options_association":             resourceAwsVpcDhcpOptionsAssociation(),
 			"aws_vpc_dhcp_options":                         resourceAwsVpcDhcpOptions(),
 			"aws_vpc_peering_connection":                   resourceAwsVpcPeeringConnection(),
+			"aws_vpc_peering_connection_accept":            resourceAwsVpcPeeringConnectionAccept(),
 			"aws_vpc":                                      resourceAwsVpc(),
 			"aws_vpc_endpoint":                             resourceAwsVpcEndpoint(),
 			"aws_vpn_connection":                           resourceAwsVpnConnection(),

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_accept.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_accept.go
@@ -1,0 +1,64 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsVpcPeeringConnectionAccept() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsVPCPeeringAcceptCreate,
+		Read:   resourceAwsVPCPeeringAcceptRead,
+		Delete: resourceAwsVPCPeeringAcceptDelete,
+
+		Schema: map[string]*schema.Schema{
+			"peering_connection_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"accept_status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsVPCPeeringAcceptCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if cur, ok := d.Get("accept_status").(string); ok && cur == ec2.VpcPeeringConnectionStateReasonCodeActive {
+		// already accepted
+		return nil
+	}
+
+	status, err := resourceVPCPeeringConnectionAccept(conn, d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("accept_status", status)
+
+	// TODO: should we poll until this resolves? VpcPeeringConnectionStateReasonCodePendingAcceptance
+
+	if status != ec2.VpcPeeringConnectionStateReasonCodeActive {
+		return fmt.Errorf("Error accepting connection, state: %s", status)
+	}
+	return nil
+}
+
+func resourceAwsVPCPeeringAcceptRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	_, status, err := resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, d.Id())()
+	if err != nil {
+		return err
+	}
+	d.Set("accept_status", status)
+	d.SetId(d.Get("peering_connection_id").(string))
+	return nil
+}
+
+func resourceAwsVPCPeeringAcceptDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_accept_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_accept_test.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccAWSVPCPeeringConnectionAccept_basic(t *testing.T) {
+	var connection ec2.VpcPeeringConnection
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if os.Getenv("AWS_ACCOUNT_ID") == "" {
+				t.Fatal("AWS_ACCOUNT_ID must be set")
+			}
+		},
+
+		IDRefreshName:   "aws_vpc_peering_connection.foo",
+		IDRefreshIgnore: []string{"auto_accept"},
+
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcPeeringAcceptConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists("aws_vpc_peering_connection.foo", &connection),
+					testAccCheckAWSVpcPeeringConnectionAccepted(&connection),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSVpcPeeringConnectionAccepted(conn *ec2.VpcPeeringConnection) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if conn.Status == nil {
+			return fmt.Errorf("No vpc peering connection status")
+		}
+		if *conn.Status.Code != ec2.VpcPeeringConnectionStateReasonCodeActive {
+			return fmt.Errorf("Vpc peering connection not accepted: %s", conn.Status.Code)
+		}
+		return nil
+	}
+}
+
+const testAccVpcPeeringAcceptConfig = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc" "bar" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc_peering_connection" "foo" {
+  vpc_id = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+  auto_accept = false
+}
+
+resource "aws_vpc_peering_connection_accept" "foo" {
+  peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
+}
+`

--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_vpc_peering_connection"
 sidebar_current: "docs-aws-resource-vpc-peering"
 description: |-
-  Provides an VPC Peering Connection resource.
+  Provides a VPC Peering Connection resource.
 ---
 
 # aws\_vpc\_peering\_connection
 
-Provides an VPC Peering Connection resource.
+Provides a VPC Peering Connection resource.
 
 ## Example Usage
 

--- a/website/source/docs/providers/aws/r/vpc_peering_accept.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering_accept.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: aws_vpc_peering_connection_accept"
+sidebar_current: "docs-aws-resource-vpc-peering-accept"
+description: |-
+  Provides a VPC Peering Connection Accept resource.
+---
+
+# aws\_vpc\_peering\_connection\_accept
+
+Provides a VPC Peering Connection Accept resource.
+
+## Example Usage
+
+Basic usage:
+
+```
+resource "aws_vpc" "main" {
+    cidr_block = "10.0.0.0/16"
+}
+
+provider "aws" {
+    // another AWS account creds
+    access_key = "..."
+    secret_key = "..."
+    alias = "peer"
+}
+
+resource "aws_vpc" "peer" {
+    provider = "aws.peer"
+    cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc_peering_connection" "peer" {
+    vpc_id = "${aws_vpc.main.id}"
+    peer_vpc_id = "${aws_vpc.peer.id}"
+    auto_accept = false
+}
+
+resource "aws_vpc_peering_connection_accept" "peer" {
+    provider = "aws.peer"
+    peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `peering_connection_id` - (Required) The VPC Peering Connection ID to accept.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the VPC Peering Connection.
+* `accept_status` - The Status of the VPC peering connection request.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -786,6 +786,10 @@
                             <a href="/docs/providers/aws/r/vpc_peering.html">aws_vpc_peering_connection</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-vpc-peering-accept") %>>
+                            <a href="/docs/providers/aws/r/vpc_peering_accept.html">aws_vpc_peering_connection_accept</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-vpn-connection") %>>
                             <a href="/docs/providers/aws/r/vpn_connection.html">aws_vpn_connection</a>
                         </li>


### PR DESCRIPTION
## Problem

Currently `aws_vpc_peering_connection` provides a way to `auto_accept` a peering connection.  This works great until you have a peering connection between 2 VPCs that are in different aws accounts.  If you specify `auto_accept = true` to automate the peering connection accept, aws will error during a terraform apply that you are not authorized to accept.
## Solution

The solution is to utilize provider aliases to execute the accept under different aws account credentials.  See example below.

```
resource "aws_vpc_peering_connection" "peer1" {
  // use peering connection like normal
  auto_accept = false
}

provider "aws" {
  alias = "other"
  // other account credentials
}

resource "aws_vpc_peering_connection_accept" "peer1" {
  peering_connection_id = "${aws_vpc_peering_connection.peer1.id}"

  provider = "aws.other"
}
```
