### PR TITLE
Silence log output during tests when not verbose

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -1,7 +1,9 @@
 package command
 
 import (
+	"flag"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -25,6 +28,19 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Verbose() {
+		// if we're verbose, use the logging requested by TF_LOG
+		logging.SetOutput()
+	} else {
+		// otherwise silence all logs
+		log.SetOutput(ioutil.Discard)
+	}
+
+	os.Exit(m.Run())
 }
 
 func tempDir(t *testing.T) string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,14 +1,33 @@
 package config
 
 import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/logging"
 )
 
 // This is the directory where our test fixtures are.
 const fixtureDir = "./test-fixtures"
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Verbose() {
+		// if we're verbose, use the logging requested by TF_LOG
+		logging.SetOutput()
+	} else {
+		// otherwise silence all logs
+		log.SetOutput(ioutil.Discard)
+	}
+
+	os.Exit(m.Run())
+}
 
 func TestConfigCopy(t *testing.T) {
 	c := testConfig(t, "copy-basic")

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -1,12 +1,31 @@
 package dag
 
 import (
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/logging"
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Verbose() {
+		// if we're verbose, use the logging requested by TF_LOG
+		logging.SetOutput()
+	} else {
+		// otherwise silence all logs
+		log.SetOutput(ioutil.Discard)
+	}
+
+	os.Exit(m.Run())
+}
 
 func TestAcyclicGraphRoot(t *testing.T) {
 	var g AcyclicGraph

--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -47,6 +47,22 @@ func LogOutput() (logOutput io.Writer, err error) {
 	return
 }
 
+// SetOutput checks for a log destination with LogOutput, and calls
+// log.SetOutput with the result. If LogOutput returns nil, SetOutput uses
+// ioutil.Discard. Any error from LogOutout is fatal.
+func SetOutput() {
+	out, err := LogOutput()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if out == nil {
+		out = ioutil.Discard
+	}
+
+	log.SetOutput(out)
+}
+
 // LogLevel returns the current log level string based the environment vars
 func LogLevel() string {
 	envLevel := os.Getenv(EnvLog)

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1,9 +1,11 @@
 package terraform
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,10 +15,24 @@ import (
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/helper/logging"
 )
 
 // This is the directory where our test fixtures are.
 const fixtureDir = "./test-fixtures"
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Verbose() {
+		// if we're verbose, use the logging requested by TF_LOG
+		logging.SetOutput()
+	} else {
+		// otherwise silence all logs
+		log.SetOutput(ioutil.Discard)
+	}
+
+	os.Exit(m.Run())
+}
 
 func tempDir(t *testing.T) string {
 	dir, err := ioutil.TempDir("", "tf")


### PR DESCRIPTION
Set the default log package output to iotuil.Discard during tests if the
`-v` flag isn't set. If we are verbose, then apply the filter according
to the TF_LOG env variable.

Fixes #7898 