### PR TITLE
Update ecs_task_definition.html.markdown

### DIFF
--- a/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 
 * `family` - (Required) The family, unique name for your task definition.
 * `container_definitions` - (Required) A list of container definitions in JSON format. See [AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html) for syntax. Note, you only need the containerDefinitions array, not the parent hash including the family and volumes keys.
+* `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. 
 * `volume` - (Optional) A volume block. Volumes documented below.
 
 Volumes support the following:


### PR DESCRIPTION
Add a note about the recently added task_role_arn argument.

This feature is available in version 0.7.0, but is not present in the documentation.