### PR TITLE
aws: AMI data source docs fixed

### DIFF
--- a/website/source/docs/providers/aws/d/ami.html.markdown
+++ b/website/source/docs/providers/aws/d/ami.html.markdown
@@ -31,22 +31,22 @@ data "aws_ami" "nat_ami" {
 
 ## Argument Reference
 
- * `most_recent` (optional): If more than one result is returned, use the most
+* `most_recent` - (Optional) If more than one result is returned, use the most
 recent AMI.
 
- * `executable_users`: Limit search to users with *explicit* launch permission on
+* `executable_users` - (Optional) Limit search to users with *explicit* launch permission on
  the image. Valid items are the numeric account ID or `self`.
 
-* `filter`: One or more name/value pairs to filter off of. There are
+* `filter` - (Optional) One or more name/value pairs to filter off of. There are
 several valid keys, for a full reference, check out
 [describe-images in the AWS CLI reference][1].
 
-* `owners`: Limit search to specific AMI owners. Valid items are the numeric
+* `owners` - (Optional) Limit search to specific AMI owners. Valid items are the numeric
 account ID, `amazon`, or `self`.
 
-~> **NOTE:** one of `executable_users`, `filter`, or `owners` must be specified.
+~> **NOTE:** At least one of `executable_users`, `filter`, or `owners` must be specified.
 
-~> **NOTE:** if more or less than a single match is returned by the search,
+~> **NOTE:** If more or less than a single match is returned by the search,
 Terraform will fail. Ensure that your search is specific enough to return
 a single AMI ID only, or use `most_recent` to choose the most recent one.
 
@@ -55,7 +55,7 @@ a single AMI ID only, or use `most_recent` to choose the most recent one.
 `id` is set to the ID of the found AMI. In addition, the following attributes
 are exported:
 
-~> **NOTE:** some values are not always set and may not be available for
+~> **NOTE:** Some values are not always set and may not be available for
 interpolation.
 
 * `architecture` - The OS architecture of the AMI (ie: `i368` or `x86_64`).


### PR DESCRIPTION
The extra spacing was causing the following formatting:

![screen shot 2016-07-05 at 10 38 41](https://cloud.githubusercontent.com/assets/287584/16580493/b1ec417c-429c-11e6-9aaa-1ce92a3efbfd.png)
