### PR TITLE
Extend state backend http with HTTP headers

### DIFF
--- a/state/remote/http.go
+++ b/state/remote/http.go
@@ -60,8 +60,8 @@ func httpFactory(conf map[string]string) (Client, error) {
 	}
 
 	return &HTTPClient{
-		URL:    url,
-		Client: client,
+		URL:     url,
+		Client:  client,
 		Headers: headers,
 	}, nil
 }
@@ -74,7 +74,14 @@ type HTTPClient struct {
 }
 
 func (c *HTTPClient) Get() (*Payload, error) {
-	resp, err := c.Client.Get(c.URL.String())
+	req, err := http.NewRequest("GET", c.URL.String(), nil)
+
+	// Prepare the request
+	for headerKey, headerValue := range c.Headers {
+		req.Header.Set(headerKey, headerValue)
+	}
+
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +162,9 @@ func (c *HTTPClient) Put(data []byte) error {
 	}
 
 	// Prepare the request
-	for headerKey, headerValue := range c.Headers { req.Header.Set(headerKey, headerValue) }
+	for headerKey, headerValue := range c.Headers {
+		req.Header.Set(headerKey, headerValue)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-MD5", b64)
 
@@ -181,6 +190,11 @@ func (c *HTTPClient) Delete() error {
 	req, err := http.NewRequest("DELETE", c.URL.String(), nil)
 	if err != nil {
 		return fmt.Errorf("Failed to make HTTP request: %s", err)
+	}
+
+	// Prepare the request
+	for headerKey, headerValue := range c.Headers {
+		req.Header.Set(headerKey, headerValue)
 	}
 
 	// Make the request

--- a/website/source/docs/state/remote/http.html.md
+++ b/website/source/docs/state/remote/http.html.md
@@ -19,6 +19,14 @@ terraform remote config \
 	-backend=http \
 	-backend-config="address=http://my.rest.api.com"
 ```
+## Example Usage with Headers (Optional)
+
+```
+terraform remote config \
+	-backend=http \
+	-backend-config="address=http://my.rest.api.com" \
+	-backend-config="headers=X-HEADER:myValue,X-ANOTHER:myValue"
+```
 
 ## Example Referencing
 
@@ -36,5 +44,6 @@ resource "terraform_remote_state" "foo" {
 The following configuration options are supported:
 
  * `address` - (Required) The address of the REST endpoint
+ * `headers` - (Optional) Add headers in the form of `key1:value1,key2:value2,...`
  * `skip_cert_verification` - (Optional) Whether to skip TLS verification.
    Defaults to `false`.


### PR DESCRIPTION
This code allows one to set a new `headers` option for the `http` state backend. This allows http state providers to provide stronger authentication (or other features!). On the command line:

``` bash
terraform remote config \
    -backend=http \
    -backend-config="address=http://my.rest.api.com" \
    -backend-config="headers=X-HEADER:myValue,X-ANOTHER:myValue"
```
