### PR TITLE
provider/azurerm: Remove storage containers and blobs when storage accounts are not found

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_blob_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob_test.go
@@ -120,9 +120,12 @@ func testCheckAzureRMStorageBlobExists(name string) resource.TestCheckFunc {
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
-		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
 		if err != nil {
 			return err
+		}
+		if !accountExists {
+			return fmt.Errorf("Bad: Storage Account %q does not exist", storageAccountName)
 		}
 
 		exists, err := blobClient.BlobExists(storageContainerName, name)
@@ -153,8 +156,11 @@ func testCheckAzureRMStorageBlobDestroy(s *terraform.State) error {
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
-		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
 		if err != nil {
+			return nil
+		}
+		if !accountExists {
 			return nil
 		}
 

--- a/builtin/providers/azurerm/resource_arm_storage_container.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container.go
@@ -67,9 +67,12 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
 	if err != nil {
 		return err
+	}
+	if !accountExists {
+		return fmt.Errorf("Storage Account %q Not Found", storageAccountName)
 	}
 
 	name := d.Get("name").(string)
@@ -99,9 +102,14 @@ func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
 	if err != nil {
 		return err
+	}
+	if !accountExists {
+		log.Printf("[DEBUG] Storage account %q not found, removing container %q from state", storageAccountName, d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	name := d.Get("name").(string)
@@ -142,9 +150,14 @@ func resourceArmStorageContainerExists(d *schema.ResourceData, meta interface{})
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
 	if err != nil {
 		return false, err
+	}
+	if !accountExists {
+		log.Printf("[DEBUG] Storage account %q not found, removing container %q from state", storageAccountName, d.Id())
+		d.SetId("")
+		return false, nil
 	}
 
 	name := d.Get("name").(string)
@@ -171,9 +184,13 @@ func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{})
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
+	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroupName, storageAccountName)
 	if err != nil {
 		return err
+	}
+	if !accountExists {
+		log.Printf("[INFO]Storage Account %q doesn't exist so the container won't exist", storageAccountName)
+		return nil
 	}
 
 	name := d.Get("name").(string)

--- a/builtin/providers/azurerm/resource_arm_storage_container_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -12,6 +13,8 @@ import (
 )
 
 func TestAccAzureRMStorageContainer_basic(t *testing.T) {
+	var c storage.Container
+
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
 	config := fmt.Sprintf(testAccAzureRMStorageContainer_basic, ri, rs)
@@ -24,14 +27,38 @@ func TestAccAzureRMStorageContainer_basic(t *testing.T) {
 			resource.TestStep{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageContainerExists("azurerm_storage_container.test"),
+					testCheckAzureRMStorageContainerExists("azurerm_storage_container.test", &c),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureRMStorageContainerExists(name string) resource.TestCheckFunc {
+func TestAccAzureRMStorageContainer_disappears(t *testing.T) {
+	var c storage.Container
+
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageContainer_basic, ri, rs)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageContainerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageContainerExists("azurerm_storage_container.test", &c),
+					testAccARMStorageContainerDisappears("azurerm_storage_container.test", &c),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMStorageContainerExists(name string, c *storage.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, ok := s.RootModule().Resources[name]
@@ -47,9 +74,12 @@ func testCheckAzureRMStorageContainerExists(name string) resource.TestCheckFunc 
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
-		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
 		if err != nil {
 			return err
+		}
+		if !accountExists {
+			return fmt.Errorf("Bad: Storage Account %q does not exist", storageAccountName)
 		}
 
 		containers, err := blobClient.ListContainers(storage.ListContainersParameters{
@@ -65,11 +95,45 @@ func testCheckAzureRMStorageContainerExists(name string) resource.TestCheckFunc 
 		for _, container := range containers.Containers {
 			if container.Name == name {
 				found = true
+				*c = container
 			}
 		}
 
 		if !found {
 			return fmt.Errorf("Bad: Storage Container %q (storage account: %q) does not exist", name, storageAccountName)
+		}
+
+		return nil
+	}
+}
+
+func testAccARMStorageContainerDisappears(name string, c *storage.Container) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage container: %s", c.Name)
+		}
+
+		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return err
+		}
+		if !accountExists {
+			log.Printf("[INFO]Storage Account %q doesn't exist so the container won't exist", storageAccountName)
+			return nil
+		}
+
+		_, err = blobClient.DeleteContainerIfExists(c.Name)
+		if err != nil {
+			return err
 		}
 
 		return nil
@@ -90,9 +154,12 @@ func testCheckAzureRMStorageContainerDestroy(s *terraform.State) error {
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
-		blobClient, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
 		if err != nil {
 			//If we can't get keys then the blob can't exist
+			return nil
+		}
+		if !accountExists {
 			return nil
 		}
 

--- a/builtin/providers/azurerm/resource_arm_storage_queue.go
+++ b/builtin/providers/azurerm/resource_arm_storage_queue.go
@@ -71,9 +71,12 @@ func resourceArmStorageQueueCreate(d *schema.ResourceData, meta interface{}) err
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	queueClient, accountExists, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
 	if err != nil {
 		return err
+	}
+	if !accountExists {
+		return fmt.Errorf("Storage Account %q Not Found", storageAccountName)
 	}
 
 	name := d.Get("name").(string)
@@ -109,9 +112,14 @@ func resourceArmStorageQueueExists(d *schema.ResourceData, meta interface{}) (bo
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	queueClient, accountExists, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
 	if err != nil {
 		return false, err
+	}
+	if !accountExists {
+		log.Printf("[DEBUG] Storage account %q not found, removing queue %q from state", storageAccountName, d.Id())
+		d.SetId("")
+		return false, nil
 	}
 
 	name := d.Get("name").(string)
@@ -136,9 +144,13 @@ func resourceArmStorageQueueDelete(d *schema.ResourceData, meta interface{}) err
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	queueClient, accountExists, err := armClient.getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName)
 	if err != nil {
 		return err
+	}
+	if !accountExists {
+		log.Printf("[INFO]Storage Account %q doesn't exist so the blob won't exist", storageAccountName)
+		return nil
 	}
 
 	name := d.Get("name").(string)

--- a/builtin/providers/azurerm/resource_arm_storage_queue_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_queue_test.go
@@ -87,9 +87,12 @@ func testCheckAzureRMStorageQueueExists(name string) resource.TestCheckFunc {
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
-		queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroup, storageAccountName)
+		queueClient, accountExists, err := armClient.getQueueServiceClientForStorageAccount(resourceGroup, storageAccountName)
 		if err != nil {
 			return err
+		}
+		if !accountExists {
+			return fmt.Errorf("Bad: Storage Account %q does not exist", storageAccountName)
 		}
 
 		exists, err := queueClient.QueueExists(name)
@@ -119,8 +122,11 @@ func testCheckAzureRMStorageQueueDestroy(s *terraform.State) error {
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
-		queueClient, err := armClient.getQueueServiceClientForStorageAccount(resourceGroup, storageAccountName)
+		queueClient, accountExists, err := armClient.getQueueServiceClientForStorageAccount(resourceGroup, storageAccountName)
 		if err != nil {
+			return nil
+		}
+		if !accountExists {
 			return nil
 		}
 


### PR DESCRIPTION
Fixes #6725

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMStorageAccount'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMStorageAccount -timeout 120m
=== RUN   TestAccAzureRMStorageAccount_basic
--- PASS: TestAccAzureRMStorageAccount_basic (181.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	181.892s


make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMStorageQueue'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMStorageQueue -timeout 120m
=== RUN   TestAccAzureRMStorageQueue_basic
--- PASS: TestAccAzureRMStorageQueue_basic (158.08s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	158.094s


make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMStorageBlob'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMStorageBlob -timeout 120m
=== RUN   TestAccAzureRMStorageBlob_basic
--- PASS: TestAccAzureRMStorageBlob_basic (161.40s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	161.415s


make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMStorageContainer'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMStorageContainer -timeout 120m
=== RUN   TestAccAzureRMStorageContainer_basic
--- PASS: TestAccAzureRMStorageContainer_basic (156.35s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	156.370s
```