### PR TITLE
provider/azurerm: `azurerm_storage_blob` validation fix

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_blob.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob.go
@@ -70,12 +70,12 @@ func validateArmStorageBlobSize(v interface{}, k string) (ws []string, errors []
 func validateArmStorageBlobType(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
 	validTypes := map[string]struct{}{
-		"blob": struct{}{},
-		"page": struct{}{},
+		"block": struct{}{},
+		"page":  struct{}{},
 	}
 
 	if _, ok := validTypes[value]; !ok {
-		errors = append(errors, fmt.Errorf("Blob type %q is invalid, must be %q or %q", value, "blob", "page"))
+		errors = append(errors, fmt.Errorf("Blob type %q is invalid, must be %q or %q", value, "block", "page"))
 	}
 	return
 }

--- a/builtin/providers/azurerm/resource_arm_storage_blob_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob_test.go
@@ -25,15 +25,15 @@ func TestResourceAzureRMStorageBlobType_validation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    "blob",
+			Value:    "block",
 			ErrCount: 0,
 		},
 		{
-			Value:    "BLOB",
+			Value:    "BLOCK",
 			ErrCount: 0,
 		},
 		{
-			Value:    "Blob",
+			Value:    "Block",
 			ErrCount: 0,
 		},
 	}


### PR DESCRIPTION
The validation for the `azurerm_storage_blob` `type` parameter was
checking for `blob` where it should have been `block`

This commits fixes it up

```
make testacc TEST=./builtin/providers/azurerm
TESTARGS='-run=TestResourceAzureRMStorageBlobType_validation'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestResourceAzureRMStorageBlobType_validation -timeout 120m
=== RUN   TestResourceAzureRMStorageBlobType_validation
--- PASS: TestResourceAzureRMStorageBlobType_validation (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
0.014s
```