### PR TITLE
provider/azurerm: Support Import of `azurerm_virtual_network`

### DIFF
--- a/builtin/providers/azurerm/import_arm_virtual_network_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_network_test.go
@@ -1,0 +1,34 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMVirtualNetwork_importBasic(t *testing.T) {
+	resourceName := "azurerm_virtual_network.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualNetwork_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -17,6 +17,9 @@ func resourceArmVirtualNetwork() *schema.Resource {
 		Read:   resourceArmVirtualNetworkRead,
 		Update: resourceArmVirtualNetworkCreate,
 		Delete: resourceArmVirtualNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -139,6 +142,8 @@ func resourceArmVirtualNetworkRead(d *schema.ResourceData, meta interface{}) err
 	vnet := *resp.Properties
 
 	// update appropriate values
+	d.Set("name", resp.Name)
+	d.Set("location", resp.Location)
 	d.Set("address_space", vnet.AddressSpace.AddressPrefixes)
 
 	subnets := &schema.Set{


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMVirtualNetwork_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMVirtualNetwork_ -timeout 120m
=== RUN   TestAccAzureRMVirtualNetwork_importBasic
--- PASS: TestAccAzureRMVirtualNetwork_importBasic (129.61s)
=== RUN   TestAccAzureRMVirtualNetwork_basic
--- PASS: TestAccAzureRMVirtualNetwork_basic (128.37s)
=== RUN   TestAccAzureRMVirtualNetwork_withTags
--- PASS: TestAccAzureRMVirtualNetwork_withTags (151.55s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
409.541s
```