### PR TITLE
Skip IAM/STS validation and metadata check

### DIFF
--- a/builtin/providers/aws/auth_helpers_test.go
+++ b/builtin/providers/aws/auth_helpers_test.go
@@ -218,7 +218,7 @@ func TestAWSGetCredentials_shouldError(t *testing.T) {
 	defer resetEnv()
 	cfg := Config{}
 
-	c := GetCredentials(cfg.AccessKey, cfg.SecretKey, cfg.Token, cfg.Profile, cfg.CredsFilename)
+	c := GetCredentials(&cfg)
 	_, err := c.Get()
 	if awsErr, ok := err.(awserr.Error); ok {
 		if awsErr.Code() != "NoCredentialProviders" {
@@ -251,7 +251,7 @@ func TestAWSGetCredentials_shouldBeStatic(t *testing.T) {
 			Token:     c.Token,
 		}
 
-		creds := GetCredentials(cfg.AccessKey, cfg.SecretKey, cfg.Token, cfg.Profile, cfg.CredsFilename)
+		creds := GetCredentials(&cfg)
 		if creds == nil {
 			t.Fatalf("Expected a static creds provider to be returned")
 		}
@@ -286,7 +286,7 @@ func TestAWSGetCredentials_shouldIAM(t *testing.T) {
 	// An empty config, no key supplied
 	cfg := Config{}
 
-	creds := GetCredentials(cfg.AccessKey, cfg.SecretKey, cfg.Token, cfg.Profile, cfg.CredsFilename)
+	creds := GetCredentials(&cfg)
 	if creds == nil {
 		t.Fatalf("Expected a static creds provider to be returned")
 	}
@@ -335,7 +335,7 @@ func TestAWSGetCredentials_shouldIgnoreIAM(t *testing.T) {
 			Token:     c.Token,
 		}
 
-		creds := GetCredentials(cfg.AccessKey, cfg.SecretKey, cfg.Token, cfg.Profile, cfg.CredsFilename)
+		creds := GetCredentials(&cfg)
 		if creds == nil {
 			t.Fatalf("Expected a static creds provider to be returned")
 		}
@@ -362,7 +362,7 @@ func TestAWSGetCredentials_shouldErrorWithInvalidEndpoint(t *testing.T) {
 	ts := invalidAwsEnv(t)
 	defer ts()
 
-	creds := GetCredentials("", "", "", "", "")
+	creds := GetCredentials(&Config{})
 	v, err := creds.Get()
 	if err == nil {
 		t.Fatal("Expected error returned when getting creds w/ invalid EC2 endpoint")
@@ -380,7 +380,7 @@ func TestAWSGetCredentials_shouldIgnoreInvalidEndpoint(t *testing.T) {
 	ts := invalidAwsEnv(t)
 	defer ts()
 
-	creds := GetCredentials("accessKey", "secretKey", "", "", "")
+	creds := GetCredentials(&Config{AccessKey: "accessKey", SecretKey: "secretKey"})
 	v, err := creds.Get()
 	if err != nil {
 		t.Fatalf("Getting static credentials w/ invalid EC2 endpoint failed: %s", err)
@@ -406,7 +406,7 @@ func TestAWSGetCredentials_shouldCatchEC2RoleProvider(t *testing.T) {
 	ts := awsEnv(t)
 	defer ts()
 
-	creds := GetCredentials("", "", "", "", "")
+	creds := GetCredentials(&Config{})
 	if creds == nil {
 		t.Fatalf("Expected an EC2Role creds provider to be returned")
 	}
@@ -452,7 +452,7 @@ func TestAWSGetCredentials_shouldBeShared(t *testing.T) {
 		t.Fatalf("Error resetting env var AWS_SHARED_CREDENTIALS_FILE: %s", err)
 	}
 
-	creds := GetCredentials("", "", "", "myprofile", file.Name())
+	creds := GetCredentials(&Config{Profile: "myprofile", CredsFilename: file.Name()})
 	if creds == nil {
 		t.Fatalf("Expected a provider chain to be returned")
 	}
@@ -479,7 +479,7 @@ func TestAWSGetCredentials_shouldBeENV(t *testing.T) {
 	defer resetEnv()
 
 	cfg := Config{}
-	creds := GetCredentials(cfg.AccessKey, cfg.SecretKey, cfg.Token, cfg.Profile, cfg.CredsFilename)
+	creds := GetCredentials(&cfg)
 	if creds == nil {
 		t.Fatalf("Expected a static creds provider to be returned")
 	}

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -70,15 +70,16 @@ type Config struct {
 	AllowedAccountIds   []interface{}
 	ForbiddenAccountIds []interface{}
 
-	DynamoDBEndpoint     string
-	KinesisEndpoint      string
-	Ec2Endpoint          string
-	IamEndpoint          string
-	ElbEndpoint          string
-	S3Endpoint           string
-	Insecure             bool
-	SkipIamValidation    bool
-	SkipMetadataApiCheck bool
+	DynamoDBEndpoint       string
+	KinesisEndpoint        string
+	Ec2Endpoint            string
+	IamEndpoint            string
+	ElbEndpoint            string
+	S3Endpoint             string
+	Insecure               bool
+	SkipIamCredsValidation bool
+	SkipIamAccountId       bool
+	SkipMetadataApiCheck   bool
 }
 
 type AWSClient struct {
@@ -202,12 +203,15 @@ func (c *Config) Client() (interface{}, error) {
 		client.iamconn = iam.New(awsIamSess)
 		client.stsconn = sts.New(sess)
 
-		if c.SkipIamValidation == false {
+		if c.SkipIamCredsValidation == false {
 			err = c.ValidateCredentials(client.stsconn)
 			if err != nil {
 				errs = append(errs, err)
 				return nil, &multierror.Error{Errors: errs}
 			}
+		}
+
+		if c.SkipIamAccountId == false {
 			accountId, err := GetAccountId(client.iamconn, client.stsconn, cp.ProviderName)
 			if err == nil {
 				client.accountid = accountId

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -198,11 +198,11 @@ func (c *Config) Client() (interface{}, error) {
 		dynamoSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DynamoDBEndpoint)})
 		kinesisSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.KinesisEndpoint)})
 
-		if c.SkipIamValidation == false {
-			// These two services need to be set up early so we can check on AccountID
-			client.iamconn = iam.New(awsIamSess)
-			client.stsconn = sts.New(sess)
+		// These two services need to be set up early so we can check on AccountID
+		client.iamconn = iam.New(awsIamSess)
+		client.stsconn = sts.New(sess)
 
+		if c.SkipIamValidation == false {
 			err = c.ValidateCredentials(client.stsconn)
 			if err != nil {
 				errs = append(errs, err)

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -110,11 +110,18 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["insecure"],
 			},
 
-			"skip_iam_validation": &schema.Schema{
+			"skip_iam_creds_validation": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: descriptions["skip_iam_validation"],
+				Description: descriptions["skip_iam_creds_validation"],
+			},
+
+			"skip_iam_account_id": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["skip_iam_account_id"],
 			},
 
 			"skip_metadata_api_check": &schema.Schema{
@@ -343,7 +350,10 @@ func init() {
 		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
 			"default value is `false`",
 
-		"skip_iam_validation": "Skip the IAM/STS identity validation. " +
+		"skip_iam_creds_validation": "Skip the IAM/STS credentials validation. " +
+			"Used for AWS API implementations that do not use IAM.",
+
+		"skip_iam_account_id": "Skip the request of account id to IAM/STS. " +
 			"Used for AWS API implementations that do not use IAM.",
 
 		"skip_medatadata_api_check": "Skip the AWS Metadata API check. " +
@@ -353,18 +363,19 @@ func init() {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AccessKey:            d.Get("access_key").(string),
-		SecretKey:            d.Get("secret_key").(string),
-		Profile:              d.Get("profile").(string),
-		CredsFilename:        d.Get("shared_credentials_file").(string),
-		Token:                d.Get("token").(string),
-		Region:               d.Get("region").(string),
-		MaxRetries:           d.Get("max_retries").(int),
-		DynamoDBEndpoint:     d.Get("dynamodb_endpoint").(string),
-		KinesisEndpoint:      d.Get("kinesis_endpoint").(string),
-		Insecure:             d.Get("insecure").(bool),
-		SkipIamValidation:    d.Get("skip_iam_validation").(bool),
-		SkipMetadataApiCheck: d.Get("skip_metadata_api_check").(bool),
+		AccessKey:              d.Get("access_key").(string),
+		SecretKey:              d.Get("secret_key").(string),
+		Profile:                d.Get("profile").(string),
+		CredsFilename:          d.Get("shared_credentials_file").(string),
+		Token:                  d.Get("token").(string),
+		Region:                 d.Get("region").(string),
+		MaxRetries:             d.Get("max_retries").(int),
+		DynamoDBEndpoint:       d.Get("dynamodb_endpoint").(string),
+		KinesisEndpoint:        d.Get("kinesis_endpoint").(string),
+		Insecure:               d.Get("insecure").(bool),
+		SkipIamCredsValidation: d.Get("skip_iam_creds_validation").(bool),
+		SkipIamAccountId:       d.Get("skip_iam_account_id").(bool),
+		SkipMetadataApiCheck:   d.Get("skip_metadata_api_check").(bool),
 	}
 
 	endpointsSet := d.Get("endpoints").(*schema.Set)

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -100,6 +100,7 @@ func Provider() terraform.ResourceProvider {
 				Default:     "",
 				Description: descriptions["kinesis_endpoint"],
 			},
+
 			"endpoints": endpointsSchema(),
 
 			"insecure": &schema.Schema{
@@ -107,6 +108,20 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				Default:     false,
 				Description: descriptions["insecure"],
+			},
+
+			"skip_iam_validation": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["skip_iam_validation"],
+			},
+
+			"skip_metadata_api_check": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["skip_metadata_api_check"],
 			},
 		},
 
@@ -327,21 +342,29 @@ func init() {
 
 		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
 			"default value is `false`",
+
+		"skip_iam_validation": "Skip the IAM/STS identity validation. " +
+			"Used for AWS API implementations that do not use IAM.",
+
+		"skip_medatadata_api_check": "Skip the AWS Metadata API check. " +
+			"Used for AWS API implementations that do not have a metadata api endpoint.",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AccessKey:        d.Get("access_key").(string),
-		SecretKey:        d.Get("secret_key").(string),
-		Profile:          d.Get("profile").(string),
-		CredsFilename:    d.Get("shared_credentials_file").(string),
-		Token:            d.Get("token").(string),
-		Region:           d.Get("region").(string),
-		MaxRetries:       d.Get("max_retries").(int),
-		DynamoDBEndpoint: d.Get("dynamodb_endpoint").(string),
-		KinesisEndpoint:  d.Get("kinesis_endpoint").(string),
-		Insecure:         d.Get("insecure").(bool),
+		AccessKey:            d.Get("access_key").(string),
+		SecretKey:            d.Get("secret_key").(string),
+		Profile:              d.Get("profile").(string),
+		CredsFilename:        d.Get("shared_credentials_file").(string),
+		Token:                d.Get("token").(string),
+		Region:               d.Get("region").(string),
+		MaxRetries:           d.Get("max_retries").(int),
+		DynamoDBEndpoint:     d.Get("dynamodb_endpoint").(string),
+		KinesisEndpoint:      d.Get("kinesis_endpoint").(string),
+		Insecure:             d.Get("insecure").(bool),
+		SkipIamValidation:    d.Get("skip_iam_validation").(bool),
+		SkipMetadataApiCheck: d.Get("skip_metadata_api_check").(bool),
 	}
 
 	endpointsSet := d.Get("endpoints").(*schema.Set)

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -60,7 +60,13 @@ func s3Factory(conf map[string]string) (Client, error) {
 	kmsKeyID := conf["kms_key_id"]
 
 	var errs []error
-	creds := terraformAws.GetCredentials(conf["access_key"], conf["secret_key"], conf["token"], conf["profile"], conf["shared_credentials_file"])
+	creds := terraformAws.GetCredentials(&terraformAws.Config{
+		AccessKey:     conf["access_key"],
+		SecretKey:     conf["secret_key"],
+		Token:         conf["token"],
+		Profile:       conf["profile"],
+		CredsFilename: conf["shared_credentials_file"],
+	})
 	// Call Get to check for credential provider. If nothing found, we'll get an
 	// error, and we can present it nicely to the user
 	_, err := creds.Get()


### PR DESCRIPTION
Skip IAM/STS validation and metadata check

* Skip IAM/STS identity validation - For environments or other api
  implementations where there are no IAM/STS endpoints available, this
  option lets you opt out from that provider initialization step.
* Skip metdata api check - For environments in which you know ahead of
  time there isn't going to be a metadta api endpoint, this option lets
  you opt out from that check to save time.

Sample provider config:

```hcl
provider "aws" {
  region = "us-east-1"
  skip_iam_creds_validation = true
  skip_iam_account_id = true
  skip_metadata_api_check = true
}
```