### PR TITLE
core: Fix bug with interpolation of unknown multi-variables

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -667,6 +667,9 @@ func interpolationFuncElement() ast.Function {
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
 			list := args[0].([]ast.Variable)
+			if len(list) == 0 {
+				return nil, fmt.Errorf("element() may not be used with an empty list")
+			}
 
 			index, err := strconv.Atoi(args[1].(string))
 			if err != nil || index < 0 {

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -952,6 +952,7 @@ func TestInterpolateFuncElement(t *testing.T) {
 		Vars: map[string]ast.Variable{
 			"var.a_list":       interfaceToVariableSwallowError([]string{"foo", "baz"}),
 			"var.a_short_list": interfaceToVariableSwallowError([]string{"foo"}),
+			"var.empty_list":   interfaceToVariableSwallowError([]interface{}{}),
 		},
 		Cases: []testFunctionCase{
 			{
@@ -976,6 +977,13 @@ func TestInterpolateFuncElement(t *testing.T) {
 			// Negative number should fail
 			{
 				`${element(var.a_short_list, "-1")}`,
+				nil,
+				true,
+			},
+
+			// Empty list should fail
+			{
+				`${element(var.empty_list, 0)}`,
 				nil,
 				true,
 			},

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -49,6 +49,27 @@ func TestContext2Input(t *testing.T) {
 	}
 }
 
+func TestContext2Input_moduleComputedOutputElement(t *testing.T) {
+	m := testModule(t, "input-module-computed-output-element")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	p.InputFn = func(i UIInput, c *ResourceConfig) (*ResourceConfig, error) {
+		return c, nil
+	}
+
+	if err := ctx.Input(InputModeStd); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestContext2Input_badVarDefault(t *testing.T) {
 	m := testModule(t, "input-bad-var-default")
 	p := testProvider("aws")

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -162,7 +162,6 @@ func (i *Interpolater) valueModuleVar(
 		} else {
 			// Same reasons as the comment above.
 			result[n] = unknownVariable()
-
 		}
 	}
 
@@ -485,11 +484,15 @@ func (i *Interpolater) computeResourceMultiVariable(
 			err)
 	}
 
-	// If we have no module in the state yet or count, return empty
-	if module == nil || len(module.Resources) == 0 || count == 0 {
+	// If count is zero, we return an empty list
+	if count == 0 {
 		return &ast.Variable{Type: ast.TypeList, Value: []ast.Variable{}}, nil
 	}
 
+	// If we have no module in the state yet or count, return unknown
+	if module == nil || len(module.Resources) == 0 {
+		return &unknownVariable, nil
+	}
 	var values []string
 	for j := 0; j < count; j++ {
 		id := fmt.Sprintf("%s.%d", v.ResourceId(), j)

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -635,8 +635,7 @@ type OutputState struct {
 }
 
 func (s *OutputState) String() string {
-	// This is a v0.6.x implementation only
-	return fmt.Sprintf("%s", s.Value.(string))
+	return fmt.Sprintf("%#v", s.Value)
 }
 
 // Equal compares two OutputState structures for equality. nil values are

--- a/terraform/test-fixtures/input-module-computed-output-element/main.tf
+++ b/terraform/test-fixtures/input-module-computed-output-element/main.tf
@@ -1,0 +1,9 @@
+module "b" {
+  source = "./modb"
+}
+
+module "a" {
+  source = "./moda"
+
+  single_element = "${element(module.b.computed_list, 0)}"
+}

--- a/terraform/test-fixtures/input-module-computed-output-element/moda/main.tf
+++ b/terraform/test-fixtures/input-module-computed-output-element/moda/main.tf
@@ -1,0 +1,3 @@
+variable "single_element" {
+  type = "string"
+}

--- a/terraform/test-fixtures/input-module-computed-output-element/modb/main.tf
+++ b/terraform/test-fixtures/input-module-computed-output-element/modb/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "test" {
+  count = 3
+}
+
+output "computed_list" {
+  value = ["${aws_instance.test.*.id}"]
+}


### PR DESCRIPTION
This PR includes a number of commits necessary to fix interpolation during the Input walk when using the `element()` function with a multi-variable generated by the splat syntax. We now correctly proceed on to the planning stage during the Input stage rather than panicing, as non-reified multi-variables are treated as `UnknownVariable` rather than empty lists.