### PR TITLE
provider/aws: Allow import of efs_file_system

### DIFF
--- a/builtin/providers/aws/import_aws_efs_file_system_test.go
+++ b/builtin/providers/aws/import_aws_efs_file_system_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSEFSFileSystem_importBasic(t *testing.T) {
+	resourceName := "aws_efs_file_system.foo-with-tags"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEFSFileSystemConfigWithTags,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"reference_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_efs_file_system.go
+++ b/builtin/providers/aws/resource_aws_efs_file_system.go
@@ -19,6 +19,10 @@ func resourceAwsEfsFileSystem() *schema.Resource {
 		Update: resourceAwsEfsFileSystemUpdate,
 		Delete: resourceAwsEfsFileSystemDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"reference_name": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
#### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEFSFileSystem_importBasic'
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEFSFileSystem_importBasic -timeout 120m
=== RUN   TestAccAWSEFSFileSystem_importBasic
--- PASS: TestAccAWSEFSFileSystem_importBasic (31.98s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	31.998s
```