### PR TITLE
provider/azurerm: Support Import for `azurerm_public_ip`

### DIFF
--- a/builtin/providers/azurerm/import_arm_public_ip_test.go
+++ b/builtin/providers/azurerm/import_arm_public_ip_test.go
@@ -1,0 +1,34 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMPublicIpStatic_importBasic(t *testing.T) {
+	resourceName := "azurerm_public_ip.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_public_ip.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip.go
@@ -17,6 +17,9 @@ func resourceArmPublicIp() *schema.Resource {
 		Read:   resourceArmPublicIpRead,
 		Update: resourceArmPublicIpCreate,
 		Delete: resourceArmPublicIpDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -42,6 +45,9 @@ func resourceArmPublicIp() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validatePublicIpAllocation,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"idle_timeout_in_minutes": {
@@ -166,6 +172,10 @@ func resourceArmPublicIpRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error making Read request on Azure public ip %s: %s", name, err)
 	}
+
+	d.Set("location", resp.Location)
+	d.Set("name", resp.Name)
+	d.Set("public_ip_address_allocation", strings.ToLower(string(resp.Properties.PublicIPAllocationMethod)))
 
 	if resp.Properties.DNSSettings != nil && resp.Properties.DNSSettings.Fqdn != nil && *resp.Properties.DNSSettings.Fqdn != "" {
 		d.Set("fqdn", resp.Properties.DNSSettings.Fqdn)


### PR DESCRIPTION
Had to make some changes to this resource. Params were not being set in
the Read func - also added a statefunc to the IPAddressAllocation as
that was coming back in a different case to how we were sending it. We
need to treat that property as case-insensitive

```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMPublicIpStatic_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMPublicIpStatic_ -timeout 120m
=== RUN   TestAccAzureRMPublicIpStatic_importBasic
--- PASS: TestAccAzureRMPublicIpStatic_importBasic (128.06s)
=== RUN   TestAccAzureRMPublicIpStatic_basic
--- PASS: TestAccAzureRMPublicIpStatic_basic (126.25s)
=== RUN   TestAccAzureRMPublicIpStatic_withTags
--- PASS: TestAccAzureRMPublicIpStatic_withTags (145.99s)
=== RUN   TestAccAzureRMPublicIpStatic_update
--- PASS: TestAccAzureRMPublicIpStatic_update (192.32s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
592.648s
```