### PR TITLE
core: don't check any parts of a computed set in InstanceDiff.Same

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -443,35 +443,30 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 			// values. So check if there is an approximate hash in the key
 			// and if so, try to match the key.
 			if strings.Contains(k, "~") {
-				// TODO (SvH): There should be a better way to do this...
 				parts := strings.Split(k, ".")
-				parts2 := strings.Split(k, ".")
+				parts2 := append([]string(nil), parts...)
+
 				re := regexp.MustCompile(`^~\d+$`)
 				for i, part := range parts {
 					if re.MatchString(part) {
+						// we're going to consider this the base of a
+						// computed hash, and remove all longer matching fields
+						ok = true
+
 						parts2[i] = `\d+`
+						parts2 = parts2[:i+1]
+						break
 					}
 				}
-				re, err := regexp.Compile("^" + strings.Join(parts2, `\.`) + "$")
+
+				re, err := regexp.Compile("^" + strings.Join(parts2, `\.`))
 				if err != nil {
 					return false, fmt.Sprintf("regexp failed to compile; err: %#v", err)
 				}
+
 				for k2, _ := range checkNew {
 					if re.MatchString(k2) {
 						delete(checkNew, k2)
-
-						if diffOld.NewComputed && strings.HasSuffix(k, ".#") {
-							// This is a computed list or set, so remove any keys with this
-							// prefix from the check list.
-							prefix := k2[:len(k2)-1]
-							for k2, _ := range checkNew {
-								if strings.HasPrefix(k2, prefix) {
-									delete(checkNew, k2)
-								}
-							}
-						}
-						ok = true
-						break
 					}
 				}
 			}

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -525,6 +525,47 @@ func TestInstanceDiffSame(t *testing.T) {
 			"",
 		},
 
+		// Computed sets may not contain all fields in the original diff, and
+		// because multiple entries for the same set can compute to the same
+		// hash before the values are computed or interpolated, the overall
+		// count can change as well.
+		{
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo.#": &ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"foo.~35964334.bar": &ResourceAttrDiff{
+						Old: "",
+						New: "${var.foo}",
+					},
+				},
+			},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo.#": &ResourceAttrDiff{
+						Old: "0",
+						New: "2",
+					},
+					"foo.87654323.bar": &ResourceAttrDiff{
+						Old: "",
+						New: "12",
+					},
+					"foo.87654325.bar": &ResourceAttrDiff{
+						Old: "",
+						New: "12",
+					},
+					"foo.87654325.baz": &ResourceAttrDiff{
+						Old: "",
+						New: "12",
+					},
+				},
+			},
+			true,
+			"",
+		},
+
 		// In a DESTROY/CREATE scenario, the plan diff will be run against the
 		// state of the old instance, while the apply diff will be run against an
 		// empty state (because the state is cleared when the destroy runs.)


### PR DESCRIPTION
When checking for "same" values in a computed hash, not only might some
of the values differ between versions changing the hash, but there may be
fields not included at all in the original map, and different overall
counts.

Instead of trying to match individual set fields with different hashes,
remove any hashed key longer than the computed key with the same base
name.

Fixes #2027 (and hopefully a number of other "diffs didn't match during apply" issues)