### PR TITLE
Fix OpenStack documentation

### DIFF
--- a/website/source/docs/providers/openstack/r/networking_network_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_network_v2.html.markdown
@@ -40,7 +40,7 @@ resource "openstack_networking_port_v2" "port_1" {
   name = "port_1"
   network_id = "${openstack_networking_network_v2.network_1.id}"
   admin_state_up = "true"
-  security_groups = ["${openstack_compute_secgroup_v2.secgroup_1.id}"]
+  security_group_ids = ["${openstack_compute_secgroup_v2.secgroup_1.id}"]
 
   fixed_ip {
       "subnet_id" =  "008ba151-0b8c-4a67-98b5-0d2b87666062"

--- a/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
@@ -82,7 +82,7 @@ The following attributes are exported:
 * `mac_address` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `device_owner` - See Argument Reference above.
-* `security_groups` - See Argument Reference above.
+* `security_group_ids` - See Argument Reference above.
 * `device_id` - See Argument Reference above.
 * `fixed_ip/ip_address` - See Argument Reference above.
 


### PR DESCRIPTION
References to security_groups attribute on network objects should
actually be security_group_ids.