### PR TITLE
provider/aws: Elastic Beanstalk scheduledaction

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -140,6 +140,24 @@ func TestAccAWSBeanstalkEnv_config(t *testing.T) {
 	})
 }
 
+func TestAccAWSBeanstalkEnv_resource(t *testing.T) {
+	var app elasticbeanstalk.EnvironmentDescription
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBeanstalkResourceOptionSetting,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBeanstalkEnvDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).elasticbeanstalkconn
 
@@ -411,6 +429,39 @@ resource "aws_elastic_beanstalk_configuration_template" "tftest" {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "TEMPLATE"
     value     = "2"
+  }
+}
+`
+const testAccBeanstalkResourceOptionSetting = `
+resource "aws_elastic_beanstalk_application" "tftest" {
+  name = "tf-test-name"
+  description = "tf-test-desc"
+}
+
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name = "tf-test-name"
+  application = "${aws_elastic_beanstalk_application.tftest.name}"
+  solution_stack_name = "64bit Amazon Linux running Python"
+
+  setting {
+    namespace = "aws:autoscaling:scheduledaction"
+    resource = "ScheduledAction01"
+    name = "MinSize"
+    value = "2"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:scheduledaction"
+    resource = "ScheduledAction01"
+    name = "MaxSize"
+    value = "6"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:scheduledaction"
+    resource = "ScheduledAction01"
+    name = "Recurrence"
+    value = "0 8 * * *"
   }
 }
 `

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_configuration_template.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_configuration_template.html.markdown
@@ -47,10 +47,10 @@ off of. Example stacks can be found in the [Amazon API documentation][1]
 
 The `setting` field supports the following format:
 
-* `namespace` - (Optional) unique namespace identifying the option's 
-  associated AWS resource
-* `name` - (Optional) name of the configuration option
-* `value` - (Optional) value for the configuration option
+* `namespace` - unique namespace identifying the option's associated AWS resource
+* `name` - name of the configuration option
+* `value` - value for the configuration option
+* `resource` - (Optional) resource name for [scheduled action](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-autoscalingscheduledaction)
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -67,10 +67,10 @@ for supported options and examples.
 
 The `setting` and `all_settings` mappings support the following format:
 
-* `namespace` - (Optional) unique namespace identifying the option's
-  associated AWS resource
-* `name` - (Optional) name of the configuration option
-* `value` - (Optional) value for the configuration option
+* `namespace` - unique namespace identifying the option's associated AWS resource
+* `name` - name of the configuration option
+* `value` - value for the configuration option
+* `resource` - (Optional) resource name for [scheduled action](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-autoscalingscheduledaction)
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add support for scheduled actions in Elastic Beanstalk option settings
by adding optional `resource` attribute for option setting resource. #6476 

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkEnv_resource -timeout 120m
=== RUN   TestAccAWSBeanstalkEnv_resource
--- PASS: TestAccAWSBeanstalkEnv_resource (382.48s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    382.500s
```