### PR TITLE
provider/aws: Restore Defaults to SQS Queues

### DIFF
--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -70,7 +70,7 @@ func resourceAwsSqsQueue() *schema.Resource {
 			"visibility_timeout_seconds": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  30,
 			},
 			"policy": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -50,22 +50,22 @@ func resourceAwsSqsQueue() *schema.Resource {
 			"delay_seconds": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  0,
 			},
 			"max_message_size": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  262144,
 			},
 			"message_retention_seconds": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  345600,
 			},
 			"receive_wait_time_seconds": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  0,
 			},
 			"visibility_timeout_seconds": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -22,13 +22,19 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue-with-defaults"),
+					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSSQSConfigWithOverrides,
+				Config: testAccAWSSQSConfigWithOverrides(queueName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSExistsWithOverrides("aws_sqs_queue.queue-with-overrides"),
+					testAccCheckAWSSQSExistsWithOverrides("aws_sqs_queue.queue"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSSQSConfigWithDefaults(queueName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue"),
 				),
 			},
 		},
@@ -197,22 +203,23 @@ func testAccCheckAWSSQSExistsWithOverrides(n string) resource.TestCheckFunc {
 
 func testAccAWSSQSConfigWithDefaults(r string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue-with-defaults" {
+resource "aws_sqs_queue" "queue" {
     name = "%s"
 }
 `, r)
 }
 
-const testAccAWSSQSConfigWithOverrides = `
-resource "aws_sqs_queue" "queue-with-overrides" {
-  name                       = "test-sqs-queue-with-overrides"
+func testAccAWSSQSConfigWithOverrides(r string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+  name                       = "%s"
   delay_seconds              = 90
   max_message_size           = 2048
   message_retention_seconds  = 86400
   receive_wait_time_seconds  = 10
   visibility_timeout_seconds = 60
+}`, r)
 }
-`
 
 func testAccAWSSQSConfigWithRedrive(name string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
Fixes #7505 by removing `computed` and adding `default` values, to match with the SDK defaults.

I think this is somewhat new territory, as we typically just do nothing with the _removal_ of an optional, computed value, but here we restore the defaults because they are documented. Without this, you couldn't remove a setting once you set it, you'd have to find the default yourself and manually set it. 