### PR TITLE
Update S3 notification documentation

### DIFF
--- a/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_notification.html.markdown
@@ -135,6 +135,72 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 }
 ```
 
+### Add multiple notification configurations to SQS Queue
+
+```
+resource "aws_sqs_queue" "queue" {
+    name = "s3-event-notification-queue"
+    policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+	  "Resource": "arn:aws:sqs:*:*:s3-event-notification-queue",
+      "Condition": {
+        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.bucket.arn}" }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "your_bucket_name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	queue {
+		id = "image-upload-event"
+		queue_arn = "${aws_sqs_queue.queue.arn}"
+		events = ["s3:ObjectCreated:*"]
+		filter_prefix = "images/"
+	}
+	queue {
+		id = "video-upload-event"
+		queue_arn = "${aws_sqs_queue.queue.arn}"
+		events = ["s3:ObjectCreated:*"]
+		filter_prefix = "videos/"
+	}
+}
+```
+
+For Terraform's [JSON syntax](https://www.terraform.io/docs/configuration/syntax.html), use an array instead of defining the `queue` key twice.
+
+```
+{
+	"bucket": "${aws_s3_bucket.bucket.id}",
+	"queue": [
+		{
+			"id": "image-upload-event",
+			"queue_arn": "${aws_sqs_queue.queue.arn}",
+			"events": ["s3:ObjectCreated:*"],
+			"filter_prefix": "images/"
+		},
+		{
+			"id": "video-upload-event",
+			"queue_arn": "${aws_sqs_queue.queue.arn}",
+			"events": ["s3:ObjectCreated:*"],
+			"filter_prefix": "videos/"
+		}
+	]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
When adding multiple notifications from one S3 bucket to one SQS queue, it wasn't immediately intuitive how to do this. At first I created two `aws_s3_bucket_notification` configs and it seemed to work fine, however the config for one event will overwrite the other. In order to have multiple events, you can defined the `queue` key twice, or use an array if you're working with the JSON syntax. I tried to make this more clear in the documentation.