### PR TITLE
provider/aws: Beanstalk environments, bump the minimum timeout between API calls

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -249,7 +249,7 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 		Refresh:    environmentStateRefreshFunc(conn, d.Id()),
 		Timeout:    waitForReadyTimeOut,
 		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+                MinTimeout: 20 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
@@ -321,7 +321,7 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 		Refresh:    environmentStateRefreshFunc(conn, d.Id()),
 		Timeout:    waitForReadyTimeOut,
 		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+                MinTimeout: 20 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
@@ -567,7 +567,7 @@ func resourceAwsElasticBeanstalkEnvironmentDelete(d *schema.ResourceData, meta i
 		Refresh:    environmentStateRefreshFunc(conn, d.Id()),
 		Timeout:    waitForReadyTimeOut,
 		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+                MinTimeout: 20 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -263,6 +263,7 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 
 	pollInterval, err := time.ParseDuration(d.Get("poll_interval").(string))
 	if err != nil {
+		pollInterval = 0
 		log.Printf("[WARN] Error parsing poll_interval, using default backoff")
 	}
 
@@ -348,6 +349,7 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 		}
 		pollInterval, err := time.ParseDuration(d.Get("poll_interval").(string))
 		if err != nil {
+			pollInterval = 0
 			log.Printf("[WARN] Error parsing poll_interval, using default backoff")
 		}
 
@@ -600,6 +602,7 @@ func resourceAwsElasticBeanstalkEnvironmentDelete(d *schema.ResourceData, meta i
 	}
 	pollInterval, err := time.ParseDuration(d.Get("poll_interval").(string))
 	if err != nil {
+		pollInterval = 0
 		log.Printf("[WARN] Error parsing poll_interval, using default backoff")
 	}
 

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -146,7 +146,7 @@ func resourceAwsElasticBeanstalkEnvironment() *schema.Resource {
 					}
 					if duration < 10*time.Second || duration > 60*time.Second {
 						errors = append(errors, fmt.Errorf(
-							"%q must be between 10s and 60s", k))
+							"%q must be between 10s and 180s", k))
 					}
 					return
 				},

--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -26,6 +26,7 @@ type StateChangeConf struct {
 	Target         []string         // Target state
 	Timeout        time.Duration    // The amount of time to wait before timeout
 	MinTimeout     time.Duration    // Smallest time to wait before refreshes
+	PollInterval   time.Duration    // Override MinTimeout/backoff and only poll this often
 	NotFoundChecks int              // Number of times to allow not found
 
 	// This is to work around inconsistent APIs
@@ -72,14 +73,20 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 		time.Sleep(conf.Delay)
 
 		var err error
+		var wait time.Duration
 		for tries := 0; ; tries++ {
 			// Wait between refreshes using an exponential backoff
-			wait := time.Duration(math.Pow(2, float64(tries))) *
-				100 * time.Millisecond
-			if wait < conf.MinTimeout {
-				wait = conf.MinTimeout
-			} else if wait > 10*time.Second {
-				wait = 10 * time.Second
+			// If a poll interval has been specified, choose that interval
+			if conf.PollInterval > 0 && conf.PollInterval < 180*time.Second {
+				wait = conf.PollInterval
+			} else {
+				wait = time.Duration(math.Pow(2, float64(tries))) *
+					100 * time.Millisecond
+				if wait < conf.MinTimeout {
+					wait = conf.MinTimeout
+				} else if wait > 10*time.Second {
+					wait = 10 * time.Second
+				}
 			}
 
 			log.Printf("[TRACE] Waiting %s before next try", wait)

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -51,10 +51,13 @@ The following arguments are supported:
 off of. Example stacks can be found in the [Amazon API documentation][1]
 * `template_name` – (Optional) The name of the Elastic Beanstalk Configuration
   template to use in deployment
-* `wait_for_ready_timeout` - (Default: "10m") The maximum
+* `wait_for_ready_timeout` - (Default: `10m`) The maximum
   [duration](https://golang.org/pkg/time/#ParseDuration) that Terraform should
   wait for an Elastic Beanstalk Environment to be in a ready state before timing
   out.
+* `poll_interval` – (Default: `10s`) The time between polling the AWS API to
+check if changes have been applied. Use this to adjust the rate of API calls
+for any `create` or `update` action. Minimum `10s`, maximum `60s`
 * `tags` – (Optional) A set of tags to apply to the Environment. **Note:** at
 this time the Elastic Beanstalk API does not provide a programatic way of
 changing these tags after initial application

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -55,9 +55,10 @@ off of. Example stacks can be found in the [Amazon API documentation][1]
   [duration](https://golang.org/pkg/time/#ParseDuration) that Terraform should
   wait for an Elastic Beanstalk Environment to be in a ready state before timing
   out.
-* `poll_interval` – (Default: `10s`) The time between polling the AWS API to
+* `poll_interval` – The time between polling the AWS API to
 check if changes have been applied. Use this to adjust the rate of API calls
-for any `create` or `update` action. Minimum `10s`, maximum `60s`
+for any `create` or `update` action. Minimum `10s`, maximum `180s`. Omit this to
+use the default behavior, which is an exponential backoff
 * `tags` – (Optional) A set of tags to apply to the Environment. **Note:** at
 this time the Elastic Beanstalk API does not provide a programatic way of
 changing these tags after initial application


### PR DESCRIPTION
This is a band-aid to https://github.com/hashicorp/terraform/issues/6870. Beanstalk environments can take a long time to setup, and if you are managing many of them you can hit API rate limits for your account. 

A more permanent solution may be to expose a knob to set a customizable timeout / poll interval, but as I mention in #6870 the design of such a knob hasn't been planed out yet. 