### PR TITLE
provider/openstack: Rebuild On Network Changes

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -114,26 +114,31 @@ func resourceComputeInstanceV2() *schema.Resource {
 						"uuid": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							Computed: true,
 						},
 						"name": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							Computed: true,
 						},
 						"port": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							Computed: true,
 						},
 						"fixed_ip_v4": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							Computed: true,
 						},
 						"fixed_ip_v6": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							Computed: true,
 						},
 						"floating_ip": &schema.Schema{

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -267,16 +267,19 @@ The following arguments are supported:
 The `network` block supports:
 
 * `uuid` - (Required unless `port`  or `name` is provided) The network UUID to
-    attach to the server.
+    attach to the server. Changing this creates a new server.
 
 * `name` - (Required unless `uuid` or `port` is provided) The human-readable
-    name of the network.
+    name of the network. Changing this creates a new server.
 
 * `port` - (Required unless `uuid` or `name` is provided) The port UUID of a
-    network to attach to the server.
+    network to attach to the server. Changing this creates a new server.
 
 * `fixed_ip_v4` - (Optional) Specifies a fixed IPv4 address to be used on this
-    network.
+    network. Changing this creates a new server.
+
+* `fixed_ip_v6` - (Optional) Specifies a fixed IPv6 address to be used on this
+    network. Changing this creates a new server.
 
 * `floating_ip` - (Optional) Specifies a floating IP address to be associated
     with this network. Cannot be combined with a top-level floating IP. See


### PR DESCRIPTION
This commit makes it so that openstack_compute_instance_v2 resources
are recreated when any network setting (except Floating IPs) is
changed.

Fixes #6740