### PR TITLE
Improve influxdb provider

### DIFF
--- a/builtin/providers/influxdb/continuous_query.go
+++ b/builtin/providers/influxdb/continuous_query.go
@@ -1,0 +1,120 @@
+package influxdb
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/influxdata/influxdb/client"
+)
+
+func resourceContinuousQuery() *schema.Resource {
+	return &schema.Resource{
+		Create: createContinuousQuery,
+		Read:   readContinuousQuery,
+		Delete: deleteContinuousQuery,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"database": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"query": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func createContinuousQuery(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+
+	name := d.Get("name").(string)
+	database := d.Get("database").(string)
+
+	queryStr := fmt.Sprintf("CREATE CONTINUOUS QUERY %s ON %s BEGIN %s END", name, quoteIdentifier(database), d.Get("query").(string))
+	query := client.Query{
+		Command: queryStr,
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	d.Set("name", name)
+	d.Set("database", database)
+	d.Set("query", d.Get("query").(string))
+	d.SetId(fmt.Sprintf("influxdb-cq:%s", name))
+
+	return readContinuousQuery(d, meta)
+}
+
+func readContinuousQuery(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+	name := d.Get("name").(string)
+	database := d.Get("database").(string)
+
+	// InfluxDB doesn't have a command to check the existence of a single
+	// ContinuousQuery, so we instead must read the list of all ContinuousQuerys and see
+	// if ours is present in it.
+	query := client.Query{
+		Command: "SHOW CONTINUOUS QUERIES",
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	for _, series := range resp.Results[0].Series {
+		if series.Name == database {
+			for _, result := range series.Values {
+				if result[0].(string) == name {
+					return nil
+				}
+			}
+		}
+	}
+
+	// If we fell out here then we didn't find our ContinuousQuery in the list.
+	d.SetId("")
+
+	return nil
+}
+
+func deleteContinuousQuery(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+	name := d.Get("name").(string)
+	database := d.Get("database").(string)
+
+	queryStr := fmt.Sprintf("DROP CONTINUOUS QUERY %s ON %s", name, quoteIdentifier(database))
+	query := client.Query{
+		Command: queryStr,
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/builtin/providers/influxdb/continuous_query_test.go
+++ b/builtin/providers/influxdb/continuous_query_test.go
@@ -1,0 +1,87 @@
+package influxdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/influxdata/influxdb/client"
+)
+
+func TestAccInfluxDBContiuousQuery(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContiuousQueryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContiuousQueryExists("influxdb_continuous_query.minnie"),
+					resource.TestCheckResourceAttr(
+						"influxdb_continuous_query.minnie", "name", "minnie",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_continuous_query.minnie", "database", "terraform-test",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_continuous_query.minnie", "query", "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckContiuousQueryExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ContiuousQuery id set")
+		}
+
+		conn := testAccProvider.Meta().(*client.Client)
+
+		query := client.Query{
+			Command: "SHOW CONTINUOUS QUERIES",
+		}
+
+		resp, err := conn.Query(query)
+		if err != nil {
+			return err
+		}
+
+		if resp.Err != nil {
+			return resp.Err
+		}
+
+		for _, series := range resp.Results[0].Series {
+			if series.Name == rs.Primary.Attributes["database"] {
+				for _, result := range series.Values {
+					if result[0].(string) == rs.Primary.Attributes["name"] {
+						return nil
+					}
+				}
+			}
+		}
+
+		return fmt.Errorf("ContiuousQuery %q does not exist", rs.Primary.Attributes["name"])
+	}
+}
+
+var testAccContiuousQueryConfig = `
+
+resource "influxdb_database" "test" {
+    name = "terraform-test"
+}
+
+resource "influxdb_continuous_query" "minnie" {
+    name = "minnie"
+    database = "${influxdb_database.test.name}"
+    query = "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)"
+}
+
+`

--- a/builtin/providers/influxdb/provider.go
+++ b/builtin/providers/influxdb/provider.go
@@ -16,8 +16,9 @@ var quoteReplacer = strings.NewReplacer(`"`, `\"`)
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"influxdb_database": resourceDatabase(),
-			"influxdb_user":     resourceUser(),
+			"influxdb_database":         resourceDatabase(),
+			"influxdb_user":             resourceUser(),
+			"influxdb_continuous_query": resourceContinuousQuery(),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/builtin/providers/influxdb/provider.go
+++ b/builtin/providers/influxdb/provider.go
@@ -16,7 +16,8 @@ var quoteReplacer = strings.NewReplacer(`"`, `\"`)
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"influxdb_database": ResourceDatabase(),
+			"influxdb_database": resourceDatabase(),
+			"influxdb_user":     resourceUser(),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -39,11 +40,11 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
-		ConfigureFunc: Configure,
+		ConfigureFunc: configure,
 	}
 }
 
-func Configure(d *schema.ResourceData) (interface{}, error) {
+func configure(d *schema.ResourceData) (interface{}, error) {
 	url, err := url.Parse(d.Get("url").(string))
 	if err != nil {
 		return nil, fmt.Errorf("invalid InfluxDB URL: %s", err)
@@ -69,5 +70,5 @@ func Configure(d *schema.ResourceData) (interface{}, error) {
 }
 
 func quoteIdentifier(ident string) string {
-	return fmt.Sprintf(`"%s"`, quoteReplacer.Replace(ident))
+	return fmt.Sprintf(`%q`, quoteReplacer.Replace(ident))
 }

--- a/builtin/providers/influxdb/resource_database.go
+++ b/builtin/providers/influxdb/resource_database.go
@@ -7,11 +7,11 @@ import (
 	"github.com/influxdata/influxdb/client"
 )
 
-func ResourceDatabase() *schema.Resource {
+func resourceDatabase() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateDatabase,
-		Read:   ReadDatabase,
-		Delete: DeleteDatabase,
+		Create: createDatabase,
+		Read:   readDatabase,
+		Delete: deleteDatabase,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -23,7 +23,7 @@ func ResourceDatabase() *schema.Resource {
 	}
 }
 
-func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
+func createDatabase(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*client.Client)
 
 	name := d.Get("name").(string)
@@ -45,7 +45,7 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
+func readDatabase(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*client.Client)
 	name := d.Id()
 
@@ -76,7 +76,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func DeleteDatabase(d *schema.ResourceData, meta interface{}) error {
+func deleteDatabase(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*client.Client)
 	name := d.Id()
 

--- a/builtin/providers/influxdb/resource_database_test.go
+++ b/builtin/providers/influxdb/resource_database_test.go
@@ -1,18 +1,22 @@
 package influxdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/influxdata/influxdb/client"
 )
 
-func TestAccDatabase(t *testing.T) {
+func TestAccInfluxDBDatabase(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDatabaseConfig,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseExists("influxdb_database.test"),
 					resource.TestCheckResourceAttr(
 						"influxdb_database.test", "name", "terraform-test",
 					),
@@ -20,6 +24,42 @@ func TestAccDatabase(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckDatabaseExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No database id set")
+		}
+
+		conn := testAccProvider.Meta().(*client.Client)
+
+		query := client.Query{
+			Command: "SHOW DATABASES",
+		}
+
+		resp, err := conn.Query(query)
+		if err != nil {
+			return err
+		}
+
+		if resp.Err != nil {
+			return resp.Err
+		}
+
+		for _, result := range resp.Results[0].Series[0].Values {
+			if result[0] == rs.Primary.Attributes["name"] {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Database %q does not exist", rs.Primary.Attributes["name"])
+	}
 }
 
 var testAccDatabaseConfig = `

--- a/builtin/providers/influxdb/resource_user.go
+++ b/builtin/providers/influxdb/resource_user.go
@@ -76,7 +76,7 @@ func createUser(d *schema.ResourceData, meta interface{}) error {
 		return resp.Err
 	}
 
-	d.SetId(name)
+	d.SetId(fmt.Sprintf("influxdb-user:%s", name))
 
 	if v, ok := d.GetOk("grant"); ok {
 		grants := v.([]interface{})
@@ -122,7 +122,7 @@ func revokeAllOn(conn *client.Client, user string) error {
 
 func readUser(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*client.Client)
-	name := d.Id()
+	name := d.Get("name").(string)
 
 	// InfluxDB doesn't have a command to check the existence of a single
 	// User, so we instead must read the list of all Users and see
@@ -160,7 +160,7 @@ func readUser(d *schema.ResourceData, meta interface{}) error {
 
 func readGrants(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*client.Client)
-	name := d.Id()
+	name := d.Get("name").(string)
 
 	query := client.Query{
 		Command: fmt.Sprintf("SHOW GRANTS FOR %s", name),
@@ -191,7 +191,7 @@ func readGrants(d *schema.ResourceData, meta interface{}) error {
 
 func updateUser(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*client.Client)
-	name := d.Id()
+	name := d.Get("name").(string)
 
 	if d.HasChange("admin") {
 		if !d.Get("admin").(bool) {
@@ -250,7 +250,7 @@ func updateUser(d *schema.ResourceData, meta interface{}) error {
 
 func deleteUser(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*client.Client)
-	name := d.Id()
+	name := d.Get("name").(string)
 
 	queryStr := fmt.Sprintf("DROP USER %s", name)
 	query := client.Query{

--- a/builtin/providers/influxdb/resource_user.go
+++ b/builtin/providers/influxdb/resource_user.go
@@ -1,0 +1,259 @@
+package influxdb
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/influxdata/influxdb/client"
+)
+
+func resourceUser() *schema.Resource {
+	return &schema.Resource{
+		Create: createUser,
+		Read:   readUser,
+		Update: updateUser,
+		Delete: deleteUser,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"admin": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"grant": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"database": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"privilege": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createUser(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+
+	name := d.Get("name").(string)
+	password := d.Get("password").(string)
+
+	is_admin := d.Get("admin").(bool)
+	admin_privileges := ""
+	if is_admin {
+		admin_privileges = "WITH ALL PRIVILEGES"
+	}
+
+	queryStr := fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s' %s", name, password, admin_privileges)
+	query := client.Query{
+		Command: queryStr,
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	d.SetId(name)
+
+	if v, ok := d.GetOk("grant"); ok {
+		grants := v.([]interface{})
+		for _, vv := range grants {
+			grant := vv.(map[string]interface{})
+			if err := grantPrivilegeOn(conn, grant["privilege"].(string), grant["database"].(string), name); err != nil {
+				return err
+			}
+		}
+	}
+
+	return readUser(d, meta)
+}
+
+func grantPrivilegeOn(conn *client.Client, privilege, database, user string) error {
+	return changePrivilegeOn(conn, "GRANT", "TO", privilege, database, user)
+}
+
+func revokePrivilegeOn(conn *client.Client, privilege, database, user string) error {
+	return changePrivilegeOn(conn, "REVOKE", "FROM", privilege, database, user)
+}
+
+func changePrivilegeOn(conn *client.Client, method, target, privilege, database, user string) error {
+	queryStr := fmt.Sprintf("%s %s ON %s %s %s", method, privilege, quoteIdentifier(database), target, user)
+	query := client.Query{
+		Command: queryStr,
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	return nil
+}
+
+func readUser(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+	name := d.Id()
+
+	// InfluxDB doesn't have a command to check the existence of a single
+	// User, so we instead must read the list of all Users and see
+	// if ours is present in it.
+	query := client.Query{
+		Command: "SHOW USERS",
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	var found = false
+	for _, result := range resp.Results[0].Series[0].Values {
+		if result[0] == name {
+			found = true
+			d.Set("admin", result[1].(bool))
+			break
+		}
+	}
+
+	if !found {
+		// If we fell out here then we didn't find our User in the list.
+		d.SetId("")
+
+		return nil
+	}
+
+	return readGrants(d, meta)
+}
+
+func readGrants(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+	name := d.Id()
+
+	query := client.Query{
+		Command: fmt.Sprintf("SHOW GRANTS FOR %s", name),
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	var grants = []map[string]string{}
+	for _, result := range resp.Results[0].Series[0].Values {
+		if result[1].(string) != "NO PRIVILEGES" {
+			var grant = map[string]string{
+				"database":  result[0].(string),
+				"privilege": strings.ToLower(result[1].(string)),
+			}
+			grants = append(grants, grant)
+		}
+	}
+	d.Set("grant", grants)
+	return nil
+}
+
+func updateUser(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+	name := d.Id()
+
+	if d.HasChange("grant") {
+		oldGrantV, newGrantV := d.GetChange("grant")
+		oldGrant := oldGrantV.([]interface{})
+		newGrant := newGrantV.([]interface{})
+
+		for _, oGV := range oldGrant {
+			oldGrant := oGV.(map[string]interface{})
+
+			exists := false
+			privilege := oldGrant["privilege"].(string)
+			for _, nGV := range newGrant {
+				newGrant := nGV.(map[string]interface{})
+
+				if newGrant["database"].(string) == oldGrant["database"].(string) {
+					exists = true
+					privilege = newGrant["privilege"].(string)
+				}
+			}
+
+			if !exists {
+				revokePrivilegeOn(conn, oldGrant["privilege"].(string), oldGrant["database"].(string), name)
+			} else {
+				if privilege != oldGrant["privilege"].(string) {
+					grantPrivilegeOn(conn, privilege, oldGrant["database"].(string), name)
+				}
+			}
+		}
+
+		for _, nGV := range newGrant {
+			newGrant := nGV.(map[string]interface{})
+
+			exists := false
+			for _, oGV := range oldGrant {
+				oldGrant := oGV.(map[string]interface{})
+
+				exists = exists || (newGrant["database"].(string) == oldGrant["database"].(string) && newGrant["privilege"].(string) == oldGrant["privilege"].(string))
+			}
+
+			if !exists {
+				grantPrivilegeOn(conn, newGrant["privilege"].(string), newGrant["database"].(string), name)
+			}
+		}
+	}
+
+	return readUser(d, meta)
+}
+
+func deleteUser(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*client.Client)
+	name := d.Id()
+
+	queryStr := fmt.Sprintf("DROP USER %s", name)
+	query := client.Query{
+		Command: queryStr,
+	}
+
+	resp, err := conn.Query(query)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/builtin/providers/influxdb/resource_user_test.go
+++ b/builtin/providers/influxdb/resource_user_test.go
@@ -1,0 +1,294 @@
+package influxdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/influxdata/influxdb/client"
+)
+
+func TestAccInfluxDBUser_admin(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccUserConfig_admin,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists("influxdb_user.test"),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.test", "name", "terraform_test",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.test", "password", "terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.test", "admin", "true",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccInfluxDBUser_grant(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccUserConfig_grant,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists("influxdb_user.read-only"),
+					testAccCheckUserGrants("influxdb_user.read-only", "terraform-green", "READ"),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "name", "terraform_test",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "password", "terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "admin", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "grant.#", "1",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccUserConfig_grantUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGrants("influxdb_user.read-only", "terraform-green", "WRITE"),
+					testAccCheckUserGrants("influxdb_user.read-only", "terraform-blue", "READ"),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "name", "terraform_test",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "password", "terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "admin", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "grant.#", "2",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccInfluxDBUser_revoke(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccUserConfig_grant,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists("influxdb_user.read-only"),
+					testAccCheckUserGrants("influxdb_user.read-only", "terraform-green", "READ"),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "name", "terraform_test",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "password", "terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "admin", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "grant.#", "1",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccUserConfig_revoke,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGrantsEmpty("influxdb_user.read-only"),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "name", "terraform_test",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "password", "terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "admin", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_user.read-only", "grant.#", "0",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckUserExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No user id set")
+		}
+
+		conn := testAccProvider.Meta().(*client.Client)
+
+		query := client.Query{
+			Command: "SHOW USERS",
+		}
+
+		resp, err := conn.Query(query)
+		if err != nil {
+			return err
+		}
+
+		if resp.Err != nil {
+			return resp.Err
+		}
+
+		for _, result := range resp.Results[0].Series[0].Values {
+			if result[0] == rs.Primary.Attributes["name"] {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("User %q does not exist", rs.Primary.Attributes["name"])
+	}
+}
+
+func testAccCheckUserGrantsEmpty(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No user id set")
+		}
+
+		conn := testAccProvider.Meta().(*client.Client)
+
+		query := client.Query{
+			Command: fmt.Sprintf("SHOW GRANTS FOR %s", rs.Primary.Attributes["name"]),
+		}
+
+		resp, err := conn.Query(query)
+		if err != nil {
+			return err
+		}
+
+		if resp.Err != nil {
+			return resp.Err
+		}
+
+		for _, result := range resp.Results[0].Series[0].Values {
+			if result[1].(string) != "NO PRIVILEGES" {
+				return fmt.Errorf("User %q still has grants: %#v", rs.Primary.ID, resp.Results[0].Series[0].Values)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckUserGrants(n, database, privilege string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No user id set")
+		}
+
+		conn := testAccProvider.Meta().(*client.Client)
+
+		query := client.Query{
+			Command: fmt.Sprintf("SHOW GRANTS FOR %s", rs.Primary.Attributes["name"]),
+		}
+
+		resp, err := conn.Query(query)
+		if err != nil {
+			return err
+		}
+
+		if resp.Err != nil {
+			return resp.Err
+		}
+
+		for _, result := range resp.Results[0].Series[0].Values {
+			if result[0].(string) == database && result[1].(string) == privilege {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Privilege %q on %q for %q does not exist", privilege, database, rs.Primary.Attributes["name"])
+	}
+}
+
+var testAccUserConfig_admin = `
+
+resource "influxdb_user" "test" {
+    name = "terraform_test"
+    password = "terraform"
+    admin = true
+}
+
+`
+
+var testAccUserConfig_grant = `
+resource "influxdb_database" "green" {
+    name = "terraform-green"
+}
+
+resource "influxdb_user" "read-only" {
+    name = "terraform_test"
+    password = "terraform"
+
+    grant {
+      database = "${influxdb_database.green.name}"
+      privilege = "read"
+    }
+}
+`
+
+var testAccUserConfig_revoke = `
+resource "influxdb_database" "green" {
+    name = "terraform-green"
+}
+
+resource "influxdb_user" "read-only" {
+    name = "terraform_test"
+    password = "terraform"
+}
+`
+
+var testAccUserConfig_grantUpdate = `
+resource "influxdb_database" "green" {
+    name = "terraform-green"
+}
+
+resource "influxdb_database" "blue" {
+    name = "terraform-blue"
+}
+
+resource "influxdb_user" "read-only" {
+    name = "terraform_test"
+    password = "terraform"
+
+    grant {
+      database = "${influxdb_database.green.name}"
+      privilege = "write"
+    }
+
+    grant {
+      database = "${influxdb_database.blue.name}"
+      privilege = "read"
+    }
+}
+`

--- a/website/source/docs/providers/influxdb/index.html.markdown
+++ b/website/source/docs/providers/influxdb/index.html.markdown
@@ -37,4 +37,9 @@ provider "influxdb" {
 resource "influxdb_database" "metrics" {
     name = "awesome_app"
 }
+
+resource "influxdb_user" "paul" {
+    name = "paul"
+    password = "super-secret"
+}
 ```

--- a/website/source/docs/providers/influxdb/index.html.markdown
+++ b/website/source/docs/providers/influxdb/index.html.markdown
@@ -38,6 +38,12 @@ resource "influxdb_database" "metrics" {
     name = "awesome_app"
 }
 
+resource "influxdb_continuous_query" "minnie" {
+    name = "minnie"
+    database = "${influxdb_database.metrics.name}"
+    query = "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)"
+}
+
 resource "influxdb_user" "paul" {
     name = "paul"
     password = "super-secret"

--- a/website/source/docs/providers/influxdb/r/continuous_query.html.md
+++ b/website/source/docs/providers/influxdb/r/continuous_query.html.md
@@ -1,0 +1,38 @@
+---
+layout: "influxdb"
+page_title: "InfluxDB: influxdb_continuous_query"
+sidebar_current: "docs-influxdb-resource-continuous_query"
+description: |-
+  The influxdb_continuous_query resource allows an InfluxDB continuous query to be managed.
+---
+
+# influxdb\_continuous\_query
+
+The continuous_query resource allows a continuous query to be created on an InfluxDB server.
+
+## Example Usage
+
+```
+resource "influxdb_database" "test" {
+    name = "terraform-test"
+}
+
+resource "influxdb_continuous_query" "minnie" {
+    name = "minnie"
+    database = "${influxdb_database.test.name}"
+    query = "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name for the continuous_query. This must be unique on the InfluxDB server.
+* `database` - (Required) The database for the continuous_query. This must be an existing influxdb database.
+* `query` - (Required) The query for the continuous_query. 
+
+## Attributes Reference
+
+This resource exports no further attributes.

--- a/website/source/docs/providers/influxdb/r/user.html.md
+++ b/website/source/docs/providers/influxdb/r/user.html.md
@@ -1,0 +1,47 @@
+---
+layout: "influxdb"
+page_title: "InfluxDB: influxdb_user"
+sidebar_current: "docs-influxdb-resource-user"
+description: |-
+  The influxdb_user resource allows an InfluxDB users to be managed.
+---
+
+# influxdb\_user
+
+The user resource allows a user to be created on an InfluxDB server.
+
+## Example Usage
+
+```
+resource "influxdb_database" "green" {
+    name = "terraform-green"
+}
+
+resource "influxdb_user" "paul" {
+    name = "paul"
+    password = "super-secret"
+
+    grant {
+      database = "${influxdb_database.green.name}"
+      privilege = "write"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name for the user. 
+* `password` - (Required) The password for the user. 
+* `admin` - (Optional) Mark the user as admin.
+* `grant` - (Optional) A list of grants for non-admin users
+
+Each `grant` supports the following:
+
+* `database` - (Required) The name of the database the privilege is associated with
+* `privilege` - (Required) The privilege to grant (READ|WRITE|ALL)
+
+## Attributes Reference
+
+* `admin` - (Bool) indication if the user is an admin or not.

--- a/website/source/layouts/influxdb.erb
+++ b/website/source/layouts/influxdb.erb
@@ -17,7 +17,10 @@
               <a href="/docs/providers/influxdb/r/database.html">influxdb_database</a>
             </li>
             <li<%= sidebar_current("docs-influxdb-resource-user") %>>
-							<a href="/docs/providers/influxdb/r/user.html">influxdb_user</a>
+              <a href="/docs/providers/influxdb/r/user.html">influxdb_user</a>
+            </li>
+            <li<%= sidebar_current("docs-influxdb-resource-continuous_query") %>>
+							<a href="/docs/providers/influxdb/r/continuous_query.html">influxdb_continuous_query</a>
 						</li>
 					</ul>
 				</li>

--- a/website/source/layouts/influxdb.erb
+++ b/website/source/layouts/influxdb.erb
@@ -14,7 +14,10 @@
 					<a href="#">Resources</a>
 					<ul class="nav nav-visible">
 						<li<%= sidebar_current("docs-influxdb-resource-database") %>>
-							<a href="/docs/providers/influxdb/r/database.html">influxdb_database</a>
+              <a href="/docs/providers/influxdb/r/database.html">influxdb_database</a>
+            </li>
+            <li<%= sidebar_current("docs-influxdb-resource-user") %>>
+							<a href="/docs/providers/influxdb/r/user.html">influxdb_user</a>
 						</li>
 					</ul>
 				</li>


### PR DESCRIPTION
- reduce public funcs. We should not make things public that don't need to be public
- improve tests by verifying remote state
- add `influxdb_user` resource

    allows you to manage influxdb users:

    ```
    resource "influxdb_user" "admin" {
      name = "administrator"
      password = "super-secret"
      admin = true
    }
    ```

    and also database specific grants:

    ```
    resource "influxdb_user" "ro" {
      name = "read-only"
      password = "read-only"

      grant {
        database = "a"
        privilege = "read"
      }
    }
    ```

- add `influxdb_continuous_query` resource

    allows you to manage influxdb continuous queries:

    ```
    resource "influxdb_continuous_query" "minnie" {
        name = "minnie"
        database = "metrics"
        query = "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)"
    }

    ```


this PR includes tests & documentation changes.

looking forward to your feedback!