### PR TITLE
fixed that "output" never got set with outputValueMap

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -59,9 +59,11 @@ func dataSourceRemoteStateRead(d *schema.ResourceData, meta interface{}) error {
 			//This is ok for 0.6.17 as outputs will have been strings
 			outputValueMap[key] = output.Value.(string)
 		}
+		d.Set("output", outputValueMap)
+	} else {
+		d.Set("output", outputs)
 	}
 
 	d.SetId(time.Now().UTC().String())
-	d.Set("output", outputs)
 	return nil
 }


### PR DESCRIPTION
Hi,

Just wanted to report that neither the resource shim or data version of the remote_terraform_state works for me in master/0.7.0-rc1. Totally plain defintions like this, that has worked fine for 0.6.*:

    data "terraform_remote_state" "account" {
        backend = "s3"
        config {
            bucket = "example-hngkr-terraform"
            key = "account"
            region = "eu-west-1"
        }
    }

    resource "terraform_remote_state" "resource_account" {
        backend = "s3"
        config {
            bucket = "example-hngkr-terraform"
            key = "account"
            region = "eu-west-1"
        }
    }

The remote_terraform_state resource always comes up with no output variables and an error along the lines of:

    * Resource 'data.terraform_remote_state.account' does not have attribute 'output.example' for 
    variable 'data.terraform_remote_state.account.output.example'

I took a look at the code and it seems that "output" simply never gets set to the outputValueMap in buildin/providers/terraform/data_source_state.go - the attached PR shows what I did to make it work again .

But it probably only fixes string output variables -- I don't know if the "list/map as first-class citizens" also extends to remote state output variables... I'm sure that @apparentlymart or one of you smarter guys can come up with something better.

Thanks for the work going into 0.7.0 -- it looks to be a really-really great release that fixes a lot of really significant stuff.
