### PR TITLE
provider/aws: Add support for `encryption` and `kms_key_id` to `aws_ami`

### DIFF
--- a/builtin/providers/aws/resource_aws_ami_copy.go
+++ b/builtin/providers/aws/resource_aws_ami_copy.go
@@ -24,6 +24,20 @@ func resourceAwsAmiCopy() *schema.Resource {
 		ForceNew: true,
 	}
 
+	resourceSchema["encrypted"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+		ForceNew: true,
+	}
+
+	resourceSchema["kms_key_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+	}
+
 	return &schema.Resource{
 		Create: resourceAwsAmiCopyCreate,
 
@@ -45,6 +59,11 @@ func resourceAwsAmiCopyCreate(d *schema.ResourceData, meta interface{}) error {
 		Description:   aws.String(d.Get("description").(string)),
 		SourceImageId: aws.String(d.Get("source_ami_id").(string)),
 		SourceRegion:  aws.String(d.Get("source_ami_region").(string)),
+		Encrypted:     aws.Bool(d.Get("encrypted").(bool)),
+	}
+
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		req.KmsKeyId = aws.String(v.(string))
 	}
 
 	res, err := client.CopyImage(req)

--- a/website/source/docs/providers/aws/r/ami.html.markdown
+++ b/website/source/docs/providers/aws/r/ami.html.markdown
@@ -78,6 +78,11 @@ Nested `ebs_block_device` blocks have the following structure:
   as the selected snapshot.
 * `volume_type` - (Optional) The type of EBS volume to create. Can be one of "standard" (the
   default), "io1" or "gp2".
+* `encrypted` - (Optional) Specifies whether the destination snapshots of the copied image should be encrypted. 
+The default CMK for EBS is used unless a non-default AWS Key Management Service (AWS KMS) CMK is specified with KmsKeyId.
+* `kms_key_id` - (Optional) The full ARN of the AWS Key Management Service (AWS KMS) CMK to use when encrypting the snapshots of 
+an image during a copy operation. This parameter is only required if you want to use a non-default CMK; 
+if this parameter is not specified, the default CMK for EBS is used
 
 Nested `ephemeral_block_device` blocks have the following structure:
 


### PR DESCRIPTION
This fixes #7157. It doesn't change the way aws_ami works

```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSAMICopy'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAMICopy
-timeout 120m
=== RUN   TestAccAWSAMICopy
--- PASS: TestAccAWSAMICopy (479.75s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    479.769s
```