### PR TITLE
provider/aws: Update state on `aws_elasticache_subnet_group` not found exception

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -87,6 +87,11 @@ func resourceAwsElasticacheSubnetGroupRead(d *schema.ResourceData, meta interfac
 
 	res, err := conn.DescribeCacheSubnetGroups(req)
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "CacheSubnetGroupNotFoundFault" {
+			// Update state to indicate the db subnet no longer exists.
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	if len(res.CacheSubnetGroups) == 0 {


### PR DESCRIPTION
Fixes #7062

make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheSubnetGroup'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticacheSubnetGroup -timeout 120m
=== RUN   TestAccAWSElasticacheSubnetGroup_basic
--- PASS: TestAccAWSElasticacheSubnetGroup_basic (44.62s)
=== RUN   TestAccAWSElasticacheSubnetGroup_update
--- PASS: TestAccAWSElasticacheSubnetGroup_update (73.74s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	118.379s