### PR TITLE
provider/aws: Fix aws_route53_record 0-2 migration

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record_migrate.go
+++ b/builtin/providers/aws/resource_aws_route53_record_migrate.go
@@ -12,8 +12,12 @@ func resourceAwsRoute53RecordMigrateState(
 	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
-		log.Println("[INFO] Found AWS Route53 Record State v0; migrating to v1")
-		return migrateRoute53RecordStateV0toV1(is)
+		log.Println("[INFO] Found AWS Route53 Record State v0; migrating to v1 then v2")
+		v1InstanceState, err := migrateRoute53RecordStateV0toV1(is)
+		if err != nil {
+			return v1InstanceState, err
+		}
+		return migrateRoute53RecordStateV1toV2(v1InstanceState)
 	case 1:
 		log.Println("[INFO] Found AWS Route53 Record State v1; migrating to v2")
 		return migrateRoute53RecordStateV1toV2(is)

--- a/builtin/providers/aws/resource_aws_route53_record_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_route53_record_migrate_test.go
@@ -79,7 +79,7 @@ func TestAWSRoute53RecordMigrateStateV1toV2(t *testing.T) {
 			},
 		},
 		"v0_2": {
-			StateVersion: 1,
+			StateVersion: 0,
 			Attributes: map[string]string{
 				"weight": "-1",
 			},


### PR DESCRIPTION
When migrating the state of an `aws_route53_record`, a v0 state was never upgraded to v2, and a typo in a unit test masked this. This commit fixes the migration by chaining the invocation of the migration function, and corrects the test.