### PR TITLE
Remove unused variables

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_rule.go
@@ -157,10 +157,8 @@ func resourceAwsCloudWatchEventRuleUpdate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Updating CloudWatch Event Rule: %s", input)
 
 	// IAM Roles take some time to propagate
-	var out *events.PutRuleOutput
 	err := resource.Retry(30*time.Second, func() *resource.RetryError {
-		var err error
-		out, err = conn.PutRule(input)
+		_, err := conn.PutRule(input)
 		pattern := regexp.MustCompile("cannot be assumed by principal '[a-z]+\\.amazonaws\\.com'\\.$")
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -299,10 +299,8 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Updating CodeDeploy DeploymentGroup %s", d.Id())
 	// Retry to handle IAM role eventual consistency.
-	var resp *codedeploy.UpdateDeploymentGroupOutput
-	var err error
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		resp, err = conn.UpdateDeploymentGroup(&input)
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.UpdateDeploymentGroup(&input)
 		if err != nil {
 			retry := false
 			codedeployErr, ok := err.(awserr.Error)

--- a/builtin/providers/aws/resource_aws_opsworks_application.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application.go
@@ -347,10 +347,8 @@ func resourceAwsOpsworksApplicationUpdate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Updating OpsWorks layer: %s", d.Id())
 
-	var resp *opsworks.UpdateAppOutput
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var cerr error
-		resp, cerr = client.UpdateApp(req)
+		_, cerr := client.UpdateApp(req)
 		if cerr != nil {
 			log.Printf("[INFO] client error")
 			if opserr, ok := cerr.(awserr.Error); ok {


### PR DESCRIPTION
For some reason these prevent [errcheck](https://github.com/kisielk/errcheck) from running successfully.

Side note: errcheck reports 2590 unchecked errors (excluding tests and vendored dependencies). It would have prevented the longstanding bug in #7448.