### PR TITLE
aws/docs: Make item ordering in sidebar alphabetical

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -712,12 +712,12 @@
                             <a href="/docs/providers/aws/r/ses_active_receipt_rule_set.html">aws_ses_active_receipt_rule_set</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-aws-resource-ses-receipt-rule") %>>
-                            <a href="/docs/providers/aws/r/ses_receipt_rule.html">aws_ses_receipt_rule</a>
-                        </li>
-
                         <li<%= sidebar_current("docs-aws-resource-ses-receipt-filter") %>>
                             <a href="/docs/providers/aws/r/ses_receipt_filter.html">aws_ses_receipt_filter</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-ses-receipt-rule") %>>
+                            <a href="/docs/providers/aws/r/ses_receipt_rule.html">aws_ses_receipt_rule</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-ses-receipt-rule-set") %>>


### PR DESCRIPTION
`F` goes before `R`. 😉 