### PR TITLE
provider/openstack: Fixing boot volume interference

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -388,6 +388,47 @@ func TestAccComputeV2Instance_bootFromVolumeImage(t *testing.T) {
 	})
 }
 
+func TestAccComputeV2Instance_bootFromVolumeImageWithAttachedVolume(t *testing.T) {
+	var instance servers.Server
+	var testAccComputeV2Instance_bootFromVolumeImageWithAttachedVolume = fmt.Sprintf(`
+		resource "openstack_blockstorage_volume_v1" "volume_1" {
+  		name = "volume_1"
+  		size = 1
+		}
+
+		resource "openstack_compute_instance_v2" "instance_1" {
+			name = "instance_1"
+			security_groups = ["default"]
+			block_device {
+				uuid = "%s"
+				source_type = "image"
+				volume_size = 2
+				boot_index = 0
+				destination_type = "volume"
+				delete_on_termination = true
+			}
+
+			volume {
+				volume_id = "${openstack_blockstorage_volume_v1.volume_1.id}"
+			}
+		}`,
+		os.Getenv("OS_IMAGE_ID"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_bootFromVolumeImageWithAttachedVolume,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.instance_1", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeV2Instance_bootFromVolumeVolume(t *testing.T) {
 	var instance servers.Server
 	var testAccComputeV2Instance_bootFromVolumeVolume = fmt.Sprintf(`


### PR DESCRIPTION
This commit fixes the situation where instances with both a
bootable volume and attached block storage volumes were reporting
an inconsistent state.

Fixes #7297