### PR TITLE
Updated API GW integration response documentation

### DIFF
--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Provides an HTTP Method Integration Response for an API Gateway Resource.
 
+-> **Note:** Depends on having `aws_api_gateway_integration` inside your rest api. To ensure this
+you might need to add an explicit `depends_on` for clean runs.
+
 ## Example Usage
 
 ```


### PR DESCRIPTION
### Reasoning for docs update
Recently, I've been using Terraform to manage AWS API GWs with Lambda backends.
It appears that an explicit `depends_on`dependency is required when adding an `aws_api_gateway_integration_response ` resource. Not setting it would lead to this error:

> [...] Error creating API Gateway Integration Response: NotFoundException: No integration defined for method

### Relevant Terraform version
Checked against 0.6.16

### Thread Issue
https://github.com/hashicorp/terraform/issues/6128