### PR TITLE
[WIP] schema: Get() of a nested Set in List outputs empty set

### DIFF
--- a/helper/schema/field_reader_map_test.go
+++ b/helper/schema/field_reader_map_test.go
@@ -106,3 +106,186 @@ func TestMapFieldReader_extra(t *testing.T) {
 		}
 	}
 }
+
+func TestMapFieldReader_SetInSet(t *testing.T) {
+	schema := map[string]*Schema{
+		"main_set": &Schema{
+			Type:     TypeSet,
+			Optional: true,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"inner_string_set": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Set:      HashString,
+						Elem:     &Schema{Type: TypeString},
+					},
+				},
+			},
+		},
+		"main_int": &Schema{
+			Type:     TypeInt,
+			Optional: true,
+		},
+	}
+
+	r := &MapFieldReader{
+		Schema: schema,
+		Map: BasicMapReader(map[string]string{
+			"id":                                              "8395051352714003426",
+			"main_int":                                        "9",
+			"main_set.#":                                      "1",
+			"main_set.2813616083.inner_string_set.#":          "2",
+			"main_set.2813616083.inner_string_set.2654390964": "blue",
+			"main_set.2813616083.inner_string_set.3499814433": "green",
+		}),
+	}
+
+	result, err := r.ReadField([]string{"main_set"})
+	if err != nil {
+		t.Fatalf("ReadField failed: %#v", err)
+	}
+
+	v := result.Value
+	if v == nil {
+		t.Fatal("Expected Value to be not nil")
+	}
+	list := v.(*Set).List()
+	if len(list) != 1 {
+		t.Fatalf("Expected exactly 1 instance, got %d", len(list))
+	}
+	if list[0] == nil {
+		t.Fatalf("Expected value to be not nil: %#v", list)
+	}
+
+	m := list[0].(map[string]interface{})
+	set := m["inner_string_set"].(*Set).List()
+
+	expectedSet := NewSet(HashString, []interface{}{"blue", "green"}).List()
+
+	if !reflect.DeepEqual(set, expectedSet) {
+		t.Fatalf("Given: %#v\n\nExpected: %#v", set, expectedSet)
+	}
+}
+
+func TestMapFieldReader_SetInList(t *testing.T) {
+	schema := map[string]*Schema{
+		"main_list": &Schema{
+			Type:     TypeList,
+			Optional: true,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"inner_string_set": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Set:      HashString,
+						Elem:     &Schema{Type: TypeString},
+					},
+				},
+			},
+		},
+		"main_int": &Schema{
+			Type:     TypeInt,
+			Optional: true,
+		},
+	}
+
+	r := &MapFieldReader{
+		Schema: schema,
+		Map: BasicMapReader(map[string]string{
+			"id":                                      "8395051352714003426",
+			"main_int":                                "9",
+			"main_list.#":                             "1",
+			"main_list.0.inner_string_set.#":          "2",
+			"main_list.0.inner_string_set.2654390964": "blue",
+			"main_list.0.inner_string_set.3499814433": "green",
+		}),
+	}
+
+	result, err := r.ReadField([]string{"main_list"})
+	if err != nil {
+		t.Fatalf("ReadField failed: %#v", err)
+	}
+
+	v := result.Value
+	if v == nil {
+		t.Fatal("Expected Value to be not nil")
+	}
+	list := v.([]interface{})
+	if len(list) != 1 {
+		t.Fatalf("Expected exactly 1 instance, got %d", len(list))
+	}
+	if list[0] == nil {
+		t.Fatalf("Expected value to be not nil: %#v", list)
+	}
+
+	m := list[0].(map[string]interface{})
+	set := m["inner_string_set"].(*Set).List()
+
+	expectedSet := NewSet(HashString, []interface{}{"blue", "green"}).List()
+
+	if !reflect.DeepEqual(set, expectedSet) {
+		t.Fatalf("Given: %#v\n\nExpected: %#v", set, expectedSet)
+	}
+}
+
+func TestMapFieldReader_readSet_SetInSet(t *testing.T) {
+	schema := map[string]*Schema{
+		"main_set": &Schema{
+			Type:     TypeSet,
+			Optional: true,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"inner_string_set": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Set:      HashString,
+						Elem:     &Schema{Type: TypeString},
+					},
+				},
+			},
+		},
+		"main_int": &Schema{
+			Type:     TypeInt,
+			Optional: true,
+		},
+	}
+
+	r := &MapFieldReader{
+		Schema: schema,
+		Map: BasicMapReader(map[string]string{
+			"id":                                              "8395051352714003426",
+			"main_int":                                        "9",
+			"main_set.#":                                      "1",
+			"main_set.2813616083.inner_string_set.#":          "2",
+			"main_set.2813616083.inner_string_set.2654390964": "blue",
+			"main_set.2813616083.inner_string_set.3499814433": "green",
+		}),
+	}
+
+	result, err := r.readSet([]string{"main_set"}, schema["main_set"])
+	if err != nil {
+		t.Fatalf("readSet failed: %#v", err)
+	}
+
+	v := result.Value
+	if v == nil {
+		t.Fatal("Expected Value to be not nil")
+	}
+	list := v.(*Set).List()
+	if len(list) != 1 {
+		t.Fatalf("Expected exactly 1 instance, got %d", len(list))
+	}
+	if list[0] == nil {
+		t.Fatalf("Expected value to be not nil: %#v", list)
+	}
+
+	m := list[0].(map[string]interface{})
+	set := m["inner_string_set"].(*Set).List()
+
+	expectedSet := NewSet(HashString, []interface{}{"blue", "green"}).List()
+
+	if !reflect.DeepEqual(set, expectedSet) {
+		t.Fatalf("Given: %#v\n\nExpected: %#v", set, expectedSet)
+	}
+}

