### PR TITLE
provider/azurerm: Support Import `azurerm_network_security_rule`

### DIFF
--- a/builtin/providers/azurerm/import_arm_network_security_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_network_security_rule_test.go
@@ -1,0 +1,29 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMNetworkSecurityRule_importBasic(t *testing.T) {
+	resourceName := "azurerm_network_security_rule.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkSecurityRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkSecurityRule_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_name", "network_security_group_name"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_network_security_rule.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_rule.go
@@ -14,6 +14,9 @@ func resourceArmNetworkSecurityRule() *schema.Resource {
 		Read:   resourceArmNetworkSecurityRuleRead,
 		Update: resourceArmNetworkSecurityRuleCreate,
 		Delete: resourceArmNetworkSecurityRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -179,6 +182,17 @@ func resourceArmNetworkSecurityRuleRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return fmt.Errorf("Error making Read request on Azure Network Security Rule %s: %s", sgRuleName, err)
 	}
+
+	d.Set("access", resp.Properties.Access)
+	d.Set("destination_address_prefix", resp.Properties.DestinationAddressPrefix)
+	d.Set("destination_port_range", resp.Properties.DestinationPortRange)
+	d.Set("direction", resp.Properties.Direction)
+	d.Set("description", resp.Properties.Description)
+	d.Set("name", resp.Name)
+	d.Set("priority", resp.Properties.Priority)
+	d.Set("protocol", resp.Properties.Protocol)
+	d.Set("source_address_prefix", resp.Properties.SourceAddressPrefix)
+	d.Set("source_port_range", resp.Properties.SourcePortRange)
 
 	return nil
 }


### PR DESCRIPTION
Soooo many missing fields not being set on the Read!

```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMNetworkSecurityRule_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMNetworkSecurityRule_ -timeout 120m
=== RUN   TestAccAzureRMNetworkSecurityRule_importBasic
--- PASS: TestAccAzureRMNetworkSecurityRule_importBasic (208.10s)
=== RUN   TestAccAzureRMNetworkSecurityRule_basic
--- PASS: TestAccAzureRMNetworkSecurityRule_basic (190.66s)
=== RUN   TestAccAzureRMNetworkSecurityRule_addingRules
--- PASS: TestAccAzureRMNetworkSecurityRule_addingRules (256.73s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm
655.514s
```