### PR TITLE
core: Don't set Modules to nil during state upgrade

### DIFF
--- a/terraform/state_upgrade_v1_to_v2.go
+++ b/terraform/state_upgrade_v1_to_v2.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/copystructure"
 )
 
@@ -76,9 +77,6 @@ func (old *moduleStateV1) upgradeToV2() (*ModuleState, error) {
 			Sensitive: false,
 		}
 	}
-	if len(outputs) == 0 {
-		outputs = nil
-	}
 
 	resources := make(map[string]*ResourceState)
 	for key, oldResource := range old.Resources {
@@ -87,9 +85,6 @@ func (old *moduleStateV1) upgradeToV2() (*ModuleState, error) {
 			return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
 		}
 		resources[key] = upgraded
-	}
-	if len(resources) == 0 {
-		resources = nil
 	}
 
 	dependencies, err := copystructure.Copy(old.Dependencies)

--- a/terraform/upgrade_state_v1_test.go
+++ b/terraform/upgrade_state_v1_test.go
@@ -68,6 +68,54 @@ func TestReadUpgradeStateV1toV3_outputs(t *testing.T) {
 	}
 }
 
+// Upgrading the state should not lose empty module Outputs and Resources maps
+// during upgrade. The init for a new module initializes new maps, so we may not
+// be expecting to check for a nil map.
+func TestReadUpgradeStateV1toV3_emptyState(t *testing.T) {
+	// ReadState should transparently detect the old version but will upgrade
+	// it on Write.
+	orig, err := ReadStateV1([]byte(testV1EmptyState))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	stateV2, err := upgradeStateV1ToV2(orig)
+	for _, m := range stateV2.Modules {
+		if m.Resources == nil {
+			t.Fatal("V1 to V2 upgrade lost module.Resources")
+		}
+		if m.Outputs == nil {
+			t.Fatal("V1 to V2 upgrade lost module.Outputs")
+		}
+	}
+
+	stateV3, err := upgradeStateV2ToV3(stateV2)
+	for _, m := range stateV3.Modules {
+		if m.Resources == nil {
+			t.Fatal("V2 to V3 upgrade lost module.Resources")
+		}
+		if m.Outputs == nil {
+			t.Fatal("V2 to V3 upgrade lost module.Outputs")
+		}
+	}
+
+}
+
+const testV1EmptyState = `{
+    "version": 1,
+    "serial": 0,
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {}
+        }
+    ]
+}
+`
+
 const testV1State = `{
     "version": 1,
     "serial": 9,


### PR DESCRIPTION
The state Modules map is accessed and always expected to be non-nil. The
V1->V2 upgrade was setting the map to nil if the len == 0.

Fixes #7394 