--- a/helper/schema/field_reader_multi_test.go
+++ b/helper/schema/field_reader_multi_test.go
@@ -268,3 +268,175 @@ func TestMultiLevelFieldReaderReadFieldMerge(t *testing.T) {
 		}
 	}
 }
+
+func TestMultiLevelFieldReader_ReadField_SetInSet(t *testing.T) {
+	schema := map[string]*Schema{
+		"main_set": &Schema{
+			Type:     TypeSet,
+			Optional: true,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"inner_string_set": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Set:      HashString,
+						Elem:     &Schema{Type: TypeString},
+					},
+				},
+			},
+		},
+		"main_int": &Schema{
+			Type:     TypeInt,
+			Optional: true,
+		},
+	}
+
+	var readers = make(map[string]FieldReader)
+	readers["state"] = &MapFieldReader{
+		Schema: schema,
+		Map: BasicMapReader(map[string]string{
+			"id":                                              "8395051352714003426",
+			"main_int":                                        "9",
+			"main_set.#":                                      "1",
+			"main_set.2813616083.inner_string_set.#":          "2",
+			"main_set.2813616083.inner_string_set.2654390964": "blue",
+			"main_set.2813616083.inner_string_set.3499814433": "green",
+		}),
+	}
+	readers["diff"] = &DiffFieldReader{
+		Schema: schema,
+		Diff: &terraform.InstanceDiff{
+			Attributes: map[string]*terraform.ResourceAttrDiff{
+				"main_int": &terraform.ResourceAttrDiff{
+					Old: "9",
+					New: "2",
+				},
+			},
+		},
+		Source: &MultiLevelFieldReader{
+			Levels:  []string{"state", "config"},
+			Readers: readers,
+		},
+	}
+
+	mr := &MultiLevelFieldReader{
+		Levels: []string{
+			"state",
+			"diff",
+		},
+
+		Readers: readers,
+	}
+
+	result, err := mr.ReadField([]string{"main_set"})
+	if err != nil {
+		t.Fatalf("ReadField failed: %#v", err)
+	}
+
+	v := result.Value
+	if v == nil {
+		t.Fatal("Expected Value to be not nil")
+	}
+	list := v.(*Set).List()
+	if len(list) != 1 {
+		t.Fatalf("Expected exactly 1 instance, got %d", len(list))
+	}
+	if list[0] == nil {
+		t.Fatalf("Expected value to be not nil: %#v", list)
+	}
+
+	m := list[0].(map[string]interface{})
+	set := m["inner_string_set"].(*Set).List()
+
+	expectedSet := NewSet(HashString, []interface{}{"blue", "green"}).List()
+
+	if !reflect.DeepEqual(set, expectedSet) {
+		t.Fatalf("Given: %#v\n\nExpected: %#v", set, expectedSet)
+	}
+}
+
+func TestMultiLevelFieldReader_ReadField_SetInList(t *testing.T) {
+	schema := map[string]*Schema{
+		"main_list": &Schema{
+			Type:     TypeList,
+			Optional: true,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"inner_string_set": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Set:      HashString,
+						Elem:     &Schema{Type: TypeString},
+					},
+				},
+			},
+		},
+		"main_int": &Schema{
+			Type:     TypeInt,
+			Optional: true,
+		},
+	}
+
+	var readers = make(map[string]FieldReader)
+	readers["state"] = &MapFieldReader{
+		Schema: schema,
+		Map: BasicMapReader(map[string]string{
+			"id":                                      "8395051352714003426",
+			"main_int":                                "9",
+			"main_list.#":                             "1",
+			"main_list.0.inner_string_set.#":          "2",
+			"main_list.0.inner_string_set.2654390964": "blue",
+			"main_list.0.inner_string_set.3499814433": "green",
+		}),
+	}
+	readers["diff"] = &DiffFieldReader{
+		Schema: schema,
+		Diff: &terraform.InstanceDiff{
+			Attributes: map[string]*terraform.ResourceAttrDiff{
+				"main_int": &terraform.ResourceAttrDiff{
+					Old: "9",
+					New: "2",
+				},
+			},
+		},
+		Source: &MultiLevelFieldReader{
+			Levels:  []string{"state", "config"},
+			Readers: readers,
+		},
+	}
+
+	mr := &MultiLevelFieldReader{
+		Levels: []string{
+			"state",
+			"diff",
+		},
+
+		Readers: readers,
+	}
+
+	result, err := mr.ReadField([]string{"main_list"})
+	if err != nil {
+		t.Fatalf("ReadField failed: %#v", err)
+	}
+
+	v := result.Value
+	if v == nil {
+		t.Fatal("Expected Value to be not nil")
+	}
+	list := v.([]interface{})
+	if len(list) != 1 {
+		t.Fatalf("Expected exactly 1 instance, got %d", len(list))
+	}
+	if list[0] == nil {
+		t.Fatalf("Expected value to be not nil: %#v", list)
+	}
+
+	m := list[0].(map[string]interface{})
+	set := m["inner_string_set"].(*Set).List()
+
+	expectedSet := NewSet(HashString, []interface{}{"blue", "green"}).List()
+
+	if !reflect.DeepEqual(set, expectedSet) {
+		t.Fatalf("Given: %#v\n\nExpected: %#v", set, expectedSet)
+	}
+}

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -751,6 +751,140 @@ func TestResourceDataGet(t *testing.T) {
 	}
 }
 
