### PR TITLE
provider/azurerm: `azurerm_dns_zone` now returns `name_servers`

### DIFF
--- a/builtin/providers/azurerm/resource_arm_dns_zone.go
+++ b/builtin/providers/azurerm/resource_arm_dns_zone.go
@@ -39,6 +39,13 @@ func resourceArmDnsZone() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"name_servers": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 		},
 	}
 }
@@ -103,6 +110,14 @@ func resourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("number_of_record_sets", resp.NumberOfRecordSets)
 	d.Set("max_number_of_record_sets", resp.MaxNumberOfRecordSets)
+
+	nameServers := make([]string, 0, len(resp.NameServers))
+	for _, ns := range resp.NameServers {
+		nameServers = append(nameServers, *ns)
+	}
+	if err := d.Set("name_servers", nameServers); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/vendor/github.com/jen20/riviera/dns/get_dns_cname_recordset.go
+++ b/vendor/github.com/jen20/riviera/dns/get_dns_cname_recordset.go
@@ -3,12 +3,12 @@ package dns
 import "github.com/jen20/riviera/azure"
 
 type GetCNAMERecordSetResponse struct {
-	ID          string             `mapstructure:"id"`
-	Name        string             `mapstructure:"name"`
-	Location    string             `mapstructure:"location"`
-	Tags        map[string]*string `mapstructure:"tags"`
-	TTL         *int               `mapstructure:"TTL"`
-	CNAMERecord CNAMERecord        `mapstructure:"CNAMERecord"`
+	ID           string             `mapstructure:"id"`
+	Name         string             `mapstructure:"name"`
+	Location     string             `mapstructure:"location"`
+	Tags         map[string]*string `mapstructure:"tags"`
+	TTL          *int               `mapstructure:"TTL"`
+	CNAMERecord  CNAMERecord        `mapstructure:"CNAMERecord"`
 }
 
 type GetCNAMERecordSet struct {

--- a/vendor/github.com/jen20/riviera/dns/get_dns_zone.go
+++ b/vendor/github.com/jen20/riviera/dns/get_dns_zone.go
@@ -9,6 +9,7 @@ type GetDNSZoneResponse struct {
 	Tags                  *map[string]*string `mapstructure:"tags"`
 	NumberOfRecordSets    *string             `mapstructure:"numberOfRecordSets"`
 	MaxNumberOfRecordSets *string             `mapstructure:"maxNumberOfRecordSets"`
+	NameServers           []*string           `mapstructure:"nameServers"`
 }
 
 type GetDNSZone struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -951,32 +951,32 @@
 		{
 			"checksumSHA1": "oPpOfZn11Ef6DWOoETxSW9Venzs=",
 			"path": "github.com/jen20/riviera/azure",
-			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
-			"revisionTime": "2016-06-10T12:18:12Z"
+			"revision": "1159d86fc8144abafeb29ee7c5a3e2e85af336ba",
+			"revisionTime": "2016-06-30T14:11:29Z"
 		},
 		{
-			"checksumSHA1": "A2Ycn6MySifUKTHOnsG9oLwjitE=",
+			"checksumSHA1": "ncdT+1PFEF5ly0niXuQc9/pKzT0=",
 			"path": "github.com/jen20/riviera/dns",
-			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
-			"revisionTime": "2016-06-10T12:18:12Z"
+			"revision": "1159d86fc8144abafeb29ee7c5a3e2e85af336ba",
+			"revisionTime": "2016-06-30T14:11:29Z"
 		},
 		{
 			"checksumSHA1": "zVXx6ha3bt0N4ukRbRHXjSl91S4=",
 			"path": "github.com/jen20/riviera/search",
-			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
-			"revisionTime": "2016-06-10T12:18:12Z"
+			"revision": "1159d86fc8144abafeb29ee7c5a3e2e85af336ba",
+			"revisionTime": "2016-06-30T14:11:29Z"
 		},
 		{
 			"checksumSHA1": "KfquDaeBPGchw92QnojlJFsJKgk=",
 			"path": "github.com/jen20/riviera/sql",
-			"revision": "2f01b8f5b09bbc20a591b1dc4b48af0665106b3f",
-			"revisionTime": "2016-06-10T12:18:12Z"
+			"revision": "1159d86fc8144abafeb29ee7c5a3e2e85af336ba",
+			"revisionTime": "2016-06-30T14:11:29Z"
 		},
 		{
 			"checksumSHA1": "nKUCquNpJ9ifHgkXoT4K3Xar6R8=",
 			"path": "github.com/jen20/riviera/storage",
-			"revision": "64de55fa8cdd0c52f7d59494c1b03c1b583c52b4",
-			"revisionTime": "2016-02-18T23:50:40Z"
+			"revision": "1159d86fc8144abafeb29ee7c5a3e2e85af336ba",
+			"revisionTime": "2016-06-30T14:11:29Z"
 		},
 		{
 			"comment": "0.2.2-2-gc01cf91",


### PR DESCRIPTION
Fixes #7374

The introduction of the AzureRM SDK 3.0.0-beta means that the
`name_servers` for the DNS Zone are returned from the API

This PR has a dependency on #7420 being merged first

``` make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMDnsZone_'
==> Checking that code complies with gofmt requirements...
$(go list ./... | grep -v /vendor/) 
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMDnsZone_ -timeout 120m
=== RUN   TestAccAzureRMDnsZone_basic
--- PASS: TestAccAzureRMDnsZone_basic (92.42s) PASS ok
github.com/hashicorp/terraform/builtin/providers/azurerm 92.444s
```