### PR TITLE
providers/google: Move URLMap hosts to TypeSet from TypeList

### DIFF
--- a/builtin/providers/google/resource_compute_url_map.go
+++ b/builtin/providers/google/resource_compute_url_map.go
@@ -40,8 +40,10 @@ func resourceComputeUrlMap() *schema.Resource {
 			},
 
 			"host_rule": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
+				// TODO(evandbrown): Enable when lists support validation
+				//ValidateFunc: validateHostRules,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"description": &schema.Schema{
@@ -258,10 +260,10 @@ func resourceComputeUrlMapCreate(d *schema.ResourceData, meta interface{}) error
 		urlMap.Description = v.(string)
 	}
 
-	_hostRules := d.Get("host_rule").([]interface{})
-	urlMap.HostRules = make([]*compute.HostRule, len(_hostRules))
+	_hostRules := d.Get("host_rule").(*schema.Set)
+	urlMap.HostRules = make([]*compute.HostRule, _hostRules.Len())
 
-	for i, v := range _hostRules {
+	for i, v := range _hostRules.List() {
 		urlMap.HostRules[i] = createHostRule(v)
 	}
 
@@ -332,7 +334,7 @@ func resourceComputeUrlMapRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	/* Only read host rules into our TF state that we have defined */
-	_hostRules := d.Get("host_rule").([]interface{})
+	_hostRules := d.Get("host_rule").(*schema.Set).List()
 	_newHostRules := make([]interface{}, 0)
 	for _, v := range _hostRules {
 		_hostRule := v.(map[string]interface{})
@@ -463,12 +465,12 @@ func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error
 		_oldHostRulesMap := make(map[string]interface{})
 		_newHostRulesMap := make(map[string]interface{})
 
-		for _, v := range _oldHostRules.([]interface{}) {
+		for _, v := range _oldHostRules.(*schema.Set).List() {
 			_hostRule := v.(map[string]interface{})
 			_oldHostRulesMap[_hostRule["path_matcher"].(string)] = v
 		}
 
-		for _, v := range _newHostRules.([]interface{}) {
+		for _, v := range _newHostRules.(*schema.Set).List() {
 			_hostRule := v.(map[string]interface{})
 			_newHostRulesMap[_hostRule["path_matcher"].(string)] = v
 		}
@@ -515,7 +517,7 @@ func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error
 					}
 
 					/* Now add in the brand new entries */
-					for host, _ := range _oldHostsSet {
+					for host, _ := range _newHostsSet {
 						hostRule.Hosts = append(hostRule.Hosts, host)
 					}
 
@@ -644,7 +646,6 @@ func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error
 
 		urlMap.Tests = newTests
 	}
-
 	op, err := config.clientCompute.UrlMaps.Update(project, urlMap.Name, urlMap).Do()
 
 	if err != nil {
@@ -683,4 +684,19 @@ func resourceComputeUrlMapDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	return nil
+}
+
+func validateHostRules(v interface{}, k string) (ws []string, es []error) {
+	pathMatchers := make(map[string]bool)
+	hostRules := v.([]interface{})
+	for _, hri := range hostRules {
+		hr := hri.(map[string]interface{})
+		pm := hr["path_matcher"].(string)
+		if pathMatchers[pm] {
+			es = append(es, fmt.Errorf("Multiple host_rule entries with the same path_matcher are not allowed. Please collapse all hosts with the same path_matcher into one host_rule"))
+			return
+		}
+		pathMatchers[pm] = true
+	}
+	return
 }


### PR DESCRIPTION
Using TypeSet allows host entries to be ordered arbitrarily in a manifest.

Acceptance test output:

```
❯ make testacc TEST=./builtin/providers/google GOOGLE_PROJECT=evandbrown17 GOOGLE_REGION=us-central1 TESTARGS='-
 run=TestAccComputeUrlMap'
 ==> Checking that code complies with gofmt requirements...
 /home/evanbrown/dev/golang/bin/stringer
 go generate $(go list ./... | grep -v /vendor/)
 2016/07/02 15:19:36 Generated command/internal_plugin_list.go
 TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeUrlMap -timeout 120m
 === RUN   TestAccComputeUrlMap_basic
 --- PASS: TestAccComputeUrlMap_basic (78.97s)
 === RUN   TestAccComputeUrlMap_update_path_matcher
 --- PASS: TestAccComputeUrlMap_update_path_matcher (158.01s)
 === RUN   TestAccComputeUrlMap_advanced
 --- PASS: TestAccComputeUrlMap_advanced (157.52s)
 PASS
 ok      github.com/hashicorp/terraform/builtin/providers/google 394.608s
```

The TypeList to TypeSet migration appears to happen automatically.