### PR TITLE
provider/azurerm: catch azurerm_template_deployment errors

### DIFF
--- a/builtin/providers/azurerm/resource_arm_template_deployment.go
+++ b/builtin/providers/azurerm/resource_arm_template_deployment.go
@@ -101,7 +101,7 @@ func resourceArmTemplateDeploymentCreate(d *schema.ResourceData, meta interface{
 
 	_, err := deployClient.CreateOrUpdate(resGroup, name, deployment, make(chan struct{}))
 	if err != nil {
-		return nil
+		return fmt.Errorf("Error creating deployment: %s", err)
 	}
 
 	read, err := deployClient.Get(resGroup, name)


### PR DESCRIPTION
The error was ignored causing Terraform to report that the deployments was
successful rather than in a bad state. This commit cause the apply operation
to report the error.

Added a test which attempts to create a storage account with a name longer
than the maximum permitted length to force a failure.

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMTemplateDeployment_ -timeout 120m
=== RUN   TestAccAzureRMTemplateDeployment_basic
--- PASS: TestAccAzureRMTemplateDeployment_basic (377.78s)
=== RUN   TestAccAzureRMTemplateDeployment_withParams
--- PASS: TestAccAzureRMTemplateDeployment_withParams (327.89s)
=== RUN   TestAccAzureRMTemplateDeployment_withError
--- PASS: TestAccAzureRMTemplateDeployment_withError (226.64s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	932.440s
```