### PR TITLE
build: Fix errors in FreeBSD build

### DIFF
--- a/config/module/inode_freebsd.go
+++ b/config/module/inode_freebsd.go
@@ -1,5 +1,3 @@
-// +build !windows !freebsd
-
 package module
 
 import (
@@ -15,7 +13,7 @@ func inode(path string) (uint64, error) {
 		return 0, err
 	}
 	if st, ok := stat.Sys().(*syscall.Stat_t); ok {
-		return st.Ino, nil
+		return uint64(st.Ino), nil
 	}
 	return 0, fmt.Errorf("could not determine file inode")
 }


### PR DESCRIPTION
Fixes the following error when cross compiling:

```
--> freebsd/amd64 error: exit status 2
Stderr: # github.com/hashicorp/terraform/config/module
config/module/inode.go:18: cannot use st.Ino (type uint32) as type uint64 in return argument
```