### PR TITLE
provider/azurerm: Support Import of `azurerm_resource_group`

### DIFF
--- a/builtin/providers/azurerm/import_arm_resource_group_test.go
+++ b/builtin/providers/azurerm/import_arm_resource_group_test.go
@@ -1,0 +1,35 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMResourceGroup_importBasic(t *testing.T) {
+	resourceName := "azurerm_resource_group.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMResourceGroup_basic, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				//ImportStateVerifyIgnore: []string{"resource_group_name"},
+				//this isn't returned from the API!
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_resource_group_test.go
+++ b/builtin/providers/azurerm/import_arm_resource_group_test.go
@@ -27,8 +27,6 @@ func TestAccAzureRMResourceGroup_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				//ImportStateVerifyIgnore: []string{"resource_group_name"},
-				//this isn't returned from the API!
 			},
 		},
 	})

--- a/builtin/providers/azurerm/resource_arm_resource_group.go
+++ b/builtin/providers/azurerm/resource_arm_resource_group.go
@@ -17,6 +17,9 @@ func resourceArmResourceGroup() *schema.Resource {
 		Update: resourceArmResourceGroupUpdate,
 		Exists: resourceArmResourceGroupExists,
 		Delete: resourceArmResourceGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMResourceGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMResourceGroup_ -timeout 120m
=== RUN   TestAccAzureRMResourceGroup_importBasic
--- PASS: TestAccAzureRMResourceGroup_importBasic (92.84s)
=== RUN   TestAccAzureRMResourceGroup_basic
--- PASS: TestAccAzureRMResourceGroup_basic (91.56s)
=== RUN   TestAccAzureRMResourceGroup_withTags
--- PASS: TestAccAzureRMResourceGroup_withTags (110.42s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
294.832s
```