### PR TITLE
provider/aws: Add entry to changelog to note backwards incompatibilty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
  * `openstack_networking_subnet_v2` now defaults to turning DHCP on.
  * `resource_aws_instance`: EC2 Classic users may continue to use
    `security_groups` to reference Security Groups by their `name`. Users who are
-   using Instances inside VPCs will need to use `vpc_security_group_ids` instead, 
+   managing Instances inside VPCs will need to use `vpc_security_group_ids` instead, 
    and reference the security groups by their `id`. 
    Ref https://github.com/hashicorp/terraform/issues/6416#issuecomment-219145065
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
  * The `terraform plan` command no longer persists state. This makes the command much safer to run, since it is now side-effect free. The `refresh` and `apply` commands still persist state to local and remote storage. Any automation that assumes that `terraform plan` persists state will need to be reworked to explicitly call `terraform refresh` to get the equivalent side-effect.
  * The `concat()` interpolation function can no longer be used to join strings.
  * `openstack_networking_subnet_v2` now defaults to turning DHCP on.
+ * `resource_aws_instance`: EC2 Classic users may continue to use
+   `security_groups` to reference Security Groups by their `name`. All VPC users will
+   need to use `vpc_security_group_ids` instead and reference groups by their `id`.
+   Ref https://github.com/hashicorp/terraform/issues/6416#issuecomment-219145065
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
  * The `concat()` interpolation function can no longer be used to join strings.
  * `openstack_networking_subnet_v2` now defaults to turning DHCP on.
  * `resource_aws_instance`: EC2 Classic users may continue to use
-   `security_groups` to reference Security Groups by their `name`. All VPC users will
-   need to use `vpc_security_group_ids` instead and reference groups by their `id`.
+   `security_groups` to reference Security Groups by their `name`. Users who are
+   using Instances inside VPCs will need to use `vpc_security_group_ids` instead, 
+   and reference the security groups by their `id`. 
    Ref https://github.com/hashicorp/terraform/issues/6416#issuecomment-219145065
 
 FEATURES:

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -49,7 +49,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 * `key_name` - (Optional) The key name to use for the instance.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)
 * `security_groups` - (Optional) A list of security group names to associate with.
-   If you are within a non-default VPC, you'll need to use `vpc_security_group_ids` instead.
+   If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 * `vpc_security_group_ids` - (Optional) A list of security group IDs to associate with.
 * `subnet_id` - (Optional) The VPC Subnet ID to launch in.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.  Boolean value. 


### PR DESCRIPTION
Make note of the backwards incompatibly with AWS Instance and `security_groups` and `vpc_security_group_ids`. Links to  https://github.com/hashicorp/terraform/issues/6416#issuecomment-219145065. Opening this PR for any wordsmithing needed