### PR TITLE
provider/openstack: Missing OS_EXTGW_ID in OpenStack Docs

### DIFF
--- a/website/source/docs/providers/openstack/index.html.markdown
+++ b/website/source/docs/providers/openstack/index.html.markdown
@@ -144,6 +144,8 @@ variables must also be set:
 
 * `OS_NETWORK_ID` - The UUID of a network in your test environment.
 
+* `OS_EXTGW_ID` - The UUID of the external gateway.
+
 To make development easier, the `builtin/providers/openstack/devstack/deploy.sh`
 script will assist in installing and configuring a standardized
 [DevStack](http://docs.openstack.org/developer/devstack/) environment along with


### PR DESCRIPTION
This commit adds a note about the requirement for the OS_EXTGW_ID
environment variable in order to run the OpenStack Provider acceptance
tests.