### PR TITLE
provider/aws: Support Import of `aws_db_instance`

### DIFF
--- a/builtin/providers/aws/import_aws_db_instance_test.go
+++ b/builtin/providers/aws/import_aws_db_instance_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDBInstance_importBasic(t *testing.T) {
+	resourceName := "aws_db_instance.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBInstanceConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password", "skip_final_snapshot"},
+			},
+		},
+	})
+}


### PR DESCRIPTION

    Just needed some rejigging of the skip_final_snapshot work as that isn't
    returned by the API and skipping it means the destroy fails due to
    missing final_snapshot_identifier

    ```
    % make testacc TEST=./builtin/providers/aws
    % TESTARGS='-run=TestAccAWSDBInstance_'                              
    ==> Checking that code complies with gofmt requirements...
    /Users/stacko/Code/go/bin/stringer
    go generate $(go list ./... | grep -v /vendor/)
    2016/07/07 15:28:31 Generated command/internal_plugin_list.go
    TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBInstance_
    -timeout 120m
    === RUN   TestAccAWSDBInstance_importBasic
    --- PASS: TestAccAWSDBInstance_importBasic (588.70s)
    === RUN   TestAccAWSDBInstance_basic
    --- PASS: TestAccAWSDBInstance_basic (595.71s)
    === RUN   TestAccAWSDBInstance_kmsKey
    --- PASS: TestAccAWSDBInstance_kmsKey (726.46s)
    === RUN   TestAccAWSDBInstance_optionGroup
    --- PASS: TestAccAWSDBInstance_optionGroup (681.78s)
    === RUN   TestAccAWSDBInstance_iops_update
    --- PASS: TestAccAWSDBInstance_iops_update
    (590.81s)
    ```

    Please note that I cannot run the enhanced monitoring test in my
    environment as I have already got it attached to an IAM role. Running
    that test gives me this result:

    * aws_iam_role.enhanced_policy_role: Error creating IAM Role enhanced-monitoring-role:        EntityAlreadyExists: Role with name enhanced-monitoring-role already exists.