### PR TITLE
provider/template: validate vars are primitives

### DIFF
--- a/builtin/providers/template/datasource_template_file_test.go
+++ b/builtin/providers/template/datasource_template_file_test.go
@@ -71,6 +71,49 @@ func TestValidateTemplateAttribute(t *testing.T) {
 	}
 }
 
+func TestValidateVarsAttribute(t *testing.T) {
+	cases := map[string]struct {
+		Vars      map[string]interface{}
+		ExpectErr string
+	}{
+		"lists are invalid": {
+			map[string]interface{}{
+				"list": []interface{}{},
+			},
+			`vars: cannot contain non-primitives`,
+		},
+		"maps are invalid": {
+			map[string]interface{}{
+				"map": map[string]interface{}{},
+			},
+			`vars: cannot contain non-primitives`,
+		},
+		"strings, integers, floats, and bools are AOK": {
+			map[string]interface{}{
+				"string": "foo",
+				"int":    1,
+				"bool":   true,
+				"float":  float64(1.0),
+			},
+			``,
+		},
+	}
+
+	for tn, tc := range cases {
+		_, es := validateVarsAttribute(tc.Vars, "vars")
+		if len(es) > 0 {
+			if tc.ExpectErr == "" {
+				t.Fatalf("%s: expected no err, got: %#v", tn, es)
+			}
+			if !strings.Contains(es[0].Error(), tc.ExpectErr) {
+				t.Fatalf("%s: expected\n%s\nto contain\n%s", tn, es[0], tc.ExpectErr)
+			}
+		} else if tc.ExpectErr != "" {
+			t.Fatalf("%s: expected err containing %q, got none!", tn, tc.ExpectErr)
+		}
+	}
+}
+
 // This test covers a panic due to config.Func formerly being a
 // shared map, causing multiple template_file resources to try and
 // accessing it parallel during their lang.Eval() runs.

--- a/website/source/docs/providers/template/d/file.html.md
+++ b/website/source/docs/providers/template/d/file.html.md
@@ -31,7 +31,9 @@ The following arguments are supported:
   from a file on disk using the [`file()` interpolation
   function](/docs/configuration/interpolation.html#file_path_).
 
-* `vars` - (Optional) Variables for interpolation within the template.
+* `vars` - (Optional) Variables for interpolation within the template. Note
+  that variables must all be primitives. Direct references to lists or maps
+  will cause a validation error.
 
 The following arguments are maintained for backwards compatibility and may be
 removed in a future version:


### PR DESCRIPTION
Closes #7160 by returning a proper error.