### PR TITLE
provider/aws: Retry finding route after creating it

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -179,14 +179,18 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating route: %s", err)
 	}
 
-	route, err := findResourceRoute(conn, d.Get("route_table_id").(string), d.Get("destination_cidr_block").(string))
+	var route *ec2.Route
+	err = resource.Retry(15*time.Second, func() *resource.RetryError {
+		route, err = findResourceRoute(conn, d.Get("route_table_id").(string), d.Get("destination_cidr_block").(string))
+		return resource.RetryableError(err)
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("Error finding route after creating it: %s", err)
 	}
 
 	d.SetId(routeIDHash(d, route))
-
-	return resourceAwsRouteRead(d, meta)
+	resourceAwsRouteSetResourceData(d, route)
+	return nil
 }
 
 func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
@@ -195,7 +199,11 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	resourceAwsRouteSetResourceData(d, route)
+	return nil
+}
 
+func resourceAwsRouteSetResourceData(d *schema.ResourceData, route *ec2.Route) {
 	d.Set("destination_prefix_list_id", route.DestinationPrefixListId)
 	d.Set("gateway_id", route.GatewayId)
 	d.Set("nat_gateway_id", route.NatGatewayId)
@@ -205,8 +213,6 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("origin", route.Origin)
 	d.Set("state", route.State)
 	d.Set("vpc_peering_connection_id", route.VpcPeeringConnectionId)
-
-	return nil
 }
 
 func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -380,7 +386,7 @@ func findResourceRoute(conn *ec2.EC2, rtbid string, cidr string) (*ec2.Route, er
 		}
 	}
 
-	return nil, fmt.Errorf(`
-error finding matching route for Route table (%s) and destination CIDR block (%s)`,
+	return nil, fmt.Errorf(
+		`error finding matching route for Route table (%s) and destination CIDR block (%s)`,
 		rtbid, cidr)
 }


### PR DESCRIPTION
The symptom is that a route "fails" to create, then every subsequent `terraform apply` fails with RouteAlreadyExists.

CreateRoute was succeeding but the very next DescribeRouteTables was not listing the new route.