### PR TITLE
provider/aws: Support Import of `aws_redshift_cluster`

### DIFF
--- a/builtin/providers/aws/import_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/import_aws_redshift_cluster_test.go
@@ -1,0 +1,32 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSRedshiftCluster_importBasic(t *testing.T) {
+	resourceName := "aws_redshift_cluster.default"
+	config := fmt.Sprintf(testAccAWSRedshiftClusterConfig_basic, acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"master_password", "skip_final_snapshot"},
+			},
+		},
+	})
+}


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftCluster_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSRedshiftCluster_importBasic -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_importBasic
--- PASS: TestAccAWSRedshiftCluster_importBasic (623.52s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    623.546s
```