### PR TITLE
Add a link to the cloudwatch dimensions aws page in the docs

### DIFF
--- a/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 * `actions_enabled` - (Optional) Indicates whether or not actions should be executed during any changes to the alarm's state. Defaults to `true`.
 * `alarm_actions` - (Optional) The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN).
 * `alarm_description` - (Optional) The description for the alarm.
-* `dimensions` - (Optional) The dimensions for the alarm's associated metric.
+* `dimensions` - (Optional) The dimensions for the alarm's associated metric.  For the list of available dimensions see the AWS documentation [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
 * `insufficient_data_actions` - (Optional) The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. Each action is specified as an Amazon Resource Number (ARN).
 * `ok_actions` - (Optional) The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Number (ARN).
 * `unit` - (Optional) The unit for the alarm's associated metric.


### PR DESCRIPTION
Thought it would be handy to add the link directly here.