### PR TITLE
provider/aws: Support Import for `aws_iam_group`

### DIFF
--- a/builtin/providers/aws/import_aws_iam_group_test.go
+++ b/builtin/providers/aws/import_aws_iam_group_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSIAMGroup_importBasic(t *testing.T) {
+	resourceName := "aws_iam_group.group"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -16,6 +16,9 @@ func resourceAwsIamGroup() *schema.Resource {
 		Read:   resourceAwsIamGroupRead,
 		Update: resourceAwsIamGroupUpdate,
 		Delete: resourceAwsIamGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
@@ -53,15 +56,16 @@ func resourceAwsIamGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error creating IAM Group %s: %s", name, err)
 	}
+	d.SetId(*createResp.Group.GroupName)
+
 	return resourceAwsIamGroupReadResult(d, createResp.Group)
 }
 
 func resourceAwsIamGroupRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
-	name := d.Get("name").(string)
 
 	request := &iam.GetGroupInput{
-		GroupName: aws.String(name),
+		GroupName: aws.String(d.Id()),
 	}
 
 	getResp, err := iamconn.GetGroup(request)
@@ -76,7 +80,6 @@ func resourceAwsIamGroupRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsIamGroupReadResult(d *schema.ResourceData, group *iam.Group) error {
-	d.SetId(*group.GroupName)
 	if err := d.Set("name", group.GroupName); err != nil {
 		return err
 	}

--- a/builtin/providers/aws/resource_aws_iam_group_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_test.go
@@ -29,7 +29,7 @@ func TestAccAWSIAMGroup_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSGroupConfig2,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
+					testAccCheckAWSGroupExists("aws_iam_group.group2", &conf),
 					testAccCheckAWSGroupAttributes(&conf, "test-group2", "/funnypath/"),
 				),
 			},
@@ -113,7 +113,7 @@ resource "aws_iam_group" "group" {
 }
 `
 const testAccAWSGroupConfig2 = `
-resource "aws_iam_group" "group" {
+resource "aws_iam_group" "group2" {
 	name = "test-group2"
 	path = "/funnypath/"
 }


### PR DESCRIPTION
Small change to the test as it was failing sometimes as it was using the
same identifier. The small change has made it more stable when running
it in quick succession as it isn't an update

```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSIAMGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSIAMGroup_
-timeout 120m
=== RUN   TestAccAWSIAMGroup_importBasic
--- PASS: TestAccAWSIAMGroup_importBasic (14.14s)
=== RUN   TestAccAWSIAMGroup_basic
--- PASS: TestAccAWSIAMGroup_basic (22.88s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    37.040s
```