### PR TITLE
Ignore missing ENI attachment when trying to detach ENI

### DIFF
--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -193,7 +193,9 @@ func resourceAwsNetworkInterfaceDetach(oa *schema.Set, meta interface{}, eniId s
 		conn := meta.(*AWSClient).ec2conn
 		_, detach_err := conn.DetachNetworkInterface(detach_request)
 		if detach_err != nil {
-			return fmt.Errorf("Error detaching ENI: %s", detach_err)
+			if awsErr, _ := detach_err.(awserr.Error); awsErr.Code() != "InvalidAttachmentID.NotFound" {
+				return fmt.Errorf("Error detaching ENI: %s", detach_err)
+			}
 		}
 
 		log.Printf("[DEBUG] Waiting for ENI (%s) to become dettached", eniId)


### PR DESCRIPTION
When I taint an EC2 instance with an ENI attached, running `terraform apply` fails when trying to detach the ENI from the instance because the ENI attachment no longer exists. The ENI attachment disappears after deleting the EC2 instance. What this pull requests does is ignore the scenario where the ENI attachment is already gone, and should print the error if it is anything else.

Interestingly the ENI detachment method is very similar to the Volume attachment delete method https://github.com/hashicorp/terraform/blob/5fdcf5d16a557276ef310387dec8c6fb9140a5fd/builtin/providers/aws/resource_aws_volume_attachment.go#L150-L182. As an alternative to the change made in this PR, this error handling could be omitted entirely making the methods more similar. Just a thought...