### PR TITLE
provider/aws: Fix issue updating ElasticBeanstalk Environment templates

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -311,7 +311,9 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 
 	if d.HasChange("solution_stack_name") {
 		hasChange = true
-		updateOpts.SolutionStackName = aws.String(d.Get("solution_stack_name").(string))
+		if v, ok := d.GetOk("solution_stack_name"); ok {
+			updateOpts.SolutionStackName = aws.String(v.(string))
+		}
 	}
 
 	if d.HasChange("setting") {
@@ -332,7 +334,9 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 
 	if d.HasChange("template_name") {
 		hasChange = true
-		updateOpts.TemplateName = aws.String(d.Get("template_name").(string))
+		if v, ok := d.GetOk("template_name"); ok {
+			updateOpts.TemplateName = aws.String(v.(string))
+		}
 	}
 
 	if hasChange {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/6603 , only set the `TemplateName` in a request if it's not empty. Includes regression test.