### PR TITLE
provider/aws: Allow import of KMS key

### DIFF
--- a/builtin/providers/aws/import_aws_kms_key_test.go
+++ b/builtin/providers/aws/import_aws_kms_key_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSKMSKey_importBasic(t *testing.T) {
+	resourceName := "aws_kms_key.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSKmsKey,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_kms_key.go
+++ b/builtin/providers/aws/resource_aws_kms_key.go
@@ -19,6 +19,10 @@ func resourceAwsKmsKey() *schema.Resource {
 		Update: resourceAwsKmsKeyUpdate,
 		Delete: resourceAwsKmsKeyDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
#### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSKMSKey_importBasic'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSKMSKey_importBasic -timeout 120m
=== RUN   TestAccAWSKMSKey_importBasic
--- PASS: TestAccAWSKMSKey_importBasic (137.19s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	137.215s
```