### PR TITLE
Bug fix terraform 0.7.0 remote state data docs

### DIFF
--- a/website/source/docs/providers/terraform/d/remote_state.html.md
+++ b/website/source/docs/providers/terraform/d/remote_state.html.md
@@ -22,7 +22,7 @@ data "terraform_remote_state" "vpc" {
 
 resource "aws_instance" "foo" {
     # ...
-    subnet_id = "${data.terraform_remote_state.vpc.output.subnet_id}"
+    subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"
 }
 ```
 

--- a/website/source/docs/providers/terraform/index.html.markdown
+++ b/website/source/docs/providers/terraform/index.html.markdown
@@ -26,6 +26,6 @@ data "terraform_remote_state" "vpc" {
 
 resource "aws_instance" "foo" {
     # ...
-    subnet_id = "${data.terraform_remote_state.vpc.output.subnet_id}"
+    subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"
 }
 ```


### PR DESCRIPTION
Terraform 0.7.0 data resource for remote state does not use the 'output' path