### PR TITLE
core: Fix crash with tainted resource

### DIFF
--- a/command/format_state.go
+++ b/command/format_state.go
@@ -111,7 +111,7 @@ func formatStateModuleExpand(
 		}
 
 		taintStr := ""
-		if rs.Primary.Tainted {
+		if rs.Primary != nil && rs.Primary.Tainted {
 			taintStr = " (tainted)"
 		}
 


### PR DESCRIPTION
This commit fixes a crash in `terraform show` where there is no primary resource, but there is a tainted resource, because of the changes made to tainted resource handling in 0.7.