### PR TITLE
provider/aws: Support Import `aws_dynamodb_table`

### DIFF
--- a/builtin/providers/aws/import_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/import_aws_dynamodb_table_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDynamoDbTable_importBasic(t *testing.T) {
+	resourceName := "aws_dynamodb_table.basic-dynamodb-table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDynamoDbConfigInitialState(),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
There were some changes required to the Read func to get this working.
The initial set of tests showed the following:

```
testing.go:255: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=8) {
         (string) (len=8) "hash_key": (string) (len=16) "TestTableHashKey",
         (string) (len=23) "local_secondary_index.#": (string) (len=1) "1",
         (string) (len=36) "local_secondary_index.884610231.name": (string) (len=12) "TestTableLSI",
         (string) (len=52) "local_secondary_index.884610231.non_key_attributes.#": (string) (len=1) "0",
         (string) (len=47) "local_secondary_index.884610231.projection_type": (string) (len=3) "ALL",
         (string) (len=41) "local_secondary_index.884610231.range_key": (string) (len=15) "TestLSIRangeKey",
         (string) (len=4) "name": (string) (len=38) "TerraformTestTable-2710929679033484576",
         (string) (len=9) "range_key": (string) (len=17) "TestTableRangeKey"
        }
```

On investigation, this was telling me that `hash_key`, `range_key`, `name` and `local_secondary_index` were not being set on the Read func

When they were being set, all looks as expected:

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDynamoDbTable_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDynamoDbTable_ -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (20.39s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (39.99s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (50.44s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	110.841s
```