### PR TITLE
cli: Fix registration of `state mv`.

### DIFF
--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -19,7 +19,7 @@ func (c *StateMvCommand) Run(args []string) int {
 
 	// We create two metas to track the two states
 	var meta1, meta2 Meta
-	cmdFlags := c.Meta.flagSet("state show")
+	cmdFlags := c.Meta.flagSet("state mv")
 	cmdFlags.StringVar(&meta1.stateOutPath, "backup", "", "backup")
 	cmdFlags.StringVar(&meta1.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&meta2.stateOutPath, "backup-out", "", "backup")

--- a/commands.go
+++ b/commands.go
@@ -171,6 +171,12 @@ func init() {
 			}, nil
 		},
 
+		"state mv": func() (cli.Command, error) {
+			return &command.StateMvCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"state show": func() (cli.Command, error) {
 			return &command.StateShowCommand{
 				Meta: meta,


### PR DESCRIPTION
Fixes #7259.