### PR TITLE
provider/aws: Rename parameter_group_name to db_cluster_parameter_group_name (supersedes #7068)

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -61,7 +61,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Computed: true,
 			},
 
-			"parameter_group_name": &schema.Schema{
+			"db_cluster_parameter_group_name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -201,7 +201,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		createOpts.DBSubnetGroupName = aws.String(attr.(string))
 	}
 
-	if attr, ok := d.GetOk("parameter_group_name"); ok {
+	if attr, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
 		createOpts.DBClusterParameterGroupName = aws.String(attr.(string))
 	}
 
@@ -296,7 +296,7 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
-	d.Set("parameter_group_name", dbc.DBClusterParameterGroup)
+	d.Set("db_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
 	d.Set("endpoint", dbc.Endpoint)
 	d.Set("engine", dbc.Engine)
 	d.Set("master_username", dbc.MasterUsername)
@@ -357,9 +357,9 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_period").(int)))
 	}
 
-	if d.HasChange("parameter_group_name") {
-		d.SetPartial("parameter_group_name")
-		req.DBClusterParameterGroupName = aws.String(d.Get("parameter_group_name").(string))
+	if d.HasChange("db_cluster_parameter_group_name") {
+		d.SetPartial("db_cluster_parameter_group_name")
+		req.DBClusterParameterGroupName = aws.String(d.Get("db_cluster_parameter_group_name").(string))
 	}
 
 	_, err := conn.ModifyDBCluster(req)

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -28,7 +28,7 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster.default", "storage_encrypted", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "parameter_group_name", "default.aurora5.6"),
+						"aws_rds_cluster.default", "db_cluster_parameter_group_name", "default.aurora5.6"),
 				),
 			},
 		},
@@ -50,7 +50,7 @@ func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster.default", "storage_encrypted", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "parameter_group_name", "default.aurora5.6"),
+						"aws_rds_cluster.default", "db_cluster_parameter_group_name", "default.aurora5.6"),
 				),
 			},
 		},
@@ -168,7 +168,7 @@ resource "aws_rds_cluster" "default" {
   database_name = "mydb"
   master_username = "foo"
   master_password = "mustbeeightcharaters"
-  parameter_group_name = "default.aurora5.6"
+  db_cluster_parameter_group_name = "default.aurora5.6"
 }`, n)
 }
 

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -77,7 +77,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
      are applied immediately, or during the next maintenance window. Default is
      `false`. See [Amazon RDS Documentation for more information.](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance. **NOTE:** This must match the `db_subnet_group_name` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
-* `parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
+* `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Build off of #7068 but still include the `parameter_group_name` for backwards compatibility. 
While `parameter_group_name` was only introduced in the v0.7.0rc, I still think it important to not break existing configs. I have a note to remove this parameter after future versions are released.

`db_cluster_parameter_group_name` takes precedence over the two.

This is a _better safe than sorry_ PR. I think it's not totally unreasonable to simply merge #7068 as-is simple because the config parameter in question was introduced in v0.7.0, however, for anyone on `master` or the release candidate and using that parameter would be greeted with a configuration error, and I thought it was easy enough to avoid with this addition 

Fixed https://github.com/hashicorp/terraform/issues/7046