### PR TITLE
Add state filter to aws_availability_zones data source.

### DIFF
--- a/builtin/providers/aws/data_source_availability_zones.go
+++ b/builtin/providers/aws/data_source_availability_zones.go
@@ -24,7 +24,6 @@ func dataSourceAwsAvailabilityZones() *schema.Resource {
 			"state": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "available",
 				ValidateFunc: validateStateType,
 			},
 		},
@@ -37,14 +36,17 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Reading Availability Zones.")
 	d.SetId(time.Now().UTC().String())
 
-	request := &ec2.DescribeAvailabilityZonesInput{
-		Filters: []*ec2.Filter{
+	request := &ec2.DescribeAvailabilityZonesInput{}
+
+	if v, ok := d.GetOk("state"); ok {
+		request.Filters = []*ec2.Filter{
 			&ec2.Filter{
 				Name:   aws.String("state"),
-				Values: []*string{aws.String(d.Get("state").(string))},
+				Values: []*string{aws.String(v.(string))},
 			},
-		},
+		}
 	}
+
 	log.Printf("[DEBUG] Availability Zones request options: %#v", *request)
 
 	resp, err := conn.DescribeAvailabilityZones(request)

--- a/website/source/docs/providers/aws/d/availability_zones.html.markdown
+++ b/website/source/docs/providers/aws/d/availability_zones.html.markdown
@@ -39,7 +39,8 @@ The following arguments are supported:
 
 * `state` - (Optional) Allows to filter list of Availability Zones based on their
 current state. Can be either `"available"`, `"information"`, `"impaired"` or
-`"unavailable"` (Default: `"available"`).
+`"unavailable"`. By default the list includes a complete set of Availability Zones
+to which the underlying AWS account has access, regardless of their state.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/d/availability_zones.html.markdown
+++ b/website/source/docs/providers/aws/d/availability_zones.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_availability_zones"
 sidebar_current: "docs-aws-datasource-availability-zones"
 description: |-
-    Provides a list of availability zones which can be used by an AWS account
+    Provides a list of Availability Zones which can be used by an AWS account.
 ---
 
 # aws\_availability\_zones
@@ -35,10 +35,14 @@ resource "aws_subnet" "secondary" {
 
 ## Argument Reference
 
-There are no arguments for this data source.
+The following arguments are supported:
+
+* `state` - (Optional) Allows to filter list of Availability Zones based on their
+current state. Can be either `"available"`, `"information"`, `"impaired"` or
+`"unavailable"` (Default: `"available"`).
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `names` - A list of the availability zone names available to the account.
+* `names` - A list of the Availability Zone names available to the account.


### PR DESCRIPTION
This commit adds an ability to filter Availability Zones based on state.

Be advised that this does not always works reliably for an older accounts which
have been created in the pre-VPC era of EC2. These accounts tends to retrieve
availability zones that are not VPC-enabled, thus creation of a custom subnet
within such Availability Zone would result in a failure.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>