### PR TITLE
provider/azurerm: Support Import `azurerm_storage_account`

### DIFF
--- a/builtin/providers/azurerm/import_arm_storage_account_test.go
+++ b/builtin/providers/azurerm/import_arm_storage_account_test.go
@@ -1,0 +1,36 @@
+package azurerm
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMStorageAccount_importBasic(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	config := fmt.Sprintf(testAccAzureRMStorageAccount_basic, ri, rs)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_storage_account.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account.go
@@ -16,6 +16,9 @@ func resourceArmStorageAccount() *schema.Resource {
 		Read:   resourceArmStorageAccountRead,
 		Update: resourceArmStorageAccountUpdate,
 		Delete: resourceArmStorageAccountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -251,6 +254,8 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 			d.Set("secondary_table_endpoint", "")
 		}
 	}
+
+	d.Set("name", resp.Name)
 
 	flattenAndSetTags(d, resp.Tags)
 

--- a/builtin/providers/azurerm/resource_arm_storage_account_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -50,13 +51,18 @@ func TestValidateArmStorageAccountName(t *testing.T) {
 }
 
 func TestAccAzureRMStorageAccount_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	preConfig := fmt.Sprintf(testAccAzureRMStorageAccount_basic, ri, rs)
+	postConfig := fmt.Sprintf(testAccAzureRMStorageAccount_update, ri, rs)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAzureRMStorageAccount_basic,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
 					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_type", "Standard_LRS"),
@@ -66,7 +72,7 @@ func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccAzureRMStorageAccount_update,
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
 					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_type", "Standard_GRS"),
@@ -131,12 +137,12 @@ func testCheckAzureRMStorageAccountDestroy(s *terraform.State) error {
 
 var testAccAzureRMStorageAccount_basic = `
 resource "azurerm_resource_group" "testrg" {
-    name = "testAccAzureRMStorageAccountBasic"
+    name = "testAccAzureRMSA-%d"
     location = "westus"
 }
 
 resource "azurerm_storage_account" "testsa" {
-    name = "unlikely23exst2acct1435"
+    name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
     location = "westus"
@@ -149,12 +155,12 @@ resource "azurerm_storage_account" "testsa" {
 
 var testAccAzureRMStorageAccount_update = `
 resource "azurerm_resource_group" "testrg" {
-    name = "testAccAzureRMStorageAccountBasic"
+    name = "testAccAzureRMSA-%d"
     location = "westus"
 }
 
 resource "azurerm_storage_account" "testsa" {
-    name = "unlikely23exst2acct1435"
+    name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
     location = "westus"


### PR DESCRIPTION
Also included the randomizing of the storage account and resource group
names

```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMStorageAccount_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMStorageAccount_ -timeout 120m
=== RUN   TestAccAzureRMStorageAccount_importBasic
--- PASS: TestAccAzureRMStorageAccount_importBasic (141.66s)
=== RUN   TestAccAzureRMStorageAccount_basic
--- PASS: TestAccAzureRMStorageAccount_basic (160.18s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
301.852s
```