### PR TITLE
provider/docker: Docker documentation and additional test message

### DIFF
--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -95,7 +95,7 @@ func TestAccDockerContainer_customized(t *testing.T) {
 		}
 
 		if c.HostConfig.MemorySwap != (2048 * 1024 * 1024) {
-			return fmt.Errorf("Container has wrong memory swap setting: %d", c.HostConfig.MemorySwap)
+			return fmt.Errorf("Container has wrong memory swap setting: %d\n\r\tPlease check that you machine supports memory swap (you can do that by running 'docker info' command).", c.HostConfig.MemorySwap)
 		}
 
 		if c.HostConfig.CPUShares != 32 {

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `volumes` - (Optional, block) See [Volumes](#volumes) below for details.
 * `memory` - (Optional, int) The memory limit for the container in MBs.
 * `memory_swap` - (Optional, int) The total memory limit (memory + swap) for the
-  container in MBs. This setting may compute to '-1' on after 'terraform apply' if the target host doesn't support memory swap when that is the case docker will use a soft limitation.
+  container in MBs. This setting may compute to '-1' after 'terraform apply' if the target host doesn't support memory swapm, when that is the case docker will use a soft limitation.
 * `cpu_shares` - (Optional, int) CPU shares (relative weight) for the container.
 * `log_driver` - (Optional, string) The logging driver to use for the container.
   Defaults to "json-file".

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `volumes` - (Optional, block) See [Volumes](#volumes) below for details.
 * `memory` - (Optional, int) The memory limit for the container in MBs.
 * `memory_swap` - (Optional, int) The total memory limit (memory + swap) for the
-  container in MBs. This setting may compute to '-1' after 'terraform apply' if the target host doesn't support memory swap, when that is the case docker will use a soft limitation.
+  container in MBs. This setting may compute to `-1` after `terraform apply` if the target host doesn't support memory swap, when that is the case docker will use a soft limitation.
 * `cpu_shares` - (Optional, int) CPU shares (relative weight) for the container.
 * `log_driver` - (Optional, string) The logging driver to use for the container.
   Defaults to "json-file".

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `volumes` - (Optional, block) See [Volumes](#volumes) below for details.
 * `memory` - (Optional, int) The memory limit for the container in MBs.
 * `memory_swap` - (Optional, int) The total memory limit (memory + swap) for the
-  container in MBs. This setting may compute to '-1' after 'terraform apply' if the target host doesn't support memory swapm, when that is the case docker will use a soft limitation.
+  container in MBs. This setting may compute to '-1' after 'terraform apply' if the target host doesn't support memory swap, when that is the case docker will use a soft limitation.
 * `cpu_shares` - (Optional, int) CPU shares (relative weight) for the container.
 * `log_driver` - (Optional, string) The logging driver to use for the container.
   Defaults to "json-file".

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
     `user` or `user:group` which user and group can be passed literraly or
     by name.
 * `dns` - (Optional, set of strings) Set of DNS servers.
+* `dns_opts` - (Optional, set of strings) Set of DNS options used by the DNS provider(s), see `resolv.conf` documentation for valid list of options.
+* `dns_search` - (Optional, set of strings) Set of DNS search domains that are used when bare unqualified hostnames are used inside of the container.
 * `env` - (Optional, set of strings) Environmental variables to set.
 * `labels` - (Optional, map of strings) Key/value pairs to set as labels on the
   container.
@@ -68,7 +70,7 @@ The following arguments are supported:
 * `volumes` - (Optional, block) See [Volumes](#volumes) below for details.
 * `memory` - (Optional, int) The memory limit for the container in MBs.
 * `memory_swap` - (Optional, int) The total memory limit (memory + swap) for the
-  container in MBs.
+  container in MBs. This setting may compute to '-1' on after 'terraform apply' if the target host doesn't support memory swap when that is the case docker will use a soft limitation.
 * `cpu_shares` - (Optional, int) CPU shares (relative weight) for the container.
 * `log_driver` - (Optional, string) The logging driver to use for the container.
   Defaults to "json-file".


### PR DESCRIPTION
As discussed on: https://github.com/hashicorp/terraform/pull/7392

Added

- additional information in case of docker test fail on `memory_swap` assert.
- updated website documentation to reflect new additions on https://github.com/hashicorp/terraform/pull/7392
  - added `dns_opts`, `dns_search` information.
  - modified `memory_swap` to highlight that if 'terraform apply` is run on a system that doesn't support memory swap the property will always compute to -1 as it is returned like this by docker rest api.