### PR TITLE
core: Better error for dot indexing on user vars

### DIFF
--- a/config/interpolate.go
+++ b/config/interpolate.go
@@ -282,6 +282,10 @@ func NewUserVariable(key string) (*UserVariable, error) {
 		name = name[:idx]
 	}
 
+	if len(elem) > 0 {
+		return nil, fmt.Errorf("Invalid dot index found: 'var.%s.%s'. Values in maps and lists can be referenced using square bracket indexing, like: 'var.mymap[\"key\"]' or 'var.mylist[1]'.", name, elem)
+	}
+
 	return &UserVariable{
 		key: key,
 

--- a/config/interpolate_test.go
+++ b/config/interpolate_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hil"
@@ -143,20 +144,10 @@ func TestNewUserVariable(t *testing.T) {
 	}
 }
 
-func TestNewUserVariable_map(t *testing.T) {
-	v, err := NewUserVariable("var.bar.baz")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	if v.Name != "bar" {
-		t.Fatalf("bad: %#v", v.Name)
-	}
-	if v.Elem != "baz" {
-		t.Fatalf("bad: %#v", v.Elem)
-	}
-	if v.FullKey() != "var.bar.baz" {
-		t.Fatalf("bad: %#v", v)
+func TestNewUserVariable_oldMapDotIndexErr(t *testing.T) {
+	_, err := NewUserVariable("var.bar.baz")
+	if err == nil || !strings.Contains(err.Error(), "Invalid dot index") {
+		t.Fatalf("Expected dot index err, got: %#v", err)
 	}
 }
 

--- a/config/test-fixtures/validate-good/main.tf
+++ b/config/test-fixtures/validate-good/main.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "firewall" {
 }
 
 resource aws_instance "web" {
-    ami = "${var.amis.east}"
+    ami = "${var.amis["east"]}"
     security_groups = [
         "foo",
         "${aws_security_group.firewall.foo}"


### PR DESCRIPTION
Dot indexing worked in the "regexps and strings" world of 0.6.x, but it
no longer works on the 0.7 series w/ proper List / Map types.

There is plenty of dot-indexed config out in the wild, so we need to do
what we can to point users to the new syntax.

Here is one place we can do it for user variables (`var.somemap`). We'll
also need to address Resource Variables and Module Variables in a
separate PR.

This fixes the panic in #7103 - a proper error message is now returned.