### PR TITLE
provider/aws: Delete access keys before deleting IAM user

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -132,37 +132,40 @@ func resourceAwsIamUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	return nil
 }
+
 func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
 	// IAM Users must be removed from all groups before they can be deleted
 	var groups []string
-	var marker *string
-	truncated := aws.Bool(true)
-
-	for *truncated == true {
-		listOpts := iam.ListGroupsForUserInput{
-			UserName: aws.String(d.Id()),
-		}
-
-		if marker != nil {
-			listOpts.Marker = marker
-		}
-
-		r, err := iamconn.ListGroupsForUser(&listOpts)
-		if err != nil {
-			return err
-		}
-
-		for _, g := range r.Groups {
+	listGroups := &iam.ListGroupsForUserInput{
+		UserName: aws.String(d.Id()),
+	}
+	pageOfGroups := func(page *iam.ListGroupsForUserOutput, lastPage bool) (shouldContinue bool) {
+		for _, g := range page.Groups {
 			groups = append(groups, *g.GroupName)
 		}
+		return true
+	}
+	err := iamconn.ListGroupsForUserPages(listGroups, pageOfGroups)
+	if err != nil {
+		return fmt.Errorf("Error removing user %q from all groups: %s", d.Id(), err)
+	}
 
-		// if there's a marker present, we need to save it for pagination
-		if r.Marker != nil {
-			*marker = *r.Marker
+	// All access keys for the user must be removed
+	var accessKeys []string
+	listAccessKeys := &iam.ListAccessKeysInput{
+		UserName: aws.String(d.Id()),
+	}
+	pageOfAccessKeys := func(page *iam.ListAccessKeysOutput, lastPage bool) (shouldContinue bool) {
+		for _, g := range page.AccessKeyMetadata {
+			accessKeys = append(accessKeys, *g.AccessKeyId)
 		}
-		*truncated = *r.IsTruncated
+		return true
+	}
+	err = iamconn.ListAccessKeysPages(listAccessKeys, pageOfAccessKeys)
+	if err != nil {
+		return fmt.Errorf("Error removing access keys of user %s: %s", d.Id(), err)
 	}
 
 	for _, g := range groups {
@@ -170,6 +173,16 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] Removing IAM User %s from IAM Group %s", d.Id(), g)
 		if err := removeUsersFromGroup(iamconn, []*string{aws.String(d.Id())}, g); err != nil {
 			return err
+		}
+	}
+
+	for _, k := range accessKeys {
+		_, err := iamconn.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+			UserName:    aws.String(d.Id()),
+			AccessKeyId: aws.String(k),
+		})
+		if err != nil {
+			return fmt.Errorf("Error deleting access key %s: %s", k, err)
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -151,7 +151,7 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 		for _, g := range page.Groups {
 			groups = append(groups, *g.GroupName)
 		}
-		return true
+		return !lastPage
 	}
 	err := iamconn.ListGroupsForUserPages(listGroups, pageOfGroups)
 	if err != nil {
@@ -175,7 +175,7 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 			for _, k := range page.AccessKeyMetadata {
 				accessKeys = append(accessKeys, *k.AccessKeyId)
 			}
-			return true
+			return !lastPage
 		}
 		err = iamconn.ListAccessKeysPages(listAccessKeys, pageOfAccessKeys)
 		if err != nil {

--- a/website/source/docs/providers/aws/r/iam_user.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user.html.markdown
@@ -48,6 +48,9 @@ The following arguments are supported:
 
 * `name` - (Required) The user's name.
 * `path` - (Optional, default "/") Path in which to create the user.
+* `force_destroy` - (Optional, default false) When destroying this user, destroy
+  even if it has non-Terraform-managed IAM access keys. Without `force_destroy`
+  a user with non-Terraform-managed access keys will fail to be destroyed.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Without this change:

```
Error deleting IAM User my-user: DeleteConflict: Cannot delete entity, must delete access keys first.
```

We add access keys outside of Terraform because we do not want the secret keys in the tfstate.