### PR TITLE
provider/docker: Add `destroy_grace_seconds` option to stop container before delete

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -285,6 +285,11 @@ func resourceDockerContainer() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"destroy_grace_seconds": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -265,6 +265,14 @@ func resourceDockerContainerUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceDockerContainerDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*dc.Client)
 
+	// Stop the container before removing if destroy_grace_seconds is defined
+	if d.Get("destroy_grace_seconds").(int) > 0 {
+		var timeout = uint(d.Get("destroy_grace_seconds").(int))
+		if err := client.StopContainer(d.Id(), timeout); err != nil {
+			return fmt.Errorf("Error stopping container %s: %s", d.Id(), err)
+		}
+	}
+
 	removeOpts := dc.RemoveContainerOptions{
 		ID:            d.Id(),
 		RemoveVolumes: true,

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -255,6 +255,7 @@ resource "docker_container" "foo" {
 	entrypoint = ["/bin/bash", "-c", "ping localhost"]
 	user = "root:root"
 	restart = "on-failure"
+	destroy_grace_seconds = 10
 	max_retry_count = 5
 	memory = 512
 	memory_swap = 2048

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -79,6 +79,7 @@ The following arguments are supported:
 * `network_mode` - (Optional, string) Network mode of the container.
 * `networks` - (Optional, set of strings) Id of the networks in which the
   container is.
+* `destroy_grace_seconds` - (Optional, int) If defined will attempt to stop the container before destroying. Container will be destroyed after `n` seconds or on successful stop.
 
 <a id="ports"></a>
 ### Ports


### PR DESCRIPTION
This PR adds an option for stopping containers before delete on destroy actions. This is useful for causing containers to execute graceful shutdown processes e.g. deregistration from Consul or alerting solutions, draining db nodes, etc. Takes an integer which defines the timeout of the [docker stop command](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/stop-a-container).