### PR TITLE
provider/azurerm: `azurerm_storage_table` resource

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -355,6 +355,23 @@ func (armClient *ArmClient) getBlobStorageClientForStorageAccount(resourceGroupN
 	blobClient := storageClient.GetBlobService()
 	return &blobClient, true, nil
 }
+func (armClient *ArmClient) getTableServiceClientForStorageAccount(resourceGroupName, storageAccountName string) (*mainStorage.TableServiceClient, bool, error) {
+	key, accountExists, err := armClient.getKeyForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return nil, accountExists, err
+	}
+	if accountExists == false {
+		return nil, false, nil
+	}
+
+	storageClient, err := mainStorage.NewBasicClient(storageAccountName, key)
+	if err != nil {
+		return nil, true, fmt.Errorf("Error creating storage client for storage account %q: %s", storageAccountName, err)
+	}
+
+	tableClient := storageClient.GetTableService()
+	return &tableClient, true, nil
+}
 
 func (armClient *ArmClient) getQueueServiceClientForStorageAccount(resourceGroupName, storageAccountName string) (*mainStorage.QueueServiceClient, bool, error) {
 	key, accountExists, err := armClient.getKeyForStorageAccount(resourceGroupName, storageAccountName)

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -60,6 +60,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_storage_blob":              resourceArmStorageBlob(),
 			"azurerm_storage_container":         resourceArmStorageContainer(),
 			"azurerm_storage_queue":             resourceArmStorageQueue(),
+			"azurerm_storage_table":             resourceArmStorageTable(),
 			"azurerm_subnet":                    resourceArmSubnet(),
 			"azurerm_template_deployment":       resourceArmTemplateDeployment(),
 			"azurerm_virtual_machine":           resourceArmVirtualMachine(),

--- a/builtin/providers/azurerm/resource_arm_storage_table.go
+++ b/builtin/providers/azurerm/resource_arm_storage_table.go
@@ -43,7 +43,7 @@ func validateArmStorageTableName(v interface{}, k string) (ws []string, errors [
 			"Table Storage %q cannot use the word `table`: %q",
 			k, value))
 	}
