### PR TITLE
aws:Allow reassignment of EIP instances appropriately

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -219,11 +219,12 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	var numTargets int
 	var setTarget string
+
 	allowedTargets := []string{
 		"gateway_id",
 		"nat_gateway_id",
-		"instance_id",
 		"network_interface_id",
+		"instance_id",
 		"vpc_peering_connection_id",
 	}
 	replaceOpts := &ec2.ReplaceRouteInput{}
@@ -236,8 +237,18 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if numTargets > 1 {
-		return routeTargetValidationError
+	switch setTarget {
+	//instance_id is a special case due to the fact that AWS will "discover" the network_interace_id
+	//when it creates the route and return that data.  In the case of an update, we should ignore the
+	//existing network_interface_id
+	case "instance_id":
+		if numTargets > 2 || (numTargets == 2 && len(d.Get("network_interface_id").(string)) == 0) {
+			return routeTargetValidationError
+		}
+	default:
+		if numTargets > 1 {
+			return routeTargetValidationError
+		}
 	}
 
 	// Formulate ReplaceRouteInput based on the target type
@@ -259,8 +270,6 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
 			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
 			InstanceId:           aws.String(d.Get("instance_id").(string)),
-			//NOOP: Ensure we don't blow away network interface id that is set after instance is launched
-			NetworkInterfaceId: aws.String(d.Get("network_interface_id").(string)),
 		}
 	case "network_interface_id":
 		replaceOpts = &ec2.ReplaceRouteInput{


### PR DESCRIPTION
Recreated from PR https://github.com/hashicorp/terraform/pull/6682 because I fubared the merge and it was easier just to cherry-pick

fixes #6076

As atward described, when using the instance_id attribute for the association, in the background AWS is also assigning the network_interface_id. The current way of checking would essentially eliminate any possibility of reallocating the route to a new instance id due to the numTargets check always returning 2 in that case and fast failing.

Update order of precedence to ensure that allowedTargets is evaluated so that instance_id comes after network_interface_id to allow for check
If there are multiple but they are instance_id and network_interface_id is the other let AWS handle the network_interface_id
NOTE: One thing I would have liked to add a test for but had a family emergency come up is tainting the original instance and reapplying. I did not see any direct example of doing this and was considering simply standing up 2 instances in the test and running a re-apply to associate the 2nd instance. If I get a chance before this is merged I will try and do so however I do not have cycles immediately.