### PR TITLE
provider/azurerm: Add MaxItems to `azurerm_virtual_machine` data_disk

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -161,6 +161,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 			"storage_data_disk": {
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {


### PR DESCRIPTION
Fixes #7321

When testing to see how many data_disks could be added to a machine, I
got the following response from the Azure RM API

```
{
	"error": {
		"code": "OperationNotAllowed",
		"target": "dataDisks",
		"message": "The maximum number of data disks allowed to be attached to a VM is 1."
	}
}
```

We should ensure the schema copes with this so as to avoid waiting on the creation to throw the error