### PR TITLE
provider/aws: Support kms_key_id for `aws_rds_cluster`

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -196,6 +196,13 @@ func resourceAwsRDSCluster() *schema.Resource {
 				},
 			},
 
+			"kms_key_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -341,6 +348,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			createOpts.PreferredMaintenanceWindow = aws.String(v.(string))
 		}
 
+		if attr, ok := d.GetOk("kms_key_id"); ok {
+			createOpts.KmsKeyId = aws.String(attr.(string))
+		}
+
 		log.Printf("[DEBUG] RDS Cluster create options: %s", createOpts)
 		resp, err := conn.CreateDBCluster(createOpts)
 		if err != nil {
@@ -431,6 +442,7 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
 	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", dbc.PreferredMaintenanceWindow)
+	d.Set("kms_key_id", dbc.KmsKeyId)
 
 	var vpcg []string
 	for _, g := range dbc.VpcSecurityGroups {

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -83,6 +83,20 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"kms_key_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"storage_encrypted": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +29,27 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
+	var v rds.DBInstance
+	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSClusterInstanceConfigKmsKey(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster_instance.cluster_instances", "kms_key_id", keyRegex),
 				),
 			},
 		},
@@ -198,4 +220,64 @@ resource "aws_db_parameter_group" "bar" {
   }
 }
 `, n, n, n)
+}
+
+func testAccAWSClusterInstanceConfigKmsKey(n int) string {
+	return fmt.Sprintf(`
+
+resource "aws_kms_key" "foo" {
+    description = "Terraform acc test %d"
+    policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-test-%d"
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "mustbeeightcharaters"
+  storage_encrypted = true
+  kms_key_id = "${aws_kms_key.foo.arn}"
+}
+
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  identifier              = "tf-cluster-instance-%d"
+  cluster_identifier      = "${aws_rds_cluster.default.id}"
+  instance_class          = "db.r3.large"
+  db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
+  storage_encrypted = true
+  kms_key_id = "${aws_kms_key.foo.arn}"
+}
+
+resource "aws_db_parameter_group" "bar" {
+  name   = "tfcluster-test-group-%d"
+  family = "aurora5.6"
+
+  parameter {
+    name         = "back_log"
+    value        = "32767"
+    apply_method = "pending-reboot"
+  }
+
+  tags {
+    foo = "bar"
+  }
+}
+`, n, n, n, n)
 }

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -64,6 +64,28 @@ func TestAccAWSRDSCluster_updateTags(t *testing.T) {
 	})
 }
 
+func TestAccAWSRDSCluster_kmsKey(t *testing.T) {
+ 	var v rds.DBCluster
+ 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+
+ 	resource.Test(t, resource.TestCase{
+ 		PreCheck:     func() { testAccPreCheck(t) },
+ 		Providers:    testAccProviders,
+ 		CheckDestroy: testAccCheckAWSClusterDestroy,
+ 		Steps: []resource.TestStep{
+ 			resource.TestStep{
+ 				Config: testAccAWSClusterConfig_kmsKey(acctest.RandInt()),
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+ 					resource.TestMatchResourceAttr(
+ 						"aws_rds_cluster.default", "kms_key_id", keyRegex),
+ 				),
+ 			},
+ 		},
+ 	})
+ }
+
+
 func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 	var v rds.DBCluster
 
@@ -219,6 +241,43 @@ resource "aws_rds_cluster" "default" {
   }
 }`, n)
 }
