### PR TITLE
provider/digitalocean: Support Import `digitalocean_domain`

### DIFF
--- a/builtin/providers/digitalocean/import_digitalocean_domain_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_domain_test.go
@@ -1,0 +1,34 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDigitalOceanDomain_importBasic(t *testing.T) {
+	resourceName := "digitalocean_domain.foobar"
+	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDomainDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDomainConfig_basic, domainName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"ip_address"}, //we ignore the IP Address as we do not set to state
+			},
+		},
+	})
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_domain.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_domain.go
@@ -13,6 +13,9 @@ func resourceDigitalOceanDomain() *schema.Resource {
 		Create: resourceDigitalOceanDomainCreate,
 		Read:   resourceDigitalOceanDomainRead,
 		Delete: resourceDigitalOceanDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/digitalocean
TESTARGS='-run=TestAccDigitalOceanDomain_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=TestAccDigitalOceanDomain_ -timeout 120m
=== RUN   TestAccDigitalOceanDomain_importBasic
--- PASS: TestAccDigitalOceanDomain_importBasic (3.07s)
=== RUN   TestAccDigitalOceanDomain_Basic
--- PASS: TestAccDigitalOceanDomain_Basic (1.99s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/digitalocean
5.072s
```