### PR TITLE
core: Adding Sensitive attribute to resource schema

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -44,8 +44,9 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"password": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 
 			"engine": &schema.Schema{

--- a/command/format_plan.go
+++ b/command/format_plan.go
@@ -147,26 +147,38 @@ func formatPlanModuleExpand(
 				v = "<computed>"
 			}
 
-			newResource := ""
+			if attrDiff.Sensitive {
+				v = "<sensitive>"
+			}
+
+			updateMsg := ""
 			if attrDiff.RequiresNew && rdiff.Destroy {
-				newResource = opts.Color.Color(" [red](forces new resource)")
+				updateMsg = opts.Color.Color(" [red](forces new resource)")
+			} else if attrDiff.Sensitive && oldValues {
+				updateMsg = opts.Color.Color(" [yellow](attribute changed)")
 			}
 
 			if oldValues {
+				var u string
+				if attrDiff.Sensitive {
+					u = "<sensitive>"
+				} else {
+					u = attrDiff.Old
+				}
 				buf.WriteString(fmt.Sprintf(
 					"    %s:%s %#v => %#v%s\n",
 					attrK,
 					strings.Repeat(" ", keyLen-len(attrK)),
-					attrDiff.Old,
+					u,
 					v,
-					newResource))
+					updateMsg))
 			} else {
 				buf.WriteString(fmt.Sprintf(
 					"    %s:%s %#v%s\n",
 					attrK,
 					strings.Repeat(" ", keyLen-len(attrK)),
 					v,
-					newResource))
+					updateMsg))
 			}
 		}
 

--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -103,15 +103,21 @@ func (h *UiHook) PreApply(
 		attrDiff := d.Attributes[attrK]
 
 		v := attrDiff.New
+		u := attrDiff.Old
 		if attrDiff.NewComputed {
 			v = "<computed>"
+		}
+
+		if attrDiff.Sensitive {
+			u = "<sensitive>"
+			v = "<sensitive>"
 		}
 
 		attrBuf.WriteString(fmt.Sprintf(
 			"  %s:%s %#v => %#v\n",
 			attrK,
 			strings.Repeat(" ", keyLen-len(attrK)),
-			attrDiff.Old,
+			u,
 			v))
 	}
 

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -147,6 +147,12 @@ type Schema struct {
 	//
 	// ValidateFunc currently only works for primitive types.
 	ValidateFunc SchemaValidateFunc
+
+	// Sensitive ensures that the attribute's value does not get displayed in
+	// logs or regular output. It should be used for passwords or other
+	// secret fields. Futrure versions of Terraform may encrypt these
+	// values.
+	Sensitive bool
 }
 
 // SchemaDefaultFunc is a function called to return a default value for
@@ -279,6 +285,11 @@ func (s *Schema) finalizeDiff(
 	if s.ForceNew {
 		// Force new, set it to true in the diff
 		d.RequiresNew = true
+	}
+
+	if s.Sensitive {
+		// Set the Sensitive flag so output is hidden in the UI
+		d.Sensitive = true
 	}
 
 	return d

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -247,22 +247,30 @@ func (d *ModuleDiff) String() string {
 			attrDiff := rdiff.Attributes[attrK]
 
 			v := attrDiff.New
+			u := attrDiff.Old
 			if attrDiff.NewComputed {
 				v = "<computed>"
 			}
 
-			newResource := ""
+			if attrDiff.Sensitive {
+				u = "<sensitive>"
+				v = "<sensitive>"
+			}
+
+			updateMsg := ""
 			if attrDiff.RequiresNew {
-				newResource = " (forces new resource)"
+				updateMsg = " (forces new resource)"
+			} else if attrDiff.Sensitive {
+				updateMsg = " (attribute changed)"
 			}
 
 			buf.WriteString(fmt.Sprintf(
 				"  %s:%s %#v => %#v%s\n",
 				attrK,
 				strings.Repeat(" ", keyLen-len(attrK)),
-				attrDiff.Old,
+				u,
 				v,
-				newResource))
+				updateMsg))
 		}
 	}
 
@@ -284,6 +292,7 @@ type ResourceAttrDiff struct {
 	NewRemoved  bool        // True if this attribute is being removed
 	NewExtra    interface{} // Extra information for the provider
 	RequiresNew bool        // True if change requires new resource
+	Sensitive   bool        // True if the data should not be displayed in UI output
 	Type        DiffAttrType
 }
 

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -153,6 +153,11 @@ func TestModuleDiff_String(t *testing.T) {
 						New:         "bar",
 						RequiresNew: true,
 					},
+					"secretfoo": &ResourceAttrDiff{
+						Old:       "foo",
+						New:       "bar",
+						Sensitive: true,
+					},
 				},
 			},
 		},
@@ -607,7 +612,8 @@ func TestInstanceDiffSame(t *testing.T) {
 
 const moduleDiffStrBasic = `
 CREATE: nodeA
-  bar:     "foo" => "<computed>"
-  foo:     "foo" => "bar"
-  longfoo: "foo" => "bar" (forces new resource)
+  bar:       "foo" => "<computed>"
+  foo:       "foo" => "bar"
+  longfoo:   "foo" => "bar" (forces new resource)
+  secretfoo: "<sensitive>" => "<sensitive>" (attribute changed)
 `


### PR DESCRIPTION
Reference: #516

This is something that I've been mulling for a while but whipped up because we have a use case for it at PBP.

While state can be encrypted on storage, and things can be scripted easily enough to ensure that cached state is dropped after a run, it's a little tougher to hide values from logs when there isn't support for it in core.

This adds the `Sensitive` attribute to the schema, which allows resource and data source maintainers the ability to mark some fields as sensitive so that their output does not get displayed in the diffs and logs that are output to the user. Much like the `sensitive` attribute on an `output`, this currently is a very superficial setting, and only affects output. 

Also, in the future, we could possibly look at leveraging this to start encrypting values in the state, say via something like a pre-shared key supplied via input or an environment variable.

I figured that this was a pretty non-invasive way of working towards better storage of sensitive data, in addition to extending the output obfuscation that's already available in outputs to TF as a whole.

Let me know what you guys think!

PS: As an example, I've updated the `aws_db_instance` resource to mark the `password` field as sensitive.
