### PR TITLE
core: Format empty lists and maps in output

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -148,6 +148,7 @@ func formatListOutput(indent, outputName string, outputList []interface{}) strin
 	keyIndent := ""
 
 	outputBuf := new(bytes.Buffer)
+
 	if outputName != "" {
 		outputBuf.WriteString(fmt.Sprintf("%s%s = [", indent, outputName))
 		keyIndent = "  "
@@ -158,7 +159,11 @@ func formatListOutput(indent, outputName string, outputList []interface{}) strin
 	}
 
 	if outputName != "" {
-		outputBuf.WriteString(fmt.Sprintf("\n%s]", indent))
+		if len(outputList) > 0 {
+			outputBuf.WriteString(fmt.Sprintf("\n%s]", indent))
+		} else {
+			outputBuf.WriteString("]")
+		}
 	}
 
 	return strings.TrimPrefix(outputBuf.String(), "\n")
@@ -185,7 +190,11 @@ func formatMapOutput(indent, outputName string, outputMap map[string]interface{}
 	}
 
 	if outputName != "" {
-		outputBuf.WriteString(fmt.Sprintf("\n%s}", indent))
+		if len(outputMap) > 0 {
+			outputBuf.WriteString(fmt.Sprintf("\n%s}", indent))
+		} else {
+			outputBuf.WriteString("}")
+		}
 	}
 
 	return strings.TrimPrefix(outputBuf.String(), "\n")


### PR DESCRIPTION
`terraform output` and it's brethren now consolidate empty maps and lists on a single line of output instead of the pathological behaviour of taking three lines previously. The same code paths are used across all output mechanisms:

```
$ cat main.tf
variable "emptystring" {
    type = "string"
    default = ""
}

variable "emptylist" {
    type = "list"
    default = []
}

variable "emptymap" {
    type = "map"
    default = {}
}

output "emptystring" {
    value = "${var.emptystring}"
}

output "emptylist" {
    value = "${var.emptylist}"
}

output "emptymap" {
    value = "${var.emptymap}"
}

$ terraform apply

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

emptylist = []
emptymap = {}
emptystring =

$ terraform output
emptylist = []
emptymap = {}
emptystring =

$ terraform show

Outputs:

emptylist = []
emptymap = {}
emptystring =
```