### PR TITLE
vendor: joyent/gosign/auth update to master

### DIFF
--- a/vendor/github.com/joyent/gosign/auth/auth.go
+++ b/vendor/github.com/joyent/gosign/auth/auth.go
@@ -114,22 +114,19 @@ func getHashFunction(algorithm string) (hashFunc crypto.Hash) {
 }
 
 func (cred *Credentials) Region() string {
-	sdcUrl := cred.SdcEndpoint.URL
-
-	if isLocalhost(sdcUrl) {
-		return "some-region"
-	}
-	return sdcUrl[strings.LastIndex(sdcUrl, "/")+1 : strings.Index(sdcUrl, ".")]
-}
-
-func isLocalhost(u string) bool {
-	parsedUrl, err := url.Parse(u)
+	parsedUrl, err := url.Parse(cred.SdcEndpoint.URL)
 	if err != nil {
-		return false
+		// Bogus URL - no region.
+		return ""
 	}
 	if strings.HasPrefix(parsedUrl.Host, "localhost") || strings.HasPrefix(parsedUrl.Host, "127.0.0.1") {
-		return true
+		return "some-region"
 	}
 
-	return false
+	host := parsedUrl.Host
+	firstDotIdx := strings.Index(host, ".")
+	if firstDotIdx >= 0 {
+		return host[:firstDotIdx]
+	}
+	return host
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -954,8 +954,10 @@
 			"revision": "0697a5c4f39a71a4f9e3b154380b47dbfcc3da6e"
 		},
 		{
+			"checksumSHA1": "N0NRIcJF7aj1wd56DA1N9GpYq/4=",
 			"path": "github.com/joyent/gosign/auth",
-			"revision": "a1f3aa7d52213987117e47d721bcc9a499994d5f"
+			"revision": "8978c75ffefb3f63a977ad9cbfce40caeb40177e",
+			"revisionTime": "2016-06-16T18:50:15Z"
 		},
 		{
 			"comment": "v0.3.0-33-g53d1c0a",


### PR DESCRIPTION
Updates Joyent's gosign to the latest version. 
On the vendor side it addressed issue joyent/gosign#8 which in turn should close hashicorp/terraform#7155.