### PR TITLE
provider/azurerm: Support Import for `azurerm_availability_set`

### DIFF
--- a/builtin/providers/azurerm/import_arm_availability_set_test.go
+++ b/builtin/providers/azurerm/import_arm_availability_set_test.go
@@ -1,0 +1,36 @@
+package azurerm
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMAvailabilitySet_importBasic(t *testing.T) {
+	resourceName := "azurerm_availability_set.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name"},
+				//this isn't returned from the API!
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_availability_set.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set.go
@@ -16,6 +16,9 @@ func resourceArmAvailabilitySet() *schema.Resource {
 		Read:   resourceArmAvailabilitySetRead,
 		Update: resourceArmAvailabilitySetCreate,
 		Delete: resourceArmAvailabilitySetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -125,6 +128,8 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 	availSet := *resp.Properties
 	d.Set("platform_update_domain_count", availSet.PlatformUpdateDomainCount)
 	d.Set("platform_fault_domain_count", availSet.PlatformFaultDomainCount)
+	d.Set("name", resp.Name)
+	d.Set("location", resp.Location)
 
 	flattenAndSetTags(d, resp.Tags)
 


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMAvailabilitySet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMAvailabilitySet_ -timeout 120m
=== RUN   TestAccAzureRMAvailabilitySet_importBasic
--- PASS: TestAccAzureRMAvailabilitySet_importBasic (150.75s)
=== RUN   TestAccAzureRMAvailabilitySet_basic
--- PASS: TestAccAzureRMAvailabilitySet_basic (103.37s)
=== RUN   TestAccAzureRMAvailabilitySet_withTags
--- PASS: TestAccAzureRMAvailabilitySet_withTags (137.65s)
=== RUN   TestAccAzureRMAvailabilitySet_withDomainCounts
--- PASS: TestAccAzureRMAvailabilitySet_withDomainCounts (88.78s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
480.564s
```