### PR TITLE
Timing out is not success

### DIFF
--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -38,6 +38,20 @@ func TestRetry_timeout(t *testing.T) {
 	}
 }
 
+func TestRetry_hang(t *testing.T) {
+	t.Parallel()
+
+	f := func() *RetryError {
+		time.Sleep(2 * time.Second)
+		return nil
+	}
+
+	err := Retry(1*time.Second, f)
+	if err == nil {
+		t.Fatal("should error")
+	}
+}
+
 func TestRetry_error(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Practically every caller of `Retry` depends on this. Anything that looks like:

```go
var out *Type
err = Retry(10*time.Second, func() *RetryError {
    out, err = f()
    return // ...
})
if err != nil {
    return // ...
}
use(out.Field)
```

Without this change, the last line will panic if `f` hangs.