### PR TITLE
provider/aws: Support Import `aws_sns_topic_subscription`

### DIFF
--- a/builtin/providers/aws/import_aws_sns_topic_subscription_test.go
+++ b/builtin/providers/aws/import_aws_sns_topic_subscription_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSNSTopicSubscription_importBasic(t *testing.T) {
+	resourceName := "aws_sns_topic.test_topic"
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSNSTopicSubscriptionConfig(ri),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -24,6 +24,9 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 		Read:   resourceAwsSnsTopicSubscriptionRead,
 		Update: resourceAwsSnsTopicSubscriptionUpdate,
 		Delete: resourceAwsSnsTopicSubscriptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"protocol": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
@@ -7,18 +7,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSSNSTopicSubscription_basic(t *testing.T) {
+	ri := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSSNSTopicSubscriptionConfig,
+				Config: testAccAWSSNSTopicSubscriptionConfig(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),
 					testAccCheckAWSSNSTopicSubscriptionExists("aws_sns_topic_subscription.test_subscription"),
@@ -83,13 +86,14 @@ func testAccCheckAWSSNSTopicSubscriptionExists(n string) resource.TestCheckFunc 
 	}
 }
 
-const testAccAWSSNSTopicSubscriptionConfig = `
+func testAccAWSSNSTopicSubscriptionConfig(i int) string {
+	return fmt.Sprintf(`
 resource "aws_sns_topic" "test_topic" {
     name = "terraform-test-topic"
 }
 
 resource "aws_sqs_queue" "test_queue" {
-	name = "terraform-subscription-test-queue"
+	name = "terraform-subscription-test-queue-%d"
 }
 
 resource "aws_sns_topic_subscription" "test_subscription" {
@@ -97,4 +101,5 @@ resource "aws_sns_topic_subscription" "test_subscription" {
     protocol = "sqs"
     endpoint = "${aws_sqs_queue.test_queue.arn}"
 }
-`
+`, i)
+}


### PR DESCRIPTION
Had to change the way that the tests were working to include a random sqs-queue name due to this error:

```

`aws_sqs_queue.test_queue: Error creating SQS queue: AWS.SimpleQueueService.QueueDeletedRecently: You must wait 60 seconds after deleting a queue before you can create another with the same name.
			status code: 400, request id: b58e800a-ae27-556e-b6de-cfe1bbf9dc09``

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSNSTopicSubscription_ -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_importBasic
--- PASS: TestAccAWSSNSTopicSubscription_importBasic (24.44s)
=== RUN   TestAccAWSSNSTopicSubscription_basic
--- PASS: TestAccAWSSNSTopicSubscription_basic (25.26s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	49.722s
```