### PR TITLE
provider/aws: Fix data.aws_iam_policy_document

### DIFF
--- a/builtin/providers/aws/data_source_aws_iam_policy_document_test.go
+++ b/builtin/providers/aws/data_source_aws_iam_policy_document_test.go
@@ -16,7 +16,7 @@ func TestAccAWSIAMPolicyDocument(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSIAMPolicyDocumentConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStateValue(
@@ -52,7 +52,9 @@ func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
 
 var testAccAWSIAMPolicyDocumentConfig = `
 data "aws_iam_policy_document" "test" {
+    policy_id = "policy_id"
     statement {
+    	sid = "1"
         actions = [
             "s3:ListAllMyBuckets",
             "s3:GetBucketLocation",
@@ -110,8 +112,10 @@ data "aws_iam_policy_document" "test" {
 
 var testAccAWSIAMPolicyDocumentExpectedJSON = `{
   "Version": "2012-10-17",
+  "Id": "policy_id",
   "Statement": [
     {
+      "Sid": "1",
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",

--- a/builtin/providers/aws/iam_policy_model.go
+++ b/builtin/providers/aws/iam_policy_model.go
@@ -5,8 +5,8 @@ import (
 )
 
 type IAMPolicyDoc struct {
-	Id         string                `json:",omitempty"`
 	Version    string                `json:",omitempty"`
+	Id         string                `json:",omitempty"`
 	Statements []*IAMPolicyStatement `json:"Statement"`
 }
 

--- a/website/source/docs/providers/aws/d/iam_policy_document.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_policy_document.html.markdown
@@ -17,6 +17,7 @@ such as the `aws_iam_policy` resource.
 ```
 data "aws_iam_policy_document" "example" {
     statement {
+        sid = "1"
         actions = [
             "s3:ListAllMyBuckets",
             "s3:GetBucketLocation",
@@ -71,14 +72,14 @@ valid to use literal JSON strings within your configuration, or to use the
 
 The following arguments are supported:
 
-* `id` (Optional) - An ID for the policy document.
+* `policy_id` (Optional) - An ID for the policy document.
 * `statement` (Required) - A nested configuration block (described below)
   configuring one *statement* to be included in the policy document.
 
 Each document configuration must have one or more `statement` blocks, which
 each accept the following arguments:
 
-* `id` (Optional) - An ID for the policy statement.
+* `sid` (Optional) - An ID for the policy statement.
 * `effect` (Optional) - Either "Allow" or "Deny", to specify whether this
   statement allows or denies the given actions. The default is "Allow".
 * `actions` (Optional) - A list of actions that this statement either allows


### PR DESCRIPTION
Adds ID and Version support to policy documents.

Fixes #7499.