### PR TITLE
vSphere file resource: extending functionality to copy files in vSphere

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_file.go
+++ b/builtin/providers/vsphere/resource_vsphere_file.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/govmomi"
@@ -13,10 +14,14 @@ import (
 )
 
 type file struct {
-	datacenter      string
-	datastore       string
-	sourceFile      string
-	destinationFile string
+	sourceDatacenter  string
+	datacenter        string
+	sourceDatastore   string
+	datastore         string
+	sourceFile        string
+	destinationFile   string
+	createDirectories bool
+	copyFile          bool
 }
 
 func resourceVSphereFile() *schema.Resource {
@@ -30,10 +35,20 @@ func resourceVSphereFile() *schema.Resource {
 			"datacenter": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+
+			"source_datacenter": {
+				Type:     schema.TypeString,
+				Optional: true,
 				ForceNew: true,
 			},
 
 			"datastore": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"source_datastore": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -49,6 +64,11 @@ func resourceVSphereFile() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			"create_directories": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -60,8 +80,18 @@ func resourceVSphereFileCreate(d *schema.ResourceData, meta interface{}) error {
 
 	f := file{}
 
+	if v, ok := d.GetOk("source_datacenter"); ok {
+		f.sourceDatacenter = v.(string)
+		f.copyFile = true
+	}
+
 	if v, ok := d.GetOk("datacenter"); ok {
 		f.datacenter = v.(string)
+	}
+
+	if v, ok := d.GetOk("source_datastore"); ok {
+		f.sourceDatastore = v.(string)
+		f.copyFile = true
 	}
 
 	if v, ok := d.GetOk("datastore"); ok {
@@ -80,6 +110,10 @@ func resourceVSphereFileCreate(d *schema.ResourceData, meta interface{}) error {
 		f.destinationFile = v.(string)
 	} else {
 		return fmt.Errorf("destination_file argument is required")
+	}
+
+	if v, ok := d.GetOk("create_directories"); ok {
+		f.createDirectories = v.(bool)
 	}
 
 	err := createFile(client, &f)
@@ -108,16 +142,53 @@ func createFile(client *govmomi.Client, f *file) error {
 		return fmt.Errorf("error %s", err)
 	}
 
-	dsurl, err := ds.URL(context.TODO(), dc, f.destinationFile)
-	if err != nil {
-		return err
+	if f.copyFile {
+		// Copying file from withing vSphere
+		source_dc, err := finder.Datacenter(context.TODO(), f.sourceDatacenter)
+		if err != nil {
+			return fmt.Errorf("error %s", err)
+		}
+		finder = finder.SetDatacenter(dc)
+
+		source_ds, err := getDatastore(finder, f.sourceDatastore)
+		if err != nil {
+			return fmt.Errorf("error %s", err)
+		}
+
+		fm := object.NewFileManager(client.Client)
+		if f.createDirectories {
+			directoryPathIndex := strings.LastIndex(f.destinationFile, "/")
+			path := f.destinationFile[0:directoryPathIndex]
+			err = fm.MakeDirectory(context.TODO(), ds.Path(path), dc, true)
+			if err != nil {
+				return fmt.Errorf("error %s", err)
+			}
+		}
+		task, err := fm.CopyDatastoreFile(context.TODO(), source_ds.Path(f.sourceFile), source_dc, ds.Path(f.destinationFile), dc, true)
+
+		if err != nil {
+			return fmt.Errorf("error %s", err)
+		}
+
+		_, err = task.WaitForResult(context.TODO(), nil)
+		if err != nil {
+			return fmt.Errorf("error %s", err)
+		}
+
+	} else {
+		// Uploading file to vSphere
+		dsurl, err := ds.URL(context.TODO(), dc, f.destinationFile)
+		if err != nil {
+			return fmt.Errorf("error %s", err)
+		}
+
+		p := soap.DefaultUpload
+		err = client.Client.UploadFile(f.sourceFile, dsurl, &p)
+		if err != nil {
+			return fmt.Errorf("error %s", err)
+		}
 	}
 
-	p := soap.DefaultUpload
-	err = client.Client.UploadFile(f.sourceFile, dsurl, &p)
-	if err != nil {
-		return fmt.Errorf("error %s", err)
-	}
 	return nil
 }
 
@@ -126,8 +197,16 @@ func resourceVSphereFileRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] reading file: %#v", d)
 	f := file{}
 
+	if v, ok := d.GetOk("source_datacenter"); ok {
+		f.sourceDatacenter = v.(string)
+	}
+
 	if v, ok := d.GetOk("datacenter"); ok {
 		f.datacenter = v.(string)
+	}
+
+	if v, ok := d.GetOk("source_datastore"); ok {
+		f.sourceDatastore = v.(string)
 	}
 
 	if v, ok := d.GetOk("datastore"); ok {
@@ -179,57 +258,69 @@ func resourceVSphereFileRead(d *schema.ResourceData, meta interface{}) error {
 func resourceVSphereFileUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] updating file: %#v", d)
-	if d.HasChange("destination_file") {
-		oldDestinationFile, newDestinationFile := d.GetChange("destination_file")
-		f := file{}
 
-		if v, ok := d.GetOk("datacenter"); ok {
-			f.datacenter = v.(string)
-		}
-
-		if v, ok := d.GetOk("datastore"); ok {
-			f.datastore = v.(string)
+	if d.HasChange("destination_file") || d.HasChange("datacenter") || d.HasChange("datastore") {
+		// File needs to be moved, get old and new destination changes
+		var oldDataceneter, newDatacenter, oldDatastore, newDatastore, oldDestinationFile, newDestinationFile string
+		if d.HasChange("datacenter") {
+			tmpOldDataceneter, tmpNewDatacenter := d.GetChange("datacenter")
+			oldDataceneter = tmpOldDataceneter.(string)
+			newDatacenter = tmpNewDatacenter.(string)
 		} else {
-			return fmt.Errorf("datastore argument is required")
+			if v, ok := d.GetOk("datacenter"); ok {
+				oldDataceneter = v.(string)
+				newDatacenter = oldDataceneter
+			}
 		}
-
-		if v, ok := d.GetOk("source_file"); ok {
-			f.sourceFile = v.(string)
+		if d.HasChange("datastore") {
+			tmpOldDatastore, tmpNewDatastore := d.GetChange("datastore")
+			oldDatastore = tmpOldDatastore.(string)
+			newDatastore = tmpNewDatastore.(string)
 		} else {
-			return fmt.Errorf("source_file argument is required")
+			oldDatastore = d.Get("datastore").(string)
+			newDatastore = oldDatastore
 		}
-
-		if v, ok := d.GetOk("destination_file"); ok {
-			f.destinationFile = v.(string)
+		if d.HasChange("destination_file") {
+			tmpOldDestinationFile, tmpNewDestinationFile := d.GetChange("destination_file")
+			oldDestinationFile = tmpOldDestinationFile.(string)
+			newDestinationFile = tmpNewDestinationFile.(string)
 		} else {
-			return fmt.Errorf("destination_file argument is required")
+			oldDestinationFile = d.Get("destination_file").(string)
+			newDestinationFile = oldDestinationFile
 		}
 
+		// Get old and new dataceter and datastore
 		client := meta.(*govmomi.Client)
-		dc, err := getDatacenter(client, f.datacenter)
+		dcOld, err := getDatacenter(client, oldDataceneter)
 		if err != nil {
 			return err
 		}
-
+		dcNew, err := getDatacenter(client, newDatacenter)
+		if err != nil {
+			return err
+		}
 		finder := find.NewFinder(client.Client, true)
-		finder = finder.SetDatacenter(dc)
-
-		ds, err := getDatastore(finder, f.datastore)
+		finder = finder.SetDatacenter(dcOld)
+		dsOld, err := getDatastore(finder, oldDatastore)
+		if err != nil {
+			return fmt.Errorf("error %s", err)
+		}
+		finder = finder.SetDatacenter(dcNew)
+		dsNew, err := getDatastore(finder, newDatastore)
 		if err != nil {
 			return fmt.Errorf("error %s", err)
 		}
 
+		// Move file between old/new dataceter, datastore and path (destination_file)
 		fm := object.NewFileManager(client.Client)
-		task, err := fm.MoveDatastoreFile(context.TODO(), ds.Path(oldDestinationFile.(string)), dc, ds.Path(newDestinationFile.(string)), dc, true)
+		task, err := fm.MoveDatastoreFile(context.TODO(), dsOld.Path(oldDestinationFile), dcOld, dsNew.Path(newDestinationFile), dcNew, true)
 		if err != nil {
 			return err
 		}
-
 		_, err = task.WaitForResult(context.TODO(), nil)
 		if err != nil {
 			return err
 		}
-
 	}
 
 	return nil

--- a/website/source/docs/providers/vsphere/r/file.html.markdown
+++ b/website/source/docs/providers/vsphere/r/file.html.markdown
@@ -3,28 +3,49 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_file"
 sidebar_current: "docs-vsphere-resource-file"
 description: |-
-  Provides a VMware vSphere virtual machine file resource. This can be used to upload files (e.g. vmdk disks) from the Terraform host machine to a remote vSphere.
+  Provides a VMware vSphere virtual machine file resource. This can be used to upload files (e.g. vmdk disks) from the Terraform host machine to a remote vSphere or copy fields withing vSphere.
 ---
 
 # vsphere\_file
 
-Provides a VMware vSphere virtual machine file resource. This can be used to upload files (e.g. vmdk disks) from the Terraform host machine to a remote vSphere.
+Provides a VMware vSphere virtual machine file resource. This can be used to upload files (e.g. vmdk disks) from the Terraform host machine to a remote vSphere.  The file resource can also be used to copy files within vSphere.  Files can be copied between Datacenters and/or Datastores.
 
-## Example Usage
+Updates to file resources will handle moving a file to a new destination (datacenter and/or datastore and/or destination_file).  If any source parameter (e.g. `source_datastore`, `source_datacenter` or `source_file`) are changed, this results in a new resource (new file uploaded or copied and old one being deleted).
 
+## Example Usages
+
+**Upload file to vSphere:**
 ```
-resource "vsphere_file" "ubuntu_disk" {
+resource "vsphere_file" "ubuntu_disk_upload" {
+  datacenter = "my_datacenter"
   datastore = "local"
   source_file = "/home/ubuntu/my_disks/custom_ubuntu.vmdk"
   destination_file = "/my_path/disks/custom_ubuntu.vmdk"
 }
 ```
 
+**Copy file within vSphere:**
+```
+resource "vsphere_file" "ubuntu_disk_copy" {
+  source_datacenter = "my_datacenter"
+  datacenter = "my_datacenter"
+  source_datastore = "local"
+  datastore = "local"
+  source_file = "/my_path/disks/custom_ubuntu.vmdk"
+  destination_file = "/my_path/custom_ubuntu_id.vmdk"
+}
+```
+
 ## Argument Reference
+
+If `source_datacenter` and `source_datastore` are not provided, the file resource will upload the file from Terraform host.  If either `source_datacenter` or `source_datastore` are provided, the file resource will copy from within specified locations in vSphere.
 
 The following arguments are supported:
 
-* `source_file` - (Required) The path to the file on the Terraform host that will be uploaded to vSphere.
-* `destination_file` - (Required) The path to where the file should be uploaded to on vSphere.
-* `datacenter` - (Optional) The name of a Datacenter in which the file will be created/uploaded to.
-* `datastore` - (Required) The name of the Datastore in which to create/upload the file to.
+* `source_file` - (Required) The path to the file being uploaded from the Terraform host to vSphere or copied within vSphere.
+* `destination_file` - (Required) The path to where the file should be uploaded or copied to on vSphere.
+* `source_datacenter` - (Optional) The name of a Datacenter in which the file will be copied from.
+* `datacenter` - (Optional) The name of a Datacenter in which the file will be uploaded to.
+* `source_datastore` - (Optional) The name of the Datastore in which file will be copied from.
+* `datastore` - (Required) The name of the Datastore in which to upload the file to.
+* `create_directories` - (Optional) Create directories in `destination_file` path parameter if any missing for copy operation.  *Note: Directories are not deleted on destroy operation.


### PR DESCRIPTION
This PR addresses issue #7917:

* Enables copy of files within vSphere
* Can copy files between different datacenters and datastores
* Update can move uploaded or copied files between datacenters and datastores
* Preserves original functionality for backward compatibility

File resource acceptance tests verified in vSphere 5.5 (vCenter 6.0), snippet:

```
make testacc TEST=./builtin/providers/vsphere GOFLAGS=-v
==> Checking that code complies with gofmt requirements...
/home/davide/goland/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/03 14:03:38 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/vsphere -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccVSphereFile_basic
Expected error received: cannot stat '[datastore1] tf_file_test.vmdk': No such file
--- PASS: TestAccVSphereFile_basic (4.75s)
=== RUN   TestAccVSphereFile_basicUploadAndCopy
Expected error received: cannot stat '[datastore1] tf_file_test.vmdk': No such file
--- PASS: TestAccVSphereFile_basicUploadAndCopy (7.07s)
=== RUN   TestAccVSphereFile_renamePostCreation
Expected error received: cannot stat '[datastore1] tf_test_file_moved.vmdk': No such file
Expected error received: cannot stat '[datastore1] tf_test_file.vmdk': No such file
Expected error received: cannot stat '[datastore1] tf_test_file_moved.vmdk': No such file
--- PASS: TestAccVSphereFile_renamePostCreation (8.75s)
=== RUN   TestAccVSphereFile_uploadAndCopyAndUpdate
Expected error received: cannot stat '[datastore1] tf_file_test_copy.vmdk': No such file
Expected error received: cannot stat '[datastore1] tf_test_file_moved.vmdk': No such file
--- PASS: TestAccVSphereFile_uploadAndCopyAndUpdate (10.99s)
```