### PR TITLE
provider/aws: Support Import `aws_cloudfront_origin_access_identity`

### DIFF
--- a/builtin/providers/aws/import_aws_cloudfront_origin_access_identity_test.go
+++ b/builtin/providers/aws/import_aws_cloudfront_origin_access_identity_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudFrontOriginAccessIdentity_importBasic(t *testing.T) {
+	resourceName := "aws_cloudfront_origin_access_identity.origin_access_identity"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudFrontOriginAccessIdentityConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				//ImportStateVerifyIgnore: []string{"enable_log_file_validation", "is_multi_region_trail", "include_global_service_events", "enable_logging"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_cloudfront_origin_access_identity.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_origin_access_identity.go
@@ -15,6 +15,9 @@ func resourceAwsCloudFrontOriginAccessIdentity() *schema.Resource {
 		Read:   resourceAwsCloudFrontOriginAccessIdentityRead,
 		Update: resourceAwsCloudFrontOriginAccessIdentityUpdate,
 		Delete: resourceAwsCloudFrontOriginAccessIdentityDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"comment": &schema.Schema{


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudFrontOriginAccessIdentity_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSCloudFrontOriginAccessIdentity_ -timeout 120m
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_importBasic
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_importBasic (17.07s)
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_basic
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_basic (15.34s)
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_noComment
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_noComment (16.29s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    48.717s
```