### PR TITLE
[WIP] core: Ensure that DataSourcesMap is handled during apply w/destroy

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -168,7 +168,15 @@ func (p *Provider) Apply(
 	info *terraform.InstanceInfo,
 	s *terraform.InstanceState,
 	d *terraform.InstanceDiff) (*terraform.InstanceState, error) {
-	r, ok := p.ResourcesMap[info.Type]
+	m := p.ResourcesMap
+	for k, v := range p.DataSourcesMap {
+		if _, ok := m[k]; ok {
+			panic(fmt.Errorf("Data source %s is also a resource. This is a bug and should be reported.", k))
+		}
+		m[k] = v
+	}
+
+	r, ok := m[info.Type]
 	if !ok {
 		return nil, fmt.Errorf("unknown resource type: %s", info.Type)
 	}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -133,11 +133,12 @@ func (r *Resource) Apply(
 
 	if d.Destroy || d.RequiresNew() {
 		if s.ID != "" {
-			// Destroy the resource since it is created
-			if err := r.Delete(data, meta); err != nil {
-				return r.recordCurrentSchemaVersion(data.State()), err
+			if r.Delete != nil {
+				// Destroy the resource since it is created
+				if err := r.Delete(data, meta); err != nil {
+					return r.recordCurrentSchemaVersion(data.State()), err
+				}
 			}
-
 			// Make sure the ID is gone.
 			data.SetId("")
 		}

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -100,6 +100,36 @@ func TestResourceApply_destroy(t *testing.T) {
 	}
 }
 
+func TestResourceApply_destroyDataSource(t *testing.T) {
+	// data sources do not have a destroy function, so we need to test that a
+	// destroy operation will properly skip over it if it is not defined.
+	r := &Resource{
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+	}
+
+	s := &terraform.InstanceState{
+		ID: "bar",
+	}
+
+	d := &terraform.InstanceDiff{
+		Destroy: true,
+	}
+
+	actual, err := r.Apply(s, d, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if actual != nil {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestResourceApply_destroyCreate(t *testing.T) {
 	r := &Resource{
 		Schema: map[string]*Schema{


### PR DESCRIPTION
Fixes #6881, which came up for me in #6911 as well. 

WIP because I'm still trying to find a good way to test the `*schema.Provider` part.
