### PR TITLE
Update AMI ID on documentation

### DIFF
--- a/website/source/intro/getting-started/change.html.md
+++ b/website/source/intro/getting-started/change.html.md
@@ -33,7 +33,7 @@ resource "aws_instance" "example" {
 }
 ```
 
-~> **Note:** EC2 Classic users please use AMI `ami-2106ed4c` and type `t1.micro`
+~> **Note:** EC2 Classic users please use AMI `ami-656be372` and type `t1.micro`
 
 We've changed the AMI from being an Ubuntu 14.04 LTS AMI to being
 an Ubuntu 16.04 LTS AMI. Terraform configurations are meant to be


### PR DESCRIPTION
It looks like the AMI ID for Ubuntu 16.04 used on the official documentation is outdated and not working anymore, so I have changed it with the current AMI ID of a Ubuntu 16.04 image.

This is what I get when attempting to use the one currently on the website:

```
Error applying plan:

1 error(s) occurred:

* aws_instance.example: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-2106ed4c]' does not exist
	status code: 400, request id:
```

PS. Such an awesome tool, keep up the great work!