### PR TITLE
provider/google: Use resource-specific project when waiting for creation, instead of global

### DIFF
--- a/builtin/providers/google/compute_operation.go
+++ b/builtin/providers/google/compute_operation.go
@@ -82,11 +82,11 @@ func (e ComputeOperationError) Error() string {
 	return buf.String()
 }
 
-func computeOperationWaitGlobal(config *Config, op *compute.Operation, activity string) error {
+func computeOperationWaitGlobal(config *Config, op *compute.Operation, project string, activity string) error {
 	w := &ComputeOperationWaiter{
 		Service: config.clientCompute,
 		Op:      op,
-		Project: config.Project,
+		Project: project,
 		Type:    ComputeOperationWaitGlobal,
 	}
 
@@ -107,11 +107,11 @@ func computeOperationWaitGlobal(config *Config, op *compute.Operation, activity 
 	return nil
 }
 
-func computeOperationWaitRegion(config *Config, op *compute.Operation, region, activity string) error {
+func computeOperationWaitRegion(config *Config, op *compute.Operation, project string, region, activity string) error {
 	w := &ComputeOperationWaiter{
 		Service: config.clientCompute,
 		Op:      op,
-		Project: config.Project,
+		Project: project,
 		Type:    ComputeOperationWaitRegion,
 		Region:  region,
 	}
@@ -133,15 +133,15 @@ func computeOperationWaitRegion(config *Config, op *compute.Operation, region, a
 	return nil
 }
 
-func computeOperationWaitZone(config *Config, op *compute.Operation, zone, activity string) error {
-	return computeOperationWaitZoneTime(config, op, zone, 4, activity)
+func computeOperationWaitZone(config *Config, op *compute.Operation, project string, zone, activity string) error {
+	return computeOperationWaitZoneTime(config, op, project, zone, 4, activity)
 }
 
-func computeOperationWaitZoneTime(config *Config, op *compute.Operation, zone string, minutes int, activity string) error {
+func computeOperationWaitZoneTime(config *Config, op *compute.Operation, project string, zone string, minutes int, activity string) error {
 	w := &ComputeOperationWaiter{
 		Service: config.clientCompute,
 		Op:      op,
-		Project: config.Project,
+		Project: project,
 		Zone:    zone,
 		Type:    ComputeOperationWaitZone,
 	}

--- a/builtin/providers/google/resource_compute_address.go
+++ b/builtin/providers/google/resource_compute_address.go
@@ -71,7 +71,7 @@ func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) erro
 	// It probably maybe worked, so store the ID now
 	d.SetId(addr.Name)
 
-	err = computeOperationWaitRegion(config, op, region, "Creating Address")
+	err = computeOperationWaitRegion(config, op, project, region, "Creating Address")
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func resourceComputeAddressDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error deleting address: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Deleting Address")
+	err = computeOperationWaitRegion(config, op, project, region, "Deleting Address")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_autoscaler.go
+++ b/builtin/providers/google/resource_compute_autoscaler.go
@@ -233,7 +233,7 @@ func resourceComputeAutoscalerCreate(d *schema.ResourceData, meta interface{}) e
 	// It probably maybe worked, so store the ID now
 	d.SetId(scaler.Name)
 
-	err = computeOperationWaitZone(config, op, zone.Name, "Creating Autoscaler")
+	err = computeOperationWaitZone(config, op, project, zone.Name, "Creating Autoscaler")
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func resourceComputeAutoscalerUpdate(d *schema.ResourceData, meta interface{}) e
 	// It probably maybe worked, so store the ID now
 	d.SetId(scaler.Name)
 
-	err = computeOperationWaitZone(config, op, zone, "Updating Autoscaler")
+	err = computeOperationWaitZone(config, op, project, zone, "Updating Autoscaler")
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func resourceComputeAutoscalerDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting autoscaler: %s", err)
 	}
 
-	err = computeOperationWaitZone(config, op, zone, "Deleting Autoscaler")
+	err = computeOperationWaitZone(config, op, project, zone, "Deleting Autoscaler")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -181,7 +181,7 @@ func resourceComputeBackendServiceCreate(d *schema.ResourceData, meta interface{
 
 	d.SetId(service.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Backend Service")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Backend Service")
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{
 
 	d.SetId(service.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Updating Backend Service")
+	err = computeOperationWaitGlobal(config, op, project, "Updating Backend Service")
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func resourceComputeBackendServiceDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting backend service: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Backend Service")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Backend Service")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -138,7 +138,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	// It probably maybe worked, so store the ID now
 	d.SetId(disk.Name)
 
-	err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Creating Disk")
+	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Creating Disk")
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	zone := d.Get("zone").(string)
-	err = computeOperationWaitZone(config, op, zone, "Creating Disk")
+	err = computeOperationWaitZone(config, op, project, zone, "Creating Disk")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -138,7 +138,7 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 	// It probably maybe worked, so store the ID now
 	d.SetId(firewall.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Firewall")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Firewall")
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error updating firewall: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Updating Firewall")
+	err = computeOperationWaitGlobal(config, op, project, "Updating Firewall")
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error deleting firewall: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Firewall")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Firewall")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -107,7 +107,7 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 	// It probably maybe worked, so store the ID now
 	d.SetId(frule.Name)
 
-	err = computeOperationWaitRegion(config, op, region, "Creating Fowarding Rule")
+	err = computeOperationWaitRegion(config, op, project, region, "Creating Fowarding Rule")
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func resourceComputeForwardingRuleUpdate(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error updating target: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, region, "Updating Forwarding Rule")
+		err = computeOperationWaitRegion(config, op, project, region, "Updating Forwarding Rule")
 		if err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ func resourceComputeForwardingRuleDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting ForwardingRule: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Deleting Forwarding Rule")
+	err = computeOperationWaitRegion(config, op, project, region, "Deleting Forwarding Rule")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_global_address.go
+++ b/builtin/providers/google/resource_compute_global_address.go
@@ -60,7 +60,7 @@ func resourceComputeGlobalAddressCreate(d *schema.ResourceData, meta interface{}
 	// It probably maybe worked, so store the ID now
 	d.SetId(addr.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Global Address")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Global Address")
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func resourceComputeGlobalAddressDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error deleting address: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Global Address")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Global Address")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_global_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_global_forwarding_rule.go
@@ -101,7 +101,7 @@ func resourceComputeGlobalForwardingRuleCreate(d *schema.ResourceData, meta inte
 	// It probably maybe worked, so store the ID now
 	d.SetId(frule.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Global Fowarding Rule")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Global Fowarding Rule")
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func resourceComputeGlobalForwardingRuleUpdate(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error updating target: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, "Updating Global Forwarding Rule")
+		err = computeOperationWaitGlobal(config, op, project, "Updating Global Forwarding Rule")
 		if err != nil {
 			return err
 		}
@@ -186,7 +186,7 @@ func resourceComputeGlobalForwardingRuleDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error deleting GlobalForwardingRule: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting GlobalForwarding Rule")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting GlobalForwarding Rule")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -131,7 +131,7 @@ func resourceComputeHttpHealthCheckCreate(d *schema.ResourceData, meta interface
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Http Health Check")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Http Health Check")
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Updating Http Health Check")
+	err = computeOperationWaitGlobal(config, op, project, "Updating Http Health Check")
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func resourceComputeHttpHealthCheckDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error deleting HttpHealthCheck: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Http Health Check")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Http Health Check")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_https_health_check.go
+++ b/builtin/providers/google/resource_compute_https_health_check.go
@@ -131,7 +131,7 @@ func resourceComputeHttpsHealthCheckCreate(d *schema.ResourceData, meta interfac
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Https Health Check")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Https Health Check")
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func resourceComputeHttpsHealthCheckUpdate(d *schema.ResourceData, meta interfac
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Updating Https Health Check")
+	err = computeOperationWaitGlobal(config, op, project, "Updating Https Health Check")
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func resourceComputeHttpsHealthCheckDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting HttpsHealthCheck: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Https Health Check")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Https Health Check")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -577,7 +577,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(instance.Name)
 
 	// Wait for the operation to complete
-	waitErr := computeOperationWaitZone(config, op, zone.Name, "instance to create")
+	waitErr := computeOperationWaitZone(config, op, project, zone.Name, "instance to create")
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -786,7 +786,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return fmt.Errorf("Error updating metadata: %s", err)
 			}
 
-			opErr := computeOperationWaitZone(config, op, zone, "metadata to update")
+			opErr := computeOperationWaitZone(config, op, project, zone, "metadata to update")
 			if opErr != nil {
 				return opErr
 			}
@@ -806,7 +806,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
 
-		opErr := computeOperationWaitZone(config, op, zone, "tags to update")
+		opErr := computeOperationWaitZone(config, op, project, zone, "tags to update")
 		if opErr != nil {
 			return opErr
 		}
@@ -837,7 +837,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating scheduling policy: %s", err)
 		}
 
-		opErr := computeOperationWaitZone(config, op, zone,
+		opErr := computeOperationWaitZone(config, op, project, zone,
 			"scheduling policy update")
 		if opErr != nil {
 			return opErr
@@ -879,7 +879,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					if err != nil {
 						return fmt.Errorf("Error deleting old access_config: %s", err)
 					}
-					opErr := computeOperationWaitZone(config, op, zone, "old access_config to delete")
+					opErr := computeOperationWaitZone(config, op, project, zone,
+						"old access_config to delete")
 					if opErr != nil {
 						return opErr
 					}
@@ -898,7 +899,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					if err != nil {
 						return fmt.Errorf("Error adding new access_config: %s", err)
 					}
-					opErr := computeOperationWaitZone(config, op, zone, "new access_config to add")
+					opErr := computeOperationWaitZone(config, op, project, zone,
+						"new access_config to add")
 					if opErr != nil {
 						return opErr
 					}
@@ -929,7 +931,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// Wait for the operation to complete
-	opErr := computeOperationWaitZone(config, op, zone, "instance to delete")
+	opErr := computeOperationWaitZone(config, op, project, zone, "instance to delete")
 	if opErr != nil {
 		return opErr
 	}

--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -136,7 +136,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(instanceGroup.Name)
 
 	// Wait for the operation to complete
-	err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Creating InstanceGroup")
+	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Creating InstanceGroup")
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 		}
 
 		// Wait for the operation to complete
-		err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Adding instances to InstanceGroup")
+		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Adding instances to InstanceGroup")
 		if err != nil {
 			return err
 		}
@@ -264,7 +264,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			}
 
 			// Wait for the operation to complete
-			err = computeOperationWaitZone(config, removeOp, d.Get("zone").(string), "Updating InstanceGroup")
+			err = computeOperationWaitZone(config, removeOp, project, d.Get("zone").(string), "Updating InstanceGroup")
 			if err != nil {
 				return err
 			}
@@ -284,7 +284,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			}
 
 			// Wait for the operation to complete
-			err = computeOperationWaitZone(config, addOp, d.Get("zone").(string), "Updating InstanceGroup")
+			err = computeOperationWaitZone(config, addOp, project, d.Get("zone").(string), "Updating InstanceGroup")
 			if err != nil {
 				return err
 			}
@@ -307,7 +307,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("Error updating named ports for InstanceGroup: %s", err)
 		}
 
-		err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Updating InstanceGroup")
+		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroup")
 		if err != nil {
 			return err
 		}
@@ -333,7 +333,7 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error deleting InstanceGroup: %s", err)
 	}
 
-	err = computeOperationWaitZone(config, op, zone, "Deleting InstanceGroup")
+	err = computeOperationWaitZone(config, op, project, zone, "Deleting InstanceGroup")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -176,7 +176,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 	d.SetId(manager.Name)
 
 	// Wait for the operation to complete
-	err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Creating InstanceGroupManager")
+	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Creating InstanceGroupManager")
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		// Wait for the operation to complete
-		err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Updating InstanceGroupManager")
+		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
 		if err != nil {
 			return err
 		}
@@ -269,7 +269,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		// Wait for the operation to complete
-		err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Updating InstanceGroupManager")
+		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
 		if err != nil {
 			return err
 		}
@@ -296,7 +296,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			// Wait for the operation to complete
-			err = computeOperationWaitZoneTime(config, op, d.Get("zone").(string),
+			err = computeOperationWaitZoneTime(config, op, project, d.Get("zone").(string),
 				managedInstanceCount*4, "Restarting InstanceGroupManagers instances")
 			if err != nil {
 				return err
@@ -323,7 +323,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		// Wait for the operation to complete:
-		err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Updating InstanceGroupManager")
+		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
 		if err != nil {
 			return err
 		}
@@ -344,7 +344,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			// Wait for the operation to complete
-			err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Updating InstanceGroupManager")
+			err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
 			if err != nil {
 				return err
 			}
@@ -375,7 +375,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 	currentSize := int64(d.Get("target_size").(int))
 
 	// Wait for the operation to complete
-	err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Deleting InstanceGroupManager")
+	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Deleting InstanceGroupManager")
 
 	for err != nil && currentSize > 0 {
 		if !strings.Contains(err.Error(), "timeout") {
@@ -397,7 +397,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 
 		currentSize = instanceGroup.Size
 
-		err = computeOperationWaitZone(config, op, d.Get("zone").(string), "Deleting InstanceGroupManager")
+		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Deleting InstanceGroupManager")
 	}
 
 	d.SetId("")

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -562,7 +562,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	// Store the ID now
 	d.SetId(instanceTemplate.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Instance Template")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Instance Template")
 	if err != nil {
 		return err
 	}
@@ -620,7 +620,7 @@ func resourceComputeInstanceTemplateDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting instance template: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Instance Template")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Instance Template")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_network.go
+++ b/builtin/providers/google/resource_compute_network.go
@@ -110,7 +110,7 @@ func resourceComputeNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	// It probably maybe worked, so store the ID now
 	d.SetId(network.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Network")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Network")
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func resourceComputeNetworkDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error deleting network: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Network")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Network")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_project_metadata.go
+++ b/builtin/providers/google/resource_compute_project_metadata.go
@@ -77,7 +77,7 @@ func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface
 
 		log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
 
-		return computeOperationWaitGlobal(config, op, "SetCommonMetadata")
+		return computeOperationWaitGlobal(config, op, project.Name, "SetCommonMetadata")
 	}
 
 	err = MetadataRetryWrapper(createMD)
@@ -156,7 +156,7 @@ func resourceComputeProjectMetadataUpdate(d *schema.ResourceData, meta interface
 			// Optimistic locking requires the fingerprint received to match
 			// the fingerprint we send the server, if there is a mismatch then we
 			// are working on old data, and must retry
-			return computeOperationWaitGlobal(config, op, "SetCommonMetadata")
+			return computeOperationWaitGlobal(config, op, project.Name, "SetCommonMetadata")
 		}
 
 		err := MetadataRetryWrapper(updateMD)
@@ -194,7 +194,7 @@ func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
 
-	err = computeOperationWaitGlobal(config, op, "SetCommonMetadata")
+	err = computeOperationWaitGlobal(config, op, project.Name, "SetCommonMetadata")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -167,7 +167,7 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 	// It probably maybe worked, so store the ID now
 	d.SetId(route.Name)
 
-	err = computeOperationWaitGlobal(config, op, "Creating Route")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Route")
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func resourceComputeRouteDelete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error deleting route: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Route")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Route")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_ssl_certificate.go
+++ b/builtin/providers/google/resource_compute_ssl_certificate.go
@@ -86,7 +86,7 @@ func resourceComputeSslCertificateCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error creating ssl certificate: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Creating SslCertificate")
+	err = computeOperationWaitGlobal(config, op, project, "Creating SslCertificate")
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func resourceComputeSslCertificateDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting ssl certificate: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting SslCertificate")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting SslCertificate")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_subnetwork.go
+++ b/builtin/providers/google/resource_compute_subnetwork.go
@@ -115,7 +115,7 @@ func resourceComputeSubnetworkCreate(d *schema.ResourceData, meta interface{}) e
 	subnetwork.Region = region
 	d.SetId(createSubnetID(subnetwork))
 
