### PR TITLE
providers/aws: #8051 :: bumped aws_rds_cluster timeout to 40 minutes

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -373,7 +373,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		Pending:    []string{"creating", "backing-up", "modifying"},
 		Target:     []string{"available"},
 		Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
-		Timeout:    15 * time.Minute,
+		Timeout:    40 * time.Minute,
 		MinTimeout: 3 * time.Second,
 	}
 


### PR DESCRIPTION
This PR addresses this issue reported in #8051 ; the timeout for aws_rds_cluster create actions has been increased to 40 minutes from 15 minutes.