### PR TITLE
provider/powerdns: Add support for PowerDNS 4 API

### DIFF
--- a/builtin/providers/powerdns/client.go
+++ b/builtin/providers/powerdns/client.go
@@ -126,7 +126,7 @@ func parseId(recId string) (string, string, error) {
 
 // Detects the API version in use on the server
 // Uses int to represent the API version: 0 is the legacy AKA version 3.4 API
-// Any other integer correlates with te same API version
+// Any other integer correlates with the same API version
 func (client *Client) detectApiVersion() (int, error) {
 	req, err := client.newRequest("GET", "/api/v1/servers", nil)
 	if err != nil {

--- a/builtin/providers/powerdns/client.go
+++ b/builtin/providers/powerdns/client.go
@@ -46,7 +46,7 @@ func (c *Client) newRequest(method string, endpoint string, body []byte) (*http.
 	}
 	url, err := url.Parse(urlStr)
 	if err != nil {
-		return nil, fmt.Errorf("Error during parting request URL: %s", err)
+		return nil, fmt.Errorf("Error during parsing request URL: %s", err)
 	}
 
 	var bodyReader io.Reader

--- a/builtin/providers/powerdns/client.go
+++ b/builtin/providers/powerdns/client.go
@@ -278,7 +278,7 @@ func (client *Client) CreateRecord(zone string, record Record) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 204 {
 		errorResp := new(errorResponse)
 		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
 			return "", fmt.Errorf("Error creating record: %s", record.Id())
@@ -309,7 +309,7 @@ func (client *Client) ReplaceRecordSet(zone string, rrSet ResourceRecordSet) (st
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 204 {
 		errorResp := new(errorResponse)
 		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
 			return "", fmt.Errorf("Error creating record set: %s", rrSet.Id())
@@ -344,7 +344,7 @@ func (client *Client) DeleteRecordSet(zone string, name string, tpe string) erro
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 204 {
 		errorResp := new(errorResponse)
 		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
 			return fmt.Errorf("Error deleting record: %s %s", name, tpe)

--- a/builtin/providers/powerdns/resource_powerdns_record.go
+++ b/builtin/providers/powerdns/resource_powerdns_record.go
@@ -57,6 +57,7 @@ func resourcePDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	rrSet := ResourceRecordSet{
 		Name: d.Get("name").(string),
 		Type: d.Get("type").(string),
+		TTL:  d.Get("ttl").(int),
 	}
 
 	zone := d.Get("zone").(string)

--- a/website/source/docs/providers/powerdns/index.html.markdown
+++ b/website/source/docs/providers/powerdns/index.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # PowerDNS Provider
 
 The PowerDNS provider is used manipulate DNS records supported by PowerDNS server. The provider needs to be configured
-with the proper credentials before it can be used. It supports both the [legacy API](https://doc.powerdns.com/3/httpapi/api_spec/) and the new [version 1 API](https://doc.powerdns.com/md/httpapi/api_spec/), however recources may need to be configured differently.
+with the proper credentials before it can be used. It supports both the [legacy API](https://doc.powerdns.com/3/httpapi/api_spec/) and the new [version 1 API](https://doc.powerdns.com/md/httpapi/api_spec/), however resources may need to be configured differently.
 
 Use the navigation to the left to read about the available resources.
 

--- a/website/source/docs/providers/powerdns/index.html.markdown
+++ b/website/source/docs/providers/powerdns/index.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # PowerDNS Provider
 
 The PowerDNS provider is used manipulate DNS records supported by PowerDNS server. The provider needs to be configured
-with the proper credentials before it can be used.
+with the proper credentials before it can be used. It supports both the [legacy API](https://doc.powerdns.com/3/httpapi/api_spec/) and the new [version 1 API](https://doc.powerdns.com/md/httpapi/api_spec/), however recources may need to be configured differently.
 
 Use the navigation to the left to read about the available resources.
 

--- a/website/source/docs/providers/powerdns/r/record.html.markdown
+++ b/website/source/docs/providers/powerdns/r/record.html.markdown
@@ -12,10 +12,23 @@ Provides a PowerDNS record resource.
 
 ## Example Usage
 
+For the legacy API (PowerDNS version 3.4):
 ```
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
-	zone = "example.com"
+	zone = "example.com."
+	name = "www.example.com"
+	type = "A"
+	ttl = 300
+	records = ["192.168.0.11"]
+}
+```
+
+For the v1 API (PowerDNS version 4):
+```
+# Add a record to the zone
+resource "powerdns_record" "foobar" {
+	zone = "example.com."
 	name = "www.example.com"
 	type = "A"
 	ttl = 300

--- a/website/source/docs/providers/powerdns/r/record.html.markdown
+++ b/website/source/docs/providers/powerdns/r/record.html.markdown
@@ -12,7 +12,7 @@ Provides a PowerDNS record resource.
 
 ## Example Usage
 
-For the legacy API (PowerDNS version 3.4):
+For the v1 API (PowerDNS version 4):
 ```
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
@@ -24,11 +24,11 @@ resource "powerdns_record" "foobar" {
 }
 ```
 
-For the v1 API (PowerDNS version 4):
+For the legacy API (PowerDNS version 3.4):
 ```
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
-	zone = "example.com."
+	zone = "example.com"
 	name = "www.example.com"
 	type = "A"
 	ttl = 300

--- a/website/source/docs/providers/powerdns/r/record.html.markdown
+++ b/website/source/docs/providers/powerdns/r/record.html.markdown
@@ -12,6 +12,8 @@ Provides a PowerDNS record resource.
 
 ## Example Usage
 
+Note that PowerDNS internally lowercases certain records (e.g. CNAME and AAAA), which can lead to resources being marked for a change in every singe plan.
+
 For the v1 API (PowerDNS version 4):
 ```
 # Add a record to the zone


### PR DESCRIPTION
This adds support for the non-experimental API present in PowerDNS 4, while retaining support for 3.X, with minimal changes.

Notes:
* I left the acceptance tests alone in this PR, but by add a trailing `.` to all DNS names (including in the records), they all succeeded against an actual 4.0.0 server
* I noted an edge case regarding case sensitivity, but refrained from trying to fix it, since it's not clear which records and/or situations it effects.

If the plan is to drop 3.X entirely, I don't mind fixing those two things up, but that's not a decision I wanted to make alone.

Fixes #6056 