### PR TITLE
numeric variables aren't always interpreted as str

### DIFF
--- a/command/hcl_printer.go
+++ b/command/hcl_printer.go
@@ -107,7 +107,7 @@ func (e *encodeState) encodeInt(i interface{}) error {
 }
 
 func (e *encodeState) encodeFloat(f interface{}) error {
-	_, err := fmt.Fprintf(e, "%f", f)
+	_, err := fmt.Fprintf(e, "%g", f)
 	return err
 }
 

--- a/command/hcl_printer.go
+++ b/command/hcl_printer.go
@@ -35,7 +35,13 @@ func encodeHCL(i interface{}) ([]byte, error) {
 	// now strip that first assignment off
 	eq := regexp.MustCompile(`=\s+`).FindIndex(hcl)
 
-	return hcl[eq[1]:], nil
+	// strip of an extra \n if it's there
+	end := len(hcl)
+	if hcl[end-1] == '\n' {
+		end -= 1
+	}
+
+	return hcl[eq[1]:end], nil
 }
 
 type encodeState struct {

--- a/command/push.go
+++ b/command/push.go
@@ -327,25 +327,15 @@ RANGE:
 		case string:
 			tfv.Value = v
 
-		case []interface{}:
-			hcl, err = encodeHCL(v)
-			if err != nil {
-				break RANGE
-			}
-
-			tfv.Value = string(hcl)
-			tfv.IsHCL = true
-
-		case map[string]interface{}:
-			hcl, err = encodeHCL(v)
-			if err != nil {
-				break RANGE
-			}
-
-			tfv.Value = string(hcl)
-			tfv.IsHCL = true
 		default:
-			err = fmt.Errorf("unknown type %T for variable %s", v, k)
+			// everything that's not a string is now HCL encoded
+			hcl, err = encodeHCL(v)
+			if err != nil {
+				break RANGE
+			}
+
+			tfv.Value = string(hcl)
+			tfv.IsHCL = true
 		}
 
 		tfVars = append(tfVars, tfv)

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -389,6 +389,8 @@ func TestPush_tfvars(t *testing.T) {
 	args := []string{
 		"-var-file", path + "/terraform.tfvars",
 		"-vcs=false",
+		"-var",
+		"bar=1",
 		path,
 	}
 	if code := c.Run(args); code != 0 {
@@ -412,12 +414,19 @@ func TestPush_tfvars(t *testing.T) {
 
 	//now check TFVars
 	tfvars := pushTFVars()
+	// update bar to match cli value
+	for i, v := range tfvars {
+		if v.Key == "bar" {
+			tfvars[i].Value = "1"
+			tfvars[i].IsHCL = true
+		}
+	}
 
 	for i, expected := range tfvars {
 		got := client.UpsertOptions.TFVars[i]
 		if got != expected {
 			t.Logf("%2d expected: %#v", i, expected)
-			t.Logf("        got: %#v", got)
+			t.Fatalf("        got: %#v", got)
 		}
 	}
 }
@@ -589,9 +598,8 @@ func pushTFVars() []atlas.TFVar {
 		{"baz", `{
   A      = "a"
   interp = "${file("t.txt")}"
-}
-`, true},
-		{"fob", `["a", "quotes \"in\" quotes"]` + "\n", true},
+}`, true},
+		{"fob", `["a", "quotes \"in\" quotes"]`, true},
 		{"foo", "bar", false},
 	}
 }


### PR DESCRIPTION
If we have a number value in our config variables, format it as a
string, and send it with the HCL=true flag just in case.

Also use %g for for float encoding, as the output is a generally a
little friendlier.