### PR TITLE
provider/openstack stop before destroy

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -840,3 +840,31 @@ func testAccCheckComputeV2InstanceInstanceIDsDoNotMatch(
 		return nil
 	}
 }
+
+func TestAccComputeV2Instance_stop_before_destroy(t *testing.T) {
+	var instance servers.Server
+	var testAccComputeV2Instance_stop_before_destroy = fmt.Sprintf(`
+		resource "openstack_compute_instance_v2" "foo" {
+			name = "terraform-test"
+			security_groups = ["default"]
+			network {
+				uuid = "%s"
+			}
+			stop_before_destroy = true
+		}`,
+		os.Getenv("OS_NETWORK_ID"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_stop_before_destroy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
+				),
+			},
+		},
+	})
+}

--- a/vendor/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/startstop/doc.go
+++ b/vendor/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/startstop/doc.go
@@ -1,0 +1,5 @@
+/*
+Package startstop provides functionality to start and stop servers that have
+been provisioned by the OpenStack Compute service.
+*/
+package startstop

--- a/vendor/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/startstop/fixtures.go
+++ b/vendor/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/startstop/fixtures.go
@@ -1,0 +1,29 @@
+// +build fixtures
+
+package startstop
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func mockStartServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"os-start": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockStopServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"os-stop": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/vendor/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/startstop/requests.go
+++ b/vendor/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/startstop/requests.go
@@ -1,0 +1,23 @@
+package startstop
+
+import "github.com/rackspace/gophercloud"
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}
+
+// Start is the operation responsible for starting a Compute server.
+func Start(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
+	var res gophercloud.ErrResult
+	reqBody := map[string]interface{}{"os-start": nil}
+	_, res.Err = client.Post(actionURL(client, id), reqBody, nil, nil)
+	return res
+}
+
+// Stop is the operation responsible for stopping a Compute server.
+func Stop(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
+	var res gophercloud.ErrResult
+	reqBody := map[string]interface{}{"os-stop": nil}
+	_, res.Err = client.Post(actionURL(client, id), reqBody, nil, nil)
+	return res
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1185,6 +1185,12 @@
 			"revisionTime": "2016-06-03T22:34:01Z"
 		},
 		{
+			"checksumSHA1": "jqSmOJoNKVtGwDhuoilAF7iftqA=",
+			"path": "github.com/rackspace/gophercloud/openstack/compute/v2/extensions/startstop",
+			"revision": "d47105ce4ef90cea9a14b85c8dd172b760085828",
+			"revisionTime": "2016-06-03T22:34:01Z"
+		},
+		{
 			"checksumSHA1": "rHEOEAm10HDsfBLU8FqKSUdwqFY=",
 			"path": "github.com/rackspace/gophercloud/openstack/compute/v2/extensions/tenantnetworks",
 			"revision": "d47105ce4ef90cea9a14b85c8dd172b760085828",

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -264,6 +264,11 @@ The following arguments are supported:
     defining one or more files and their contents. The personality structure
     is described below.
 
+* `stop_before_destroy` - (Optional) Whether to try stop instance gracefully
+    before destroying it, thus giving chance for guest OS daemons to stop correctly.
+    If instance doesn't stop within timeout, it will be destroyed anyway.
+
+
 The `network` block supports:
 
 * `uuid` - (Required unless `port`  or `name` is provided) The network UUID to


### PR DESCRIPTION
@jtopjian Please review this patch for #7129 behavior. It includes 1 added dependency to `gophercloud` package and basic opt-in implementation of stop_before_destroy flag.

Need advice on acceptance test for it. Currently it was tested manually within corporate openstack setup.

First scenario was a mini consul cluster, where clients were configured with [`leave_on_terminate`](https://www.consul.io/docs/agent/options.html) option. When I scaled down consul machines - they correctly left cluster and disappeared from node catatlog, thus it subjectively proves that Nova sent ACPI shutdown signal to guests OS. Without `stop_before_destroy` consul shows all nodes in failing state.

Another check is to peek at instance [action history API](http://developer.openstack.org/api-ref/compute/?expanded=list-actions-for-server-detail#servers-actions-servers-os-instance-actions). With  `stop_before_destroy` enabled, action history should include `stop`:
```
+--------+------------------------------------------+---------+----------------------------+
| Action | Request_ID                               | Message | Start_Time                 |
+--------+------------------------------------------+---------+----------------------------+
| create | req-e0d5c543-161a-43a0-9fb5-527b802faa03 | -       | 2016-06-15T20:01:39.000000 |
| stop   | req-b86d88e3-8916-47e3-a139-8b0cf5cfb35a | -       | 2016-06-15T20:03:47.000000 |
+--------+------------------------------------------+---------+----------------------------+
```
But, unfortunately, I didn't find implementation of history API in `gophercloud`