### PR TITLE
provider/aws: Mark Lambda function as gone when it's gone

### DIFF
--- a/helper/resource/error.go
+++ b/helper/resource/error.go
@@ -1,5 +1,10 @@
 package resource
 
+import (
+	"fmt"
+	"strings"
+)
+
 type NotFoundError struct {
 	LastError    error
 	LastRequest  interface{}
@@ -14,4 +19,34 @@ func (e *NotFoundError) Error() string {
 	}
 
 	return "couldn't find resource"
+}
+
+// UnexpectedStateError is returned when Refresh returns a state that's neither in Target nor Pending
+type UnexpectedStateError struct {
+	LastError     error
+	State         string
+	ExpectedState []string
+}
+
+func (e *UnexpectedStateError) Error() string {
+	return fmt.Sprintf(
+		"unexpected state '%s', wanted target '%s'. last error: %s",
+		e.State,
+		strings.Join(e.ExpectedState, ", "),
+		e.LastError,
+	)
+}
+
+// TimeoutError is returned when WaitForState times out
+type TimeoutError struct {
+	LastError     error
+	ExpectedState []string
+}
+
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf(
+		"timeout while waiting for state to become '%s'. last error: %s",
+		strings.Join(e.ExpectedState, ", "),
+		e.LastError,
+	)
 }


### PR DESCRIPTION
Replaces https://github.com/hashicorp/terraform/pull/5205

Patches we discussed in that linked PR are implemented + functionality verified (and verifiable by anyone else) manually via `apply`ing https://gist.github.com/radeksimko/e81daddbde9c5aec0fdf3886231a2922 then running

```
aws lambda remove-permission --function-name lambda_function_name --statement-id AllowExecutionFromSNS
```
and then
```
terraform refresh
```

cc @Bowbaq 