### PR TITLE
provider/vsphere: virtual_machine -- Allow timeout when no IP will be allocated

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -918,7 +918,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 
 	// wait for interfaces to appear
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	func() {
 		defer cancel()
 		_, err = vm.WaitForNetIP(ctx, true)


### PR DESCRIPTION
### Abstract

I work in a context where the VMs will have no IP address until we give them one.
### Problem addressed

In that case the vSphere provider will wait forever for an IP address to show up.
### Solution

I give the API 10 seconds to give me IP addresses and I ignore it if none can be found. This allows for a more universal support.
### Points to be improved

Allow to configure the wait timeout in the provider config
Allow to be blocking until an IP address is allocated (current behaviour)
Test and find the best default timeout value.
### Unit tests

No changes needed in the current unit tests.
