### PR TITLE
provider/aws: Allow defining network interfaces in aws_instance

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -704,7 +704,7 @@ func flattenGroupIdentifiers(dtos []*ec2.GroupIdentifier) []string {
 //Expands an array of IPs into a ec2 Private IP Address Spec
 func expandPrivateIPAddresses(ips []interface{}) []*ec2.PrivateIpAddressSpecification {
 	dtos := make([]*ec2.PrivateIpAddressSpecification, 0, len(ips))
-	for i, v := range ips {
+	for i, v := range sortInterfaceSlice(ips) {
 		new_private_ip := &ec2.PrivateIpAddressSpecification{
 			PrivateIpAddress: aws.String(v.(string)),
 		}


### PR DESCRIPTION
Implement aws network_interface for aws_instance type.  We can now create instances with multiple network interfaces, like so:

```
resource "aws_instance" "instanceName" {
  network_interface {
    network_interface_id = "${element(aws_network_interface.mgmt.*.id, count.index)}"
    device_index = 1
  }
  network_interface {
    network_interface_id = "${element(aws_network_interface.public.*.id, count.index)}"
    device_index = 0
  }
  network_interface {
    network_interface_id = "${element(aws_network_interface.private.*.id, count.index)}"
    device_index = 2
  }
}
```

I know I didn't do everything, such as documentation updated, so please tell me what I need.  I also don't officially know Go, so there's that.
It works though ;-)
