### PR TITLE
Add tf_vars to the variables sent in push

### DIFF
--- a/command/hcl_printer.go
+++ b/command/hcl_printer.go
@@ -1,0 +1,114 @@
+package command
+
+// Marshal an object as an hcl value.
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/hcl/hcl/printer"
+)
+
+// This will only work operate on []interface{}, map[string]interface{}, and
+// primitive types.
+func encodeHCL(i interface{}) ([]byte, error) {
+
+	state := &encodeState{}
+	err := state.encode(i)
+	if err != nil {
+		return nil, err
+	}
+
+	hcl := state.Bytes()
+	if len(hcl) == 0 {
+		return hcl, nil
+	}
+
+	// the HCL parser requires an assignment. Strip it off again later
+	fakeAssignment := append([]byte("X = "), hcl...)
+
+	// use the real hcl parser to verify our output, and format it canonically
+	hcl, err = printer.Format(fakeAssignment)
+
+	// now strip that first assignment off
+	eq := regexp.MustCompile(`=\s+`).FindIndex(hcl)
+	return hcl[eq[1]:], err
+}
+
+type encodeState struct {
+	bytes.Buffer
+}
+
+func (e *encodeState) encode(i interface{}) error {
+	switch v := i.(type) {
+	case []interface{}:
+		return e.encodeList(v)
+
+	case map[string]interface{}:
+		return e.encodeMap(v)
+
+	case int, int8, int32, int64, uint8, uint32, uint64:
+		return e.encodeInt(i)
+
+	case float32, float64:
+		return e.encodeFloat(i)
+
+	case string:
+		return e.encodeString(v)
+
+	case nil:
+		return nil
+
+	default:
+		return fmt.Errorf("invalid type %T", i)
+	}
+
+}
+
+func (e *encodeState) encodeList(l []interface{}) error {
+	e.WriteString("[")
+	for i, v := range l {
+		err := e.encode(v)
+		if err != nil {
+			return err
+		}
+		if i < len(l)-1 {
+			e.WriteString(", ")
+		}
+	}
+	e.WriteString("]")
+	return nil
+}
+
+func (e *encodeState) encodeMap(m map[string]interface{}) error {
+	e.WriteString("{\n")
+	for i, k := range sortedKeys(m) {
+		v := m[k]
+
+		e.WriteString(k + " = ")
+		err := e.encode(v)
+		if err != nil {
+			return err
+		}
+		if i < len(m)-1 {
+			e.WriteString("\n")
+		}
+	}
+	e.WriteString("}")
+	return nil
+}
+
+func (e *encodeState) encodeString(s string) error {
+	_, err := fmt.Fprintf(e, "%q", s)
+	return err
+}
+
+func (e *encodeState) encodeInt(i interface{}) error {
+	_, err := fmt.Fprintf(e, "%d", i)
+	return err
+}
+
+func (e *encodeState) encodeFloat(f interface{}) error {
+	_, err := fmt.Fprintf(e, "%f", f)
+	return err
+}

