### PR TITLE
provider/aws: Add Import support for `aws_cloudwatch_log_group`

### DIFF
--- a/builtin/providers/aws/import_aws_cloudwatch_log_group_test.go
+++ b/builtin/providers/aws/import_aws_cloudwatch_log_group_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudWatchLogGroup_importBasic(t *testing.T) {
+	resourceName := "aws_cloudwatch_log_group.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchLogGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudWatchLogGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"}, //this has a default value
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -16,6 +16,9 @@ func resourceAwsCloudWatchLogGroup() *schema.Resource {
 		Read:   resourceAwsCloudWatchLogGroupRead,
 		Update: resourceAwsCloudWatchLogGroupUpdate,
 		Delete: resourceAwsCloudWatchLogGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -60,7 +63,7 @@ func resourceAwsCloudWatchLogGroupCreate(d *schema.ResourceData, meta interface{
 func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 	log.Printf("[DEBUG] Reading CloudWatch Log Group: %q", d.Get("name").(string))
-	lg, err := lookupCloudWatchLogGroup(conn, d.Get("name").(string), nil)
+	lg, err := lookupCloudWatchLogGroup(conn, d.Id(), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSCloudWatchLogGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSCloudWatchLogGroup_ -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_importBasic
--- PASS: TestAccAWSCloudWatchLogGroup_importBasic (17.24s)
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (16.69s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (29.10s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (22.09s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    85.140s
```