### PR TITLE
provider/aws: Support Import for `aws_redshift_subnet_group`

### DIFF
--- a/builtin/providers/aws/import_aws_redshift_subnet_group_test.go
+++ b/builtin/providers/aws/import_aws_redshift_subnet_group_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSRedshiftSubnetGroup_importBasic(t *testing.T) {
+	resourceName := "aws_redshift_subnet_group.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRedshiftSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRedshiftSubnetGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_redshift_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group.go
@@ -19,6 +19,9 @@ func resourceAwsRedshiftSubnetGroup() *schema.Resource {
 		Read:   resourceAwsRedshiftSubnetGroupRead,
 		Update: resourceAwsRedshiftSubnetGroupUpdate,
 		Delete: resourceAwsRedshiftSubnetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSRedshiftSubnetGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSRedshiftSubnetGroup_ -timeout 120m
=== RUN   TestAccAWSRedshiftSubnetGroup_importBasic
--- PASS: TestAccAWSRedshiftSubnetGroup_importBasic (47.76s)
=== RUN   TestAccAWSRedshiftSubnetGroup_basic
--- PASS: TestAccAWSRedshiftSubnetGroup_basic (47.75s)
=== RUN   TestAccAWSRedshiftSubnetGroup_updateSubnetIds
--- PASS: TestAccAWSRedshiftSubnetGroup_updateSubnetIds (77.74s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    173.271s
```