### PR TITLE
Add S3 endpoint override ability and expose S3 path style option

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -80,6 +80,7 @@ type Config struct {
 	SkipCredsValidation     bool
 	SkipRequestingAccountId bool
 	SkipMetadataApiCheck    bool
+	S3ForcePathStyle        bool
 }
 
 type AWSClient struct {
@@ -163,10 +164,11 @@ func (c *Config) Client() (interface{}, error) {
 		log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
 
 		awsConfig := &aws.Config{
-			Credentials: creds,
-			Region:      aws.String(c.Region),
-			MaxRetries:  aws.Int(c.MaxRetries),
-			HTTPClient:  cleanhttp.DefaultClient(),
+			Credentials:      creds,
+			Region:           aws.String(c.Region),
+			MaxRetries:       aws.Int(c.MaxRetries),
+			HTTPClient:       cleanhttp.DefaultClient(),
+			S3ForcePathStyle: aws.Bool(c.S3ForcePathStyle),
 		}
 
 		if logging.IsDebugOrHigher() {
@@ -199,6 +201,7 @@ func (c *Config) Client() (interface{}, error) {
 		awsEc2Sess := sess.Copy(&aws.Config{Endpoint: aws.String(c.Ec2Endpoint)})
 		awsElbSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.ElbEndpoint)})
 		awsIamSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.IamEndpoint)})
+		awsS3Sess := sess.Copy(&aws.Config{Endpoint: aws.String(c.S3Endpoint)})
 		dynamoSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DynamoDBEndpoint)})
 		kinesisSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.KinesisEndpoint)})
 
@@ -259,7 +262,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.rdsconn = rds.New(sess)
 		client.redshiftconn = redshift.New(sess)
 		client.simpledbconn = simpledb.New(sess)
-		client.s3conn = s3.New(sess)
+		client.s3conn = s3.New(awsS3Sess)
 		client.sesConn = ses.New(sess)
 		client.snsconn = sns.New(sess)
 		client.sqsconn = sqs.New(sess)

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -182,6 +182,10 @@ The following arguments are supported in the `provider` block:
   `true` prevents Terraform from authenticating via Metadata API - i.e. you may need to use other auth methods
   (static credentials set as ENV vars or config)
 
+* `s3_force_path_style` - (Optional) set this to true to force the request to use
+  path-style adressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By default, the
+  S3 client will use virtual hosted bucket addressing when possible
+  (http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.
 
 Nested `endpoints` block supports the followings:
 
@@ -196,6 +200,10 @@ Nested `endpoints` block supports the followings:
 * `elb` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
   custom elb endpoints.
+
+* `s3` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  custom s3 endpoints.
 
 ## Getting the Account ID
 


### PR DESCRIPTION
Add S3 endpoint override ability and expose S3 path style option

* **Overriding S3 endpoint** - Enable specifying your own S3 api endpoint to override the default one, under endpoints.
* **Force S3 path style** - Expose this option from the aws-sdk-go configuration to the provider.

Sample provider config:

```
provider "aws" {
  region = "us-east-1"
  s3_force_path_style = true
  endpoints {
    s3 = "https://1.2.3.4"
  }
}
```