--- a/command/hcl_printer.go
+++ b/command/hcl_printer.go
@@ -12,7 +12,6 @@ import (
 // This will only work operate on []interface{}, map[string]interface{}, and
 // primitive types.
 func encodeHCL(i interface{}) ([]byte, error) {
-
 	state := &encodeState{}
 	err := state.encode(i)
 	if err != nil {

--- a/command/push.go
+++ b/command/push.go
@@ -137,25 +137,46 @@ func (c *PushCommand) Run(args []string) int {
 		c.client = &atlasPushClient{Client: client}
 	}
 
-	// Get the variables we might already have
+	// Get the variables we already have in atlas
 	atlasVars, err := c.client.Get(name)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(
 			"Error looking up previously pushed configuration: %s", err))
 		return 1
 	}
-	for k, v := range atlasVars {
-		if _, ok := overwriteMap[k]; ok {
-			continue
-		}
 
-		ctx.SetVariable(k, v)
+	// filter any overwrites from the atlas vars
+	for k := range overwriteMap {
+		delete(atlasVars, k)
+	}
+
+	// Set remote variables in the context if we don't have a value here. These
+	// don't have to be correct, it just prevents the Input walk from prompting
+	// the user for input, The atlas variable may be an hcl-encoded object, but
+	// we're just going to set it as the raw string value.
+	ctxVars := ctx.Variables()
+	for k, av := range atlasVars {
+		if _, ok := ctxVars[k]; !ok {
+			ctx.SetVariable(k, av.Value)
+		}
 	}
 
 	// Ask for input
 	if err := ctx.Input(c.InputMode()); err != nil {
 		c.Ui.Error(fmt.Sprintf(
 			"Error while asking for variable input:\n\n%s", err))
+		return 1
+	}
+
+	// Now that we've gone through the input walk, we can be sure we have all
+	// the variables we're going to get.
+	// We are going to keep these separate from the atlas variables until
+	// upload, so we can notify the user which local variables we're sending.
+	serializedVars, err := tfVars(ctx.Variables())
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"An error has occurred while serializing the variables for uploading:\n"+
+				"%s", err))
 		return 1
 	}
 
