### PR TITLE
provider/aws: Add import functionality for `aws_ecr_repository`

### DIFF
--- a/builtin/providers/aws/import_aws_ecr_repository.go
+++ b/builtin/providers/aws/import_aws_ecr_repository.go
@@ -1,0 +1,40 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsEcrRepositoryImportState(
+	d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*AWSClient).ecrconn
+
+	id := d.Id()
+	resp, err := conn.DescribeRepositories(&ecr.DescribeRepositoriesInput{
+		RepositoryNames: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Repositories) < 1 || resp.Repositories[0] == nil {
+		return nil, fmt.Errorf("ECR %s is not found", id)
+	}
+	ecr := resp.Repositories[0]
+
+	results := make([]*schema.ResourceData, 1, 1)
+	results[0] = d
+
+	d.SetId(id)
+	d.SetType("aws_ecr_repository")
+	d.Set("registry_id", ecr.RegistryId)
+	d.Set("repository_url", ecr.RepositoryUri)
+	d.Set("arn", ecr.RepositoryArn)
+	d.Set("name", d.Id())
+
+	return results, nil
+
+}

--- a/builtin/providers/aws/import_aws_ecr_repository_test.go
+++ b/builtin/providers/aws/import_aws_ecr_repository_test.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSEcrRepository_importBasic(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		// Expect 1: repository
+		if len(s) != 1 {
+			return fmt.Errorf("bad states: %#v", s)
+		}
+
+		return nil
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcrRepository,
+			},
+
+			resource.TestStep{
+				ResourceName:     "aws_ecr_repository.default",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_ecr_repository.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository.go
@@ -16,6 +16,9 @@ func resourceAwsEcrRepository() *schema.Resource {
 		Create: resourceAwsEcrRepositoryCreate,
 		Read:   resourceAwsEcrRepositoryRead,
 		Delete: resourceAwsEcrRepositoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsEcrRepositoryImportState,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_ecr_repository_test.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_test.go
@@ -71,11 +71,6 @@ func testAccCheckAWSEcrRepositoryExists(name string) resource.TestCheckFunc {
 }
 
 var testAccAWSEcrRepository = `
-# ECR initially only available in us-east-1
-# https://aws.amazon.com/blogs/aws/ec2-container-registry-now-generally-available/
-provider "aws" {
-	region = "us-east-1"
-}
 resource "aws_ecr_repository" "default" {
 	name = "foo-repository-terraform"
 }


### PR DESCRIPTION
This adds the ability to import ECR repositories. Changed the ECR
Repository from using us-east-1 as this was no longer limited to that
region

```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSEcrRepository_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSEcrRepository_importBasic -timeout 120m
=== RUN   TestAccAWSEcrRepository_importBasic
--- PASS: TestAccAWSEcrRepository_importBasic (19.79s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    19.812s
```