### PR TITLE
provider/aws: Check for LoadBalancerNotFound when reading AppCookieStickinessPolicy

### DIFF
--- a/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_app_cookie_stickiness_policy.go
@@ -98,9 +98,10 @@ func resourceAwsAppCookieStickinessPolicyRead(d *schema.ResourceData, meta inter
 
 	getResp, err := elbconn.DescribeLoadBalancerPolicies(request)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "PolicyNotFound" {
-			// The policy is gone.
-			d.SetId("")
+		if ec2err, ok := err.(awserr.Error); ok {
+			if ec2err.Code() == "PolicyNotFound" || ec2err.Code() == "LoadBalancerNotFound" {
+				d.SetId("")
+			}
 			return nil
 		}
 		return fmt.Errorf("Error retrieving policy: %s", err)


### PR DESCRIPTION
When reading an AppCookieStickinessPolicy, check for LoadBalancerNotFound
as well as PolicyNotFound. This prevents errors when when destroying a
policy on an ELB that no longer exists.

Fixes #7065 