### PR TITLE
provider/aws: Clean up aws config path a bit

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -179,19 +179,6 @@ func (c *Config) Client() (interface{}, error) {
 		sess := session.New(awsConfig)
 		sess.Handlers.Build.PushFrontNamed(addTerraformVersionToUserAgent)
 
-		log.Println("[INFO] Initializing IAM Connection")
-		awsIamSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.IamEndpoint)})
-		client.iamconn = iam.New(awsIamSess)
-
-		log.Println("[INFO] Initializing STS connection")
-		client.stsconn = sts.New(sess)
-
-		err = c.ValidateCredentials(client.stsconn)
-		if err != nil {
-			errs = append(errs, err)
-			return nil, &multierror.Error{Errors: errs}
-		}
-
 		// Some services exist only in us-east-1, e.g. because they manage
 		// resources that can span across multiple regions, or because
 		// signature format v4 requires region to be us-east-1 for global
@@ -199,128 +186,65 @@ func (c *Config) Client() (interface{}, error) {
 		// http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
 		usEast1Sess := sess.Copy(&aws.Config{Region: aws.String("us-east-1")})
 
+		// Some services have user-configurable endpoints
+		awsEc2Sess := sess.Copy(&aws.Config{Endpoint: aws.String(c.Ec2Endpoint)})
+		awsElbSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.ElbEndpoint)})
+		awsIamSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.IamEndpoint)})
+		dynamoSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DynamoDBEndpoint)})
+		kinesisSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.KinesisEndpoint)})
+
+		client.stsconn = sts.New(sess)
+		err = c.ValidateCredentials(client.stsconn)
+		if err != nil {
+			errs = append(errs, err)
+			return nil, &multierror.Error{Errors: errs}
+		}
 		accountId, err := GetAccountId(client.iamconn, client.stsconn, cp.ProviderName)
 		if err == nil {
 			client.accountid = accountId
 		}
-
-		log.Println("[INFO] Initializing DynamoDB connection")
-		dynamoSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DynamoDBEndpoint)})
-		client.dynamodbconn = dynamodb.New(dynamoSess)
-
-		log.Println("[INFO] Initializing Cloudfront connection")
-		client.cloudfrontconn = cloudfront.New(sess)
-
-		log.Println("[INFO] Initializing ELB connection")
-		awsElbSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.ElbEndpoint)})
-		client.elbconn = elb.New(awsElbSess)
-
-		log.Println("[INFO] Initializing S3 connection")
-		client.s3conn = s3.New(sess)
-
-		log.Println("[INFO] Initializing SES connection")
-		client.sesConn = ses.New(sess)
-
-		log.Println("[INFO] Initializing SimpleDB connection")
-		client.simpledbconn = simpledb.New(sess)
-
-		log.Println("[INFO] Initializing SQS connection")
-		client.sqsconn = sqs.New(sess)
-
-		log.Println("[INFO] Initializing SNS connection")
-		client.snsconn = sns.New(sess)
-
-		log.Println("[INFO] Initializing RDS Connection")
-		client.rdsconn = rds.New(sess)
-
-		log.Println("[INFO] Initializing Kinesis Connection")
-		kinesisSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.KinesisEndpoint)})
-		client.kinesisconn = kinesis.New(kinesisSess)
-
-		log.Println("[INFO] Initializing Elastic Beanstalk Connection")
-		client.elasticbeanstalkconn = elasticbeanstalk.New(sess)
-
-		log.Println("[INFO] Initializing Elastic Transcoder Connection")
-		client.elastictranscoderconn = elastictranscoder.New(sess)
 
 		authErr := c.ValidateAccountId(client.accountid)
 		if authErr != nil {
 			errs = append(errs, authErr)
 		}
 
-		log.Println("[INFO] Initializing Kinesis Firehose Connection")
-		client.firehoseconn = firehose.New(sess)
-
-		log.Println("[INFO] Initializing AutoScaling connection")
-		client.autoscalingconn = autoscaling.New(sess)
-
-		log.Println("[INFO] Initializing EC2 Connection")
-
-		awsEc2Sess := sess.Copy(&aws.Config{Endpoint: aws.String(c.Ec2Endpoint)})
-		client.ec2conn = ec2.New(awsEc2Sess)
-
-		log.Println("[INFO] Initializing ECR Connection")
-		client.ecrconn = ecr.New(sess)
-
-		log.Println("[INFO] Initializing API Gateway")
 		client.apigateway = apigateway.New(sess)
