### PR TITLE
core: Do not assume HCL parser has touched vars

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -181,11 +181,16 @@ func NewContext(opts *ContextOpts) (*Context, error) {
 							if existingMap, ok := existing.(map[string]interface{}); !ok {
 								panic(fmt.Sprintf("%s is not a map, this is a bug in Terraform.", k))
 							} else {
-								if newMap, ok := varVal.(map[string]interface{}); ok {
-									for newKey, newVal := range newMap {
+								switch typedV := varVal.(type) {
+								case []map[string]interface{}:
+									for newKey, newVal := range typedV[0] {
 										existingMap[newKey] = newVal
 									}
-								} else {
+								case map[string]interface{}:
+									for newKey, newVal := range typedV {
+										existingMap[newKey] = newVal
+									}
+								default:
 									panic(fmt.Sprintf("%s is not a map, this is a bug in Terraform.", k))
 								}
 							}
@@ -208,11 +213,16 @@ func NewContext(opts *ContextOpts) (*Context, error) {
 							if existingMap, ok := existing.(map[string]interface{}); !ok {
 								panic(fmt.Sprintf("%s is not a map, this is a bug in Terraform.", k))
 							} else {
-								if newMap, ok := v.([]map[string]interface{}); ok {
-									for newKey, newVal := range newMap[0] {
+								switch typedV := v.(type) {
+								case []map[string]interface{}:
+									for newKey, newVal := range typedV[0] {
 										existingMap[newKey] = newVal
 									}
-								} else {
+								case map[string]interface{}:
+									for newKey, newVal := range typedV {
+										existingMap[newKey] = newVal
+									}
+								default:
 									panic(fmt.Sprintf("%s is not a map, this is a bug in Terraform.", k))
 								}
 							}

--- a/terraform/test-fixtures/issue-7824/main.tf
+++ b/terraform/test-fixtures/issue-7824/main.tf
@@ -1,0 +1,6 @@
+variable "test" {
+  type = "map"
+  default = {
+    "test" = "1"
+  }
+}


### PR DESCRIPTION
This PR fixes #7824, which crashed when applying a plan file. The bug is that while a map which has come from the HCL parser reifies as a `[]map[string]interface{}`, the variable saved in the plan file was not. We now cover both cases.

Fixes #7824.