### PR TITLE
helper/resource: Consolidate unit test override

### DIFF
--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestState_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		OverrideEnvVar: true,
-		PreCheck:       func() { testAccPreCheck(t) },
-		Providers:      testAccProviders,
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccState_basic,
@@ -26,10 +25,9 @@ func TestState_basic(t *testing.T) {
 }
 
 func TestState_complexOutputs(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		OverrideEnvVar: true,
-		PreCheck:       func() { testAccPreCheck(t) },
-		Providers:      testAccProviders,
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccState_complexOutputs,


### PR DESCRIPTION
I noticed we had two mechanisms for unit test override. One that dropped
a sentinel into the env var, and another with a struct member on
TestCase. This consolidates the two, using the cleaner struct member
internal mechanism and the nicer `resource.UnitTest()` entry point.