### PR TITLE
provider/aws: Support Import of `aws_db_security_group`

### DIFF
--- a/builtin/providers/aws/import_aws_db_security_group_test.go
+++ b/builtin/providers/aws/import_aws_db_security_group_test.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDBSecurityGroup_importBasic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	resourceName := "aws_db_security_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBSecurityGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_db_security_group.go
+++ b/builtin/providers/aws/resource_aws_db_security_group.go
@@ -23,6 +23,9 @@ func resourceAwsDbSecurityGroup() *schema.Resource {
 		Read:   resourceAwsDbSecurityGroupRead,
 		Update: resourceAwsDbSecurityGroupUpdate,
 		Delete: resourceAwsDbSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{

--- a/website/source/docs/providers/aws/r/db_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_security_group.html.markdown
@@ -49,3 +49,11 @@ The following attributes are exported:
 * `id` - The db security group ID.
 * `arn` - The arn of the DB security group.
 
+
+## Import
+
+DB Security groups can be imported using the `name`, e.g. 
+
+```
+$ terraform import aws_db_security_group.default aws_rds_sg-1
+```

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -95,7 +95,7 @@ this instance is a read replica
 
 ## Import
 
-Redshift Cluster Instances can be imported using the `identifier`, e.g.
+RDS Cluster Instances can be imported using the `identifier`, e.g.
 
 ```
 $ terraform import aws_rds_cluster_instance.prod_instance_1 aurora-cluster-instance-1

--- a/website/source/docs/providers/aws/r/rds_cluster_parameter_group.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_parameter_group.markdown
@@ -56,7 +56,7 @@ The following attributes are exported:
 
 ## Import
 
-Redshift Clusters can be imported using the `name`, e.g. 
+RDS Cluster Parameter Groups can be imported using the `name`, e.g. 
 
 ```
 $ terraform import aws_rds_cluster_parameter_group.cluster_pg production-pg-1


### PR DESCRIPTION
This test overrides the AWS_DEFAULT_REGION parameter as the security
groups are created in us-east-1 (due to classic VPC requirements)

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBSecurityGroup_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDBSecurityGroup_importBasic -timeout 120m
=== RUN   TestAccAWSDBSecurityGroup_importBasic
--- PASS: TestAccAWSDBSecurityGroup_importBasic (49.46s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    49.487s
```