### PR TITLE
Update docs to centralize on ARM-based Azure provider

### DIFF
--- a/website/source/docs/providers/azure/index.html.markdown
+++ b/website/source/docs/providers/azure/index.html.markdown
@@ -1,14 +1,16 @@
 ---
 layout: "azure"
-page_title: "Provider: Azure"
+page_title: "Provider: Azure Service Management"
 sidebar_current: "docs-azure-index"
 description: |-
   The Azure provider is used to interact with the many resources supported by Azure. The provider needs to be configured with a publish settings file and optionally a subscription ID before it can be used.
 ---
 
-# Azure Provider
+# Azure Service Management Provider
 
-The Azure provider is used to interact with the many resources supported
+[arm]: /docs/providers/azurerm/index.html
+
+The Azure Service Management Provider is used to interact with the many resources supported
 by Azure. The provider needs to be configured with a [publish settings
 file](https://manage.windowsazure.com/publishsettings) and optionally a
 subscription ID before it can be used.

--- a/website/source/docs/providers/azurerm/index.html.markdown
+++ b/website/source/docs/providers/azurerm/index.html.markdown
@@ -6,19 +6,22 @@ description: |-
   The Azure Resource Manager provider is used to interact with the many resources supported by Azure, via the ARM API. This supercedes the Azure provider, which interacts with Azure using the Service Management API. The provider needs to be configured with a credentials file, or credentials needed to generate OAuth tokens for the ARM API.
 ---
 
-# Azure Resource Manager Provider
+# Microsoft Azure Provider
 
-The Azure Resource Manager provider is used to interact with the many resources
-supported by Azure, via the ARM API. This supercedes the Azure provider, which
-interacts with Azure using the Service Management API. The provider needs to be
-configured with the credentials needed to generate OAuth tokens for the ARM API.
+The Microsoft Azure Provider provider is used to interact with the many
+resources supported by Azure, via the ARM API. This supercedes the [legacy Azure
+provider][asm], which interacts with Azure using the Service Management API. The
+provider needs to be configured with the credentials needed to generate OAuth
+tokens for the ARM API.
+
+[asm]: /docs/providers/azure/index.html
 
 Use the navigation to the left to read about the available resources.
 
 ## Example Usage
 
 ```
-# Configure the Azure Resource Manager Provider
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
   subscription_id = "..."
   client_id       = "..."

--- a/website/source/layouts/azure.erb
+++ b/website/source/layouts/azure.erb
@@ -7,7 +7,7 @@
                 </li>
 
                 <li<%= sidebar_current("docs-azure-index") %>>
-                    <a href="/docs/providers/azure/index.html">Azure Provider</a>
+                    <a href="/docs/providers/azure/index.html">Azure Service Management Provider</a>
                 </li>
 
                 <li<%= sidebar_current(/^docs-azure-resource/) %>>
@@ -78,9 +78,21 @@
                         </li>
                     </ul>
                 </li>
+
+              <li>
+                <a href="/docs/providers/azurerm/index.html">Microsoft Azure Provider &raquo;</a>
+              </li>
             </ul>
         </div>
     <% end %>
+
+    <div class="alert alert-warning" role="alert">
+      <strong>NOTE:</strong> The Azure Service Management Provider is no longer
+      being actively developed by HashiCorp employees. It continues to be
+      supported by the community. We recommend using the Azure Resource Manager
+      based <a href="/docs/providers/azurerm">Microsoft Azure Provider</a>
+      instead if possible.
+    </div>
 
     <%= yield %>
 <% end %>

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -8,7 +8,7 @@
             </li>
 
             <li<%= sidebar_current("docs-azurerm-index") %>>
-              <a href="/docs/providers/azurerm/index.html">Azure Resource Manager Provider</a>
+              <a href="/docs/providers/azurerm/index.html">Microsoft Azure Provider</a>
             </li>
 
             <li<%= sidebar_current(/^docs-azurerm-resource-resource/) %>>
@@ -198,6 +198,9 @@
               </ul>
             </li>
 
+            <li>
+              <a href="/docs/providers/azure/index.html">Azure Service Management Provider &raquo;</a>
+            </li>
           </ul>
         </div>
     <% end %>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -170,14 +170,6 @@
 					<a href="/docs/providers/aws/index.html">AWS</a>
 					</li>
 
-					<li<%= sidebar_current("docs-providers-azure") %>>
-					<a href="/docs/providers/azure/index.html">Azure (Service Management)</a>
-					</li>
-
-					<li<%= sidebar_current("docs-providers-azurerm") %>>
-					<a href="/docs/providers/azurerm/index.html">Azure (Resource Manager)</a>
-					</li>
-
 					<li<%= sidebar_current("docs-providers-chef") %>>
 					<a href="/docs/providers/chef/index.html">Chef</a>
 					</li>
@@ -260,6 +252,14 @@
 
 					<li<%= sidebar_current("docs-providers-mailgun") %>>
 					<a href="/docs/providers/mailgun/index.html">Mailgun</a>
+					</li>
+
+					<li<%= sidebar_current("docs-providers-azurerm") %>>
+					<a href="/docs/providers/azurerm/index.html">Microsoft Azure</a>
+					</li>
+
+					<li<%= sidebar_current("docs-providers-azurerm") %>>
+					<a href="/docs/providers/azure/index.html">Microsoft Azure (Legacy ASM)</a>
 					</li>
 
 					<li<%= sidebar_current("docs-providers-mysql") %>>


### PR DESCRIPTION
Sidebar:

 - Rename "Azure (Resource Manager)" to "Microsoft Azure" and sort
   accordingly
 - Rename "Azure (Service Management)" to "Microsoft Azure (Legacy ASM)"
   and sort accordingly

ARM provider docs:

 - Name changes everywhere to Microsoft Azure Provider
 - Mention and link to "legacy Azure Service Management Provider" in opening paragraph
 - Sidebar gains link at bottom to Azure Service Management Provider

ASM provider docs:
 - Name changes everywhere to Azure Service Management Provider
 - Sidebar gains link at bottom to Microsoft Azure Provider
 - Every page gets a header with the following
 - "NOTE: The Azure Service Management provider is no longer being actively developed by HashiCorp employees. It continues to be supported by the community. We recommend using the Azure Resource Manager based [Microsoft Azure Provider] instead if possible."