### PR TITLE
provider/aws: `aws_redshift_cluster` `number_of_nodes` was having the wrong value set to state

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -373,7 +373,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 	} else {
 		d.Set("cluster_type", "single-node")
 	}
-	d.Set("number_of_nodes", len(rsc.ClusterNodes))
+	d.Set("number_of_nodes", rsc.NumberOfNodes)
 	d.Set("publicly_accessible", rsc.PubliclyAccessible)
 
 	var vpcg []string


### PR DESCRIPTION
we used `len(ClusterNodes)` rather than NumberOfNodes :)

This was picked up by the nightly tests! <3