### PR TITLE
provider/aws: Allow importing lambda_function

### DIFF
--- a/builtin/providers/aws/import_aws_lambda_function_test.go
+++ b/builtin/providers/aws/import_aws_lambda_function_test.go
@@ -1,0 +1,81 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSLambdaFunction_importLocalFile(t *testing.T) {
+	resourceName := "aws_lambda_function.lambda_function_test"
+
+	rName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSLambdaConfigBasic(rName),
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaFunction_importLocalFile_VPC(t *testing.T) {
+	resourceName := "aws_lambda_function.lambda_function_test"
+
+	rName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSLambdaConfigWithVPC(rName),
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaFunction_importS3(t *testing.T) {
+	resourceName := "aws_lambda_function.lambda_function_s3test"
+
+	rName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSLambdaConfigS3(rName),
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"s3_bucket", "s3_key"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -24,6 +24,13 @@ func resourceAwsLambdaFunction() *schema.Resource {
 		Update: resourceAwsLambdaFunctionUpdate,
 		Delete: resourceAwsLambdaFunctionDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("function_name", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"filename": &schema.Schema{
 				Type:          schema.TypeString,


### PR DESCRIPTION
#### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLambdaFunction_import'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLambdaFunction_import -timeout 120m
=== RUN   TestAccAWSLambdaFunction_importLocalFile
--- PASS: TestAccAWSLambdaFunction_importLocalFile (55.92s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (67.18s)
=== RUN   TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_importS3 (82.74s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	205.865s
```