### PR TITLE
provider/docker: Docker DNS Setting Enhancements

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/builtin/providers/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -221,7 +221,7 @@ func resourceAwsElasticTranscoderPipelineCreate(d *schema.ResourceData, meta int
 	d.SetId(*resp.Pipeline.Id)
 
 	for _, w := range resp.Warnings {
-		log.Printf("[WARN] Elastic Transcoder Pipeline %s: %s", w.Code, w.Message)
+		log.Printf("[WARN] Elastic Transcoder Pipeline %v: %v", *w.Code, *w.Message)
 	}
 
 	return resourceAwsElasticTranscoderPipelineRead(d, meta)
@@ -383,7 +383,7 @@ func resourceAwsElasticTranscoderPipelineUpdate(d *schema.ResourceData, meta int
 	}
 
 	for _, w := range output.Warnings {
-		log.Printf("[WARN] Elastic Transcoder Pipeline %s: %s", w.Code, w.Message)
+		log.Printf("[WARN] Elastic Transcoder Pipeline %v: %v", *w.Code, *w.Message)
 	}
 
 	return resourceAwsElasticTranscoderPipelineRead(d, meta)

--- a/builtin/providers/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -27,7 +27,7 @@ func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 					return nil
 				}
 
-				return fmt.Errorf("Preset Id %s should not exist", preset.Id)
+				return fmt.Errorf("Preset Id %v should not exist", *preset.Id)
 			}
 
 			rs, ok := s.RootModule().Resources[name]

--- a/builtin/providers/aws/resource_aws_elb_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_elb_attachment_test.go
@@ -75,7 +75,7 @@ func TestAccAWSELBAttachment_drift(t *testing.T) {
 			Instances:        conf.Instances,
 		}
 
-		log.Printf("[DEBUG] deregistering instance %s from ELB", conf.Instances[0].InstanceId)
+		log.Printf("[DEBUG] deregistering instance %v from ELB", *conf.Instances[0].InstanceId)
 
 		_, err := conn.DeregisterInstancesFromLoadBalancer(&deRegisterInstancesOpts)
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
+++ b/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
@@ -120,7 +120,7 @@ func testAccCheckAwsSESReceiptRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		if !*response.Rule.Enabled {
-			return fmt.Errorf("Enabled (%s) was not set to true", *response.Rule.Enabled)
+			return fmt.Errorf("Enabled (%v) was not set to true", *response.Rule.Enabled)
 		}
 
 		if !reflect.DeepEqual(response.Rule.Recipients, []*string{aws.String("test@example.com")}) {
@@ -128,7 +128,7 @@ func testAccCheckAwsSESReceiptRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		if !*response.Rule.ScanEnabled {
-			return fmt.Errorf("ScanEnabled (%s) was not set to true", *response.Rule.ScanEnabled)
+			return fmt.Errorf("ScanEnabled (%v) was not set to true", *response.Rule.ScanEnabled)
 		}
 
 		if *response.Rule.TlsPolicy != "Require" {
@@ -162,7 +162,7 @@ func testAccCheckAwsSESReceiptRuleOrder(n string) resource.TestCheckFunc {
 		}
 
 		if len(response.Rules) != 2 {
-			return fmt.Errorf("Number of rules (%s) was not equal to 2", len(response.Rules))
+			return fmt.Errorf("Number of rules (%d) was not equal to 2", len(response.Rules))
 		} else if *response.Rules[0].Name != "first" || *response.Rules[1].Name != "second" {
 			return fmt.Errorf("Order of rules (%v) was incorrect", response.Rules)
 		}

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -95,6 +95,22 @@ func resourceDockerContainer() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"dns_opts": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"dns_search": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"publish_all_ports": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -128,6 +128,14 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		hostConfig.DNS = stringSetToStringSlice(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("dns_opts"); ok {
+		hostConfig.DNSOptions = stringSetToStringSlice(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("dns_search"); ok {
+		hostConfig.DNSSearch = stringSetToStringSlice(v.(*schema.Set))
+	}
+
 	if v, ok := d.GetOk("links"); ok {
 		hostConfig.Links = stringSetToStringSlice(v.(*schema.Set))
 	}

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -102,6 +102,38 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
 		}
 
+		if len(c.HostConfig.DNS) == 1 {
+			return fmt.Errorf("Container does not have the correct number of dns entries: %d", len(c.HostConfig.DNS))
+		}
+
+		if c.HostConfig.DNS[0] != "8.8.8.8" {
+			return fmt.Errorf("Container has wrong dns setting: %v", c.HostConfig.DNS[0])
+		}
+
+		if len(c.HostConfig.DNSOptions) == 1 {
+			return fmt.Errorf("Container does not have the correct number of dns option entries: %d", len(c.HostConfig.DNS))
+		}
+
+		if c.HostConfig.DNSOptions[0] != "rotate" {
+			return fmt.Errorf("Container has wrong dns option setting: %v", c.HostConfig.DNS[0])
+		}
+
+		if len(c.HostConfig.DNSSearch) == 1 {
+			return fmt.Errorf("Container does not have the correct number of dns search entries: %d", len(c.HostConfig.DNS))
+		}
+
+		if c.HostConfig.DNSSearch[0] != "example.com" {
+			return fmt.Errorf("Container has wrong dns search setting: %v", c.HostConfig.DNS[0])
+		}
+
+		if c.HostConfig.CPUShares != 32 {
+			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
+		}
+
+		if c.HostConfig.CPUShares != 32 {
+			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
+		}
+
 		if c.Config.Labels["env"] != "prod" || c.Config.Labels["role"] != "test" {
 			return fmt.Errorf("Container does not have the correct labels")
 		}
@@ -227,6 +259,9 @@ resource "docker_container" "foo" {
 	memory = 512
 	memory_swap = 2048
 	cpu_shares = 32
+	dns = ["8.8.8.8"]
+	dns_opts = ["rotate"]
+	dns_search = ["example.com"]
 	labels {
 		env = "prod"
 		role = "test"

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -102,7 +102,7 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
 		}
 
-		if len(c.HostConfig.DNS) == 1 {
+		if len(c.HostConfig.DNS) != 1 {
 			return fmt.Errorf("Container does not have the correct number of dns entries: %d", len(c.HostConfig.DNS))
 		}
 
@@ -110,7 +110,7 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has wrong dns setting: %v", c.HostConfig.DNS[0])
 		}
 
-		if len(c.HostConfig.DNSOptions) == 1 {
+		if len(c.HostConfig.DNSOptions) != 1 {
 			return fmt.Errorf("Container does not have the correct number of dns option entries: %d", len(c.HostConfig.DNS))
 		}
 
@@ -118,7 +118,7 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has wrong dns option setting: %v", c.HostConfig.DNS[0])
 		}
 
-		if len(c.HostConfig.DNSSearch) == 1 {
+		if len(c.HostConfig.DNSSearch) != 1 {
 			return fmt.Errorf("Container does not have the correct number of dns search entries: %d", len(c.HostConfig.DNS))
 		}
 


### PR DESCRIPTION
Added support for docker dns settings: --dns-opt and --dns-search

Also fixed vet issues on aws provider builtin

Tests updated

You can now specify the following on your docker container resource

```
resource "docker_container" "website" {
	count = 1
	image = "${docker_image.website.name}"
	name = "website"
	dns = ["8.8.8.8"]

	#new fields	
	dns_opts = ["rotate", "user-vc"]
	dns_search = ["example.com."]

	ports {
		internal = 8080
		external = 8080
	}
}

resource "docker_image" "website" {
	name = "website:1.0.0"
}
```