### PR TITLE
[WIP] provider/aws: Add normalizeJsonString and validateJsonString functions.

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -1399,6 +1399,7 @@ func removeNil(data map[string]interface{}) map[string]interface{} {
 	return withoutNil
 }
 
+// DEPRECATED. Please consider using `normalizeJsonString` function instead.
 func normalizeJson(jsonString interface{}) string {
 	if jsonString == nil || jsonString == "" {
 		return ""

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1567,3 +1567,24 @@ func flattenPolicyAttributes(list []*elb.PolicyAttributeDescription) []interface
 
 	return attributes
 }
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func normalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -1143,7 +1143,7 @@ func TestNormalizeJsonString(t *testing.T) {
 	}
 
 	if actual != expected {
-		t.Fatalf("Got:\n\n%#s\n\nExpected:\n\n%#s\n", actual, expected)
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, expected)
 	}
 
 	// Well formatted but not valid,
@@ -1165,6 +1165,6 @@ func TestNormalizeJsonString(t *testing.T) {
 
 	// We expect the invalid JSON to be shown back to us again.
 	if actual != invalidJson {
-		t.Fatalf("Got:\n\n%#s\n\nExpected:\n\n%#s\n", expected, invalidJson)
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", expected, invalidJson)
 	}
 }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -1122,14 +1122,14 @@ func TestNormalizeJsonString(t *testing.T) {
 	var actual string
 
 	// Well formatted and valid.
-	validJson := `{  
-   "abc": {  
+	validJson := `{
+   "abc": {
       "def": 123,
-      "xyz": [  
-         {  
+      "xyz": [
+         {
             "a": "ホリネズミ"
          },
-         {  
+         {
             "b": "1\\n2"
          }
       ]
@@ -1148,11 +1148,11 @@ func TestNormalizeJsonString(t *testing.T) {
 
 	// Well formatted but not valid,
 	// missing closing squre bracket.
-	invalidJson := `{  
-   "abc": {  
+	invalidJson := `{
+   "abc": {
       "def": 123,
-      "xyz": [  
-         {  
+      "xyz": [
+         {
             "a": "1"
          }
       }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -1116,3 +1116,55 @@ func TestFlattenPolicyAttributes(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeJsonString(t *testing.T) {
+	var err error
+	var actual string
+
+	// Well formatted and valid.
+	validJson := `{  
+   "abc": {  
+      "def": 123,
+      "xyz": [  
+         {  
+            "a": "ホリネズミ"
+         },
+         {  
+            "b": "1\\n2"
+         }
+      ]
+   }
+}`
+	expected := `{"abc":{"def":123,"xyz":[{"a":"ホリネズミ"},{"b":"1\\n2"}]}}`
+
+	actual, err = normalizeJsonString(validJson)
+	if err != nil {
+		t.Fatalf("Expected not to throw an error while parsing JSON, but got: %s", err)
+	}
+
+	if actual != expected {
+		t.Fatalf("Got:\n\n%#s\n\nExpected:\n\n%#s\n", actual, expected)
+	}
+
+	// Well formatted but not valid,
+	// missing closing squre bracket.
+	invalidJson := `{  
+   "abc": {  
+      "def": 123,
+      "xyz": [  
+         {  
+            "a": "1"
+         }
+      }
+   }
+}`
+	actual, err = normalizeJsonString(invalidJson)
+	if err == nil {
+		t.Fatalf("Expected to throw an error while parsing JSON, but got: %s", err)
+	}
+
+	// We expect the invalid JSON to be shown back to us again.
+	if actual != invalidJson {
+		t.Fatalf("Got:\n\n%#s\n\nExpected:\n\n%#s\n", expected, invalidJson)
+	}
+}

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -462,8 +462,7 @@ func validateApiGatewayIntegrationPassthroughBehavior(v interface{}, k string) (
 }
 
 func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if _, err := normalizeJsonString(value); err != nil {
+	if _, err := normalizeJsonString(v); err != nil {
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
 	}
 	return

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -460,3 +460,11 @@ func validateApiGatewayIntegrationPassthroughBehavior(v interface{}, k string) (
 	}
 	return
 }
+
+func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if _, err := normalizeJsonString(value); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -553,3 +553,58 @@ func TestValidateDbEventSubscriptionName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateJsonString(t *testing.T) {
+	type testCases struct {
+		Value    string
+		ErrCount int
+	}
+
+	invalidCases := []testCases{
+		{
+			Value:    `{0:"1"}`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `{'abc':1}`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `{"def":}`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `{"xyz":[}}`,
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range invalidCases {
+		_, errors := validateJsonString(tc.Value, "json")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
+		}
+	}
+
+	validCases := []testCases{
+		{
+			Value:    ``,
+			ErrCount: 0,
+		},
+		{
+			Value:    `{}`,
+			ErrCount: 0,
+		},
+		{
+			Value:    `{"abc":["1","2"]}`,
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range validCases {
+		_, errors := validateJsonString(tc.Value, "json")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds ValidateFunc to the policy attribute so that JSON parsing
errors can be caught early. Generally, when there is a ValidateFunc set for the
attribute, one can safely assume that before any of the creation and/or update
of the existing resource would happen it would have to succeed validation. Also
adds support for new helper function which is used to normalise JSON string.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>