### PR TITLE
Fix mixing internal and external plugins

### DIFF
--- a/config.go
+++ b/config.go
@@ -120,32 +120,34 @@ func (c *Config) Discover(ui cli.Ui) error {
 	}
 
 	// Finally, if we have a plugin compiled into Terraform and we didn't find
-	// a replacement on disk, we'll just use the internal version.
-	for name, _ := range command.InternalProviders {
-		if path, found := c.Providers[name]; found {
-			ui.Warn(fmt.Sprintf("[WARN] %s overrides an internal plugin for %s-provider.\n"+
-				"  If you did not expect to see this message you will need to remove the old plugin.\n"+
-				"  See https://www.terraform.io/docs/internals/internal-plugins.html", path, name))
-		} else {
-
-			cmd, err := command.BuildPluginCommandString("provider", name)
-			if err != nil {
-				return err
+	// a replacement on disk, we'll just use the internal version. Only do this
+	// from the main process.
+	if os.Getenv("TF_PLUGIN_MAGIC_COOKIE") == "" {
+		for name, _ := range command.InternalProviders {
+			if path, found := c.Providers[name]; found {
+				ui.Warn(fmt.Sprintf("[WARN] %s overrides an internal plugin for %s-provider.\n"+
+					"  If you did not expect to see this message you will need to remove the old plugin.\n"+
+					"  See https://www.terraform.io/docs/internals/internal-plugins.html", path, name))
+			} else {
+				cmd, err := command.BuildPluginCommandString("provider", name)
+				if err != nil {
+					return err
+				}
+				c.Providers[name] = cmd
 			}
-			c.Providers[name] = cmd
 		}
-	}
-	for name, _ := range command.InternalProvisioners {
-		if path, found := c.Provisioners[name]; found {
-			ui.Warn(fmt.Sprintf("[WARN] %s overrides an internal plugin for %s-provisioner.\n"+
-				"  If you did not expect to see this message you will need to remove the old plugin.\n"+
-				"  See https://www.terraform.io/docs/internals/internal-plugins.html", path, name))
-		} else {
-			cmd, err := command.BuildPluginCommandString("provisioner", name)
-			if err != nil {
-				return err
+		for name, _ := range command.InternalProvisioners {
+			if path, found := c.Provisioners[name]; found {
+				ui.Warn(fmt.Sprintf("[WARN] %s overrides an internal plugin for %s-provisioner.\n"+
+					"  If you did not expect to see this message you will need to remove the old plugin.\n"+
+					"  See https://www.terraform.io/docs/internals/internal-plugins.html", path, name))
+			} else {
+				cmd, err := command.BuildPluginCommandString("provisioner", name)
+				if err != nil {
+					return err
+				}
+				c.Provisioners[name] = cmd
 			}
-			c.Provisioners[name] = cmd
 		}
 	}
 


### PR DESCRIPTION
- Only display the warning in the main process, which prevents the plugin handshake from failing
- Added `TF_PLUGIN_DEV` environment variable; if set the external plugin warning will not be displayed

/cc @stack72 @jen20