### PR TITLE
provider/aws: Randomize the ELB name in an AWS route53 acceptance test

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -214,6 +215,8 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_alias(t *testing.T) {
+	rs := acctest.RandString(10)
+	config := fmt.Sprintf(testAccRoute53ElbAliasRecord, rs)
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.alias",
@@ -221,7 +224,7 @@ func TestAccAWSRoute53Record_alias(t *testing.T) {
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRoute53ElbAliasRecord,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53RecordExists("aws_route53_record.alias"),
 				),
@@ -758,7 +761,7 @@ resource "aws_route53_record" "alias" {
 }
 
 resource "aws_elb" "main" {
-  name = "foobar-terraform-elb"
+  name = "foobar-terraform-elb-%s"
   availability_zones = ["us-west-2a"]
 
   listener {


### PR DESCRIPTION
FYI @catsby

The acceptance test was throwing the error:

```
* aws_elb.main: DuplicateLoadBalancerName: Load Balancer named
* foobar-terraform-elb already exists and it is configured with
* different parameters.
```

So randomized the name and the test still passes as expected:

```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSRoute53Record_alias'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRoute53Record_alias -timeout 120m
=== RUN   TestAccAWSRoute53Record_alias
--- PASS: TestAccAWSRoute53Record_alias (97.70s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    97.722s
```