### PR TITLE
vSphere provider - Graceful read miss

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_file.go
+++ b/builtin/providers/vsphere/resource_vsphere_file.go
@@ -164,8 +164,13 @@ func resourceVSphereFileRead(d *schema.ResourceData, meta interface{}) error {
 
 	_, err = ds.Stat(context.TODO(), f.destinationFile)
 	if err != nil {
+		log.Printf("[DEBUG] resourceVSphereFileRead - stat failed on: %v", f.destinationFile)
 		d.SetId("")
-		return err
+
+		_, ok := err.(object.DatastoreNoSuchFileError)
+		if !ok {
+			return err
+		}
 	}
 
 	return nil

--- a/builtin/providers/vsphere/resource_vsphere_virtual_disk.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_disk.go
@@ -173,7 +173,12 @@ func resourceVSphereVirtualDiskRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		log.Printf("[DEBUG] resourceVSphereVirtualDiskRead - stat failed on: %v", vDisk.vmdkPath)
 		d.SetId("")
-		return err
+
+		_, ok := err.(object.DatastoreNoSuchFileError)
+		if !ok {
+			return err
+		}
+		return nil
 	}
 	fileInfo = fileInfo.GetFileInfo()
 	log.Printf("[DEBUG] resourceVSphereVirtualDiskRead - fileinfo: %#v", fileInfo)


### PR DESCRIPTION
For both the file and virtual_disk resource, Stat is used during read,
but if Stat returns an error, read() will return that error. In doing
so, if a resource is deleted manually, the TF user would then not be
able to destroy the resource because the read would block the Delete()
call. With this patch, read() will only return an error if that error
is NOT a DatastoreNoSuchFileError.