### PR TITLE
provider/cloudstack: add root_disk_size

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_instance.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_instance.go
@@ -124,6 +124,12 @@ func resourceCloudStackInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"root_disk_size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -250,6 +256,11 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	// If there is a group supplied, add it to the parameter struct
 	if group, ok := d.GetOk("group"); ok {
 		p.SetGroup(group.(string))
+	}
+
+	// If there is a root_disk_size supplied, add it to the parameter struct
+	if rootdisksize, ok := d.GetOk("root_disk_size"); ok {
+		p.SetRootdisksize(int64(rootdisksize.(int)))
 	}
 
 	// Create the new instance

--- a/website/source/docs/providers/cloudstack/r/instance.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/instance.html.markdown
@@ -66,6 +66,10 @@ The following arguments are supported:
 * `expunge` - (Optional) This determines if the instance is expunged when it is
     destroyed (defaults false)
 
+* `root_disk_size` - (Optional) The size of the root disk in
+    gigabytes. The root disk is resized on deploy. Only applies to
+    template-based deployments.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Add support for setting rootdisksize.

From http://cloudstack.apache.org/api/apidocs-4.8/root_admin/deployVirtualMachine.html
```
rootdisksize
	Optional field to resize root disk on deploy. Value is in GB. Only applies to template-based deployments. Analogous to details[0].rootdisksize, which takes precedence over this parameter if both are provided
```