### PR TITLE
provider/aws: Support Import for `aws_elasticache_subnet_group`

### DIFF
--- a/builtin/providers/aws/import_aws_elasticache_subnet_group_test.go
+++ b/builtin/providers/aws/import_aws_elasticache_subnet_group_test.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSElasticacheSubnetGroup_importBasic(t *testing.T) {
+	resourceName := "aws_elasticache_subnet_group.bar"
+	config := fmt.Sprintf(testAccAWSElasticacheSubnetGroupConfig, acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_subnet_group.go
@@ -19,6 +19,9 @@ func resourceAwsElasticacheSubnetGroup() *schema.Resource {
 		Read:   resourceAwsElasticacheSubnetGroupRead,
 		Update: resourceAwsElasticacheSubnetGroupUpdate,
 		Delete: resourceAwsElasticacheSubnetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"description": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSElasticacheSubnetGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSElasticacheSubnetGroup_ -timeout 120m
=== RUN   TestAccAWSElasticacheSubnetGroup_importBasic
--- PASS: TestAccAWSElasticacheSubnetGroup_importBasic (46.80s)
=== RUN   TestAccAWSElasticacheSubnetGroup_basic
--- PASS: TestAccAWSElasticacheSubnetGroup_basic (48.79s)
=== RUN   TestAccAWSElasticacheSubnetGroup_update
--- PASS: TestAccAWSElasticacheSubnetGroup_update (76.81s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    172.431s
```