### PR TITLE
api.opscode.com should be api.chef.io

### DIFF
--- a/website/source/docs/providers/chef/index.html.markdown
+++ b/website/source/docs/providers/chef/index.html.markdown
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available resources.
 ```
 # Configure the Chef provider
 provider "chef" {
-     server_url = "https://api.opscode.com/organizations/example/"
+     server_url = "https://api.chef.io/organizations/example/"
 
      // You can set up a "Client" within the Chef Server management console.
      client_name = "terraform"


### PR DESCRIPTION
The old name still works, but it's better to use the new one.