### PR TITLE
provider/aws: Support Import of `aws_redshift_security_group`

### DIFF
--- a/builtin/providers/aws/import_aws_redshift_security_group_test.go
+++ b/builtin/providers/aws/import_aws_redshift_security_group_test.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSRedshiftSecurityGroup_importBasic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	resourceName := "aws_redshift_security_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSRedshiftSecurityGroupConfig_ingressCidr,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_redshift_security_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_security_group.go
@@ -22,6 +22,9 @@ func resourceAwsRedshiftSecurityGroup() *schema.Resource {
 		Read:   resourceAwsRedshiftSecurityGroupRead,
 		Update: resourceAwsRedshiftSecurityGroupUpdate,
 		Delete: resourceAwsRedshiftSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsRedshiftClusterImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/website/source/docs/providers/aws/r/redshift_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_security_group.html.markdown
@@ -43,3 +43,10 @@ The following attributes are exported:
 
 * `id` - The Redshift security group ID.
 
+## Import
+
+Redshift security groups can be imported using the `name`, e.g. 
+
+```
+$ terraform import aws_redshift_security_group.testgroup1 redshift_test_group
+```


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftSecurityGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSRedshiftSecurityGroup_ -timeout 120m
=== RUN   TestAccAWSRedshiftSecurityGroup_importBasic
--- PASS: TestAccAWSRedshiftSecurityGroup_importBasic (30.87s)
=== RUN   TestAccAWSRedshiftSecurityGroup_ingressCidr
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressCidr (30.45s)
=== RUN   TestAccAWSRedshiftSecurityGroup_updateIngressCidr
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressCidr (72.78s)
=== RUN   TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup (49.73s)
=== RUN   TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup
(92.44s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    276.291s
```