### PR TITLE
core: Disallow strings as arguments to concat

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -311,31 +311,25 @@ func interpolationFuncCoalesce() ast.Function {
 // multiple lists.
 func interpolationFuncConcat() ast.Function {
 	return ast.Function{
-		ArgTypes:     []ast.Type{ast.TypeAny},
+		ArgTypes:     []ast.Type{ast.TypeList},
 		ReturnType:   ast.TypeList,
 		Variadic:     true,
-		VariadicType: ast.TypeAny,
+		VariadicType: ast.TypeList,
 		Callback: func(args []interface{}) (interface{}, error) {
 			var outputList []ast.Variable
 
 			for _, arg := range args {
-				switch arg := arg.(type) {
-				case []ast.Variable:
-					for _, v := range arg {
-						switch v.Type {
-						case ast.TypeString:
-							outputList = append(outputList, v)
-						case ast.TypeList:
-							outputList = append(outputList, v)
-						case ast.TypeMap:
-							outputList = append(outputList, v)
-						default:
-							return nil, fmt.Errorf("concat() does not support lists of %s", v.Type.Printable())
-						}
+				for _, v := range arg.([]ast.Variable) {
+					switch v.Type {
+					case ast.TypeString:
+						outputList = append(outputList, v)
+					case ast.TypeList:
+						outputList = append(outputList, v)
+					case ast.TypeMap:
+						outputList = append(outputList, v)
+					default:
+						return nil, fmt.Errorf("concat() does not support lists of %s", v.Type.Printable())
 					}
-
-				default:
-					return nil, fmt.Errorf("concat() does not support type %T", arg)
 				}
 			}
 

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -320,8 +320,6 @@ func interpolationFuncConcat() ast.Function {
 
 			for _, arg := range args {
 				switch arg := arg.(type) {
-				case string:
-					outputList = append(outputList, ast.Variable{Type: ast.TypeString, Value: arg})
 				case []ast.Variable:
 					for _, v := range arg {
 						switch v.Type {
@@ -337,7 +335,7 @@ func interpolationFuncConcat() ast.Function {
 					}
 
 				default:
-					return nil, fmt.Errorf("concat() does not support %T", arg)
+					return nil, fmt.Errorf("concat() does not support type %T", arg)
 				}
 			}
 

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -362,17 +362,19 @@ func TestInterpolateFuncConcat(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
 			// String + list
+			// no longer supported, now returns an error
 			{
 				`${concat("a", split(",", "b,c"))}`,
-				[]interface{}{"a", "b", "c"},
-				false,
+				nil,
+				true,
 			},
 
 			// List + string
+			// no longer supported, now returns an error
 			{
 				`${concat(split(",", "a,b"), "c")}`,
-				[]interface{}{"a", "b", "c"},
-				false,
+				nil,
+				true,
 			},
 
 			// Single list
@@ -425,6 +427,14 @@ func TestInterpolateFuncConcat(t *testing.T) {
 				`${concat("${var.maps}", "${var.maps}")}`,
 				[]interface{}{map[string]interface{}{"key1": "a", "key2": "b"}, map[string]interface{}{"key1": "a", "key2": "b"}},
 				false,
+			},
+
+			// multiple strings
+			// no longer supported, now returns an error
+			{
+				`${concat("string1", "string2")}`,
+				nil,
+				true,
 			},
 
 			// mismatched types
@@ -1532,15 +1542,16 @@ type testFunctionCase struct {
 
 func testFunction(t *testing.T, config testFunctionConfig) {
 	for i, tc := range config.Cases {
+		fmt.Println("running", i)
 		ast, err := hil.Parse(tc.Input)
 		if err != nil {
-			t.Fatalf("Case #%d: input: %#v\nerr: %s", i, tc.Input, err)
+			t.Fatalf("Case #%d: input: %#v\nerr: %v", i, tc.Input, err)
 		}
 
 		result, err := hil.Eval(ast, langEvalConfig(config.Vars))
-		t.Logf("err: %s", err)
+		t.Logf("err: %v", err)
 		if err != nil != tc.Error {
-			t.Fatalf("Case #%d:\ninput: %#v\nerr: %s", i, tc.Input, err)
+			t.Fatalf("Case #%d:\ninput: %#v\nerr: %v", i, tc.Input, err)
 		}
 
 		if !reflect.DeepEqual(result.Value, tc.Result) {


### PR DESCRIPTION
The concat interpolation function now only accepts list arguments.
Strings are no longer supported, for concatenation or appending to
lists. All arguments must be a list, and single elements can be promoted
with the `list` interpolation function.