### PR TITLE
provider/aws: Support Import `aws_vpn_connection`

### DIFF
--- a/builtin/providers/aws/import_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/import_aws_vpn_connection_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVpnConnection_importBasic(t *testing.T) {
+	resourceName := "aws_vpn_connection.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsVpnConnectionConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -51,6 +51,9 @@ func resourceAwsVpnConnection() *schema.Resource {
 		Read:   resourceAwsVpnConnectionRead,
 		Update: resourceAwsVpnConnectionUpdate,
 		Delete: resourceAwsVpnConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"vpn_gateway_id": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpnConnection_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnConnection_ -timeout 120m
=== RUN   TestAccAWSVpnConnection_importBasic
--- PASS: TestAccAWSVpnConnection_importBasic (201.02s)
=== RUN   TestAccAWSVpnConnection_basic
--- PASS: TestAccAWSVpnConnection_basic (336.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	537.426s
```