### PR TITLE
build: Remove format check from plugin-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ core-test: generate
 
 # Shorthand for building and installing just one plugin for local testing.
 # Run as (for example): make plugin-dev PLUGIN=provider-aws
-plugin-dev: fmtcheck generate
+plugin-dev: generate
 	go install github.com/hashicorp/terraform/builtin/bins/$(PLUGIN)
 	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
 


### PR DESCRIPTION
This is intended to reduce cycle time during provider development.