### PR TITLE
core: No destroy nodes necessary for data sources

### DIFF
--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -245,6 +245,10 @@ func (n *GraphNodeConfigResource) DestroyNode() GraphNodeDestroy {
 		return nil
 	}
 
+	if n.Resource.Mode == config.DataResourceMode {
+		return nil
+	}
+
 	result := &graphNodeResourceDestroy{
 		GraphNodeConfigResource: *n.Copy(),
 		Original:                n,


### PR DESCRIPTION
We don't need to construct destroy nodes for data sources, as there is nothing to do beyond removing them from state. This patch checks the mode during expansion and bails early if we are dealing with a data source.

Prior to this patch, destruction of data sources would (usually) fail with an "unknown resource type x" error, as demonstrated in the tests of the aws_iam_policy_document resource.