### PR TITLE
provider/azurerm: Support Import of `azurerm_sql_firewall_rule`

### DIFF
--- a/builtin/providers/azurerm/import_arm_sql_firewall_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_sql_firewall_rule_test.go
@@ -1,0 +1,34 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMSqlFirewallRule_importBasic(t *testing.T) {
+	resourceName := "azurerm_sql_firewall_rule.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSqlFirewallRule_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSqlFirewallRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name", "server_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_sql_firewall_rule.go
+++ b/builtin/providers/azurerm/resource_arm_sql_firewall_rule.go
@@ -15,6 +15,9 @@ func resourceArmSqlFirewallRule() *schema.Resource {
 		Read:   resourceArmSqlFirewallRuleRead,
 		Update: resourceArmSqlFirewallRuleCreate,
 		Delete: resourceArmSqlFirewallRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -109,6 +112,7 @@ func resourceArmSqlFirewallRuleRead(d *schema.ResourceData, meta interface{}) er
 
 	resp := readResponse.Parsed.(*sql.GetFirewallRuleResponse)
 
+	d.Set("name", resp.Name)
 	d.Set("start_ip_address", resp.StartIPAddress)
 	d.Set("end_ip_address", resp.EndIPAddress)
 


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/azurerm  TESTARGS='-run=TestAccAzureRMSqlFirewallRule_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMSqlFirewallRule_ -timeout 120m
=== RUN   TestAccAzureRMSqlFirewallRule_importBasic
--- PASS: TestAccAzureRMSqlFirewallRule_importBasic (146.88s)
=== RUN   TestAccAzureRMSqlFirewallRule_basic
--- PASS: TestAccAzureRMSqlFirewallRule_basic (154.34s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
301.231s
```