### PR TITLE
provider/aws: Support Import `aws_rds_cluster_instance`

### DIFF
--- a/builtin/providers/aws/import_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/import_aws_rds_cluster_instance_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSRDSClusterInstance_importBasic(t *testing.T) {
+	resourceName := "aws_rds_cluster_instance.cluster_instances"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSClusterInstanceConfig(acctest.RandInt()),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -17,6 +17,9 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 		Read:   resourceAwsRDSClusterInstanceRead,
 		Update: resourceAwsRDSClusterInstanceUpdate,
 		Delete: resourceAwsRDSClusterInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"identifier": &schema.Schema{
@@ -185,9 +188,12 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Set("publicly_accessible", db.PubliclyAccessible)
+	d.Set("cluster_identifier", db.DBClusterIdentifier)
+	d.Set("instance_class", db.DBInstanceClass)
+	d.Set("identifier", db.DBInstanceIdentifier)
 
 	if len(db.DBParameterGroups) > 0 {
-		d.Set("parameter_group_name", db.DBParameterGroups[0].DBParameterGroupName)
+		d.Set("db_parameter_group_name", db.DBParameterGroups[0].DBParameterGroupName)
 	}
 
 	// Fetch and save tags


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSClusterInstance_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSClusterInstance_ -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_importBasic
--- PASS: TestAccAWSRDSClusterInstance_importBasic (1375.04s)
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (1053.18s)
=== RUN   TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSClusterInstance_disappears (1291.28s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	3719.519s
```