### PR TITLE
provider/digitalocean: Support Import `digitalocean_ssh_key`

### DIFF
--- a/builtin/providers/digitalocean/import_digitalocean_ssh_key_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_ssh_key_test.go
@@ -1,0 +1,28 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDigitalOceanSSHKey_importBasic(t *testing.T) {
+	resourceName := "digitalocean_ssh_key.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanSSHKeyConfig_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
@@ -15,6 +15,9 @@ func resourceDigitalOceanSSHKey() *schema.Resource {
 		Read:   resourceDigitalOceanSSHKeyRead,
 		Update: resourceDigitalOceanSSHKeyUpdate,
 		Delete: resourceDigitalOceanSSHKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
@@ -84,6 +87,7 @@ func resourceDigitalOceanSSHKeyRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("name", key.Name)
 	d.Set("fingerprint", key.Fingerprint)
+	d.Set("public_key", key.PublicKey)
 
 	return nil
 }


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/digitalocean
TESTARGS='-run=TestAccDigitalOceanSSHKey_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=TestAccDigitalOceanSSHKey_ -timeout 120m
=== RUN   TestAccDigitalOceanSSHKey_importBasic
--- PASS: TestAccDigitalOceanSSHKey_importBasic (2.13s)
=== RUN   TestAccDigitalOceanSSHKey_Basic
--- PASS: TestAccDigitalOceanSSHKey_Basic (1.52s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/digitalocean
3.665s
```