+
+func testAccAWSClusterConfig_kmsKey(n int) string {
+ 	return fmt.Sprintf(`
+
+ resource "aws_kms_key" "foo" {
+     description = "Terraform acc test %d"
+     policy = <<POLICY
+ {
+   "Version": "2012-10-17",
+   "Id": "kms-tf-1",
+   "Statement": [
+     {
+       "Sid": "Enable IAM User Permissions",
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "*"
+       },
+       "Action": "kms:*",
+       "Resource": "*"
+     }
+   ]
+ }
+ POLICY
+ }
+
+ resource "aws_rds_cluster" "default" {
+   cluster_identifier = "tf-aurora-cluster-%d"
+   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+   database_name = "mydb"
+   master_username = "foo"
+   master_password = "mustbeeightcharaters"
+   db_cluster_parameter_group_name = "default.aurora5.6"
+   storage_encrypted = true
+   kms_key_id = "${aws_kms_key.foo.arn}"
+ }`, n, n)
+ }
+
 
 func testAccAWSClusterConfig_encrypted(n int) string {
 	return fmt.Sprintf(`

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -65,26 +66,25 @@ func TestAccAWSRDSCluster_updateTags(t *testing.T) {
 }
 
 func TestAccAWSRDSCluster_kmsKey(t *testing.T) {
- 	var v rds.DBCluster
- 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+	var v rds.DBCluster
+	keyRegex := regexp.MustCompile("^arn:aws:kms:")
 
- 	resource.Test(t, resource.TestCase{
- 		PreCheck:     func() { testAccPreCheck(t) },
- 		Providers:    testAccProviders,
- 		CheckDestroy: testAccCheckAWSClusterDestroy,
- 		Steps: []resource.TestStep{
- 			resource.TestStep{
- 				Config: testAccAWSClusterConfig_kmsKey(acctest.RandInt()),
- 				Check: resource.ComposeTestCheckFunc(
- 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
- 					resource.TestMatchResourceAttr(
- 						"aws_rds_cluster.default", "kms_key_id", keyRegex),
- 				),
- 			},
- 		},
- 	})
- }
-
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSClusterConfig_kmsKey(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster.default", "kms_key_id", keyRegex),
+				),
+			},
+		},
+	})
+}
 
 func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 	var v rds.DBCluster
@@ -243,7 +243,7 @@ resource "aws_rds_cluster" "default" {
 }
 
 func testAccAWSClusterConfig_kmsKey(n int) string {
- 	return fmt.Sprintf(`
+	return fmt.Sprintf(`
 
  resource "aws_kms_key" "foo" {
      description = "Terraform acc test %d"
@@ -276,8 +276,7 @@ func testAccAWSClusterConfig_kmsKey(n int) string {
    storage_encrypted = true
    kms_key_id = "${aws_kms_key.foo.arn}"
  }`, n, n)
- }
-
+}
 
 func testAccAWSClusterConfig_encrypted(n int) string {
 	return fmt.Sprintf(`

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -79,7 +79,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
      `false`. See [Amazon RDS Documentation for more information.](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance. **NOTE:** This must match the `db_subnet_group_name` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
-* `kms_key_id` - (Optional) The ARN for the KMS encryption key.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -79,6 +79,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
      `false`. See [Amazon RDS Documentation for more information.](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance. **NOTE:** This must match the `db_subnet_group_name` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -65,6 +65,8 @@ details on controlling this property.
 * `db_parameter_group_name` - (Optional) The name of the DB parameter group to associate with this instance.
 * `apply_immediately` - (Optional) Specifies whether any database modifications
      are applied immediately, or during the next maintenance window. Default is`false`.
+* `storage_encrypted` - (Optional) Specifies whether the DB cluster instance is encrypted. The default is `false` if not specified.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true
 * `tags` - (Optional) A mapping of tags to assign to the instance.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes #7655 

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSCluster_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSCluster_
-timeout 120m
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (127.57s)
=== RUN   TestAccAWSRDSCluster_kmsKey
--- PASS: TestAccAWSRDSCluster_kmsKey (323.72s)
=== RUN   TestAccAWSRDSCluster_encrypted
--- PASS: TestAccAWSRDSCluster_encrypted (173.25s)
=== RUN   TestAccAWSRDSCluster_backupsUpdate
--- PASS: TestAccAWSRDSCluster_backupsUpdate (264.07s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    888.638s
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSClusterInstance_kmsKey'              2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSClusterInstance_kmsKey -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (1152.36s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1152.395s
```