### PR TITLE
provider/aws: Support Import for `aws_redshift_parameter_group`

### DIFF
--- a/builtin/providers/aws/import_aws_redshift_parameter_group_test.go
+++ b/builtin/providers/aws/import_aws_redshift_parameter_group_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSRedshiftParameterGroup_importBasic(t *testing.T) {
+	resourceName := "aws_redshift_parameter_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSRedshiftParameterGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_redshift_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_parameter_group.go
@@ -22,6 +22,9 @@ func resourceAwsRedshiftParameterGroup() *schema.Resource {
 		Read:   resourceAwsRedshiftParameterGroupRead,
 		Update: resourceAwsRedshiftParameterGroupUpdate,
 		Delete: resourceAwsRedshiftParameterGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSRedshiftParameterGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftParameterGroup_ -timeout 120m
=== RUN   TestAccAWSRedshiftParameterGroup_importBasic
--- PASS: TestAccAWSRedshiftParameterGroup_importBasic (25.97s)
=== RUN   TestAccAWSRedshiftParameterGroup_withParameters
--- PASS: TestAccAWSRedshiftParameterGroup_withParameters (21.26s)
=== RUN   TestAccAWSRedshiftParameterGroup_withoutParameters
--- PASS: TestAccAWSRedshiftParameterGroup_withoutParameters (20.79s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    68.045s
```