### PR TITLE
provider/aws: Set `storage_encrypted` to state in `aws_rds_cluster_instance`

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -205,6 +205,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set("cluster_identifier", db.DBClusterIdentifier)
 	d.Set("instance_class", db.DBInstanceClass)
 	d.Set("identifier", db.DBInstanceIdentifier)
+	d.Set("storage_encrypted", db.StorageEncrypted)
 
 	if len(db.DBParameterGroups) > 0 {
 		d.Set("db_parameter_group_name", db.DBParameterGroups[0].DBParameterGroupName)


### PR DESCRIPTION
The Import test showed that there was no setting of the
`storage_encrypted` value back to state on the Read func.

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSClusterInstance_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSRDSClusterInstance_importBasic -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_importBasic
--- PASS: TestAccAWSRDSClusterInstance_importBasic (754.30s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    754.411s
```