### PR TITLE
core: Remove tests from provider binaries

### DIFF
--- a/builtin/bins/provider-atlas/main_test.go
+++ b/builtin/bins/provider-atlas/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-aws/main_test.go
+++ b/builtin/bins/provider-aws/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-azure/main_test.go
+++ b/builtin/bins/provider-azure/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-clc/main_test.go
+++ b/builtin/bins/provider-clc/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-cloudflare/main_test.go
+++ b/builtin/bins/provider-cloudflare/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-cloudstack/main_test.go
+++ b/builtin/bins/provider-cloudstack/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-consul/main_test.go
+++ b/builtin/bins/provider-consul/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-datadog/main_test.go
+++ b/builtin/bins/provider-datadog/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-digitalocean/main_test.go
+++ b/builtin/bins/provider-digitalocean/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-dme/main_test.go
+++ b/builtin/bins/provider-dme/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-dnsimple/main_test.go
+++ b/builtin/bins/provider-dnsimple/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-docker/main_test.go
+++ b/builtin/bins/provider-docker/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-dyn/main_test.go
+++ b/builtin/bins/provider-dyn/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-fastly/main_test.go
+++ b/builtin/bins/provider-fastly/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-github/main_test.go
+++ b/builtin/bins/provider-github/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-google/main_test.go
+++ b/builtin/bins/provider-google/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-heroku/main_test.go
+++ b/builtin/bins/provider-heroku/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-influxdb/main_test.go
+++ b/builtin/bins/provider-influxdb/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-librato/main_test.go
+++ b/builtin/bins/provider-librato/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-mailgun/main_test.go
+++ b/builtin/bins/provider-mailgun/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-mysql/main_test.go
+++ b/builtin/bins/provider-mysql/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-null/main_test.go
+++ b/builtin/bins/provider-null/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-postgresql/main_test.go
+++ b/builtin/bins/provider-postgresql/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-powerdns/main_test.go
+++ b/builtin/bins/provider-powerdns/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-random/main_test.go
+++ b/builtin/bins/provider-random/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-softlayer/main_test.go
+++ b/builtin/bins/provider-softlayer/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-terraform/main_test.go
+++ b/builtin/bins/provider-terraform/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provider-vsphere/main_test.go
+++ b/builtin/bins/provider-vsphere/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provisioner-chef/main_test.go
+++ b/builtin/bins/provisioner-chef/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provisioner-file/main_test.go
+++ b/builtin/bins/provisioner-file/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provisioner-local-exec/main_test.go
+++ b/builtin/bins/provisioner-local-exec/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/builtin/bins/provisioner-remote-exec/main_test.go
+++ b/builtin/bins/provisioner-remote-exec/main_test.go
@@ -1,1 +1,0 @@
-package main


### PR DESCRIPTION
These tests run each time Travis builds, causing additional noise and a (negligible) speed decrease. However, since the advent of internal plugins, these tests are unnecessary, and each file only carries a package declaration anyway - so there are no tests actually executed!