### PR TITLE
provider/aws: Import `aws_placement_group`

### DIFF
--- a/builtin/providers/aws/import_aws_placement_group.go
+++ b/builtin/providers/aws/import_aws_placement_group.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsPlacementGroupImportState(
+	d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*AWSClient).ec2conn
+
+	id := d.Id()
+	resp, err := conn.DescribePlacementGroups(&ec2.DescribePlacementGroupsInput{
+		GroupNames: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.PlacementGroups) < 1 || resp.PlacementGroups[0] == nil {
+		return nil, fmt.Errorf("Placement Group %s is not found", id)
+	}
+	pg := resp.PlacementGroups[0]
+
+	results := make([]*schema.ResourceData, 1, 1)
+	results[0] = d
+
+	d.SetId(id)
+	d.SetType("aws_placement_group")
+	d.Set("name", pg.GroupName)
+	d.Set("strategy", pg.Strategy)
+
+	return results, nil
+
+}

--- a/builtin/providers/aws/import_aws_placement_group_test.go
+++ b/builtin/providers/aws/import_aws_placement_group_test.go
@@ -3,11 +3,21 @@ package aws
 import (
 	"testing"
 
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSPlacementGroup_importBasic(t *testing.T) {
-	resourceName := "aws_placement_group.pg"
+	checkFn := func(s []*terraform.InstanceState) error {
+		// Expect 1: placement group
+		if len(s) != 1 {
+			return fmt.Errorf("bad states: %#v", s)
+		}
+
+		return nil
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,9 +29,9 @@ func TestAccAWSPlacementGroup_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:     "aws_placement_group.pg",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
 			},
 		},
 	})

--- a/builtin/providers/aws/resource_aws_placement_group.go
+++ b/builtin/providers/aws/resource_aws_placement_group.go
@@ -18,7 +18,7 @@ func resourceAwsPlacementGroup() *schema.Resource {
 		Read:   resourceAwsPlacementGroupRead,
 		Delete: resourceAwsPlacementGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceAwsPlacementGroupImportState,
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSPlacementGroup_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSPlacementGroup_importBasic -timeout 120m
=== RUN   TestAccAWSPlacementGroup_importBasic
--- PASS: TestAccAWSPlacementGroup_importBasic (21.70s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    21.723s
```