-	err = computeOperationWaitRegion(config, op, region, "Creating Subnetwork")
+	err = computeOperationWaitRegion(config, op, project, region, "Creating Subnetwork")
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func resourceComputeSubnetworkDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting subnetwork: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Deleting Subnetwork")
+	err = computeOperationWaitRegion(config, op, project, region, "Deleting Subnetwork")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_target_http_proxy.go
+++ b/builtin/providers/google/resource_compute_target_http_proxy.go
@@ -78,7 +78,7 @@ func resourceComputeTargetHttpProxyCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating TargetHttpProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Creating Target Http Proxy")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Target Http Proxy")
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func resourceComputeTargetHttpProxyUpdate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("Error updating target: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, "Updating Target Http Proxy")
+		err = computeOperationWaitGlobal(config, op, project, "Updating Target Http Proxy")
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func resourceComputeTargetHttpProxyDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error deleting TargetHttpProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Target Http Proxy")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Target Http Proxy")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_target_https_proxy.go
+++ b/builtin/providers/google/resource_compute_target_https_proxy.go
@@ -92,7 +92,7 @@ func resourceComputeTargetHttpsProxyCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error creating TargetHttpsProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Creating Target Https Proxy")
+	err = computeOperationWaitGlobal(config, op, project, "Creating Target Https Proxy")
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("Error updating Target HTTPS proxy URL map: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, "Updating Target Https Proxy URL Map")
+		err = computeOperationWaitGlobal(config, op, project, "Updating Target Https Proxy URL Map")
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("Error updating Target Https Proxy SSL Certificates: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, "Updating Target Https Proxy SSL certificates")
+		err = computeOperationWaitGlobal(config, op, project, "Updating Target Https Proxy SSL certificates")
 		if err != nil {
 			return err
 		}
@@ -257,7 +257,7 @@ func resourceComputeTargetHttpsProxyDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting TargetHttpsProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Deleting Target Https Proxy")
+	err = computeOperationWaitGlobal(config, op, project, "Deleting Target Https Proxy")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -172,7 +172,7 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 	// It probably maybe worked, so store the ID now
 	d.SetId(tpool.Name)
 
-	err = computeOperationWaitRegion(config, op, region, "Creating Target Pool")
+	err = computeOperationWaitRegion(config, op, project, region, "Creating Target Pool")
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, region, "Updating Target Pool")
+		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, region, "Updating Target Pool")
+		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -301,7 +301,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, region, "Updating Target Pool")
+		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -316,7 +316,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
-		err = computeOperationWaitRegion(config, op, region, "Updating Target Pool")
+		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -334,7 +334,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating backup_pool: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, region, "Updating Target Pool")
+		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -398,7 +398,7 @@ func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting TargetPool: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Deleting Target Pool")
+	err = computeOperationWaitRegion(config, op, project, region, "Deleting Target Pool")
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_url_map.go
+++ b/builtin/providers/google/resource_compute_url_map.go
@@ -288,7 +288,7 @@ func resourceComputeUrlMapCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error, failed to insert Url Map %s: %s", name, err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Insert Url Map")
+	err = computeOperationWaitGlobal(config, op, project, "Insert Url Map")
 
 	if err != nil {
 		return fmt.Errorf("Error, failed waitng to insert Url Map %s: %s", name, err)
@@ -651,7 +651,7 @@ func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error, failed to update Url Map %s: %s", name, err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Update Url Map")
+	err = computeOperationWaitGlobal(config, op, project, "Update Url Map")
 
 	if err != nil {
 		return fmt.Errorf("Error, failed waitng to update Url Map %s: %s", name, err)
@@ -676,7 +676,7 @@ func resourceComputeUrlMapDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error, failed to delete Url Map %s: %s", name, err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, "Delete Url Map")
+	err = computeOperationWaitGlobal(config, op, project, "Delete Url Map")
 
 	if err != nil {
 		return fmt.Errorf("Error, failed waitng to delete Url Map %s: %s", name, err)

--- a/builtin/providers/google/resource_compute_vpn_gateway.go
+++ b/builtin/providers/google/resource_compute_vpn_gateway.go
@@ -89,7 +89,7 @@ func resourceComputeVpnGatewayCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error Inserting VPN Gateway %s into network %s: %s", name, network, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Inserting VPN Gateway")
+	err = computeOperationWaitRegion(config, op, project, region, "Inserting VPN Gateway")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Insert VPN Gateway %s into network %s: %s", name, network, err)
 	}
