### PR TITLE
Removed azurerm_network_interface from scale set example

### DIFF
--- a/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
@@ -32,18 +32,6 @@ resource "azurerm_subnet" "test" {
     address_prefix = "10.0.2.0/24"
 }
 
-resource "azurerm_network_interface" "test" {
-    name = "acctni"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-
-    ip_configuration {
-    	name = "testconfiguration1"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-    }
-}
-
 resource "azurerm_storage_account" "test" {
     name = "accsa"
     resource_group_name = "${azurerm_resource_group.test.name}"


### PR DESCRIPTION
Azure scale sets encapsulates the creation of network interfaces so it is not valid in this example.

I'm also think there maybe a issue with some of the parameter docs in the example they are prefixed with 'virtual_machine_' but not descriptions below the example. I was going to fix this as well but wasn't sure which was correct. The tests use the prefix but the schema in code doesn't appear to?