### PR TITLE
code: Add proper build constraints for GH-7273

### DIFF
--- a/config/module/inode.go
+++ b/config/module/inode.go
@@ -1,0 +1,21 @@
+// +build !windows
+
+package module
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// lookup the inode of a file on posix systems
+func inode(path string) (uint64, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if st, ok := stat.Sys().(*syscall.Stat_t); ok {
+		return st.Ino, nil
+	}
+	return 0, fmt.Errorf("could not determine file inode")
+}

--- a/config/module/inode_windows.go
+++ b/config/module/inode_windows.go
@@ -1,0 +1,6 @@
+package module
+
+// no syscall.Stat_t on windows, return 0 for inodes
+func inode(path string) (uint64, error) {
+	return 0, nil
+}


### PR DESCRIPTION
The syscall.Stat_t type doesn't exist on windows, so the inode lookup
needs to be in a file with proper build constraints.