### PR TITLE
providers/google: Allow custom Compute Engine service account

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -250,14 +250,16 @@ func resourceComputeInstance() *schema.Resource {
 
 			"service_account": &schema.Schema{
 				Type:     schema.TypeList,
+				MaxItems: 1,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"email": &schema.Schema{
 							Type:     schema.TypeString,
-							Computed: true,
 							ForceNew: true,
+							Optional: true,
+							Computed: true,
 						},
 
 						"scopes": &schema.Schema{
@@ -524,8 +526,13 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			scopes[i] = canonicalizeServiceScope(v.(string))
 		}
 
+		email := "default"
+		if v := d.Get(prefix + ".email"); v != nil {
+			email = v.(string)
+		}
+
 		serviceAccount := &compute.ServiceAccount{
-			Email:  "default",
+			Email:  email,
 			Scopes: scopes,
 		}
 

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -101,6 +101,7 @@ The following arguments are supported:
     this configuration option are detailed below.
 
 * `service_account` - (Optional) Service account to attach to the instance.
+    Structure is documented below.
 
 * `tags` - (Optional) Tags to attach to the instance.
 
@@ -151,17 +152,20 @@ The `access_config` block supports:
 * `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's
     network ip. If not given, one will be generated.
 
+The `service_account` block supports:
+
+* `email` - (Optional) The service account e-mail address. If not given, the
+    default Google Compute Engine service account is used.
+
+* `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
+    short names are supported.
+
 (DEPRECATED) The `network` block supports:
 
 * `source` - (Required) The name of the network to attach this interface to.
 
 * `address` - (Optional) The IP address of a reserved IP address to assign
     to this interface.
-
-The `service_account` block supports:
-
-* `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
-    short names are supported.
 
 The `scheduling` block supports:
 


### PR DESCRIPTION
This commit allows an operator to specify the e-mail address of a service
account to use with a Google Compute Engine instance. If no service account
e-mail is provided, the default service account is used.

Closes #7985