### PR TITLE
core: Rebase #7111 and rename unique() to distinct()

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -71,6 +71,7 @@ func Funcs() map[string]ast.Function {
 		"lower":        interpolationFuncLower(),
 		"md5":          interpolationFuncMd5(),
 		"uuid":         interpolationFuncUUID(),
+		"uniq":         interpolationFuncUniq(),
 		"replace":      interpolationFuncReplace(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
@@ -380,6 +381,42 @@ func interpolationFuncIndex() ast.Function {
 			return nil, fmt.Errorf("Could not find '%s' in '%s'", needle, haystack)
 		},
 	}
+}
+
+// interpolationFuncUniq implements the "uniq" function that
+// removes duplicate elements from a list.
+func interpolationFuncUniq() ast.Function {
+	return ast.Function{
+		ArgTypes:     []ast.Type{ast.TypeList},
+		ReturnType:   ast.TypeList,
+		Variadic:     true,
+		VariadicType: ast.TypeList,
+		Callback: func(args []interface{}) (interface{}, error) {
+			var list []string
+
+			if len(args) != 1 {
+				return nil, fmt.Errorf("uniq() excepts only one argument.")
+			}
+
+			if argument, ok := args[0].([]ast.Variable); ok {
+				for _, element := range argument {
+					list = appendIfMissing(list, element.Value.(string))
+				}
+			}
+
+			return stringSliceToVariableValue(list), nil
+		},
+	}
+}
+
+// helper function to add an element to a list, if it does not already exsit
+func appendIfMissing(slice []string, element string) []string {
+	for _, ele := range slice {
+		if ele == element {
+			return slice
+		}
+	}
+	return append(slice, element)
 }
 
 // interpolationFuncJoin implements the "join" function that allows

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -60,6 +60,7 @@ func Funcs() map[string]ast.Function {
 		"coalesce":     interpolationFuncCoalesce(),
 		"compact":      interpolationFuncCompact(),
 		"concat":       interpolationFuncConcat(),
+		"distinct":     interpolationFuncDistinct(),
 		"element":      interpolationFuncElement(),
 		"file":         interpolationFuncFile(),
 		"format":       interpolationFuncFormat(),
@@ -71,7 +72,6 @@ func Funcs() map[string]ast.Function {
 		"lower":        interpolationFuncLower(),
 		"md5":          interpolationFuncMd5(),
 		"uuid":         interpolationFuncUUID(),
-		"uniq":         interpolationFuncUniq(),
 		"replace":      interpolationFuncReplace(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
@@ -383,9 +383,9 @@ func interpolationFuncIndex() ast.Function {
 	}
 }
 
-// interpolationFuncUniq implements the "uniq" function that
+// interpolationFuncDistinct implements the "distinct" function that
 // removes duplicate elements from a list.
-func interpolationFuncUniq() ast.Function {
+func interpolationFuncDistinct() ast.Function {
 	return ast.Function{
 		ArgTypes:     []ast.Type{ast.TypeList},
 		ReturnType:   ast.TypeList,
@@ -395,7 +395,7 @@ func interpolationFuncUniq() ast.Function {
 			var list []string
 
 			if len(args) != 1 {
-				return nil, fmt.Errorf("uniq() excepts only one argument.")
+				return nil, fmt.Errorf("distinct() excepts only one argument.")
 			}
 
 			if argument, ok := args[0].([]ast.Variable); ok {

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -261,24 +261,24 @@ func TestInterpolationFuncConcatListOfMaps(t *testing.T) {
 	}
 }
 
-func TestInterpolateFuncUniq(t *testing.T) {
+func TestInterpolateFuncDistinct(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
 			// 3 duplicates
 			{
-				`${uniq(concat(split(",", "user1,user2,user3"), split(",", "user1,user2,user3")))}`,
+				`${distinct(concat(split(",", "user1,user2,user3"), split(",", "user1,user2,user3")))}`,
 				[]interface{}{"user1", "user2", "user3"},
 				false,
 			},
 			// 1 duplicate
 			{
-				`${uniq(concat(split(",", "user1,user2,user3"), split(",", "user1,user4")))}`,
+				`${distinct(concat(split(",", "user1,user2,user3"), split(",", "user1,user4")))}`,
 				[]interface{}{"user1", "user2", "user3", "user4"},
 				false,
 			},
 			// too many args
 			{
-				`${uniq(concat(split(",", "user1,user2,user3"), split(",", "user1,user4")), "foo")}`,
+				`${distinct(concat(split(",", "user1,user2,user3"), split(",", "user1,user4")), "foo")}`,
 				nil,
 				true,
 			},

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -261,6 +261,31 @@ func TestInterpolationFuncConcatListOfMaps(t *testing.T) {
 	}
 }
 
+func TestInterpolateFuncUniq(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			// 3 duplicates
+			{
+				`${uniq(concat(split(",", "user1,user2,user3"), split(",", "user1,user2,user3")))}`,
+				[]interface{}{"user1", "user2", "user3"},
+				false,
+			},
+			// 1 duplicate
+			{
+				`${uniq(concat(split(",", "user1,user2,user3"), split(",", "user1,user4")))}`,
+				[]interface{}{"user1", "user2", "user3", "user4"},
+				false,
+			},
+			// too many args
+			{
+				`${uniq(concat(split(",", "user1,user2,user3"), split(",", "user1,user4")), "foo")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncFile(t *testing.T) {
 	tf, err := ioutil.TempFile("", "tf")
 	if err != nil {

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -114,6 +114,10 @@ The supported built-in functions are:
   * `concat(list1, list2)` - Combines two or more lists into a single list.
      Example: `concat(aws_instance.db.*.tags.Name, aws_instance.web.*.tags.Name)`
 
+  * `distinct(list)` - Removes duplicate items from a list. Keeps the first
+     occurrence of each element, and removes subsequent occurences.
+     Example: `distinct(var.usernames)`
+
   * `element(list, index)` - Returns a single element from a list
       at the given index. If the index is greater than the number of
       elements, this function will wrap using a standard mod algorithm.


### PR DESCRIPTION
This pull request rebases #7111 onto master, and renames the new interpolation function `distinct()` instead of `uniq()`. It also adds documentation.