### PR TITLE
provider/aws: Set the correct AssumeRole for `aws_codedeploy_deployment_group` AcceptanceTest

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -678,7 +678,9 @@ resource "aws_iam_role" "foo_role" {
 			"Sid": "",
 			"Effect": "Allow",
 			"Principal": {
-				"Service": "codedeploy.amazonaws.com"
+				"Service": [
+				  "codedeploy.amazonaws.com"
+				]
 			},
 			"Action": "sts:AssumeRole"
 		}


### PR DESCRIPTION
@catsby 

One of the acceptance tests was broken for AssumeRole policy

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
--- FAIL: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (40.03s)
	testing.go:255: Step 1 error: Error applying: 1 error(s) occurred:

		* aws_codedeploy_deployment_group.foo_group: InvalidRoleException: Cannot assume role provided.


			status code: 400, request id: 783dbc0a-3be5-11e6-88d9-b3a2d3e45836
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/aws	40.050s
make: *** [testacc] Error 1
```

Now looks like:

```
terraform [master●] % make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (55.20s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	55.224s
```