### PR TITLE
core: Keep errors/warning out of stdout for ease of automation

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -26,7 +26,7 @@ func init() {
 		OutputPrefix: OutputPrefix,
 		InfoPrefix:   OutputPrefix,
 		ErrorPrefix:  ErrorPrefix,
-		Ui:           &cli.BasicUi{Writer: os.Stdout},
+		Ui:           &cli.BasicUi{Writer: os.Stdout, ErrorWriter: os.Stderr},
 	}
 
 	meta := command.Meta{


### PR DESCRIPTION
Some warnings about internal plugins were cluttering the output and confusing scripts depending on that output. This seems to keep the warnings & such out of `stdout`