### PR TITLE
[docs] Clarify 'join' produces a string

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -152,7 +152,7 @@ The supported built-in functions are:
   * `index(list, elem)` - Finds the index of a given element in a list. Example:
       `index(aws_instance.foo.*.tags.Name, "foo-test")`
 
-  * `join(delim, list)` - Joins the list with the delimiter. A list is
+  * `join(delim, list)` - Joins the list with the delimiter for a resultant string. A list is
       only possible with splat variables from resources with a count
       greater than one. Example: `join(",", aws_instance.foo.*.id)`
 


### PR DESCRIPTION
It's not clear that join produces a string and not a list - after reading all the available functions "concat" produces a list and that is properly noted. 

