### PR TITLE
provider/azurerm: Support Import `azurerm_local_network_gateway`

### DIFF
--- a/builtin/providers/azurerm/import_arm_local_network_gateway_test.go
+++ b/builtin/providers/azurerm/import_arm_local_network_gateway_test.go
@@ -1,0 +1,30 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMLocalNetworkGateway_importBasic(t *testing.T) {
+	resourceName := "azurerm_local_network_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name"},
+				//this isn't returned from the API!
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_local_network_gateway.go
+++ b/builtin/providers/azurerm/resource_arm_local_network_gateway.go
@@ -14,6 +14,9 @@ func resourceArmLocalNetworkGateway() *schema.Resource {
 		Read:   resourceArmLocalNetworkGatewayRead,
 		Update: resourceArmLocalNetworkGatewayCreate,
 		Delete: resourceArmLocalNetworkGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -115,6 +118,8 @@ func resourceArmLocalNetworkGatewayRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error reading the state of Azure ARM local network gateway '%s': %s", name, err)
 	}
 
+	d.Set("name", resp.Name)
+	d.Set("location", resp.Location)
 	d.Set("gateway_address", resp.Properties.GatewayIPAddress)
 
 	prefs := []string{}


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMLocalNetworkGateway_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMLocalNetworkGateway_ -timeout 120m
=== RUN   TestAccAzureRMLocalNetworkGateway_importBasic
--- PASS: TestAccAzureRMLocalNetworkGateway_importBasic (137.98s)
=== RUN   TestAccAzureRMLocalNetworkGateway_basic
--- PASS: TestAccAzureRMLocalNetworkGateway_basic (128.17s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
266.169s
```