### PR TITLE
provider/aws: Support Import for `aws_vpn_gateway`

### DIFF
--- a/builtin/providers/aws/import_aws_vpn_gateway_test.go
+++ b/builtin/providers/aws/import_aws_vpn_gateway_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVpnGateway_importBasic(t *testing.T) {
+	resourceName := "aws_vpn_gateway.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpnGatewayConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -18,6 +18,9 @@ func resourceAwsVpnGateway() *schema.Resource {
 		Read:   resourceAwsVpnGatewayRead,
 		Update: resourceAwsVpnGatewayUpdate,
 		Delete: resourceAwsVpnGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"availability_zone": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSVpnGateway_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnGateway_
-timeout 120m
=== RUN   TestAccAWSVpnGateway_importBasic
--- PASS: TestAccAWSVpnGateway_importBasic (48.29s)
=== RUN   TestAccAWSVpnGateway_basic
--- PASS: TestAccAWSVpnGateway_basic (86.98s)
=== RUN   TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGateway_reattach (97.93s)
=== RUN   TestAccAWSVpnGateway_delete
--- PASS: TestAccAWSVpnGateway_delete (65.61s)
=== RUN   TestAccAWSVpnGateway_tags
--- PASS: TestAccAWSVpnGateway_tags (73.81s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    372.624s
```