### PR TITLE
provider/aws: Support import functionality for `aws_ecr_repository`

### DIFF
--- a/builtin/providers/aws/import_aws_ecr_repository_test.go
+++ b/builtin/providers/aws/import_aws_ecr_repository_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSEcrRepository_importBasic(t *testing.T) {
+	resourceName := "aws_ecr_repository.default"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcrRepository,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_ecr_repository.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository.go
@@ -16,6 +16,9 @@ func resourceAwsEcrRepository() *schema.Resource {
 		Create: resourceAwsEcrRepositoryCreate,
 		Read:   resourceAwsEcrRepositoryRead,
 		Delete: resourceAwsEcrRepositoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -68,7 +71,6 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Reading repository %s", d.Id())
 	out, err := conn.DescribeRepositories(&ecr.DescribeRepositoriesInput{
-		RegistryId:      aws.String(d.Get("registry_id").(string)),
 		RepositoryNames: []*string{aws.String(d.Id())},
 	})
 	if err != nil {
@@ -86,6 +88,7 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(*repository.RepositoryName)
 	d.Set("arn", *repository.RepositoryArn)
 	d.Set("registry_id", *repository.RegistryId)
+	d.Set("name", repository.RepositoryName)
 
 	repositoryUrl := buildRepositoryUrl(repository, meta.(*AWSClient).region)
 	log.Printf("[INFO] Setting the repository url to be %s", repositoryUrl)

--- a/builtin/providers/aws/resource_aws_ecr_repository_test.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_test.go
@@ -36,7 +36,6 @@ func testAccCheckAWSEcrRepositoryDestroy(s *terraform.State) error {
 		}
 
 		input := ecr.DescribeRepositoriesInput{
-			RegistryId:      aws.String(rs.Primary.Attributes["registry_id"]),
 			RepositoryNames: []*string{aws.String(rs.Primary.Attributes["name"])},
 		}
 
@@ -71,11 +70,6 @@ func testAccCheckAWSEcrRepositoryExists(name string) resource.TestCheckFunc {
 }
 
 var testAccAWSEcrRepository = `
-# ECR initially only available in us-east-1
-# https://aws.amazon.com/blogs/aws/ec2-container-registry-now-generally-available/
-provider "aws" {
-	region = "us-east-1"
-}
 resource "aws_ecr_repository" "default" {
 	name = "foo-repository-terraform"
 }


### PR DESCRIPTION
Changes required:

* ECR Read func doesn't need to take ``registry_id` as it uses the
current account Id
* `name` wasn't being set in the ECR Read so the import was failing as
name wasn't found
* the tests were being run against us-east-1 as this used to be the only supported region - that restriction has been removed

```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSEcrRepository_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSEcrRepository_ -timeout 120m
=== RUN   TestAccAWSEcrRepository_importBasic
--- PASS: TestAccAWSEcrRepository_importBasic (17.37s)
=== RUN   TestAccAWSEcrRepository_basic
--- PASS: TestAccAWSEcrRepository_basic (16.05s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    33.437s
```