### PR TITLE
provider/aws: Support Import `aws_api_gateway_account`

### DIFF
--- a/builtin/providers/aws/import_aws_api_gateway_account_test.go
+++ b/builtin/providers/aws/import_aws_api_gateway_account_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSAPIGatewayAccount_importBasic(t *testing.T) {
+	resourceName := "aws_api_gateway_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayAccountDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayAccountConfig_empty,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_api_gateway_account.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_account.go
@@ -18,6 +18,9 @@ func resourceAwsApiGatewayAccount() *schema.Resource {
 		Read:   resourceAwsApiGatewayAccountRead,
 		Update: resourceAwsApiGatewayAccountUpdate,
 		Delete: resourceAwsApiGatewayAccountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"cloudwatch_role_arn": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSAPIGatewayAccount_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAPIGatewayAccount_importBasic -timeout 120m
=== RUN   TestAccAWSAPIGatewayAccount_importBasic
--- PASS: TestAccAWSAPIGatewayAccount_importBasic (16.43s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    16.450s
```