### PR TITLE
Update aws api gateway docs to add some examples

### DIFF
--- a/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
@@ -34,11 +34,18 @@ resource "aws_api_gateway_method" "test" {
   authorization = "NONE"
 }
 
+resource "aws_api_gateway_integration" "MyDemoIntegration" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
+  http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+  type = "MOCK"
+}
+
 resource "aws_api_gateway_deployment" "MyDemoDeployment" {
-  depends_on = ["aws_api_gateway_integration.test"]
 
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-
+  stage_name = "test"
+  
   variables = {
     "answer" = "42"
   }

--- a/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
@@ -21,15 +21,15 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
   description = "This is my API for demonstration purposes"
 }
 
-resource "aws_api_gateway_resource" "test" {
+resource "aws_api_gateway_resource" "MyDemoResource" {
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   parent_id = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
   path_part = "test"
 }
 
-resource "aws_api_gateway_method" "test" {
+resource "aws_api_gateway_method" "MyDemoMethod" {
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
+  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
   http_method = "GET"
   authorization = "NONE"
 }
@@ -42,10 +42,11 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
 }
 
 resource "aws_api_gateway_deployment" "MyDemoDeployment" {
+  depends_on = ["aws_api_gateway_method.MyDemoMethod"]
 
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   stage_name = "test"
-  
+
   variables = {
     "answer" = "42"
   }

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -58,4 +58,6 @@ The following arguments are supported:
 * `request_templates` - (Optional) A map of the integration's request templates.
 * `request_parameters_in_json` - (Optional) A map written as a JSON string specifying
   the request query string parameters and headers that should be passed to the
-  backend responder
+  backend responder.
+  For example: `request_parameters_in_json = "{\"integration.request.header.X-Some-Other-Header\":\"method.request.header.X-Some-Header\"}"` 
+  would add the header `X-Some-Header` from method to the integration as the header `X-Some-Other-Header`.

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -67,3 +67,5 @@ The following arguments are supported:
   For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
 * `response_templates` - (Optional) A map specifying the templates used to transform the integration response body
 * `response_parameters_in_json` - (Optional) A map written as JSON string specifying response parameters that can be read from the backend response
+  For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":\"integration.response.header.X-Some-Other-Header\"}"`, 
+  would add the header `X-Some-Other-Header` from the integration response to the method response as the header `X-Some-Header`.

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -46,3 +46,5 @@ The following arguments are supported:
   and value is either `Error`, `Empty` (built-in models) or `aws_api_gateway_model`'s `name`.
 * `request_parameters_in_json` - (Optional) A map written as a JSON string specifying
   the request query string parameters and headers that should be passed to the integration
+  For example: `request_parameters_in_json = "{\"method.request.header.X-Some-Header\":true}"`  
+  would define that the header X-Some-Header must be provided on the request.

--- a/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
@@ -56,3 +56,5 @@ The following arguments are supported:
 * `status_code` - (Required) The HTTP status code
 * `response_models` - (Optional) A map of the API models used for the response's content type
 * `response_parameters_in_json` - (Optional) A map written as a JSON string representing response parameters that can be sent to the caller
+   For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":true}"` 
+   would define that the header X-Some-Header can be provided on the response.


### PR DESCRIPTION
Reasoning for docs update: 

I have recently been using terraform to define aws api gateways and thought that request_parameters_in_json was fairly ambiguous, so I have added some examples for requests/responses.

I have also corrected an error in the gateway deployment example where there was a missing aws_api_gateway_integration and aws_api_gateway_deployment.stage_name.

Relevant Terraform version:

Tested against latest master.

Any feedback would be appreciated.