### PR TITLE
add an example of cidrsubnet() being used with ipv6

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -99,7 +99,9 @@ The supported built-in functions are:
   * `cidrsubnet(iprange, newbits, netnum)` - Takes an IP address range in
     CIDR notation (like ``10.0.0.0/8``) and extends its prefix to include an
     additional subnet number. For example,
-    ``cidrsubnet("10.0.0.0/8", 8, 2)`` returns ``10.2.0.0/16``.
+    ``cidrsubnet("10.0.0.0/8", 8, 2)`` returns ``10.2.0.0/16``;
+    ``cidrsubnet("2607:f298:6051:516c::/64", 8, 2)`` returns
+    ``2607:f298:6051:516c:200::/72``.
 
   * `coalesce(string1, string2, ...)` - Returns the first non-empty value from
     the given arguments. At least two arguments must be provided.


### PR DESCRIPTION
...as this will hopefully clue people in that this function will indeed work
to manipulate ipv6 networks.

Not that I completely spaced on that for quite some time, or anything like
that.

Nope, not me.  Not at all.