### PR TITLE
provider/dns: Implementing dns provider.

### DIFF
--- a/builtin/bins/provider-dns/main.go
+++ b/builtin/bins/provider-dns/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/dns"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: dns.Provider,
+	})
+}

--- a/builtin/providers/dns/data_dns_a_record.go
+++ b/builtin/providers/dns/data_dns_a_record.go
@@ -26,15 +26,6 @@ func dataSourceDnsARecord() *schema.Resource {
 				Default:  true,
 			},
 
-			// Optionally filter IPv6 records from DNS replies.
-			// This is helpful for other resources that do no support IPv6 yet,
-			// such as AWS security groups
-			"ipv4": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
 			"addrs": &schema.Schema{
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -53,16 +44,13 @@ func dataSourceDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	addrs := make([]string, 0)
-	ipv4only := d.Get("ipv4").(bool)
 	sortingEnabled := d.Get("sort").(bool)
 
 	for _, ip := range records {
-		if ipv4only {
-			if ipv4 := ip.To4(); ipv4 != nil {
-				addrs = append(addrs, ipv4.String())
-			}
-		} else {
-			addrs = append(addrs, ip.String())
+		// LookupIP returns A (IPv4) and AAAA (IPv6) records
+		// Filter out AAAA records
+		if ipv4 := ip.To4(); ipv4 != nil {
+			addrs = append(addrs, ipv4.String())
 		}
 	}
 

--- a/builtin/providers/dns/data_dns_a_record.go
+++ b/builtin/providers/dns/data_dns_a_record.go
@@ -1,0 +1,77 @@
+package dns
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"net"
+	"sort"
+)
+
+func dataSourceDnsARecord() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsARecordRead,
+		Schema: map[string]*schema.Schema{
+			"host": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// Optionally sort A records in alphabetical order.
+			// This is helpful when a name uses round-robin DNS, which may
+			// sort records with multiple addresses in a non-deterministic order.
+			// This random sorting can cause flapping in terraform plans, where
+			// the changes in sort order cause dependent resources to update
+			// despite having no real change in the set of addresses.
+			"sort": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			// Optionally filter IPv6 records from DNS replies.
+			// This is helpful for other resources that do no support IPv6 yet,
+			// such as AWS security groups
+			"ipv4": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"addrs": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
+	host := d.Get("host").(string)
+
+	records, err := net.LookupIP(host)
+	if err != nil {
+		return err
+	}
+
+	addrs := make([]string, 0)
+	ipv4only := d.Get("ipv4").(bool)
+	sortingEnabled := d.Get("sort").(bool)
+
+	for _, ip := range records {
+		if ipv4only {
+			if ipv4 := ip.To4(); ipv4 != nil {
+				addrs = append(addrs, ipv4.String())
+			}
+		} else {
+			addrs = append(addrs, ip.String())
+		}
+	}
+
+	if sortingEnabled {
+		sort.Strings(addrs)
+	}
+
+	d.Set("addrs", addrs)
+	d.SetId(host)
+
+	return nil
+}

--- a/builtin/providers/dns/data_dns_a_record.go
+++ b/builtin/providers/dns/data_dns_a_record.go
@@ -14,18 +14,6 @@ func dataSourceDnsARecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			// Optionally sort A records in alphabetical order.
-			// This is helpful when a name uses round-robin DNS, which may
-			// sort records with multiple addresses in a non-deterministic order.
-			// This random sorting can cause flapping in terraform plans, where
-			// the changes in sort order cause dependent resources to update
-			// despite having no real change in the set of addresses.
-			"sort": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
 			"addrs": &schema.Schema{
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -44,7 +32,6 @@ func dataSourceDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	addrs := make([]string, 0)
-	sortingEnabled := d.Get("sort").(bool)
 
 	for _, ip := range records {
 		// LookupIP returns A (IPv4) and AAAA (IPv6) records
@@ -54,9 +41,7 @@ func dataSourceDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if sortingEnabled {
-		sort.Strings(addrs)
-	}
+	sort.Strings(addrs)
 
 	d.Set("addrs", addrs)
 	d.SetId(host)

--- a/builtin/providers/dns/data_dns_a_record_test.go
+++ b/builtin/providers/dns/data_dns_a_record_test.go
@@ -14,7 +14,6 @@ func TestAccDnsARecord_Basic(t *testing.T) {
 			`
 			data "dns_a_record" "foo" {
 			  host = "127.0.0.1.xip.io"
-			  ipv4 = true
 			}
 			`,
 			[]string{

--- a/builtin/providers/dns/data_dns_a_record_test.go
+++ b/builtin/providers/dns/data_dns_a_record_test.go
@@ -1,0 +1,39 @@
+package dns
+
+import (
+	r "github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccDnsARecord_Basic(t *testing.T) {
+	tests := []struct {
+		DataSourceBlock string
+		Expected        []string
+	}{
+		{
+			`
+			data "dns_a_record" "foo" {
+			  host = "127.0.0.1.xip.io"
+			  ipv4 = true
+			}
+			`,
+			[]string{
+				"127.0.0.1",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		r.UnitTest(t, r.TestCase{
+			Providers: testAccProviders,
+			Steps: []r.TestStep{
+				r.TestStep{
+					Config: test.DataSourceBlock,
+					Check: r.ComposeTestCheckFunc(
+						testCheckAttrStringArray("data.dns_a_record.foo", "addrs", test.Expected),
+					),
+				},
+			},
+		})
+	}
+}

--- a/builtin/providers/dns/data_dns_cname_record.go
+++ b/builtin/providers/dns/data_dns_cname_record.go
@@ -1,0 +1,39 @@
+package dns
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"net"
+)
+
+func dataSourceDnsCnameRecord() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsCnameRecordRead,
+
+		Schema: map[string]*schema.Schema{
+			"host": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"cname": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error {
+	host := d.Get("host").(string)
+
+	cname, err := net.LookupCNAME(host)
+	if err != nil {
+		return err
+	}
+
+	d.Set("cname", cname)
+	d.SetId(host)
+
+	return nil
+}

--- a/builtin/providers/dns/data_dns_cname_record_test.go
+++ b/builtin/providers/dns/data_dns_cname_record_test.go
@@ -1,0 +1,36 @@
+package dns
+
+import (
+	r "github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccDnsCnameRecord_Basic(t *testing.T) {
+	tests := []struct {
+		DataSourceBlock string
+		Expected        string
+	}{
+		{
+			`
+			data "dns_cname_record" "foo" {
+			  host = "www.hashicorp.com"
+			}
+			`,
+			"prod.k.ssl.global.fastly.net.",
+		},
+	}
+
+	for _, test := range tests {
+		r.UnitTest(t, r.TestCase{
+			Providers: testAccProviders,
+			Steps: []r.TestStep{
+				r.TestStep{
+					Config: test.DataSourceBlock,
+					Check: r.ComposeTestCheckFunc(
+						r.TestCheckResourceAttr("data.dns_cname_record.foo", "cname", test.Expected),
+					),
+				},
+			},
+		})
+	}
+}

--- a/builtin/providers/dns/data_dns_txt_record.go
+++ b/builtin/providers/dns/data_dns_txt_record.go
@@ -1,0 +1,46 @@
+package dns
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"net"
+)
+
+func dataSourceDnsTxtRecord() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsTxtRecordRead,
+
+		Schema: map[string]*schema.Schema{
+			"host": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"record": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"records": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error {
+	records, err := net.LookupTXT(d.Get("host").(string))
+	if err != nil {
+		return err
+	}
+
+	if len(records) > 0 {
+		d.Set("record", records[0])
+	} else {
+		d.Set("record", "")
+	}
+	d.Set("records", records)
+	return nil
+}

--- a/builtin/providers/dns/provider.go
+++ b/builtin/providers/dns/provider.go
@@ -1,0 +1,24 @@
+package dns
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+
+		ResourcesMap: map[string]*schema.Resource{
+			"dns_a_record": schema.DataSourceResourceShim(
+				"dns_a_record",
+				dataSourceDnsARecord(),
+			),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"dns_a_record":     dataSourceDnsARecord(),
+			"dns_cname_record": dataSourceDnsCnameRecord(),
+			"dns_text_record":  dataSourceDnsTxtRecord(),
+		},
+	}
+}

--- a/builtin/providers/dns/provider_test.go
+++ b/builtin/providers/dns/provider_test.go
@@ -1,0 +1,18 @@
+package dns
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders = map[string]terraform.ResourceProvider{
+	"dns": Provider(),
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}

--- a/builtin/providers/dns/test_check_attr_string_array.go
+++ b/builtin/providers/dns/test_check_attr_string_array.go
@@ -1,0 +1,51 @@
+package dns
+
+import (
+	"fmt"
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"strconv"
+)
+
+func testCheckAttrStringArray(name, key string, value []string) r.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		is := rs.Primary
+		if is == nil {
+			return fmt.Errorf("No primary instance: %s", name)
+		}
+
+		attrKey := fmt.Sprintf("%s.#", key)
+		count, ok := is.Attributes[attrKey]
+		if !ok {
+			return fmt.Errorf("Attributes not found for %s", attrKey)
+		}
+
+		got, _ := strconv.Atoi(count)
+		if got != len(value) {
+			return fmt.Errorf("Mismatch array count for %s: got %s, wanted %d", key, count, len(value))
+		}
+
+		for i, want := range value {
+			attrKey = fmt.Sprintf("%s.%d", key, i)
+			got, ok := is.Attributes[attrKey]
+			if !ok {
+				return fmt.Errorf("Missing array item for %s", attrKey)
+			}
+			if got != want {
+				return fmt.Errorf(
+					"Mismatched array item for %s: got %s, want %s",
+					attrKey,
+					got,
+					want)
+			}
+		}
+
+		return nil
+	}
+}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -19,6 +19,7 @@ import (
 	datadogprovider "github.com/hashicorp/terraform/builtin/providers/datadog"
 	digitaloceanprovider "github.com/hashicorp/terraform/builtin/providers/digitalocean"
 	dmeprovider "github.com/hashicorp/terraform/builtin/providers/dme"
+	dnsprovider "github.com/hashicorp/terraform/builtin/providers/dns"
 	dnsimpleprovider "github.com/hashicorp/terraform/builtin/providers/dnsimple"
 	dockerprovider "github.com/hashicorp/terraform/builtin/providers/docker"
 	dynprovider "github.com/hashicorp/terraform/builtin/providers/dyn"
@@ -73,6 +74,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"dme":          dmeprovider.Provider,
 	"dnsimple":     dnsimpleprovider.Provider,
 	"docker":       dockerprovider.Provider,
+	"dns":          dnsprovider.Provider,
 	"dyn":          dynprovider.Provider,
 	"fastly":       fastlyprovider.Provider,
 	"github":       githubprovider.Provider,

--- a/website/source/docs/providers/dns/d/a-record.html.markdown
+++ b/website/source/docs/providers/dns/d/a-record.html.markdown
@@ -28,8 +28,6 @@ The following arguments are supported:
 
  * `host` - (required): Host to look up
 
- * `ipv4` - (optional) A flag to only use IPv4 records. By default, `ipv4 = false`.
-
  * `sort` - (optional) A flag to sort IPv4 records or allow round-robin retrieval. By default, `sort = true`,
 
 ## Attributes Reference

--- a/website/source/docs/providers/dns/d/a-record.html.markdown
+++ b/website/source/docs/providers/dns/d/a-record.html.markdown
@@ -28,12 +28,10 @@ The following arguments are supported:
 
  * `host` - (required): Host to look up
 
- * `sort` - (optional) A flag to sort IPv4 records or allow round-robin retrieval. By default, `sort = true`,
-
 ## Attributes Reference
 
 The following attributes are exported:
 
  * `id` - Set to `host`.
 
- * `addrs` - A list of IP addresses.
+ * `addrs` - A list of IP addresses. IP addresses are always sorted to avoid constant changing plans.

--- a/website/source/docs/providers/dns/d/a-record.html.markdown
+++ b/website/source/docs/providers/dns/d/a-record.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "dns"
+page_title: "DNS: dns_a_record"
+sidebar_current: "docs-dns-datasource-a-record"
+description: |-
+  Get DNS A records.
+---
+
+# dns\_a\_record
+
+Use this data source to get DNS A records of the host.
+
+## Example Usage
+
+```
+data "dns_a_record" "google" {
+  host = "google.com"
+}
+
+output "google_addrs" {
+  value = "${join(",", data.dns_a_record.google.addrs)}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+ * `host` - (required): Host to look up
+
+ * `ipv4` - (optional) A flag to only use IPv4 records. By default, `ipv4 = false`.
+
+ * `sort` - (optional) A flag to sort IPv4 records or allow round-robin retrieval. By default, `sort = true`,
+
+## Attributes Reference
+
+The following attributes are exported:
+
+ * `id` - Set to `host`.
+
+ * `addrs` - A list of IP addresses.

--- a/website/source/docs/providers/dns/d/cname-record.html.markdown
+++ b/website/source/docs/providers/dns/d/cname-record.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "dns"
+page_title: "DNS: dns_cname_record"
+sidebar_current: "docs-dns-datasource-cname-record"
+description: |-
+  Get DNS CNAME records.
+---
+
+# dns\_cname\_record
+
+Use this data source to get DNS CNAME records of the host.
+
+## Example Usage
+
+```
+data "dns_cname_record" "hashicorp" {
+  host = "www.hashicorp.com"
+}
+
+output "hashi_cname" {
+  value = "${data.dns_cname_record.hashi.cname}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+ * `host` - (required): Host to look up
+
+## Attributes Reference
+
+The following attributes are exported:
+
+ * `id` - Set to `host`.
+
+ * `cname` - A CNAME record associated with host.

--- a/website/source/docs/providers/dns/d/txt-record.html.markdown
+++ b/website/source/docs/providers/dns/d/txt-record.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "dns"
+page_title: "DNS: dns_txt_record"
+sidebar_current: "docs-dns-datasource-txt-record"
+description: |-
+  Get DNS TXT records.
+---
+
+# dns\_txt\_record
+
+Use this data source to get DNS TXT records of the host.
+
+## Example Usage
+
+```
+data "dns_txt_record" "hashicorp" {
+  host = "www.hashicorp.com"
+}
+
+output "hashi_txt" {
+  value = "${data.dns_txt_record.hashi.record}"
+}
+
+output "hashi_txts" {
+  value = "${join(",", data.dns_txt_record.hashi.records})"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+ * `host` - (required): Host to look up
+
+## Attributes Reference
+
+The following attributes are exported:
+
+ * `id` - Set to `host`.
+
+ * `record` - The first TXT record.
+ 
+ * `records` - A list of TXT records.

--- a/website/source/docs/providers/dns/index.html.markdown
+++ b/website/source/docs/providers/dns/index.html.markdown
@@ -1,0 +1,25 @@
+---
+layout: "dns"
+page_title: "Provider: DNS"
+sidebar_current: "docs-dns-index"
+description: |-
+  The DNS provider exposes data sources used to query DNS records. There is no provider configuration at this time.
+---
+
+# DNS Provider
+
+The DNS provider exposes data sources used to query DNS records. 
+There is no provider configuration at this time.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```
+provider "dns" {
+}
+```
+
+## Argument Reference
+
+There are no provider arguments.

--- a/website/source/layouts/dns.erb
+++ b/website/source/layouts/dns.erb
@@ -1,0 +1,30 @@
+<% wrap_layout :inner do %>
+    <% content_for :sidebar do %>
+        <div class="docs-sidebar hidden-print affix-top" role="complementary">
+            <ul class="nav docs-sidenav">
+                <li<%= sidebar_current("docs-home") %>>
+                    <a href="/docs/providers/index.html">&laquo; Documentation Home</a>
+                </li>
+
+                <li<%= sidebar_current("docs-dns-index") %>>
+                    <a href="/docs/providers/dns/index.html">DNS Provider</a>
+                </li>
+
+                <li<%= sidebar_current(/^docs-dns-datasource/) %>>
+                <a href="#">Data Sources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-dns-datasource-a-record") %>>
+                            <a href="/docs/providers/dns/d/a-record.html">dns_a_record</a>
+                        </li>
+                        <li<%= sidebar_current("docs-dns-datasource-cname-record") %>>
+                            <a href="/docs/providers/dns/d/cname-record.html">dns_cname_record</a>
+                        </li>
+                    </ul>
+                </li>
+
+            </ul>
+        </div>
+    <% end %>
+
+    <%= yield %>
+<% end %>


### PR DESCRIPTION
## Purpose

This introduces a provider to read dns records.
This PR is inspired by https://github.com/Shopify/terraform-provider-dns.
Code was adapted from that repository to work as `data` sources instead of `resources`.
## Checklist
- [x] Implement `dns` provider
- [x] Implement `data "dns_a_record"`
- [x] Test `data "dns_a_record"`
- [x] Implement `data "dns_cname_record"`
- [x] Test `data "dns_cname_record"`
- [x] Implement `data "dns_txt_record"`
- [x] ~~Test `data "dns_txt_record"`~~
- [x] Add `dns` provider docs to site
