### PR TITLE
provider/aws: Fix regression in Security Group Rules with self reference

### DIFF
--- a/builtin/providers/aws/import_aws_security_group.go
+++ b/builtin/providers/aws/import_aws_security_group.go
@@ -49,6 +49,34 @@ func resourceAwsSecurityGroupImportState(
 			d.SetType("aws_security_group_rule")
 			d.Set("security_group_id", sgId)
 			d.Set("type", ruleType)
+
+			// 'self' is false by default. Below, we range over the group ids and set true
+			// if the parent sg id is found
+			d.Set("self", false)
+
+			if len(perm.UserIdGroupPairs) > 0 {
+				s := perm.UserIdGroupPairs[0]
+
+				// Check for Pair that is the same as the Security Group, to denote self.
+				// Otherwise, mark the group id in source_security_group_id
+				isVPC := sg.VpcId != nil && *sg.VpcId != ""
+				if isVPC {
+					if *s.GroupId == *sg.GroupId {
+						d.Set("self", true)
+						// prune the self reference from the UserIdGroupPairs, so we don't
+						// have duplicate sg ids (both self and in source_security_group_id)
+						perm.UserIdGroupPairs = append(perm.UserIdGroupPairs[:0], perm.UserIdGroupPairs[0+1:]...)
+					}
+				} else {
+					if *s.GroupName == *sg.GroupName {
+						d.Set("self", true)
+						// prune the self reference from the UserIdGroupPairs, so we don't
+						// have duplicate sg ids (both self and in source_security_group_id)
+						perm.UserIdGroupPairs = append(perm.UserIdGroupPairs[:0], perm.UserIdGroupPairs[0+1:]...)
+					}
+				}
+			}
+
 			// XXX If the rule contained more than one source security group, this
 			// will choose one of them. We actually need to create one rule for each
 			// source security group.

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -498,7 +498,6 @@ func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) (*ec2.IpPermiss
 	}
 
 	if v, ok := d.GetOk("self"); ok && v.(bool) {
-		// if sg.GroupId != nil {
 		if sg.VpcId != nil && *sg.VpcId != "" {
 			groups[*sg.GroupId] = true
 		} else {
@@ -574,10 +573,6 @@ func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPe
 
 	d.Set("cidr_blocks", cb)
 
-	// 'self' is false by default. Below, we range over the group ids and set true
-	// if the parent sg id is found
-	d.Set("self", false)
-
 	var pl []string
 	for _, p := range rule.PrefixListIds {
 		pl = append(pl, *p.PrefixListId)
@@ -587,17 +582,9 @@ func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPe
 	if len(rule.UserIdGroupPairs) > 0 {
 		s := rule.UserIdGroupPairs[0]
 
-		// Check for Pair that is the same as the Security Group, to denote self.
-		// Otherwise, mark the group id in source_security_group_id
 		if isVPC {
-			if *s.GroupId == *sg.GroupId {
-				d.Set("self", true)
-			}
 			d.Set("source_security_group_id", *s.GroupId)
 		} else {
-			if *s.GroupName == *sg.GroupName {
-				d.Set("self", true)
-			}
 			d.Set("source_security_group_id", *s.GroupName)
 		}
 	}


### PR DESCRIPTION
To fix an issue with importing Security Group Rules #7164 was introduced to set the `self` attribute accordingly. That itself however introduced a regression (#7670) where users with matching `security_group_id` and `source_security_group_id` were getting a "force new" recreation loop with their rules. 

Example config:

```hcl
resource "aws_vpc" "foo" {
  cidr_block = "10.1.0.0/16"
}

resource "aws_security_group" "allow_all" {
  name        = "allow_all"
  description = "Allow all inbound traffic"
  vpc_id      = "${aws_vpc.foo.id}"
}

resource "aws_security_group_rule" "allow_self" {
  type                     = "ingress"
  from_port                = 0
  to_port                  = 0
  protocol                 = "-1"
  security_group_id        = "${aws_security_group.allow_all.id}"
  source_security_group_id = "${aws_security_group.allow_all.id}"
}
```

This configuration works as expected on v0.6.16, but loops in v0.7.0rc3:

```console
-/+ aws_security_group_rule.allow_self
    from_port:                "0" => "0"
    protocol:                 "-1" => "-1"
    security_group_id:        "sg-f0d8e58b" => "sg-f0d8e58b"
    self:                     "true" => "false" (forces new resource)
    source_security_group_id: "sg-f0d8e58b" => "sg-f0d8e58b"
    to_port:                  "0" => "0"
    type:                     "ingress" => "ingress"
```

The modifications to the method [setFromIPPerm ](https://github.com/hashicorp/terraform/pull/7164/files#diff-7af0362dbadfdc3cfd6233049cbe05b2)  in `resource_aws_security_group_rule` set's the `self` attribute to `false` by default, only to re-set it to `true` in the above scenario, which causes our loop.

The code in #7164 was added to fix the case of importing security groups (and rules), and in hindsight was likely placed in the wrong location, and subsequently reevaluated with every `READ`. The intent of the code is to sort out the `self` attribute in absence of a configuration file (importing). For situations with a configuration file, the correct setting of `self` is already handled.

In this PR I've moved that logic into the `import` method for `resource_aws_security_group`, since that was it's original use case. 

The `TestAccAWSSecurityGroup_importSelf` test still passes, and I've added a new test that demonstrates the problem, `TestAccAWSSecurityGroupRule_SelfSource`. 