### PR TITLE
provider/digitalocean: Support Import `digitalocean_droplet`

### DIFF
--- a/builtin/providers/digitalocean/import_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_droplet_test.go
@@ -1,0 +1,30 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
+	resourceName := "digitalocean_droplet.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanDropletConfig_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"ssh_keys", "user_data"}, //we ignore the ssh_keys and user_data as we do not set to state
+			},
+		},
+	})
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -18,6 +18,9 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 		Read:   resourceDigitalOceanDropletRead,
 		Update: resourceDigitalOceanDropletUpdate,
 		Delete: resourceDigitalOceanDropletDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"image": &schema.Schema{


### PR DESCRIPTION
```
ake testacc TEST=./builtin/providers/digitalocean
TESTARGS='-run=TestAccDigitalOceanDroplet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=TestAccDigitalOceanDroplet_ -timeout 120m
=== RUN   TestAccDigitalOceanDroplet_importBasic
--- PASS: TestAccDigitalOceanDroplet_importBasic (39.42s)
=== RUN   TestAccDigitalOceanDroplet_Basic
--- PASS: TestAccDigitalOceanDroplet_Basic (38.46s)
=== RUN   TestAccDigitalOceanDroplet_Update
--- PASS: TestAccDigitalOceanDroplet_Update (244.82s)
=== RUN   TestAccDigitalOceanDroplet_UpdateUserData
--- PASS: TestAccDigitalOceanDroplet_UpdateUserData (73.05s)
=== RUN   TestAccDigitalOceanDroplet_PrivateNetworkingIpv6
--- PASS: TestAccDigitalOceanDroplet_PrivateNetworkingIpv6 (67.24s)
PASS
```