### PR TITLE
provider/aws: Add dns_name to aws_efs_mount_target

### DIFF
--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -48,6 +49,10 @@ func resourceAwsEfsMountTarget() *schema.Resource {
 			},
 
 			"network_interface_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dns_name": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -163,7 +168,31 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("security_groups", schema.NewSet(schema.HashString, flattenStringList(sgResp.SecurityGroups)))
 
+	// DNS name per http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html
+	az, err := getAzFromSubnetId(*mt.SubnetId, meta.(*AWSClient).ec2conn)
+	if err != nil {
+		return fmt.Errorf("Failed getting AZ from subnet ID (%s): %s", *mt.SubnetId, err)
+	}
+	region := meta.(*AWSClient).region
+	d.Set("dns_name", fmt.Sprintf("%s.%s.efs.%s.amazonaws.com", az, *mt.FileSystemId, region))
+
 	return nil
+}
+
+func getAzFromSubnetId(subnetId string, conn *ec2.EC2) (string, error) {
+	input := ec2.DescribeSubnetsInput{
+		SubnetIds: []*string{aws.String(subnetId)},
+	}
+	out, err := conn.DescribeSubnets(&input)
+	if err != nil {
+		return "", err
+	}
+
+	if len(out.Subnets) != 1 {
+		return "", fmt.Errorf("Expected exactly 1 subnet returned for %q", subnetId)
+	}
+
+	return *out.Subnets[0].AvailabilityZone, nil
 }
 
 func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_efs_mount_target_test.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -24,6 +25,11 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 					testAccCheckEfsMountTarget(
 						"aws_efs_mount_target.alpha",
 					),
+					resource.TestMatchResourceAttr(
+						"aws_efs_mount_target.alpha",
+						"dns_name",
+						regexp.MustCompile("^us-west-2a.[^.]+.efs.us-west-2.amazonaws.com$"),
+					),
 				),
 			},
 			resource.TestStep{
@@ -32,8 +38,18 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 					testAccCheckEfsMountTarget(
 						"aws_efs_mount_target.alpha",
 					),
+					resource.TestMatchResourceAttr(
+						"aws_efs_mount_target.alpha",
+						"dns_name",
+						regexp.MustCompile("^us-west-2a.[^.]+.efs.us-west-2.amazonaws.com$"),
+					),
 					testAccCheckEfsMountTarget(
 						"aws_efs_mount_target.beta",
+					),
+					resource.TestMatchResourceAttr(
+						"aws_efs_mount_target.beta",
+						"dns_name",
+						regexp.MustCompile("^us-west-2b.[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
 				),
 			},

--- a/website/source/docs/providers/aws/r/efs_mount_target.html.markdown
+++ b/website/source/docs/providers/aws/r/efs_mount_target.html.markdown
@@ -41,7 +41,10 @@ The following arguments are supported:
 
 ## Attributes Reference
 
+~> **Note:** The `dns_name` attribute is only useful if the mount target is in a VPC with `enable_dns_hostnames = true`.
+
 The following attributes are exported:
 
 * `id` - The ID of the mount target
+* `dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html)
 * `network_interface_id` - The ID of the network interface that Amazon EFS created when it created the mount target.


### PR DESCRIPTION
This can be useful for people who prefer DNS names over IPs in configs.

It also expands the permissions scope for `aws_efs_mount_target` as `ec2:DescribeSubnets` is now required. I think it's worth expanding, given the convenience.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEFSMountTarget'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEFSMountTarget -timeout 120m
=== RUN   TestAccAWSEFSMountTarget_basic
--- PASS: TestAccAWSEFSMountTarget_basic (416.17s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	416.193s
```