### PR TITLE
provider/aws: Support Import for `aws_iam_account_password_policy`

### DIFF
--- a/builtin/providers/aws/import_aws_iam_account_password_policy_test.go
+++ b/builtin/providers/aws/import_aws_iam_account_password_policy_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSIAMAccountPasswordPolicy_importBasic(t *testing.T) {
+	resourceName := "aws_iam_account_password_policy.default"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIAMAccountPasswordPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSIAMAccountPasswordPolicy,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_iam_account_password_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_account_password_policy.go
@@ -17,6 +17,9 @@ func resourceAwsIamAccountPasswordPolicy() *schema.Resource {
 		Read:   resourceAwsIamAccountPasswordPolicyRead,
 		Update: resourceAwsIamAccountPasswordPolicyUpdate,
 		Delete: resourceAwsIamAccountPasswordPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"allow_users_to_change_password": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSIAMAccountPasswordPolicy_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSIAMAccountPasswordPolicy_ -timeout 120m
=== RUN   TestAccAWSIAMAccountPasswordPolicy_importBasic
--- PASS: TestAccAWSIAMAccountPasswordPolicy_importBasic (14.75s)
=== RUN   TestAccAWSIAMAccountPasswordPolicy_basic
--- PASS: TestAccAWSIAMAccountPasswordPolicy_basic (26.06s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    40.831s
```