### PR TITLE
provider/triton: add machine domain names

### DIFF
--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -167,6 +167,14 @@ func resourceMachine() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"domain_names": {
+				Description: "list of domain names from Triton's CNS",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 
 			// computed resources from metadata
 			"root_authorized_keys": {
@@ -298,6 +306,7 @@ func resourceMachineRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("image", machine.Image)
 	d.Set("primaryip", machine.PrimaryIP)
 	d.Set("firewall_enabled", machine.FirewallEnabled)
+	d.Set("domain_names", machine.DomainNames)
 
 	// create and update NICs
 	var (

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -600,6 +600,26 @@ func TestCheckOutput(name, value string) TestCheckFunc {
 	}
 }
 
+func TestMatchOutput(name string, r *regexp.Regexp) TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Outputs[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if !r.MatchString(rs.Value.(string)) {
+			return fmt.Errorf(
+				"Output '%s': %#v didn't match %q",
+				name,
+				rs,
+				r.String())
+		}
+
+		return nil
+	}
+}
+
 // TestT is the interface used to handle the test lifecycle of a test.
 //
 // Users should just use a *testing.T object, which implements this.

--- a/vendor/github.com/joyent/gosdc/cloudapi/machines.go
+++ b/vendor/github.com/joyent/gosdc/cloudapi/machines.go
@@ -30,6 +30,7 @@ type Machine struct {
 	PrimaryIP       string            // The primary (public) IP address for the machine
 	Networks        []string          // The network IDs for the machine
 	FirewallEnabled bool              `json:"firewall_enabled"` // whether or not the firewall is enabled
+	DomainNames     []string          `json:"dns_names"` // The domain names of this machine
 }
 
 // Equals compares two machines. Ignores state and timestamps.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -950,8 +950,10 @@
 			"revision": "ade826b8b54e81a779ccb29d358a45ba24b7809c"
 		},
 		{
+			"checksumSHA1": "PDzjpRNeytdYU39/PByzwCMvKQ8=",
 			"path": "github.com/joyent/gosdc/cloudapi",
-			"revision": "0697a5c4f39a71a4f9e3b154380b47dbfcc3da6e"
+			"revision": "042c6e9de2b48a646d310e70cc0050c83fe18200",
+			"revisionTime": "2016-04-26T05:09:12Z"
 		},
 		{
 			"path": "github.com/joyent/gosign/auth",


### PR DESCRIPTION
Adds domain names assigned by [Triton CNS](https://www.joyent.com/blog/introducing-triton-container-name-service).

Until @jen20 finds a fix for the acceptance test in PR #7130 (triton tags with dots) you have to set `triton.cns.services` this way:

```
provider "triton" {
} 

variable "tags" {
  default = {
   triton.cns.services = "my-service"
  }
}
resource "triton_machine" "test" {
  count = 1
  name = "test"
  package = "g4-highcpu-128M"

  # Using minimal-64-lts
  image = "e1faace4-e19b-11e5-928b-83849e2fd94a"

  firewall_enabled = false

  tags="${var.tags}"
}
output "Test Domain Names" {
  value = "${join(", ", triton_machine.test.domain_names)}"
}
```