### PR TITLE
Revert "provider/aws: Read Elastic Beanstalk stack name"

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -404,10 +404,6 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 		}
 	}
 
-	if err := d.Set("solution_stack_name", *env.SolutionStackName); err != nil {
-		return err
-	}
-
 	if err := d.Set("autoscaling_groups", flattenBeanstalkAsg(resources.EnvironmentResources.AutoScalingGroups)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Reverts hashicorp/terraform#7445

This causes a cycle so reverting it