### PR TITLE
provider/aws: Increase timeout for creating IAM role

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -105,10 +105,10 @@ func resourceAwsIamRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var createResp *iam.CreateRoleOutput
-	err := resource.Retry(10*time.Second, func() *resource.RetryError {
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
 		var err error
 		createResp, err = iamconn.CreateRole(request)
-		// IAM roles can take ~10 seconds to propagate in AWS:
+		// IAM roles can take ~30 seconds to propagate in AWS:
 		// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
 		if isAWSErr(err, "MalformedPolicyDocument", "Invalid principal in policy") {
 			return resource.RetryableError(err)


### PR DESCRIPTION
I am seeing `terraform apply` fail with:

> Error creating IAM Role my-role: timeout while waiting for state to become 'success'. last error: %!s(<nil>)

(The message is fixed in #7732.)

All subsequent `terraform apply`s fail with:

> Error creating IAM Role my-role: EntityAlreadyExists: Role with name my-role already exists.