### PR TITLE
Allow empty names in aws_route53_record

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -695,7 +695,11 @@ func expandRecordName(name, zone string) string {
 	rn := strings.ToLower(strings.TrimSuffix(name, "."))
 	zone = strings.TrimSuffix(zone, ".")
 	if !strings.HasSuffix(rn, zone) {
-		rn = strings.Join([]string{name, zone}, ".")
+		if len(name) == 0 {
+			rn = zone
+		} else {
+			rn = strings.Join([]string{name, zone}, ".")
+		}
 	}
 	return rn
 }

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -339,6 +339,23 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Record_empty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_route53_record.empty",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRoute53RecordConfigEmptyName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.empty"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).r53conn
 	for _, rs := range s.RootModule().Resources {

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -972,3 +972,17 @@ resource "aws_route53_record" "sample" {
   records = ["127.0.0.1", "8.8.8.8"]
 }
 `
+
+const testAccRoute53RecordConfigEmptyName = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_record" "empty" {
+	zone_id = "${aws_route53_zone.main.zone_id}"
+	name = ""
+	type = "A"
+	ttl = "30"
+	records = ["127.0.0.1"]
+}
+`

--- a/builtin/providers/aws/resource_aws_route53_record_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_test.go
@@ -992,7 +992,7 @@ resource "aws_route53_record" "sample" {
 
 const testAccRoute53RecordConfigEmptyName = `
 resource "aws_route53_zone" "main" {
-	name = "notexample.com"
+	name = "not.example.com"
 }
 
 resource "aws_route53_record" "empty" {


### PR DESCRIPTION
Empty names are supported by DNS and AWS, but do not work, because in terraform they result in `.zone` instead of only `zone`.