### PR TITLE
provider/aws: guard against missing image_digest 

### DIFF
--- a/builtin/providers/aws/data_source_aws_ecs_container_definition.go
+++ b/builtin/providers/aws/data_source_aws_ecs_container_definition.go
@@ -77,7 +77,10 @@ func dataSourceAwsEcsContainerDefinitionRead(d *schema.ResourceData, meta interf
 
 		d.SetId(fmt.Sprintf("%s/%s", aws.StringValue(taskDefinition.TaskDefinitionArn), d.Get("container_name").(string)))
 		d.Set("image", aws.StringValue(def.Image))
-		d.Set("image_digest", strings.Split(aws.StringValue(def.Image), ":")[1])
+		image := aws.StringValue(def.Image)
+		if strings.Contains(image, ":") {
+			d.Set("image_digest", strings.Split(image, ":")[1])
+		}
 		d.Set("cpu", aws.Int64Value(def.Cpu))
 		d.Set("memory", aws.Int64Value(def.Memory))
 		d.Set("disable_networking", aws.BoolValue(def.DisableNetworking))

--- a/builtin/providers/aws/data_source_aws_ecs_container_definition_test.go
+++ b/builtin/providers/aws/data_source_aws_ecs_container_definition_test.go
@@ -15,6 +15,7 @@ func TestAccAWSEcsDataSource_ecsContainerDefinition(t *testing.T) {
 				Config: testAccCheckAwsEcsContainerDefinitionDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "image", "mongo:latest"),
+					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "image_digest", "latest"),
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "memory", "128"),
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "cpu", "128"),
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "environment.SECRET", "KEY"),


### PR DESCRIPTION
This PR fixes #7956. 

AWS does not add an explicit `:latest` when no digest is given, which leads to a crash for setups like this.

```
resource "aws_ecs_task_definition" "mongo" {
  family = "mongodb"
  container_definitions = <<DEFINITION
[
  {
    "cpu": 128,
    "environment": [{
      "name": "SECRET",
      "value": "KEY"
    }],
    "essential": true,
    "image": "mongo",
    "memory": 128,
    "name": "mongodb"
  }
]
DEFINITION
}
```

This PR fixes this issue.