### PR TITLE
provider/azurerm: DNS CNAME resource wasn't posting records

### DIFF
--- a/builtin/providers/azurerm/resource_arm_dns_cname_record.go
+++ b/builtin/providers/azurerm/resource_arm_dns_cname_record.go
@@ -34,10 +34,16 @@ func resourceArmDnsCNameRecord() *schema.Resource {
 			},
 
 			"records": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Elem:       &schema.Schema{Type: schema.TypeString},
+				Set:        schema.HashString,
+				Deprecated: "Use `record` instead. This attribute will be removed in a future version",
+			},
+
+			"record": &schema.Schema{
+				Type:     schema.TypeString,
 				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 
 			"ttl": &schema.Schema{
@@ -64,16 +70,10 @@ func resourceArmDnsCNameRecordCreate(d *schema.ResourceData, meta interface{}) e
 		ZoneName:          d.Get("zone_name").(string),
 		TTL:               d.Get("ttl").(int),
 		Tags:              *expandedTags,
+		CNAMERecord: dns.CNAMERecord{
+			CNAME: d.Get("record").(string),
+		},
 	}
-
-	recordStrings := d.Get("records").(*schema.Set).List()
-	records := make([]dns.CNAMERecord, len(recordStrings))
-	for i, v := range recordStrings {
-		records[i] = dns.CNAMERecord{
-			CNAME: v.(string),
-		}
-	}
-	createCommand.CNAMERecords = records
 
 	createRequest := rivieraClient.NewRequest()
 	createRequest.Command = createCommand
@@ -127,17 +127,7 @@ func resourceArmDnsCNameRecordRead(d *schema.ResourceData, meta interface{}) err
 	resp := readResponse.Parsed.(*dns.GetCNAMERecordSetResponse)
 
 	d.Set("ttl", resp.TTL)
-
-	if resp.CNAMERecords != nil {
-		records := make([]string, 0, len(resp.CNAMERecords))
-		for _, record := range resp.CNAMERecords {
-			records = append(records, record.CNAME)
-		}
-
-		if err := d.Set("records", records); err != nil {
-			return err
-		}
-	}
+	d.Set("record", resp.CNAMERecord.CNAME)
 
 	flattenAndSetTags(d, &resp.Tags)
 

--- a/builtin/providers/azurerm/resource_arm_dns_cname_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_cname_record_test.go
@@ -29,6 +29,27 @@ func TestAccAzureRMDnsCNameRecord_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMDnsCNameRecord_subdomain(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsCNameRecord_subdomain, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsCNameRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDnsCNameRecordExists("azurerm_dns_cname_record.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_dns_cname_record.test", "record", "test.contoso.com"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMDnsCNameRecord_updateRecords(t *testing.T) {
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAzureRMDnsCNameRecord_basic, ri, ri, ri)
@@ -151,7 +172,26 @@ resource "azurerm_dns_cname_record" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     zone_name = "${azurerm_dns_zone.test.name}"
     ttl = "300"
-    records = ["contoso.com"]
+    record = "contoso.com"
+}
+`
+
+var testAccAzureRMDnsCNameRecord_subdomain = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_dns_zone" "test" {
+    name = "acctestzone%d.com"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_dns_cname_record" "test" {
+    name = "myarecord%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    zone_name = "${azurerm_dns_zone.test.name}"
+    ttl = "300"
+    record = "test.contoso.com"
 }
 `
 
@@ -170,7 +210,7 @@ resource "azurerm_dns_cname_record" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     zone_name = "${azurerm_dns_zone.test.name}"
     ttl = "300"
-    records = ["contoso.co.uk"]
+    record = "contoso.co.uk"
 }
 `
 
@@ -189,7 +229,7 @@ resource "azurerm_dns_cname_record" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     zone_name = "${azurerm_dns_zone.test.name}"
     ttl = "300"
-    records = ["contoso.com"]
+    record = "contoso.com"
 
     tags {
 	environment = "Production"
@@ -213,7 +253,7 @@ resource "azurerm_dns_cname_record" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     zone_name = "${azurerm_dns_zone.test.name}"
     ttl = "300"
-    records = ["contoso.com"]
+    record = "contoso.com"
 
     tags {
 	environment = "staging"

--- a/vendor/github.com/jen20/riviera/dns/create_dns_cname_recordset.go
+++ b/vendor/github.com/jen20/riviera/dns/create_dns_cname_recordset.go
@@ -12,7 +12,7 @@ type CreateCNAMERecordSetResponse struct {
 	Location     string             `mapstructure:"location"`
 	Tags         map[string]*string `mapstructure:"tags"`
 	TTL          *int               `mapstructure:"TTL"`
-	CNAMERecords []CNAMERecord      `mapstructure:"CNAMERecords"`
+	CNAMERecord  CNAMERecord        `mapstructure:"CNAMERecord"`
 }
 
 type CreateCNAMERecordSet struct {
@@ -22,7 +22,7 @@ type CreateCNAMERecordSet struct {
 	Location          string             `json:"-" riviera:"location"`
 	Tags              map[string]*string `json:"-" riviera:"tags"`
 	TTL               int                `json:"TTL"`
-	CNAMERecords      []CNAMERecord      `json:"CNAMERecords"`
+	CNAMERecord       CNAMERecord        `json:"CNAMERecord"`
 }
 
 func (command CreateCNAMERecordSet) APIInfo() azure.APIInfo {

--- a/vendor/github.com/jen20/riviera/dns/get_dns_cname_recordset.go
+++ b/vendor/github.com/jen20/riviera/dns/get_dns_cname_recordset.go
@@ -3,12 +3,12 @@ package dns
 import "github.com/jen20/riviera/azure"
 
 type GetCNAMERecordSetResponse struct {
-	ID           string             `mapstructure:"id"`
-	Name         string             `mapstructure:"name"`
-	Location     string             `mapstructure:"location"`
-	Tags         map[string]*string `mapstructure:"tags"`
-	TTL          *int               `mapstructure:"TTL"`
-	CNAMERecords []CNAMERecord      `mapstructure:"CNAMERecords"`
+	ID          string             `mapstructure:"id"`
+	Name        string             `mapstructure:"name"`
+	Location    string             `mapstructure:"location"`
+	Tags        map[string]*string `mapstructure:"tags"`
+	TTL         *int               `mapstructure:"TTL"`
+	CNAMERecord CNAMERecord        `mapstructure:"CNAMERecord"`
 }
 
 type GetCNAMERecordSet struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -895,20 +895,28 @@
 			"revision": "f233a8bac88d1f2dc282a98186f5a3363b806181"
 		},
 		{
+			"checksumSHA1": "oPpOfZn11Ef6DWOoETxSW9Venzs=",
 			"path": "github.com/jen20/riviera/azure",
-			"revision": "70dac624f9d3e37295dfa4012040106e5f7b1add"
+			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
+			"revisionTime": "2016-06-10T12:18:12Z"
 		},
 		{
+			"checksumSHA1": "A2Ycn6MySifUKTHOnsG9oLwjitE=",
 			"path": "github.com/jen20/riviera/dns",
-			"revision": "70dac624f9d3e37295dfa4012040106e5f7b1add"
+			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
+			"revisionTime": "2016-06-10T12:18:12Z"
 		},
 		{
+			"checksumSHA1": "zVXx6ha3bt0N4ukRbRHXjSl91S4=",
 			"path": "github.com/jen20/riviera/search",
-			"revision": "70dac624f9d3e37295dfa4012040106e5f7b1add"
+			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
+			"revisionTime": "2016-06-10T12:18:12Z"
 		},
 		{
+			"checksumSHA1": "KfquDaeBPGchw92QnojlJFsJKgk=",
 			"path": "github.com/jen20/riviera/sql",
-			"revision": "70dac624f9d3e37295dfa4012040106e5f7b1add"
+			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
+			"revisionTime": "2016-06-10T12:18:12Z"
 		},
 		{
 			"comment": "0.2.2-2-gc01cf91",


### PR DESCRIPTION
Azure changed the API for CNAME at some point and since then we haven't
been creating CNAME records. The API changes from []records to a single
record

This PR changes the schema for dns cnames to have a record parameter and
adds a deprecation warning around records. Talked with @jen20 on this
and we decided that it's currently broken and we should handle this as
part of 0.7 where there are other breaking changes

```
TF_LOG=1 make testacc TEST=./builtin/providers/azurerm
TESTARGS='-run=TestAccAzureRMDnsCNameRecord' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMDnsCNameRecord -timeout 120m
=== RUN   TestAccAzureRMDnsCNameRecord_basic
--- PASS: TestAccAzureRMDnsCNameRecord_basic (97.22s)
=== RUN   TestAccAzureRMDnsCNameRecord_subdomain
--- PASS: TestAccAzureRMDnsCNameRecord_subdomain (94.94s)
=== RUN   TestAccAzureRMDnsCNameRecord_updateRecords
--- PASS: TestAccAzureRMDnsCNameRecord_updateRecords (116.62s)
```