### PR TITLE
provider/aws: Support Import `aws_rds_cluster_parameter_group`

### DIFF
--- a/builtin/providers/aws/import_aws_rds_cluster_parameter_group_test.go
+++ b/builtin/providers/aws/import_aws_rds_cluster_parameter_group_test.go
@@ -22,8 +22,6 @@ func TestAccAWSDBClusterParameterGroup_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				//ImportStateVerifyIgnore: []string{
-				//	"description"},
 			},
 		},
 	})

--- a/builtin/providers/aws/import_aws_rds_cluster_parameter_group_test.go
+++ b/builtin/providers/aws/import_aws_rds_cluster_parameter_group_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDBClusterParameterGroup_importBasic(t *testing.T) {
+	resourceName := "aws_rds_cluster_parameter_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBClusterParameterGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				//ImportStateVerifyIgnore: []string{
+				//	"description"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
@@ -21,6 +21,10 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 		Read:   resourceAwsRDSClusterParameterGroupRead,
 		Update: resourceAwsRDSClusterParameterGroupUpdate,
 		Delete: resourceAwsRDSClusterParameterGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBClusterParameterGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBClusterParameterGroup_ -timeout 120m
=== RUN   TestAccAWSDBClusterParameterGroup_importBasic
--- PASS: TestAccAWSDBClusterParameterGroup_importBasic (29.60s)
=== RUN   TestAccAWSDBClusterParameterGroup_basic
--- PASS: TestAccAWSDBClusterParameterGroup_basic (47.27s)
=== RUN   TestAccAWSDBClusterParameterGroup_disappears
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (21.58s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	98.483s
```