### PR TITLE
provider/aws: Documentation update for Elasticache Snapshot

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -91,7 +91,8 @@ begin taking a daily snapshot of your cache cluster. Example: 05:00-09:00
 * `snapshot_retention_limit` - (Optional, Redis only) The number of days for which ElastiCache will
 retain automatic cache cluster snapshots before deleting them. For example, if you set
 SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days
-before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off
+before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.
+Please note that setting a `snapshot_retention_limit` is not supported on cache.t1.micro or cache.t2.* cache nodes
 
 * `notification_topic_arn` – (Optional) An Amazon Resource Name (ARN) of an
 SNS topic to send ElastiCache notifications to. Example:


### PR DESCRIPTION
Fixes #4947: To avoid confusion on using snapshots and t2 instance
sizes, a note has been added to the documentation