### PR TITLE
provider/aws: Defensively code around `db_security_group` ingress rules

### DIFF
--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -159,10 +159,15 @@ func resourceAwsDbSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	for _, g := range sg.EC2SecurityGroups {
-		rule := map[string]interface{}{
-			"security_group_name":     *g.EC2SecurityGroupName,
-			"security_group_id":       *g.EC2SecurityGroupId,
-			"security_group_owner_id": *g.EC2SecurityGroupOwnerId,
+		rule := map[string]interface{}{}
+		if g.EC2SecurityGroupId != nil {
+			rule["security_group_id"] = *g.EC2SecurityGroupId
+		}
+		if g.EC2SecurityGroupName != nil {
+			rule["security_group_name"] = *g.EC2SecurityGroupName
+		}
+		if g.EC2SecurityGroupOwnerId != nil {
+			rule["security_group_owner_id"] = *g.EC2SecurityGroupOwnerId
 		}
 		rules.Add(rule)
 	}


### PR DESCRIPTION
Fixes #7812

All of the options of `aws_db_security_group` ingress rules are
optional. Therefore, when one of them isn't set (and AWS doesn't
calculate the value), Terraform threw a panic

This commit just defensively codes around this fact. It checks to make
sure there is a value returned from the API before adding it to the map

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBSecurityGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDBSecurityGroup_ -timeout 120m
=== RUN   TestAccAWSDBSecurityGroup_basic
--- PASS: TestAccAWSDBSecurityGroup_basic (38.66s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    38.682s
```