### PR TITLE
provider/aws: import elastic beanstalk

### DIFF
--- a/builtin/providers/aws/import_aws_elastic_beanstalk_application_test.go
+++ b/builtin/providers/aws/import_aws_elastic_beanstalk_application_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAWSElasticBeanstalkApplication_importBasic(t *testing.T) {
+	resourceName := "aws_elastic_beanstalk_application.tftest"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkAppDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBeanstalkAppConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/import_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/import_aws_elastic_beanstalk_environment_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAWSElasticBeanstalkEnvironment_importBasic(t *testing.T) {
+	resourceName := "aws_elastic_beanstalk_application.tftest"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkAppDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBeanstalkEnvConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_application.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_application.go
@@ -19,6 +19,9 @@ func resourceAwsElasticBeanstalkApplication() *schema.Resource {
 		Read:   resourceAwsElasticBeanstalkApplicationRead,
 		Update: resourceAwsElasticBeanstalkApplicationUpdate,
 		Delete: resourceAwsElasticBeanstalkApplicationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -94,6 +97,7 @@ func resourceAwsElasticBeanstalkApplicationRead(d *schema.ResourceData, meta int
 		return err
 	}
 
+	d.Set("name", a.ApplicationName)
 	d.Set("description", a.Description)
 	return nil
 }


### PR DESCRIPTION
@stack72 Here is some initial work on the new import feature for the beanstalk resources. I ran into an issue with the `elastic_beanstalk_configuration_template` resource. To describe this resource from the api, both the template name (resource id) and the beanstalk application name are needed. Is there going to be a way to pass extra information like that to the `import` command?

I should be able to finish the tests on this in the near future, but wanted to get the config template question out here.

Loving this new feature!