### PR TITLE
core: Fix -module for terraform output command

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -251,7 +251,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	}
 
 	if !c.Destroy {
-		if outputs := outputsAsString(state, ctx.Module().Config().Outputs, true); outputs != "" {
+		if outputs := outputsAsString(state, terraform.RootModulePath, ctx.Module().Config().Outputs, true); outputs != "" {
 			c.Ui.Output(c.Colorize().Color(outputs))
 		}
 	}
@@ -377,12 +377,12 @@ Options:
 	return strings.TrimSpace(helpText)
 }
 
-func outputsAsString(state *terraform.State, schema []*config.Output, includeHeader bool) string {
+func outputsAsString(state *terraform.State, modPath []string, schema []*config.Output, includeHeader bool) string {
 	if state == nil {
 		return ""
 	}
 
-	outputs := state.RootModule().Outputs
+	outputs := state.ModuleByPath(modPath).Outputs
 	outputBuf := new(bytes.Buffer)
 	if len(outputs) > 0 {
 		schemaMap := make(map[string]*config.Output)

--- a/command/output.go
+++ b/command/output.go
@@ -88,7 +88,7 @@ func (c *OutputCommand) Run(args []string) int {
 			c.Ui.Output(string(jsonOutputs))
 			return 0
 		} else {
-			c.Ui.Output(outputsAsString(state, nil, false))
+			c.Ui.Output(outputsAsString(state, modPath, nil, false))
 			return 0
 		}
 	}

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
 )
 
 // RefreshCommand is a cli.Command implementation that refreshes the state
@@ -109,7 +111,7 @@ func (c *RefreshCommand) Run(args []string) int {
 		return 1
 	}
 
-	if outputs := outputsAsString(newState, ctx.Module().Config().Outputs, true); outputs != "" {
+	if outputs := outputsAsString(newState, terraform.RootModulePath, ctx.Module().Config().Outputs, true); outputs != "" {
 		c.Ui.Output(c.Colorize().Color(outputs))
 	}
 

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -14,10 +14,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
-	"github.com/satori/go.uuid"
-
 	"github.com/hashicorp/terraform/config"
 	"github.com/mitchellh/copystructure"
+	"github.com/satori/go.uuid"
 )
 
 const (


### PR DESCRIPTION
The behaviour whereby outputs for a particular nested module can be output was broken by the changes for lists and maps. This pull-request restores the previous behaviour by passing the module path into the `outputsAsString` function.

We also add a new test of this since the code path for indivdual output vs all outputs for a module has diverged.

Fixes #7840.