### PR TITLE
Azurerm cacert

### DIFF
--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -48,9 +48,11 @@ type connectionInfo struct {
 func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 	connInfo := &connectionInfo{}
 
-	var cabyte = []byte(connInfo.CACertFile)
-	cabyteptr := &cabyte
-	connInfo.CACert = cabyteptr
+	if connInfo.CACertFile != "" {
+		var cabyte = []byte(connInfo.CACertFile)
+		cabyteptr := &cabyte
+		connInfo.CACert = cabyteptr
+	}
 
 	decConf := &mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,

--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -40,12 +40,18 @@ type connectionInfo struct {
 	Timeout    string
 	ScriptPath string        `mapstructure:"script_path"`
 	TimeoutVal time.Duration `mapstructure:"-"`
+	CACertFile string
 }
 
 // parseConnectionInfo is used to convert the ConnInfo of the InstanceState into
 // a ConnectionInfo struct
 func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 	connInfo := &connectionInfo{}
+
+	var cabyte = []byte(connInfo.CACertFile)
+	cabyteptr := &cabyte
+	connInfo.CACert = cabyteptr
+
 	decConf := &mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
 		Result:           connInfo,

--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -48,12 +48,6 @@ type connectionInfo struct {
 func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 	connInfo := &connectionInfo{}
 
-	if connInfo.CACertFile != "" {
-		var cabyte = []byte(connInfo.CACertFile)
-		cabyteptr := &cabyte
-		connInfo.CACert = cabyteptr
-	}
-
 	decConf := &mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
 		Result:           connInfo,
@@ -90,6 +84,11 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		connInfo.TimeoutVal = safeDuration(connInfo.Timeout, DefaultTimeout)
 	} else {
 		connInfo.TimeoutVal = DefaultTimeout
+	}
+	if connInfo.CACertFile != "" {
+		var cabyte = []byte(connInfo.CACertFile)
+		cabyteptr := &cabyte
+		connInfo.CACert = cabyteptr
 	}
 
 	return connInfo, nil


### PR DESCRIPTION
since Terraform still doesn't support []byte variables, secure connection using cacert is currently not functioning, I added a cacertfile attribute to the winrm, which allow to use .pem