### PR TITLE
Return nonnegative hash if int is 32 bits

### DIFF
--- a/helper/hashcode/hashcode.go
+++ b/helper/hashcode/hashcode.go
@@ -11,9 +11,12 @@ import (
 // and invert it if the result is negative.
 func String(s string) int {
 	v := int(crc32.ChecksumIEEE([]byte(s)))
-	if v < 0 {
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
 		return -v
 	}
-
-	return v
+	// v == MinInt
+	return 0
 }

--- a/helper/hashcode/hashcode_test.go
+++ b/helper/hashcode/hashcode_test.go
@@ -16,7 +16,8 @@ func TestString(t *testing.T) {
 }
 
 func TestString_positiveIndex(t *testing.T) {
-	ips := []string{"192.168.1.3", "192.168.1.5"}
+	// "2338615298" hashes to uint32(2147483648) which is math.MinInt32
+	ips := []string{"192.168.1.3", "192.168.1.5", "2338615298"}
 	for _, ip := range ips {
 		if index := String(ip); index < 0 {
 			t.Fatalf("Bad Index %#v for ip %s", index, ip)


### PR DESCRIPTION
`hashcode.String("2338615298")` was negative on 32-bit.