### PR TITLE
provider/aws: Support Import for `aws_simpledb_domain`

### DIFF
--- a/builtin/providers/aws/import_aws_simpledb_domain_test.go
+++ b/builtin/providers/aws/import_aws_simpledb_domain_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSimpleDBDomain_importBasic(t *testing.T) {
+	resourceName := "aws_simpledb_domain.test_domain"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSimpleDBDomainDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSimpleDBDomainConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_simpledb_domain.go
+++ b/builtin/providers/aws/resource_aws_simpledb_domain.go
@@ -16,6 +16,9 @@ func resourceAwsSimpleDBDomain() *schema.Resource {
 		Create: resourceAwsSimpleDBDomainCreate,
 		Read:   resourceAwsSimpleDBDomainRead,
 		Delete: resourceAwsSimpleDBDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSimpleDBDomain_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSSimpleDBDomain_ -timeout 120m
=== RUN   TestAccAWSSimpleDBDomain_importBasic
--- PASS: TestAccAWSSimpleDBDomain_importBasic (19.59s)
=== RUN   TestAccAWSSimpleDBDomain_basic
--- PASS: TestAccAWSSimpleDBDomain_basic (19.93s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    39.535s
```