### PR TITLE
core: Return an error when there's no remote state

### DIFF
--- a/state/remote/remote_test.go
+++ b/state/remote/remote_test.go
@@ -41,3 +41,21 @@ func testClient(t *testing.T, c Client) {
 		t.Fatalf("bad: %#v", p)
 	}
 }
+
+func TestRemoteClient_noPayload(t *testing.T) {
+	s := &State{
+		Client: nilClient{},
+	}
+	if err := s.RefreshState(); err != ErrRemoteStateNotFound {
+		t.Fatal("expected ErrRemoteStateNotFound, got", err)
+	}
+}
+
+// nilClient returns nil for everything
+type nilClient struct{}
+
+func (nilClient) Get() (*Payload, error) { return nil, nil }
+
+func (c nilClient) Put([]byte) error { return nil }
+
+func (c nilClient) Delete() error { return nil }

--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -2,9 +2,12 @@ package remote
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/hashicorp/terraform/terraform"
 )
+
+var ErrRemoteStateNotFound = errors.New("no remote state found")
 
 // State implements the State interfaces in the state package to handle
 // reading and writing the remote state. This State on its own does no
@@ -34,12 +37,13 @@ func (s *State) RefreshState() error {
 		return err
 	}
 
-	var state *terraform.State
-	if payload != nil {
-		state, err = terraform.ReadState(bytes.NewReader(payload.Data))
-		if err != nil {
-			return err
-		}
+	if payload == nil {
+		return ErrRemoteStateNotFound
+	}
+
+	state, err := terraform.ReadState(bytes.NewReader(payload.Data))
+	if err != nil {
+		return err
 	}
 
 	s.state = state


### PR DESCRIPTION
When refreshing remote state, indicate when no state file was found with
an ErrRemoteStateNotFound error. This prevents us from inadvertantly
getting a nil state into a terraform.State where we assume there's
always a root module.

Fixes #7455 