### PR TITLE
provider/aws: Support Import for `aws_db_parameter_group`

### DIFF
--- a/builtin/providers/aws/import_aws_db_parameter_group_group_test.go
+++ b/builtin/providers/aws/import_aws_db_parameter_group_group_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDBParameterGroup_importBasic(t *testing.T) {
+	resourceName := "aws_db_parameter_group.bar"
+	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBParameterGroupConfig(groupName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -23,6 +23,10 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 		Read:   resourceAwsDbParameterGroupRead,
 		Update: resourceAwsDbParameterGroupUpdate,
 		Delete: resourceAwsDbParameterGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSDBParameterGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBParameterGroup_ -timeout 120m
=== RUN   TestAccAWSDBParameterGroup_importBasic
--- PASS: TestAccAWSDBParameterGroup_importBasic (31.03s)
=== RUN   TestAccAWSDBParameterGroup_basic
--- PASS: TestAccAWSDBParameterGroup_basic (51.22s)
=== RUN   TestAccAWSDBParameterGroup_Only
--- PASS: TestAccAWSDBParameterGroup_Only (25.45s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    107.725s
```