### PR TITLE
provider/aws: Fixes for Opsworks documentation

### DIFF
--- a/website/source/docs/providers/aws/r/opsworks_permission.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_permission.html.markdown
@@ -4,7 +4,7 @@ page_title: "AWS: aws_opsworks_permission"
 sidebar_current: "docs-aws-resource-opsworks-permission"
 description: |-
   Provides an OpsWorks permission resource.
--------------------------------------------
+---
 
 # aws\_opsworks\_permission
 

--- a/website/source/docs/providers/aws/r/opsworks_user_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_user_profile.html.markdown
@@ -1,10 +1,10 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_opsworks_user_profile_"
+page_title: "AWS: aws_opsworks_user_profile"
 sidebar_current: "docs-aws-resource-opsworks-user-profile"
 description: |-
   Provides an OpsWorks User Profile resource.
----------------------------------------------
+---
 
 # aws\_opsworks\_user\_profile
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -603,6 +603,10 @@
                             <a href="/docs/providers/aws/r/opsworks_nodejs_app_layer.html">aws_opsworks_nodejs_app_layer</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-opsworks-permission") %>>
+                            <a href="/docs/providers/aws/r/opsworks_permission.html">aws_opsworks_permission</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-opsworks-php-app-layer") %>>
                             <a href="/docs/providers/aws/r/opsworks_php_app_layer.html">aws_opsworks_php_app_layer</a>
                         </li>
@@ -617,6 +621,10 @@
 
                         <li<%= sidebar_current("docs-aws-resource-opsworks-static-web-layer") %>>
                             <a href="/docs/providers/aws/r/opsworks_static_web_layer.html">aws_opsworks_static_web_layer</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-opsworks-user-profile") %>>
+                            <a href="/docs/providers/aws/r/opsworks_user_profile.html">aws_opsworks_user_profile</a>
                         </li>
 
                     </ul>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -567,6 +567,10 @@
                     <a href="#">OpsWorks Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-opsworks-application") %>>
+                            <a href="/docs/providers/aws/r/opsworks_application.html">aws_opsworks_application</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-opsworks-custom-layer") %>>
                             <a href="/docs/providers/aws/r/opsworks_custom_layer.html">aws_opsworks_custom_layer</a>
                         </li>
@@ -613,10 +617,6 @@
 
                         <li<%= sidebar_current("docs-aws-resource-opsworks-static-web-layer") %>>
                             <a href="/docs/providers/aws/r/opsworks_static_web_layer.html">aws_opsworks_static_web_layer</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-aws-resource-opsworks-application") %>>
-                            <a href="/docs/providers/aws/r/opsworks_application.html">aws_opsworks_application</a>
                         </li>
 
                     </ul>


### PR DESCRIPTION
- Fix broken documents (e.g. [opsworks_permission.html](https://www.terraform.io/docs/providers/aws/r/opsworks_permission.html))
- Add orphaned page link to sidebar