### PR TITLE
provider/aws: Support Import of `aws_ses_receipt_filter`

### DIFF
--- a/builtin/providers/aws/import_aws_ses_receipt_filter_test.go
+++ b/builtin/providers/aws/import_aws_ses_receipt_filter_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSESReceiptFilter_importBasic(t *testing.T) {
+	resourceName := "aws_ses_receipt_filter.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESReceiptFilterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSESReceiptFilterConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_ses_receipt_filter.go
+++ b/builtin/providers/aws/resource_aws_ses_receipt_filter.go
@@ -14,6 +14,9 @@ func resourceAwsSesReceiptFilter() *schema.Resource {
 		Create: resourceAwsSesReceiptFilterCreate,
 		Read:   resourceAwsSesReceiptFilterRead,
 		Delete: resourceAwsSesReceiptFilterDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -77,6 +80,7 @@ func resourceAwsSesReceiptFilterRead(d *schema.ResourceData, meta interface{}) e
 		if *element.Name == d.Id() {
 			d.Set("cidr", element.IpFilter.Cidr)
 			d.Set("policy", element.IpFilter.Policy)
+			d.Set("name", element.Name)
 			found = true
 		}
 	}


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws  TESTARGS='-run=TestAccAWSSESReceiptFilter_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSSESReceiptFilter_ -timeout 120m
=== RUN   TestAccAWSSESReceiptFilter_importBasic
--- PASS: TestAccAWSSESReceiptFilter_importBasic (18.18s)
=== RUN   TestAccAWSSESReceiptFilter_basic
--- PASS: TestAccAWSSESReceiptFilter_basic (18.42s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    36.633s
```