### PR TITLE
provider/aws: Support `task_role_arn` on `aws_ecs_task_definition`

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -46,6 +46,12 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 				},
 			},
 
+			"task_role_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"volume": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -81,6 +87,10 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 	input := ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: definitions,
 		Family:               aws.String(d.Get("family").(string)),
+	}
+
+	if v, ok := d.GetOk("task_role_arn"); ok {
+		input.TaskRoleArn = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("volume"); ok {
@@ -127,6 +137,7 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("family", *taskDefinition.Family)
 	d.Set("revision", *taskDefinition.Revision)
 	d.Set("container_definitions", taskDefinition.ContainerDefinitions)
+	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
 	d.Set("volumes", flattenEcsVolumes(taskDefinition.Volumes))
 
 	return nil


### PR DESCRIPTION
Fixes #7633 

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcsTaskDefinition_'                         ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcsTaskDefinition_ -timeout 120m
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (34.09s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (18.32s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (146.41s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (21.85s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	220.699s
```