### PR TITLE
provider/aws: Populate self in Security Group Rule imports

### DIFF
--- a/builtin/providers/aws/import_aws_security_group_test.go
+++ b/builtin/providers/aws/import_aws_security_group_test.go
@@ -35,3 +35,22 @@ func TestAccAWSSecurityGroup_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAWSSecurityGroup_importSelf(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupConfig_importSelf,
+			},
+
+			resource.TestStep{
+				ResourceName:      "aws_security_group.allow_all",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -511,23 +511,23 @@ func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPe
 
 	d.Set("cidr_blocks", cb)
 
-        // 'self' is false by default. Below, we range over the group ids and set true
-        // if the parent sg id is found
-        d.Set("self", false)
+	// 'self' is false by default. Below, we range over the group ids and set true
+	// if the parent sg id is found
+	d.Set("self", false)
 	if len(rule.UserIdGroupPairs) > 0 {
 		s := rule.UserIdGroupPairs[0]
 
-                // Check for Pair that is the same as the Security Group, to denote self.
-                // Otherwise, mark the group id in source_security_group_id
+		// Check for Pair that is the same as the Security Group, to denote self.
+		// Otherwise, mark the group id in source_security_group_id
 		if isVPC {
-                        if *s.GroupId == *sg.GroupId {
-                                d.Set("self", true)
-                        }
+			if *s.GroupId == *sg.GroupId {
+				d.Set("self", true)
+			}
 			d.Set("source_security_group_id", *s.GroupId)
 		} else {
-                        if *s.GroupName == *sg.GroupName {
-                                d.Set("self", true)
-                        }
+			if *s.GroupName == *sg.GroupName {
+				d.Set("self", true)
+			}
 			d.Set("source_security_group_id", *s.GroupName)
 		}
 	}

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -511,11 +511,23 @@ func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPe
 
 	d.Set("cidr_blocks", cb)
 
+        // 'self' is false by default. Below, we range over the group ids and set true
+        // if the parent sg id is found
+        d.Set("self", false)
 	if len(rule.UserIdGroupPairs) > 0 {
 		s := rule.UserIdGroupPairs[0]
+
+                // Check for Pair that is the same as the Security Group, to denote self.
+                // Otherwise, mark the group id in source_security_group_id
 		if isVPC {
+                        if *s.GroupId == *sg.GroupId {
+                                d.Set("self", true)
+                        }
 			d.Set("source_security_group_id", *s.GroupId)
 		} else {
+                        if *s.GroupName == *sg.GroupName {
+                                d.Set("self", true)
+                        }
 			d.Set("source_security_group_id", *s.GroupName)
 		}
 	}

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -1594,3 +1594,38 @@ resource "aws_security_group" "nat" {
   }
 }
 `
+const testAccAWSSecurityGroupConfig_importSelf = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "tf_sg_import_test"
+  }
+}
+
+resource "aws_security_group" "allow_all" {
+  name        = "allow_all"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${aws_vpc.foo.id}"
+}
+
+resource "aws_security_group_rule" "allow_all" {
+  type        = "ingress"
+  from_port   = 0
+  to_port     = 65535
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.allow_all.id}"
+}
+
+resource "aws_security_group_rule" "allow_all-1" {
+  type      = "ingress"
+  from_port = 65534
+  to_port   = 65535
+  protocol  = "tcp"
+
+  self              = true
+  security_group_id = "${aws_security_group.allow_all.id}"
+}
+`


### PR DESCRIPTION
Fix #7039 and Security Group Rule imports by populating the `self` attribute.
Doing a selective TravisCI run for these tests on branch `b-aws-sg-import`, but they passed locally:

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSecurity -timeout 120m
=== RUN   TestAccAWSSecurityGroup_importBasic
--- PASS: TestAccAWSSecurityGroup_importBasic (20.15s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_VPC
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (12.74s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Protocol
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (22.59s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Classic
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (13.88s)
=== RUN   TestAccAWSSecurityGroupRule_MultiIngress
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (15.31s)
=== RUN   TestAccAWSSecurityGroupRule_Egress
--- PASS: TestAccAWSSecurityGroupRule_Egress (14.02s)
=== RUN   TestAccAWSSecurityGroupRule_SelfReference
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (22.50s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_basic
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (25.67s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_Source
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (25.10s)
=== RUN   TestAccAWSSecurityGroupRule_Issue5310
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (26.36s)
=== RUN   TestAccAWSSecurityGroupRule_Race
--- PASS: TestAccAWSSecurityGroupRule_Race (263.60s)
=== RUN   TestAccAWSSecurityGroup_basic
--- PASS: TestAccAWSSecurityGroup_basic (19.48s)
=== RUN   TestAccAWSSecurityGroup_namePrefix
--- PASS: TestAccAWSSecurityGroup_namePrefix (9.64s)
=== RUN   TestAccAWSSecurityGroup_self
--- PASS: TestAccAWSSecurityGroup_self (19.32s)
=== RUN   TestAccAWSSecurityGroup_vpc
--- PASS: TestAccAWSSecurityGroup_vpc (19.86s)
=== RUN   TestAccAWSSecurityGroup_vpcNegOneIngress
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (18.88s)
=== RUN   TestAccAWSSecurityGroup_MultiIngress
--- PASS: TestAccAWSSecurityGroup_MultiIngress (23.14s)
=== RUN   TestAccAWSSecurityGroup_Change
--- PASS: TestAccAWSSecurityGroup_Change (31.39s)
=== RUN   TestAccAWSSecurityGroup_generatedName
--- PASS: TestAccAWSSecurityGroup_generatedName (19.05s)
=== RUN   TestAccAWSSecurityGroup_DefaultEgress
--- PASS: TestAccAWSSecurityGroup_DefaultEgress (30.11s)
=== RUN   TestAccAWSSecurityGroup_drift
--- PASS: TestAccAWSSecurityGroup_drift (12.04s)
=== RUN   TestAccAWSSecurityGroup_drift_complex
--- PASS: TestAccAWSSecurityGroup_drift_complex (23.11s)
=== RUN   TestAccAWSSecurityGroup_tags
--- PASS: TestAccAWSSecurityGroup_tags (30.42s)
=== RUN   TestAccAWSSecurityGroup_CIDRandGroups
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (22.99s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs (24.15s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic (14.73s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	780.258s
Test:
```

Custom test run (linked below too) https://travis-ci.org/hashicorp/terraform/builds/137581964 (it passed)