### PR TITLE
[WIP]: core/diff: Fix attribute mismatch with tags.%

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -488,7 +488,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 			// Similarly, in a RequiresNew scenario, a list that shows up in the plan
 			// diff can disappear from the apply diff, which is calculated from an
 			// empty state.
-			if d.RequiresNew() && strings.HasSuffix(k, ".#") {
+			if d.RequiresNew() && (strings.HasSuffix(k, ".#") || strings.HasSuffix(k, ".%")) {
 				ok = true
 			}
 

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -595,6 +595,38 @@ func TestInstanceDiffSame(t *testing.T) {
 			true,
 			"",
 		},
+
+		{
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"reqnew": &ResourceAttrDiff{
+						Old:         "old",
+						New:         "new",
+						RequiresNew: true,
+					},
+					"somemap.%": &ResourceAttrDiff{
+						Old: "1",
+						New: "0",
+					},
+					"somemap.oldkey": &ResourceAttrDiff{
+						Old:        "long ago",
+						New:        "",
+						NewRemoved: true,
+					},
+				},
+			},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"reqnew": &ResourceAttrDiff{
+						Old:         "",
+						New:         "new",
+						RequiresNew: true,
+					},
+				},
+			},
+			true,
+			"",
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This is the start of a patch to fix the acceptance test `TestAccAWSInstance_forceNewAndTagsDrift`. Right now it's failing like so:

```
--- FAIL: TestAccAWSInstance_forceNewAndTagsDrift (103.36s)
	testing.go:247: Step 1 error: Error applying: 1 error(s) occurred:
		
		* aws_instance.foo: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.
		
		Please include the following information in your report:
		
		    Terraform Version: 0.7.0
		    Resource ID: aws_instance.foo
		    Mismatch reason: attribute mismatch: tags.%
```

(from https://travis-ci.org/hashicorp/terraform/jobs/136731270)

It's a regression test that was introduced in https://github.com/hashicorp/terraform/pull/4749 . With the recent addition of native lists, the state syntax for maps changed(?) from `thing.#` to `thing.%`, and so the safety provided in #4749 was lost (sort of).

This is my first foray into core-land so it's not clear to me if the test case is sufficient, and if the additional `HasSuffix` is enough of we need more of those in other place. I poke with @phinze and we started this at the end of the day, so I wanted to get the PR open to preserve some context.