### PR TITLE
Allow Elasticsearch version to be specified

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -21,6 +21,12 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 		Delete: resourceAwsElasticSearchDomainDelete,
 
 		Schema: map[string]*schema.Schema{
+			"elasticsearch_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"access_policies": &schema.Schema{
 				Type:      schema.TypeString,
 				StateFunc: normalizeJson,
@@ -145,6 +151,10 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 		input.AccessPolicies = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("elasticsearch_version"); ok {
+		input.ElasticsearchVersion = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("advanced_options"); ok {
 		input.AdvancedOptions = stringMapToPointers(v.(map[string]interface{}))
 	}
@@ -267,6 +277,7 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	if ds.Endpoint != nil {
 		d.Set("endpoint", *ds.Endpoint)
 	}
+	d.Set("elasticsearch_version", *ds.ElasticsearchVersion)
 
 	err = d.Set("ebs_options", flattenESEBSOptions(ds.EBSOptions))
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -41,6 +41,8 @@ func TestAccAWSElasticSearchDomain_complex(t *testing.T) {
 				Config: testAccESDomainConfig_complex,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttr(
+						"aws_elasticsearch_domain.example", "elasticsearch_version", "2.3"),
 				),
 			},
 		},
@@ -163,7 +165,8 @@ resource "aws_elasticsearch_domain" "example" {
 
 const testAccESDomainConfig_complex = `
 resource "aws_elasticsearch_domain" "example" {
-  domain_name = "tf-test-2"
+  domain_name           = "tf-test-2"
+  elasticsearch_version = "2.3"
 
   advanced_options {
     "indices.fielddata.cache.size" = 80

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/api.go
@@ -653,6 +653,12 @@ type CreateElasticsearchDomainInput struct {
 	// type and number of instances in the domain cluster.
 	ElasticsearchClusterConfig *ElasticsearchClusterConfig `type:"structure"`
 
+	// String of format X.Y to specify version for the Elasticsearch domain eg.
+	// "1.5" or "2.3". For more information, see Creating Elasticsearch Domains
+	// (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomains"
+	// target="_blank) in the Amazon Elasticsearch Service Developer Guide.
+	ElasticsearchVersion *string `type:"string"`
+
 	// Option to set time, in UTC format, of the daily automated snapshot. Default
 	// value is 0 hours.
 	SnapshotOptions *SnapshotOptions `type:"structure"`
@@ -1062,6 +1068,9 @@ type ElasticsearchDomainConfig struct {
 	// Specifies the ElasticsearchClusterConfig for the Elasticsearch domain.
 	ElasticsearchClusterConfig *ElasticsearchClusterConfigStatus `type:"structure"`
 
+	// String of format X.Y to specify version for the Elasticsearch domain.
+	ElasticsearchVersion *ElasticsearchVersionStatus `type:"structure"`
+
 	// Specifies the SnapshotOptions for the Elasticsearch domain.
 	SnapshotOptions *SnapshotOptionsStatus `type:"structure"`
 }
@@ -1118,6 +1127,8 @@ type ElasticsearchDomainStatus struct {
 	// The type and number of instances in the domain cluster.
 	ElasticsearchClusterConfig *ElasticsearchClusterConfig `type:"structure" required:"true"`
 
+	ElasticsearchVersion *string `type:"string"`
+
 	// The Elasticsearch domain endpoint that you use to submit index and search
 	// requests.
 	Endpoint *string `type:"string"`
@@ -1138,6 +1149,29 @@ func (s ElasticsearchDomainStatus) String() string {
 
 // GoString returns the string representation
 func (s ElasticsearchDomainStatus) GoString() string {
+	return s.String()
+}
+
+// Status of the Elasticsearch version options for the specified Elasticsearch
+// domain.
+type ElasticsearchVersionStatus struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the Elasticsearch version for the specified Elasticsearch domain.
+	Options *string `type:"string" required:"true"`
+
+	// Specifies the status of the Elasticsearch version options for the specified
+	// Elasticsearch domain.
+	Status *OptionStatus `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s ElasticsearchVersionStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ElasticsearchVersionStatus) GoString() string {
 	return s.String()
 }
 
