### PR TITLE
Prevent overwriting states with other unrelated states

### DIFF
--- a/command/remote_pull_test.go
+++ b/command/remote_pull_test.go
@@ -41,7 +41,7 @@ func TestRemotePull_local(t *testing.T) {
 	s.Serial = 10
 	conf, srv := testRemoteState(t, s, 200)
 
-	s = terraform.NewState()
+	s = s.DeepCopy()
 	s.Serial = 5
 	s.Remote = conf
 	defer srv.Close()

--- a/command/remote_push_test.go
+++ b/command/remote_push_test.go
@@ -36,7 +36,7 @@ func TestRemotePush_local(t *testing.T) {
 	conf, srv := testRemoteState(t, s, 200)
 	defer srv.Close()
 
-	s = terraform.NewState()
+	s = s.DeepCopy()
 	s.Serial = 10
 	s.Remote = conf
 

--- a/state/local.go
+++ b/state/local.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -50,6 +51,15 @@ func (s *LocalState) WriteState(state *terraform.State) error {
 		}
 
 		return err
+	}
+
+	// Don't allow clobbering with a state of a different lineage unless
+	// our existing state is empty. This is intended to prevent accidental
+	// loss of states through misconfiguration.
+	if s.readState.HasResources() && !s.readState.SameLineage(state) {
+		return fmt.Errorf(
+			"can't overwrite local state with state of different lineage",
+		)
 	}
 
 	// Create all the directories

--- a/state/local_test.go
+++ b/state/local_test.go
@@ -14,6 +14,62 @@ func TestLocalState(t *testing.T) {
 	TestState(t, ls)
 }
 
+func TestLocalState_conflictUpdate(t *testing.T) {
+	ls := testLocalState(t)
+	defer os.Remove(ls.Path)
+
+	state := ls.State()
+	state.EnsureHasLineage()
+
+	// Writing an unrelated (different lineage) state should work
+	// as long as there are no resources in the existing state.
+	{
+		emptyState := state.DeepCopy()
+		emptyState.Modules = []*terraform.ModuleState{
+			{
+				Path:      []string{"root"},
+				Resources: map[string]*terraform.ResourceState{},
+			},
+		}
+
+		if err := ls.WriteState(emptyState); err != nil {
+			t.Fatalf("error %#v while writing empty state; want success", err)
+		}
+
+		unrelatedState := emptyState.DeepCopy()
+		unrelatedState.Lineage = "--unrelated--"
+
+		if err := ls.WriteState(unrelatedState); err != nil {
+			t.Fatalf("error %#v while writing unrelated, empty state; want success", err)
+		}
+	}
+
+	// On the other hand, writing un unrelated state that *has* resources
+	// *should* fail.
+	{
+		initialState := state.DeepCopy()
+		initialState.Modules = []*terraform.ModuleState{
+			{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo": {},
+				},
+			},
+		}
+
+		if err := ls.WriteState(initialState); err != nil {
+			t.Fatalf("error %#v while writing initial state; want success", err)
+		}
+
+		unrelatedState := initialState.DeepCopy()
+		unrelatedState.Lineage = "--unrelated--"
+
+		if err := ls.WriteState(unrelatedState); err == nil {
+			t.Fatalf("success writing unrelated state; want error")
+		}
+	}
+}
+
 func TestLocalState_pathOut(t *testing.T) {
 	f, err := ioutil.TempFile("", "tf")
 	if err != nil {

--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -23,6 +24,16 @@ func (s *State) State() *terraform.State {
 
 // StateWriter impl.
 func (s *State) WriteState(state *terraform.State) error {
+
+	// Don't allow clobbering with a state of a different lineage unless
+	// our existing state is empty. This is intended to prevent accidental
+	// loss of states through misconfiguration.
+	if s.state.HasResources() && !s.state.SameLineage(state) {
+		return fmt.Errorf(
+			"can't overwrite remote state with state of different lineage",
+		)
+	}
+
 	s.state = state
 	return nil
 }

--- a/state/remote/state_test.go
+++ b/state/remote/state_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/state"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestState(t *testing.T) {
@@ -17,6 +18,68 @@ func TestState(t *testing.T) {
 	}
 
 	state.TestState(t, s)
+}
+
+func TestState_conflictUpdate(t *testing.T) {
+	s := &State{
+		Client:    new(InmemClient),
+		state:     state.TestStateInitial(),
+		readState: state.TestStateInitial(),
+	}
+	if err := s.PersistState(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state := s.State()
+	state.EnsureHasLineage()
+
+	// Writing an unrelated (different lineage) state should work
+	// as long as there are no resources in the existing state.
+	{
+		emptyState := state.DeepCopy()
+		emptyState.Modules = []*terraform.ModuleState{
+			{
+				Path:      []string{"root"},
+				Resources: map[string]*terraform.ResourceState{},
+			},
+		}
+
+		if err := s.WriteState(emptyState); err != nil {
+			t.Fatalf("error %#v while writing empty state; want success", err)
+		}
+
+		unrelatedState := emptyState.DeepCopy()
+		unrelatedState.Lineage = "--unrelated--"
+
+		if err := s.WriteState(unrelatedState); err != nil {
+			t.Fatalf("error %#v while writing unrelated, empty state; want success", err)
+		}
+	}
+
+	// On the other hand, writing un unrelated state that *has* resources
+	// *should* fail.
+	{
+		initialState := state.DeepCopy()
+		initialState.Modules = []*terraform.ModuleState{
+			{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo": {},
+				},
+			},
+		}
+
+		if err := s.WriteState(initialState); err != nil {
+			t.Fatalf("error %#v while writing initial state; want success", err)
+		}
+
+		unrelatedState := initialState.DeepCopy()
+		unrelatedState.Lineage = "--unrelated--"
+
+		if err := s.WriteState(unrelatedState); err == nil {
+			t.Fatalf("success writing unrelated state; want error")
+		}
+	}
 }
 
 func TestState_impl(t *testing.T) {

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -7,12 +7,15 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-version"
+	"github.com/satori/go.uuid"
+
 	"github.com/hashicorp/terraform/config"
 	"github.com/mitchellh/copystructure"
 )
@@ -61,6 +64,14 @@ type State struct {
 	// the State file. It is used to detect potentially conflicting
 	// updates.
 	Serial int64 `json:"serial"`
+
+	// Lineage is set when a new, blank state is created and then
+	// never updated. This allows us to determine whether the serials
+	// of two states can be meaningfully compared.
+	// Apart from the guarantee that collisions between two lineages
+	// are very unlikely, this value is opaque and external callers
+	// should only compare lineage strings byte-for-byte for equality.
+	Lineage string `json:"lineage,omitempty"`
 
 	// Remote is used to track the metadata required to
 	// pull and push state files from a remote storage endpoint.
@@ -382,6 +393,68 @@ func (s *State) Equal(other *State) bool {
 	return true
 }
 
+type StateAgeComparison int
+
+const (
+	StateAgeEqual         StateAgeComparison = 0
+	StateAgeReceiverNewer StateAgeComparison = 1
+	StateAgeReceiverOlder StateAgeComparison = -1
+)
+
+// CompareAges compares one state with another for which is "older".
+//
+// This is a simple check using the state's serial, and is thus only as
+// reliable as the serial itself. In the normal case, only one state
+// exists for a given combination of lineage/serial, but Terraform
+// does not guarantee this and so the result of this method should be
+// used with care.
+//
+// Returns an integer that is negative if the receiver is older than
+// the argument, positive if the converse, and zero if they are equal.
+// An error is returned if the two states are not of the same lineage,
+// in which case the integer returned has no meaning.
+func (s *State) CompareAges(other *State) (StateAgeComparison, error) {
+
+	// nil states are "older" than actual states
+	switch {
+	case s != nil && other == nil:
+		return StateAgeReceiverNewer, nil
+	case s == nil && other != nil:
+		return StateAgeReceiverOlder, nil
+	case s == nil && other == nil:
+		return StateAgeEqual, nil
+	}
+
+	if !s.SameLineage(other) {
+		return StateAgeEqual, fmt.Errorf(
+			"can't compare two states of differing lineage",
+		)
+	}
+
+	switch {
+	case s.Serial < other.Serial:
+		return StateAgeReceiverOlder, nil
+	case s.Serial > other.Serial:
+		return StateAgeReceiverNewer, nil
+	default:
+		return StateAgeEqual, nil
+	}
+}
+
+// SameLineage returns true only if the state given in argument belongs
+// to the same "lineage" of states as the reciever.
+func (s *State) SameLineage(other *State) bool {
+	// If one of the states has no lineage then it is assumed to predate
+	// this concept, and so we'll accept it as belonging to any lineage
+	// so that a lineage string can be assigned to newer versions
+	// without breaking compatibility with older versions.
+	if s.Lineage == "" || other.Lineage == "" {
+		return true
+	}
+
+	return s.Lineage == other.Lineage
+}
+
 // DeepCopy performs a deep copy of the state structure and returns
 // a new structure.
 func (s *State) DeepCopy() *State {
@@ -390,6 +463,7 @@ func (s *State) DeepCopy() *State {
 	}
 	n := &State{
 		Version:   s.Version,
+		Lineage:   s.Lineage,
 		TFVersion: s.TFVersion,
 		Serial:    s.Serial,
 		Modules:   make([]*ModuleState, 0, len(s.Modules)),
@@ -442,6 +516,16 @@ func (s *State) init() {
 	}
 	if s.ModuleByPath(rootModulePath) == nil {
 		s.AddModule(rootModulePath)
+	}
+	s.EnsureHasLineage()
+}
+
+func (s *State) EnsureHasLineage() {
+	if s.Lineage == "" {
+		s.Lineage = uuid.NewV4().String()
+		log.Printf("[DEBUG] New state was assigned lineage %q\n", s.Lineage)
+	} else {
+		log.Printf("[TRACE] Preserving existing state lineage %q\n", s.Lineage)
 	}
 }
 

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -220,6 +220,24 @@ func (s *State) Empty() bool {
 	return len(s.Modules) == 0
 }
 
+// HasResources returns true if the state contains any resources.
+//
+// This is similar to !s.Empty, but returns true also in the case where the
+// state has modules but all of them are devoid of resources.
+func (s *State) HasResources() bool {
+	if s.Empty() {
+		return false
+	}
+
+	for _, mod := range s.Modules {
+		if len(mod.Resources) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsRemote returns true if State represents a state that exists and is
 // remote.
 func (s *State) IsRemote() bool {

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -1136,6 +1136,64 @@ func TestStateEmpty(t *testing.T) {
 	}
 }
 
+func TestStateHasResources(t *testing.T) {
+	cases := []struct {
+		In     *State
+		Result bool
+	}{
+		{
+			nil,
+			false,
+		},
+		{
+			&State{},
+			false,
+		},
+		{
+			&State{
+				Remote: &RemoteState{Type: "foo"},
+			},
+			false,
+		},
+		{
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{},
+				},
+			},
+			false,
+		},
+		{
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{},
+					&ModuleState{},
+				},
+			},
+			false,
+		},
+		{
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{},
+					&ModuleState{
+						Resources: map[string]*ResourceState{
+							"foo.foo": &ResourceState{},
+						},
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for i, tc := range cases {
+		if tc.In.HasResources() != tc.Result {
+			t.Fatalf("bad %d %#v:\n\n%#v", i, tc.Result, tc.In)
+		}
+	}
+}
+
 func TestStateFromFutureTerraform(t *testing.T) {
 	cases := []struct {
 		In     string

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -338,6 +338,156 @@ func TestStateEqual(t *testing.T) {
 	}
 }
 
+func TestStateCompareAges(t *testing.T) {
+	cases := []struct {
+		Result   StateAgeComparison
+		Err      bool
+		One, Two *State
+	}{
+		{
+			StateAgeEqual, false,
+			&State{
+				Lineage: "1",
+				Serial:  2,
+			},
+			&State{
+				Lineage: "1",
+				Serial:  2,
+			},
+		},
+		{
+			StateAgeReceiverOlder, false,
+			&State{
+				Lineage: "1",
+				Serial:  2,
+			},
+			&State{
+				Lineage: "1",
+				Serial:  3,
+			},
+		},
+		{
+			StateAgeReceiverNewer, false,
+			&State{
+				Lineage: "1",
+				Serial:  3,
+			},
+			&State{
+				Lineage: "1",
+				Serial:  2,
+			},
+		},
+		{
+			StateAgeEqual, true,
+			&State{
+				Lineage: "1",
+				Serial:  2,
+			},
+			&State{
+				Lineage: "2",
+				Serial:  2,
+			},
+		},
+		{
+			StateAgeEqual, true,
+			&State{
+				Lineage: "1",
+				Serial:  3,
+			},
+			&State{
+				Lineage: "2",
+				Serial:  2,
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		result, err := tc.One.CompareAges(tc.Two)
+
+		if err != nil && !tc.Err {
+			t.Errorf(
+				"%d: got error, but want success\n\n%s\n\n%s",
+				i, tc.One, tc.Two,
+			)
+			continue
+		}
+
+		if err == nil && tc.Err {
+			t.Errorf(
+				"%d: got success, but want error\n\n%s\n\n%s",
+				i, tc.One, tc.Two,
+			)
+			continue
+		}
+
+		if result != tc.Result {
+			t.Errorf(
+				"%d: got result %d, but want %d\n\n%s\n\n%s",
+				i, result, tc.Result, tc.One, tc.Two,
+			)
+			continue
+		}
+	}
+}
+
+func TestStateSameLineage(t *testing.T) {
+	cases := []struct {
+		Result   bool
+		One, Two *State
+	}{
+		{
+			true,
+			&State{
+				Lineage: "1",
+			},
+			&State{
+				Lineage: "1",
+			},
+		},
+		{
+			// Empty lineage is compatible with all
+			true,
+			&State{
+				Lineage: "",
+			},
+			&State{
+				Lineage: "1",
+			},
+		},
+		{
+			// Empty lineage is compatible with all
+			true,
+			&State{
+				Lineage: "1",
+			},
+			&State{
+				Lineage: "",
+			},
+		},
+		{
+			false,
+			&State{
+				Lineage: "1",
+			},
+			&State{
+				Lineage: "2",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		result := tc.One.SameLineage(tc.Two)
+
+		if result != tc.Result {
+			t.Errorf(
+				"%d: got %v, but want %v\n\n%s\n\n%s",
+				i, result, tc.Result, tc.One, tc.Two,
+			)
+			continue
+		}
+	}
+}
+
 func TestStateIncrementSerialMaybe(t *testing.T) {
 	cases := map[string]struct {
 		S1, S2 *State


### PR DESCRIPTION
Through real-world use of Terraform in production I have encountered [a variety of "gotchas" relating to state management](https://gist.github.com/apparentlymart/657885e730d1e5abc6ea). This PR is an attempt to tackle one of these where I think I have a reasonable path forward: protecting against overwriting an remote states.

One common way this occurs is through clumsy use of `terraform remote config`. One variant of this is to forget to enable remote state and then try to enable it afterwards:
- `terraform apply`
- oh whoops! I forgot to enable remote state and now I have duplicated my resources
- `terraform destroy` (deletes all of the stuff in the local state, leaving an empty state)
- `terraform remote config ...`
- whoops! I've now overwritten that remote state with my empty local state.

Another variant is when switching from one remote to another:
- `terraform remote config ...`
- `terraform apply`
- `terraform remote config ...`
- whoops! I've now overwritten the second remote state with the contents of the first.

---

This PR first introduces the idea  of "state lineage", which allows us to determine when one state is an earlier or later version of another state vs. when the two states are entirely unrelated. Comparing `Serial` is only expected to produce meaningful results when `Lineage` matches.

Building on this, when syncing local and remote state, fail with an error if the two states are of different lineage. This includes running `terraform remote config` to enable or re-configure remote state when a local state is already present.

As a special case, if local cache has different lineage but it is entirely empty of resources then just silently drop it and replace it with the remote state, since the loss of an _empty_ state is trivial to recover from and this will reduce friction when users are bootstrapping a new config.

The primary goal here is to return an error when the user seems to be accidentally doing something dangerous, with as little impact as possible to "legitimate" workflows. In future version of Terraform we may make more fundamental changes to these features to help the user not make these mistakes in the first place, but this is intended as a short-term fix to reduce the risk of a state-related catastrophe.

This is the same set of changes as from #6540 except that the change to prevent applying a stale plan is removed, since it no longer works in light of the `plan` behavior change introduced in #6811.
