### PR TITLE
Remove unused variables

### DIFF
--- a/builtin/providers/aws/resource_aws_appautoscaling_target.go
+++ b/builtin/providers/aws/resource_aws_appautoscaling_target.go
@@ -88,10 +88,9 @@ func resourceAwsAppautoscalingTargetCreate(d *schema.ResourceData, meta interfac
 	targetOpts.ServiceNamespace = aws.String(d.Get("service_namespace").(string))
 
 	log.Printf("[DEBUG] Application autoscaling target create configuration %#v", targetOpts)
-	var out *applicationautoscaling.RegisterScalableTargetOutput
 	var err error
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		out, err = conn.RegisterScalableTarget(&targetOpts)
+		_, err = conn.RegisterScalableTarget(&targetOpts)
 
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ValidationException" {

--- a/builtin/providers/aws/resource_aws_opsworks_permission.go
+++ b/builtin/providers/aws/resource_aws_opsworks_permission.go
@@ -131,10 +131,9 @@ func resourceAwsOpsworksPermissionCreate(d *schema.ResourceData, meta interface{
 		StackId:    aws.String(d.Get("stack_id").(string)),
 	}
 
-	var resp *opsworks.SetPermissionOutput
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var cerr error
-		resp, cerr = client.SetPermission(req)
+		_, cerr = client.SetPermission(req)
 		if cerr != nil {
 			log.Printf("[INFO] client error")
 			if opserr, ok := cerr.(awserr.Error); ok {


### PR DESCRIPTION
These variables weren't used, but the compiler misses them since they
are captured in a closure.