### PR TITLE
provider/scaleway: Expose IPv6 support, improve documentation

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_ip.go
+++ b/builtin/providers/scaleway/resource_scaleway_ip.go
@@ -54,7 +54,9 @@ func resourceScalewayIPRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.Set("ip", resp.IP.Address)
-	d.Set("server", resp.IP.Server.Identifier)
+	if resp.IP.Server != nil {
+		d.Set("server", resp.IP.Server.Identifier)
+	}
 	return nil
 }
 

--- a/builtin/providers/scaleway/resource_scaleway_ip_test.go
+++ b/builtin/providers/scaleway/resource_scaleway_ip_test.go
@@ -112,7 +112,11 @@ func testAccCheckScalewayIPAttachment(n string, check func(string) bool, msg str
 			return err
 		}
 
-		if !check(ip.IP.Server.Identifier) {
+		var serverID = ""
+		if ip.IP.Server != nil {
+			serverID = ip.IP.Server.Identifier
+		}
+		if !check(serverID) {
 			return fmt.Errorf("IP check failed: %q", msg)
 		}
 

--- a/builtin/providers/scaleway/resource_scaleway_security_group.go
+++ b/builtin/providers/scaleway/resource_scaleway_security_group.go
@@ -110,6 +110,15 @@ func resourceScalewaySecurityGroupDelete(d *schema.ResourceData, m interface{}) 
 
 	err := scaleway.DeleteSecurityGroup(d.Id())
 	if err != nil {
+		if serr, ok := err.(api.ScalewayAPIError); ok {
+			log.Printf("[DEBUG] error reading Security Group Rule: %q\n", serr.APIMessage)
+
+			if serr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+
 		return err
 	}
 

--- a/builtin/providers/scaleway/resource_scaleway_security_group.go
+++ b/builtin/providers/scaleway/resource_scaleway_security_group.go
@@ -90,7 +90,7 @@ func resourceScalewaySecurityGroupRead(d *schema.ResourceData, m interface{}) er
 func resourceScalewaySecurityGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	var req = api.ScalewayNewSecurityGroup{
+	var req = api.ScalewayUpdateSecurityGroup{
 		Organization: scaleway.Organization,
 		Name:         d.Get("name").(string),
 		Description:  d.Get("description").(string),

--- a/builtin/providers/scaleway/resource_scaleway_security_group_rule.go
+++ b/builtin/providers/scaleway/resource_scaleway_security_group_rule.go
@@ -154,6 +154,15 @@ func resourceScalewaySecurityGroupRuleDelete(d *schema.ResourceData, m interface
 
 	err := scaleway.DeleteSecurityGroupRule(d.Get("security_group").(string), d.Id())
 	if err != nil {
+		if serr, ok := err.(api.ScalewayAPIError); ok {
+			log.Printf("[DEBUG] error reading Security Group Rule: %q\n", serr.APIMessage)
+
+			if serr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+
 		return err
 	}
 

--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -40,13 +40,18 @@ func resourceScalewayServer() *schema.Resource {
 				},
 				Optional: true,
 			},
-			"ipv4_address_private": &schema.Schema{
+			"private_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ipv4_address_public": &schema.Schema{
+			"public_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"enable_ipv6": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 			"state": &schema.Schema{
 				Type:     schema.TypeString,
@@ -73,6 +78,7 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 		Name:         d.Get("name").(string),
 		Image:        String(image),
 		Organization: scaleway.Organization,
+		EnableIPV6:   d.Get("enable_ipv6").(bool),
 	}
 
 	server.DynamicIPRequired = Bool(d.Get("dynamic_ip_required").(bool))
@@ -127,8 +133,9 @@ func resourceScalewayServerRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("ipv4_address_private", server.PrivateIP)
-	d.Set("ipv4_address_public", server.PublicAddress.IP)
+	d.Set("private_ip", server.PrivateIP)
+	d.Set("public_ip", server.PublicAddress.IP)
+
 	d.Set("state", server.State)
 	d.Set("state_detail", server.StateDetail)
 	d.Set("tags", server.Tags)
@@ -159,6 +166,10 @@ func resourceScalewayServerUpdate(d *schema.ResourceData, m interface{}) error {
 			}
 			req.Tags = &tags
 		}
+	}
+
+	if d.HasChange("enable_ipv6") {
+		req.EnableIPV6 = Bool(d.Get("enable_ipv6").(bool))
 	}
 
 	if d.HasChange("dynamic_ip_required") {

--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -61,19 +61,10 @@ func resourceScalewayServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"enable_ipv6": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 			"state": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-			},
-			"dynamic_ip_required": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
 			},
 			"state_detail": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -181,6 +181,12 @@ func resourceScalewayServerUpdate(d *schema.ResourceData, m interface{}) error {
 		req.DynamicIPRequired = Bool(d.Get("dynamic_ip_required").(bool))
 	}
 
+	if d.HasChange("security_group") {
+		req.SecurityGroup = &api.ScalewaySecurityGroup{
+			Identifier: d.Get("security_group").(string),
+		}
+	}
+
 	if err := scaleway.PatchServer(d.Id(), req); err != nil {
 		return fmt.Errorf("Failed patching scaleway server: %q", err)
 	}

--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -40,6 +40,19 @@ func resourceScalewayServer() *schema.Resource {
 				},
 				Optional: true,
 			},
+			"enable_ipv6": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"dynamic_ip_required": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"security_group": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"private_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -75,10 +88,11 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 
 	image := d.Get("image").(string)
 	var server = api.ScalewayServerDefinition{
-		Name:         d.Get("name").(string),
-		Image:        String(image),
-		Organization: scaleway.Organization,
-		EnableIPV6:   d.Get("enable_ipv6").(bool),
+		Name:          d.Get("name").(string),
+		Image:         String(image),
+		Organization:  scaleway.Organization,
+		EnableIPV6:    d.Get("enable_ipv6").(bool),
+		SecurityGroup: d.Get("security_group").(string),
 	}
 
 	server.DynamicIPRequired = Bool(d.Get("dynamic_ip_required").(bool))

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/api/logger.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/api/logger.go
@@ -32,18 +32,46 @@ type defaultLogger struct {
 }
 
 func (l *defaultLogger) LogHTTP(r *http.Request) {
-	l.Printf("%s %s\n", r.Method, r.URL.Path)
+	l.Printf("%s %s\n", r.Method, r.URL.RawPath)
 }
+
 func (l *defaultLogger) Fatalf(format string, v ...interface{}) {
 	l.Printf("[FATAL] %s\n", fmt.Sprintf(format, v))
 	os.Exit(1)
 }
+
 func (l *defaultLogger) Debugf(format string, v ...interface{}) {
 	l.Printf("[DEBUG] %s\n", fmt.Sprintf(format, v))
 }
+
 func (l *defaultLogger) Infof(format string, v ...interface{}) {
 	l.Printf("[INFO ] %s\n", fmt.Sprintf(format, v))
 }
+
 func (l *defaultLogger) Warnf(format string, v ...interface{}) {
 	l.Printf("[WARN ] %s\n", fmt.Sprintf(format, v))
+}
+
+type disableLogger struct {
+}
+
+// NewDisableLogger returns a logger which is configured to do nothing
+func NewDisableLogger() Logger {
+	return &disableLogger{}
+}
+
+func (d *disableLogger) LogHTTP(r *http.Request) {
+}
+
+func (d *disableLogger) Fatalf(format string, v ...interface{}) {
+	panic(fmt.Sprintf(format, v))
+}
+
+func (d *disableLogger) Debugf(format string, v ...interface{}) {
+}
+
+func (d *disableLogger) Infof(format string, v ...interface{}) {
+}
+
+func (d *disableLogger) Warnf(format string, v ...interface{}) {
 }

--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -28,6 +28,10 @@ The following arguments are supported:
 * `name` - (Required) name of ARM server
 * `image` - (Required) base image of ARM server
 * `type` - (Required) type of ARM server
+* `bootscript` - (Optional) server bootscript
+* `tags` - (Optional) list of tags for server
+* `enable_ipv6` - (Optional) enable ipv6
+* `dynamic_ip_required` - (Optional) make server publicly available
 
 Field `name`, `type` are editable.
 
@@ -36,3 +40,5 @@ Field `name`, `type` are editable.
 The following attributes are exported:
 
 * `id` - id of the new resource
+* `private_ip` - private ip of the new resource
+* `public_ip` - public ip of the new resource

--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -32,8 +32,9 @@ The following arguments are supported:
 * `tags` - (Optional) list of tags for server
 * `enable_ipv6` - (Optional) enable ipv6
 * `dynamic_ip_required` - (Optional) make server publicly available
+* `security_group` - (Optional) assign security group to server
 
-Field `name`, `type` are editable.
+Field `name`, `type`, `tags`, `dynamic_ip_required`, `security_group` are editable.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR improves the Scaleway provider by

- exposing IPv6 support for the `scaleway_server` resource
- exposing security group support for the `scaleway_server` resource
- unifying attribute names (`ipv4_address_public` -> `public_ip`, `ipv4_address_private` -> `private_ip`)
- updating `scaleway_server` resource docs with more options