### PR TITLE
provider/aws: Support Import of `aws_ses_receipt_rule_set`

### DIFF
--- a/builtin/providers/aws/import_aws_ses_receipt_rule_set_test.go
+++ b/builtin/providers/aws/import_aws_ses_receipt_rule_set_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSESReceiptRuleSet_importBasic(t *testing.T) {
+	resourceName := "aws_ses_receipt_rule_set.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESReceiptRuleSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSESReceiptRuleSetConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_ses_receipt_rule_set.go
+++ b/builtin/providers/aws/resource_aws_ses_receipt_rule_set.go
@@ -14,6 +14,9 @@ func resourceAwsSesReceiptRuleSet() *schema.Resource {
 		Create: resourceAwsSesReceiptRuleSetCreate,
 		Read:   resourceAwsSesReceiptRuleSetRead,
 		Delete: resourceAwsSesReceiptRuleSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"rule_set_name": &schema.Schema{
@@ -50,11 +53,14 @@ func resourceAwsSesReceiptRuleSetRead(d *schema.ResourceData, meta interface{}) 
 	if !ruleSetExists {
 		log.Printf("[WARN] SES Receipt Rule Set (%s) not found", d.Id())
 		d.SetId("")
+		return nil
 	}
 
 	if err != nil {
 		return err
 	}
+
+	d.Set("rule_set_name", d.Id())
 
 	return nil
 }


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSESReceiptRuleSet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSSESReceiptRuleSet_ -timeout 120m
=== RUN   TestAccAWSSESReceiptRuleSet_importBasic
--- PASS: TestAccAWSSESReceiptRuleSet_importBasic (18.60s)
=== RUN   TestAccAWSSESReceiptRuleSet_basic
--- PASS: TestAccAWSSESReceiptRuleSet_basic (26.92s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    45.550s
```