### PR TITLE
provider/openstack: Deprecate openstack_lb_pool_v1 member attribute

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1.go
@@ -64,8 +64,9 @@ func resourceLBPoolV1() *schema.Resource {
 				Computed: true,
 			},
 			"member": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:       schema.TypeSet,
+				Deprecated: "Use openstack_lb_member_v1 instead. This attribute will be removed in a future version.",
+				Optional:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"region": &schema.Schema{


### PR DESCRIPTION
This commit marks the "member" attribute of the
openstack_lb_pool_v1 resource as being deprecated. Users should begin
migrating to the openstack_lb_member_v1 resource.