### PR TITLE
provider/scaleway add default_security_group datasource

### DIFF
--- a/builtin/providers/scaleway/datasource_scaleway_default_security_group.go
+++ b/builtin/providers/scaleway/datasource_scaleway_default_security_group.go
@@ -1,0 +1,46 @@
+package scaleway
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceScalewayDefaultSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceScalewayDefaultSecurityGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func datasourceScalewayDefaultSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+	scaleway := meta.(*Client).scaleway
+
+	log.Printf("[DEBUG] Reading default security group")
+	resp, err := scaleway.GetSecurityGroups()
+	if err != nil {
+		return fmt.Errorf("Error fetching security groups")
+	}
+
+	for _, sg := range resp.SecurityGroups {
+		if sg.OrganizationDefault {
+			d.SetId(sg.ID)
+			d.Set("name", sg.Name)
+			d.Set("description", sg.Description)
+			break
+		}
+	}
+
+	return nil
+}

--- a/builtin/providers/scaleway/datasource_scaleway_default_security_group_test.go
+++ b/builtin/providers/scaleway/datasource_scaleway_default_security_group_test.go
@@ -1,0 +1,48 @@
+package scaleway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccScalewayDefaultSecurityGroup_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayDefaultSecurityGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupMeta("data.scaleway_default_security_group.default", "name", "Default security group"),
+					testAccCheckSecurityGroupMeta("data.scaleway_default_security_group.default", "description", "Auto generated security group."),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSecurityGroupMeta(n, key, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find resource: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource ID not set")
+		}
+
+		if rs.Primary.Attributes[key] != value {
+			return fmt.Errorf("Expected %q, got %q\n", value, rs.Primary.Attributes[key])
+		}
+
+		return nil
+	}
+}
+
+var testAccCheckScalewayDefaultSecurityGroupConfig = `
+data "scaleway_default_security_group" "default" {}
+`

--- a/builtin/providers/scaleway/provider.go
+++ b/builtin/providers/scaleway/provider.go
@@ -32,6 +32,10 @@ func Provider() terraform.ResourceProvider {
 			"scaleway_volume_attachment":   resourceScalewayVolumeAttachment(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"scaleway_default_security_group": datasourceScalewayDefaultSecurityGroup(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/website/source/docs/providers/scaleway/d/default_security_group.html.markdown
+++ b/website/source/docs/providers/scaleway/d/default_security_group.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: default_security_group"
+sidebar_current: "docs-scaleway-datasource-default_security_group"
+description: |-
+    Lookup the default security group
+---
+
+# scaleway\_default\_security\_group
+
+The Default Security Group data source allows identifying the default security group
+which is created by Scaleway for you. This is usefull when you want to attach additional
+security group rules
+
+## Example Usage
+
+```
+# Declare the data source
+data "scaleway_default_security_group" "default" {}
+
+# reference default security group
+resource "scaleway_security_group_rule" "http" {
+  security_group = "${data.scaleway_default_security_group.default.id}"
+
+  action = "drop"
+  direction = "inbound"
+  ip_range = "0.0.0.0/0"
+  protocol = "TCP"
+  port = 80
+}
+```
+
+## Argument Reference
+
+There are no arguments for this data source.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - the ID of the default security group.
+* `name` - the name of the default security group.
+* `description` - the description of the default security group.

--- a/website/source/layouts/scaleway.erb
+++ b/website/source/layouts/scaleway.erb
@@ -10,6 +10,15 @@
           <a href="/docs/providers/scaleway/index.html">Scaleway Provider</a>
         </li>
 
+        <li<%= sidebar_current(/^docs-scaleway-datasource/) %>>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-scaleway-datasource-default_security_group") %>>
+                <a href="/docs/providers/scaleway/d/default_security_group.html">default_security_group</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current(/^docs-scaleway-resource/) %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">


### PR DESCRIPTION
Scaleway automatically creates one security group per organization. When you want to manage your security group rules for the entire org you have to know which security group is the default.

This PR adds a data source dedicated to that purpose:

```
# lookup default security group
data "scaleway_default_security_group" "default" {}

# modify rules within the default security group
resource "scaleway_security_group_rule" "http" {
  security_group = "${data.scaleway_default_security_group.default.id}"

  action = "drop"
  direction = "inbound"
  ip_range = "0.0.0.0/0"
  protocol = "TCP"
  port = 80
}
```