### PR TITLE
provider/scaleway properly handle server tags

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_server_test.go
+++ b/builtin/providers/scaleway/resource_scaleway_server_test.go
@@ -23,6 +23,8 @@ func TestAccScalewayServer_Basic(t *testing.T) {
 						"scaleway_server.base", "type", "C1"),
 					resource.TestCheckResourceAttr(
 						"scaleway_server.base", "name", "test"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "tags.0", "terraform-test"),
 				),
 			},
 		},
@@ -110,4 +112,5 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
+  tags = [ "terraform-test" ]
 }`, armImageIdentifier)


### PR DESCRIPTION
When #7331 was merged I missed that tags did not work properly just yet.
Assigning tags on servers will lead to a panic.

This PR fixes tag handling for the resource `scaleway_server`, so no more panic when writing something like this:

```
resource "scaleway_server" "base" {
  name = "test"
  # ubuntu 14.04
  image = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
  type = "C1"
  tags = [ "terraform-test" ]
}
```