### PR TITLE
provider/azurerm: fix vault_certificates in vm/vm scale_sets

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -339,7 +339,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 						},
 
 						"vault_certificates": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -908,7 +908,7 @@ func expandAzureRmVirtualMachineOsProfileSecrets(d *schema.ResourceData) *[]comp
 		}
 
 		if v := config["vault_certificates"]; v != nil {
-			certsConfig := v.(*schema.Set).List()
+			certsConfig := v.([]interface{})
 			certs := make([]compute.VaultCertificate, 0, len(certsConfig))
 			for _, certConfig := range certsConfig {
 				config := certConfig.(map[string]interface{})

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -111,7 +111,7 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 						},
 
 						"vault_certificates": &schema.Schema{
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -1063,7 +1063,7 @@ func expandAzureRmVirtualMachineScaleSetOsProfileSecrets(d *schema.ResourceData)
 		}
 
 		if v := config["vault_certificates"]; v != nil {
-			certsConfig := v.(*schema.Set).List()
+			certsConfig := v.([]interface{})
 			certs := make([]compute.VaultCertificate, 0, len(certsConfig))
 			for _, certConfig := range certsConfig {
 				config := certConfig.(map[string]interface{})


### PR DESCRIPTION
When setting the `certificate_url` and `certificate_store` values in
`os_profile_secrets` / `vault_certificates` for a Windows VM in AzureRM, I
was getting the following error:

```
[DEBUG] Error setting Virtual Machine Storage OS Profile Secrets:
&errors.errorString{s:"Invalid address to set:
[]string{\"os_profile_secrets\", \"0\", \"vault_certificates\"}"}
```

This seemed to have resolve the issue when creating a regular VM (`resource_arm_virtual_machine.go`) and I went ahead and made the corresponding changes for VM scale sets as well (`resource_arm_virtual_machine_scale_set.go`).

Regarding the tests, I wasn't sure if it would be possible to handle this scenario as from what I can see, there is no way to create/interact with Azure Key Vaults from Terraform.