### PR TITLE
core: Don't try to copy files over themselves

### DIFF
--- a/config/module/get.go
+++ b/config/module/get.go
@@ -37,6 +37,8 @@ func GetCopy(dst, src string) error {
 	if err != nil {
 		return err
 	}
+	// FIXME: This isn't completely safe. Creating and removing our temp path
+	//        exposes where to race to inject files.
 	if err := os.RemoveAll(tmpDir); err != nil {
 		return err
 	}


### PR DESCRIPTION
When copying a config module, make sure the full path for src and dst
files don't match, and also check the inode in case we resolved a
different path to the same file.

Make a note about the unsafe usage of reusing a tempDir path.

fixes #7238 