### PR TITLE
add Aurora instance failover priority feature

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -155,7 +155,6 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		createOpts.MonitoringInterval = aws.Int64(int64(attr.(int)))
 	}
 
-
 	log.Printf("[DEBUG] Creating RDS DB Instance opts: %s", createOpts)
 	resp, err := conn.CreateDBInstance(createOpts)
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -109,6 +109,12 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 				Default:  0,
 			},
 
+			"promotion_tier": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -146,6 +152,10 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 
 	if attr, ok := d.GetOk("monitoring_interval"); ok {
 		createOpts.MonitoringInterval = aws.Int64(int64(attr.(int)))
+	}
+
+	if attr, ok := d.GetOk("promotion_tier"); ok {
+		createOpts.PromotionTier = aws.Int64(int64(attr.(int)))
 	}
 
 	log.Printf("[DEBUG] Creating RDS DB Instance opts: %s", createOpts)
@@ -226,6 +236,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set("instance_class", db.DBInstanceClass)
 	d.Set("identifier", db.DBInstanceIdentifier)
 	d.Set("storage_encrypted", db.StorageEncrypted)
+	d.Set("promotion_tier", db.PromotionTier)
 
 	if db.MonitoringInterval != nil {
 		d.Set("monitoring_interval", db.MonitoringInterval)
@@ -282,6 +293,12 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("monitoring_interval") {
 		d.SetPartial("monitoring_interval")
 		req.MonitoringInterval = aws.Int64(int64(d.Get("monitoring_interval").(int)))
+		requestUpdate = true
+	}
+
+	if d.HasChange("promotion_tier") {
+		d.SetPartial("promotion_tier")
+		req.PromotionTier = aws.Int64(int64(d.Get("promotion_tier").(int)))
 		requestUpdate = true
 	}
 

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -129,6 +129,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
 		Engine:              aws.String("aurora"),
 		PubliclyAccessible:  aws.Bool(d.Get("publicly_accessible").(bool)),
+		PromotionTier:       aws.Int64(int64(d.Get("promotion_tier").(int))),
 		Tags:                tags,
 	}
 
@@ -154,9 +155,6 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		createOpts.MonitoringInterval = aws.Int64(int64(attr.(int)))
 	}
 
-	if attr, ok := d.GetOk("promotion_tier"); ok {
-		createOpts.PromotionTier = aws.Int64(int64(attr.(int)))
-	}
 
 	log.Printf("[DEBUG] Creating RDS DB Instance opts: %s", createOpts)
 	resp, err := conn.CreateDBInstance(createOpts)

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -222,6 +222,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   cluster_identifier      = "${aws_rds_cluster.default.id}"
   instance_class          = "db.r3.large"
   db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
+  promotion_tier          = "3"
 }
 
 resource "aws_db_parameter_group" "bar" {

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -70,6 +70,7 @@ details on controlling this property.
 enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html)
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `monitoring_interval` - (Optional) The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.
+* `promotion_tier` - (Optional) Default 0. Failover Priority setting on instance level. The reader who has lower tier has higher priority to get promoter to writer
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true
 * `tags` - (Optional) A mapping of tags to assign to the instance.
 


### PR DESCRIPTION
Add Aurora instance level failover priority setting.

rds modify-db-instances --promotion-tier