### PR TITLE
provider/aws: Bump rds_cluster timeout to 15 mins

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -251,7 +251,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 				Pending:    []string{"creating", "backing-up", "modifying"},
 				Target:     []string{"available"},
 				Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
-				Timeout:    5 * time.Minute,
+				Timeout:    15 * time.Minute,
 				MinTimeout: 3 * time.Second,
 				Delay:      30 * time.Second, // Wait 30 secs before starting
 			}
@@ -345,7 +345,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		Pending:    []string{"creating", "backing-up", "modifying"},
 		Target:     []string{"available"},
 		Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
-		Timeout:    5 * time.Minute,
+		Timeout:    15 * time.Minute,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -509,7 +509,7 @@ func resourceAwsRDSClusterDelete(d *schema.ResourceData, meta interface{}) error
 		Pending:    []string{"available", "deleting", "backing-up", "modifying"},
 		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
-		Timeout:    5 * time.Minute,
+		Timeout:    15 * time.Minute,
 		MinTimeout: 3 * time.Second,
 	}
 


### PR DESCRIPTION
Apparently it takes more than 5 minutes to destroy the cluster.
I bumped the other two timeouts too, just in case.

```
module.rdscluster.aws_rds_cluster.default: Still destroying... (4m20s elapsed)
module.rdscluster.aws_rds_cluster.default: Still destroying... (4m30s elapsed)
module.rdscluster.aws_rds_cluster.default: Still destroying... (4m40s elapsed)
module.rdscluster.aws_rds_cluster.default: Still destroying... (4m50s elapsed)
module.rdscluster.aws_rds_cluster.default: Still destroying... (5m0s elapsed)
Error applying plan:

1 error(s) occurred:

* aws_rds_cluster.default: [WARN] Error deleting RDS Cluster (mydb): timeout while waiting for state to become '[destroyed]'

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```