### PR TITLE
provider/azurerm: Support Import for `azurerm_dns_zone`

### DIFF
--- a/builtin/providers/azurerm/import_arm_dns_zone_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_zone_test.go
@@ -1,0 +1,34 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsZone_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_zone.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsZone_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_dns_zone.go
+++ b/builtin/providers/azurerm/resource_arm_dns_zone.go
@@ -14,6 +14,9 @@ func resourceArmDnsZone() *schema.Resource {
 		Read:   resourceArmDnsZoneRead,
 		Update: resourceArmDnsZoneCreate,
 		Delete: resourceArmDnsZoneDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -110,6 +113,7 @@ func resourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("number_of_record_sets", resp.NumberOfRecordSets)
 	d.Set("max_number_of_record_sets", resp.MaxNumberOfRecordSets)
+	d.Set("name", resp.Name)
 
 	nameServers := make([]string, 0, len(resp.NameServers))
 	for _, ns := range resp.NameServers {


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMDnsZone_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMDnsZone_ -timeout 120m
=== RUN   TestAccAzureRMDnsZone_importBasic
--- PASS: TestAccAzureRMDnsZone_importBasic (88.68s)
=== RUN   TestAccAzureRMDnsZone_basic
--- PASS: TestAccAzureRMDnsZone_basic (93.18s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
181.874s
```