### PR TITLE
Force the re-creation of the template resource if its content is modifed

### DIFF
--- a/builtin/providers/template/resource_cloudinit_config.go
+++ b/builtin/providers/template/resource_cloudinit_config.go
@@ -27,6 +27,7 @@ func resourceCloudinitConfig() *schema.Resource {
 			"part": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"content_type": &schema.Schema{

--- a/builtin/providers/template/resource_cloudinit_config.go
+++ b/builtin/providers/template/resource_cloudinit_config.go
@@ -19,7 +19,6 @@ func resourceCloudinitConfig() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudinitConfigCreate,
 		Delete: resourceCloudinitConfigDelete,
-		Update: resourceCloudinitConfigCreate,
 		Exists: resourceCloudinitConfigExists,
 		Read:   resourceCloudinitConfigRead,
 


### PR DESCRIPTION
Fixes #6899

At the moment the provider makes the assumption that the template can be "modified" (while still being the same resource), this is not going to work as expected because the resource doesn't notify the system to mention that the resource has changed.

In the case of templates, there is no "update" it gets thrown away and recreated.