### PR TITLE
provider/vsphere: Make `vsphere_virtual_machine` `product_key` optional

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -232,7 +232,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"product_key": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ForceNew: true,
 						},
 


### PR DESCRIPTION
Fixes #6690

Luckily, the code was already checking to see if the product_key was
specified