@@ -155,7 +155,7 @@ func resourceComputeVpnGatewayDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error Reading VPN Gateway %s: %s", name, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Deleting VPN Gateway")
+	err = computeOperationWaitRegion(config, op, project, region, "Deleting VPN Gateway")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Delete VPN Gateway %s: %s", name, err)
 	}

--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -144,7 +144,7 @@ func resourceComputeVpnTunnelCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error Inserting VPN Tunnel %s : %s", name, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Inserting VPN Tunnel")
+	err = computeOperationWaitRegion(config, op, project, region, "Inserting VPN Tunnel")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Insert VPN Tunnel %s: %s", name, err)
 	}
@@ -212,7 +212,7 @@ func resourceComputeVpnTunnelDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error Reading VPN Tunnel %s: %s", name, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, region, "Deleting VPN Tunnel")
+	err = computeOperationWaitRegion(config, op, project, region, "Deleting VPN Tunnel")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Delete VPN Tunnel %s: %s", name, err)
 	}


### PR DESCRIPTION
Creating a google_compute_instance resource uses the compute_operation to wait for the creation to complete. However, the computeOperationWaitZone function always uses the global `config.Project`, instead of the instance-specific one.

This means that creating an instance in a project other than the main one fails with a 404 on the operation resource.

This patch uses the project from google_compute_instance instead of the global one.