### PR TITLE
core: Add sort() interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -75,6 +75,7 @@ func Funcs() map[string]ast.Function {
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
 		"signum":       interpolationFuncSignum(),
+		"sort":         interpolationFuncSort(),
 		"split":        interpolationFuncSplit(),
 		"trimspace":    interpolationFuncTrimSpace(),
 		"upper":        interpolationFuncUpper(),
@@ -525,6 +526,34 @@ func interpolationFuncSignum() ast.Function {
 			default:
 				return 0, nil
 			}
+		},
+	}
+}
+
+// interpolationFuncSort sorts a list of a strings lexographically
+func interpolationFuncSort() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeList},
+		ReturnType: ast.TypeList,
+		Variadic:   false,
+		Callback: func(args []interface{}) (interface{}, error) {
+			inputList := args[0].([]ast.Variable)
+
+			// Ensure that all the list members are strings and
+			// create a string slice from them
+			members := make([]string, len(inputList))
+			for i, val := range inputList {
+				if val.Type != ast.TypeString {
+					return nil, fmt.Errorf(
+						"sort() may only be used with lists of strings - %s at index %d",
+						val.Type.String(), i)
+				}
+
+				members[i] = val.Value.(string)
+			}
+
+			sort.Strings(members)
+			return stringSliceToVariableValue(members), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -638,6 +638,40 @@ func TestInterpolateFuncSignum(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncSort(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.strings": ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{Type: ast.TypeString, Value: "c"},
+					{Type: ast.TypeString, Value: "a"},
+					{Type: ast.TypeString, Value: "b"},
+				},
+			},
+			"var.notstrings": ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{Type: ast.TypeList, Value: []ast.Variable{}},
+					{Type: ast.TypeString, Value: "b"},
+				},
+			},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${sort(var.strings)}`,
+				[]interface{}{"a", "b", "c"},
+				false,
+			},
+			{
+				`${sort(var.notstrings)}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncSplit(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -195,6 +195,11 @@ The supported built-in functions are:
       Example: `element(split(",", var.r53_failover_policy), signum(count.index))`
       where the 0th index points to `PRIMARY` and 1st to `FAILOVER`
 
+  * `sort(list)` - Returns a lexographically sorted list of the strings contained in
+      the list passed as an argument. Sort may only be used with lists which contain only
+      strings.
+      Examples: `sort(aws_instance.foo.*.id)`, `sort(var.list_of_strings)`
+
   * `split(delim, string)` - Splits the string previously created by `join`
       back into a list. This is useful for pushing lists through module
       outputs since they currently only support string values. Depending on the


### PR DESCRIPTION
This may be required to maintian the ordering of sorted multi-variable lists in Terraform 0.7, since values are now sorted by list index rather than value. Discussed during review of #7127.

cc @phinze