### PR TITLE
core: Add list() interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -69,6 +69,7 @@ func Funcs() map[string]ast.Function {
 		"join":         interpolationFuncJoin(),
 		"jsonencode":   interpolationFuncJSONEncode(),
 		"length":       interpolationFuncLength(),
+		"list":         interpolationFuncList(),
 		"lower":        interpolationFuncLower(),
 		"md5":          interpolationFuncMd5(),
 		"uuid":         interpolationFuncUUID(),
@@ -80,6 +81,26 @@ func Funcs() map[string]ast.Function {
 		"split":        interpolationFuncSplit(),
 		"trimspace":    interpolationFuncTrimSpace(),
 		"upper":        interpolationFuncUpper(),
+	}
+}
+
+// interpolationFuncList creates a list from the parameters passed
+// to it.
+func interpolationFuncList() ast.Function {
+	return ast.Function{
+		ArgTypes:     []ast.Type{},
+		ReturnType:   ast.TypeList,
+		Variadic:     true,
+		VariadicType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			var outputList []string
+
+			for _, val := range args {
+				outputList = append(outputList, val.(string))
+			}
+
+			return stringSliceToVariableValue(outputList), nil
+		},
 	}
 }
 

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -258,10 +258,8 @@ func interpolationFuncCoalesce() ast.Function {
 	}
 }
 
