### PR TITLE
Allow aws opsworks application Attributes also in no rail apps

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_application.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application.go
@@ -548,9 +548,6 @@ func resourceAwsOpsworksSetApplicationSsl(d *schema.ResourceData, v *opsworks.Ss
 }
 
 func resourceAwsOpsworksApplicationAttributes(d *schema.ResourceData) map[string]*string {
-	if d.Get("type") != opsworks.AppTypeRails {
-		return nil
-	}
 	attributes := make(map[string]*string)
 
 	if val := d.Get("document_root").(string); len(val) > 0 {
@@ -580,9 +577,6 @@ func resourceAwsOpsworksSetApplicationAttributes(d *schema.ResourceData, v map[s
 	d.Set("aws_flow_ruby_settings", nil)
 	d.Set("auto_bundle_on_deploy", nil)
 
-	if d.Get("type") != opsworks.AppTypeRails {
-		return
-	}
 	if val, ok := v[opsworks.AppAttributesKeysDocumentRoot]; ok {
 		d.Set("document_root", val)
 	}

--- a/website/source/docs/providers/aws/r/opsworks_application.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_application.html.markdown
@@ -62,8 +62,8 @@ The following arguments are supported:
 * `data_source_database_name` - (Optional) The database name.
 * `domains` -  (Optional) A list of virtual host alias.
 * `document_root` - (Optional) Subfolder for the document root.
-* `auto_bundle_on_deploy` - (Optional) Run bundle install when deploying for application of type `rails`.
-* `rails_env` - (Required if `type` = `rails`) The name of the Rails environment for application of type `rails`.
+* `auto_bundle_on_deploy` - (Optional) Run bundle install.
+* `rails_env` - (Required if `type` = `rails`) The name of the Rails environment.
 * `aws_flow_ruby_settings` - (Optional) Specify activity and workflow workers for your app using the aws-flow gem.
 
 An `app_source` block supports the following arguments (can only be defined once per resource):

--- a/website/source/docs/providers/aws/r/opsworks_application.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_application.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `data_source_type` - (Optional) The data source's type one of `AutoSelectOpsworksMysqlInstance`, `OpsworksMysqlInstance`, or `RdsDbInstance`.
 * `data_source_database_name` - (Optional) The database name.
 * `domains` -  (Optional) A list of virtual host alias.
-* `document_root` - (Optional) Subfolder for the document root for application of type `rails`.
+* `document_root` - (Optional) Subfolder for the document root.
 * `auto_bundle_on_deploy` - (Optional) Run bundle install when deploying for application of type `rails`.
 * `rails_env` - (Required if `type` = `rails`) The name of the Rails environment for application of type `rails`.
 * `aws_flow_ruby_settings` - (Optional) Specify activity and workflow workers for your app using the aws-flow gem.


### PR DESCRIPTION
BUG:  aws_opsworks_application does not take into account the document_root parameter in apps that are not rails.

SOLUTION:
When creating or modifying an application in AWS Opsworks, there is a parameter called Attributes as shown here
http://docs.aws.amazon.com/opsworks/latest/APIReference/API_CreateApp.html#opsworks-CreateApp-request-Attributes
Possible values inside Attributes are: DocumentRoot, RailsEnv, AutoBundleOnDeploy and AwsFlowRubySettings.
AWS DOES allow setting any of these attributes freely without taking into account application type.
So aws_opsworks_application should allow setting this attributes also when the app type is not rails.
This commits allows setting these Attributes wichout checking the app type.
Documentation is updaded as well.