### PR TITLE
provider/azurerm: Fix `azurerm_virtual_machine` windows_config

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -241,7 +241,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 							Optional: true,
 						},
 						"winrm": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -576,18 +576,6 @@ func resourceArmVirtualMachineStorageOsProfileHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["computer_name"].(string)))
 	return hashcode.String(buf.String())
 }
-
-//func resourceArmVirtualMachineStorageDataDiskHash(v interface{}) int {
-//	var buf bytes.Buffer
-//	m := v.(map[string]interface{})
-//	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-//	buf.WriteString(fmt.Sprintf("%s-", m["vhd_uri"].(string)))
-//	buf.WriteString(fmt.Sprintf("%s-", m["create_option"].(string)))
-//	buf.WriteString(fmt.Sprintf("%d-", m["disk_size_gb"].(int)))
-//	buf.WriteString(fmt.Sprintf("%d-", m["lun"].(int)))
-//
-//	return hashcode.String(buf.String())
-//}
 
 func resourceArmVirtualMachineStorageOsDiskHash(v interface{}) int {
 	var buf bytes.Buffer
@@ -958,7 +946,7 @@ func expandAzureRmVirtualMachineOsProfileWindowsConfig(d *schema.ResourceData) (
 	}
 
 	if v := osProfileConfig["winrm"]; v != nil {
-		winRm := v.(*schema.Set).List()
+		winRm := v.([]interface{})
 		if len(winRm) > 0 {
 			winRmListners := make([]compute.WinRMListener, 0, len(winRm))
 			for _, winRmConfig := range winRm {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -131,6 +131,24 @@ func TestAccAzureRMVirtualMachine_windowsUnattendedConfig(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachine_winRMConfig(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachine_winRMConfig, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMVirtualMachineExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -611,6 +629,91 @@ resource "azurerm_virtual_machine" "test" {
             component = "Microsoft-Windows-Shell-Setup"
             setting_name = "FirstLogonCommands"
             content = "<FirstLogonCommands><SynchronousCommand><CommandLine>shutdown /r /t 0 /c \"initial reboot\"</CommandLine><Description>reboot</Description><Order>1</Order></SynchronousCommand></FirstLogonCommands>"
+        }
+    }
+}
+`
+
+var testAccAzureRMVirtualMachine_winRMConfig = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accsa%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine" "test" {
+    name = "acctvm-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    network_interface_ids = ["${azurerm_network_interface.test.id}"]
+    vm_size = "Standard_A0"
+
+    storage_image_reference {
+	publisher = "MicrosoftWindowsServer"
+	offer = "WindowsServer"
+	sku = "2012-Datacenter"
+	version = "latest"
+    }
+
+    storage_os_disk {
+        name = "myosdisk1"
+        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+        caching = "ReadWrite"
+        create_option = "FromImage"
+    }
+
+    os_profile {
+	computer_name = "winhost01"
+	admin_username = "testadmin"
+	admin_password = "Password1234!"
+    }
+
+    os_profile_windows_config {
+        winrm {
+	  protocol = "http"
         }
     }
 }


### PR DESCRIPTION
When using winrm config block, we had an address issue. This is no
longer a set but a list (As a list fits it more approp)

```
    make testacc TEST=./builtin/providers/azurerm
    TESTARGS='-run=TestAccAzureRMVirtualMachine_'
    ==> Checking that code complies with gofmt requirements...
    go generate $(go list ./... | grep -v /vendor/)
    TF_ACC=1 go test ./builtin/providers/azurerm -v
    -run=TestAccAzureRMVirtualMachine_ -timeout 120m
    === RUN   TestAccAzureRMVirtualMachine_basicLinuxMachine
    --- PASS: TestAccAzureRMVirtualMachine_basicLinuxMachine (587.80s)
    === RUN   TestAccAzureRMVirtualMachine_tags
    --- PASS: TestAccAzureRMVirtualMachine_tags (554.53s)
    === RUN   TestAccAzureRMVirtualMachine_updateMachineSize
    --- PASS: TestAccAzureRMVirtualMachine_updateMachineSize (612.52s)
    === RUN   TestAccAzureRMVirtualMachine_basicWindowsMachine
    --- PASS: TestAccAzureRMVirtualMachine_basicWindowsMachine (765.90s)
    === RUN   TestAccAzureRMVirtualMachine_windowsUnattendedConfig
    --- PASS: TestAccAzureRMVirtualMachine_windowsUnattendedConfig
    (770.53s)
    === RUN   TestAccAzureRMVirtualMachine_winRMConfig
    --- PASS: TestAccAzureRMVirtualMachine_winRMConfig (827.90s)
    PASS
    ok      github.com/hashicorp/terraform/builtin/providers/azurerm
    4119.192s
 ```