### PR TITLE
provider/mysql: Empty Provider Credentials Caused Panic

### DIFF
--- a/builtin/providers/mysql/provider.go
+++ b/builtin/providers/mysql/provider.go
@@ -17,12 +17,28 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("MYSQL_ENDPOINT", nil),
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if value == "" {
+						errors = append(errors, fmt.Errorf("Endpoint must not be an empty string"))
+					}
+
+					return
+				},
 			},
 
 			"username": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("MYSQL_USERNAME", nil),
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if value == "" {
+						errors = append(errors, fmt.Errorf("Username must not be an empty string"))
+					}
+
+					return
+				},
 			},
 
 			"password": &schema.Schema{


### PR DESCRIPTION
Fixes #7199 There are currently no checks on username and endpoint in the provider
schema from being an empty value. This PR adds support to make sure that
endpoint and username are not empty strings as that can cause a panic

Results of the PR:

```
 % terraform apply
There are warnings and/or errors related to your configuration. Please
fix these before continuing.

Errors:

  * provider.mysql: Endpoint must not be an empty string
```