### PR TITLE
Ensure kms_key_id docs indicate it is an ARN

### DIFF
--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
     defined for notification of log file delivery.
 * `enable_log_file_validation` - (Optional) Specifies whether log file integrity validation is enabled.
     Defaults to `false`.
-* `kms_key_id` - (Optional) Specifies the KMS key ID to use to encrypt the logs delivered by CloudTrail.
+* `kms_key_id` - (Optional) Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail.
 * `tags` - (Optional) A mapping of tags to assign to the trail
 
 ## Attribute Reference

--- a/website/source/docs/providers/aws/r/ebs_volume.html.md
+++ b/website/source/docs/providers/aws/r/ebs_volume.html.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `size` - (Optional) The size of the drive in GB.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `type` - (Optional) The type of EBS volume. Can be "standard", "gp2", "io1", or "st1" (Default: "standard").
-* `kms_key_id` - (Optional) The KMS key ID for the volume.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -52,7 +52,7 @@ string.
 * `number_of_nodes` - (Optional) The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node. Default is 1.
 * `publicly_accessible` - (Optional) If true, the cluster can be accessed from a public network. Default is `true`.
 * `encrypted` - (Optional) If true , the data in the cluster is encrypted at rest.
-* `kms_key_id` - (Optional) The KMS key ID for the cluster.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
 * `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is true.
 * `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.


### PR DESCRIPTION
If you specify just a bare ID, then the initial application works but
subsequent applications may end up doing bad things, like:

```
-/+ aws_ebs_volume.vol_1
    availability_zone: "us-east-1a" => "us-east-1a"
    encrypted:         "true" => "true"
    iops:              "" => "<computed>"
    kms_key_id:        "arn:aws:kms:us-east-1:123456789:key/59faf88b-0912-4cca-8b6c-bd107a6ba8c4" => "59faf88b-0912-4cca-8b6c-bd107a6ba8c4" (forces new resource)
    size:              "100" => "100"
    snapshot_id:       "" => "<computed>"
```