### PR TITLE
provider/aws: Read Elastic Beanstalk stack name

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -404,6 +404,10 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 		}
 	}
 
+	if err := d.Set("solution_stack_name", *env.SolutionStackName); err != nil {
+		return err
+	}
+
 	if err := d.Set("autoscaling_groups", flattenBeanstalkAsg(resources.EnvironmentResources.AutoScalingGroups)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #7300 where an Elastic Beanstalk error or change outside of Terraform modifies the `solution_stack_name` attribute, which results in a stale value in the state file.