### PR TITLE
provider/vsphere: Add migration for `enable_disk_uuid` on `virtual_machine`

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_migrate.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_migrate.go
@@ -40,6 +40,10 @@ func migrateVSphereVirtualMachineStateV0toV1(is *terraform.InstanceState) (*terr
 		is.Attributes["skip_customization"] = "false"
 	}
 
+	if is.Attributes["enable_disk_uuid"] == "" {
+		is.Attributes["enable_disk_uuid"] = "false"
+	}
+
 	for k, _ := range is.Attributes {
 		if strings.HasPrefix(k, "disk.") && strings.HasSuffix(k, ".size") {
 			diskParts := strings.Split(k, ".")

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_migrate_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_migrate_test.go
@@ -20,6 +20,13 @@ func TestVSphereVirtualMachineMigrateState(t *testing.T) {
 				"skip_customization": "false",
 			},
 		},
+		"enable_disk_uuid before 0.6.16": {
+			StateVersion: 0,
+			Attributes:   map[string]string{},
+			Expected: map[string]string{
+				"enable_disk_uuid": "false",
+			},
+		},
 		"disk controller_type": {
 			StateVersion: 0,
 			Attributes: map[string]string{


### PR DESCRIPTION
Fixes #7275 - a state migration was missed when `enable_disk_uuid` was
merged

```
make testacc TEST=./builtin/providers/vsphere
TESTARGS='-run=TestVSphereVirtualMachineMigrateState'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/vsphere -v
-run=TestVSphereVirtualMachineMigrateState -timeout 120m
=== RUN   TestVSphereVirtualMachineMigrateState
--- PASS: TestVSphereVirtualMachineMigrateState (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/vsphere
0.018s
```