### PR TITLE
provider/aws: Support `aws_elasticsearch_domain` upgrades to `elasticsearch_version` 2.3

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -129,6 +129,13 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 					},
 				},
 			},
+			"elasticsearch_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "1.5",
+				ForceNew: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -138,7 +145,8 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 	conn := meta.(*AWSClient).esconn
 
 	input := elasticsearch.CreateElasticsearchDomainInput{
-		DomainName: aws.String(d.Get("domain_name").(string)),
+		DomainName:           aws.String(d.Get("domain_name").(string)),
+		ElasticsearchVersion: aws.String(d.Get("elasticsearch_version").(string)),
 	}
 
 	if v, ok := d.GetOk("access_policies"); ok {
@@ -262,8 +270,9 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	d.Set("domain_id", *ds.DomainId)
-	d.Set("domain_name", *ds.DomainName)
+	d.Set("domain_id", ds.DomainId)
+	d.Set("domain_name", ds.DomainName)
+	d.Set("elasticsearch_version", ds.ElasticsearchVersion)
 	if ds.Endpoint != nil {
 		d.Set("endpoint", *ds.Endpoint)
 	}
@@ -282,7 +291,7 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 		})
 	}
 
-	d.Set("arn", *ds.ARN)
+	d.Set("arn", ds.ARN)
 
 	listOut, err := conn.ListTags(&elasticsearch.ListTagsInput{
 		ARN: ds.ARN,

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,9 +22,32 @@ func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccESDomainConfig,
+				Config: testAccESDomainConfig(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttr(
+						"aws_elasticsearch_domain.example", "elasticsearch_version", "1.5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticSearchDomain_v23(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccESDomainConfigV23(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttr(
+						"aws_elasticsearch_domain.example", "elasticsearch_version", "2.3"),
 				),
 			},
 		},
@@ -31,6 +56,7 @@ func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 
 func TestAccAWSElasticSearchDomain_complex(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -38,7 +64,7 @@ func TestAccAWSElasticSearchDomain_complex(t *testing.T) {
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccESDomainConfig_complex,
+				Config: testAccESDomainConfig_complex(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
 				),
@@ -50,6 +76,7 @@ func TestAccAWSElasticSearchDomain_complex(t *testing.T) {
 func TestAccAWSElasticSearch_tags(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 	var td elasticsearch.ListTagsOutput
+	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,14 +84,14 @@ func TestAccAWSElasticSearch_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccESDomainConfig,
+				Config: testAccESDomainConfig(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccESDomainConfig_TagUpdate,
+				Config: testAccESDomainConfig_TagUpdate(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
 					testAccLoadESTags(&domain, &td),
@@ -144,26 +171,31 @@ func testAccCheckESDomainDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccESDomainConfig = `
+func testAccESDomainConfig(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "example" {
-  domain_name = "tf-test-1"
+  domain_name = "tf-test-%d"
 }
-`
+`, randInt)
+}
 
-const testAccESDomainConfig_TagUpdate = `
+func testAccESDomainConfig_TagUpdate(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "example" {
-  domain_name = "tf-test-1"
+  domain_name = "tf-test-%d"
 
   tags {
     foo = "bar"
     new = "type"
   }
 }
-`
+`, randInt)
+}
 
-const testAccESDomainConfig_complex = `
+func testAccESDomainConfig_complex(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "example" {
-  domain_name = "tf-test-2"
+  domain_name = "tf-test-%d"
 
   advanced_options {
     "indices.fielddata.cache.size" = 80
@@ -186,4 +218,14 @@ resource "aws_elasticsearch_domain" "example" {
     bar = "complex"
   }
 }
-`
+`, randInt)
+}
+
+func testAccESDomainConfigV23(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticsearch_domain" "example" {
+  domain_name = "tf-test-%d"
+  elasticsearch_version = "2.3"
+}
+`, randInt)
+}

--- a/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
@@ -14,6 +14,7 @@ description: |-
 ```
 resource "aws_elasticsearch_domain" "es" {
 	domain_name = "tf-test"
+	elasticsearch_version = "1.5"
 	advanced_options {
 		"rest.action.multi.allow_explicit_index" = true
 	}
@@ -54,6 +55,7 @@ The following arguments are supported:
 * `ebs_options` - (Optional) EBS related options, see below.
 * `cluster_config` - (Optional) Cluster configuration of the domain, see below.
 * `snapshot_options` - (Optional) Snapshot related options, see below.
+* `elasticsearch_version` - (Optional) The version of ElasticSearch to deploy. Only valid values are `1.5` and `2.3`. Defaults to `1.5`
 * `tags` - (Optional) A mapping of tags to assign to the resource
 
 **ebs_options** supports the following attributes:


### PR DESCRIPTION
Fixes #7836 This will allow ElasticSearch domains to be deployed with
version 2.3 of ElasticSearch

The other slight modifications are to stop dereferencing values before
passing to d.Set in the Read func. It is safer to pass the pointer to d.Set
and allow that to dereference if there is a value

```
% make testacc TEST=./builtin/providers/aws
TESTARGS='-run=TestAccAWSElasticSearchDomain_'
==> Checking that code complies with gofmt requirements... go generate $(go
list ./... | grep -v /terraform/vendor/) TF_ACC=1 go test
./builtin/providers/aws -v -run=TestAccAWSElasticSearchDomain_ -timeout
120m
=== RUN   TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_basic (1611.74s)
=== RUN   TestAccAWSElasticSearchDomain_v23
--- PASS: TestAccAWSElasticSearchDomain_v23 (1898.80s)
=== RUN   TestAccAWSElasticSearchDomain_complex
--- PASS: TestAccAWSElasticSearchDomain_complex (1802.44s) PASS ok
github.com/hashicorp/terraform/builtin/providers/aws	5313.006s
```