### PR TITLE
provider/aws: Allow `source_ids` in `aws_db_event_subscription` to be Updatable

### DIFF
--- a/builtin/providers/aws/resource_aws_db_event_subscription.go
+++ b/builtin/providers/aws/resource_aws_db_event_subscription.go
@@ -38,7 +38,6 @@ func resourceAwsDbEventSubscription() *schema.Resource {
 			"source_ids": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 				// ValidateFunc: validateDbEventSubscriptionSourceIds,
@@ -265,6 +264,50 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 	} else {
 		d.SetPartial("tags")
 	}
+
+	if d.HasChange("source_ids") {
+		o, n := d.GetChange("source_ids")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+		remove := expandStringList(os.Difference(ns).List())
+		add := expandStringList(ns.Difference(os).List())
+
+		if len(remove) > 0 {
+			for _, removing := range remove {
+				log.Printf("[INFO] Removing %s as a Source Identifier from %q", removing, d.Id())
+				_, err := rdsconn.RemoveSourceIdentifierFromSubscription(&rds.RemoveSourceIdentifierFromSubscriptionInput{
+					SourceIdentifier: removing,
+					SubscriptionName: aws.String(d.Id()),
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if len(add) > 0 {
+
+			for _, adding := range add {
+				log.Printf("[INFO] Adding %s as a Source Identifier to %q", adding, d.Id())
+				_, err := rdsconn.AddSourceIdentifierToSubscription(&rds.AddSourceIdentifierToSubscriptionInput{
+					SourceIdentifier: adding,
+					SubscriptionName: aws.String(d.Id()),
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+		d.SetPartial("source_ids")
+	}
+
 	d.Partial(false)
 
 	return nil

--- a/builtin/providers/aws/resource_aws_db_event_subscription.go
+++ b/builtin/providers/aws/resource_aws_db_event_subscription.go
@@ -293,7 +293,6 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		}
 
 		if len(add) > 0 {
-
 			for _, adding := range add {
 				log.Printf("[INFO] Adding %s as a Source Identifier to %q", adding, d.Id())
 				_, err := rdsconn.AddSourceIdentifierToSubscription(&rds.AddSourceIdentifierToSubscriptionInput{

--- a/builtin/providers/aws/resource_aws_db_event_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_db_event_subscription_test.go
@@ -49,6 +49,46 @@ func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
+	var v rds.EventSubscription
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBEventSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBEventSubscriptionConfigWithSourceIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "name", "tf-acc-test-rds-event-subs-with-ids"),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "source_ids.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSDBEventSubscriptionConfigUpdateSourceIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "name", "tf-acc-test-rds-event-subs-with-ids"),
+					resource.TestCheckResourceAttr(
+						"aws_db_event_subscription.bar", "source_ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSDBEventSubscriptionExists(n string, v *rds.EventSubscription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -157,6 +197,62 @@ resource "aws_db_event_subscription" "bar" {
   ]
   tags {
     Name = "new-name"
+  }
+}
+`
+
+var testAccAWSDBEventSubscriptionConfigWithSourceIds = `
+resource "aws_sns_topic" "aws_sns_topic" {
+  name = "tf-acc-test-rds-event-subs-sns-topic"
+}
+
+resource "aws_db_parameter_group" "bar" {
+  name = "db-parameter-group-event-1"
+  family = "mysql5.6"
+  description = "Test parameter group for terraform"
+}
+
+resource "aws_db_event_subscription" "bar" {
+  name = "tf-acc-test-rds-event-subs-with-ids"
+  sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
+  source_type = "db-parameter-group"
+  source_ids = ["${aws_db_parameter_group.bar.id}"]
+  event_categories = [
+    "configuration change"
+  ]
+  tags {
+    Name = "name"
+  }
+}
+`
+
+var testAccAWSDBEventSubscriptionConfigUpdateSourceIds = `
+resource "aws_sns_topic" "aws_sns_topic" {
+  name = "tf-acc-test-rds-event-subs-sns-topic"
+}
+
+resource "aws_db_parameter_group" "bar" {
+  name = "db-parameter-group-event-1"
+  family = "mysql5.6"
+  description = "Test parameter group for terraform"
+}
+
+resource "aws_db_parameter_group" "foo" {
+  name = "db-parameter-group-event-2"
+  family = "mysql5.6"
+  description = "Test parameter group for terraform"
+}
+
+resource "aws_db_event_subscription" "bar" {
+  name = "tf-acc-test-rds-event-subs-with-ids"
+  sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
+  source_type = "db-parameter-group"
+  source_ids = ["${aws_db_parameter_group.bar.id}","${aws_db_parameter_group.foo.id}"]
+  event_categories = [
+    "configuration change"
+  ]
+  tags {
+    Name = "name"
   }
 }
 `


### PR DESCRIPTION
Fixes #7809

This commit adds support for `source_ids` to be updated rather than
forcing new each time. Unfortunately, it must range over the difference
in the source_ids and add and remove them 1 at a time. AWS does not
support batch updating source_ids

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBEventSubscription_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDBEventSubscription_ -timeout 120m
=== RUN   TestAccAWSDBEventSubscription_basicUpdate
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (1277.87s)
=== RUN   TestAccAWSDBEventSubscription_withSourceIds
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (1012.96s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws
2290.844s
```