### PR TITLE
provider/aws: Support Import `aws_vpc_peering_connection`

### DIFF
--- a/builtin/providers/aws/import_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/import_aws_vpc_peering_connection_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVPCPeeringConnection_importBasic(t *testing.T) {
+	resourceName := "aws_vpc_peering_connection.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcPeeringConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"auto_accept"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -18,6 +18,9 @@ func resourceAwsVpcPeeringConnection() *schema.Resource {
 		Read:   resourceAwsVPCPeeringRead,
 		Update: resourceAwsVPCPeeringUpdate,
 		Delete: resourceAwsVPCPeeringDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"peer_owner_id": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVPCPeeringConnection_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVPCPeeringConnection_ -timeout 120m
=== RUN   TestAccAWSVPCPeeringConnection_importBasic
--- PASS: TestAccAWSVPCPeeringConnection_importBasic (42.58s)
=== RUN   TestAccAWSVPCPeeringConnection_basic
--- PASS: TestAccAWSVPCPeeringConnection_basic (45.00s)
=== RUN   TestAccAWSVPCPeeringConnection_plan
--- PASS: TestAccAWSVPCPeeringConnection_plan (40.92s)
=== RUN   TestAccAWSVPCPeeringConnection_tags
--- SKIP: TestAccAWSVPCPeeringConnection_tags (0.00s)
	resource_aws_vpc_peering_connection_test.go:85: Error: TestAccAWSVPCPeeringConnection_tags requires a peer id to be set
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	128.517s
```