### PR TITLE
provider/azurerm: add option to delete VMs Data disks on termination

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -206,6 +206,12 @@ func resourceArmVirtualMachine() *schema.Resource {
 				},
 			},
 
+			"delete_data_disks_on_termination": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"os_profile": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -561,19 +567,43 @@ func resourceArmVirtualMachineDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	if deleteOsDisk := d.Get("delete_os_disk_on_termination").(bool); !deleteOsDisk {
-		log.Printf("[INFO] delete_os_disk_on_termination is false, skipping delete")
-		return nil
+	// delete OS Disk if opted in
+	if deleteOsDisk := d.Get("delete_os_disk_on_termination").(bool); deleteOsDisk {
+		log.Printf("[INFO] delete_os_disk_on_termination is enabled, deleting")
+
+		osDisk, err := expandAzureRmVirtualMachineOsDisk(d)
+		if err != nil {
+			return fmt.Errorf("Error expanding OS Disk: %s", err)
+		}
+
+		if err = resourceArmVirtualMachineDeleteVhd(*osDisk.Vhd.URI, resGroup, meta); err != nil {
+			return fmt.Errorf("Error deleting OS Disk VHD: %s", err)
+		}
 	}
 
-	osDisk, err := expandAzureRmVirtualMachineOsDisk(d)
-	if err != nil {
-		return fmt.Errorf("Error expanding OS Disk")
+	// delete Data disks if opted in
+	if deleteDataDisks := d.Get("delete_data_disks_on_termination").(bool); deleteDataDisks {
+		log.Printf("[INFO] delete_data_disks_on_termination is enabled, deleting each data disk")
+
+		disks, err := expandAzureRmVirtualMachineDataDisk(d)
+		if err != nil {
+			return fmt.Errorf("Error expanding Data Disks: %s", err)
+		}
+
+		for _, disk := range disks {
+			if err = resourceArmVirtualMachineDeleteVhd(*disk.Vhd.URI, resGroup, meta); err != nil {
+				return fmt.Errorf("Error deleting Data Disk VHD: %s", err)
+			}
+		}
 	}
 
-	vhdURL, err := url.Parse(*osDisk.Vhd.URI)
+	return nil
+}
+
+func resourceArmVirtualMachineDeleteVhd(uri, resGroup string, meta interface{}) error {
+	vhdURL, err := url.Parse(uri)
 	if err != nil {
-		return fmt.Errorf("Cannot parse OS Disk VHD URI: %s", err)
+		return fmt.Errorf("Cannot parse Disk VHD URI: %s", err)
 	}
 
 	// VHD URI is in the form: https://storageAccountName.blob.core.windows.net/containerName/blobName
@@ -582,12 +612,12 @@ func resourceArmVirtualMachineDelete(d *schema.ResourceData, meta interface{}) e
 	containerName := path[0]
 	blobName := path[1]
 
-	blobClient, storageAccountExists, err := meta.(*ArmClient).getBlobStorageClientForStorageAccount(id.ResourceGroup, storageAccountName)
+	blobClient, saExists, err := meta.(*ArmClient).getBlobStorageClientForStorageAccount(resGroup, storageAccountName)
 	if err != nil {
-		return fmt.Errorf("Error creating blob store account for VHD deletion: %s", err)
+		return fmt.Errorf("Error creating blob store client for VHD deletion: %s", err)
 	}
 
-	if !storageAccountExists {
+	if !saExists {
 		log.Printf("[INFO] Storage Account %q doesn't exist so the VHD blob won't exist", storageAccountName)
 		return nil
 	}

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -212,6 +212,7 @@ The following arguments are supported:
 * `storage_os_disk` - (Required) A Storage OS Disk block as referenced below.
 * `delete_os_disk_on_termination` - (Optional) Flag to enable deletion of the OS Disk VHD blob when the VM is deleted, defaults to `false`
 * `storage_data_disk` - (Optional) A list of Storage Data disk blocks as referenced below.
+* `delete_data_disks_on_termination` - (Optional) Flag to enable deletion of Storage Disk VHD blobs when the VM is deleted, defaults to `false`
 * `os_profile` - (Required) An OS Profile block as documented below.
 * `os_profile_windows_config` - (Required, when a windows machine) A Windows config block as documented below.
 * `os_profile_linux_config` - (Required, when a linux machine) A Linux config block as documented below.


### PR DESCRIPTION
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMVirtualMachine_deleteVHD -timeout 120m
=== RUN   TestAccAzureRMVirtualMachine_deleteVHDOptOut
--- PASS: TestAccAzureRMVirtualMachine_deleteVHDOptOut (621.84s)
=== RUN   TestAccAzureRMVirtualMachine_deleteVHDOptIn
--- PASS: TestAccAzureRMVirtualMachine_deleteVHDOptIn (623.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	1245.930s
```