### PR TITLE
provider/azurerm: `azurerm_network_security_group` now polls for State succeeded

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_security_group.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group.go
@@ -3,10 +3,13 @@ package azurerm
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -157,6 +160,18 @@ func resourceArmNetworkSecurityGroupCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Cannot read Virtual Network %s (resource group %s) ID", name, resGroup)
 	}
 
+	log.Printf("[DEBUG] Waiting for NSG (%s) to become available", d.Get("name"))
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"Updating", "Creating"},
+		Target:     []string{"Succeeded"},
+		Refresh:    networkSecurityGroupStateRefreshFunc(client, resGroup, name),
+		Timeout:    30 * time.Minute,
+		MinTimeout: 15 * time.Second,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for NSG (%s) to become available: %s", d.Get("name"), err)
+	}
+
 	d.SetId(*read.ID)
 
 	return resourceArmNetworkSecurityGroupRead(d, meta)
@@ -281,4 +296,15 @@ func expandAzureRmSecurityRules(d *schema.ResourceData) ([]network.SecurityRule,
 	}
 
 	return rules, nil
+}
+
+func networkSecurityGroupStateRefreshFunc(client *ArmClient, resourceGroupName string, sgName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.secGroupClient.Get(resourceGroupName, sgName, "")
+		if err != nil {
+			return nil, "", fmt.Errorf("Error issuing read request in networkSecurityGroupStateRefreshFunc to Azure ARM for NSG '%s' (RG: '%s'): %s", sgName, resourceGroupName, err)
+		}
+
+		return res, *res.Properties.ProvisioningState, nil
+	}
 }


### PR DESCRIPTION
This fixes #7122 where the SG was not fully configured before a
dependant service was created

```
make testacc TEST=./builtin/providers/azurerm
TESTARGS='-run=TestAccAzureRMNetworkSecurityGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMNetworkSecurityGroup_ -timeout 120m
=== RUN   TestAccAzureRMNetworkSecurityGroup_basic
--- PASS: TestAccAzureRMNetworkSecurityGroup_basic (128.93s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_withTags
--- PASS: TestAccAzureRMNetworkSecurityGroup_withTags (164.52s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_addingExtraRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_addingExtraRules (178.20s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
471.677s
```