### PR TITLE
Adding a simple way to support authenticate registry.

### DIFF
--- a/builtin/providers/docker/resource_docker_image_funcs.go
+++ b/builtin/providers/docker/resource_docker_image_funcs.go
@@ -156,7 +156,9 @@ func pullImage(data *Data, client *dc.Client, image string) error {
 
 	if pullOpts.Registry != "" {
 		auths, _ := dc.NewAuthConfigurationsFromDockerCfg()
-		auth = auths.Configs["https://"+pullOpts.Registry]
+		if auths != nil {
+			auth = auths.Configs["https://"+pullOpts.Registry]
+		}
 	}
 
 	if err := client.PullImage(pullOpts, auth); err != nil {

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -73,3 +73,5 @@ The following attributes are exported
 
 * `id` - the `key` of the resource supplied above
 * `etag` - the ETag generated for the object (an MD5 sum of the object content).
+* `version_id` - A unique version ID value for the object, if bucket versioning
+is enabled.


### PR DESCRIPTION
This change will allow terraform to support the docker mechanism for authenticated private registry. It is simple in the sense that it does not require any changes to the manifest. The credentials are provided via the normal docker config.json authentication scheme.