### PR TITLE
provider/aws: Normalize actions and resources in IAM policy document

### DIFF
--- a/builtin/providers/aws/data_source_aws_iam_policy_document_test.go
+++ b/builtin/providers/aws/data_source_aws_iam_policy_document_test.go
@@ -1,9 +1,9 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
-	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -121,22 +121,14 @@ var testAccAWSIAMPolicyDocumentExpectedJSON = `{
         "s3:GetBucketLocation",
         "s3:ListAllMyBuckets"
       ],
-      "Resource": [
-        "arn:aws:s3:::*"
-      ]
+      "Resource": "arn:aws:s3:::*"
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::foo"
-      ],
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::foo",
       "NotPrincipal": {
-        "AWS": [
-          "arn:blahblah:example"
-        ]
+        "AWS": "arn:blahblah:example"
       },
       "Condition": {
         "StringLike": {
@@ -150,27 +142,19 @@ var testAccAWSIAMPolicyDocumentExpectedJSON = `{
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
+      "Action": "s3:*",
       "Resource": [
         "arn:aws:s3:::foo/home/${aws:username}/*",
         "arn:aws:s3:::foo/home/${aws:username}"
       ],
       "Principal": {
-        "AWS": [
-          "arn:blahblah:example"
-        ]
+        "AWS": "arn:blahblah:example"
       }
     },
     {
       "Effect": "Deny",
-      "NotAction": [
-        "s3:*"
-      ],
-      "NotResource": [
-        "arn:aws:s3:::*"
-      ]
+      "NotAction": "s3:*",
+      "NotResource": "arn:aws:s3:::*"
     }
   ]
 }`


### PR DESCRIPTION
Fixes #7495.

Tested with the Terraform file in the ticket.

Also tested with:

```
$ TF_ACC=1 go test -v ./builtin/providers/aws -run TestAccAWSIAMPolicyDocument
```