-// interpolationFuncConcat implements the "concat" function that
-// concatenates multiple strings. This isn't actually necessary anymore
-// since our language supports string concat natively, but for backwards
-// compat we do this.
+// interpolationFuncConcat implements the "concat" function that concatenates
+// multiple lists.
 func interpolationFuncConcat() ast.Function {
 	return ast.Function{
 		ArgTypes:     []ast.Type{ast.TypeAny},
@@ -269,33 +267,42 @@ func interpolationFuncConcat() ast.Function {
 		Variadic:     true,
 		VariadicType: ast.TypeAny,
 		Callback: func(args []interface{}) (interface{}, error) {
-			var finalListElements []string
+			var outputList []ast.Variable
 
 			for _, arg := range args {
-				// Append strings for backward compatibility
-				if argument, ok := arg.(string); ok {
-					finalListElements = append(finalListElements, argument)
-					continue
-				}
-
-				// Otherwise variables
-				if argument, ok := arg.([]ast.Variable); ok {
-					for _, element := range argument {
-						t := element.Type
-						switch t {
+				switch arg := arg.(type) {
+				case string:
+					outputList = append(outputList, ast.Variable{Type: ast.TypeString, Value: arg})
+				case []ast.Variable:
+					for _, v := range arg {
+						switch v.Type {
 						case ast.TypeString:
-							finalListElements = append(finalListElements, element.Value.(string))
+							outputList = append(outputList, v)
+						case ast.TypeList:
+							outputList = append(outputList, v)
+						case ast.TypeMap:
+							outputList = append(outputList, v)
 						default:
-							return nil, fmt.Errorf("concat() does not support lists of %s", t.Printable())
+							return nil, fmt.Errorf("concat() does not support lists of %s", v.Type.Printable())
 						}
 					}
-					continue
-				}
 
-				return nil, fmt.Errorf("arguments to concat() must be a string or list of strings")
+				default:
+					return nil, fmt.Errorf("concat() does not support %T", arg)
+				}
 			}
 
-			return stringSliceToVariableValue(finalListElements), nil
+			// we don't support heterogeneous types, so make sure all types match the first
+			if len(outputList) > 0 {
+				firstType := outputList[0].Type
+				for _, v := range outputList[1:] {
+					if v.Type != firstType {
+						return nil, fmt.Errorf("unexpected %s in list of %s", v.Type.Printable(), firstType.Printable())
+					}
+				}
+			}
+
+			return outputList, nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -38,7 +38,28 @@ func TestInterpolateFuncList(t *testing.T) {
 
 			// not a string input gives error
 			{
-				`${list("hello", "${var.list}")}`,
+				`${list("hello", 42)}`,
+				nil,
+				true,
+			},
+
+			// list of lists
+			{
+				`${list("${var.list}", "${var.list2}")}`,
+				[]interface{}{[]interface{}{"Hello", "World"}, []interface{}{"bar", "baz"}},
+				false,
+			},
+
+			// list of maps
+			{
+				`${list("${var.map}", "${var.map2}")}`,
+				[]interface{}{map[string]interface{}{"key": "bar"}, map[string]interface{}{"key2": "baz"}},
+				false,
+			},
+
+			// error on a heterogeneous list
+			{
+				`${list("first", "${var.list}")}`,
 				nil,
 				true,
 			},
@@ -54,6 +75,38 @@ func TestInterpolateFuncList(t *testing.T) {
 					{
 						Type:  ast.TypeString,
 						Value: "World",
+					},
+				},
+			},
+			"var.list2": {
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type:  ast.TypeString,
+						Value: "bar",
+					},
+					{
+						Type:  ast.TypeString,
+						Value: "baz",
+					},
+				},
+			},
+
+			"var.map": {
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"key": {
+						Type:  ast.TypeString,
+						Value: "bar",
+					},
+				},
+			},
+			"var.map2": {
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"key2": {
+						Type:  ast.TypeString,
+						Value: "baz",
 					},
 				},
 			},

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -12,6 +12,55 @@ import (
 	"github.com/hashicorp/hil/ast"
 )
 
+func TestInterpolateFuncList(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			// empty input returns empty list
+			{
+				`${list()}`,
+				[]interface{}{},
+				false,
+			},
+
+			// single input returns list of length 1
+			{
+				`${list("hello")}`,
+				[]interface{}{"hello"},
+				false,
+			},
+
+			// two inputs returns list of length 2
+			{
+				`${list("hello", "world")}`,
+				[]interface{}{"hello", "world"},
+				false,
+			},
+
+			// not a string input gives error
+			{
+				`${list("hello", "${var.list}")}`,
+				nil,
+				true,
+			},
+		},
+		Vars: map[string]ast.Variable{
+			"var.list": {
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type:  ast.TypeString,
+						Value: "Hello",
+					},
+					{
+						Type:  ast.TypeString,
+						Value: "World",
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncCompact(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -168,6 +168,11 @@ The supported built-in functions are:
       * `${length(split(",", "a,b,c"))}` = 3
       * `${length("a,b,c")}` = 5
 
+  * `list(items...)` - Returns a list consisting of the arguments to the function.
+      This function provides a way of representing list literals in interpolation.
+      * `${list("a", "b", "c")}` returns a list of `"a", "b", "c"`.
+      * `${list()}` returns an empty list.
+ 
   * `lookup(map, key [, default])` - Performs a dynamic lookup into a mapping
       variable. The `map` parameter should be another variable, such
       as `var.amis`. If `key` does not exist in `map`, the interpolation will

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -172,7 +172,7 @@ The supported built-in functions are:
       This function provides a way of representing list literals in interpolation.
       * `${list("a", "b", "c")}` returns a list of `"a", "b", "c"`.
       * `${list()}` returns an empty list.
- 
+
   * `lookup(map, key [, default])` - Performs a dynamic lookup into a mapping
       variable. The `map` parameter should be another variable, such
       as `var.amis`. If `key` does not exist in `map`, the interpolation will


### PR DESCRIPTION
The list() interpolation function provides a way to add support for list literals to HIL without having to invent new syntax for it and modify the HIL parser.

It presents as a function, thus:

    - list() -> []
    - list("a") -> ["a"]
    - list("a", "b") -> ["a", "b"]

Thanks to @wr0ngway for the idea of this approach, fixes #7460.

Assuming this is the route we wish to follow, we should make it work with types other than strings - the initial quick implementation is to get a feel for using a function rather than syntax.

cc @phinze, @mitchellh, @jbardin