### PR TITLE
Fix Google Cloud Two-Tier Example

### DIFF
--- a/examples/google-two-tier/main.tf
+++ b/examples/google-two-tier/main.tf
@@ -36,7 +36,7 @@ resource "google_compute_instance" "www" {
   tags = ["www-node"]
 
   disk {
-    image = "ubuntu-os-cloud/ubuntu-1404-trusty-v20160314"
+    image = "ubuntu-os-cloud/ubuntu-1404-trusty-v20160602"
   }
 
   network_interface {
@@ -70,7 +70,7 @@ resource "google_compute_instance" "www" {
     }
     inline = [
       "chmod +x ${var.install_script_dest_path}",
-      "${var.install_script_dest_path} ${count.index}"
+      "sudo ${var.install_script_dest_path} ${count.index}"
     ]
   }
 

--- a/examples/google-two-tier/terraform.tfvars.example
+++ b/examples/google-two-tier/terraform.tfvars.example
@@ -1,6 +1,6 @@
 region = "us-central1"
 region_zone = "us-central1-a"
 project_name = "my-project-id-123"
-account_file_path = "~/.gcloud/Terraform.json"
+credentials_file_path = "~/.gcloud/Terraform.json"
 public_key_path = "~/.ssh/gcloud_id_rsa.pub"
 private_key_path = "~/.ssh/gcloud_id_rsa"


### PR DESCRIPTION
There were a few issues with the Google Two-Tier example as provided in the Terraform repo:
- The credentials file path variable in the example file didn't match the real variable being called. Fixed the example file.
- The installation script calls a number of privileged commands, but logs in with an unprivileged user. Added a sudo to the inline remote_exec call.
- Bumped the Ubuntu image to the latest for 14.04-trusty