### PR TITLE
core: send version info to atlas

### DIFF
--- a/builtin/providers/atlas/provider.go
+++ b/builtin/providers/atlas/provider.go
@@ -52,6 +52,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			return nil, err
 		}
 	}
+	client.DefaultHeader.Set(terraform.VersionHeader, terraform.Version)
 	client.Token = d.Get("token").(string)
 
 	return client, nil

--- a/builtin/providers/atlas/provider.go
+++ b/builtin/providers/atlas/provider.go
@@ -52,7 +52,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			return nil, err
 		}
 	}
-	client.DefaultHeader.Set(terraform.VersionHeader, terraform.Version)
+	client.DefaultHeader.Set(terraform.VersionHeader, terraform.VersionString())
 	client.Token = d.Get("token").(string)
 
 	return client, nil

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -397,7 +397,7 @@ func (c *Config) ValidateAccountId(accountId string) error {
 var addTerraformVersionToUserAgent = request.NamedHandler{
 	Name: "terraform.TerraformVersionUserAgentHandler",
 	Fn: request.MakeAddToUserAgentHandler(
-		"terraform", terraform.Version, terraform.VersionPrerelease),
+		"terraform", terraform.VersionString()),
 }
 
 type awsLogger struct{}

--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -92,13 +92,7 @@ func withRequestLogging() autorest.SendDecorator {
 }
 
 func setUserAgent(client *autorest.Client) {
-	var version string
-	if terraform.VersionPrerelease != "" {
-		version = fmt.Sprintf("%s-%s", terraform.Version, terraform.VersionPrerelease)
-	} else {
-		version = terraform.Version
-	}
-
+	version := terraform.VersionString()
 	client.UserAgent = fmt.Sprintf("HashiCorp-Terraform-v%s", version)
 }
 

--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -85,11 +85,7 @@ func (c *Config) loadAndValidate() error {
 		}
 	}
 
-	versionString := terraform.Version
-	prerelease := terraform.VersionPrerelease
-	if len(prerelease) > 0 {
-		versionString = fmt.Sprintf("%s-%s", versionString, prerelease)
-	}
+	versionString := terraform.VersionString()
 	userAgent := fmt.Sprintf(
 		"(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, versionString)
 

--- a/command/push.go
+++ b/command/push.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/atlas-go/archive"
 	"github.com/hashicorp/atlas-go/v1"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 type PushCommand struct {
@@ -125,6 +126,8 @@ func (c *PushCommand) Run(args []string) int {
 				return 1
 			}
 		}
+
+		client.DefaultHeader.Set(terraform.VersionHeader, terraform.Version)
 
 		if atlasToken != "" {
 			client.Token = atlasToken

--- a/terraform/version.go
+++ b/terraform/version.go
@@ -16,3 +16,7 @@ const VersionPrerelease = "dev"
 // benefit of verifying during tests and init time that our version is a
 // proper semantic version, which should always be the case.
 var SemVersion = version.Must(version.NewVersion(Version))
+
+// VersionHeader is the header name used to send the current terraform version
+// in http requests.
+const VersionHeader = "Terraform-Version"

--- a/terraform/version.go
+++ b/terraform/version.go
@@ -1,6 +1,8 @@
 package terraform
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-version"
 )
 
@@ -20,3 +22,10 @@ var SemVersion = version.Must(version.NewVersion(Version))
 // VersionHeader is the header name used to send the current terraform version
 // in http requests.
 const VersionHeader = "Terraform-Version"
+
+func VersionString() string {
+	if VersionPrerelease != "" {
+		return fmt.Sprintf("%s-%s", Version, VersionPrerelease)
+	}
+	return Version
+}

--- a/vendor/github.com/hashicorp/atlas-go/v1/client.go
+++ b/vendor/github.com/hashicorp/atlas-go/v1/client.go
@@ -70,6 +70,10 @@ type Client struct {
 
 	// HTTPClient is the underlying http client with which to make requests.
 	HTTPClient *http.Client
+
+	// DefaultHeaders is a set of headers that will be added to every request.
+	// This minimally includes the atlas user-agent string.
+	DefaultHeader http.Header
 }
 
 // DefaultClient returns a client that connects to the Atlas API.
@@ -108,9 +112,12 @@ func NewClient(urlString string) (*Client, error) {
 	}
 
 	client := &Client{
-		URL:   parsedURL,
-		Token: token,
+		URL:           parsedURL,
+		Token:         token,
+		DefaultHeader: make(http.Header),
 	}
+
+	client.DefaultHeader.Set("User-Agent", userAgent)
 
 	if err := client.init(); err != nil {
 		return nil, err
@@ -227,10 +234,12 @@ func (c *Client) rawRequest(verb string, u *url.URL, ro *RequestOptions) (*http.
 		return nil, err
 	}
 
-	// Set the User-Agent
-	request.Header.Set("User-Agent", userAgent)
+	// set our default headers first
+	for k, v := range c.DefaultHeader {
+		request.Header[k] = v
+	}
 
-	// Add any headers (auth will be here if set)
+	// Add any request headers (auth will be here if set)
 	for k, v := range ro.Headers {
 		request.Header.Add(k, v)
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -920,9 +920,11 @@
 			"revision": "95fa852edca41c06c4ce526af4bb7dec4eaad434"
 		},
 		{
+			"checksumSHA1": "EWGfo74RcoKaYFZNSkvzYRJMgrY=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/v1",
-			"revision": "95fa852edca41c06c4ce526af4bb7dec4eaad434"
+			"revision": "c8b26aa95f096efc0f378b2d2830ca909631d584",
+			"revisionTime": "2016-07-22T13:58:36Z"
 		},
 		{
 			"comment": "v0.6.3-28-g3215b87",


### PR DESCRIPTION
Set a default `Terraform-Version` header in atlas requests.

Also adds a helper function to build the version string, since we were formatting that in various places throughout the code. 