### PR TITLE
Sort the list of private_ips

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -704,7 +704,7 @@ func flattenGroupIdentifiers(dtos []*ec2.GroupIdentifier) []string {
 //Expands an array of IPs into a ec2 Private IP Address Spec
 func expandPrivateIPAddresses(ips []interface{}) []*ec2.PrivateIpAddressSpecification {
 	dtos := make([]*ec2.PrivateIpAddressSpecification, 0, len(ips))
-	for i, v := range ips {
+	for i, v := range sortInterfaceSlice(ips) {
 		new_private_ip := &ec2.PrivateIpAddressSpecification{
 			PrivateIpAddress: aws.String(v.(string)),
 		}


### PR DESCRIPTION
Very simple change to sort the private_ips before tagging the first one as the primary.  This should really be changed to have private_ips as a sorted list, and use the first, or better, use private_ip as the primary IP address for the instance and private_ips as secondary IP addresses.  For now, this appears to work.  Ran all tests, and created all binaries.  Tested binary on Mac OS X and it uses the "lowest" IP address in the list.  Note that this is a string sort, so lowest is dependent on the natural / canonical order of strings, not numbers, and certainly not real IP addresses.  This works for me, and can't possibly cause problems over a completely arbitrary ordering that was present in the original, but should really sort IPs properly (or use private_ip and private_ips as described above, then no sorting required).
