### PR TITLE
provider/aws: Re-implement api gateway parameter handling

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -75,8 +74,9 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 				Elem:     schema.TypeString,
 			},
 
-			"request_parameters_in_json": &schema.Schema{
-				Type:     schema.TypeString,
+			"request_parameters": &schema.Schema{
+				Type:     schema.TypeMap,
+				Elem:     schema.TypeString,
 				Optional: true,
 			},
 
@@ -107,9 +107,9 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 	}
 
 	parameters := make(map[string]string)
-	if v, ok := d.GetOk("request_parameters_in_json"); ok {
-		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
-			return fmt.Errorf("Error unmarshaling request_parameters_in_json: %s", err)
+	if kv, ok := d.GetOk("request_parameters"); ok {
+		for k, v := range kv.(map[string]interface{}) {
+			parameters[k] = v.(string)
 		}
 	}
 
@@ -175,6 +175,7 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 	d.Set("credentials", integration.Credentials)
 	d.Set("type", integration.Type)
 	d.Set("uri", integration.Uri)
+	d.Set("request_parameters", aws.StringValueMap(integration.RequestParameters))
 	d.Set("request_parameters_in_json", aws.StringValueMap(integration.RequestParameters))
 	d.Set("passthrough_behavior", integration.PassthroughBehavior)
 

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_response.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_response.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -56,8 +55,9 @@ func resourceAwsApiGatewayIntegrationResponse() *schema.Resource {
 				Elem:     schema.TypeString,
 			},
 
-			"response_parameters_in_json": &schema.Schema{
-				Type:     schema.TypeString,
+			"response_parameters": &schema.Schema{
+				Type:     schema.TypeMap,
+				Elem:     schema.TypeString,
 				Optional: true,
 			},
 		},
@@ -73,19 +73,18 @@ func resourceAwsApiGatewayIntegrationResponseCreate(d *schema.ResourceData, meta
 	}
 
 	parameters := make(map[string]string)
-	if v, ok := d.GetOk("response_parameters_in_json"); ok {
-		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
-			return fmt.Errorf("Error unmarshaling response_parameters_in_json: %s", err)
+	if kv, ok := d.GetOk("response_parameters"); ok {
+		for k, v := range kv.(map[string]interface{}) {
+			parameters[k] = v.(string)
 		}
 	}
 
 	input := apigateway.PutIntegrationResponseInput{
-		HttpMethod:        aws.String(d.Get("http_method").(string)),
-		ResourceId:        aws.String(d.Get("resource_id").(string)),
-		RestApiId:         aws.String(d.Get("rest_api_id").(string)),
-		StatusCode:        aws.String(d.Get("status_code").(string)),
-		ResponseTemplates: aws.StringMap(templates),
-		// TODO reimplement once [GH-2143](https://github.com/hashicorp/terraform/issues/2143) has been implemented
+		HttpMethod:         aws.String(d.Get("http_method").(string)),
+		ResourceId:         aws.String(d.Get("resource_id").(string)),
+		RestApiId:          aws.String(d.Get("rest_api_id").(string)),
+		StatusCode:         aws.String(d.Get("status_code").(string)),
+		ResponseTemplates:  aws.StringMap(templates),
 		ResponseParameters: aws.StringMap(parameters),
 	}
 	if v, ok := d.GetOk("selection_pattern"); ok {
@@ -125,7 +124,7 @@ func resourceAwsApiGatewayIntegrationResponseRead(d *schema.ResourceData, meta i
 	d.SetId(fmt.Sprintf("agir-%s-%s-%s-%s", d.Get("rest_api_id").(string), d.Get("resource_id").(string), d.Get("http_method").(string), d.Get("status_code").(string)))
 	d.Set("response_templates", integrationResponse.ResponseTemplates)
 	d.Set("selection_pattern", integrationResponse.SelectionPattern)
-	d.Set("response_parameters_in_json", aws.StringValueMap(integrationResponse.ResponseParameters))
+	d.Set("response_parameters", aws.StringValueMap(integrationResponse.ResponseParameters))
 	return nil
 }
 

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_response_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_response_test.go
@@ -185,11 +185,9 @@ resource "aws_api_gateway_method_response" "error" {
     "application/json" = "Error"
   }
 
-	response_parameters_in_json = <<PARAMS
-	{
-		"method.response.header.Content-Type": true
+	response_parameters = {
+		"method.response.header.Content-Type" = true
 	}
-	PARAMS
 }
 
 resource "aws_api_gateway_integration" "test" {
@@ -217,11 +215,9 @@ resource "aws_api_gateway_integration_response" "test" {
     "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
-	response_parameters_in_json = <<PARAMS
-	{
-		"method.response.header.Content-Type": "integration.response.body.type"
+	response_parameters = {
+		"method.response.header.Content-Type" = "integration.response.body.type"
 	}
-	PARAMS
 }
 `
 
@@ -257,11 +253,9 @@ resource "aws_api_gateway_method_response" "error" {
     "application/json" = "Error"
   }
 
-	response_parameters_in_json = <<PARAMS
-	{
-		"method.response.header.Content-Type": true
+	response_parameters = {
+		"method.response.header.Content-Type" = true
 	}
-	PARAMS
 }
 
 resource "aws_api_gateway_integration" "test" {

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
@@ -188,11 +188,9 @@ resource "aws_api_gateway_integration" "test" {
     "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
-  request_parameters_in_json = <<PARAMS
-  {
-	  "integration.request.header.X-Authorization": "'static'"
+  request_parameters = {
+	  "integration.request.header.X-Authorization" = "'static'"
   }
-  PARAMS
 
   type = "HTTP"
   uri = "https://www.google.de"
@@ -228,11 +226,9 @@ resource "aws_api_gateway_integration" "test" {
   resource_id = "${aws_api_gateway_resource.test.id}"
   http_method = "${aws_api_gateway_method.test.http_method}"
 
-  request_parameters_in_json = <<PARAMS
-  {
-	  "integration.request.header.X-Authorization": "'updated'"
+  request_parameters = {
+	  "integration.request.header.X-Authorization" = "'updated'"
   }
-  PARAMS
 
   type = "MOCK"
   passthrough_behavior = "NEVER"

--- a/builtin/providers/aws/resource_aws_api_gateway_method.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -165,7 +166,11 @@ func resourceAwsApiGatewayMethodUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("request_parameters") {
 		parameters := make(map[string]bool)
 		for k, v := range d.Get("request_parameters").(map[string]interface{}) {
-			parameters[k] = v.(bool)
+			parameters[k], ok = v.(bool)
+			if !ok {
+				value, _ := strconv.ParseBool(v.(string))
+				parameters[k] = value
+			}
 		}
 		ops, err := expandApiGatewayMethodParametersOperations(d, "request_parameters", "requestParameters")
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_api_gateway_method.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method.go
@@ -159,6 +159,7 @@ func resourceAwsApiGatewayMethodUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return err
 		}
+		operations = append(operations, ops...)
 	}
 
 	if d.HasChange("request_parameters") {

--- a/builtin/providers/aws/resource_aws_api_gateway_method.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method.go
@@ -86,10 +86,14 @@ func resourceAwsApiGatewayMethodCreate(d *schema.ResourceData, meta interface{})
 	parameters := make(map[string]bool)
 	if kv, ok := d.GetOk("request_parameters"); ok {
 		for k, v := range kv.(map[string]interface{}) {
-			parameters[k] = v.(bool)
+			parameters[k], ok = v.(bool)
+			if !ok {
+				value, _ := strconv.ParseBool(v.(string))
+				parameters[k] = value
+			}
 		}
 	}
-	if v, ok := d.GetOk("request_parameters"); ok {
+	if v, ok := d.GetOk("request_parameters_in_json"); ok {
 		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
 			return fmt.Errorf("Error unmarshaling request_parameters_in_json: %s", err)
 		}
@@ -165,6 +169,7 @@ func resourceAwsApiGatewayMethodUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("request_parameters") {
 		parameters := make(map[string]bool)
+		var ok bool
 		for k, v := range d.Get("request_parameters").(map[string]interface{}) {
 			parameters[k], ok = v.(bool)
 			if !ok {

--- a/builtin/providers/aws/resource_aws_api_gateway_method_response.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_response.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -51,8 +50,9 @@ func resourceAwsApiGatewayMethodResponse() *schema.Resource {
 				Elem:     schema.TypeString,
 			},
 
-			"response_parameters_in_json": &schema.Schema{
-				Type:     schema.TypeString,
+			"response_parameters": &schema.Schema{
+				Type:     schema.TypeMap,
+				Elem:     schema.TypeBool,
 				Optional: true,
 			},
 		},
@@ -68,19 +68,18 @@ func resourceAwsApiGatewayMethodResponseCreate(d *schema.ResourceData, meta inte
 	}
 
 	parameters := make(map[string]bool)
-	if v, ok := d.GetOk("response_parameters_in_json"); ok {
-		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
-			return fmt.Errorf("Error unmarshaling request_parameters_in_json: %s", err)
+	if kv, ok := d.GetOk("response_parameters"); ok {
+		for k, v := range kv.(map[string]interface{}) {
+			parameters[k] = v.(bool)
 		}
 	}
 
 	_, err := conn.PutMethodResponse(&apigateway.PutMethodResponseInput{
-		HttpMethod:     aws.String(d.Get("http_method").(string)),
-		ResourceId:     aws.String(d.Get("resource_id").(string)),
-		RestApiId:      aws.String(d.Get("rest_api_id").(string)),
-		StatusCode:     aws.String(d.Get("status_code").(string)),
-		ResponseModels: aws.StringMap(models),
-		// TODO reimplement once [GH-2143](https://github.com/hashicorp/terraform/issues/2143) has been implemented
+		HttpMethod:         aws.String(d.Get("http_method").(string)),
+		ResourceId:         aws.String(d.Get("resource_id").(string)),
+		RestApiId:          aws.String(d.Get("rest_api_id").(string)),
+		StatusCode:         aws.String(d.Get("status_code").(string)),
+		ResponseModels:     aws.StringMap(models),
 		ResponseParameters: aws.BoolMap(parameters),
 	})
 	if err != nil {
@@ -113,7 +112,7 @@ func resourceAwsApiGatewayMethodResponseRead(d *schema.ResourceData, meta interf
 
 	log.Printf("[DEBUG] Received API Gateway Method: %s", methodResponse)
 	d.Set("response_models", aws.StringValueMap(methodResponse.ResponseModels))
-	d.Set("response_parameters_in_json", aws.BoolValueMap(methodResponse.ResponseParameters))
+	d.Set("response_parameters", aws.BoolValueMap(methodResponse.ResponseParameters))
 	d.SetId(fmt.Sprintf("agmr-%s-%s-%s-%s", d.Get("rest_api_id").(string), d.Get("resource_id").(string), d.Get("http_method").(string), d.Get("status_code").(string)))
 
 	return nil
@@ -129,8 +128,8 @@ func resourceAwsApiGatewayMethodResponseUpdate(d *schema.ResourceData, meta inte
 		operations = append(operations, expandApiGatewayRequestResponseModelOperations(d, "response_models", "responseModels")...)
 	}
 
-	if d.HasChange("response_parameters_in_json") {
-		ops, err := expandApiGatewayMethodParametersJSONOperations(d, "response_parameters_in_json", "responseParameters")
+	if d.HasChange("response_parameters") {
+		ops, err := expandApiGatewayMethodParametersOperations(d, "response_parameters", "responseParameters")
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/aws/resource_aws_api_gateway_method_response.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_response.go
@@ -148,6 +148,7 @@ func resourceAwsApiGatewayMethodResponseUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return err
 		}
+		operations = append(operations, ops...)
 	}
 
 	if d.HasChange("response_parameters") {

--- a/builtin/providers/aws/resource_aws_api_gateway_method_response.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -79,7 +80,11 @@ func resourceAwsApiGatewayMethodResponseCreate(d *schema.ResourceData, meta inte
 	parameters := make(map[string]bool)
 	if kv, ok := d.GetOk("response_parameters"); ok {
 		for k, v := range kv.(map[string]interface{}) {
-			parameters[k] = v.(bool)
+			parameters[k], ok = v.(bool)
+			if !ok {
+				value, _ := strconv.ParseBool(v.(string))
+				parameters[k] = value
+			}
 		}
 	}
 	if v, ok := d.GetOk("response_parameters_in_json"); ok {

--- a/builtin/providers/aws/resource_aws_api_gateway_method_response_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_response_test.go
@@ -184,11 +184,9 @@ resource "aws_api_gateway_method_response" "error" {
     "application/json" = "Error"
   }
 
-  response_parameters_in_json = <<PARAMS
-  {
-    "method.response.header.Content-Type": true
+  response_parameters = {
+    "method.response.header.Content-Type" = true
   }
-  PARAMS
 }
 `
 
@@ -224,11 +222,8 @@ resource "aws_api_gateway_method_response" "error" {
     "application/json" = "Empty"
   }
 
-  response_parameters_in_json = <<PARAMS
-  {
-    "method.response.header.Host": true
+  response_parameters = {
+    "method.response.header.Host" = true
   }
-  PARAMS
-
 }
 `

--- a/builtin/providers/aws/resource_aws_api_gateway_method_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_test.go
@@ -175,12 +175,10 @@ resource "aws_api_gateway_method" "test" {
     "application/json" = "Error"
   }
 
-  request_parameters_in_json = <<PARAMS
-  {
-    "method.request.header.Content-Type": false,
-	"method.request.querystring.page": true
+  request_parameters = {
+    "method.request.header.Content-Type" = false,
+	  "method.request.querystring.page" = true
   }
-  PARAMS
 }
 `
 
@@ -205,10 +203,8 @@ resource "aws_api_gateway_method" "test" {
     "application/json" = "Error"
   }
 
-  request_parameters_in_json = <<PARAMS
-  {
-	"method.request.querystring.page": false
+  request_parameters = {
+	  "method.request.querystring.page" = false
   }
-  PARAMS
 }
 `

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1156,9 +1156,14 @@ func expandApiGatewayMethodParametersOperations(d *schema.ResourceData, key stri
 		}
 
 		for nK, nV := range newParametersMap {
+			b, ok := nV.(bool)
+			if !ok {
+				value, _ := strconv.ParseBool(nV.(string))
+				b = value
+			}
 			if nK == k {
 				operation.Op = aws.String("replace")
-				operation.Value = aws.String(strconv.FormatBool(nV.(bool)))
+				operation.Value = aws.String(strconv.FormatBool(b))
 			}
 		}
 
@@ -1173,10 +1178,15 @@ func expandApiGatewayMethodParametersOperations(d *schema.ResourceData, key stri
 			}
 		}
 		if !exists {
+			b, ok := nV.(bool)
+			if !ok {
+				value, _ := strconv.ParseBool(nV.(string))
+				b = value
+			}
 			operation := apigateway.PatchOperation{
 				Op:    aws.String("add"),
 				Path:  aws.String(fmt.Sprintf("/%s/%s", prefix, nK)),
-				Value: aws.String(strconv.FormatBool(nV.(bool))),
+				Value: aws.String(strconv.FormatBool(b)),
 			}
 			operations = append(operations, &operation)
 		}

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1090,22 +1090,12 @@ func expandApiGatewayRequestResponseModelOperations(d *schema.ResourceData, key 
 	return operations
 }
 
-func expandApiGatewayMethodParametersJSONOperations(d *schema.ResourceData, key string, prefix string) ([]*apigateway.PatchOperation, error) {
+func expandApiGatewayMethodParametersOperations(d *schema.ResourceData, key string, prefix string) ([]*apigateway.PatchOperation, error) {
 	operations := make([]*apigateway.PatchOperation, 0)
 
 	oldParameters, newParameters := d.GetChange(key)
-	oldParametersMap := make(map[string]interface{})
-	newParametersMap := make(map[string]interface{})
-
-	if err := json.Unmarshal([]byte(oldParameters.(string)), &oldParametersMap); err != nil {
-		err := fmt.Errorf("Error unmarshaling old %s: %s", key, err)
-		return operations, err
-	}
-
-	if err := json.Unmarshal([]byte(newParameters.(string)), &newParametersMap); err != nil {
-		err := fmt.Errorf("Error unmarshaling new %s: %s", key, err)
-		return operations, err
-	}
+	oldParametersMap := oldParameters.(map[string]interface{})
+	newParametersMap := newParameters.(map[string]interface{})
 
 	for k, _ := range oldParametersMap {
 		operation := apigateway.PatchOperation{

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -56,9 +56,10 @@ The following arguments are supported:
   Not all methods are compatible with all `AWS` integrations.
   e.g. Lambda function [can only be invoked](https://github.com/awslabs/aws-apigateway-importer/issues/9#issuecomment-129651005) via `POST`.
 * `request_templates` - (Optional) A map of the integration's request templates.
+* `request_parameters` - (Optional) Request query string parameters and headers that should be passed to the
 * `passthrough_behavior` - (Optional) The integration passthrough behavior (`WHEN_NO_MATCH`, `WHEN_NO_TEMPLATES`, `NEVER`).  **Required** if `request_templates` is used.
 * `request_parameters_in_json` - (Optional) A map written as a JSON string specifying
   the request query string parameters and headers that should be passed to the
   backend responder.
-  For example: `request_parameters_in_json = "{\"integration.request.header.X-Some-Other-Header\":\"method.request.header.X-Some-Header\"}"` 
+  For example: `request_parameters = { "integration.request.header.X-Some-Other-Header" = "method.request.header.X-Some-Header" }`
   would add the header `X-Some-Header` from method to the integration as the header `X-Some-Other-Header`.

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -58,8 +58,4 @@ The following arguments are supported:
 * `request_templates` - (Optional) A map of the integration's request templates.
 * `request_parameters` - (Optional) Request query string parameters and headers that should be passed to the
 * `passthrough_behavior` - (Optional) The integration passthrough behavior (`WHEN_NO_MATCH`, `WHEN_NO_TEMPLATES`, `NEVER`).  **Required** if `request_templates` is used.
-* `request_parameters_in_json` - (Optional) A map written as a JSON string specifying
-  the request query string parameters and headers that should be passed to the
-  backend responder.
-  For example: `request_parameters = { "integration.request.header.X-Some-Other-Header" = "method.request.header.X-Some-Header" }`
-  would add the header `X-Some-Header` from method to the integration as the header `X-Some-Other-Header`.
+* `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -71,4 +71,6 @@ The following arguments are supported:
 * `response_templates` - (Optional) A map specifying the templates used to transform the integration response body
 * `response_parameters` - (Optional) Specify the response parameters that can be read from the backend response
   For example: `response_parameters = { "method.response.header.X-Some-Header" = "integration.response.header.X-Some-Other-Header" }`,
+* `response_parameters_in_json` - (Optional, Deprecated) A map written as JSON string specifying response parameters that can be read from the backend response
+  For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":\"integration.response.header.X-Some-Other-Header\"}"`,
   would add the header `X-Some-Other-Header` from the integration response to the method response as the header `X-Some-Header`.

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -69,6 +69,6 @@ The following arguments are supported:
   If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched.
   For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
 * `response_templates` - (Optional) A map specifying the templates used to transform the integration response body
-* `response_parameters_in_json` - (Optional) A map written as JSON string specifying response parameters that can be read from the backend response
-  For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":\"integration.response.header.X-Some-Other-Header\"}"`, 
+* `response_parameters` - (Optional) Specify the response parameters that can be read from the backend response
+  For example: `response_parameters = { "method.response.header.X-Some-Header" = "integration.response.header.X-Some-Other-Header" }`,
   would add the header `X-Some-Other-Header` from the integration response to the method response as the header `X-Some-Header`.

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -71,6 +71,4 @@ The following arguments are supported:
 * `response_templates` - (Optional) A map specifying the templates used to transform the integration response body
 * `response_parameters` - (Optional) Specify the response parameters that can be read from the backend response
   For example: `response_parameters = { "method.response.header.X-Some-Header" = "integration.response.header.X-Some-Other-Header" }`,
-* `response_parameters_in_json` - (Optional, Deprecated) A map written as JSON string specifying response parameters that can be read from the backend response
-  For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":\"integration.response.header.X-Some-Other-Header\"}"`,
-  would add the header `X-Some-Other-Header` from the integration response to the method response as the header `X-Some-Header`.
+* `response_parameters_in_json` - **Deprecated**, use `response_parameters` instead.

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -47,6 +47,4 @@ The following arguments are supported:
 * `request_parameters` - (Optional) Specify which request query string parameters and headers that should be passed to the integration
   For example: `request_parameters = { "method.request.header.X-Some-Header" = true }`
   would define that the header X-Some-Header must be provided on the request.
-* `request_parameters_in_json` - (Optional, Deprecated) A map written as a JSON string specifying
-  the request query string parameters and headers that should be passed to the integration
-  For example: `request_parameters_in_json = "{\"method.request.header.X-Some-Header\":true}"`
+* `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -47,3 +47,6 @@ The following arguments are supported:
 * `request_parameters` - (Optional) Specify which request query string parameters and headers that should be passed to the integration
   For example: `request_parameters = { "method.request.header.X-Some-Header" = true }`
   would define that the header X-Some-Header must be provided on the request.
+* `request_parameters_in_json` - (Optional, Deprecated) A map written as a JSON string specifying
+  the request query string parameters and headers that should be passed to the integration
+  For example: `request_parameters_in_json = "{\"method.request.header.X-Some-Header\":true}"`

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -44,7 +44,6 @@ The following arguments are supported:
 * `request_models` - (Optional) A map of the API models used for the request's content type
   where key is the content type (e.g. `application/json`)
   and value is either `Error`, `Empty` (built-in models) or `aws_api_gateway_model`'s `name`.
-* `request_parameters_in_json` - (Optional) A map written as a JSON string specifying
-  the request query string parameters and headers that should be passed to the integration
-  For example: `request_parameters_in_json = "{\"method.request.header.X-Some-Header\":true}"`  
+* `request_parameters` - (Optional) Specify which request query string parameters and headers that should be passed to the integration
+  For example: `request_parameters = { "method.request.header.X-Some-Header" = true }`
   would define that the header X-Some-Header must be provided on the request.

--- a/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
@@ -58,3 +58,5 @@ The following arguments are supported:
 * `response_parameters` - (Optional) Response parameters that can be sent to the caller
    For example: `response_parameters = { "method.response.header.X-Some-Header" = true }`
    would define that the header X-Some-Header can be provided on the response.
+* `response_parameters_in_json` - (Optional) A map written as a JSON string representing response parameters that can be sent to the caller
+  For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":true}"`

--- a/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
@@ -55,6 +55,6 @@ The following arguments are supported:
 * `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
 * `status_code` - (Required) The HTTP status code
 * `response_models` - (Optional) A map of the API models used for the response's content type
-* `response_parameters_in_json` - (Optional) A map written as a JSON string representing response parameters that can be sent to the caller
-   For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":true}"` 
+* `response_parameters` - (Optional) Response parameters that can be sent to the caller
+   For example: `response_parameters = { "method.response.header.X-Some-Header" = true }`
    would define that the header X-Some-Header can be provided on the response.

--- a/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
@@ -58,5 +58,4 @@ The following arguments are supported:
 * `response_parameters` - (Optional) Response parameters that can be sent to the caller
    For example: `response_parameters = { "method.response.header.X-Some-Header" = true }`
    would define that the header X-Some-Header can be provided on the response.
-* `response_parameters_in_json` - (Optional) A map written as a JSON string representing response parameters that can be sent to the caller
-  For example: `response_parameters_in_json = "{\"method.response.header.X-Some-Header\":true}"`
+* `response_parameters_in_json` - **Deprecated**, use `response_parameters` instead.


### PR DESCRIPTION
This PR is a follow up of my original API Gateway PR, #4295

Now that GH-2143 is finally closed this PR does away with the ugly `request_parameters_in_json` and `response_parameters_in_json` hack.

E.g. before:

```
resource "aws_api_gateway_method" "test" {
  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
  resource_id = "${aws_api_gateway_resource.test.id}"
  http_method = "GET"
  authorization = "NONE"

  request_models = {
    "application/json" = "Error"
  }

  request_parameters = <<PARAM 
  {
	  "method.request.querystring.page": false
  }
PARAM
}
```

after

```
resource "aws_api_gateway_method" "test" {
  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
  resource_id = "${aws_api_gateway_resource.test.id}"
  http_method = "GET"
  authorization = "NONE"

  request_models = {
    "application/json" = "Error"
  }

  request_parameters = {
	  "method.request.querystring.page" = false
  }
}
```

