### PR TITLE
Remove redundant const from command package

### DIFF
--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -466,7 +466,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 	defer func() { test = true }()
 	tmp, cwd := testCwd(t)
 	defer testFixCwd(t, tmp, cwd)
-	remoteStatePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	remoteStatePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(remoteStatePath), 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -10,9 +10,6 @@ import (
 // Set to true when we're testing
 var test bool = false
 
-// DefaultDataDir is the default directory for storing local data.
-const DefaultDataDir = ".terraform"
-
 // DefaultStateFilename is the default filename used for the state file.
 const DefaultStateFilename = "terraform.tfstate"
 
@@ -22,8 +19,8 @@ const DefaultVarsFilename = "terraform.tfvars"
 // DefaultBackupExtension is added to the state file to form the path
 const DefaultBackupExtension = ".backup"
 
-// DefaultDataDirectory is the directory where local state is stored
-// by default.
+// DefaultDataDirectory is the directory where local state and data is
+// stored by default.
 const DefaultDataDirectory = ".terraform"
 
 // DefaultParallelism is the limit Terraform places on total parallel

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -169,7 +169,7 @@ func testStateFileDefault(t *testing.T, s *terraform.State) string {
 // testStateFileRemote writes the state out to the remote statefile
 // in the cwd. Use `testCwd` to change into a temp cwd.
 func testStateFileRemote(t *testing.T, s *terraform.State) string {
-	path := filepath.Join(DefaultDataDir, DefaultStateFilename)
+	path := filepath.Join(DefaultDataDirectory, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -174,7 +174,7 @@ func TestInit_remoteState(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)); err != nil {
+	if _, err := os.Stat(filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)); err != nil {
 		t.Fatalf("missing state: %s", err)
 	}
 }
@@ -210,7 +210,7 @@ func TestInit_remoteStateSubdir(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(subdir, DefaultDataDir, DefaultStateFilename)); err != nil {
+	if _, err := os.Stat(filepath.Join(subdir, DefaultDataDirectory, DefaultStateFilename)); err != nil {
 		t.Fatalf("missing state: %s", err)
 	}
 }
@@ -254,7 +254,7 @@ func TestInit_remoteStateWithRemote(t *testing.T) {
 	tmp, cwd := testCwd(t)
 	defer testFixCwd(t, tmp, cwd)
 
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(statePath), 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/push.go
+++ b/command/push.go
@@ -160,7 +160,7 @@ func (c *PushCommand) Run(args []string) int {
 	archiveOpts := &archive.ArchiveOpts{
 		VCS: archiveVCS,
 		Extra: map[string]string{
-			DefaultDataDir: c.DataDir(),
+			DefaultDataDirectory: c.DataDir(),
 		},
 	}
 	if !moduleUpload {

--- a/command/remote_config_test.go
+++ b/command/remote_config_test.go
@@ -29,7 +29,7 @@ func TestRemoteConfig_disable(t *testing.T) {
 	s.Remote = conf
 
 	// Write the state
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	state := &state.LocalState{Path: statePath}
 	if err := state.WriteState(s); err != nil {
 		t.Fatalf("err: %s", err)
@@ -84,7 +84,7 @@ func TestRemoteConfig_disable_noPull(t *testing.T) {
 	s.Remote = conf
 
 	// Write the state
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	state := &state.LocalState{Path: statePath}
 	if err := state.WriteState(s); err != nil {
 		t.Fatalf("err: %s", err)
@@ -150,7 +150,7 @@ func TestRemoteConfig_disable_otherState(t *testing.T) {
 	s.Serial = 5
 
 	// Write the state
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	state := &state.LocalState{Path: statePath}
 	if err := state.WriteState(s); err != nil {
 		t.Fatalf("err: %s", err)
@@ -194,7 +194,7 @@ func TestRemoteConfig_managedAndNonManaged(t *testing.T) {
 	s.Serial = 5
 
 	// Write the state
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	state := &state.LocalState{Path: statePath}
 	if err := state.WriteState(s); err != nil {
 		t.Fatalf("err: %s", err)
@@ -251,7 +251,7 @@ func TestRemoteConfig_initBlank(t *testing.T) {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 
-	remotePath := filepath.Join(DefaultDataDir, DefaultStateFilename)
+	remotePath := filepath.Join(DefaultDataDirectory, DefaultStateFilename)
 	ls := &state.LocalState{Path: remotePath}
 	if err := ls.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
@@ -301,7 +301,7 @@ func TestRemoteConfig_updateRemote(t *testing.T) {
 	}
 
 	// Write the state
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	ls := &state.LocalState{Path: statePath}
 	if err := ls.WriteState(s); err != nil {
 		t.Fatalf("err: %s", err)
@@ -328,7 +328,7 @@ func TestRemoteConfig_updateRemote(t *testing.T) {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 
-	remotePath := filepath.Join(DefaultDataDir, DefaultStateFilename)
+	remotePath := filepath.Join(DefaultDataDirectory, DefaultStateFilename)
 	ls = &state.LocalState{Path: remotePath}
 	if err := ls.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
@@ -384,7 +384,7 @@ func TestRemoteConfig_enableRemote(t *testing.T) {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 
-	remotePath := filepath.Join(DefaultDataDir, DefaultStateFilename)
+	remotePath := filepath.Join(DefaultDataDirectory, DefaultStateFilename)
 	ls := &state.LocalState{Path: remotePath}
 	if err := ls.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
@@ -434,7 +434,7 @@ func testRemoteLocalBackup(t *testing.T, exists bool) {
 }
 
 func testRemoteLocalCache(t *testing.T, exists bool) {
-	_, err := os.Stat(filepath.Join(DefaultDataDir, DefaultStateFilename))
+	_, err := os.Stat(filepath.Join(DefaultDataDirectory, DefaultStateFilename))
 	if os.IsNotExist(err) && !exists {
 		return
 	}

--- a/command/remote_pull_test.go
+++ b/command/remote_pull_test.go
@@ -47,7 +47,7 @@ func TestRemotePull_local(t *testing.T) {
 	defer srv.Close()
 
 	// Store the local state
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(statePath), 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/remote_push_test.go
+++ b/command/remote_push_test.go
@@ -41,7 +41,7 @@ func TestRemotePush_local(t *testing.T) {
 	s.Remote = conf
 
 	// Store the local state
-	statePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	statePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(statePath), 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -130,7 +130,7 @@ func TestShow_noArgsRemoteState(t *testing.T) {
 	defer testFixCwd(t, tmp, cwd)
 
 	// Pretend like we have a local cache of remote state
-	remoteStatePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
+	remoteStatePath := filepath.Join(tmp, DefaultDataDirectory, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(remoteStatePath), 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/state.go
+++ b/command/state.go
@@ -179,7 +179,7 @@ func StateFromPlan(
 
 		// It looks like we have a remote state in the plan, so
 		// we have to initialize that.
-		resultPath = filepath.Join(DefaultDataDir, DefaultStateFilename)
+		resultPath = filepath.Join(DefaultDataDirectory, DefaultStateFilename)
 		result, err = remoteState(plan.State, resultPath, false)
 		if err != nil {
 			return nil, "", err


### PR DESCRIPTION
Replace usages of DefaultDataDir with the equivalent DefaultDataDirectory
Remove now unused DefaultDataDir const