### PR TITLE
Clarify HTTP URL module source docs

### DIFF
--- a/website/source/docs/modules/sources.html.markdown
+++ b/website/source/docs/modules/sources.html.markdown
@@ -29,6 +29,8 @@ Terraform supports the following sources:
 
   * HTTP URLs
 
+Note that all remote modules are git-based.  The `HTTP URL` source redirects terraform to use another one of the sources.
+
 Each is documented further below.
 
 ## Local File Paths
@@ -194,8 +196,9 @@ parameters:
 
 ## HTTP URLs
 
-Any HTTP endpoint can serve up Terraform modules. For HTTP URLs (SSL is
-supported, as well), Terraform will make a GET request to the given URL.
+An HTTP URL can be used to redirect Terraform to get the module source from 
+one of the other sources.  For HTTP URLs (SSL is supported, as well), 
+Terraform will make a GET request to the given URL.
 An additional GET parameter `terraform-get=1` will be appended, allowing
 you to optionally render the page differently when Terraform is requesting it.
 
@@ -206,7 +209,13 @@ the source URL of the actual module. This will be used.
 
 If the header isn't present, Terraform will look for a `<meta>` tag
 with the name of "terraform-get". The value will be used as the source
-URL.
+URL.  
+
+Example:
+
+```
+<meta name=“terraform-get” content="github.com/hashicorp/example" />
+```
 
 ## Forced Source Type
 


### PR DESCRIPTION
Updated [Module Sources](https://www.terraform.io/docs/modules/sources.html) website documentation to be more clear about how `HTTP URL` module sources work.  The following line in the documentation seems to indicate that you can serve up modules over HTTP.  Also the fact that `HTTP URLs` is listed alongside the other options makes this misleading.

> Any HTTP endpoint can serve up Terraform modules.

I made a tweak to indicate that HTTP URLs are just redirects to other module sources rather than being an actual module source in and of itself.