### PR TITLE
Correct typo in `length()` documentation

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -165,8 +165,7 @@ The supported built-in functions are:
 
   * `keys(map)` - Returns a lexically sorted list of the map keys.
 
-  * `length(list)` - Returns a number of members in a given list, map, or string.
-      or a number of characters in a given string.
+  * `length(list)` - Returns a number of members in a given list or map, or a number of characters in a given string.
       * `${length(split(",", "a,b,c"))}` = 3
       * `${length("a,b,c")}` = 5
       * `${length(map("key", "val"))}` = 1


### PR DESCRIPTION
_Reasoning for docs update:_ **Typo**
_Relevant Terraform version:_ **0.7**

P.S. Thank you for the native lists and maps in 0.7!