### PR TITLE
provider/openstack: Enforce ForceNew on Instance Block Device

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -193,37 +193,43 @@ func resourceComputeInstanceV2() *schema.Resource {
 			"block_device": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"source_type": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"uuid": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"volume_size": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 						},
 						"destination_type": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"boot_index": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 						},
 						"delete_on_termination": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+							ForceNew: true,
 						},
 						"guest_format": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -290,22 +290,26 @@ The `network` block supports:
 
 The `block_device` block supports:
 
-* `uuid` - (Required unless `source_type` is set to `"blank"` ) The UUID of the image, volume, or snapshot.
+* `uuid` - (Required unless `source_type` is set to `"blank"` ) The UUID of
+    the image, volume, or snapshot. Changing this creates a new server.
 
 * `source_type` - (Required) The source type of the device. Must be one of
-    "blank", "image", "volume", or "snapshot".
+    "blank", "image", "volume", or "snapshot". Changing this creates a new
+    server.
 
 * `volume_size` - The size of the volume to create (in gigabytes). Required
     in the following combinations: source=image and destination=volume,
-    source=blank and destination=local.
+    source=blank and destination=local. Changing this creates a new server.
 
 * `boot_index` - (Optional) The boot index of the volume. It defaults to 0.
+    Changing this creates a new server.
 
 * `destination_type` - (Optional) The type that gets created. Possible values
-    are "volume" and "local".
+    are "volume" and "local". Changing this creates a new server.
 
 * `delete_on_termination` - (Optional) Delete the volume / block device upon
-    termination of the instance. Defaults to false.
+    termination of the instance. Defaults to false. Changing this creates a
+    new server.
 
 The `volume` block supports:
 


### PR DESCRIPTION
This commit causes openstack_compute_instance_v2 resources to be
destroyed and recreated upon changes to any block_device argument.

Fixes #6473