### PR TITLE
[WIP] Add support for specifying AWS Elasticsearch version

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -44,6 +44,12 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 					return
 				},
 			},
+			"version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -139,6 +145,10 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 
 	input := elasticsearch.CreateElasticsearchDomainInput{
 		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+
+	if v, ok := d.GetOk("version"); ok {
+		input.Elasticsearch-Version = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("access_policies"); ok {
@@ -264,6 +274,7 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	}
 	d.Set("domain_id", *ds.DomainId)
 	d.Set("domain_name", *ds.DomainName)
+	d.Set("version", *ds.Elasticsearch-Version)
 	if ds.Endpoint != nil {
 		d.Set("endpoint", *ds.Endpoint)
 	}
@@ -314,6 +325,10 @@ func resourceAwsElasticSearchDomainUpdate(d *schema.ResourceData, meta interface
 
 	input := elasticsearch.UpdateElasticsearchDomainConfigInput{
 		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+
+	if d.HasChange("version") {
+		input.AccessPolicies = aws.String(d.Get("version").(string))
 	}
 
 	if d.HasChange("access_policies") {

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -150,6 +150,13 @@ resource "aws_elasticsearch_domain" "example" {
 }
 `
 
+const testAccESDomainConfig_VersionUpdate = `
+resource "aws_elasticsearch_domain" "example" {
+  domain_name = "tf-test-1"
+  version = "0.0"
+}
+`
+
 const testAccESDomainConfig_TagUpdate = `
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-1"

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/api.go
@@ -646,6 +646,10 @@ type CreateElasticsearchDomainInput struct {
 	// a-z (lowercase), 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
 
+	// The version of Elasticsearch to use for the cluster. The default is 1.5 but 2.3
+	// is now optionally available and recommended.
+	Elasticsearch-Version *string `min:"3" type:"string"`
+
 	// Options to enable, disable and specify the type and size of EBS storage volumes.
 	EBSOptions *EBSOptions `type:"structure"`
 


### PR DESCRIPTION
_"I have no idea what I'm doing"_

I don't usually develop in Go. I have never contributed to terraform. I am a DevOps engineer with some programming experience.

I **think** I have covered everything I need to in order to incorporate this one parameter to allow for the creation of a v2.3 AWS Elasticsearch domain.

If you agree, yay. If you don't please advise. If you want to completely reject my code and rewrite it, that's absolutely fine too - I just want to see support for v2.3 ES domains in terraform as soon as is humanly possible and have done my best to help that effort.