### PR TITLE
docs: Make middleman work offline out of the box

### DIFF
--- a/website/config.rb
+++ b/website/config.rb
@@ -1,7 +1,12 @@
 set :base_url, "https://www.terraform.io/"
 
+configure :development do
+  set :releases_enabled, false
+end
+
 activate :hashicorp do |h|
-  h.name        = "terraform"
-  h.version     = "0.6.16"
-  h.github_slug = "hashicorp/terraform"
+  h.name             = "terraform"
+  h.version          = "0.6.16"
+  h.github_slug      = "hashicorp/terraform"
+  h.releases_enabled = config[:releases_enabled]
 end


### PR DESCRIPTION
Details & reasoning behind solution discussed in https://github.com/hashicorp/middleman-hashicorp/pull/28

### Test plan

1. `bundle exec middleman`
2. Go to `http://localhost:4567/downloads.html` to verify there's a single default build

This behaviour is now default no matter if you're online or offline (in `development` environment).

The assumption this is built on is that most contributors/maintainers update content rather than tune downloads page. If anyone needs to verify changes in the downloads page they'll need to do this:

```
set :releases_enabled, true
```