### PR TITLE
provider/aws: Remove `aws_codedeploy_deployment_group` from state on 404

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -238,6 +238,12 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 		DeploymentGroupName: aws.String(d.Get("deployment_group_name").(string)),
 	})
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "DeploymentGroupDoesNotExistException" {
+			log.Printf("[INFO] CodeDeployment DeploymentGroup %s not found", d.Get("deployment_group_name").(string))
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Fixes #4802

The manual removal will now force Terraform to remove the resource from
state and then report it needs recreated

```
% make testacc TEST=./builtin/providers/aws TESTARGS ='- run=TestAccAWSCodeDeployDeploymentGroup_'             
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCodeDeployDeploymentGroup_ -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (49.14s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (33.49s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_disappears
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (45.27s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (45.49s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (49.16s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	222.580s
```