### PR TITLE
provider/aws: Fix typo in ELB import test

### DIFF
--- a/builtin/providers/aws/import_aws_elb_test.go
+++ b/builtin/providers/aws/import_aws_elb_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAccAWSELB_importBasic(t *testing.T) {
-	resourceName := "aws_subnet.bar"
+	resourceName := "aws_elb.bar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
Fixes a simple typo and `TestAccAWSELB_importBasic` will now pass 