### PR TITLE
docs/commands: clarify -state w/ remote state

### DIFF
--- a/website/source/docs/commands/apply.html.markdown
+++ b/website/source/docs/commands/apply.html.markdown
@@ -43,9 +43,11 @@ The command-line flags are all optional. The list of available flags are:
   apply.
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
-  `-state` path will be used.
+  `-state` path will be used. Ignored when
+  [remote state](/docs/state/remote/index.html) is used.
 
 * `-target=resource` - A [Resource
   Address](/docs/internals/resource-addressing.html) to target. Operation will

--- a/website/source/docs/commands/import.html.md
+++ b/website/source/docs/commands/import.html.md
@@ -38,10 +38,11 @@ The command-line flags are all optional. The list of available flags are:
 * `-input=true` - Whether to ask for input for provider configuration.
 
 * `-state=path` - The path to read and save state files (unless state-out is
-  specified).
+  specified). Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 * `-state-out=path` - Path to write the final state file. By default, this is
-  the state path.
+  the state path. Ignored when [remote state](/docs/state/remote/index.html) is
+  used.
 
 ## Provider Configuration
 

--- a/website/source/docs/commands/output.html.markdown
+++ b/website/source/docs/commands/output.html.markdown
@@ -24,6 +24,7 @@ The command-line flags are all optional. The list of available flags are:
     a key per output. If `NAME` is specified, only the output specified will be
     returned. This can be piped into tools such as `jq` for further processing.
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 * `-module=module_name` - The module path which has needed output.
     By default this is the root path. Other modules can be specified by
     a period-separated list. Example: "foo" would reference the module

--- a/website/source/docs/commands/plan.html.markdown
+++ b/website/source/docs/commands/plan.html.markdown
@@ -51,6 +51,7 @@ The command-line flags are all optional. The list of available flags are:
 * `-refresh=true` - Update the state prior to checking for differences.
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 * `-target=resource` - A [Resource
   Address](/docs/internals/resource-addressing.html) to target. Operation will

--- a/website/source/docs/commands/refresh.html.markdown
+++ b/website/source/docs/commands/refresh.html.markdown
@@ -32,9 +32,11 @@ The command-line flags are all optional. The list of available flags are:
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
-  `-state` path will be used.
+  `-state` path will be used. Ignored when
+  [remote state](/docs/state/remote/index.html) is used.
 
 * `-target=resource` - A [Resource
   Address](/docs/internals/resource-addressing.html) to target. Operation will

--- a/website/source/docs/commands/state/list.html.md
+++ b/website/source/docs/commands/state/list.html.md
@@ -30,6 +30,7 @@ in [resource addressing format](/docs/commands/state/addressing.html).
 The command-line flags are all optional. The list of available flags are:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 ## Example: All Resources
 

--- a/website/source/docs/commands/state/mv.html.md
+++ b/website/source/docs/commands/state/mv.html.md
@@ -47,10 +47,12 @@ The command-line flags are all optional. The list of available flags are:
                        This is only necessary if `-state-out` is specified.
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 * `-state-out=path` - Path to the state file to write to. If this isn't specified
                       the state specified by `-state` will be used. This can be
-                      a new or existing path.
+                      a new or existing path. Ignored when
+                      [remote state](/docs/state/remote/index.html) is used.
 
 ## Example: Rename a Resource
 

--- a/website/source/docs/commands/state/show.html.md
+++ b/website/source/docs/commands/state/show.html.md
@@ -30,6 +30,7 @@ in [resource addressing format](/docs/commands/state/addressing.html).
 The command-line flags are all optional. The list of available flags are:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 ## Example: Show a Resource
 

--- a/website/source/docs/commands/taint.html.markdown
+++ b/website/source/docs/commands/taint.html.markdown
@@ -56,6 +56,8 @@ The command-line flags are all optional. The list of available flags are:
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
-  `-state` path will be used.
+  `-state` path will be used. Ignored when
+  [remote state](/docs/state/remote/index.html) is used.

--- a/website/source/docs/commands/untaint.html.markdown
+++ b/website/source/docs/commands/untaint.html.markdown
@@ -56,6 +56,8 @@ certain cases, see above note). The list of available flags are:
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".
+  Ignored when [remote state](/docs/state/remote/index.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
-  `-state` path will be used.
+  `-state` path will be used. Ignored when
+  [remote state](/docs/state/remote/index.html) is used.


### PR DESCRIPTION
Clarifies usage of `-state` and `-state-out` when remote state is used. Not a fix for #8014, but related to it.