### PR TITLE
provider/azurerm: azurerm_storage_account now returns storage keys value instead of their names

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_account.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account.go
@@ -220,8 +220,8 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	accessKeys := *keys.Keys
-	d.Set("primary_access_key", accessKeys[0].KeyName)
-	d.Set("secondary_access_key", accessKeys[1].KeyName)
+	d.Set("primary_access_key", accessKeys[0].Value)
+	d.Set("secondary_access_key", accessKeys[1].Value)
 	d.Set("location", resp.Location)
 	d.Set("account_type", resp.Sku.Name)
 	d.Set("primary_location", resp.Properties.PrimaryLocation)


### PR DESCRIPTION
`azurerm_storage_account` was returning storage keys name when accessing `primary_access_key` and `secondary_access_key`, which is pretty much useless for now. Now it returns the key values.

Next step would be to return a map of the keys with their name and value but I'm not familiar enough with `go` to do it right away.