### PR TITLE
Fix. Remove reference to the `rm` state sub-command.

### DIFF
--- a/website/source/layouts/commands-state.erb
+++ b/website/source/layouts/commands-state.erb
@@ -25,10 +25,6 @@
 							<a href="/docs/commands/state/mv.html">mv</a>
 						</li>
 
-						<li<%= sidebar_current("docs-state-sub-rm") %>>
-							<a href="/docs/commands/state/rm.html">rm</a>
-						</li>
-
 						<li<%= sidebar_current("docs-state-sub-show") %>>
 							<a href="/docs/commands/state/show.html">show</a>
 						</li>


### PR DESCRIPTION
At the moment the `terraform state rm ...` invocation is not supported (there
is no `state_rm.go`, etc.). This commit removes link to the page detailing the
sub-command, which does not exist at the moment, thus removing unexpected 404
error and confusion around whether this is supported or not.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>