### PR TITLE
provider/vsphere: virtual_machine support for more features

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -76,7 +76,7 @@ type memoryAllocation struct {
 	reservation int64
 }
 
-type virtualMachine struct{
+type virtualMachine struct {
 	name                  string
 	folder                string
 	datacenter            string
@@ -87,7 +87,7 @@ type virtualMachine struct{
 	memoryMb              int64
 	memoryAllocation      memoryAllocation
 	template              string
-	guestID		      types.VirtualMachineGuestOsIdentifier
+	guestID               types.VirtualMachineGuestOsIdentifier
 	networkInterfaces     []networkInterface
 	hardDisks             []hardDisk
 	cdroms                []cdrom

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -76,7 +76,7 @@ type memoryAllocation struct {
 	reservation int64
 }
 
-type virtualMachine struct {
+type virtualMachine struct{
 	name                  string
 	folder                string
 	datacenter            string
@@ -87,6 +87,7 @@ type virtualMachine struct {
 	memoryMb              int64
 	memoryAllocation      memoryAllocation
 	template              string
+	guestID		      types.VirtualMachineGuestOsIdentifier
 	networkInterfaces     []networkInterface
 	hardDisks             []hardDisk
 	cdroms                []cdrom
@@ -236,6 +237,12 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"guest_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 
 			"windows_opt_config": &schema.Schema{
@@ -677,6 +684,10 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		vm.timeZone = v.(string)
 	}
 
+	if v, ok := d.GetOk("guest_id"); ok {
+		vm.guestID = v.(types.VirtualMachineGuestOsIdentifier)
+	}
+
 	if v, ok := d.GetOk("linked_clone"); ok {
 		vm.linkedClone = v.(bool)
 	}
@@ -757,6 +768,9 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 			}
 			if v, ok := network["mac_address"].(string); ok && v != "" {
 				networks[i].macAddress = v
+			}
+			if v, ok := network["adapter_type"].(string); ok && v != "" {
+				networks[i].adapterType = v
 			}
 		}
 		vm.networkInterfaces = networks
@@ -1642,8 +1656,15 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 			DiskUuidEnabled: &vm.enableDiskUUID,
 		},
 	}
+	if vm.template != "" && vm.guestID != "" {
+		return fmt.Errorf("Cannot enforce guestID if template is set aswell")
+	}
 	if vm.template == "" {
-		configSpec.GuestId = "otherLinux64Guest"
+		if vm.guestID == "" {
+			configSpec.GuestId = "otherLinux64Guest"
+		} else {
+			configSpec.GuestId = string(vm.guestID)
+		}
 	}
 	log.Printf("[DEBUG] virtual machine config spec: %v", configSpec)
 
@@ -1710,11 +1731,16 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 	for _, network := range vm.networkInterfaces {
 		// network device
 		var networkDeviceType string
-		if vm.template == "" {
-			networkDeviceType = "e1000"
+		if network.adapterType == "" {
+			if vm.template == "" {
+				networkDeviceType = "e1000"
+			} else {
+				networkDeviceType = "vmxnet3"
+			}
 		} else {
-			networkDeviceType = "vmxnet3"
+			networkDeviceType = network.adapterType
 		}
+
 		nd, err := buildNetworkDevice(finder, network.label, networkDeviceType, network.macAddress)
 		if err != nil {
 			return err

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -387,9 +387,9 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 							Default:  "eager_zeroed",
 							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 								value := v.(string)
-								if value != "thin" && value != "eager_zeroed" {
+								if value != "thin" && value != "eager_zeroed" && value != "thick_lazy" {
 									errors = append(errors, fmt.Errorf(
-										"only 'thin' and 'eager_zeroed' are supported values for 'type'"))
+										"only 'thin', 'thick_lazy' and 'eager_zeroed' are supported values for 'type'"))
 								}
 								return
 							},
@@ -1300,6 +1300,10 @@ func addHardDisk(vm *object.VirtualMachine, size, iops int64, diskType string, d
 		} else if diskType == "thin" {
 			// thin provisioned virtual disk
 			backing.ThinProvisioned = types.NewBool(true)
+		} else if diskType == "thick_lazy" {
+			// thin provisioned virtual disk
+			backing.ThinProvisioned = types.NewBool(false)
+			backing.EagerlyScrub = types.NewBool(false)
 		}
 
 		log.Printf("[DEBUG] addHardDisk: %#v\n", disk)


### PR DESCRIPTION
## Abstract
We need to tell vSphere what OS is run into the VM.
We also need to be able to specify explicitly what kind of adapter is wanted in the NIC.

So here is the action:
Allow to specify explicitly guest_id in VM and adapter_type in network section of VM.

## Default changes
None. By default it will perform the same as before.

## What's possible with this?
Specify explicitly what kind of network adapter you want. Specify what OS will be deployed in the VM, straight from Terraform.