@@ -184,17 +205,23 @@ func (c *PushCommand) Run(args []string) int {
 
 	// Output to the user the variables that will be uploaded
 	var setVars []string
-	for k, _ := range ctx.Variables() {
-		if _, ok := overwriteMap[k]; !ok {
-			if _, ok := atlasVars[k]; ok {
-				// Atlas variable not within override, so it came from Atlas
-				continue
-			}
+	// variables to upload
+	var uploadVars []atlas.TFVar
+
+	// Now we can combine the vars for upload to atlas and list the variables
+	// we're uploading for the user
+	for _, sv := range serializedVars {
+		if av, ok := atlasVars[sv.Key]; ok {
+			// this belongs to Atlas
+			uploadVars = append(uploadVars, av)
+		} else {
+			// we're uploading our local version
+			setVars = append(setVars, sv.Key)
+			uploadVars = append(uploadVars, sv)
 		}
 
-		// This variable was set from the local value
-		setVars = append(setVars, k)
 	}
+
 	sort.Strings(setVars)
 	if len(setVars) > 0 {
 		c.Ui.Output(
@@ -210,21 +237,12 @@ func (c *PushCommand) Run(args []string) int {
 		c.Ui.Output("")
 	}
 
-	variables := ctx.Variables()
-	serializedVars, err := tfVars(variables)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf(
-			"An error has occurred while serializing the variables for uploading:\n"+
-				"%s", err))
-		return 1
-	}
-
 	// Upsert!
 	opts := &pushUpsertOptions{
 		Name:      name,
 		Archive:   archiveR,
 		Variables: ctx.Variables(),
-		TFVars:    serializedVars,
+		TFVars:    uploadVars,
 	}
 
 	c.Ui.Output("Uploading Terraform configuration...")
@@ -340,10 +358,11 @@ func (c *PushCommand) Synopsis() string {
 	return "Upload this Terraform module to Atlas to run"
 }
 
-// pushClient is implementd internally to control where pushes go. This is
-// either to Atlas or a mock for testing.
+// pushClient is implemented internally to control where pushes go. This is
+// either to Atlas or a mock for testing. We still return a map to make it
+// easier to check for variable existence when filtering the overrides.
 type pushClient interface {
-	Get(string) (map[string]interface{}, error)
+	Get(string) (map[string]atlas.TFVar, error)
 	Upsert(*pushUpsertOptions) (int, error)
 }
 
@@ -358,7 +377,7 @@ type atlasPushClient struct {
 	Client *atlas.Client
 }
 
-func (c *atlasPushClient) Get(name string) (map[string]interface{}, error) {
+func (c *atlasPushClient) Get(name string) (map[string]atlas.TFVar, error) {
 	user, name, err := atlas.ParseSlug(name)
 	if err != nil {
 		return nil, err
@@ -369,10 +388,21 @@ func (c *atlasPushClient) Get(name string) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	var variables map[string]interface{}
-	if version != nil {
-		// TODO: merge variables and TFVars
-		//variables = version.Variables
+	variables := make(map[string]atlas.TFVar)
+
+	if version == nil {
+		return variables, nil
+	}
+
+	// Variables is superseded by TFVars
+	if version.TFVars == nil {
+		for k, v := range version.Variables {
+			variables[k] = atlas.TFVar{Key: k, Value: v}
+		}
+	} else {
+		for _, v := range version.TFVars {
+			variables[v.Key] = v
+		}
 	}
 
 	return variables, nil
@@ -402,7 +432,7 @@ type mockPushClient struct {
 
 	GetCalled bool
 	GetName   string
-	GetResult map[string]interface{}
+	GetResult map[string]atlas.TFVar
 	GetError  error
 
 	UpsertCalled  bool
@@ -411,7 +441,7 @@ type mockPushClient struct {
 	UpsertError   error
 }
 
-func (c *mockPushClient) Get(name string) (map[string]interface{}, error) {
+func (c *mockPushClient) Get(name string) (map[string]atlas.TFVar, error) {
 	c.GetCalled = true
 	c.GetName = name
 	return c.GetResult, c.GetError

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -397,21 +397,29 @@ func TestPush_tfvars(t *testing.T) {
 	// make sure these dind't go missing for some reason
 	for k, v := range variables {
 		if !reflect.DeepEqual(client.UpsertOptions.Variables[k], v) {
-			t.Fatalf("bad: %#v", client.UpsertOptions.Variables)
+			t.Fatalf("bad: %#v", client.UpsertOptions.Variables[k])
 		}
 	}
 
-	//now check TFVVars
-
+	//now check TFVars
 	tfvars := []atlas.TFVar{
 		{"bar", "foo", false},
-		{"baz", "{\n  A = \"a\"\n  B = \"b\"\n}\n", true},
-		{"fob", "[\"a\", \"b\", \"c\"]\n", true},
+		{"baz", `{
+  A      = "a"
+  B      = "b"
+  interp = "${file("t.txt")}"
+}
+`, true},
+		{"fob", `["a", "b", "c", "quotes \"in\" quotes"]` + "\n", true},
 		{"foo", "bar", false},
 	}
 
-	if !reflect.DeepEqual(client.UpsertOptions.TFVars, tfvars) {
-		t.Fatalf("bad tf_vars: %#v", client.UpsertOptions.TFVars)
+	for i, expected := range tfvars {
+		got := client.UpsertOptions.TFVars[i]
+		if got != expected {
+			t.Logf("%2d expected: %#v", i, expected)
+			t.Logf("        got: %#v", got)
+		}
 	}
 }
 
@@ -582,9 +590,10 @@ func pushTFVars() map[string]interface{} {
 		"foo": "bar",
 		"bar": "foo",
 		"baz": map[string]interface{}{
-			"A": "a",
-			"B": "b",
+			"A":      "a",
+			"B":      "b",
+			"interp": `${file("t.txt")}`,
 		},
-		"fob": []interface{}{"a", "b", "c"},
+		"fob": []interface{}{"a", "b", "c", `quotes "in" quotes`},
 	}
 }

--- a/command/test-fixtures/push-tfvars/main.tf
+++ b/command/test-fixtures/push-tfvars/main.tf
@@ -1,6 +1,19 @@
 variable "foo" {}
 variable "bar" {}
 
+variable "baz" {
+    type = "map"
+    default = {
+        "A" = "a"
+        "B" = "b"
+    }
+}
+
+variable "fob" {
+    type = "list"
+    default = ["a", "b", "c"]
+}
+
 resource "test_instance" "foo" {}
 
 atlas {

--- a/command/test-fixtures/push-tfvars/main.tf
+++ b/command/test-fixtures/push-tfvars/main.tf
@@ -7,14 +7,13 @@ variable "baz" {
 
   default = {
     "A"    = "a"
-    "B"    = "b"
     interp = "${file("t.txt")}"
   }
 }
 
 variable "fob" {
   type    = "list"
-  default = ["a", "b", "c", "quotes \"in\" quotes"]
+  default = ["a", "quotes \"in\" quotes"]
 }
 
 resource "test_instance" "foo" {}

--- a/command/test-fixtures/push-tfvars/main.tf
+++ b/command/test-fixtures/push-tfvars/main.tf
@@ -1,21 +1,24 @@
 variable "foo" {}
+
 variable "bar" {}
 
 variable "baz" {
-    type = "map"
-    default = {
-        "A" = "a"
-        "B" = "b"
-    }
+  type = "map"
+
+  default = {
+    "A"     = "a"
+    "B"     = "b"
+    interp  = "${file("t.txt")}"
+  }
 }
 
 variable "fob" {
-    type = "list"
-    default = ["a", "b", "c"]
+  type    = "list"
+  default = ["a", "b", "c", "quotes \"in\" quotes"]
 }
 
 resource "test_instance" "foo" {}
 
 atlas {
-    name = "foo"
+  name = "foo"
 }

--- a/command/test-fixtures/push-tfvars/main.tf
+++ b/command/test-fixtures/push-tfvars/main.tf
@@ -6,9 +6,9 @@ variable "baz" {
   type = "map"
 
   default = {
-    "A"     = "a"
-    "B"     = "b"
-    interp  = "${file("t.txt")}"
+    "A"    = "a"
+    "B"    = "b"
+    interp = "${file("t.txt")}"
   }
 }
 

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -332,6 +332,7 @@ func (c *Context) Input(mode InputMode) error {
 
 			// Ask the user for a value for this variable
 			var value string
+			retry := 0
 			for {
 				var err error
 				value, err = c.uiInput.Input(&InputOpts{
@@ -345,7 +346,12 @@ func (c *Context) Input(mode InputMode) error {
 				}
 
 				if value == "" && v.Required() {
-					// Redo if it is required.
+					// Redo if it is required, but abort if we keep getting
+					// blank entries
+					if retry > 2 {
+						return fmt.Errorf("missing required value for %q", n)
+					}
+					retry++
 					continue
 				}
 

--- a/vendor/github.com/hashicorp/atlas-go/v1/terraform.go
+++ b/vendor/github.com/hashicorp/atlas-go/v1/terraform.go
@@ -14,7 +14,16 @@ type TerraformConfigVersion struct {
 	Version   int
 	Remotes   []string          `json:"remotes"`
 	Metadata  map[string]string `json:"metadata"`
-	Variables map[string]string `json:"variables"`
+	Variables map[string]string `json:"variables,omitempty"`
+	TFVars    []TFVar           `json:"tf_vars"`
+}
+
+// TFVar is used to serialize a single Terraform variable sent by the
+// manager as a collection of Variables in a Job payload.
+type TFVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	IsHCL bool   `json:"hcl"`
 }
 
 // TerraformConfigLatest returns the latest Terraform configuration version.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1060,11 +1060,11 @@
 			"revision": "95fa852edca41c06c4ce526af4bb7dec4eaad434"
 		},
 		{
-			"checksumSHA1": "EWGfo74RcoKaYFZNSkvzYRJMgrY=",
+			"checksumSHA1": "yylO3hSRKd0T4mveT9ho2OSARwU=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/v1",
-			"revision": "c8b26aa95f096efc0f378b2d2830ca909631d584",
-			"revisionTime": "2016-07-22T13:58:36Z"
+			"revision": "9be9a611a15ba2f857a99b332fd966896867299a",
+			"revisionTime": "2016-07-26T16:33:11Z"
 		},
 		{
 			"comment": "v0.6.3-28-g3215b87",


### PR DESCRIPTION
Add tf_vars to the data structures sent in `terraform push`. 

This takes any value of type `[]interface{}` or `map[string]interface{}` and marshals it as a string representation of the equivalent HCL. This prevents ambiguity in atlas between a string that looks like a json structure, and an actual json structure. 

For the time being we will need a way to serialize data as HCL, so the
command package has an internal `encodeHCL` function to do so. We can
remove this if we get complete package for marshaling HCL.
