### PR TITLE
provider/aws: remove ah and esp as aws endpoint does not support the string versions

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -82,8 +82,6 @@ func protocolIntegers() map[string]int {
 	var protocolIntegers = make(map[string]int)
 	protocolIntegers = map[string]int{
 		// defined at https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-		"ah":   51,
-		"esp":  50,
 		"udp":  17,
 		"tcp":  6,
 		"icmp": 1,


### PR DESCRIPTION
The AWS endpoint accessed via the aws-go-sdk does not support the string version of the "ah" and "esp" protocols. When attempting to create security group rules (via the go sdk) using the string representations the following errors are returned:

```
InvalidParameterValue: Invalid value 'ah' for IP protocol. Unknown protocol.
        status code: 400, request id: 3fb7c0d8-8fc9-40d7-948b-5b438f671cfc

InvalidParameterValue: Invalid value 'esp' for IP protocol. Unknown protocol.
        status code: 400, request id: 3fb7c0d8-8fc9-40d7-948b-5b438f671cfc
```

The fix for this problem is simply removing ah and esp from the `protocolIntegers` map which will end up in the expected behavior as there is a proper fall through here: https://github.com/hashicorp/terraform/blob/1c81aa3471ee85368cce4f5e1d8030b788012dc4/builtin/providers/aws/resource_aws_security_group.go#L878-L880

Fixes #6888 