### PR TITLE
providers/google: Fix read for the backend service resource

### DIFF
--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -244,20 +244,21 @@ func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{
 		HealthChecks: healthChecks,
 	}
 
-	if d.HasChange("backend") {
-		service.Backends = expandBackends(d.Get("backend").(*schema.Set).List())
+	// Optional things
+	if v, ok := d.GetOk("backend"); ok {
+		service.Backends = expandBackends(v.(*schema.Set).List())
 	}
-	if d.HasChange("description") {
-		service.Description = d.Get("description").(string)
+	if v, ok := d.GetOk("description"); ok {
+		service.Description = v.(string)
 	}
-	if d.HasChange("port_name") {
-		service.PortName = d.Get("port_name").(string)
+	if v, ok := d.GetOk("port_name"); ok {
+		service.PortName = v.(string)
 	}
-	if d.HasChange("protocol") {
-		service.Protocol = d.Get("protocol").(string)
+	if v, ok := d.GetOk("protocol"); ok {
+		service.Protocol = v.(string)
 	}
-	if d.HasChange("timeout_sec") {
-		service.TimeoutSec = int64(d.Get("timeout_sec").(int))
+	if v, ok := d.GetOk("timeout_sec"); ok {
+		service.TimeoutSec = int64(v.(int))
 	}
 
 	log.Printf("[DEBUG] Updating existing Backend Service %q: %#v", d.Id(), service)

--- a/builtin/providers/google/resource_compute_backend_service_test.go
+++ b/builtin/providers/google/resource_compute_backend_service_test.go
@@ -46,7 +46,6 @@ func TestAccComputeBackendService_withBackend(t *testing.T) {
 	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -54,7 +53,7 @@ func TestAccComputeBackendService_withBackend(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeBackendService_withBackend(
-					serviceName, igName, itName, checkName),
+					serviceName, igName, itName, checkName, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeBackendServiceExists(
 						"google_compute_backend_service.lipsum", &svc),
@@ -65,6 +64,47 @@ func TestAccComputeBackendService_withBackend(t *testing.T) {
 
 	if svc.TimeoutSec != 10 {
 		t.Errorf("Expected TimeoutSec == 10, got %d", svc.TimeoutSec)
+	}
+	if svc.Protocol != "HTTP" {
+		t.Errorf("Expected Protocol to be HTTP, got %q", svc.Protocol)
+	}
+	if len(svc.Backends) != 1 {
+		t.Errorf("Expected 1 backend, got %d", len(svc.Backends))
+	}
+}
+
+func TestAccComputeBackendService_withBackendAndUpdate(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var svc compute.BackendService
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeBackendService_withBackend(
+					serviceName, igName, itName, checkName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.lipsum", &svc),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeBackendService_withBackend(
+					serviceName, igName, itName, checkName, 20),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.lipsum", &svc),
+				),
+			},
+		},
+	})
+
+	if svc.TimeoutSec != 20 {
+		t.Errorf("Expected TimeoutSec == 20, got %d", svc.TimeoutSec)
 	}
 	if svc.Protocol != "HTTP" {
 		t.Errorf("Expected Protocol to be HTTP, got %q", svc.Protocol)
@@ -161,14 +201,14 @@ resource "google_compute_http_health_check" "one" {
 }
 
 func testAccComputeBackendService_withBackend(
-	serviceName, igName, itName, checkName string) string {
+	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
   port_name   = "http"
   protocol    = "HTTP"
-  timeout_sec = 10
+  timeout_sec = %v
 
   backend {
     group = "${google_compute_instance_group_manager.foobar.instance_group}"
@@ -206,5 +246,5 @@ resource "google_compute_http_health_check" "default" {
   check_interval_sec = 1
   timeout_sec        = 1
 }
-`, serviceName, igName, itName, checkName)
+`, serviceName, timeout, igName, itName, checkName)
 }


### PR DESCRIPTION
This change fixes the backend service resource to correctly read its fields after an update, and adds a test to confirm this behavior.

Acceptance test output:

```
❯ make testacc TEST=./builtin/providers/google GOOGLE_PROJECT=evandbrown17 GOOGLE_REGION=us-central1 TESTARGS='-run=TestAccComputeBackendService'
==> Checking that code complies with gofmt requirements...
/home/evanbrown/dev/golang/bin/stringer
go generate $(go list ./... | grep -v /vendor/)
2016/07/02 23:36:51 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeBackendService -timeout 120m
=== RUN   TestAccComputeBackendService_basic
--- PASS: TestAccComputeBackendService_basic (80.41s)
=== RUN   TestAccComputeBackendService_withBackend
--- PASS: TestAccComputeBackendService_withBackend (140.34s)
=== RUN   TestAccComputeBackendService_withBackendAndUpdate
--- PASS: TestAccComputeBackendService_withBackendAndUpdate (155.42s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/google 376.276s
```