### PR TITLE
provider/aws: Refresh CloudWatch Group from state on 404

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -63,9 +63,15 @@ func resourceAwsCloudWatchLogGroupCreate(d *schema.ResourceData, meta interface{
 func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 	log.Printf("[DEBUG] Reading CloudWatch Log Group: %q", d.Get("name").(string))
-	lg, err := lookupCloudWatchLogGroup(conn, d.Id(), nil)
+	lg, exists, err := lookupCloudWatchLogGroup(conn, d.Id(), nil)
 	if err != nil {
 		return err
+	}
+
+	if !exists {
+		log.Printf("[DEBUG] CloudWatch Group %q Not Found", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	log.Printf("[DEBUG] Found Log Group: %#v", *lg)
@@ -81,19 +87,19 @@ func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{})
 }
 
 func lookupCloudWatchLogGroup(conn *cloudwatchlogs.CloudWatchLogs,
-	name string, nextToken *string) (*cloudwatchlogs.LogGroup, error) {
+	name string, nextToken *string) (*cloudwatchlogs.LogGroup, bool, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		LogGroupNamePrefix: aws.String(name),
 		NextToken:          nextToken,
 	}
 	resp, err := conn.DescribeLogGroups(input)
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
 
 	for _, lg := range resp.LogGroups {
 		if *lg.LogGroupName == name {
-			return lg, nil
+			return lg, true, nil
 		}
 	}
 
@@ -101,7 +107,7 @@ func lookupCloudWatchLogGroup(conn *cloudwatchlogs.CloudWatchLogs,
 		return lookupCloudWatchLogGroup(conn, name, resp.NextToken)
 	}
 
-	return nil, fmt.Errorf("CloudWatch Log Group %q not found", name)
+	return nil, false, nil
 }
 
 func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Fixes #7543 where creating a CloudWatch Group, then deleting it from the
console will cause no action on refresh / plan

```
% make testacc TEST=./builtin/providers/aws  TESTARGS='-run=TestAccAWSCloudWatchLogGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSCloudWatchLogGroup_ -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_importBasic
--- PASS: TestAccAWSCloudWatchLogGroup_importBasic (18.10s)
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (17.34s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (49.81s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (23.74s)
=== RUN   TestAccAWSCloudWatchLogGroup_disappears
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (15.78s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    124.789s
```