### PR TITLE
provider/aws: internetgateway timing tweaks (again)

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -319,6 +319,10 @@ func IGAttachStateRefreshFunc(conn *ec2.EC2, id string, expected string) resourc
 
 		ig := resp.InternetGateways[0]
 
+		if time.Now().Sub(start) > 10*time.Second {
+			return ig, expected, nil
+		}
+
 		if len(ig.Attachments) == 0 {
 			// No attachments, we're detached
 			return ig, "detached", nil


### PR DESCRIPTION
This workaround is originally from 71b30c633f4824bba9c9a7eada788cd169db7568. According to the commit message from Mitchell Hashimoto:

> So I think the AWS API is just broken here. In the case that the state doesn't update, just assume it did after 5 seconds.

Based on my experience, this AWS API is still broken in the same way.

The timeout was later increased from 5 seconds to 10 seconds in 265cc4fffa3667ecb0ca20604ce49e162fb4e5e9.

The timeout (but not the timer) was removed inexplicably in GH-1325.

The symptom is this error from `terraform apply`:

    aws_internet_gateway.test: Error waiting for internet gateway (igw-553b4731) to attach: timeout while waiting for state to become '[available]'

followed by all subsequent `terraform apply` commands failing with this error:

    aws_internet_gateway.test: Resource.AlreadyAssociated: resource igw-553b4731 is already attached to network vpc-61bc7606