### PR TITLE
core: Fix destroy when module vars used in provider config

### DIFF
--- a/terraform/test-fixtures/apply-destroy-mod-var-provider-config/child/child.tf
+++ b/terraform/test-fixtures/apply-destroy-mod-var-provider-config/child/child.tf
@@ -1,0 +1,7 @@
+variable "input" {}
+
+provider "aws" {
+  region = "us-east-${var.input}"
+}
+
+resource "aws_instance" "foo" { }

--- a/terraform/test-fixtures/apply-destroy-mod-var-provider-config/main.tf
+++ b/terraform/test-fixtures/apply-destroy-mod-var-provider-config/main.tf
@@ -1,0 +1,4 @@
+module "child" {
+  source = "./child"
+  input = "1"
+}


### PR DESCRIPTION
For `terraform destroy`, we currently build up the same graph we do for `plan` and `apply` and we do a walk with a special Diff that says "destroy everything".

We have fought the interpolation subsystem time and again through this code path. Beginning in #2775 we gained a new feature to selectively prune out problematic graph nodes. The past chain of destroy fixes I have been involved with (#6557, #6599, #6753) have attempted to massage the "noop" definitions to properly handle the edge cases reported.

"Variable is depended on by provider config" is another edge case we add here and try to fix.

This dive only makes me more convinced that the whole `terraform destroy` code path needs to be reworked.

For now, I went with a "surgical strike" approach to the problem expressed in #7047. I found a couple of issues with the existing Noop and DestroyEdgeInclude logic, especially with regards to flattening, but I'm explicitly ignoring these for now so we can get this particular bug fixed ahead of the 0.7 release. My hope is that we can circle around with a fully specced initiative to refactor `terraform destroy`'s graph to be more state-derived than config-derived.

Until then, this fixes #7407