### PR TITLE
provider/aws: Allow import of efs_mount_target

### DIFF
--- a/builtin/providers/aws/import_aws_efs_mount_target_test.go
+++ b/builtin/providers/aws/import_aws_efs_mount_target_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSEFSMountTarget_importBasic(t *testing.T) {
+	resourceName := "aws_efs_mount_target.alpha"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsMountTargetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEFSMountTargetConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -20,6 +20,10 @@ func resourceAwsEfsMountTarget() *schema.Resource {
 		Update: resourceAwsEfsMountTargetUpdate,
 		Delete: resourceAwsEfsMountTargetDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"file_system_id": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
#### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEFSMountTarget_importBasic'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEFSMountTarget_importBasic -timeout 120m
=== RUN   TestAccAWSEFSMountTarget_importBasic
--- PASS: TestAccAWSEFSMountTarget_importBasic (231.22s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	231.245s
```