### PR TITLE
core: add "apply -confirm-plan" flag

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -121,10 +121,11 @@ type Operation struct {
 
 	// The options below are more self-explanatory and affect the runtime
 	// behavior of the operation.
-	Destroy     bool
-	Targets     []string
-	Variables   map[string]interface{}
-	AutoApprove bool
+	Destroy      bool
+	Targets      []string
+	Variables    map[string]interface{}
+	AutoApprove  bool
+	DestroyForce bool
 
 	// Input/output/control options.
 	UIIn  terraform.UIInput

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -121,9 +121,10 @@ type Operation struct {
 
 	// The options below are more self-explanatory and affect the runtime
 	// behavior of the operation.
-	Destroy   bool
-	Targets   []string
-	Variables map[string]interface{}
+	Destroy     bool
+	Targets     []string
+	Variables   map[string]interface{}
+	AutoApprove bool
 
 	// Input/output/control options.
 	UIIn  terraform.UIInput

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/command/clistate"
+	"github.com/hashicorp/terraform/command/format"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
@@ -89,9 +90,36 @@ func (b *Local) opApply(
 
 		// Perform the plan
 		log.Printf("[INFO] backend/local: apply calling Plan")
-		if _, err := tfCtx.Plan(); err != nil {
+		plan, err := tfCtx.Plan()
+		if err != nil {
 			runningOp.Err = errwrap.Wrapf("Error running plan: {{err}}", err)
 			return
+		}
+
+		trivialPlan := plan.Diff == nil || plan.Diff.Empty()
+		hasUI := op.UIOut != nil && op.UIIn != nil
+		if hasUI && !op.AutoApprove && !trivialPlan {
+			op.UIOut.Output(strings.TrimSpace(approvePlanHeader) + "\n")
+			op.UIOut.Output(format.Plan(&format.PlanOpts{
+				Plan:        plan,
+				Color:       b.Colorize(),
+				ModuleDepth: -1,
+			}))
+			desc := "Terraform will apply the plan described above.\n" +
+				"Only 'yes' will be accepted to approve."
+			v, err := op.UIIn.Input(&terraform.InputOpts{
+				Id:          "approve",
+				Query:       "Do you want to apply the plan above?",
+				Description: desc,
+			})
+			if err != nil {
+				runningOp.Err = errwrap.Wrapf("Error asking for approval: {{err}}", err)
+				return
+			}
+			if v != "yes" {
+				runningOp.Err = errors.New("Apply cancelled.")
+				return
+			}
 		}
 	}
 
@@ -287,4 +315,12 @@ const earlyStateWriteErrorFmt = `Error saving current state: %s
 Terraform encountered an error attempting to save the state before canceling
 the current operation. Once the operation is complete another attempt will be
 made to save the final state.
+`
+
+const approvePlanHeader = `
+The Terraform execution plan has been generated and is shown below.
+Resources are shown in alphabetical order for quick scanning. Green resources
+will be created (or destroyed and then created if an existing resource
+exists), yellow resources are being changed in-place, and red resources
+will be destroyed. Cyan entries are data sources to be read.
 `

--- a/command/apply.go
+++ b/command/apply.go
@@ -29,7 +29,7 @@ type ApplyCommand struct {
 }
 
 func (c *ApplyCommand) Run(args []string) int {
-	var destroyForce, refresh bool
+	var destroyForce, refresh, autoApprove bool
 	args = c.Meta.process(args, true)
 
 	cmdName := "apply"
@@ -42,6 +42,9 @@ func (c *ApplyCommand) Run(args []string) int {
 		cmdFlags.BoolVar(&destroyForce, "force", false, "force")
 	}
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
+	if !c.Destroy {
+		cmdFlags.BoolVar(&autoApprove, "auto-approve", true, "skip interactive approval of plan before applying")
+	}
 	cmdFlags.IntVar(
 		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
@@ -106,6 +109,11 @@ func (c *ApplyCommand) Run(args []string) int {
 	if plan != nil {
 		// Reset the config path for backend loading
 		configPath = ""
+
+		if !autoApprove {
+			c.Ui.Error("Cannot combine -auto-approve=false with a plan file.")
+			return 1
+		}
 	}
 
 	// Load the module if we don't have one yet (not running from plan)
@@ -189,6 +197,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.Plan = plan
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply
+	opReq.AutoApprove = autoApprove
 
 	// Perform the operation
 	ctx, ctxCancel := context.WithCancel(context.Background())
@@ -282,6 +291,10 @@ Options:
   -lock=true             Lock the state file when locking is supported.
 
   -lock-timeout=0s       Duration to retry a state lock.
+
+  -auto-approve=true     Skip interactive approval of plan before applying. In a
+                         future version of Terraform, this flag's default value
+                         will change to false.
 
   -input=true            Ask for input for variables if not directly set.
 

--- a/command/apply.go
+++ b/command/apply.go
@@ -155,41 +155,6 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
-	// If we're not forcing and we're destroying, verify with the
-	// user at this point.
-	if !destroyForce && c.Destroy {
-		// Default destroy message
-		desc := "Terraform will delete all your managed infrastructure.\n" +
-			"There is no undo. Only 'yes' will be accepted to confirm."
-
-		// If targets are specified, list those to user
-		if c.Meta.targets != nil {
-			var descBuffer bytes.Buffer
-			descBuffer.WriteString("Terraform will delete the following infrastructure:\n")
-			for _, target := range c.Meta.targets {
-				descBuffer.WriteString("\t")
-				descBuffer.WriteString(target)
-				descBuffer.WriteString("\n")
-			}
-			descBuffer.WriteString("There is no undo. Only 'yes' will be accepted to confirm")
-			desc = descBuffer.String()
-		}
-
-		v, err := c.UIInput().Input(&terraform.InputOpts{
-			Id:          "destroy",
-			Query:       "Do you really want to destroy?",
-			Description: desc,
-		})
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error asking for confirmation: %s", err))
-			return 1
-		}
-		if v != "yes" {
-			c.Ui.Output("Destroy cancelled.")
-			return 1
-		}
-	}
-
 	// Build the operation
 	opReq := c.Operation()
 	opReq.Destroy = c.Destroy
@@ -198,6 +163,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply
 	opReq.AutoApprove = autoApprove
+	opReq.DestroyForce = destroyForce
 
 	// Perform the operation
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -168,6 +168,7 @@ func (m *Meta) Operation() *backend.Operation {
 		PlanOutBackend:   m.backendState,
 		Targets:          m.targets,
 		UIIn:             m.UIInput(),
+		UIOut:            m.Ui,
 		Workspace:        m.Workspace(),
 		LockState:        m.stateLock,
 		StateLockTimeout: m.stateLockTimeout,

--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -37,6 +37,9 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-input=true` - Ask for input for variables if not directly set.
 
+* `-auto-approve=true` - Skip interactive approval of plan before applying. In a
+  future version of Terraform, this flag's default value will change to false.
+
 * `-no-color` - Disables output with coloring.
 
 * `-parallelism=n` - Limit the number of concurrent operation as Terraform


### PR DESCRIPTION
A common reason to want to use `terraform plan` is to have a chance to
review and confirm a plan before running it.  If in fact that is the
only reason you are running plan, this new `terraform apply -confirm-plan`
flag provides an easier alternative to

```
P=$(mktemp -t plan)
terraform refresh
terraform plan -refresh=false -out=$P
terraform apply $P
rm $P
```
