### PR TITLE
provider/azurerm: Support Import of `azurerm_network_security_group`

### DIFF
--- a/builtin/providers/azurerm/import_arm_network_security_group_test.go
+++ b/builtin/providers/azurerm/import_arm_network_security_group_test.go
@@ -1,0 +1,29 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMNetworkSecurityGroup_importBasic(t *testing.T) {
+	resourceName := "azurerm_network_security_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkSecurityGroup_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_network_security_group.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group.go
@@ -19,6 +19,9 @@ func resourceArmNetworkSecurityGroup() *schema.Resource {
 		Read:   resourceArmNetworkSecurityGroupRead,
 		Update: resourceArmNetworkSecurityGroupCreate,
 		Delete: resourceArmNetworkSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -200,6 +203,8 @@ func resourceArmNetworkSecurityGroupRead(d *schema.ResourceData, meta interface{
 		d.Set("security_rule", flattenNetworkSecurityRules(resp.Properties.SecurityRules))
 	}
 
+	d.Set("name", resp.Name)
+	d.Set("location", resp.Location)
 	flattenAndSetTags(d, resp.Tags)
 
 	return nil


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMNetworkSecurityGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMNetworkSecurityGroup_ -timeout 120m
=== RUN   TestAccAzureRMNetworkSecurityGroup_importBasic
--- PASS: TestAccAzureRMNetworkSecurityGroup_importBasic (148.03s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_basic
--- PASS: TestAccAzureRMNetworkSecurityGroup_basic (143.72s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_withTags
--- PASS: TestAccAzureRMNetworkSecurityGroup_withTags (180.05s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_addingExtraRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_addingExtraRules (236.28s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
708.099s
```