### PR TITLE
Add `name_prefix` to `aws_iam_instance_profile` and `aws_iam_role`

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_instance_profile_test.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile_test.go
@@ -1,9 +1,15 @@
 package aws
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
@@ -18,6 +24,100 @@ func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMInstanceProfile_namePrefix(t *testing.T) {
+	var conf iam.GetInstanceProfileOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:        func() { testAccPreCheck(t) },
+		IDRefreshName:   "aws_iam_instance_profile.test",
+		IDRefreshIgnore: []string{"name_prefix"},
+		Providers:       testAccProviders,
+		CheckDestroy:    testAccCheckAWSInstanceProfileDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSInstanceProfilePrefixNameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInstanceProfileExists("aws_iam_instance_profile.test", &conf),
+					testAccCheckAWSInstanceProfileGeneratedNamePrefix(
+						"aws_iam_instance_profile.test", "test-"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSInstanceProfileGeneratedNamePrefix(resource, prefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("Resource not found")
+		}
+		name, ok := r.Primary.Attributes["name"]
+		if !ok {
+			return fmt.Errorf("Name attr not found: %#v", r.Primary.Attributes)
+		}
+		if !strings.HasPrefix(name, prefix) {
+			return fmt.Errorf("Name: %q, does not have prefix: %q", name, prefix)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSInstanceProfileDestroy(s *terraform.State) error {
+	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iam_instance_profile" {
+			continue
+		}
+
+		// Try to get role
+		_, err := iamconn.GetInstanceProfile(&iam.GetInstanceProfileInput{
+			InstanceProfileName: aws.String(rs.Primary.ID),
+		})
+		if err == nil {
+			return fmt.Errorf("still exist.")
+		}
+
+		// Verify the error is what we want
+		ec2err, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if ec2err.Code() != "NoSuchEntity" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSInstanceProfileExists(n string, res *iam.GetInstanceProfileOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Instance Profile name is set")
+		}
+
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		resp, err := iamconn.GetInstanceProfile(&iam.GetInstanceProfileInput{
+			InstanceProfileName: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		*res = *resp
+
+		return nil
+	}
+}
+
 const testAccAwsIamInstanceProfileConfig = `
 resource "aws_iam_role" "test" {
 	name = "test"
@@ -26,6 +126,18 @@ resource "aws_iam_role" "test" {
 
 resource "aws_iam_instance_profile" "test" {
 	name = "test"
+	roles = ["${aws_iam_role.test.name}"]
+}
+`
+
+const testAccAWSInstanceProfilePrefixNameConfig = `
+resource "aws_iam_role" "test" {
+	name = "test"
+	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+
+resource "aws_iam_instance_profile" "test" {
+	name_prefix = "test-"
 	roles = ["${aws_iam_role.test.name}"]
 }
 `

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -41,7 +41,8 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Required) The profile's name.
+* `name` - (Optional, Forces new resource) The profile's name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the profile.
 * `roles` - (Required) A list of role names to include in the profile.
 

--- a/website/source/docs/providers/aws/r/iam_role.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_role.html.markdown
@@ -37,7 +37,8 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the role.
+* `name` - (Optional, Forces new resource) The name of the role.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `assume_role_policy` - (Required) The policy that grants an entity permission to assume the role.
 * `path` - (Optional) The path to the role.
   See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.


### PR DESCRIPTION
Ref #6099. Add a `name_prefix` attribute to the `aws_iam_instance_profile` and `aws_iam_role` resources.