### PR TITLE
Fix endpoint documentation for aws_rds_cluster

### DIFF
--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -19,11 +19,11 @@ Changes to a RDS Cluster can occur when you manually change a
 parameter, such as `port`, and are reflected in the next maintenance
 window. Because of this, Terraform may report a difference in it's planning
 phase because a modification has not yet taken place. You can use the
-`apply_immediately` flag to instruct the service to apply the change immediately 
-(see documentation below). 
+`apply_immediately` flag to instruct the service to apply the change immediately
+(see documentation below).
 
-~> **Note:** using `apply_immediately` can result in a 
-brief downtime as the server reboots. See the AWS Docs on [RDS Maintenance][4] 
+~> **Note:** using `apply_immediately` can result in a
+brief downtime as the server reboots. See the AWS Docs on [RDS Maintenance][4]
 for more information.
 
 ## Example Usage
@@ -66,7 +66,7 @@ string.
   instances in the DB cluster can be created in
 * `backup_retention_period` - (Optional) The days to retain backups for. Default
 1
-* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter. 
+* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.
 Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
 * `preferred_maintenance_window` - (Optional) The weekly time range during which system maintenance can occur, in (UTC) e.g. wed:04:00-wed:04:30
 * `port` - (Optional) The port on which the DB accepts connections
@@ -88,13 +88,12 @@ The following attributes are exported:
 * `id` - The RDS Cluster Identifier
 * `cluster_identifier` - The RDS Cluster Identifier
 * `cluster_members` – List of RDS Instances that are a part of this cluster
-* `address` - The address of the RDS instance.
 * `allocated_storage` - The amount of allocated storage
 * `availability_zones` - The availability zone of the instance
 * `backup_retention_period` - The backup retention period
 * `preferred_backup_window` - The backup window
 * `preferred_maintenance_window` - The maintenance window
-* `endpoint` - The primary, writeable connection endpoint
+* `endpoint` - The DNS address of the RDS instance
 * `engine` - The database engine
 * `engine_version` - The database engine version
 * `maintenance_window` - The instance maintenance window
@@ -113,7 +112,7 @@ The following attributes are exported:
 
 ## Import
 
-RDS Clusters can be imported using the `cluster_identifier`, e.g. 
+RDS Clusters can be imported using the `cluster_identifier`, e.g.
 
 ```
 $ terraform import aws_rds_cluster.aurora_cluster aurora-prod-cluster

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -80,7 +80,7 @@ The following attributes are exported:
 this instance is a read replica
 * `allocated_storage` - The amount of allocated storage
 * `availability_zones` - The availability zone of the instance
-* `endpoint` - The IP address for this instance. May not be writable
+* `endpoint` - The DNS address for this instance. May not be writable
 * `engine` - The database engine
 * `engine_version` - The database engine version
 * `database_name` - The database name
@@ -95,7 +95,7 @@ this instance is a read replica
 
 ## Import
 
-Redshift Cluster Instances can be imported using the `identifier`, e.g. 
+Redshift Cluster Instances can be imported using the `identifier`, e.g.
 
 ```
 $ terraform import aws_rds_cluster_instance.prod_instance_1 aurora-cluster-instance-1


### PR DESCRIPTION
Sorry for all the whitespace changes.  Atom automatically removes whitespace at the end of lines.  I can create a different patch if it's too annoying.