### PR TITLE
provider/aws: Fixup skip_final_snapshot import

### DIFF
--- a/builtin/providers/aws/import_aws_db_instance_test.go
+++ b/builtin/providers/aws/import_aws_db_instance_test.go
@@ -23,7 +23,10 @@ func TestAccAWSDBInstance_importBasic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"password", "skip_final_snapshot"},
+					"password",
+					"skip_final_snapshot",
+					"final_snapshot_identifier",
+				},
 			},
 		},
 	})

--- a/helper/resource/testing_import_state.go
+++ b/helper/resource/testing_import_state.go
@@ -90,8 +90,14 @@ func testStepImportState(
 			}
 
 			// Compare their attributes
-			actual := r.Primary.Attributes
-			expected := oldR.Primary.Attributes
+			actual := make(map[string]string)
+			for k, v := range r.Primary.Attributes {
+				actual[k] = v
+			}
+			expected := make(map[string]string)
+			for k, v := range oldR.Primary.Attributes {
+				expected[k] = v
+			}
 
 			// Remove fields we're ignoring
 			for _, v := range step.ImportStateVerifyIgnore {


### PR DESCRIPTION
Neither skip_final_snapshot nor final_snapshot_identifier can be fetched
from any API call, so we need to default skip_final_snapshot to false
during import so that final_snapshot_identifier is not required