### PR TITLE
provider/aws: Support Import for `aws_sns_topic`

### DIFF
--- a/builtin/providers/aws/import_aws_sns_topic_test.go
+++ b/builtin/providers/aws/import_aws_sns_topic_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSNSTopic_importBasic(t *testing.T) {
+	resourceName := "aws_sns_topic.test_topic"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSNSTopicConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -30,6 +30,9 @@ func resourceAwsSnsTopic() *schema.Resource {
 		Read:   resourceAwsSnsTopicRead,
 		Update: resourceAwsSnsTopicUpdate,
 		Delete: resourceAwsSnsTopicDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSSNSTopic_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSNSTopic_
-timeout 120m
=== RUN   TestAccAWSSNSTopic_importBasic
--- PASS: TestAccAWSSNSTopic_importBasic (17.02s)
=== RUN   TestAccAWSSNSTopic_basic
--- PASS: TestAccAWSSNSTopic_basic (16.59s)
=== RUN   TestAccAWSSNSTopic_withIAMRole
--- PASS: TestAccAWSSNSTopic_withIAMRole (28.90s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    62.536s
```