### PR TITLE
docs/aws: Fix ordering of data sources

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -16,11 +16,11 @@
                         <li<%= sidebar_current("docs-aws-datasource-ami") %>>
                             <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-ecs-container-definition") %>>
-                            <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
-                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-availability-zones") %>>
                             <a href="/docs/providers/aws/d/availability_zones.html">aws_availability_zones</a>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-datasource-ecs-container-definition") %>>
+                            <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-iam-policy-document") %>>
                             <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>


### PR DESCRIPTION
```
am
av
ec
```
😉 