### PR TITLE
provider/vSphere: Linked cloning with support for snapshots.

### DIFF
--- a/builtin/providers/vsphere/provider_test.go
+++ b/builtin/providers/vsphere/provider_test.go
@@ -2,6 +2,7 @@ package vsphere
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -40,5 +41,23 @@ func testAccPreCheck(t *testing.T) {
 
 	if v := os.Getenv("VSPHERE_SERVER"); v == "" {
 		t.Fatal("VSPHERE_SERVER must be set for acceptance tests")
+	}
+}
+
+// validateEnvArgs is a helper function to verify that required test related environment variables are set.
+func validateEnvArgs(t *testing.T, requiredVars ...string) {
+	realEnvVars := os.Environ()
+	for _, requiredVar := range requiredVars {
+		for _, v := range realEnvVars {
+			if requiredVar == strings.Split(v, "=")[0] {
+				// Remove the variable from the list of required variables if the required variable is defined in the real environment.
+				// This way of removing the required variable from the slice preserves the order of the slice (not really needed in this case though).
+				requiredVars = requiredVars[:len(requiredVars)-1]
+			}
+		}
+	}
+
+	if len(requiredVars) > 0 {
+		t.Fatalf("Some required environment variables are missing: %s\n", requiredVars)
 	}
 }

--- a/helper/schema/serialize.go
+++ b/helper/schema/serialize.go
@@ -57,6 +57,12 @@ func SerializeValueForHash(buf *bytes.Buffer, val interface{}, schema *Schema) {
 				buf.WriteString(strconv.FormatFloat(innerVal, 'g', -1, 64))
 			case string:
 				buf.WriteString(innerVal)
+			case bool:
+				if innerVal {
+					buf.WriteRune('1')
+				} else {
+					buf.WriteRune('0')
+				}
 			default:
 				panic(fmt.Sprintf("unknown value type in TypeMap %T", innerVal))
 			}

--- a/website/source/docs/providers/vsphere/index.html.markdown
+++ b/website/source/docs/providers/vsphere/index.html.markdown
@@ -62,7 +62,9 @@ resource "vsphere_virtual_machine" "web" {
   }
 
   disk {
-    template = "centos-7"
+	clone {
+		source = "centos-7"
+	}
   }
 }
 ```
@@ -168,7 +170,8 @@ set to valid values for your VMware vSphere environment:
  * VSPHERE\_IPV6\_ADDRESS
  * VSPHERE\_NETWORK\_LABEL
  * VSPHERE\_NETWORK\_LABEL\_DHCP
- * VSPHERE\_TEMPLATE
+ * VSPHERE\_CLONE\_SOURCE
+ * VSPHERE\_SNAPSHOT
  * VSPHERE\_MAC\_ADDRESS
 
 The following environment variables depend on your vSphere environment:

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -24,7 +24,9 @@ resource "vsphere_virtual_machine" "web" {
   }
 
   disk {
-    template = "centos-7"
+	clone {
+		source = "centos-7"
+	}
   }
 }
 ```
@@ -52,7 +54,9 @@ resource "vsphere_virtual_machine" "lb" {
 
   disk {
     datastore = "EAST/VMFS01-EAST"
-    template = "Templates/Centos7"
+	clone {
+		source = "Templates/Centos7"
+	}
   }
 }
 ```
@@ -77,10 +81,13 @@ The following arguments are supported:
 * `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for details
 * `cdrom` - (Optional) Configures a CDROM device and mounts an image as its media; see [CDROM](#cdrom) below for more details.
 * `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
-* `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
+* `linked_clone` - __Deprecated, please use `disk.clone.linked` instead__.
 * `enable_disk_uuid` - (Optional) This option causes the vm to mount disks by uuid on the guest OS.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
 * `skip_customization` - (Optional) skip virtual machine customization (useful if OS is not in the guest OS support matrix of VMware like "other3xLinux64Guest").
+
+<a id="network-interfaces"></a>
+## Network interfaces
 
 The `network_interface` block supports:
 
@@ -99,6 +106,9 @@ removed in a future version:
 * `ip_address` - __Deprecated, please use `ipv4_address` instead__.
 * `subnet_mask` - __Deprecated, please use `ipv4_prefix_length` instead__.
 
+<a id="windows-opt-config"></a>
+## Windows Options Config
+
 The `windows_opt_config` block supports:
 
 * `product_key` - (Optional) Serial number for new installation of Windows. This serial number is ignored if the original guest operating system was installed using a volume-licensed CD.
@@ -112,13 +122,13 @@ The `windows_opt_config` block supports:
 
 The `disk` block supports:
 
-* `template` - (Required if size and bootable_vmdk_path not provided) Template for this disk.
+* `clone` - (Required if `size` and `bootable_vmdk_path` are not provided) Cloning source for this disk; see [Clones](#clones) below for details.
 * `datastore` - (Optional) Datastore for this disk
-* `size` - (Required if template and bootable_vmdks_path not provided) Size of this disk (in GB).
-* `name` - (Required if size is provided when creating a new disk) This "name" is used for the disk file name in vSphere, when the new disk is created.
+* `size` - (Required if `clone` and `bootable_vmdks_path` are not provided) Size of this disk (in GB).
+* `name` - (Required if `size` is provided when creating a new disk) This "name" is used for the disk file name in vSphere, when the new disk is created.
 * `iops` - (Optional) Number of virtual iops to allocate for this disk.
 * `type` - (Optional) 'eager_zeroed' (the default), 'lazy', or 'thin' are supported options.
-* `vmdk` - (Required if template and size not provided) Path to a vmdk in a vSphere datastore.
+* `vmdk` - (Required if `clone` and `size` are not provided) Path to a vmdk in a vSphere datastore.
 * `bootable` - (Optional) Set to 'true' if a vmdk was given and it should attempt to boot after creation.
 * `controller_type` = (Optional) Controller type to attach the disk to.  'scsi' (the default), or 'ide' are supported options.
 
@@ -129,6 +139,15 @@ The `cdrom` block supports:
 
 * `datastore` - (Required) The name of the datastore where the disk image is stored.
 * `path` - (Required) The absolute path to the image within the datastore.
+
+<a id="clones"></a>
+## Clones
+
+The `clone` block supports:
+
+* `source` - (Required) The template source (source of the virtual machine/template to clone from).
+* `linked` - (Optional) Set to true if this should be a linked clone. Linked cloning requires the source virtual machine/template to have at least one existing snapshot which can be cloned from. Defaults to false.
+* `snapshot` - (Optional) This is silently ignored if `linked` is false. Linked clones are, by default, cloned from the latest snapshot. However, here you can specify the label of the snapshot you want to clone from.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The disk -> clone property introduced.

The disk -> template is automatically translated to disk.clone.source for
backwards compatibility (deprecated warning is shown).

The linked_clone property is automatically translated to
disk.clone.linked, if disk.clone is configured, for backwards
compatibility (deprecated warning is shown).

Linked cloning requires a snapshot to clone from. We support the ability
to provide a named snapshot. However, we try to use the current snapshot
if no named snapshot is provided.

We error out if no snapshot name is provided and there is no current
snapshot to clone from (error out if there is no snapshot available).
We error out if the requested snapshot name is not found.

Note: Breaking change when running tests!
The VSPHERE_TEMPLATE variable has been renamed to VSPHERE_CLONE_SOURCE -
since vms can be cloned from both templates and other vms.
The VSPHERE_SNAPSHOT variable introduced. It needs to be specified so
you can run the TestAccVSphereVirtualMachine_linkedCloneNamedSnapshot
test case.

Note 2: Bool subtype support added to schema.TypeMap.
