### PR TITLE
Serialization for hash panics on TypeMap

### DIFF
--- a/helper/schema/serialize_test.go
+++ b/helper/schema/serialize_test.go
@@ -13,7 +13,6 @@ func TestSerializeForHash(t *testing.T) {
 	}
 
 	tests := []testCase{
-
 		testCase{
 			Schema: &Schema{
 				Type: TypeInt,
@@ -192,6 +191,31 @@ func TestSerializeForHash(t *testing.T) {
 				"green": true,
 			},
 			Expected: "green:1;name:my-fun-database;size:12;",
+		},
+
+		// test TypeMap nested in Schema: GH-7091
+		testCase{
+			Schema: &Resource{
+				Schema: map[string]*Schema{
+					"outer": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Elem: &Schema{
+							Type:     TypeMap,
+							Optional: true,
+						},
+					},
+				},
+			},
+			Value: map[string]interface{}{
+				"outer": NewSet(func(i interface{}) int { return 42 }, []interface{}{
+					map[string]interface{}{
+						"foo": "bar",
+						"baz": "foo",
+					},
+				}),
+			},
+			Expected: "outer:{[baz:foo;foo:bar;];};",
 		},
 	}
 


### PR DESCRIPTION
The serializeCollectionMemberForHash helper can't be called for the
MapType values, because MapType doesn't have a schema.Elem. Instead, we
can write the key/value pairs directly to the buffer. This still doesn't
allow for nested maps or lists, but we need to define that use case
before committing to it here.