### PR TITLE
provider/digitalocean: Enforce Lowercase on IPV6 Addresses

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -76,6 +76,9 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			"ipv6_address": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"ipv6_address_private": &schema.Schema{
@@ -253,7 +256,7 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 
 	if publicIPv6 := findIPv6AddrByType(droplet, "public"); publicIPv6 != "" {
 		d.Set("ipv6", true)
-		d.Set("ipv6_address", publicIPv6)
+		d.Set("ipv6_address", strings.ToLower(publicIPv6))
 		d.Set("ipv6_address_private", findIPv6AddrByType(droplet, "private"))
 	}
 

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -260,6 +260,16 @@ func testAccCheckDigitalOceanDropletAttributes_PrivateNetworkingIpv6(droplet *go
 			return fmt.Errorf("No ipv6 public: %s", findIPv6AddrByType(droplet, "public"))
 		}
 
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "digitalocean_droplet" {
+				continue
+			}
+			if rs.Primary.Attributes["ipv6_address"] != strings.ToLower(findIPv6AddrByType(droplet, "public")) {
+				return fmt.Errorf("IPV6 Address should be lowercase")
+			}
+
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes #3282

IPV6 Addresses are generally case insensitive but it is recommented to
store them as lowercase (https://tools.ietf.org/html/rfc5952#section-4.3)

When Terraform didn't store them as LowerCase, we got the following
error when using in DNS records:

```
-/+ digitalocean_record.web6
    domain:   "mydomain.com" => "mydomain.com"
    fqdn:     "web02.in.mydomain.com" => "<computed>"
    name:     "web02.in" => "web02.in"
    port:     "0" => "<computed>"
    priority: "0" => "<computed>"
    type:     "AAAA" => "AAAA"
    value:    "2a03:b0c0:0003:00d0:0000:0000:0b66:6001" => "2A03:B0C0:0003:00D0:0000:0000:0B66:6001" (forces new resource)
    weight:   "0" => "<computed>"
```

There was no need for this to be the case. We now enforce lowercase on both state and also when responses are returned from the API