### PR TITLE
provider/aws: Remove EFS File System from State when NotFound

### DIFF
--- a/builtin/providers/aws/resource_aws_efs_file_system.go
+++ b/builtin/providers/aws/resource_aws_efs_file_system.go
@@ -100,6 +100,11 @@ func resourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) erro
 		FileSystemId: aws.String(d.Id()),
 	})
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "FileSystemNotFound" {
+			log.Printf("[WARN] EFS File System (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	if len(resp.FileSystems) < 1 {


### PR DESCRIPTION
Fixes #7433

When an EFS File System is created via Terraform, Deleted from the AWS
console, then Terraform would give us as error as:

```
* aws_efs_file_system.file_system: FileSystemNotFound: File system
 'fs-9d739e54' does not exist.
        status code: 404, request id:
        d505a682-3ec7-11e6-81d3-1d41202f0881
```

On a 404, we now remove the EFS File System from state so that Terraform
can recreate it as expected