### PR TITLE
Fix typo in aws_vpc resource docs (VPN -> VPC)

### DIFF
--- a/website/source/docs/providers/aws/r/vpc.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc.html.markdown
@@ -67,8 +67,8 @@ The following attributes are exported:
 
 ## Import
 
-VPNs can be imported using the `vpn id`, e.g. 
+VPCs can be imported using the `vpc id`, e.g. 
 
 ```
-$ terraform import aws_vpn.test_vpn vpc-a01106c2
+$ terraform import aws_vpc.test_vpc vpc-a01106c2
 ```


### PR DESCRIPTION
Just noticed this while browsing the docs, is this fix correct?