### PR TITLE
provider/digitalocean: Reassign Floating IP when droplet changes

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
@@ -122,6 +122,8 @@ func resourceDigitalOceanFloatingIpRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[INFO] A droplet was detected on the FloatingIP so setting the Region based on the Droplet")
 		log.Printf("[INFO] The region of the Droplet is %s", floatingIp.Droplet.Region.Slug)
 		d.Set("region", floatingIp.Droplet.Region.Slug)
+		d.Set("droplet_id", floatingIp.Droplet.ID)
+
 	} else {
 		d.Set("region", floatingIp.Region.Slug)
 	}


### PR DESCRIPTION
Fixes #6673

When a floating IP is changed in the DO console, this PR will allow it
to be reassociated to the machine that Terraform attached it to and
change it back

Initially:

2 instances 1 Floating IP created

Changing in the console

TF plan:

```
% terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

digitalocean_droplet.haproxy-primary: Refreshing state... (ID: 18390358)
digitalocean_droplet.haproxy-secondary: Refreshing state... (ID: 18390428)
digitalocean_floating_ip.primary: Refreshing state... (ID: 188.166.196.66)

No changes. Infrastructure is up-to-date. This means that Terraform
could not detect any differences between your configuration and
the real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```

Applying this code change:

```
digitalocean_droplet.haproxy-primary: Refreshing state... (ID: 18390358)
digitalocean_droplet.haproxy-secondary: Refreshing state... (ID: 18390428)
digitalocean_floating_ip.primary: Refreshing state... (ID: 188.166.196.66)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

~ digitalocean_floating_ip.primary
    droplet_id: "18390428" => "18390358"


Plan: 0 to add, 1 to change, 0 to destroy.
```
