### PR TITLE
Updated compute_address docs

### DIFF
--- a/website/source/docs/providers/google/r/compute_address.html.markdown
+++ b/website/source/docs/providers/google/r/compute_address.html.markdown
@@ -42,3 +42,4 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+* `address` - The IP of the created resource.


### PR DESCRIPTION
Added missing `address` to attribute references in the docs.