### PR TITLE
aws_availability_zones output as "names" rather than "instance"

### DIFF
--- a/builtin/providers/aws/data_source_availability_zones.go
+++ b/builtin/providers/aws/data_source_availability_zones.go
@@ -16,7 +16,7 @@ func dataSourceAwsAvailabilityZones() *schema.Resource {
 		Read: dataSourceAwsAvailabilityZonesRead,
 
 		Schema: map[string]*schema.Schema{
-			"instance": &schema.Schema{
+			"names": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -44,7 +44,7 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 
 	sort.Strings(raw)
 
-	if err := d.Set("instance", raw); err != nil {
+	if err := d.Set("names", raw); err != nil {
 		return fmt.Errorf("[WARN] Error setting availability zones")
 	}
 

--- a/builtin/providers/aws/data_source_availability_zones_test.go
+++ b/builtin/providers/aws/data_source_availability_zones_test.go
@@ -52,7 +52,7 @@ func testAccCheckAwsAvailabilityZonesMeta(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckAwsAvailabilityZonesBuildAvailable(attrs map[string]string) ([]string, error) {
-	v, ok := attrs["instance.#"]
+	v, ok := attrs["names.#"]
 	if !ok {
 		return nil, fmt.Errorf("Available AZ list is missing")
 	}
@@ -65,7 +65,7 @@ func testAccCheckAwsAvailabilityZonesBuildAvailable(attrs map[string]string) ([]
 	}
 	zones := make([]string, qty)
 	for n := range zones {
-		zone, ok := attrs["instance."+strconv.Itoa(n)]
+		zone, ok := attrs["names."+strconv.Itoa(n)]
 		if !ok {
 			return nil, fmt.Errorf("AZ list corrupt, this is definitely a bug")
 		}

--- a/website/source/docs/providers/aws/d/availability_zones.html.markdown
+++ b/website/source/docs/providers/aws/d/availability_zones.html.markdown
@@ -16,15 +16,20 @@ configured in the provider.
 
 ```
 # Declare the data source
-data "aws_availability_zones" "zones" {}
+data "aws_availability_zones" "available" {}
 
-# Create a subnet in each availability zone
-resource "aws_subnet" "public" {
-    count = "${length(data.aws_availability_zones.zones.instance)}"
-    
-    availability_zone = "${data.aws_availability_zones.zones.instance[count.index]}"
+# e.g. Create subnets in the first two available availability zones
 
-    # Other properties...
+resource "aws_subnet" "primary" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
+  # Other properties...
+}
+
+resource "aws_subnet" "secondary" {
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+
+  # Other properties...
 }
 ```
 
@@ -36,4 +41,4 @@ There are no arguments for this data source.
 
 The following attributes are exported:
 
-* `instance` - A list of the availability zone names available to the account.
+* `names` - A list of the availability zone names available to the account.


### PR DESCRIPTION
Since this resource produces a list it feels more intuitive to give its attribute a plural name, and since the noun "instance" already means something specific in the AWS provider that doesn't apply here we use "names" to indicate that these are availability zone names.

Didn't bother with a deprecation cycle on this since it's never been in a stable release, only in RCs.

Also includes updating the docs to not show a dynamic count example for now, since we don't support that yet.