### PR TITLE
provider/aws: elastic beanstalk invalid setting crash

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -370,7 +370,7 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 		return err
 	}
 
-	if tier == "WebServer" {
+	if tier == "WebServer" && env.CNAME != nil {
 		beanstalkCnamePrefixRegexp := regexp.MustCompile(`(^[^.]+).\w{2}-\w{4,9}-\d.elasticbeanstalk.com$`)
 		var cnamePrefix string
 		cnamePrefixMatch := beanstalkCnamePrefixRegexp.FindStringSubmatch(*env.CNAME)

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -225,6 +225,8 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 		createOpts.TemplateName = aws.String(templateName)
 	}
 
+	// Get the current time to filter describeBeanstalkEvents messages
+	t := time.Now()
 	log.Printf("[DEBUG] Elastic Beanstalk Environment create opts: %s", createOpts)
 	resp, err := conn.CreateEnvironment(&createOpts)
 	if err != nil {
@@ -248,6 +250,11 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 		return fmt.Errorf(
 			"Error waiting for Elastic Beanstalk Environment (%s) to become ready: %s",
 			d.Id(), err)
+	}
+
+	err = describeBeanstalkEvents(conn, d.Id(), t)
+	if err != nil {
+		return err
 	}
 
 	return resourceAwsElasticBeanstalkEnvironmentRead(d, meta)
@@ -293,6 +300,8 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 		updateOpts.TemplateName = aws.String(d.Get("template_name").(string))
 	}
 
+	// Get the current time to filter describeBeanstalkEvents messages
+	t := time.Now()
 	log.Printf("[DEBUG] Elastic Beanstalk Environment update opts: %s", updateOpts)
 	_, err = conn.UpdateEnvironment(&updateOpts)
 	if err != nil {
@@ -313,6 +322,11 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 		return fmt.Errorf(
 			"Error waiting for Elastic Beanstalk Environment (%s) to become ready: %s",
 			d.Id(), err)
+	}
+
+	err = describeBeanstalkEvents(conn, d.Id(), t)
+	if err != nil {
+		return err
 	}
 
 	return resourceAwsElasticBeanstalkEnvironmentRead(d, meta)
@@ -514,6 +528,8 @@ func resourceAwsElasticBeanstalkEnvironmentDelete(d *schema.ResourceData, meta i
 		TerminateResources: aws.Bool(true),
 	}
 
+	// Get the current time to filter describeBeanstalkEvents messages
+	t := time.Now()
 	log.Printf("[DEBUG] Elastic Beanstalk Environment terminate opts: %s", opts)
 	_, err = conn.TerminateEnvironment(&opts)
 
@@ -535,6 +551,11 @@ func resourceAwsElasticBeanstalkEnvironmentDelete(d *schema.ResourceData, meta i
 		return fmt.Errorf(
 			"Error waiting for Elastic Beanstalk Environment (%s) to become terminated: %s",
 			d.Id(), err)
+	}
+
+	err = describeBeanstalkEvents(conn, d.Id(), t)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -641,4 +662,27 @@ func dropGeneratedSecurityGroup(settingValue string, meta interface{}) string {
 	sort.Strings(legitGroups)
 
 	return strings.Join(legitGroups, ",")
+}
+
+func describeBeanstalkEvents(conn *elasticbeanstalk.ElasticBeanstalk, environmentId string, t time.Time) error {
+	beanstalkErrors, err := conn.DescribeEvents(&elasticbeanstalk.DescribeEventsInput{
+		EnvironmentId: aws.String(environmentId),
+		Severity:      aws.String("ERROR"),
+		StartTime:     aws.Time(t),
+	})
+
+	if err != nil {
+		log.Printf("[Err] Unable to get Elastic Beanstalk Evironment events: %s", err)
+	}
+
+	events := ""
+	for _, event := range beanstalkErrors.Events {
+		events = events + "\n" + event.EventDate.String() + ": " + *event.Message
+	}
+
+	if events != "" {
+		return fmt.Errorf("%s", events)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This fixes the crash in #6624/#6707/#7197. It also adds functionality to relay any failures from the elastic beanstalk environment events. As an example, the config

```
provider "aws" {
  region = "us-east-1"
}

resource "aws_elastic_beanstalk_application" "tftest" {
  name = "tf-test-name"
  description = "tf-test-desc"
}

resource "aws_elastic_beanstalk_environment" "tftest" {
  name = "tf-test-name"
  application = "${aws_elastic_beanstalk_application.tftest.name}"
  solution_stack_name = "64bit Amazon Linux 2016.03 v2.1.0 running Go 1.4"

setting {
    namespace = "aws:elb:loadbalancer"
    name = "SecurityGroups"
    value = "{\"Fn::GetAtt\":[\"AWSEBLoadBalancerSecurityGroup\",\"GroupId\"]},{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}"
  }
}
```
Results in the following output
```
aws_elastic_beanstalk_application.tftest: Creating...
  description: "" => "tf-test-desc"
  name:        "" => "tf-test-name"
aws_elastic_beanstalk_application.tftest: Creation complete
aws_elastic_beanstalk_environment.tftest: Creating...
  all_settings.#:               "" => "<computed>"
  application:                  "" => "tf-test-name"
  autoscaling_groups.#:         "" => "<computed>"
  cname:                        "" => "<computed>"
  cname_prefix:                 "" => "<computed>"
  instances.#:                  "" => "<computed>"
  launch_configurations.#:      "" => "<computed>"
  load_balancers.#:             "" => "<computed>"
  name:                         "" => "tf-test-name"
  queues.#:                     "" => "<computed>"
  setting.#:                    "" => "1"
  setting.2468988437.name:      "" => "SecurityGroups"
  setting.2468988437.namespace: "" => "aws:elb:loadbalancer"
  setting.2468988437.value:     "" => "{\"Fn::GetAtt\":[\"AWSEBLoadBalancerSecurityGroup\",\"GroupId\"]},{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}"
  solution_stack_name:          "" => "64bit Amazon Linux 2016.03 v2.1.0 running Go 1.4"
  tier:                         "" => "WebServer"
  triggers.#:                   "" => "<computed>"
  wait_for_ready_timeout:       "" => "10m"
aws_elastic_beanstalk_environment.tftest: Still creating... (10s elapsed)
aws_elastic_beanstalk_environment.tftest: Still creating... (20s elapsed)
aws_elastic_beanstalk_environment.tftest: Still creating... (30s elapsed)
Error applying plan:

1 error(s) occurred:

* aws_elastic_beanstalk_environment.tftest: 
2016-06-18 00:45:09.529 +0000 UTC: Stack named 'awseb-e-5s3a3gisjc-stack' aborted operation. Current state: 'CREATE_FAILED'  Reason: The following resource(s) failed to create: [AWSEBLoadBalancer]. 
2016-06-18 00:44:57.692 +0000 UTC: Creating load balancer failed Reason: Security group(s) can be applied to only an ELB in VPC.

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```
Most of the tests on this pass, with one exception. The worker tier test fails, I was only able to reproduce the issue in us-west-2, so it might be temporary. 