### PR TITLE
provider/digitalocean: Support Import `digitalocean_floating_ip`

### DIFF
--- a/builtin/providers/digitalocean/import_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_floating_ip_test.go
@@ -1,0 +1,49 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDigitalOceanFloatingIP_importBasicRegion(t *testing.T) {
+	resourceName := "digitalocean_floating_ip.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanFloatingIPConfig_region,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanFloatingIP_importBasicDroplet(t *testing.T) {
+	resourceName := "digitalocean_floating_ip.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
@@ -16,6 +16,9 @@ func resourceDigitalOceanFloatingIp() *schema.Resource {
 		Update: resourceDigitalOceanFloatingIpUpdate,
 		Read:   resourceDigitalOceanFloatingIpRead,
 		Delete: resourceDigitalOceanFloatingIpDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address": &schema.Schema{
@@ -122,6 +125,7 @@ func resourceDigitalOceanFloatingIpRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[INFO] A droplet was detected on the FloatingIP so setting the Region based on the Droplet")
 		log.Printf("[INFO] The region of the Droplet is %s", floatingIp.Droplet.Region.Slug)
 		d.Set("region", floatingIp.Droplet.Region.Slug)
+		d.Set("droplet_id", floatingIp.Droplet.ID)
 	} else {
 		d.Set("region", floatingIp.Region.Slug)
 	}


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/digitalocean
TESTARGS='-run=TestAccDigitalOceanFloatingIP_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=TestAccDigitalOceanFloatingIP_ -timeout 120m
=== RUN   TestAccDigitalOceanFloatingIP_importBasicRegion
--- PASS: TestAccDigitalOceanFloatingIP_importBasicRegion (3.76s)
=== RUN   TestAccDigitalOceanFloatingIP_importBasicDroplet
--- PASS: TestAccDigitalOceanFloatingIP_importBasicDroplet (72.41s)
=== RUN   TestAccDigitalOceanFloatingIP_Region
--- PASS: TestAccDigitalOceanFloatingIP_Region (3.46s)
=== RUN   TestAccDigitalOceanFloatingIP_Droplet
--- PASS: TestAccDigitalOceanFloatingIP_Droplet (74.49s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/digitalocean
154.128s
```