### PR TITLE
provider/aws: Read Elastic Beanstalk stack name

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -108,13 +108,14 @@ func resourceAwsElasticBeanstalkEnvironment() *schema.Resource {
 				Set:      optionSettingValueHash,
 			},
 			"solution_stack_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"template_name": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"solution_stack_name"},
+				Computed:      true,
+				ConflictsWith: []string{"template_name"},
+			},
+			"template_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"wait_for_ready_timeout": &schema.Schema{
 				Type:     schema.TypeString,
@@ -418,6 +419,10 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 		if err := d.Set("cname_prefix", ""); err != nil {
 			return err
 		}
+	}
+
+	if err := d.Set("solution_stack_name", env.SolutionStackName); err != nil {
+		return err
 	}
 
 	if err := d.Set("autoscaling_groups", flattenBeanstalkAsg(resources.EnvironmentResources.AutoScalingGroups)); err != nil {


### PR DESCRIPTION
@stack72 This is the fixed version of #7445 

Tests:
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalk -timeout 120m
=== RUN   TestAccAWSBeanstalkApp_basic
--- PASS: TestAccAWSBeanstalkApp_basic (16.06s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_basic
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_basic (20.20s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_VPC
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_VPC (25.54s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_Setting
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_Setting (21.28s)
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (589.11s)
=== RUN   TestAccAWSBeanstalkEnv_tier
--- PASS: TestAccAWSBeanstalkEnv_tier (577.64s)
=== RUN   TestAccAWSBeanstalkEnv_outputs
--- PASS: TestAccAWSBeanstalkEnv_outputs (395.09s)
=== RUN   TestAccAWSBeanstalkEnv_cname_prefix
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (320.44s)
=== RUN   TestAccAWSBeanstalkEnv_config
--- PASS: TestAccAWSBeanstalkEnv_config (551.92s)
=== RUN   TestAccAWSBeanstalkEnv_resource
--- PASS: TestAccAWSBeanstalkEnv_resource (486.60s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	3003.897s
```