### PR TITLE
core: Add context test for module var from splat

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2365,3 +2365,30 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 		t.Fatalf("bad:\n%s\n\nexpected\n\n%s", actual, expected)
 	}
 }
+
+func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
+	m := testModule(t, "plan-module-variable-from-splat")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(testTerraformPlanModuleVariableFromSplat)
+	if actual != expected {
+		t.Fatalf("bad:\n%s\n\nexpected\n\n%s", actual, expected)
+	}
+}

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1371,3 +1371,25 @@ STATE:
 
 <no state>
 `
+
+const testTerraformPlanModuleVariableFromSplat = `
+DIFF:
+
+module.mod1:
+  CREATE: aws_instance.test.0
+    thing: "" => "doesnt"
+    type:  "" => "aws_instance"
+  CREATE: aws_instance.test.1
+    thing: "" => "doesnt"
+    type:  "" => "aws_instance"
+module.mod2:
+  CREATE: aws_instance.test.0
+    thing: "" => "doesnt"
+    type:  "" => "aws_instance"
+  CREATE: aws_instance.test.1
+    thing: "" => "doesnt"
+    type:  "" => "aws_instance"
+
+STATE:
+
+<no state>`

--- a/terraform/test-fixtures/plan-module-variable-from-splat/main.tf
+++ b/terraform/test-fixtures/plan-module-variable-from-splat/main.tf
@@ -1,0 +1,9 @@
+module "mod1" {
+  source = "mod"
+  param  = ["this", "one", "works"]
+}
+
+module "mod2" {
+  source = "mod"
+  param  = ["${module.mod1.out_from_splat[0]}"]
+}

--- a/terraform/test-fixtures/plan-module-variable-from-splat/mod/main.tf
+++ b/terraform/test-fixtures/plan-module-variable-from-splat/mod/main.tf
@@ -1,0 +1,12 @@
+variable "param" {
+  type = "list"
+}
+
+resource "aws_instance" "test" {
+  count    = "2"
+  thing = "doesnt"
+}
+
+output "out_from_splat" {
+  value = ["${aws_instance.test.*.thing}"]
+}


### PR DESCRIPTION
This adds additional coverage of the situation reported in #7195 to prevent against regression. The actual fix was in 2356afd, in response to #7143.