### PR TITLE
DigitalOcean - uppercase region forces droplet recreation

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -35,6 +35,10 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					// DO API V2 region slug is always lowercase
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"size": &schema.Schema{


### PR DESCRIPTION
The region returned by the API is always lowercase therefore when you specify a region uppercase in your config file it forces the droplet to be regenerated on every ```terraform apply``` (even when it is not needed).