### PR TITLE
docs/powerdns: Fix invalid markdown syntax

### DIFF
--- a/website/source/docs/providers/powerdns/r/record.html.markdown
+++ b/website/source/docs/providers/powerdns/r/record.html.markdown
@@ -15,6 +15,7 @@ Provides a PowerDNS record resource.
 Note that PowerDNS internally lowercases certain records (e.g. CNAME and AAAA), which can lead to resources being marked for a change in every singe plan.
 
 For the v1 API (PowerDNS version 4):
+
 ```
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
@@ -27,6 +28,7 @@ resource "powerdns_record" "foobar" {
 ```
 
 For the legacy API (PowerDNS version 3.4):
+
 ```
 # Add a record to the zone
 resource "powerdns_record" "foobar" {


### PR DESCRIPTION
[Power DNS record resource](https://www.terraform.io/docs/providers/powerdns/r/record.html) page has broken code block. This PR will resolve it.