### PR TITLE
provider/aws: Adds acceptance tests for `aws_gateway_*` manual deletions causing non-empty plans

### DIFF
--- a/builtin/providers/aws/resource_aws_customer_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -13,6 +14,7 @@ import (
 )
 
 func TestAccAWSCustomerGateway_basic(t *testing.T) {
+	var gateway ec2.CustomerGateway
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_customer_gateway.foo",
@@ -22,29 +24,73 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCustomerGatewayConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCustomerGateway(
-						"aws_customer_gateway.foo",
-					),
+					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 				),
 			},
 			resource.TestStep{
 				Config: testAccCustomerGatewayConfigUpdateTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCustomerGateway(
-						"aws_customer_gateway.foo",
-					),
+					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 				),
 			},
 			resource.TestStep{
 				Config: testAccCustomerGatewayConfigForceReplace,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCustomerGateway(
-						"aws_customer_gateway.foo",
-					),
+					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 				),
 			},
 		},
 	})
+}
+
+func TestAccAWSCustomerGateway_disappears(t *testing.T) {
+	var gateway ec2.CustomerGateway
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCustomerGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCustomerGatewayConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
+					testAccAWSCustomerGatewayDisappears(&gateway),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccAWSCustomerGatewayDisappears(gateway *ec2.CustomerGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		opts := &ec2.DeleteCustomerGatewayInput{
+			CustomerGatewayId: gateway.CustomerGatewayId,
+		}
+		if _, err := conn.DeleteCustomerGateway(opts); err != nil {
+			return err
+		}
+		return resource.Retry(40*time.Minute, func() *resource.RetryError {
+			opts := &ec2.DescribeCustomerGatewaysInput{
+				CustomerGatewayIds: []*string{gateway.CustomerGatewayId},
+			}
+			resp, err := conn.DescribeCustomerGateways(opts)
+			if err != nil {
+				cgw, ok := err.(awserr.Error)
+				if ok && cgw.Code() == "InvalidCustomerGatewayID.NotFound" {
+					return nil
+				}
+				return resource.NonRetryableError(
+					fmt.Errorf("Error retrieving Customer Gateway: %s", err))
+			}
+			if *resp.CustomerGateways[0].State == "deleted" {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf(
+				"Waiting for Customer Gateway: %v", gateway.CustomerGatewayId))
+		})
+	}
 }
 
 func testAccCheckCustomerGatewayDestroy(s *terraform.State) error {
@@ -72,6 +118,10 @@ func testAccCheckCustomerGatewayDestroy(s *terraform.State) error {
 			if len(resp.CustomerGateways) > 0 {
 				return fmt.Errorf("Customer gateway still exists: %v", resp.CustomerGateways)
 			}
+
+			if *resp.CustomerGateways[0].State == "deleted" {
+				continue
+			}
 		}
 
 		return err
@@ -80,7 +130,7 @@ func testAccCheckCustomerGatewayDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCustomerGateway(gatewayResource string) resource.TestCheckFunc {
+func testAccCheckCustomerGateway(gatewayResource string, cgw *ec2.CustomerGateway) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[gatewayResource]
 		if !ok {
@@ -102,13 +152,16 @@ func testAccCheckCustomerGateway(gatewayResource string) resource.TestCheckFunc 
 			Values: []*string{aws.String(gateway.Primary.ID)},
 		}
 
-		_, err := ec2conn.DescribeCustomerGateways(&ec2.DescribeCustomerGatewaysInput{
+		resp, err := ec2conn.DescribeCustomerGateways(&ec2.DescribeCustomerGatewaysInput{
 			Filters: []*ec2.Filter{gatewayFilter},
 		})
 
 		if err != nil {
 			return err
 		}
+
+		respGateway := resp.CustomerGateways[0]
+		*cgw = *respGateway
 
 		return nil
 	}


### PR DESCRIPTION
Fixes #7863 

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCustomerGateway_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCustomerGateway_ -timeout 120m
=== RUN   TestAccAWSCustomerGateway_importBasic
--- PASS: TestAccAWSCustomerGateway_importBasic (31.74s)
=== RUN   TestAccAWSCustomerGateway_basic
--- PASS: TestAccAWSCustomerGateway_basic (74.13s)
=== RUN   TestAccAWSCustomerGateway_disappears
--- PASS: TestAccAWSCustomerGateway_disappears (33.49s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    139.390s


% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpnGateway_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnGateway_ -timeout 120m
=== RUN   TestAccAWSVpnGateway_importBasic
--- PASS: TestAccAWSVpnGateway_importBasic (53.23s)
=== RUN   TestAccAWSVpnGateway_basic
--- PASS: TestAccAWSVpnGateway_basic (96.77s)
=== RUN   TestAccAWSVpnGateway_disappears
--- PASS: TestAccAWSVpnGateway_disappears (53.68s)
=== RUN   TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGateway_reattach (110.57s)
=== RUN   TestAccAWSVpnGateway_delete
--- PASS: TestAccAWSVpnGateway_delete (70.62s)
=== RUN   TestAccAWSVpnGateway_tags
--- PASS: TestAccAWSVpnGateway_tags (83.12s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    468.019s
```