### PR TITLE
provider/aws: Allow VPC Classic Linking in Autoscaling Launch Configs

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -110,13 +110,13 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
-			"vpc_classiclink": &schema.Schema{
+			"vpc_classic_link_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"vpc_classiclink_security_groups": &schema.Schema{
+			"vpc_classic_link_security_groups": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,

--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -110,6 +110,20 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"vpc_classiclink": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"vpc_classiclink_security_groups": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"associate_public_ip_address": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -329,6 +343,16 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		)
 	}
 
+	if v, ok := d.GetOk("vpc_classic_link_id"); ok {
+		createLaunchConfigurationOpts.ClassicLinkVPCId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("vpc_classic_link_security_groups"); ok {
+		createLaunchConfigurationOpts.ClassicLinkVPCSecurityGroups = expandStringList(
+			v.(*schema.Set).List(),
+		)
+	}
+
 	var blockDevices []*autoscaling.BlockDeviceMapping
 
 	// We'll use this to detect if we're declaring it incorrectly as an ebs_block_device.
@@ -518,6 +542,9 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	d.Set("spot_price", lc.SpotPrice)
 	d.Set("enable_monitoring", lc.InstanceMonitoring.Enabled)
 	d.Set("security_groups", lc.SecurityGroups)
+
+	d.Set("vpc_classic_link_id", lc.ClassicLinkVPCId)
+	d.Set("vpc_classic_link_security_groups", lc.ClassicLinkVPCSecurityGroups)
 
 	if err := readLCBlockDevices(d, lc, ec2conn); err != nil {
 		return err

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -95,6 +95,8 @@ The following arguments are supported:
 * `key_name` - (Optional) The key name that should be used for the instance.
 * `security_groups` - (Optional) A list of associated security group IDS.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.
+* `vpc_classic_link_id` - (Optional) The ID of a ClassicLink-enabled VPC. Only applies to EC2-Classic instances. (eg. `vpc-2730681a`)
+* `vpc_classic_link_security_groups` - (Optional) The IDs of one or more security groups for the specified ClassicLink-enabled VPC (eg. `sg-46ae3d11`).
 * `user_data` - (Optional) The user data to provide when launching the instance.
 * `enable_monitoring` - (Optional) Enables/disables detailed monitoring. This is enabled by default.
 * `ebs_optimized` - (Optional) If true, the launched EC2 instance will be EBS-optimized.


### PR DESCRIPTION
AWS provides EC2 ClassicLink which allows instances outside of a VPC to reach instances within it. More details [here](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html). The use case is mainly for transitioning existing infrastructure into a VPC. You can specify a default VPC id and an associated security group with an autoscaling launch config so that all instances within the autoscaling group are automatically linked to a desired VPC. From my current understanding, terraform does not have support yet for VPC linking in launch configurations. 

I noticed that the acceptance tests require the use of real AWS resources. I've tested my changes against resources that we own but I've replaced those values with some of the values I've seen in other examples for obvious reasons. As a result I'm not entirely sure if they'll work using your AWS resources. I'd be interested to know how you guys manage resources for acceptance testing from outside contributors. 

```
terraform andrewsykim$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLaunchConfiguration_withVpcClassicLink'
==> Checking that code complies with gofmt requirements...
/Users/andrewsykim/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
2016/07/02 13:40:52 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLaunchConfiguration_withVpcClassicLink -timeout 120m
=== RUN   TestAccAWSLaunchConfiguration_withVpcClassicLink
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (10.37s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	10.388s
``` 