### PR TITLE
Fix nested module "unknown variable" during dest

### DIFF
--- a/terraform/graph_config_node_variable.go
+++ b/terraform/graph_config_node_variable.go
@@ -130,6 +130,9 @@ func (n *GraphNodeConfigVariable) hasDestroyEdgeInPath(opts *NoopOpts, vertex da
 	if vertex == nil {
 		vertex = opts.Vertex
 	}
+
+	var root graphNodeRoot
+
 	log.Printf("[DEBUG] hasDestroyEdgeInPath: Looking for destroy edge: %s - %T", dag.VertexName(vertex), vertex)
 	for _, v := range opts.Graph.UpEdges(vertex).List() {
 		if len(opts.Graph.UpEdges(v).List()) > 1 {
@@ -137,10 +140,12 @@ func (n *GraphNodeConfigVariable) hasDestroyEdgeInPath(opts *NoopOpts, vertex da
 				return true
 			}
 		}
+
 		// Here we borrow the implementation of DestroyEdgeInclude, whose logic
-		// and semantics are exactly what we want here.
+		// and semantics are exactly what we want here. We add a check for the
+		// the root node, since we have to always depend on its existance.
 		if cv, ok := vertex.(*GraphNodeConfigVariableFlat); ok {
-			if cv.DestroyEdgeInclude(v) {
+			if v == root || cv.DestroyEdgeInclude(v) {
 				return true
 			}
 		}

--- a/terraform/graph_config_node_variable.go
+++ b/terraform/graph_config_node_variable.go
@@ -131,8 +131,6 @@ func (n *GraphNodeConfigVariable) hasDestroyEdgeInPath(opts *NoopOpts, vertex da
 		vertex = opts.Vertex
 	}
 
-	var root graphNodeRoot
-
 	log.Printf("[DEBUG] hasDestroyEdgeInPath: Looking for destroy edge: %s - %T", dag.VertexName(vertex), vertex)
 	for _, v := range opts.Graph.UpEdges(vertex).List() {
 		if len(opts.Graph.UpEdges(v).List()) > 1 {
@@ -145,7 +143,7 @@ func (n *GraphNodeConfigVariable) hasDestroyEdgeInPath(opts *NoopOpts, vertex da
 		// and semantics are exactly what we want here. We add a check for the
 		// the root node, since we have to always depend on its existance.
 		if cv, ok := vertex.(*GraphNodeConfigVariableFlat); ok {
-			if v == root || cv.DestroyEdgeInclude(v) {
+			if dag.VertexName(v) == rootNodeName || cv.DestroyEdgeInclude(v) {
 				return true
 			}
 		}

--- a/terraform/test-fixtures/apply-destroy-nested-module-with-attrs/middle/bottom/bottom.tf
+++ b/terraform/test-fixtures/apply-destroy-nested-module-with-attrs/middle/bottom/bottom.tf
@@ -1,0 +1,1 @@
+variable "bottom_param" {}

--- a/terraform/test-fixtures/apply-destroy-nested-module-with-attrs/middle/middle.tf
+++ b/terraform/test-fixtures/apply-destroy-nested-module-with-attrs/middle/middle.tf
@@ -1,0 +1,8 @@
+variable "param" {}
+
+resource "null_resource" "n" {}
+
+module "bottom" {
+  source       = "./bottom"
+  bottom_param = "${var.param}"
+}

--- a/terraform/test-fixtures/apply-destroy-nested-module-with-attrs/top.tf
+++ b/terraform/test-fixtures/apply-destroy-nested-module-with-attrs/top.tf
@@ -1,0 +1,4 @@
+module "middle" {
+  source = "./middle"
+  param  = "foo"
+}


### PR DESCRIPTION
During a destroy with nested modules, access a variable between them
causes an "unknown variable accessed" during destroy.