### PR TITLE
Revert "core: Keep errors/warning out of stdout for ease of automation"

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -26,7 +26,7 @@ func init() {
 		OutputPrefix: OutputPrefix,
 		InfoPrefix:   OutputPrefix,
 		ErrorPrefix:  ErrorPrefix,
-		Ui:           &cli.BasicUi{Writer: os.Stdout, ErrorWriter: os.Stderr},
+		Ui:           &cli.BasicUi{Writer: os.Stdout},
 	}
 
 	meta := command.Meta{


### PR DESCRIPTION
Reverts hashicorp/terraform#6848

All errors are swallowed after this merge. Oops! 😊  

![zsh](https://cloud.githubusercontent.com/assets/37534/15519767/9c35c5a0-21c8-11e6-89ba-b8f45025146c.png)

We'll have to revisit this w/ a bit more testing.