### PR TITLE
provider/aws: Allow import of glacier_vault

### DIFF
--- a/builtin/providers/aws/import_aws_glacier_vault_test.go
+++ b/builtin/providers/aws/import_aws_glacier_vault_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSGlacierVault_importBasic(t *testing.T) {
+	resourceName := "aws_glacier_vault.full"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlacierVaultDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGlacierVault_full,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_glacier_vault.go
+++ b/builtin/providers/aws/resource_aws_glacier_vault.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -18,6 +19,10 @@ func resourceAwsGlacierVault() *schema.Resource {
 		Read:   resourceAwsGlacierVaultRead,
 		Update: resourceAwsGlacierVaultUpdate,
 		Delete: resourceAwsGlacierVaultDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -130,7 +135,15 @@ func resourceAwsGlacierVaultRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error reading Glacier Vault: %s", err.Error())
 	}
 
-	d.Set("arn", *out.VaultARN)
+	awsClient := meta.(*AWSClient)
+	d.Set("name", out.VaultName)
+	d.Set("arn", out.VaultARN)
+
+	location, err := buildGlacierVaultLocation(awsClient.accountid, d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("location", location)
 
 	tags, err := getGlacierVaultTags(glacierconn, d.Id())
 	if err != nil {
@@ -364,6 +377,13 @@ func glacierPointersToStringList(pointers []*string) []interface{} {
 		list[i] = *v
 	}
 	return list
+}
+
+func buildGlacierVaultLocation(accountId, vaultName string) (string, error) {
+	if accountId == "" {
+		return "", errors.New("AWS account ID unavailable - failed to construct Vault location")
+	}
+	return fmt.Sprintf("/" + accountId + "/vaults/" + vaultName), nil
 }
 
 func getGlacierVaultNotification(glacierconn *glacier.Glacier, vaultName string) ([]map[string]interface{}, error) {


### PR DESCRIPTION
I had to implement a function for constructing the location attribute because there doesn't seem to be any way to get it from the API for any existing Glacier Vault.

#### Test plan
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSGlacierVault_importBasic'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSGlacierVault_importBasic -timeout 120m
=== RUN   TestAccAWSGlacierVault_importBasic
--- PASS: TestAccAWSGlacierVault_importBasic (34.28s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	34.300s
```