### PR TITLE
Allow private_ip field in aws_spot_instance_request

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1046,7 +1046,7 @@ func buildAwsInstanceOpts(
 		}
 	}
 
-	if hasSubnet && associatePublicIPAddress {
+	if hasSubnet {
 		// If we have a non-default VPC / Subnet specified, we can flag
 		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
 		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise

--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -88,6 +88,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 
 		LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
 			BlockDeviceMappings: instanceOpts.BlockDeviceMappings,
+			NetworkInterfaces:   instanceOpts.NetworkInterfaces,
 			EbsOptimized:        instanceOpts.EBSOptimized,
 			Monitoring:          instanceOpts.Monitoring,
 			IamInstanceProfile:  instanceOpts.IAMInstanceProfile,
@@ -104,14 +105,6 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 
 	if v, ok := d.GetOk("block_duration_minutes"); ok {
 		spotOpts.BlockDurationMinutes = aws.Int64(int64(v.(int)))
-	}
-
-	// If the instance is configured with a Network Interface (a subnet, has
-	// public IP, etc), then the instanceOpts.SecurityGroupIds and SubnetId will
-	// be nil
-	if len(instanceOpts.NetworkInterfaces) > 0 {
-		spotOpts.LaunchSpecification.SecurityGroupIds = instanceOpts.NetworkInterfaces[0].Groups
-		spotOpts.LaunchSpecification.SubnetId = instanceOpts.NetworkInterfaces[0].SubnetId
 	}
 
 	// Make the spot instance request


### PR DESCRIPTION
It's possible to assign private ip addresses to spot instances, but it was not possible from terraform.
