### PR TITLE
provider/aws: Add support for bucket name validation

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -26,9 +26,10 @@ func resourceAwsS3Bucket() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"bucket": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateS3BucketName,
 			},
 
 			"arn": &schema.Schema{

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -435,6 +436,36 @@ func validateS3BucketLifecycleRuleId(v interface{}, k string) (ws []string, erro
 	if len(value) > 255 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot exceed 255 characters", k))
+	}
+	return
+}
+
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+func validateS3BucketName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if (len(value) < 3) || (len(value) > 63) {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain from 3 to 63 characters", k))
+	}
+	if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must not be formatted as an IP address", k))
+	}
+	if strings.HasPrefix(value, `.`) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot start with a period", k))
+	}
+	if strings.HasSuffix(value, `.`) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a period", k))
+	}
+	if strings.Contains(value, `..`) {
+		errors = append(errors, fmt.Errorf(
+			"%q can be only one period between labels", k))
 	}
 	return
 }

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -461,6 +461,39 @@ func TestValidateS3BucketLifecycleRuleId(t *testing.T) {
 	}
 }
 
+func TestValidateS3BucketName(t *testing.T) {
+	validId := []string{
+		"yadahereandthere",
+		"www.example.com",
+		"foo.bar.baz",
+		"123",
+		"foo-bar-baz",
+		strings.Repeat("w", 63),
+	}
+	for _, v := range validId {
+		_, errors := validateS3BucketName(v, "bucket")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid bucket name: %q", v, errors)
+		}
+	}
+
+	invalidId := []string{
+		"YadaHereAndThere",
+		"123.456.789.012",
+		"foo..bar.baz",
+		".foo",
+		"foo.",
+		"foo_bar",
+		strings.Repeat("w", 64),
+	}
+	for _, v := range invalidId {
+		_, errors := validateS3BucketName(v, "bucket")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid bucket name", v)
+		}
+	}
+}
+
 func TestValidateIntegerInRange(t *testing.T) {
 	validIntegers := []int{-259, 0, 1, 5, 999}
 	min := -259


### PR DESCRIPTION
Support bucket name validation.

https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
