### PR TITLE
aws/route53_zone: Make delegation_set_id conflict w/ vpc_id

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -39,9 +39,10 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			},
 
 			"vpc_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"delegation_set_id"},
 			},
 
 			"vpc_region": &schema.Schema{
@@ -57,9 +58,10 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			},
 
 			"delegation_set_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"vpc_id"},
 			},
 
 			"name_servers": &schema.Schema{

--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -57,8 +57,10 @@ The following arguments are supported:
 * `comment` - (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.
 * `tags` - (Optional) A mapping of tags to assign to the zone.
 * `vpc_id` - (Optional) The VPC to associate with a private hosted zone. Specifying `vpc_id` will create a private hosted zone.
+  Conflicts w/ `delegation_set_id` as delegation sets can only be used for public zones.
 * `vpc_region` - (Optional) The VPC's region. Defaults to the region of the AWS provider.
 * `delegation_set_id` - (Optional) The ID of the reusable delgation set whose NS records you want to assign to the hosted zone.
+  Conflicts w/ `vpc_id` as delegation sets can only be used for public zones.
 
 ## Attributes Reference
 


### PR DESCRIPTION
 - as per the API reference it is not possible to use delegation sets w/ private hosted zones
   - http://docs.aws.amazon.com/Route53/latest/APIReference/API-create-hosted-zone-private.html
   - http://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateHostedZone.html
 - if you specify both AWS returns confusing error "InvalidInput" with no further details so this should reduce potential confusions & improve UX

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSRoute53Zone'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSRoute53Zone -timeout 120m
=== RUN   TestAccAWSRoute53Zone_importBasic
--- PASS: TestAccAWSRoute53Zone_importBasic (46.12s)
=== RUN   TestAccAWSRoute53ZoneAssociation_basic
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (104.08s)
=== RUN   TestAccAWSRoute53ZoneAssociation_region
--- PASS: TestAccAWSRoute53ZoneAssociation_region (110.52s)
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (49.00s)
=== RUN   TestAccAWSRoute53Zone_updateComment
--- PASS: TestAccAWSRoute53Zone_updateComment (57.39s)
=== RUN   TestAccAWSRoute53Zone_private_basic
--- PASS: TestAccAWSRoute53Zone_private_basic (66.48s)
=== RUN   TestAccAWSRoute53Zone_private_region
--- PASS: TestAccAWSRoute53Zone_private_region (69.22s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	502.842s
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSRoute53DelegationSet'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSRoute53DelegationSet -timeout 120m
=== RUN   TestAccAWSRoute53DelegationSet_importBasic
--- PASS: TestAccAWSRoute53DelegationSet_importBasic (26.67s)
=== RUN   TestAccAWSRoute53DelegationSet_basic
--- PASS: TestAccAWSRoute53DelegationSet_basic (11.65s)
=== RUN   TestAccAWSRoute53DelegationSet_withZones
--- PASS: TestAccAWSRoute53DelegationSet_withZones (51.45s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	89.806s
```