### PR TITLE
provider/aws: Support Import for `aws_iam_user`

### DIFF
--- a/builtin/providers/aws/import_aws_iam_user_test.go
+++ b/builtin/providers/aws/import_aws_iam_user_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSUser_importBasic(t *testing.T) {
+	resourceName := "aws_iam_user.user"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSUserDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSUserConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -17,6 +17,9 @@ func resourceAwsIamUser() *schema.Resource {
 		Read:   resourceAwsIamUserRead,
 		Update: resourceAwsIamUserUpdate,
 		Delete: resourceAwsIamUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
@@ -64,14 +67,15 @@ func resourceAwsIamUserCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error creating IAM User %s: %s", name, err)
 	}
+	d.SetId(*createResp.User.UserName)
 	return resourceAwsIamUserReadResult(d, createResp.User)
 }
 
 func resourceAwsIamUserRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
-	name := d.Get("name").(string)
+
 	request := &iam.GetUserInput{
-		UserName: aws.String(name),
+		UserName: aws.String(d.Id()),
 	}
 
 	getResp, err := iamconn.GetUser(request)
@@ -87,7 +91,6 @@ func resourceAwsIamUserRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsIamUserReadResult(d *schema.ResourceData, user *iam.User) error {
-	d.SetId(*user.UserName)
 	if err := d.Set("name", user.UserName); err != nil {
 		return err
 	}


### PR DESCRIPTION
The Id wasn't being set until after the Read func returned from the API.
I needed to move that Id set up until just after the Create response
returned

The same Id's have been set - username

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSUser_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSUser_
-timeout 120m
=== RUN   TestAccAWSUser_importBasic
--- PASS: TestAccAWSUser_importBasic (14.24s)
=== RUN   TestAccAWSUser_basic
--- PASS: TestAccAWSUser_basic (24.99s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    39.261s
```