### PR TITLE
[WIP] provider/openstack - Add support for identity v3

### DIFF
--- a/builtin/providers/openstack/config.go
+++ b/builtin/providers/openstack/config.go
@@ -46,8 +46,7 @@ func (c *Config) loadAndValidate() error {
 	}
 
 	// Check if using the old tenant notation or the project notation
-	if c.TenantID != "" && c.ProjectID != "" ||
-		c.TenantName != "" && c.ProjectName != "" {
+	if (c.TenantID == "" && c.TenantName == "") == (c.ProjectID == "" && c.ProjectName == "") {
 		return fmt.Errorf("Please provide either a tenant ID/name or a projet ID/name")
 	} else if c.ProjectID != "" || c.ProjectName != "" {
 		// If using ProjectID/Name, overwrite TenantID/Name because gophercloud doesn't support

--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -18,6 +18,11 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", nil),
 			},
+			"default_domain": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_DEFAULT_DOMAIN", ""),
+			},
 			"user_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -28,6 +33,16 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Default:  "",
 			},
+			"user_domain_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_NAME", ""),
+			},
+			"user_domain_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_ID", ""),
+			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -37,6 +52,26 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_TENANT_NAME", nil),
+			},
+			"project_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_ID", nil),
+			},
+			"project_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_NAME", nil),
+			},
+			"project_domain_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_ID", ""),
+			},
+			"project_domain_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_DOMAIN_NAME", ""),
 			},
 			"password": &schema.Schema{
 				Type:        schema.TypeString,
@@ -112,19 +147,26 @@ func Provider() terraform.ResourceProvider {
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		IdentityEndpoint: d.Get("auth_url").(string),
-		Username:         d.Get("user_name").(string),
-		UserID:           d.Get("user_id").(string),
-		Password:         d.Get("password").(string),
-		Token:            d.Get("token").(string),
-		APIKey:           d.Get("api_key").(string),
-		TenantID:         d.Get("tenant_id").(string),
-		TenantName:       d.Get("tenant_name").(string),
-		DomainID:         d.Get("domain_id").(string),
-		DomainName:       d.Get("domain_name").(string),
-		Insecure:         d.Get("insecure").(bool),
-		EndpointType:     d.Get("endpoint_type").(string),
-		CACertFile:       d.Get("cacert_file").(string),
+		IdentityEndpoint:  d.Get("auth_url").(string),
+		DefaultDomain:     d.Get("default_domain").(string),
+		Username:          d.Get("user_name").(string),
+		UserID:            d.Get("user_id").(string),
+		UserDomainID:      d.Get("user_domain_id").(string),
+		UserDomainName:    d.Get("user_domain_name").(string),
+		Password:          d.Get("password").(string),
+		Token:             d.Get("token").(string),
+		APIKey:            d.Get("api_key").(string),
+		TenantID:          d.Get("tenant_id").(string),
+		TenantName:        d.Get("tenant_name").(string),
+		ProjectID:         d.Get("project_id").(string),
+		ProjectName:       d.Get("project_name").(string),
+		ProjectDomainID:   d.Get("project_domain_id").(string),
+		ProjectDomainName: d.Get("project_domain_name").(string),
+		DomainID:          d.Get("domain_id").(string),
+		DomainName:        d.Get("domain_name").(string),
+		Insecure:          d.Get("insecure").(bool),
+		EndpointType:      d.Get("endpoint_type").(string),
+		CACertFile:        d.Get("cacert_file").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -16,12 +16,12 @@ func Provider() terraform.ResourceProvider {
 			"auth_url": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", nil),
+				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", ""),
 			},
 			"default_domain": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_DEFAULT_DOMAIN", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_DEFAULT_DOMAIN", "default"),
 			},
 			"user_name": &schema.Schema{
 				Type:        schema.TypeString,
@@ -44,24 +44,24 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("OS_USER_DOMAIN_ID", ""),
 			},
 			"tenant_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_TENANT_ID", ""),
 			},
 			"tenant_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_TENANT_NAME", nil),
+				DefaultFunc: schema.EnvDefaultFunc("OS_TENANT_NAME", ""),
 			},
 			"project_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_ID", nil),
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_ID", ""),
 			},
 			"project_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_NAME", nil),
+				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_NAME", ""),
 			},
 			"project_domain_id": &schema.Schema{
 				Type:        schema.TypeString,

--- a/website/source/docs/providers/openstack/index.html.markdown
+++ b/website/source/docs/providers/openstack/index.html.markdown
@@ -59,11 +59,11 @@ The following arguments are supported:
     you can safely ignore this argument. If omitted, the `OS_API_KEY`
     environment variable is used.
 
-* `domain_id` - (Optional) If omitted, the `OS_DOMAIN_ID` environment
-    variable is used.
+* `project_id` - (Optional) Project-level authentication scope. If omitted,
+    the `OS_PROJECT_ID` environment variable is used.
 
-* `domain_name` - (Optional) If omitted, the `OS_DOMAIN_NAME`
-    environment variable is used.
+* `project_name` - (Optional) `project_id` alternative. If omitted,
+    the `OS_PROJECT_NAME` environment variable is used.
 
 * `tenant_id` - (Optional)
 
@@ -79,6 +79,32 @@ The following arguments are supported:
 * `endpoint_type` - (Optional) Specify which type of endpoint to use from the
     service catalog. It can be set using the OS_ENDPOINT_TYPE environment
     variable. If not set, public endpoints is used.
+
+Authenticating using Identity Server API v3:
+
+* `user_domain_id` - (Optional) If the user is specified by name, then the
+    domain id of the user must also be specified in order to uniquely identify
+    the user. If omitted, the `OS_USER_DOMAIN_ID` environment variable is used.
+
+* `user_domain_name` - (Optional) Alternatively to `user_domain_id`, the
+    domain name of the user may be used to uniquely identify the user. If
+    omitted, the `OS_USER_DOMAIN_NAME` environment variable is used.
+
+* `project_domain_id` - (Optional) Project scoping using the project domain
+    id. If omitted, the `OS_PROJECT_DOMAIN_ID` environment variable is used.
+
+* `project_domain_name` - (Optional) Project scoping using the project domain
+    name. If omitted, the `OS_PROJECT_DOMAIN_NAME` environment variable is used.
+
+* `domain_id` - (Optional) Domain scoping using the domain id. If omitted,
+    the `OS_DOMAIN_ID` environment variable is used.
+
+* `domain_name` - (Optional) Domain scoping using the domain name. If omitted,
+    the `OS_DOMAIN_NAME` environment variable is used.
+
+* `default_domain` - (Optional) Default domain id if the user and project
+    share the same domain. If omitted, the `OS_DEFAULT_DOMAIN` environment
+    variable is used. 
 
 ## Rackspace Compatibility
 


### PR DESCRIPTION
I just sent a PR to the gophercloud repository in order to improve the identity v3 support: https://github.com/rackspace/gophercloud/pull/593. While waiting for them to merge it, here is the code on the Terraform side. I am actually already using it for my Stackato Cloud Foundry cluster deployment automation tool (https://github.com/hpcloud/stackato-cluster-tool).

This PR adds the following keys:
- user_domain_name and user_domain_id identifying the domain where the user lives
- project_domain_name and project_domain_id for project scoping
- default_domain for shared domain when the domain scope and user scope are the same
- project_name and project_id which is the new naming for tenant since OpenStack cli 1.7.0

Before merging this PR, we would need to bump the Godeps gophercloud dependency after they merge https://github.com/rackspace/gophercloud/pull/593.

Please, let me know if I am missing something or if this PR needs to be improved.
