### PR TITLE
provider/aws: Update Lambda functions on name change

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -297,10 +297,11 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	codeUpdate := false
-	if v, ok := d.GetOk("filename"); ok && d.HasChange("source_code_hash") {
-		file, err := loadFileContent(v.(string))
+	if d.HasChange("filename") || d.HasChange("source_code_hash") {
+		name := d.Get("filename").(string)
+		file, err := loadFileContent(name)
 		if err != nil {
-			return fmt.Errorf("Unable to load %q: %s", v.(string), err)
+			return fmt.Errorf("Unable to load %q: %s", name, err)
 		}
 		codeReq.ZipFile = file
 		codeUpdate = true
@@ -312,8 +313,8 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		codeUpdate = true
 	}
 
-	log.Printf("[DEBUG] Send Update Lambda Function Code request: %#v", codeReq)
 	if codeUpdate {
+		log.Printf("[DEBUG] Send Update Lambda Function Code request: %#v", codeReq)
 		_, err := conn.UpdateFunctionCode(codeReq)
 		if err != nil {
 			return fmt.Errorf("Error modifying Lambda Function Code %s: %s", d.Id(), err)
@@ -352,8 +353,8 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		configUpdate = true
 	}
 
-	log.Printf("[DEBUG] Send Update Lambda Function Configuration request: %#v", configReq)
 	if configUpdate {
+		log.Printf("[DEBUG] Send Update Lambda Function Configuration request: %#v", configReq)
 		_, err := conn.UpdateFunctionConfiguration(configReq)
 		if err != nil {
 			return fmt.Errorf("Error modifying Lambda Function Configuration %s: %s", d.Id(), err)


### PR DESCRIPTION
Allows the updating of Lambda functions on name change alone. The current implementation will only update the code if the `filename` _and_ `source_code_hash` change _together_. Because `source_code_hash` is optional, it's possible to omit this value.

There is a misleading/erroneously placed `[DEBUG]` log message that suggests a code update is done, however, it's not. The log message is triggered regardless. 

This PR does the following:

- moves the `[DEBUG]` log messages that indicate an update is happening inside the `*Update` blocks, so they are only logged when such an update is happening
- triggers an update either `filename` \*or\* `source_code_hash` change. This should be safe because the only reasonable value of `source_code_hash` is `${base64sha256(file("<file>"))}`, where `<file>` matches `filename`
- `filename` conflicts with any of the `s3` attributes
- `source_code_hash` doesn't come into play with `s3` attributes
- adds a test, based off the existing `source_code_hash` test, that only changes the file name

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLambdaFunction_ -timeout 120m
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (50.81s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (22.52s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (25.10s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (17.52s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly   <=== New
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (31.49s)
=== RUN   TestAccAWSLambdaFunction_s3Update
--- PASS: TestAccAWSLambdaFunction_s3Update (46.23s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	193.687s
```