### PR TITLE
provisioner/chef: make using `ssl_verify_mode` more robust

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -220,6 +220,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 				"run_list":               []interface{}{"cookbook::recipe"},
 				"secret_key_path":        "test-fixtures/encrypted_data_bag_secret",
 				"server_url":             "https://chef.local",
+				"ssl_verify_mode":        "verify_none",
 				"validation_client_name": "validator",
 				"validation_key_path":    "test-fixtures/validator.pem",
 			}),
@@ -340,20 +341,15 @@ chef_server_url         "https://chef.local"
 validation_client_name  "validator"
 node_name               "nodename1"
 
-
-
-
 http_proxy          "http://proxy.local"
 ENV['http_proxy'] = "http://proxy.local"
 ENV['HTTP_PROXY'] = "http://proxy.local"
-
-
 
 https_proxy          "https://proxy.local"
 ENV['https_proxy'] = "https://proxy.local"
 ENV['HTTPS_PROXY'] = "https://proxy.local"
 
-
-
 no_proxy          "http://local.local,https://local.local"
-ENV['no_proxy'] = "http://local.local,https://local.local"`
+ENV['no_proxy'] = "http://local.local,https://local.local"
+
+ssl_verify_mode  :verify_none`

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -137,6 +137,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 				"run_list":               []interface{}{"cookbook::recipe"},
 				"secret_key_path":        "test-fixtures/encrypted_data_bag_secret",
 				"server_url":             "https://chef.local",
+				"ssl_verify_mode":        "verify_none",
 				"validation_client_name": "validator",
 				"validation_key_path":    "test-fixtures/validator.pem",
 			}),
@@ -366,20 +367,15 @@ chef_server_url         "https://chef.local"
 validation_client_name  "validator"
 node_name               "nodename1"
 
-
-
-
 http_proxy          "http://proxy.local"
 ENV['http_proxy'] = "http://proxy.local"
 ENV['HTTP_PROXY'] = "http://proxy.local"
-
-
 
 https_proxy          "https://proxy.local"
 ENV['https_proxy'] = "https://proxy.local"
 ENV['HTTPS_PROXY'] = "https://proxy.local"
 
-
-
 no_proxy          "http://local.local,https://local.local"
-ENV['no_proxy'] = "http://local.local,https://local.local"`
+ENV['no_proxy'] = "http://local.local,https://local.local"
+
+ssl_verify_mode  :verify_none`


### PR DESCRIPTION
And prettify the template output by removing additions empty lines.

Fixes issue #7712