### PR TITLE
Update vpc_peering documentation

### DIFF
--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -15,8 +15,10 @@ Provides an VPC Peering Connection resource.
 Basic usage:
 
 ```
-resource "aws_vpc" "main" {
-    cidr_block = "10.0.0.0/16"
+resource "aws_vpc_peering_connection" "foo" {
+    peer_owner_id = "${var.peer_owner_id}"
+    peer_vpc_id = "${aws_vpc.bar.id}"
+    vpc_id = "${aws_vpc.foo.id}"
 }
 ```
 
@@ -28,6 +30,11 @@ resource "aws_vpc_peering_connection" "foo" {
     peer_owner_id = "${var.peer_owner_id}"
     peer_vpc_id = "${aws_vpc.bar.id}"
     vpc_id = "${aws_vpc.foo.id}"
+    
+    auto_accept = true
+    tags { 
+      Name = "VPC Peering between foo and bar" 
+    }
 }
 
 resource "aws_vpc" "foo" {
@@ -58,4 +65,4 @@ The following attributes are exported:
 
 
 ## Notes
-You still have to accept the peering with the AWS Console, aws-cli or aws-sdk-go.
+If you are not the owner of both VPCs, or do not enable auto_accept you will still have to accept the peering with the AWS Console, aws-cli or aws-sdk-go.


### PR DESCRIPTION
The documentation wording implies that in all cases you have to manually accept peering requests.  This change is intended to clarify where this is required.  The documentation also separates between "basic usage" and "basic usage with tags", but the expanded usage didn't actually provide much additional useful information.  Expanded a bit to show the use of auto_accept since both VPCs are created by the content and to show setting the Name tag for proper display in the console.

The basic example was also just a basic example of the vpc creation stanza, so I replaced that with the simplified peering connection stanza.