### PR TITLE
Makefile: Support `make test` if Terraform itself is vendored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST?=$$(go list ./... | grep -v '/vendor/' | grep -v '/builtin/bins/')
+TEST?=$$(go list ./... | grep -v '/terraform/vendor/' | grep -v '/builtin/bins/')
 VETARGS?=-all
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
@@ -29,7 +29,8 @@ core-dev: generate
 
 # Shorthand for quickly testing the core of Terraform (i.e. "not providers")
 core-test: generate
-	@echo "Testing core packages..." && go test -tags 'core' $(TESTARGS) $(shell go list ./... | grep -v -E 'builtin|vendor')
+	@echo "Testing core packages..." && \
+		go test -tags 'core' $(TESTARGS) $(shell go list ./... | grep -v -E 'builtin|terraform/vendor')
 
 # Shorthand for building and installing just one plugin for local testing.
 # Run as (for example): make plugin-dev PLUGIN=provider-aws
@@ -79,7 +80,7 @@ generate:
 	@which stringer ; if [ $$? -ne 0 ]; then \
 	  go get -u golang.org/x/tools/cmd/stringer; \
 	fi
-	go generate $$(go list ./... | grep -v /vendor/)
+	go generate $$(go list ./... | grep -v /terraform/vendor/)
 	@go fmt command/internal_plugin_list.go > /dev/null
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ core-dev: generate
 # Shorthand for quickly testing the core of Terraform (i.e. "not providers")
 core-test: generate
 	@echo "Testing core packages..." && \
-		go test -tags 'core' $(TESTARGS) $(shell go list ./... | grep -v -E 'builtin|terraform/vendor')
+		go test -tags 'core' $(TESTARGS) $(shell go list ./... | grep -v -E 'terraform/(builtin|vendor)')
 
 # Shorthand for building and installing just one plugin for local testing.
 # Run as (for example): make plugin-dev PLUGIN=provider-aws


### PR DESCRIPTION
Just in case this is relevant to anyone else out there.

This assumes, of course, that nobody has Terraform cloned into a directory not named `terraform`.