### PR TITLE
core: Write resource mode to state

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1011,6 +1011,12 @@ type ResourceState struct {
 	// this value, it won't be persisted.
 	Type string `json:"type"`
 
+	// Mode indicates the config.ResourceMode of this resource. The default mode
+	// is a ManagedResourceMode, in which case this field will be omitted.
+	// Terraform core manages this value, resource providers should not interact
+	// with it.
+	Mode string `json:"mode,omitempty"`
+
 	// Dependencies are a list of things that this resource relies on
 	// existing to remain intact. For example: an AWS instance might
 	// depend on a subnet (which itself might depend on a VPC, and so
@@ -1537,4 +1543,29 @@ func (s moduleStateSort) Less(i, j int) bool {
 
 func (s moduleStateSort) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
+}
+
+// ResourceModeFromString parses a mode string as written to the state back
+// into a config.ResourceMode
+func ResourceModeFromString(s string) config.ResourceMode {
+	switch s {
+	case "data":
+		return config.DataResourceMode
+	default:
+		return config.ManagedResourceMode
+	}
+}
+
+// ResourceModeAsString stores a config.ResourceMode into a string suitable for
+// saving to the state.
+func ResourceModeAsString(mode config.ResourceMode) string {
+	switch mode {
+	case config.ManagedResourceMode:
+		// Normal resources just have this field omitted from the state.
+		return ""
+	case config.DataResourceMode:
+		return "data"
+	default:
+		panic(fmt.Sprintf("Unrecognized resource mode: %s", mode))
+	}
 }

--- a/terraform/transform_deposed.go
+++ b/terraform/transform_deposed.go
@@ -1,6 +1,10 @@
 package terraform
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/config"
+)
 
 // DeposedTransformer is a GraphTransformer that adds deposed resources
 // to the graph.
@@ -40,6 +44,7 @@ func (t *DeposedTransformer) Transform(g *Graph) error {
 				Index:        i,
 				ResourceName: k,
 				ResourceType: rs.Type,
+				ResourceMode: ResourceModeFromString(rs.Mode),
 				Provider:     rs.Provider,
 			})
 		}
@@ -53,6 +58,7 @@ type graphNodeDeposedResource struct {
 	Index        int
 	ResourceName string
 	ResourceType string
+	ResourceMode config.ResourceMode
 	Provider     string
 }
 
@@ -98,6 +104,7 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 				&EvalWriteStateDeposed{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					ResourceMode: n.ResourceMode,
 					Provider:     n.Provider,
 					State:        &state,
 					Index:        n.Index,
@@ -141,6 +148,7 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 				&EvalWriteStateDeposed{
 					Name:         n.ResourceName,
 					ResourceType: n.ResourceType,
+					ResourceMode: n.ResourceMode,
 					Provider:     n.Provider,
 					State:        &state,
 					Index:        n.Index,

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -306,6 +306,7 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state,
@@ -351,6 +352,7 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state,
@@ -502,6 +504,7 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state,
@@ -525,6 +528,7 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 					Else: &EvalWriteState{
 						Name:         n.stateId(),
 						ResourceType: n.Resource.Type,
+						ResourceMode: n.Resource.Mode,
 						Provider:     n.Resource.Provider,
 						Dependencies: n.StateDependencies(),
 						State:        &state,
@@ -578,6 +582,7 @@ func (n *graphNodeExpandedResource) dataResourceEvalNodes(resource *Resource, in
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state, // state is nil here
@@ -633,6 +638,7 @@ func (n *graphNodeExpandedResource) dataResourceEvalNodes(resource *Resource, in
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state,
@@ -690,6 +696,7 @@ func (n *graphNodeExpandedResource) dataResourceEvalNodes(resource *Resource, in
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state,
@@ -792,6 +799,7 @@ func (n *graphNodeExpandedResource) dataResourceEvalNodes(resource *Resource, in
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state,
@@ -905,6 +913,7 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
+					ResourceMode: n.Resource.Mode,
 					Provider:     n.Resource.Provider,
 					Dependencies: n.StateDependencies(),
 					State:        &state,


### PR DESCRIPTION
Before, the resource mode was implicitly encoded into the
ResourceStateKey (if the key was prefixed with "data."). Here, we add an
explicit "mode" field to the state which makes it easier to interpret a
data source in the state.