### PR TITLE
provider/aws: Support Import for `aws_vpc_endpoint`

### DIFF
--- a/builtin/providers/aws/import_aws_vpc_endpoint_test.go
+++ b/builtin/providers/aws/import_aws_vpc_endpoint_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVpcEndpoint_importBasic(t *testing.T) {
+	resourceName := "aws_vpc_endpoint.second-private-s3"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcEndpointWithRouteTableAndPolicyConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_vpc_endpoint.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint.go
@@ -16,6 +16,10 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 		Read:   resourceAwsVPCEndpointRead,
 		Update: resourceAwsVPCEndpointUpdate,
 		Delete: resourceAwsVPCEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"policy": &schema.Schema{
 				Type:      schema.TypeString,


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSVpcEndpoint_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpcEndpoint_
-timeout 120m
=== RUN   TestAccAWSVpcEndpoint_importBasic
--- PASS: TestAccAWSVpcEndpoint_importBasic (45.90s)
=== RUN   TestAccAWSVpcEndpoint_basic
--- PASS: TestAccAWSVpcEndpoint_basic (46.64s)
=== RUN   TestAccAWSVpcEndpoint_withRouteTableAndPolicy
--- PASS: TestAccAWSVpcEndpoint_withRouteTableAndPolicy (91.91s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    184.470s
```