### PR TITLE
provider/aws: `aws_vpn_gateway` should be removed from state when in deleted state

### DIFF
--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -86,7 +86,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if len(vpnGateway.VpcAttachments) == 0 || *vpnGateway.VpcAttachments[0].State == "detached" {
+	if len(vpnGateway.VpcAttachments) == 0 || *vpnGateway.VpcAttachments[0].State == "detached" || *vpnGateway.VpcAttachments[0].State == "deleted" {
 		// Gateway exists but not attached to the VPC
 		d.Set("vpc_id", "")
 	} else {


### PR DESCRIPTION
Fixes #7859

When a VPN Gateway has been manually deleted, we should expect it to be
added back to the plan

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpnGateway_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnGateway_
-timeout 120m
=== RUN   TestAccAWSVpnGateway_importBasic
--- PASS: TestAccAWSVpnGateway_importBasic (247.94s)
=== RUN   TestAccAWSVpnGateway_basic
--- PASS: TestAccAWSVpnGateway_basic (409.50s)
=== RUN   TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGateway_reattach (211.33s)
=== RUN   TestAccAWSVpnGateway_delete
--- PASS: TestAccAWSVpnGateway_delete (121.10s)
=== RUN   TestAccAWSVpnGateway_tags
--- PASS: TestAccAWSVpnGateway_tags (125.38s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws
1115.274s
```