-
-		log.Println("[INFO] Initializing ECS Connection")
-		client.ecsconn = ecs.New(sess)
-
-		log.Println("[INFO] Initializing EFS Connection")
-		client.efsconn = efs.New(sess)
-
-		log.Println("[INFO] Initializing ElasticSearch Connection")
-		client.esconn = elasticsearch.New(sess)
-
-		log.Println("[INFO] Initializing EMR Connection")
-		client.emrconn = emr.New(sess)
-
-		log.Println("[INFO] Initializing Route 53 connection")
-		client.r53conn = route53.New(usEast1Sess)
-
-		log.Println("[INFO] Initializing Elasticache Connection")
-		client.elasticacheconn = elasticache.New(sess)
-
-		log.Println("[INFO] Initializing Lambda Connection")
-		client.lambdaconn = lambda.New(sess)
-
-		log.Println("[INFO] Initializing Cloudformation Connection")
+		client.autoscalingconn = autoscaling.New(sess)
 		client.cfconn = cloudformation.New(sess)
-
-		log.Println("[INFO] Initializing CloudWatch SDK connection")
-		client.cloudwatchconn = cloudwatch.New(sess)
-
-		log.Println("[INFO] Initializing CloudWatch Events connection")
-		client.cloudwatcheventsconn = cloudwatchevents.New(sess)
-
-		log.Println("[INFO] Initializing CloudTrail connection")
+		client.cloudfrontconn = cloudfront.New(sess)
 		client.cloudtrailconn = cloudtrail.New(sess)
-
-		log.Println("[INFO] Initializing CloudWatch Logs connection")
+		client.cloudwatchconn = cloudwatch.New(sess)
+		client.cloudwatcheventsconn = cloudwatchevents.New(sess)
 		client.cloudwatchlogsconn = cloudwatchlogs.New(sess)
-
-		log.Println("[INFO] Initializing OpsWorks Connection")
-		client.opsworksconn = opsworks.New(usEast1Sess)
-
-		log.Println("[INFO] Initializing Directory Service connection")
-		client.dsconn = directoryservice.New(sess)
-
-		log.Println("[INFO] Initializing Glacier connection")
-		client.glacierconn = glacier.New(sess)
-
-		log.Println("[INFO] Initializing CodeDeploy Connection")
-		client.codedeployconn = codedeploy.New(sess)
-
-		log.Println("[INFO] Initializing CodeCommit SDK connection")
 		client.codecommitconn = codecommit.New(usEast1Sess)
-
-		log.Println("[INFO] Initializing Redshift SDK connection")
-		client.redshiftconn = redshift.New(sess)
-
-		log.Println("[INFO] Initializing KMS connection")
+		client.codedeployconn = codedeploy.New(sess)
+		client.dsconn = directoryservice.New(sess)
+		client.dynamodbconn = dynamodb.New(dynamoSess)
+		client.ec2conn = ec2.New(awsEc2Sess)
+		client.ecrconn = ecr.New(sess)
+		client.ecsconn = ecs.New(sess)
+		client.efsconn = efs.New(sess)
+		client.elasticacheconn = elasticache.New(sess)
+		client.elasticbeanstalkconn = elasticbeanstalk.New(sess)
+		client.elastictranscoderconn = elastictranscoder.New(sess)
+		client.elbconn = elb.New(awsElbSess)
+		client.emrconn = emr.New(sess)
+		client.esconn = elasticsearch.New(sess)
+		client.firehoseconn = firehose.New(sess)
+		client.glacierconn = glacier.New(sess)
+		client.iamconn = iam.New(awsIamSess)
+		client.kinesisconn = kinesis.New(kinesisSess)
 		client.kmsconn = kms.New(sess)
+		client.lambdaconn = lambda.New(sess)
+		client.opsworksconn = opsworks.New(usEast1Sess)
+		client.r53conn = route53.New(usEast1Sess)
+		client.rdsconn = rds.New(sess)
+		client.redshiftconn = redshift.New(sess)
+		client.s3conn = s3.New(sess)
+		client.sesConn = ses.New(sess)
+		client.snsconn = sns.New(sess)
+		client.sqsconn = sqs.New(sess)
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
Rearrange client setup, and remove the extraneous log lines we make per
connection. There's no need to log one line per API client - we're just
setting up structs for most of them.

Since this collapses the file down quite a bit, switch to alphabetized
client setup, since previously there wasn't much of an order to things.