### PR TITLE
Update go-dynect to prevent log prefix clobbering

### DIFF
--- a/vendor/github.com/nesv/go-dynect/dynect/client.go
+++ b/vendor/github.com/nesv/go-dynect/dynect/client.go
@@ -14,11 +14,6 @@ const (
 	DynAPIPrefix = "https://api.dynect.net/REST"
 )
 
-func init() {
-	// Set the logging prefix.
-	log.SetPrefix("go-dynect ")
-}
-
 // A client for use with DynECT's REST API.
 type Client struct {
 	Token        string

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1087,9 +1087,11 @@
 			"revision": "eecf4c70c626c7cfbb95c90195bc34d386c74ac6"
 		},
 		{
+			"checksumSHA1": "/iig5lYSPCL3C8J7e4nTAevYNDE=",
 			"comment": "v0.2.0-8-g841842b",
 			"path": "github.com/nesv/go-dynect/dynect",
-			"revision": "841842b16b39cf2b5007278956976d7d909bd98b"
+			"revision": "2dc6a86cf75ce4b33516d2a13c9c0c378310cf3b",
+			"revisionTime": "2016-04-25T23:31:34Z"
 		},
 		{
 			"path": "github.com/nu7hatch/gouuid",


### PR DESCRIPTION
We got https://github.com/nesv/go-dynect/pull/7 merged but never updated
our vendored copy of the library.

So let's do that! :)