### PR TITLE
[WIP] Support "hiding" ignored parameters from state.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ type ResourceLifecycle struct {
 	CreateBeforeDestroy bool     `mapstructure:"create_before_destroy"`
 	PreventDestroy      bool     `mapstructure:"prevent_destroy"`
 	IgnoreChanges       []string `mapstructure:"ignore_changes"`
+	HideIgnored         bool     `mapstructure:"hide_ignored"`
 }
 
 // Copy returns a copy of this ResourceLifecycle

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -675,7 +675,7 @@ func loadManagedResourcesHcl(list *ast.ObjectList) ([]*Resource, error) {
 		var lifecycle ResourceLifecycle
 		if o := listVal.Filter("lifecycle"); len(o.Items) > 0 {
 			// Check for invalid keys
-			valid := []string{"create_before_destroy", "ignore_changes", "prevent_destroy"}
+			valid := []string{"create_before_destroy", "ignore_changes", "hide_ignored", "prevent_destroy"}
 			if err := checkHCLKeys(o.Items[0].Val, valid); err != nil {
 				return nil, multierror.Prefix(err, fmt.Sprintf(
 					"%s[%s]:", t, k))

--- a/terraform/eval_hide_ignored.go
+++ b/terraform/eval_hide_ignored.go
@@ -1,0 +1,40 @@
+package terraform
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform/config"
+)
+
+// EvalHideIgnored is an EvalNode implementation that removes ignored
+// attributes from the state.
+type EvalHideIgnored struct {
+	Resource      *config.Resource
+	State         **InstanceState
+}
+
+func (n *EvalHideIgnored) Eval(ctx EvalContext) (interface{}, error) {
+	if n.State == nil || *n.State == nil || n.Resource == nil || n.Resource.Id() == "" {
+		return nil, nil
+	}
+	var state *InstanceState = *n.State
+
+	if !n.Resource.Lifecycle.HideIgnored {
+		return nil, nil
+	}
+
+	ignoreChanges := n.Resource.Lifecycle.IgnoreChanges
+	if len(ignoreChanges) == 0 {
+		return nil, nil
+	}
+
+	for _, ignoredName := range ignoreChanges {
+		for name := range state.Attributes {
+			if strings.HasPrefix(name, ignoredName) {
+				delete(state.Attributes, name)
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -303,6 +303,10 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 					State:    &state,
 					Output:   &state,
 				},
+				&EvalHideIgnored{
+					Resource: n.Resource,
+					State:    &state,
+				},
 				&EvalWriteState{
 					Name:         n.stateId(),
 					ResourceType: n.Resource.Type,
@@ -347,6 +351,10 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 				&EvalIgnoreChanges{
 					Resource: n.Resource,
 					Diff:     &diff,
+				},
+				&EvalHideIgnored{
+					Resource: n.Resource,
+					State:    &state,
 				},
 				&EvalWriteState{
 					Name:         n.stateId(),
@@ -498,6 +506,10 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 					Output:    &state,
 					Error:     &err,
 					CreateNew: &createNew,
+				},
+				&EvalHideIgnored{
+					Resource: n.Resource,
+					State:    &state,
 				},
 				&EvalWriteState{
 					Name:         n.stateId(),
@@ -921,6 +933,10 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 						Output:   &state,
 						Error:    &err,
 					},
+				},
+				&EvalHideIgnored{
+					Resource: n.Resource,
+					State:    &state,
 				},
 				&EvalWriteState{
 					Name:         n.stateId(),


### PR DESCRIPTION
Add a lifecycle flag "hide_ignored" to remove "ignored" resource
parameters from the final state. While definitely not perfect, this
kind of simple solution should make it possible to prevent sensitive
from being written to tfstate.

"hide_ignored" uses "ignore_changes" list since it does not make sense
to omit non-ignored prameters from state file as it would break terraform
flow.

Fixes #516

The work is not complete yet as it has no tests and documentation. What is more, probably parameter name could be better as well, I'm open to suggestions.

I would just like to hear from development team if you would accept this kind of solution and I should pursue to improve it (won't take long) or just drop the idea. While definitely not perfect, this patch is kind of simple, the flag is opt-in and I think it would be useful for many users out there (me included) as passwords in the state file pose a huge security problem. For example, I can encrypt terraform.tfvars myself to store it securely but I basically have no control of how terraform.tfstate gets stored remotely.
