### PR TITLE
provider/aws: Support Import for `aws_cloudwatch_event_rule`

### DIFF
--- a/builtin/providers/aws/import_aws_cloudwatch_event_rule_test.go
+++ b/builtin/providers/aws/import_aws_cloudwatch_event_rule_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudWatchEventRule_importBasic(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_rule.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudWatchEventRuleConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_enabled"}, //this has a default value
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
@@ -20,6 +20,9 @@ func resourceAwsCloudWatchEventRule() *schema.Resource {
 		Read:   resourceAwsCloudWatchEventRuleRead,
 		Update: resourceAwsCloudWatchEventRuleUpdate,
 		Delete: resourceAwsCloudWatchEventRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSCloudWatchEventRule_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSCloudWatchEventRule_ -timeout 120m
=== RUN   TestAccAWSCloudWatchEventRule_importBasic
--- PASS: TestAccAWSCloudWatchEventRule_importBasic (20.15s)
=== RUN   TestAccAWSCloudWatchEventRule_basic
--- PASS: TestAccAWSCloudWatchEventRule_basic (35.25s)
=== RUN   TestAccAWSCloudWatchEventRule_full
--- PASS: TestAccAWSCloudWatchEventRule_full (19.43s)
=== RUN   TestAccAWSCloudWatchEventRule_enable
--- PASS: TestAccAWSCloudWatchEventRule_enable (50.52s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    125.380s
```