### PR TITLE
core: Fix plan output for data sources

### DIFF
--- a/command/format_plan.go
+++ b/command/format_plan.go
@@ -78,6 +78,8 @@ func formatPlanModuleExpand(
 			continue
 		}
 
+		dataSource := strings.HasPrefix(name, "data.")
+
 		if moduleName != "" {
 			name = moduleName + "." + name
 		}
@@ -103,7 +105,7 @@ func formatPlanModuleExpand(
 			// Unfortunately by the time we get here we only have the name
 			// to work with, so we need to cheat and exploit knowledge of the
 			// naming scheme for data resources.
-			if strings.HasPrefix(name, "data.") {
+			if dataSource {
 				symbol = "<="
 				color = "cyan"
 			}

--- a/command/format_plan_test.go
+++ b/command/format_plan_test.go
@@ -1,0 +1,91 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/colorstring"
+)
+
+// Test that a root level data source gets a special plan output on create
+func TestFormatPlan_rootDataSource(t *testing.T) {
+	plan := &terraform.Plan{
+		Diff: &terraform.Diff{
+			Modules: []*terraform.ModuleDiff{
+				&terraform.ModuleDiff{
+					Path: []string{"root"},
+					Resources: map[string]*terraform.InstanceDiff{
+						"data.type.name": &terraform.InstanceDiff{
+							Attributes: map[string]*terraform.ResourceAttrDiff{
+								"A": &terraform.ResourceAttrDiff{
+									New:         "B",
+									RequiresNew: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	opts := &FormatPlanOpts{
+		Plan: plan,
+		Color: &colorstring.Colorize{
+			Colors:  colorstring.DefaultColors,
+			Disable: true,
+		},
+		ModuleDepth: 1,
+	}
+
+	actual := FormatPlan(opts)
+
+	expected := strings.TrimSpace(`
+ <= data.type.name
+    A: "B"
+	`)
+	if actual != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, actual)
+	}
+}
+
+// Test that data sources nested in modules get the same plan output
+func TestFormatPlan_nestedDataSource(t *testing.T) {
+	plan := &terraform.Plan{
+		Diff: &terraform.Diff{
+			Modules: []*terraform.ModuleDiff{
+				&terraform.ModuleDiff{
+					Path: []string{"root", "nested"},
+					Resources: map[string]*terraform.InstanceDiff{
+						"data.type.name": &terraform.InstanceDiff{
+							Attributes: map[string]*terraform.ResourceAttrDiff{
+								"A": &terraform.ResourceAttrDiff{
+									New:         "B",
+									RequiresNew: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	opts := &FormatPlanOpts{
+		Plan: plan,
+		Color: &colorstring.Colorize{
+			Colors:  colorstring.DefaultColors,
+			Disable: true,
+		},
+		ModuleDepth: 2,
+	}
+
+	actual := FormatPlan(opts)
+
+	expected := strings.TrimSpace(`
+ <= module.nested.data.type.name
+    A: "B"
+	`)
+	if actual != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, actual)
+	}
+}


### PR DESCRIPTION
Data sources are given a special plan output when the diff would show it
creating a new resource, to indicate that there is only a logical data
resource being read. Data sources nested in modules weren't formatted in
the plan output in the same way.

This checks for the "data." part of the path in nested modules, and adds
acceptance tests for the plan output.

Fixes #6823 