### PR TITLE
provider/aws: Only allow max. 1 health_check block for ELB

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -169,6 +169,7 @@ func resourceAwsElb() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"healthy_threshold": &schema.Schema{
@@ -590,9 +591,7 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("health_check") {
 		hc := d.Get("health_check").([]interface{})
-		if len(hc) > 1 {
-			return fmt.Errorf("Only one health check per ELB is supported")
-		} else if len(hc) > 0 {
+		if len(hc) > 0 {
 			check := hc[0].(map[string]interface{})
 			configureHealthCheckOpts := elb.ConfigureHealthCheckInput{
 				LoadBalancerName: aws.String(d.Id()),


### PR DESCRIPTION
#### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSELB'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSELB -timeout 120m
=== RUN   TestAccAWSELB_importBasic
--- PASS: TestAccAWSELB_importBasic (27.26s)
=== RUN   TestAccAWSELBAttachment_basic
--- PASS: TestAccAWSELBAttachment_basic (193.23s)
=== RUN   TestAccAWSELBAttachment_drift
--- PASS: TestAccAWSELBAttachment_drift (155.79s)
=== RUN   TestAccAWSELB_basic
--- PASS: TestAccAWSELB_basic (26.96s)
=== RUN   TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_fullCharacterRange (25.52s)
=== RUN   TestAccAWSELB_AccessLogs
--- PASS: TestAccAWSELB_AccessLogs (82.31s)
=== RUN   TestAccAWSELB_generatedName
--- PASS: TestAccAWSELB_generatedName (26.76s)
=== RUN   TestAccAWSELB_availabilityZones
--- PASS: TestAccAWSELB_availabilityZones (46.13s)
=== RUN   TestAccAWSELB_tags
--- PASS: TestAccAWSELB_tags (46.46s)
=== RUN   TestAccAWSELB_iam_server_cert
--- PASS: TestAccAWSELB_iam_server_cert (33.80s)
=== RUN   TestAccAWSELB_InstanceAttaching
--- PASS: TestAccAWSELB_InstanceAttaching (121.94s)
=== RUN   TestAccAWSELBUpdate_Listener
--- PASS: TestAccAWSELBUpdate_Listener (42.82s)
=== RUN   TestAccAWSELB_HealthCheck
--- PASS: TestAccAWSELB_HealthCheck (28.72s)
=== RUN   TestAccAWSELBUpdate_HealthCheck
--- PASS: TestAccAWSELBUpdate_HealthCheck (42.33s)
=== RUN   TestAccAWSELB_Timeout
--- PASS: TestAccAWSELB_Timeout (28.73s)
=== RUN   TestAccAWSELBUpdate_Timeout
--- PASS: TestAccAWSELBUpdate_Timeout (40.59s)
=== RUN   TestAccAWSELB_ConnectionDraining
--- PASS: TestAccAWSELB_ConnectionDraining (28.26s)
=== RUN   TestAccAWSELBUpdate_ConnectionDraining
--- PASS: TestAccAWSELBUpdate_ConnectionDraining (57.20s)
=== RUN   TestAccAWSELB_SecurityGroups
--- PASS: TestAccAWSELB_SecurityGroups (49.19s)
=== RUN   TestResourceAWSELB_validateElbNameCannotBeginWithHyphen
--- PASS: TestResourceAWSELB_validateElbNameCannotBeginWithHyphen (0.00s)
=== RUN   TestResourceAWSELB_validateElbNameCannotBeLongerThen32Characters
--- PASS: TestResourceAWSELB_validateElbNameCannotBeLongerThen32Characters (0.00s)
=== RUN   TestResourceAWSELB_validateElbNameCannotHaveSpecialCharacters
--- PASS: TestResourceAWSELB_validateElbNameCannotHaveSpecialCharacters (0.00s)
=== RUN   TestResourceAWSELB_validateElbNameCannotEndWithHyphen
--- PASS: TestResourceAWSELB_validateElbNameCannotEndWithHyphen (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1104.031s
```