### PR TITLE
Support "." in map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ BUG FIXES:
  * provider/aws: `aws_customer_gateway` refreshing from state on deleted state [GH-7482]
  * provider/aws: Retry finding `aws_route` after creating it [GH-7463]
  * provider/aws: Refresh CloudWatch Group from state on 404 [GH-7576]
+ * provider/aws: Adding in additional retry logic due to latency with delete of `db_option_group` [GH-7312]
  * provider/azurerm: Fixes terraform crash when using SSH keys with `azurerm_virtual_machine` [GH-6766]
  * provider/azurerm: Fix a bug causing 'diffs do not match' on `azurerm_network_interface` resources [GH-6790]
  * provider/azurerm: Normalizes `availability_set_id` casing to avoid spurious diffs in `azurerm_virtual_machine` [GH-6768]

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -48,14 +48,6 @@ type Resource struct {
 // its a primary instance, a tainted instance, or an orphan.
 type ResourceFlag byte
 
-const (
-	FlagPrimary ResourceFlag = 1 << iota
-	FlagTainted
-	FlagOrphan
-	FlagReplacePrimary
-	FlagDeposed
-)
-
 // InstanceInfo is used to hold information about the instance and/or
 // resource being modified.
 type InstanceInfo struct {
@@ -180,7 +172,8 @@ func (c *ResourceConfig) get(
 	}
 
 	var current interface{} = raw
-	for _, part := range parts {
+	var previous interface{} = nil
+	for i, part := range parts {
 		if current == nil {
 			return nil, false
 		}
@@ -188,12 +181,23 @@ func (c *ResourceConfig) get(
 		cv := reflect.ValueOf(current)
 		switch cv.Kind() {
 		case reflect.Map:
+			previous = current
 			v := cv.MapIndex(reflect.ValueOf(part))
 			if !v.IsValid() {
+				if i > 0 && i != (len(parts)-1) {
+					tryKey := strings.Join(parts[i:], ".")
+					v := cv.MapIndex(reflect.ValueOf(tryKey))
+					if !v.IsValid() {
+						return nil, false
+					}
+					return v.Interface(), true
+				}
+
 				return nil, false
 			}
 			current = v.Interface()
 		case reflect.Slice:
+			previous = current
 			if part == "#" {
 				current = cv.Len()
 			} else {
@@ -206,6 +210,14 @@ func (c *ResourceConfig) get(
 				}
 				current = cv.Index(int(i)).Interface()
 			}
+		case reflect.String:
+			// This happens when map keys contain "." and have a common
+			// prefix so were split as path components above.
+			actualKey := strings.Join(parts[i-1:], ".")
+			if prevMap, ok := previous.(map[string]interface{}); ok {
+				return prevMap[actualKey], true
+			}
+			return nil, false
 		default:
 			panic(fmt.Sprintf("Unknown kind: %s", cv.Kind()))
 		}


### PR DESCRIPTION
This pull request brings together various fixes for #2143 and #7130. The acceptance tests added by @sodre now pass:

```
make testacc TEST=./builtin/providers/triton TESTARGS="-run TestAccTritonMachine_metadata"
==> Checking that code complies with gofmt requirements...
/Users/James/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/07/14 12:39:07 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/triton -v -run TestAccTritonMachine_metadata -timeout 120m
=== RUN   TestAccTritonMachine_metadata
--- PASS: TestAccTritonMachine_metadata (140.83s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/triton	140.843s
```

cc @phinze