### PR TITLE
core: Allow use of computed values in maps

### DIFF
--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1355,3 +1355,19 @@ aws_instance.foo:
   ID = bar
   ami = ami-abcd1234
 `
+
+const testTerraformPlanComputedValueInMap = `
+DIFF:
+
+CREATE: aws_computed_source.intermediates
+  computed_read_only: "" => "<computed>"
+
+module.test_mod:
+  CREATE: aws_instance.inner2
+    looked_up: "" => "<computed>"
+    type:      "" => "aws_instance"
+
+STATE:
+
+<no state>
+`

--- a/terraform/test-fixtures/plan-computed-value-in-map/main.tf
+++ b/terraform/test-fixtures/plan-computed-value-in-map/main.tf
@@ -1,0 +1,15 @@
+resource "aws_computed_source" "intermediates" {}
+
+module "test_mod" {
+  source = "./mod"
+
+  services {
+    "exists" = "true"
+    "elb" = "${aws_computed_source.intermediates.computed_read_only}"
+  }
+
+  services {
+    "otherexists" = " true"
+    "elb" = "${aws_computed_source.intermediates.computed_read_only}"
+  }
+}

--- a/terraform/test-fixtures/plan-computed-value-in-map/mod/main.tf
+++ b/terraform/test-fixtures/plan-computed-value-in-map/mod/main.tf
@@ -1,0 +1,8 @@
+variable "services" {
+  type = "list"
+}
+
+resource "aws_instance" "inner2" {
+  looked_up = "${lookup(var.services[0], "elb")}"
+}
+


### PR DESCRIPTION
This pull-request is the (long-awaited!) reproduction and fix for #7241. The commit messages contain far more detail, but the TL;DR on the fix is that UnknownVariableValue must be set for specific map keys regardless of where in the variable structure they appear, rather than just at the top level in EvalVariableBlock.

cc @phinze.