### PR TITLE
core: produce diff when data resource config becomes computed

### DIFF
--- a/terraform/test-fixtures/plan-data-resource-becomes-computed/main.tf
+++ b/terraform/test-fixtures/plan-data-resource-becomes-computed/main.tf
@@ -1,0 +1,6 @@
+resource "aws_instance" "foo" {
+}
+
+data "aws_data_resource" "foo" {
+  foo = "${aws_instance.foo.computed}"
+}


### PR DESCRIPTION
Previously the plan phase would produce a data diff only if no state was already present. However, this is a faulty approach because a state will already be present in the case where the data resource depends on a managed resource that existed in state during refresh but became computed during plan, due to a "forces new resource" diff.

Now we will produce a data diff regardless of the presence of the state when the configuration is computed during the plan phase.

This fixes #6824 (and also removes a leftover `TODO` comment that was already done.)