### PR TITLE
provider/vSphere - Add DiskEnableUUID option

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -88,6 +88,7 @@ type virtualMachine struct {
 	hasBootableVmdk       bool
 	linkedClone           bool
 	skipCustomization     bool
+	enableDiskUUID        bool
 	windowsOptionalConfig windowsOptConfig
 	customConfigurations  map[string](types.AnyType)
 }
@@ -210,11 +211,19 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 				Default:  false,
 			},
 
+			"enable_disk_uuid": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
 			"custom_configuration_parameters": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
 			},
+
 			"windows_opt_config": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -661,6 +670,10 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("skip_customization"); ok {
 		vm.skipCustomization = v.(bool)
+	}
+
+	if v, ok := d.GetOk("enable_disk_uuid"); ok {
+		vm.enableDiskUUID = v.(bool)
 	}
 
 	if raw, ok := d.GetOk("dns_suffixes"); ok {
@@ -1523,6 +1536,9 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 		MemoryMB:          vm.memoryMb,
 		MemoryAllocation: &types.ResourceAllocationInfo{
 			Reservation: vm.memoryAllocation.reservation,
+		},
+		Flags: &types.VirtualMachineFlagInfo{
+			DiskUuidEnabled: &vm.enableDiskUUID,
 		},
 	}
 	if vm.template == "" {

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"path/filepath"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/govmomi"
@@ -15,7 +17,6 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
-	"path/filepath"
 )
 
 ///////
@@ -410,7 +411,7 @@ resource "vsphere_virtual_machine" "car" {
       "car" = "ferrari"
       "num" = 42
     }
-
+	enable_disk_uuid = true
 `
 
 func TestAccVSphereVirtualMachine_custom_configs(t *testing.T) {
@@ -439,6 +440,7 @@ func TestAccVSphereVirtualMachine_custom_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(vmName, "custom_configuration_parameters.foo", "bar"),
 					resource.TestCheckResourceAttr(vmName, "custom_configuration_parameters.car", "ferrari"),
 					resource.TestCheckResourceAttr(vmName, "custom_configuration_parameters.num", "42"),
+					resource.TestCheckResourceAttr(vmName, "enable_disk_uuid", "true"),
 				),
 			},
 		},

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -78,6 +78,7 @@ The following arguments are supported:
 * `cdrom` - (Optional) Configures a CDROM device and mounts an image as its media; see [CDROM](#cdrom) below for more details.
 * `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
 * `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
+* `enable_disk_uuid` - (Optional) This option causes the vm to mount disks by uuid on the guest OS.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
 * `skip_customization` - (Optional) skip virtual machine customization (useful if OS is not in the guest OS support matrix of VMware like "other3xLinux64Guest").
 


### PR DESCRIPTION
Since the custom_configuration_parameters can't take dots, we cannot
set 'disk.EnableUUID'.  This adds a parameter for this options that gets
added to a configSpec. This option causes the vm to mount disks by uuid
on the guest OS.