### PR TITLE
Fix broken link to Consul demo

### DIFF
--- a/website/source/intro/examples/consul.html.markdown
+++ b/website/source/intro/examples/consul.html.markdown
@@ -32,7 +32,7 @@ Either provide the AWS credentials as a default value in the configuration
 or invoke `apply` with the appropriate variables set.
 
 Once the `apply` has completed, we can see the keys in Consul by
-visiting the [Web UI](http://demo.consul.io/ui/#/nyc1/kv/). We can see
+visiting the [Web UI](http://demo.consul.io/ui/#/nyc3/kv/). We can see
 that the "tf\_test/id" and "tf\_test/public\_dns" values have been
 set.
 

--- a/website/source/intro/examples/consul.html.markdown
+++ b/website/source/intro/examples/consul.html.markdown
@@ -25,7 +25,7 @@ and will default to "m1.small" if that key does not exist. Once the instance is 
 the "tf\_test/id" and "tf\_test/public\_dns" keys will be set with the computed
 values for the instance.
 
-Before we run the example, use the [Web UI](http://demo.consul.io/ui/#/nyc1/kv/)
+Before we run the example, use the [Web UI](http://demo.consul.io/ui/#/nyc3/kv/)
 to set the "tf\_test/size" key to "t1.micro". Once that is done,
 copy the configuration into a configuration file ("consul.tf" works fine).
 Either provide the AWS credentials as a default value in the configuration


### PR DESCRIPTION
The links to the Key/value page on the Consul demo points to nyc1, which returns a 500.

Changing to nyc3 works.