### PR TITLE
core: Ensure EvalReadDataApply is called on expanded destroy nodes

### DIFF
--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -894,13 +894,30 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 				&EvalRequireState{
 					State: &state,
 				},
-				&EvalApply{
-					Info:     info,
-					State:    &state,
-					Diff:     &diffApply,
-					Provider: &provider,
-					Output:   &state,
-					Error:    &err,
+				// Make sure we handle data sources properly.
+				&EvalIf{
+					If: func(ctx EvalContext) (bool, error) {
+						if n.Resource.Mode == config.DataResourceMode {
+							return true, nil
+						}
+
+						return false, nil
+					},
+
+					Then: &EvalReadDataApply{
+						Info:     info,
+						Diff:     &diffApply,
+						Provider: &provider,
+						Output:   &state,
+					},
+					Else: &EvalApply{
+						Info:     info,
+						State:    &state,
+						Diff:     &diffApply,
+						Provider: &provider,
+						Output:   &state,
+						Error:    &err,
+					},
 				},
 				&EvalWriteState{
 					Name:         n.stateId(),


### PR DESCRIPTION
Ref: #6913

As per the discussion with @apparentlymart, I did a bit more digging in the code and the debug logs, and found the issue is actually with the `ResourceCountTransformer`. Log snip below:

```
2016/05/28 21:06:42 [TRACE] [walkDestroy] Exiting eval tree: provider.aws
2016/05/28 21:06:42 [DEBUG] vertex data.aws_ami_description.nat_ami (destroy), got dep: provider.aws
2016/05/28 21:06:42 [DEBUG] vertex root.data.aws_ami_description.nat_ami (destroy): walking
2016/05/28 21:06:42 [DEBUG] vertex root.data.aws_ami_description.nat_ami (destroy): evaluating
2016/05/28 21:06:42 [TRACE] [walkDestroy] Entering eval tree: data.aws_ami_description.nat_ami (destroy)
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalSequence
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalInterpolate
2016/05/28 21:06:42 [DEBUG] root: eval: terraform.EvalNoop
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalCountFixZeroOneBoundary
2016/05/28 21:06:42 [TRACE] [walkDestroy] Exiting eval tree: data.aws_ami_description.nat_ami (destroy)
2016/05/28 21:06:42 [DEBUG] vertex root.data.aws_ami_description.nat_ami (destroy): expanding/walking dynamic subgraph
2016/05/28 21:06:42 [TRACE] Graph after step *terraform.ResourceCountTransformer:

data.aws_ami_description.nat_ami (destroy) - *terraform.graphNodeExpandedResourceDestroy
2016/05/28 21:06:42 [TRACE] Graph after step *terraform.OrphanTransformer:

data.aws_ami_description.nat_ami (destroy) - *terraform.graphNodeExpandedResourceDestroy
2016/05/28 21:06:42 [TRACE] Graph after step *terraform.DeposedTransformer:

data.aws_ami_description.nat_ami (destroy) - *terraform.graphNodeExpandedResourceDestroy
2016/05/28 21:06:42 [TRACE] Graph after step *terraform.TargetsTransformer:

data.aws_ami_description.nat_ami (destroy) - *terraform.graphNodeExpandedResourceDestroy
2016/05/28 21:06:42 [TRACE] Graph after step *terraform.RootTransformer:

data.aws_ami_description.nat_ami (destroy) - *terraform.graphNodeExpandedResourceDestroy
2016/05/28 21:06:42 [DEBUG] vertex root.data.aws_ami_description.nat_ami (destroy): walking
2016/05/28 21:06:42 [DEBUG] vertex root.data.aws_ami_description.nat_ami (destroy): evaluating
2016/05/28 21:06:42 [TRACE] [walkDestroy] Entering eval tree: data.aws_ami_description.nat_ami (destroy)
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalOpFilter
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalSequence
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalReadDiff
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalFilterDiff
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalIf
2016/05/28 21:06:42 [DEBUG] root: eval: terraform.EvalNoop
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalGetProvider
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalReadState
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalRequireState
2016/05/28 21:06:42 [DEBUG] root: eval: *terraform.EvalApply
2016/05/28 21:06:42 [DEBUG] apply: data.aws_ami_description.nat_ami: executing Apply
panic: bad, not supposed to be here!
```

The node gets transformed into a `graphNodeExpandedResourceDestroy` which was not handling for data sources, putting all nodes through `EvalApply` regardless of what they were.

The fix was simple - handle the apply case properly with an `EvalIf`. Not too sure if an entirely new node type is necessary for this.