### PR TITLE
Convert tls_cert_request to be a data source

### DIFF
--- a/builtin/providers/tls/data_source_cert_request.go
+++ b/builtin/providers/tls/data_source_cert_request.go
@@ -12,11 +12,9 @@ import (
 
 const pemCertReqType = "CERTIFICATE REQUEST"
 
-func resourceCertRequest() *schema.Resource {
+func dataSourceCertRequest() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateCertRequest,
-		Delete: DeleteCertRequest,
-		Read:   ReadCertRequest,
+		Read: ReadCertRequest,
 
 		Schema: map[string]*schema.Schema{
 
@@ -24,7 +22,6 @@ func resourceCertRequest() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "List of DNS names to use as subjects of the certificate",
-				ForceNew:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -34,7 +31,6 @@ func resourceCertRequest() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "List of IP addresses to use as subjects of the certificate",
-				ForceNew:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -44,14 +40,12 @@ func resourceCertRequest() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of the algorithm to use to generate the certificate's private key",
-				ForceNew:    true,
 			},
 
 			"private_key_pem": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "PEM-encoded private key that the certificate will belong to",
-				ForceNew:    true,
 				StateFunc: func(v interface{}) string {
 					return hashForState(v.(string))
 				},
@@ -61,7 +55,6 @@ func resourceCertRequest() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				Elem:     nameSchema,
-				ForceNew: true,
 			},
 
 			"cert_request_pem": &schema.Schema{
@@ -72,7 +65,7 @@ func resourceCertRequest() *schema.Resource {
 	}
 }
 
-func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
+func ReadCertRequest(d *schema.ResourceData, meta interface{}) error {
 	key, err := parsePrivateKey(d, "private_key_pem", "key_algorithm")
 	if err != nil {
 		return err
@@ -114,14 +107,5 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(hashForState(string(certReqBytes)))
 	d.Set("cert_request_pem", certReqPem)
 
-	return nil
-}
-
-func DeleteCertRequest(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("")
-	return nil
-}
-
-func ReadCertRequest(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }

--- a/builtin/providers/tls/data_source_cert_request_test.go
+++ b/builtin/providers/tls/data_source_cert_request_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestCertRequest(t *testing.T) {
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			r.TestStep{
 				Config: fmt.Sprintf(`
-                    resource "tls_cert_request" "test" {
+                    data "tls_cert_request" "test" {
                         subject {
                             common_name = "example.com"
                             organization = "Example, Inc"
@@ -46,7 +46,7 @@ func TestCertRequest(t *testing.T) {
 EOT
                     }
                     output "key_pem" {
-                        value = "${tls_cert_request.test.cert_request_pem}"
+                        value = "${data.tls_cert_request.test.cert_request_pem}"
                     }
                 `, testPrivateKey),
 				Check: func(s *terraform.State) error {

--- a/builtin/providers/tls/provider.go
+++ b/builtin/providers/tls/provider.go
@@ -12,11 +12,18 @@ import (
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
+		DataSourcesMap: map[string]*schema.Resource{
+			"tls_cert_request": dataSourceCertRequest(),
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"tls_private_key":         resourcePrivateKey(),
 			"tls_locally_signed_cert": resourceLocallySignedCert(),
 			"tls_self_signed_cert":    resourceSelfSignedCert(),
-			"tls_cert_request":        resourceCertRequest(),
+
+			"tls_cert_request": schema.DataSourceResourceShim(
+				"tls_cert_request",
+				dataSourceCertRequest(),
+			),
 		},
 	}
 }

--- a/website/source/docs/providers/tls/d/cert_request.html.md
+++ b/website/source/docs/providers/tls/d/cert_request.html.md
@@ -13,13 +13,11 @@ typical format used to request a certificate from a certificate authority.
 
 This resource is intended to be used in conjunction with a Terraform provider
 for a particular certificate authority in order to provision a new certificate.
-This is a *logical resource*, so it contributes only to the current Terraform
-state and does not create any external managed resources.
 
 ## Example Usage
 
 ```
-resource "tls_cert_request" "example" {
+data "tls_cert_request" "example" {
     key_algorithm = "ECDSA"
     private_key_pem = "${file(\"private_key.pem\")}"
 

--- a/website/source/layouts/tls.erb
+++ b/website/source/layouts/tls.erb
@@ -10,6 +10,15 @@
 					<a href="/docs/providers/tls/index.html">TLS Provider</a>
 				</li>
 
+				<li<%= sidebar_current(/^docs-tls-data-source/) %>>
+					<a href="#">Data Sources</a>
+					<ul class="nav nav-visible">
+						<li<%= sidebar_current("docs-tls-data-source-cert-request") %>>
+							<a href="/docs/providers/tls/d/cert_request.html">tls_cert_request</a>
+						</li>
+					</ul>
+				</li>
+
 				<li<%= sidebar_current(/^docs-tls-resource/) %>>
 					<a href="#">Resources</a>
 					<ul class="nav nav-visible">
@@ -21,9 +30,6 @@
 						</li>
 						<li<%= sidebar_current("docs-tls-resourse-locally-signed-cert") %>>
 							<a href="/docs/providers/tls/r/locally_signed_cert.html">tls_locally_signed_cert</a>
-						</li>
-						<li<%= sidebar_current("docs-tls-resourse-cert-request") %>>
-							<a href="/docs/providers/tls/r/cert_request.html">tls_cert_request</a>
 						</li>
 					</ul>
 				</li>


### PR DESCRIPTION
This resource (unlike the others in this provider) isn't stateful, so it is a good candidate to be a data source.

The old resource form is preserved via the standard shim in helper/schema, which will generate a deprecation warning but will still allow the resource to be used.
