### PR TITLE
provider/openstack: Add delete_on_termination argument to docs

### DIFF
--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -304,6 +304,9 @@ The `block_device` block supports:
 * `destination_type` - (Optional) The type that gets created. Possible values
     are "volume" and "local".
 
+* `delete_on_termination` - (Optional) Delete the volume / block device upon
+    termination of the instance. Defaults to false.
+
 The `volume` block supports:
 
 * `volume_id` - (Required) The UUID of the volume to attach.


### PR DESCRIPTION
This commit adds a description of the delete_on_termination argument
to the openstack_compute_instance_v2 documentation.

Fixes #6402