### PR TITLE
provider/aws: Support Import `aws_sqs_queue`

### DIFF
--- a/builtin/providers/aws/import_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/import_aws_sqs_queue_test.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSQSQueue_importBasic(t *testing.T) {
+	resourceName := "aws_sqs_queue.queue-with-defaults"
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSQSConfigWithDefaults(queueName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				//The name is never returned after the initial create of the queue.
+				//It is part of the URL and can be split down if needed
+				//ImportStateVerifyIgnore: []string{"name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -34,6 +37,9 @@ func resourceAwsSqsQueue() *schema.Resource {
 		Read:   resourceAwsSqsQueueRead,
 		Update: resourceAwsSqsQueueUpdate,
 		Delete: resourceAwsSqsQueueDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -189,6 +195,12 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	name, err := extractNameFromSqsQueueUrl(d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("name", name)
+
 	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
 		attrmap := attributeOutput.Attributes
 		resource := *resourceAwsSqsQueue()
@@ -224,4 +236,19 @@ func resourceAwsSqsQueueDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	return nil
+}
+
+func extractNameFromSqsQueueUrl(queue string) (string, error) {
+	//http://sqs.us-west-2.amazonaws.com/123456789012/queueName
+	u, err := url.Parse(queue)
+	if err != nil {
+		return "", err
+	}
+	segments := strings.Split(u.Path, "/")
+	if len(segments) != 3 {
+		return "", fmt.Errorf("SQS Url not parsed correctly")
+	}
+
+	return segments[2], nil
+
 }

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -13,13 +13,14 @@ import (
 )
 
 func TestAccAWSSQSQueue_basic(t *testing.T) {
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSSQSConfigWithDefaults,
+				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue-with-defaults"),
 				),
@@ -194,11 +195,13 @@ func testAccCheckAWSSQSExistsWithOverrides(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccAWSSQSConfigWithDefaults = `
+func testAccAWSSQSConfigWithDefaults(r string) string {
+	return fmt.Sprintf(`
 resource "aws_sqs_queue" "queue-with-defaults" {
-    name = "test-sqs-queue-with-defaults"
+    name = "%s"
 }
-`
+`, r)
+}
 
 const testAccAWSSQSConfigWithOverrides = `
 resource "aws_sqs_queue" "queue-with-overrides" {


### PR DESCRIPTION
Needed to change the test due to SQS having issues recreating the same
queue multiple times. Now it uses a random name

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSQSQueue_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSQSQueue_
-timeout 120m
=== RUN   TestAccAWSSQSQueue_importBasic
--- PASS: TestAccAWSSQSQueue_importBasic (20.53s)
=== RUN   TestAccAWSSQSQueue_basic
--- PASS: TestAccAWSSQSQueue_basic (33.85s)
=== RUN   TestAccAWSSQSQueue_redrivePolicy
--- PASS: TestAccAWSSQSQueue_redrivePolicy (26.59s)
=== RUN   TestAccAWSSQSQueue_Policybasic
--- PASS: TestAccAWSSQSQueue_Policybasic (36.92s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    117.908s
```