### PR TITLE
[WIP] provider/vsphere: reliable network interface indices

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -264,11 +264,17 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			},
 
 			"network_interface": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"device_key": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
 						"label": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
@@ -870,7 +876,7 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		log.Printf("[DEBUG] cdrom init: %v", cdroms)
 	}
 
-	err := vm.setupVirtualMachine(client)
+	err := vm.setupVirtualMachine(d, client)
 	if err != nil {
 		return err
 	}
@@ -909,6 +915,11 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	if err := collector.RetrieveOne(context.TODO(), vm.Reference(), []string{"guest", "summary", "datastore", "config"}, &mvm); err != nil {
 		return err
 	}
+
+	// 	device_list, err := vm.Device(context.TODO())
+	// 	if err != nil {
+	// 		return err
+	// 	}
 
 	log.Printf("[DEBUG] Datacenter - %#v", dc)
 	log.Printf("[DEBUG] mvm.Summary.Config - %#v", mvm.Summary.Config)
@@ -983,11 +994,14 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Invalid disks to set: %#v", disks)
 	}
 
-	networkInterfaces := make([]map[string]interface{}, 0)
+	networkInterfaces := make(map[string]map[string]interface{}, 0)
 	for _, v := range mvm.Guest.Net {
 		if v.DeviceConfigId >= 0 {
 			log.Printf("[DEBUG] v.Network - %#v", v.Network)
 			networkInterface := make(map[string]interface{})
+			log.Printf("[DEBUG] mvm.Config.Hardware.Device - %#v", mvm.Config.Hardware.Device)
+			device_key := strconv.Itoa(int(v.DeviceConfigId))
+			networkInterface["device_key"] = device_key
 			networkInterface["label"] = v.Network
 			networkInterface["mac_address"] = v.MacAddress
 			for _, ip := range v.IpConfig.IpAddress {
@@ -1006,9 +1020,13 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 				log.Printf("[DEBUG] networkInterface: %#v", networkInterface)
 			}
 			log.Printf("[DEBUG] networkInterface: %#v", networkInterface)
-			networkInterfaces = append(networkInterfaces, networkInterface)
+			networkInterfaces[device_key] = networkInterface
 		}
 	}
+
+	// IP for SetConnInfo
+	connect_ip := ""
+
 	if mvm.Guest.IpStack != nil {
 		for _, v := range mvm.Guest.IpStack {
 			if v.IpRouteConfig != nil && v.IpRouteConfig.IpRoute != nil {
@@ -1025,8 +1043,12 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 							if err != nil {
 								log.Printf("[WARN] error at processing %s of device id %#v: %#v", gatewaySetting, route.Gateway.Device, err)
 							} else {
-								log.Printf("[DEBUG] %s of device id %d: %s", gatewaySetting, deviceID, route.Gateway.IpAddress)
-								networkInterfaces[deviceID][gatewaySetting] = route.Gateway.IpAddress
+								device_key := strconv.Itoa(int(mvm.Guest.Net[deviceID].DeviceConfigId))
+								log.Printf("[DEBUG] %s of device id %d (key %s): %s", gatewaySetting, deviceID, device_key, route.Gateway.IpAddress)
+								networkInterfaces[device_key][gatewaySetting] = route.Gateway.IpAddress
+								if gatewaySetting == "ipv4_gateway" {
+									connect_ip = networkInterfaces[device_key]["ipv4_address"].(string)
+								}
 							}
 						}
 					}
@@ -1040,10 +1062,10 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Invalid network interfaces to set: %#v", networkInterfaces)
 	}
 
-	log.Printf("[DEBUG] ip address: %v", networkInterfaces[0]["ipv4_address"].(string))
+	log.Printf("[DEBUG] ip address: %v", connect_ip)
 	d.SetConnInfo(map[string]string{
 		"type": "ssh",
-		"host": networkInterfaces[0]["ipv4_address"].(string),
+		"host": connect_ip,
 	})
 
 	var rootDatastore string
@@ -1462,7 +1484,7 @@ func createCdroms(vm *object.VirtualMachine, cdroms []cdrom) error {
 	return nil
 }
 
-func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
+func (vm *virtualMachine) setupVirtualMachine(d *schema.ResourceData, c *govmomi.Client) error {
 	dc, err := getDatacenter(c, vm.datacenter)
 
 	if err != nil {
@@ -1751,21 +1773,42 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 		return err
 	}
 
+	var known_devices map[string]bool
+
 	for _, dvc := range devices {
 		// Issue 3559/3560: Delete all ethernet devices to add the correct ones later
+		// Also required to get a reliable mapping from vsphere device to device in config
 		if devices.Type(dvc) == "ethernet" {
 			err := newVM.RemoveDevice(context.TODO(), false, dvc)
 			if err != nil {
 				return err
 			}
+		} else {
+			known_devices[strconv.Itoa(int(dvc.GetVirtualDevice().Key))] = true
 		}
 	}
+
 	// Add Network devices
 	for _, dvc := range networkDevices {
 		err := newVM.AddDevice(
 			context.TODO(), dvc.GetVirtualDeviceConfigSpec().Device)
 		if err != nil {
 			return err
+		}
+		// get refreshed device list
+		refreshed_devices, err := newVM.Device(context.TODO())
+		if err != nil {
+			log.Printf("[ERROR] Getting new list of devices failed")
+			return err
+		}
+		// look for unknown device name => has to be added device
+		for _, new_dvc := range refreshed_devices {
+			device_key := strconv.Itoa(int(new_dvc.GetVirtualDevice().Key))
+			if !known_devices[device_key] {
+				key_name := fmt.Sprintf("network_interfaces.%v.device_key", device_key)
+				known_devices[device_key] = true
+				d.Set(key_name, device_key)
+			}
 		}
 	}
 

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -93,6 +93,10 @@ type virtualMachine struct {
 	customConfigurations  map[string](types.AnyType)
 }
 
+func NetInterfaceID(v interface{}) int {
+	return strconv.Atoi(v["device_key"])
+}
+
 func (v virtualMachine) Path() string {
 	return vmPath(v.folder, v.name)
 }
@@ -265,6 +269,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 
 			"network_interface": &schema.Schema{
 				Type:     schema.TypeSet,
+				Set:      NetInterfaceID,
 				Required: true,
 				ForceNew: true,
 				Elem: &schema.Resource{


### PR DESCRIPTION
Before implementing the update of the network interfaces, we need a reliable way to match the config and the devices in VMware. 
This is a WIP since I have problems getting the data into the TF schema object structure. 
I want a map[string]map[string] structure. The outer map with the device id/device key as index and the inner map like the current structure with ip addresses, gateway,... 
Is there a way to override the hash function of the TypeSet ? With TypeMap  I get an error at runtime (will add the message later),  but the core message was that it was an invalid input for the schema object. 
cc @chrislovecnm 
