### PR TITLE
provider/openstack: Ensure CIDRs Are Lower Case

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -66,6 +67,9 @@ func resourceComputeSecGroupV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: false,
+							StateFunc: func(v interface{}) string {
+								return strings.ToLower(v.(string))
+							},
 						},
 						"from_group_id": &schema.Schema{
 							Type:     schema.TypeString,
@@ -355,7 +359,7 @@ func secgroupRuleV2Hash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%s-", m["ip_protocol"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["cidr"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["cidr"].(string))))
 	buf.WriteString(fmt.Sprintf("%s-", m["from_group_id"].(string)))
 	buf.WriteString(fmt.Sprintf("%t-", m["self"].(bool)))
 

--- a/builtin/providers/openstack/resource_openstack_compute_secgroup_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_secgroup_v2_test.go
@@ -124,6 +124,26 @@ func TestAccComputeV2SecGroup_icmpZero(t *testing.T) {
 	})
 }
 
+func TestAccComputeV2SecGroup_lowerCaseCIDR(t *testing.T) {
+	var secgroup secgroups.SecurityGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2SecGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2SecGroup_lowerCaseCIDR,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2SecGroupExists(t, "openstack_compute_secgroup_v2.test_group_1", &secgroup),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_secgroup_v2.test_group_1", "rule.3862435458.cidr", "2001:558:fc00::/39"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeV2SecGroupDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	computeClient, err := config.computeV2Client(OS_REGION_NAME)
@@ -332,5 +352,17 @@ var testAccComputeV2SecGroup_icmpZero = fmt.Sprintf(`
 			to_port = 0
 			ip_protocol = "icmp"
 			cidr = "0.0.0.0/0"
+		}
+	}`)
+
+var testAccComputeV2SecGroup_lowerCaseCIDR = fmt.Sprintf(`
+	resource "openstack_compute_secgroup_v2" "test_group_1" {
+		name = "test_group_1"
+		description = "first test security group"
+		rule {
+			from_port = 0
+			to_port = 0
+			ip_protocol = "icmp"
+			cidr = "2001:558:FC00::/39"
 		}
 	}`)

--- a/builtin/providers/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -64,6 +65,9 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
+				StateFunc: func(v interface{}) string {
+					return strings.ToLower(v.(string))
+				},
 			},
 			"security_group_id": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
This commit ensures that CIDR arguments are converted into lower
case values, specifically for IPv6 addresses.

Fixes #6451 