### PR TITLE
docs/aws: Promote aws_ami data source more

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -14,14 +14,27 @@ and deleted. Instances also support [provisioning](/docs/provisioners/index.html
 ## Example Usage
 
 ```
-# Create a new instance of the `ami-408c7f28` (Ubuntu 14.04) on an 
+# Create a new instance of the latest Ubuntu 14.04 on an
 # t1.micro node with an AWS Tag naming it "HelloWorld"
 provider "aws" {
     region = "us-east-1"
 }
-    
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name = "name"
+    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+  filter {
+    name = "virtualization-type"
+    values = ["paravirtual"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
 resource "aws_instance" "web" {
-    ami = "ami-408c7f28"
+    ami = "${data.aws_ami.ubuntu.id}"
     instance_type = "t1.micro"
     tags {
         Name = "HelloWorld"

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -13,9 +13,22 @@ Provides a resource to create a new launch configuration, used for autoscaling g
 ## Example Usage
 
 ```
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name = "name"
+    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+  filter {
+    name = "virtualization-type"
+    values = ["paravirtual"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
 resource "aws_launch_configuration" "as_conf" {
     name = "web_config"
-    image_id = "ami-408c7f28"
+    image_id = "${data.aws_ami.ubuntu.id}"
     instance_type = "t1.micro"
 }
 ```
@@ -31,9 +44,22 @@ Either omit the Launch Configuration `name` attribute, or specify a partial name
 with `name_prefix`.  Example:
 
 ```
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name = "name"
+    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+  filter {
+    name = "virtualization-type"
+    values = ["paravirtual"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
 resource "aws_launch_configuration" "as_conf" {
     name_prefix = "terraform-lc-example-"
-    image_id = "ami-408c7f28"
+    image_id = "${data.aws_ami.ubuntu.id}"
     instance_type = "t1.micro"
 
     lifecycle {
@@ -65,8 +91,21 @@ documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-in
 for more information or how to launch [Spot Instances][3] with Terraform.
 
 ```
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name = "name"
+    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+  filter {
+    name = "virtualization-type"
+    values = ["paravirtual"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
 resource "aws_launch_configuration" "as_conf" {
-    image_id = "ami-408c7f28"
+    image_id = "${data.aws_ami.ubuntu.id}"
     instance_type = "t1.micro"
     spot_price = "0.001"
     lifecycle {


### PR DESCRIPTION
This makes the example work out of the box for any region and promote the new AMI data source in documentation better.

It should also make it easier to adopt the example for users that don't have `t1.micro` available anymore.

Related: https://github.com/hashicorp/terraform/issues/3923