### PR TITLE
provider/digitalocean: Add Test for DO Tag Import

### DIFF
--- a/builtin/providers/digitalocean/import_digitalocean_tag_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_tag_test.go
@@ -1,0 +1,28 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDigitalOceanTag_importBasic(t *testing.T) {
+	resourceName := "digitalocean_tag.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanTagDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDigitalOceanTagConfig_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/digitalocean TESTARGS='-run=TestAccDigitalOceanTag_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/digitalocean -v
-run=TestAccDigitalOceanTag_ -timeout 120m
=== RUN   TestAccDigitalOceanTag_importBasic
--- PASS: TestAccDigitalOceanTag_importBasic (2.42s)
=== RUN   TestAccDigitalOceanTag_Basic
--- PASS: TestAccDigitalOceanTag_Basic (1.72s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/digitalocean
4.151s
```