### PR TITLE
provider/azurerm: Add support for storage container name validation

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_container_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container_test.go
@@ -120,6 +120,34 @@ func testCheckAzureRMStorageContainerDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestValidateArmStorageContainerName(t *testing.T) {
+	validNames := []string{
+		"valid-name",
+		"valid02-name",
+	}
+	for _, v := range validNames {
+		_, errors := validateArmStorageContainerName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Storage Container Name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"InvalidName1",
+		"-invalidname1",
+		"invalid_name",
+		"invalid!",
+		"ww",
+		strings.Repeat("w", 65),
+	}
+	for _, v := range invalidNames {
+		_, errors := validateArmStorageContainerName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid Storage Container Name", v)
+		}
+	}
+}
+
 var testAccAzureRMStorageContainer_basic = `
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"


### PR DESCRIPTION
Fixes #6846

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestValidateArmStorageContainerName'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestValidateArmStorageContainerName -timeout 120m
=== RUN   TestValidateArmStorageContainerName
--- PASS: TestValidateArmStorageContainerName (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm        0.012s
```