### PR TITLE
Correct true and false OpsWorks string values to fix manage_bundler config bug

### DIFF
--- a/builtin/providers/aws/opsworks_layers.go
+++ b/builtin/providers/aws/opsworks_layers.go
@@ -39,8 +39,8 @@ type opsworksLayerType struct {
 }
 
 var (
-	opsworksTrueString  = "1"
-	opsworksFalseString = "0"
+	opsworksTrueString  = "true"
+	opsworksFalseString = "false"
 )
 
 func (lt *opsworksLayerType) SchemaResource() *schema.Resource {


### PR DESCRIPTION
This PR implements the small change provided by @u2mejc in [his comment](https://github.com/hashicorp/terraform/issues/5907#issuecomment-218038835) on issue #5907, in order to fix a bug where the `aws_opsworks_rails_app_layer` resource's `manage_bundler` parameter is ignored, so no matter if you set it to `true`, `false`, or don't even set it, the created Rails layer's "Install and manage Bundler" setting is unconditionally "No".

There are no existing acceptance tests for `resource_aws_opsworks_rails_app_layer`. Unfortunately, I don't have the time to write them, although it seems like it would be a good opportunity to learn a little Go.

But I did compile Terraform in Vagrant (`make dev`) with this change and tested my Terraform template file which set `manage_bundler = true`, and it resulted in the created Rails layer having "Install and manage Bundler" set to "yes". So it does fix that issue, as @u2mejc said.