### PR TITLE
provider/digitalocean: Update of droplet document to add a note about resize

### DIFF
--- a/website/source/docs/providers/do/r/droplet.html.markdown
+++ b/website/source/docs/providers/do/r/droplet.html.markdown
@@ -31,7 +31,10 @@ The following arguments are supported:
 * `image` - (Required) The droplet image ID or slug.
 * `name` - (Required) The droplet name
 * `region` - (Required) The region to start in
-* `size` - (Required) The instance size to start
+* `size` - (Required) The instance size to start  
+
+-> **Note:** When resizing a droplet, only a bigger droplet size can be chosen.  
+
 * `backups` - (Optional) Boolean controlling if backups are made. Defaults to
    false.
 * `ipv6` - (Optional) Boolean controlling if IPv6 is enabled. Defaults to false.


### PR DESCRIPTION
When resizing a DO droplet, you can only increase the size not
descrease. If you try and go down in size, the API will return this
error:

```
 * digitalocean_droplet.foobar: Error resizing droplet (17090364):
   POST https://api.digitalocean.com/v2/droplets/17090364/actions:
   422 Size can not decrease size of Droplet's disk image
```

documenting DO droplet error as found in #7043