### PR TITLE
aws/docs: Fix Elastic Transcoder docs

### DIFF
--- a/website/source/docs/providers/aws/r/elastic_transcoder_pipeline.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_transcoder_pipeline.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_elastictranscoder_pipeline"
-sidebar_current: "docs-aws-resource-elastic-transcoder"
+sidebar_current: "docs-aws-resource-elastic-transcoder-pipeline"
 description: |-
   Provides an Elastic Transcoder pipeline resource.
 ---
@@ -11,8 +11,6 @@ description: |-
 Provides an Elastic Transcoder pipeline resource.
 
 ## Example Usage
-
-### Elastic Transcoder Pipeline
 
 ```
 resource "aws_elastictranscoder_pipeline" "bar" {
@@ -34,7 +32,7 @@ resource "aws_elastictranscoder_pipeline" "bar" {
 
 ## Argument Reference
 
-See ["Create Pipeline"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-pipeline.html) in the AWS docs for reference. 
+See ["Create Pipeline"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-pipeline.html) in the AWS docs for reference.
 
 The following arguments are supported:
 
@@ -54,7 +52,7 @@ which you want Elastic Transcoder to save transcoded files and playlists: which
 bucket to use, and the storage class that you want to assign to the files. If
 you specify values for `content_config`, you must also specify values for
 `thumbnail_config`. If you specify values for `content_config` and
-`thumbnail_config`, omit the `output_bucket` object. 
+`thumbnail_config`, omit the `output_bucket` object.
 
 The `content_config` object supports the following:
 

--- a/website/source/docs/providers/aws/r/elastic_transcoder_preset.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_transcoder_preset.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_elastictranscoder_preset"
-sidebar_current: "docs-aws-resource-elastic-transcoder"
+sidebar_current: "docs-aws-resource-elastic-transcoder-preset"
 description: |-
   Provides an Elastic Transcoder preset resource.
 ---
@@ -11,8 +11,6 @@ description: |-
 Provides an Elastic Transcoder preset resource.
 
 ## Example Usage
-
-### Elastic Transcoder Preset
 
 ```
 resource "aws_elastictranscoder_preset" "bar" {

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -376,11 +376,11 @@
                     <ul class="nav nav-visible">
 
                         <li<%= sidebar_current("docs-aws-resource-elastic-transcoder-pipeline") %>>
-                            <a href="/docs/providers/aws/r/elastic_transcoder_pipeline.html">aws_elasticsearch_domain</a>
+                            <a href="/docs/providers/aws/r/elastic_transcoder_pipeline.html">aws_elastictranscoder_pipeline</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-elastic-transcoder-preset") %>>
-                            <a href="/docs/providers/aws/r/elastic_transcoder_preset.html">aws_elasticsearch_domain</a>
+                            <a href="/docs/providers/aws/r/elastic_transcoder_preset.html">aws_elastictranscoder_preset</a>
                         </li>
 
                     </ul>


### PR DESCRIPTION
I was also thinking it would be worth renaming these resources to `aws_elastic_transcoder_*` (including the underscore) before these resources are actually released, but I don't have a strong opinion about it.

^ @jbardin 

Docs should certainly reflect the current situation though.