### PR TITLE
provider/aws: Support Import for `aws_cloudtrail`

### DIFF
--- a/builtin/providers/aws/import_aws_cloudtrail_test.go
+++ b/builtin/providers/aws/import_aws_cloudtrail_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudTrail_importBasic(t *testing.T) {
+	resourceName := "aws_cloudtrail.foobar"
+	cloudTrailRandInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enable_log_file_validation", "is_multi_region_trail", "include_global_service_events", "enable_logging"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_cloudtrail.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail.go
@@ -15,6 +15,9 @@ func resourceAwsCloudTrail() *schema.Resource {
 		Read:   resourceAwsCloudTrailRead,
 		Update: resourceAwsCloudTrailUpdate,
 		Delete: resourceAwsCloudTrailDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -136,10 +139,9 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudtrailconn
 
-	name := d.Get("name").(string)
 	input := cloudtrail.DescribeTrailsInput{
 		TrailNameList: []*string{
-			aws.String(name),
+			aws.String(d.Id()),
 		},
 	}
 	resp, err := conn.DescribeTrails(&input)
@@ -157,7 +159,7 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if trail == nil {
-		log.Printf("[WARN] CloudTrail (%s) not found", name)
+		log.Printf("[WARN] CloudTrail (%s) not found", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -215,7 +217,7 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*AWSClient).cloudtrailconn
 
 	input := cloudtrail.UpdateTrailInput{
-		Name: aws.String(d.Get("name").(string)),
+		Name: aws.String(d.Id()),
 	}
 
 	if d.HasChange("s3_bucket_name") {
@@ -274,11 +276,10 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 
 func resourceAwsCloudTrailDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudtrailconn
-	name := d.Get("name").(string)
 
-	log.Printf("[DEBUG] Deleting CloudTrail: %q", name)
+	log.Printf("[DEBUG] Deleting CloudTrail: %q", d.Id())
 	_, err := conn.DeleteTrail(&cloudtrail.DeleteTrailInput{
-		Name: aws.String(name),
+		Name: aws.String(d.Id()),
 	})
 
 	return err


### PR DESCRIPTION
We were setting the Id on the Create but never used it for the Delete or Read. This PR changes it to add it to the Read func for successful import

```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSCloudTrail_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudTrail_
-timeout 120m
=== RUN   TestAccAWSCloudTrail_importBasic
--- PASS: TestAccAWSCloudTrail_importBasic (64.64s)
=== RUN   TestAccAWSCloudTrail_basic
--- PASS: TestAccAWSCloudTrail_basic (97.96s)
=== RUN   TestAccAWSCloudTrail_enable_logging
--- PASS: TestAccAWSCloudTrail_enable_logging (137.07s)
=== RUN   TestAccAWSCloudTrail_is_multi_region
--- PASS: TestAccAWSCloudTrail_is_multi_region (138.51s)
=== RUN   TestAccAWSCloudTrail_logValidation
--- PASS: TestAccAWSCloudTrail_logValidation (102.61s)
=== RUN   TestAccAWSCloudTrail_tags
--- PASS: TestAccAWSCloudTrail_tags (135.66s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    676.484s
```