### PR TITLE
Update doc page for aws_elb

### DIFF
--- a/website/source/docs/providers/aws/r/elb.html.markdown
+++ b/website/source/docs/providers/aws/r/elb.html.markdown
@@ -88,13 +88,13 @@ The following arguments are supported:
 Exactly one of `availability_zones` or `subnets` must be specified: this
 determines if the ELB exists in a VPC or in EC2-classic.
 
-Access Logs support the following:
+Access Logs (`access_logs`) support the following:
 
 * `bucket` - (Required) The S3 bucket name to store the logs in.
 * `bucket_prefix` - (Optional) The S3 bucket prefix. Logs are stored in the root if not configured.
 * `interval` - (Optional) The publishing interval in minutes. Default: 60 minutes.
 
-Listeners support the following:
+Listeners (`listener`) support the following:
 
 * `instance_port` - (Required) The port on the instance to route to
 * `instance_protocol` - (Required) The protocol to use to the instance. Valid
@@ -105,7 +105,7 @@ Listeners support the following:
 * `ssl_certificate_id` - (Optional) The ARN of an SSL certificate you have
 uploaded to AWS IAM. **Only valid when `lb_protocol` is either HTTPS or SSL**
 
-Health Check supports the following:
+Health Check (`health_check`) supports the following:
 
 * `healthy_threshold` - (Required) The number of checks before the instance is declared healthy.
 * `unhealthy_threshold` - (Required) The number of checks before the instance is declared unhealthy.


### PR DESCRIPTION
I've the name arguments for `access_logs`, `listener`, and `health_check` to their corresponding paragraphs, so one won't need to scroll up and find the actual name of arguments.