### PR TITLE
Fix. Handle lack of snapshot ID for a volume.

### DIFF
--- a/builtin/providers/aws/resource_aws_ami.go
+++ b/builtin/providers/aws/resource_aws_ami.go
@@ -174,12 +174,15 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 				"delete_on_termination": *blockDev.Ebs.DeleteOnTermination,
 				"encrypted":             *blockDev.Ebs.Encrypted,
 				"iops":                  0,
-				"snapshot_id":           *blockDev.Ebs.SnapshotId,
 				"volume_size":           int(*blockDev.Ebs.VolumeSize),
 				"volume_type":           *blockDev.Ebs.VolumeType,
 			}
 			if blockDev.Ebs.Iops != nil {
 				ebsBlockDev["iops"] = int(*blockDev.Ebs.Iops)
+			}
+			// The snapshot ID might not be set.
+			if blockDev.Ebs.SnapshotId != nil {
+				ebsBlockDev["snapshot_id"] = *blockDev.Ebs.SnapshotId
 			}
 			ebsBlockDevs = append(ebsBlockDevs, ebsBlockDev)
 		} else {

--- a/builtin/providers/aws/resource_aws_ami_copy_test.go
+++ b/builtin/providers/aws/resource_aws_ami_copy_test.go
@@ -61,6 +61,9 @@ func TestAccAWSAMICopy(t *testing.T) {
 					}
 
 					for _, bdm := range image.BlockDeviceMappings {
+						// The snapshot ID might not be set,
+						// even for a block device that is an
+						// EBS volume.
 						if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
 							snapshots = append(snapshots, *bdm.Ebs.SnapshotId)
 						}


### PR DESCRIPTION
This commit resolves the issue where lack of snapshot ID in the device mapping
section of the API response to DescribeImagesResponse would cause Terraform to
crash due to a nil pointer dereference. Usually, the snapshot ID is included,
but in some unique cases (e.g. ECS-enabled AMI from Amazon available on the
Market Place) a volume that is attached might not have it.

The API documentation does not clearly define whether the snapshot ID either
should be or must be included for any volume in the response.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>