### PR TITLE
provider/aws: Support Import of `aws_cloudwatch_metric_alarm`

### DIFF
--- a/builtin/providers/aws/import_aws_cloudwatch_metric_alarm_test.go
+++ b/builtin/providers/aws/import_aws_cloudwatch_metric_alarm_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudWatchMetricAlarm_importBasic(t *testing.T) {
+	resourceName := "aws_cloudwatch_metric_alarm.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchMetricAlarmDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudWatchMetricAlarmConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -16,6 +16,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 		Read:   resourceAwsCloudWatchMetricAlarmRead,
 		Update: resourceAwsCloudWatchMetricAlarmUpdate,
 		Delete: resourceAwsCloudWatchMetricAlarmDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"alarm_name": &schema.Schema{


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSCloudWatchMetricAlarm_ -timeout 120m
=== RUN   TestAccAWSCloudWatchMetricAlarm_importBasic
--- PASS: TestAccAWSCloudWatchMetricAlarm_importBasic (17.82s)
=== RUN   TestAccAWSCloudWatchMetricAlarm_basic
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (17.11s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    34.957s
```