### PR TITLE
provider/aws: Discover supported EC2 platforms (EC2 Classic/VPC)

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -136,6 +136,7 @@ type AWSClient struct {
 	r53conn               *route53.Route53
 	partition             string
 	accountid             string
+	supportedplatforms    []string
 	region                string
 	rdsconn               *rds.RDS
 	iamconn               *iam.IAM
@@ -272,6 +273,17 @@ func (c *Config) Client() (interface{}, error) {
 		return nil, authErr
 	}
 
+	client.ec2conn = ec2.New(awsEc2Sess)
+
+	supportedPlatforms, err := GetSupportedEC2Platforms(client.ec2conn)
+	if err != nil {
+		// We intentionally fail *silently* because there's a chance
+		// user just doesn't have ec2:DescribeAccountAttributes permissions
+		log.Printf("[WARN] Unable to get supported EC2 platforms: %s", err)
+	} else {
+		client.supportedplatforms = supportedPlatforms
+	}
+
 	client.acmconn = acm.New(sess)
 	client.apigateway = apigateway.New(sess)
 	client.appautoscalingconn = applicationautoscaling.New(sess)
@@ -290,7 +302,6 @@ func (c *Config) Client() (interface{}, error) {
 	client.codepipelineconn = codepipeline.New(sess)
 	client.dsconn = directoryservice.New(sess)
 	client.dynamodbconn = dynamodb.New(dynamoSess)
-	client.ec2conn = ec2.New(awsEc2Sess)
 	client.ecrconn = ecr.New(sess)
 	client.ecsconn = ecs.New(sess)
 	client.efsconn = efs.New(sess)
@@ -387,6 +398,34 @@ func (c *Config) ValidateAccountId(accountId string) error {
 	}
 
 	return nil
+}
+
+func GetSupportedEC2Platforms(conn *ec2.EC2) ([]string, error) {
+	attrName := "supported-platforms"
+
+	input := ec2.DescribeAccountAttributesInput{
+		AttributeNames: []*string{aws.String(attrName)},
+	}
+	attributes, err := conn.DescribeAccountAttributes(&input)
+	if err != nil {
+		return nil, err
+	}
+
+	var platforms []string
+	for _, attr := range attributes.AccountAttributes {
+		if *attr.AttributeName == attrName {
+			for _, v := range attr.AttributeValues {
+				platforms = append(platforms, *v.AttributeValue)
+			}
+			break
+		}
+	}
+
+	if len(platforms) == 0 {
+		return nil, fmt.Errorf("No EC2 platforms detected")
+	}
+
+	return platforms, nil
 }
 
 // addTerraformVersionToUserAgent is a named handler that will add Terraform's


### PR DESCRIPTION
This will make it possible/easier to make decisions based on supported EC2 platforms (VPC and/or EC2 Classic) in the context of any AWS resource which needs make such decisions.

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-vpc.html#differences-ec2-classic-vpc

This would help in https://github.com/hashicorp/terraform/pull/6387, https://github.com/hashicorp/terraform/issues/9744 and _possibly_ in `aws_instance`, `aws_db_instance` (`security_groups` vs `vpc_security_group_ids`). I'm not 100% sure about the latter because we may actually need to allow `security_groups` for VPC accounts too, because that's how you reference SGs in the default VPCs.

```
make test TEST=./builtin/providers/aws TESTARGS='-run=TestGetSupportedEC2Platforms -v'
 2>/dev/null
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
go test -i ./builtin/providers/aws || exit 1
echo ./builtin/providers/aws | \
		xargs -t -n4 go test -run=TestGetSupportedEC2Platforms -v -timeout=30s -parallel=4
=== RUN   TestGetSupportedEC2Platforms
--- PASS: TestGetSupportedEC2Platforms (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.031s
```