### PR TITLE
Allow specifying a default value to lookup()

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -713,11 +713,32 @@ func TestInterpolateFuncLookup(t *testing.T) {
 				true,
 			},
 
+			// Supplied default with valid key
+			{
+				`${lookup(var.foo, "bar", "")}`,
+				"baz",
+				false,
+			},
+
+			// Supplied default with invalid key
+			{
+				`${lookup(var.foo, "zip", "")}`,
+				"",
+				false,
+			},
+
 			// Too many args
 			{
-				`${lookup(var.foo, "bar", "baz")}`,
+				`${lookup(var.foo, "bar", "", "abc")}`,
 				nil,
 				true,
+			},
+
+			// Non-empty default
+			{
+				`${lookup(var.foo, "zap", "xyz")}`,
+				"xyz",
+				false,
 			},
 		},
 	})

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -160,9 +160,11 @@ The supported built-in functions are:
       * `${length(split(",", "a,b,c"))}` = 3
       * `${length("a,b,c")}` = 5
 
-  * `lookup(map, key)` - Performs a dynamic lookup into a mapping
+  * `lookup(map, key [, default])` - Performs a dynamic lookup into a mapping
       variable. The `map` parameter should be another variable, such
-      as `var.amis`.
+      as `var.amis`. If `key` does not exist in `map`, the interpolation will
+      fail unless you specify a third argument, `default`, which should be a
+      string value to return if no `key` is found in `map.
 
   * `lower(string)` - Returns a copy of the string with all Unicode letters mapped to their lower case.
 


### PR DESCRIPTION
This should fix #4474 in which lookup() calls fail and short-circuit the entire interpolation when the given key is not found in the map. This allows an optional third argument for providing a default value when the key does not exist in the map, which will allow better composition of lookup() with coalesce() et al.