### PR TITLE
provider/aws: Support Import `aws_elasticache_parameter_group` resource

### DIFF
--- a/builtin/providers/aws/import_aws_elasticache_parameter_group_test.go
+++ b/builtin/providers/aws/import_aws_elasticache_parameter_group_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSElasticacheParameterGroup_importBasic(t *testing.T) {
+	resourceName := "aws_elasticache_parameter_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheParameterGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				//ImportStateVerifyIgnore: []string{
+				//	"description"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/import_aws_elasticache_parameter_group_test.go
+++ b/builtin/providers/aws/import_aws_elasticache_parameter_group_test.go
@@ -22,8 +22,6 @@ func TestAccAWSElasticacheParameterGroup_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				//ImportStateVerifyIgnore: []string{
-				//	"description"},
 			},
 		},
 	})

--- a/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_parameter_group.go
@@ -21,6 +21,9 @@ func resourceAwsElasticacheParameterGroup() *schema.Resource {
 		Read:   resourceAwsElasticacheParameterGroupRead,
 		Update: resourceAwsElasticacheParameterGroupUpdate,
 		Delete: resourceAwsElasticacheParameterGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSElasticacheParameterGroup_'
==> Checking that code complies with gofmt requirements...
2016/06/26 19:46:35 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticacheParameterGroup_ -timeout 120m
=== RUN   TestAccAWSElasticacheParameterGroup_importBasic
--- PASS: TestAccAWSElasticacheParameterGroup_importBasic (22.42s)
=== RUN   TestAccAWSElasticacheParameterGroup_basic
--- PASS: TestAccAWSElasticacheParameterGroup_basic (39.08s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    61.520s
```