+func TestSetInsideSet(t *testing.T) {
+	_schema := map[string]*Schema{
+		"main_set": &Schema{
+			Type:     TypeSet,
+			Optional: true,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"inner_string_set": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Set:      HashString,
+						Elem:     &Schema{Type: TypeString},
+					},
+				},
+			},
+		},
+		"main_int": &Schema{
+			Type:     TypeInt,
+			Optional: true,
+		},
+	}
+
+	existingState := &terraform.InstanceState{
+		ID: "8395051352714003426",
+		Attributes: map[string]string{
+			"id":                                              "8395051352714003426",
+			"main_int":                                        "9",
+			"main_set.#":                                      "1",
+			"main_set.2813616083.inner_string_set.#":          "2",
+			"main_set.2813616083.inner_string_set.2654390964": "blue",
+			"main_set.2813616083.inner_string_set.3499814433": "green",
+		},
+		Meta:    map[string]string{},
+		Tainted: false,
+	}
+
+	suggestedDiff := &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{
+			"main_int": &terraform.ResourceAttrDiff{
+				Old: "9",
+				New: "2",
+			},
+		},
+	}
+
+	d := &ResourceData{
+		schema: _schema,
+		state:  existingState,
+		diff:   suggestedDiff,
+	}
+
+	v := d.Get("main_set").(*Set).List()
+	if len(v) != 1 {
+		t.Fatalf("Expected exactly 1 instance of main_set, got %d", len(v))
+	}
+	if v[0] == nil {
+		t.Fatalf("Expected main_set to be not nil: %#v", v)
+	}
+
+	m := v[0].(map[string]interface{})
+	set := m["inner_string_set"].(*Set).List()
+	expectedSet := NewSet(HashString, []interface{}{"blue", "green"}).List()
+	if !reflect.DeepEqual(set, expectedSet) {
+		t.Fatalf("Given: %#v\n\nExpected: %#v", set, expectedSet)
+	}
+}
+
+func TestSetInsideList(t *testing.T) {
+	_schema := map[string]*Schema{
+		"main_list": &Schema{
+			Type:     TypeList,
+			Optional: true,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"inner_string_set": &Schema{
+						Type:     TypeSet,
+						Required: true,
+						Set:      HashString,
+						Elem:     &Schema{Type: TypeString},
+					},
+				},
+			},
+		},
+		"main_int": &Schema{
+			Type:     TypeInt,
+			Optional: true,
+		},
+	}
+
+	existingState := &terraform.InstanceState{
+		ID: "8395051352714003426",
+		Attributes: map[string]string{
+			"id":                                      "8395051352714003426",
+			"main_int":                                "9",
+			"main_list.#":                             "1",
+			"main_list.0.inner_string_set.#":          "2",
+			"main_list.0.inner_string_set.2654390964": "blue",
+			"main_list.0.inner_string_set.3499814433": "green",
+		},
+		Meta:    map[string]string{},
+		Tainted: false,
+	}
+
+	suggestedDiff := &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{
+			"main_int": &terraform.ResourceAttrDiff{
+				Old: "9",
+				New: "2",
+			},
+		},
+	}
+
+	d := &ResourceData{
+		schema: _schema,
+		state:  existingState,
+		diff:   suggestedDiff,
+	}
+
+	v := d.Get("main_list").([]interface{})
+	if len(v) != 1 {
+		t.Fatalf("Expected exactly 1 instance of main_list, got %d", len(v))
+	}
+	if v[0] == nil {
+		t.Fatalf("Expected main_list to be not nil: %#v", v)
+	}
+
+	m := v[0].(map[string]interface{})
+	set := m["inner_string_set"].(*Set).List()
+	expectedSet := NewSet(HashString, []interface{}{"blue", "green"}).List()
+	if !reflect.DeepEqual(set, expectedSet) {
+		t.Fatalf("Given: %#v\n\nExpected: %#v", set, expectedSet)
+	}
+}
+
 func TestResourceDataGetChange(t *testing.T) {
 	cases := []struct {
 		Schema   map[string]*Schema


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/issues/7253 & https://github.com/hashicorp/terraform/pull/7254

```
$ make test TEST=./helper/schema
```
```
TF_ACC= go test ./helper/schema  -timeout=30s -parallel=4
--- FAIL: TestMultiLevelFieldReader_ReadField_SetInList (0.00s)
	field_reader_multi_test.go:431: Expected value to be not nil: []interface {}{interface {}(nil)}
--- FAIL: TestSetInsideList_simple (0.00s)
	resource_data_test.go:877: Expected main_list to be not nil: []interface {}{interface {}(nil)}
--- FAIL: TestSetInsideList_complex (0.00s)
	resource_data_test.go:946: Expected exactly 1 instance of main_list, got 2
FAIL
FAIL	github.com/hashicorp/terraform/helper/schema	0.024s
make: *** [test] Error 1
```

I managed to fix two simple failing test cases <sup>[1]</sup>, then came up with more complicated ResourceData test case (`84f8186` / `TestSetInsideList_complex`) which is failing:

```
TF_ACC= go test ./helper/schema  -timeout=30s -parallel=4
--- FAIL: TestSetInsideList_complex (0.00s)
	resource_data_test.go:956: Given: []interface {}{}

		Expected: []interface {}{"blue", "green"}
FAIL
FAIL	github.com/hashicorp/terraform/helper/schema	0.022s
make: *** [test] Error 1
```

-------

<sup>[1]</sup> Bugfix is not part of this PR yet as I wanted to demonstrate the problem 1st before coming with a solution.