### PR TITLE
provider/aws: Support Import functionality for `aws_db_subnet_group`

### DIFF
--- a/builtin/providers/aws/import_aws_db_subnet_group_group_test.go
+++ b/builtin/providers/aws/import_aws_db_subnet_group_group_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDBSubnetGroup_importBasic(t *testing.T) {
+	resourceName := "aws_db_subnet_group.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDBSubnetGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_db_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_db_subnet_group.go
@@ -21,6 +21,9 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 		Read:   resourceAwsDbSubnetGroupRead,
 		Update: resourceAwsDbSubnetGroupUpdate,
 		Delete: resourceAwsDbSubnetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSDBSubnetGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDBSubnetGroup_ -timeout 120m
=== RUN   TestAccAWSDBSubnetGroup_importBasic
--- PASS: TestAccAWSDBSubnetGroup_importBasic (53.80s)
=== RUN   TestAccAWSDBSubnetGroup_basic
--- PASS: TestAccAWSDBSubnetGroup_basic (52.29s)
=== RUN   TestAccAWSDBSubnetGroup_withUndocumentedCharacters
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (54.63s)
=== RUN   TestAccAWSDBSubnetGroup_updateDescription
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (83.04s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    243.785s
```