### PR TITLE
provider/aws: Fix up `aws_api_gateway_api_key` import test

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -83,6 +83,7 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 			"passthrough_behavior": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validateApiGatewayIntegrationPassthroughBehavior,
 			},
 		},


### PR DESCRIPTION
This changes the behaviour of `aws_api_gateway_integration` to set the
`passthrough_behaviour` to be computed as this was breaking the import
test

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayApiKey_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSAPIGatewayApiKey_importBasic -timeout 120m
=== RUN   TestAccAWSAPIGatewayApiKey_importBasic
--- PASS: TestAccAWSAPIGatewayApiKey_importBasic (50.19s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    50.210s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayIntegration_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSAPIGatewayIntegration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayIntegration_basic
--- PASS: TestAccAWSAPIGatewayIntegration_basic (67.43s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    67.449s
```