### PR TITLE
provider/vsphere: Standardizing datastore references to use builtin Path func

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -901,17 +901,20 @@ resource "vsphere_virtual_machine" "foo" {
     disk {
         size = 1
         iops = 500
-	name = "one"
+        name = "one"
+%s
     }
 	disk {
         size = 1
         iops = 500
-	name = "two"
+        name = "two"
+%s
     }
 	disk {
         size = 1
         iops = 500
-	name = "three"
+        name = "three"
+%s
     }
 }
 `
@@ -935,7 +938,19 @@ func TestAccVSphereVirtualMachine_updateDisks(t *testing.T) {
 	log.Printf("[DEBUG] template= %s", testAccCheckVSphereVirtualMachineConfig_basic)
 	log.Printf("[DEBUG] template config= %s", config_basic)
 
-	config_add := basic_vars.testSprintfTemplateBody(testAccCheckVSphereVirtualMachineConfig_updateAddDisks)
+	config_add := fmt.Sprintf(
+		testAccCheckVSphereVirtualMachineConfig_updateAddDisks,
+		basic_vars.locationOpt,
+		basic_vars.label,
+		basic_vars.ipv4IpAddress,
+		basic_vars.ipv4Prefix,
+		basic_vars.ipv4Gateway,
+		basic_vars.datastoreOpt,
+		basic_vars.template,
+		basic_vars.datastoreOpt,
+		basic_vars.datastoreOpt,
+		basic_vars.datastoreOpt,
+	)
 
 	log.Printf("[DEBUG] template= %s", testAccCheckVSphereVirtualMachineConfig_basic)
 	log.Printf("[DEBUG] template config= %s", config_add)

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -61,6 +61,7 @@ import (
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
+	"archive":      archiveprovider.Provider,
 	"atlas":        atlasprovider.Provider,
 	"aws":          awsprovider.Provider,
 	"azure":        azureprovider.Provider,
@@ -105,7 +106,6 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"ultradns":     ultradnsprovider.Provider,
 	"vcd":          vcdprovider.Provider,
 	"vsphere":      vsphereprovider.Provider,
-	"archive":      archiveprovider.Provider,
 }
 
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{


### PR DESCRIPTION
This is a fix to standardizes the way datastore paths are build.  This will also allow use of datastores that are part of a datastore cluster using the syntax  `<datastore cluster name>/<datastore name>`