### PR TITLE
provider/azurerm: `azurerm_virtual_machine` computer_name now Required

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -214,8 +214,8 @@ func resourceArmVirtualMachine() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"computer_name": {
 							Type:     schema.TypeString,
-							Optional: true,
 							ForceNew: true,
+							Required: true,
 						},
 
 						"admin_username": {
@@ -847,9 +847,11 @@ func expandAzureRmVirtualMachineOsProfile(d *schema.ResourceData) (*compute.OSPr
 
 	adminUsername := osProfile["admin_username"].(string)
 	adminPassword := osProfile["admin_password"].(string)
+	computerName := osProfile["computer_name"].(string)
 
 	profile := &compute.OSProfile{
 		AdminUsername: &adminUsername,
+		ComputerName:  &computerName,
 	}
 
 	if adminPassword != "" {
@@ -883,9 +885,6 @@ func expandAzureRmVirtualMachineOsProfile(d *schema.ResourceData) (*compute.OSPr
 		}
 	}
 
-	if v := osProfile["computer_name"].(string); v != "" {
-		profile.ComputerName = &v
-	}
 	if v := osProfile["custom_data"].(string); v != "" {
 		profile.CustomData = &v
 	}

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -253,7 +253,7 @@ For more information on the different example configurations, please check out t
 
 `os_profile` supports the following:
 
-* `computer_name` - (Optional) Specifies the name of the virtual machine.
+* `computer_name` - (Required) Specifies the name of the virtual machine.
 * `admin_username` - (Required) Specifies the name of the administrator account.
 * `admin_password` - (Required) Specifies the password of the administrator account.
 * `custom_data` - (Optional) Specifies a base-64 encoded string of custom data. The base-64 encoded string is decoded to a binary array that is saved as a file on the Virtual Machine. The maximum length of the binary array is 65535 bytes.


### PR DESCRIPTION
Fixes #7229 where it was found that computer_name is not optional (as
the msdn documentation states)

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMVirtualMachine_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMVirtualMachine_ -timeout 120m
=== RUN   TestAccAzureRMVirtualMachine_basicLinuxMachine
--- PASS: TestAccAzureRMVirtualMachine_basicLinuxMachine (403.53s)
=== RUN   TestAccAzureRMVirtualMachine_tags
--- PASS: TestAccAzureRMVirtualMachine_tags (488.46s)
=== RUN   TestAccAzureRMVirtualMachine_updateMachineSize
--- PASS: TestAccAzureRMVirtualMachine_updateMachineSize (601.82s)
=== RUN   TestAccAzureRMVirtualMachine_basicWindowsMachine
--- PASS: TestAccAzureRMVirtualMachine_basicWindowsMachine (646.75s)
=== RUN   TestAccAzureRMVirtualMachine_windowsUnattendedConfig
--- PASS: TestAccAzureRMVirtualMachine_windowsUnattendedConfig (891.42s)
=== RUN   TestAccAzureRMVirtualMachine_winRMConfig
--- PASS: TestAccAzureRMVirtualMachine_winRMConfig (768.73s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	3800.734s
```