### PR TITLE
Stop swallowing errors from DescribeAlarms

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -259,7 +259,7 @@ func getAwsCloudWatchMetricAlarm(d *schema.ResourceData, meta interface{}) (*clo
 
 	resp, err := conn.DescribeAlarms(&params)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	// Find it and return it


### PR DESCRIPTION
This caused alarms to be created repeatedly if Terraform is running without DescribeAlarms permission.