### PR TITLE
Add an option that requires `terraform apply` to have an argument

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -66,6 +66,10 @@ func (c *ApplyCommand) Run(args []string) int {
 	} else if len(args) == 1 {
 		configPath = args[0]
 	} else {
+		if os.Getenv("TF_APPLY_REQUIRE_PLAN") != "" {
+			c.Ui.Error("The apply command expects a directory or plan file")
+			return 1
+		}
 		configPath = pwd
 		maybeInit = false
 	}

--- a/website/source/docs/configuration/environment-variables.html.md
+++ b/website/source/docs/configuration/environment-variables.html.md
@@ -76,3 +76,12 @@ tests, but by setting this variable you can force these tests to be skipped.
 export TF_SKIP_REMOTE_TESTS=1
 make test
 ```
+
+## TF_APPLY_REQUIRE_PLAN
+
+When given a value, causes the `terraform apply` command to require a directory
+or plan file to be provided. This protects against accidentally applying
+unplanned transformations. This is especially useful when applying a subset of
+changes with `terraform plan -target ...`. Without this environmental variable
+set, it can be quite simple to apply all transformations, rather than the
+planned subset.


### PR DESCRIPTION
This protects against running `terraform apply` performing unplanned transformations. This was implemented by adding a new environment variable `TF_APPLY_REQUIRES_PLAN`.

Note that this does include a documentation update in order to explain the use of this environment variable.

I implemented this because of an errant `terraform apply` destroyed some instances before their replacements came up due to a poorly written config file. I hoped to just incrementally apply a small change with `terraform plan -out ...` before I fixed the config, but I ended up running `terraform apply`, which destroyed my instances. Completely my fault, but it would have been very helpful to have some safety rails here to protect against mistakes.
