### PR TITLE
provider/aws: Don't delete Lambda function from state on initial call of the Read func

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -237,7 +237,7 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 
 	getFunctionOutput, err := conn.GetFunction(params)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" && !d.IsNewResource() {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Fixes #7782

Lambda functions are eventually consistent :( Therefore, when we move
from the Create func to the Read func, there is a chance that the Lambda
hasn't replicated yet and we could therefore find that it doesn't exist
and delete it as follows:

```
params := &lambda.GetFunctionInput{
        FunctionName: aws.String(d.Get("function_name").(string)),

}

    getFunctionOutput, err := conn.GetFunction(params)
    if err != nil {
            if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
                        d.SetId("")
                                    return nil

            }
                    return err

    }
```

This PR uses `d.IsNewResource()` to check if the Read is being called
after a Create and therefore, won't delete the lambda if not found. This
should allow the lambda to replicate

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLambdaFunction_'
=> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSLambdaFunction_ -timeout 120m
=== RUN   TestAccAWSLambdaFunction_importLocalFile
--- PASS: TestAccAWSLambdaFunction_importLocalFile (36.64s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (45.17s)
=== RUN   TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_importS3 (40.88s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (44.77s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (44.13s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (43.62s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (33.49s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (51.83s)
=== RUN   TestAccAWSLambdaFunction_s3Update
--- PASS: TestAccAWSLambdaFunction_s3Update (106.49s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    447.055s
```

Thanks to @radeksimko for pointing out `d.IsNewResource()`