@@ -1479,6 +1513,16 @@ const (
 	ESPartitionInstanceTypeM3XlargeElasticsearch = "m3.xlarge.elasticsearch"
 	// @enum ESPartitionInstanceType
 	ESPartitionInstanceTypeM32xlargeElasticsearch = "m3.2xlarge.elasticsearch"
+	// @enum ESPartitionInstanceType
+	ESPartitionInstanceTypeM4LargeElasticsearch = "m4.large.elasticsearch"
+	// @enum ESPartitionInstanceType
+	ESPartitionInstanceTypeM4XlargeElasticsearch = "m4.xlarge.elasticsearch"
+	// @enum ESPartitionInstanceType
+	ESPartitionInstanceTypeM42xlargeElasticsearch = "m4.2xlarge.elasticsearch"
+	// @enum ESPartitionInstanceType
+	ESPartitionInstanceTypeM44xlargeElasticsearch = "m4.4xlarge.elasticsearch"
+	// @enum ESPartitionInstanceType
+	ESPartitionInstanceTypeM410xlargeElasticsearch = "m4.10xlarge.elasticsearch"
 	// @enum ESPartitionInstanceType
 	ESPartitionInstanceTypeT2MicroElasticsearch = "t2.micro.elasticsearch"
 	// @enum ESPartitionInstanceType

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/service.go
@@ -16,7 +16,7 @@ import (
 //
 // The endpoint for configuration service requests is region-specific: es.region.amazonaws.com.
 // For example, es.us-east-1.amazonaws.com. For a current list of supported
-// regions and endpoints, see Regions and Endpoints (http://docs.aws.amazon.com/general/latest/gr/rande.html#cloudsearch_region"
+// regions and endpoints, see Regions and Endpoints (http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticsearch-service-regions"
 // target="_blank).
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -698,13 +698,13 @@
 			"versionExact": "v1.2.7"
 		},
 		{
-			"checksumSHA1": "TAuizMIsvgeuZhmGTYPA7LOXHvY=",
+			"checksumSHA1": "VAlXnW+WxxWRcCv4xsCoox2kgE0=",
 			"comment": "v1.1.23",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "565027b24171359f23f883d0fc48c228cdde301d",
-			"revisionTime": "2016-07-21T22:15:38Z",
-			"version": "v1.2.7",
-			"versionExact": "v1.2.7"
+			"revision": "3b8c171554fc7d4fc53b87e25d4926a9e7495c2e",
+			"revisionTime": "2016-07-29T00:51:21Z",
+			"version": "v1.2.10",
+			"versionExact": "v1.2.10"
 		},
 		{
 			"checksumSHA1": "qHuJHGUAuuizD9834MP3gVupfdo=",

--- a/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
@@ -13,7 +13,9 @@ description: |-
 
 ```
 resource "aws_elasticsearch_domain" "es" {
-	domain_name = "tf-test"
+	domain_name           = "tf-test"
+	elasticsearch_version = "2.3"
+
 	advanced_options {
 		"rest.action.multi.allow_explicit_index" = true
 	}
@@ -37,7 +39,7 @@ CONFIG
 	snapshot_options {
 		automated_snapshot_start_hour = 23
 	}
-	
+
 	tags {
       Domain = "TestDomain"
     }
@@ -49,6 +51,7 @@ CONFIG
 The following arguments are supported:
 
 * `domain_name` - (Required) Name of the domain.
+* `elasticsearch_version` - (Optional) The Elasticsearch version to use.
 * `access_policies` - (Optional) IAM policy document specifying the access policies for the domain
 * `advanced_options` - (Optional) Key-value string pairs to specify advanced configuration options.
 * `ebs_options` - (Optional) EBS related options, see below.


### PR DESCRIPTION
Amazon now support different versions of Elasticsearch, see https://aws.amazon.com/about-aws/whats-new/2016/07/amazon-elasticsearch-service-now-supports-elasticsearch-2-3/.