### PR TITLE
Allow the HCL input when prompted

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -363,16 +363,14 @@ func (c *Context) Input(mode InputMode) error {
 						"Error asking for %s: %s", n, err)
 				}
 
-				if value == "" {
-					if v.Required() {
-						// Redo if it is required, but abort if we keep getting
-						// blank entries
-						if retry > 2 {
-							return fmt.Errorf("missing required value for %q", n)
-						}
-						retry++
-						continue
+				if value == "" && v.Required() {
+					// Redo if it is required, but abort if we keep getting
+					// blank entries
+					if retry > 2 {
+						return fmt.Errorf("missing required value for %q", n)
 					}
+					retry++
+					continue
 				}
 
 				break

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -617,3 +617,44 @@ func TestContext2Input_interpolateVar(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestContext2Input_hcl(t *testing.T) {
+	input := new(MockUIInput)
+	m := testModule(t, "input-hcl")
+	p := testProvider("hcl")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"hcl": testProviderFuncFixed(p),
+		},
+		Variables: map[string]interface{}{},
+		UIInput:   input,
+	})
+
+	input.InputReturnMap = map[string]string{
+		"var.listed": `["a", "b"]`,
+		"var.mapped": `{x = "y", w = "z"}`,
+	}
+
+	if err := ctx.Input(InputModeVar | InputModeVarUnset); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actualStr := strings.TrimSpace(state.String())
+	expectedStr := strings.TrimSpace(testTerraformInputHCL)
+	if actualStr != expectedStr {
+		t.Logf("expected: \n%s", expectedStr)
+		t.Fatalf("bad: \n%s", actualStr)
+	}
+}

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -1223,6 +1223,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 	actual := strings.TrimSpace(plan.String())
 	expected := strings.TrimSpace(testTerraformPlanCountZeroStr)
 	if actual != expected {
+		t.Logf("expected:\n%s", expected)
 		t.Fatalf("bad:\n%s", actual)
 	}
 }

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1413,3 +1413,14 @@ module.mod2:
 STATE:
 
 <no state>`
+
+const testTerraformInputHCL = `
+hcl_instance.hcltest:
+  ID = foo
+  bar.w = z
+  bar.x = y
+  foo.# = 2
+  foo.0 = a
+  foo.1 = b
+  type = hcl_instance
+`

--- a/terraform/test-fixtures/input-hcl/main.tf
+++ b/terraform/test-fixtures/input-hcl/main.tf
@@ -1,0 +1,12 @@
+variable "mapped" {
+    type = "map"
+}
+
+variable "listed" {
+    type = "list"
+}
+
+resource "hcl_instance" "hcltest" {
+    foo = "${var.listed}"
+    bar = "${var.mapped}"
+}


### PR DESCRIPTION
We already accept HCL encoded input for -vars, and this expands that to
accept HCL when prompted for a value on the command line as well.