### PR TITLE
build: Skip running tests on /builtin/bins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST?=$$(go list ./... | grep -v /vendor/)
+TEST?=$$(go list ./... | grep -v '/vendor/' | grep -v '/builtin/bins/')
 VETARGS?=-all
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 


### PR DESCRIPTION
This is time consuming and spams the output of Travis - to run no tests.

cc @phinze, @jbardin, @catsby 