### PR TITLE
docs: Add digitalocean_tag resource to the sidebar

### DIFF
--- a/website/source/layouts/digitalocean.erb
+++ b/website/source/layouts/digitalocean.erb
@@ -32,6 +32,9 @@
                     <li<%= sidebar_current("docs-do-resource-ssh-key") %>>
                     <a href="/docs/providers/do/r/ssh_key.html">digitalocean_ssh_key</a>
                     </li>
+                    <li<%= sidebar_current("docs-do-resource-tag") %>>
+                    <a href="/docs/providers/do/r/tag.html">digitalocean_tag</a>
+                    </li>
                     <li<%= sidebar_current("docs-do-resource-volume") %>>
                     <a href="/docs/providers/do/r/volume.html">digitalocean_volume</a>
                     </li>


### PR DESCRIPTION
I noticed #7500 missed updating the sidebar with a link to the new tag resource, so this adds that.