### PR TITLE
provider/aws: Support Import for `aws_api_gateway_key`

### DIFF
--- a/builtin/providers/aws/import_aws_api_gateway_key_test.go
+++ b/builtin/providers/aws/import_aws_api_gateway_key_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSAPIGatewayApiKey_importBasic(t *testing.T) {
+	resourceName := "aws_api_gateway_api_key.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayApiKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayApiKeyConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_api_gateway_api_key.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_api_key.go
@@ -18,6 +18,9 @@ func resourceAwsApiGatewayApiKey() *schema.Resource {
 		Read:   resourceAwsApiGatewayApiKeyRead,
 		Update: resourceAwsApiGatewayApiKeyUpdate,
 		Delete: resourceAwsApiGatewayApiKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -97,6 +100,7 @@ func resourceAwsApiGatewayApiKeyRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("name", apiKey.Name)
 	d.Set("description", apiKey.Description)
 	d.Set("enabled", apiKey.Enabled)
+	d.Set("stage_key", flattenApiGatewayStageKeys(apiKey.StageKeys))
 
 	return nil
 }

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -25,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -996,6 +999,21 @@ func flattenAsgEnabledMetrics(list []*autoscaling.EnabledMetric) []string {
 		}
 	}
 	return strs
+}
+
+func flattenApiGatewayStageKeys(keys []*string) []map[string]interface{} {
+	stageKeys := make([]map[string]interface{}, 0, len(keys))
+	log.Printf("[INFO] THERE %s", spew.Sdump(keys))
+	for _, o := range keys {
+		key := make(map[string]interface{})
+		parts := strings.Split(*o, "/")
+		key["stage_name"] = parts[1]
+		key["rest_api_id"] = parts[0]
+
+		stageKeys = append(stageKeys, key)
+	}
+	log.Printf("[INFO] HERE %s", spew.Sdump(stageKeys))
+	return stageKeys
 }
 
 func expandApiGatewayStageKeys(d *schema.ResourceData) []*apigateway.StageKey {

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -959,3 +959,34 @@ func TestFlattenApiGatewayThrottleSettings(t *testing.T) {
 		t.Fatalf("Expected 'rate_limit' to equal %f, got %f", expectedRateLimit, rateLimitFloat)
 	}
 }
+
+func TestFlattenApiGatewayStageKeys(t *testing.T) {
+	cases := []struct {
+		Input  []*string
+		Output []map[string]interface{}
+	}{
+		{
+			Input: []*string{
+				aws.String("a1b2c3d4e5/dev"),
+				aws.String("e5d4c3b2a1/test"),
+			},
+			Output: []map[string]interface{}{
+				map[string]interface{}{
+					"stage_name":  "dev",
+					"rest_api_id": "a1b2c3d4e5",
+				},
+				map[string]interface{}{
+					"stage_name":  "test",
+					"rest_api_id": "e5d4c3b2a1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenApiGatewayStageKeys(tc.Input)
+		if !reflect.DeepEqual(output, tc.Output) {
+			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
+		}
+	}
+}


### PR DESCRIPTION
Previously, the `stage_key` were not being set back to state in the Read
func. Changing this means the tests now run as follows:

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayApiKey_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSAPIGatewayApiKey_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayApiKey_importBasic
--- PASS: TestAccAWSAPIGatewayApiKey_importBasic (42.42s)
=== RUN   TestAccAWSAPIGatewayApiKey_basic
--- PASS: TestAccAWSAPIGatewayApiKey_basic (42.11s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    84.549s
```