-	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{2,62}$`).MatchString(value) {
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{6,63}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"Table Storage %q cannot begin with a numeric character, only alphanumeric characters are allowed and must be between 6 and 63 characters long: %q",
 			k, value))

--- a/builtin/providers/azurerm/resource_arm_storage_table.go
+++ b/builtin/providers/azurerm/resource_arm_storage_table.go
@@ -45,7 +45,7 @@ func validateArmStorageTableName(v interface{}, k string) (ws []string, errors [
 	}
 	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{2,62}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"Table Storage %q cannot begin with a numberic character, only alphanumeric characters are allowed and must be between 6 and 63 characters long: %q",
+			"Table Storage %q cannot begin with a numeric character, only alphanumeric characters are allowed and must be between 6 and 63 characters long: %q",
 			k, value))
 	}
 

--- a/builtin/providers/azurerm/resource_arm_storage_table.go
+++ b/builtin/providers/azurerm/resource_arm_storage_table.go
@@ -1,0 +1,146 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmStorageTable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmStorageTableCreate,
+		Read:   resourceArmStorageTableRead,
+		Delete: resourceArmStorageTableDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArmStorageTableName,
+			},
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"storage_account_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func validateArmStorageTableName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value == "table" {
+		errors = append(errors, fmt.Errorf(
+			"Table Storage %q cannot use the word `table`: %q",
+			k, value))
+	}
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{2,62}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"Table Storage %q cannot begin with a numberic character, only alphanumeric characters are allowed and must be between 6 and 63 characters long: %q",
+			k, value))
+	}
+
+	return
+}
+
+func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+	if !accountExists {
+		return fmt.Errorf("Storage Account %q Not Found", storageAccountName)
+	}
+
+	name := d.Get("name").(string)
+	table := storage.AzureTable(name)
+
+	log.Printf("[INFO] Creating table %q in storage account %q.", name, storageAccountName)
+	err = tableClient.CreateTable(table)
+	if err != nil {
+		return fmt.Errorf("Error creating table %q in storage account %q: %s", name, storageAccountName, err)
+	}
+
+	d.SetId(name)
+
+	return resourceArmStorageTableRead(d, meta)
+}
+
+func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+	if !accountExists {
+		log.Printf("[DEBUG] Storage account %q not found, removing table %q from state", storageAccountName, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	name := d.Get("name").(string)
+	tables, err := tableClient.QueryTables()
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve storage tables in account %q: %s", name, err)
+	}
+
+	var found bool
+	for _, table := range tables {
+		if string(table) == name {
+			found = true
+			d.Set("name", string(table))
+		}
+	}
+
+	if !found {
+		log.Printf("[INFO] Storage table %q does not exist in account %q, removing from state...", name, storageAccountName)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+
+	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(resourceGroupName, storageAccountName)
+	if err != nil {
+		return err
+	}
+	if !accountExists {
+		log.Printf("[INFO]Storage Account %q doesn't exist so the table won't exist", storageAccountName)
+		return nil
+	}
+
+	name := d.Get("name").(string)
+	table := storage.AzureTable(name)
+
+	log.Printf("[INFO] Deleting storage table %q in account %q", name, storageAccountName)
+	if err := tableClient.DeleteTable(table); err != nil {
+		return fmt.Errorf("Error deleting storage table %q from storage account %q: %s", name, storageAccountName, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_storage_table_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_table_test.go
@@ -1,0 +1,237 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMStorageTable_basic(t *testing.T) {
+	var table storage.AzureTable
+
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageTable_basic, ri, rs, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageTableExists("azurerm_storage_table.test", &table),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStorageTable_disappears(t *testing.T) {
+	var table storage.AzureTable
+
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageTable_basic, ri, rs, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageTableExists("azurerm_storage_table.test", &table),
+					testAccARMStorageTableDisappears("azurerm_storage_table.test", &table),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMStorageTableExists(name string, t *storage.AzureTable) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return err
+		}
+		if !accountExists {
+			return fmt.Errorf("Bad: Storage Account %q does not exist", storageAccountName)
+		}
+
+		tables, err := tableClient.QueryTables()
+
+		if len(tables) == 0 {
+			return fmt.Errorf("Bad: Storage Table %q (storage account: %q) does not exist", name, storageAccountName)
+		}
+
+		var found bool
+		for _, table := range tables {
+			if string(table) == name {
+				found = true
+				*t = table
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Bad: Storage Table %q (storage account: %q) does not exist", name, storageAccountName)
+		}
+
+		return nil
+	}
+}
+
+func testAccARMStorageTableDisappears(name string, t *storage.AzureTable) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", string(*t))
+		}
+
+		tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return err
+		}
+		if !accountExists {
+			log.Printf("[INFO]Storage Account %q doesn't exist so the table won't exist", storageAccountName)
+			return nil
+		}
+
+		table := storage.AzureTable(string(*t))
+		err = tableClient.DeleteTable(table)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMStorageTableDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_storage_table" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			//If we can't get keys then the table can't exist
+			return nil
+		}
+		if !accountExists {
+			return nil
+		}
+
+		tables, err := tableClient.QueryTables()
+
+		if err != nil {
+			return nil
+		}
+
+		var found bool
+		for _, table := range tables {
+			if string(table) == name {
+				found = true
+			}
+		}
+
+		if found {
+			return fmt.Errorf("Bad: Storage Table %q (storage account: %q) still exist", name, storageAccountName)
+		}
+	}
+
+	return nil
+}
+
+func TestValidateArmStorageTableName(t *testing.T) {
+	validNames := []string{
+		"mytable01",
+		"mytable",
+		"myTable",
+		"MYTABLE",
+	}
+	for _, v := range validNames {
+		_, errors := validateArmStorageTableName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Storage Table Name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"table",
+		"-invalidname1",
+		"invalid_name",
+		"invalid!",
+		"ww",
+		strings.Repeat("w", 65),
+	}
+	for _, v := range invalidNames {
+		_, errors := validateArmStorageTableName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid Storage Table Name", v)
+		}
+	}
+}
+
+var testAccAzureRMStorageTable_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_table" "test" {
+    name = "tfacceptancetest%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+}
+`

--- a/website/source/docs/providers/azurerm/r/storage_table.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_table.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_table"
+sidebar_current: "docs-azurerm-resource-storage-table"
+description: |-
+  Create a Azure Storage Table.
+---
+
+# azurerm\_storage\_table
+
+Create an Azure Storage Table.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+}
+
+resource "azurerm_storage_table" "test" {
+    name = "mysampletable"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the storage table. Must be unique within the storage account the table is located. 
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the storage table. Changing this forces a new resource to be created.
+
+* `storage_account_name` - (Required) Specifies the storage account in which to create the storage table.
+ Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The storage table Resource ID.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -165,6 +165,10 @@
                   <a href="/docs/providers/azurerm/r/storage_queue.html">azurerm_storage_queue</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-storage-table") %>>
+                  <a href="/docs/providers/azurerm/r/storage_table.html">azurerm_storage_table</a>
+                </li>
+
               </ul>
             </li>
 


### PR DESCRIPTION
Fixes #7257

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMStorageTable_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMStorageTable_ -timeout 120m
=== RUN   TestAccAzureRMStorageTable_basic
--- PASS: TestAccAzureRMStorageTable_basic (122.29s)
=== RUN   TestAccAzureRMStorageTable_disappears
--- PASS: TestAccAzureRMStorageTable_disappears (125.64s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm    247.940s
```