### PR TITLE
providers/google: Support IAM permissions for GCP projects

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
+	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/dns/v1"
@@ -28,12 +29,13 @@ type Config struct {
 	Project     string
 	Region      string
 
-	clientCompute   *compute.Service
-	clientContainer *container.Service
-	clientDns       *dns.Service
-	clientStorage   *storage.Service
-	clientSqlAdmin  *sqladmin.Service
-	clientPubsub    *pubsub.Service
+	clientCompute         *compute.Service
+	clientContainer       *container.Service
+	clientDns             *dns.Service
+	clientPubsub          *pubsub.Service
+	clientResourceManager *cloudresourcemanager.Service
+	clientStorage         *storage.Service
+	clientSqlAdmin        *sqladmin.Service
 }
 
 func (c *Config) loadAndValidate() error {
@@ -128,6 +130,13 @@ func (c *Config) loadAndValidate() error {
 
 	log.Printf("[INFO] Instatiating Google Pubsub Client...")
 	c.clientPubsub, err = pubsub.New(client)
+	if err != nil {
+		return err
+	}
+	c.clientPubsub.UserAgent = userAgent
+
+	log.Printf("[INFO] Instatiating Google CloudResourceManager Client...")
+	c.clientResourceManager, err = cloudresourcemanager.New(client)
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/data_source_google_iam_policy.go
+++ b/builtin/providers/google/data_source_google_iam_policy.go
@@ -9,6 +9,25 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 )
 
+var iamBinding *schema.Schema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Required: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"members": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	},
+}
+
 // dataSourceGoogleIamPolicy returns a *schema.Resource that allows a customer
 // to express a Google Cloud IAM policy in a data resource. This is an example
 // of how the schema would be used in a config:
@@ -25,25 +44,8 @@ func dataSourceGoogleIamPolicy() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGoogleIamPolicyRead,
 		Schema: map[string]*schema.Schema{
-			"binding": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"role": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"members": {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
-					},
-				},
-			},
-			"policy": {
+			"binding": iamBinding,
+			"policy_data": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -81,7 +83,7 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 	}
 	pstring := string(pjson)
 
-	d.Set("policy", pstring)
+	d.Set("policy_data", pstring)
 	d.SetId(strconv.Itoa(hashcode.String(pstring)))
 
 	return nil

--- a/builtin/providers/google/data_source_google_iam_policy_document.go
+++ b/builtin/providers/google/data_source_google_iam_policy_document.go
@@ -1,0 +1,81 @@
+package google
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func dataSourceGoogleIamPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleIamPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"binding": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"members": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleIamPolicyMembers(d *schema.Set) []string {
+	var members []string
+	members = make([]string, d.Len())
+
+	for i, v := range d.List() {
+		members[i] = v.(string)
+	}
+	return members
+}
+
+func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	doc := &cloudresourcemanager.Policy{}
+
+	var bindings []*cloudresourcemanager.Binding
+
+	bindingStatements := d.Get("binding").(*schema.Set)
+	bindings = make([]*cloudresourcemanager.Binding, bindingStatements.Len())
+	doc.Bindings = bindings
+
+	for i, bindingRaw := range bindingStatements.List() {
+		bindingStatement := bindingRaw.(map[string]interface{})
+		doc.Bindings[i] = &cloudresourcemanager.Binding{
+			Role:    bindingStatement["role"].(string),
+			Members: dataSourceGoogleIamPolicyMembers(bindingStatement["members"].(*schema.Set)),
+		}
+	}
+
+	jsonDoc, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		// should never happen if the above code is correct
+		return err
+	}
+	jsonString := string(jsonDoc)
+
+	d.Set("policy", jsonString)
+	d.SetId(strconv.Itoa(hashcode.String(jsonString)))
+
+	return nil
+}

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -56,6 +56,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"google_iam_policy": dataSourceGoogleIamPolicy(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"google_compute_autoscaler":             resourceComputeAutoscaler(),
 			"google_compute_address":                resourceComputeAddress(),
@@ -89,6 +93,7 @@ func Provider() terraform.ResourceProvider {
 			"google_sql_database":                   resourceSqlDatabase(),
 			"google_sql_database_instance":          resourceSqlDatabaseInstance(),
 			"google_sql_user":                       resourceSqlUser(),
+			"google_project":                        resourceGoogleProject(),
 			"google_pubsub_topic":                   resourcePubsubTopic(),
 			"google_pubsub_subscription":            resourcePubsubSubscription(),
 			"google_storage_bucket":                 resourceStorageBucket(),

--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -1,0 +1,271 @@
+package google
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/googleapi"
+)
+
+func resourceGoogleProject() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleProjectCreate,
+		Read:   resourceGoogleProjectRead,
+		Update: resourceGoogleProjectUpdate,
+		Delete: resourceGoogleProjectDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"number": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(project)
+	if err := resourceGoogleProjectRead(d, meta); err != nil {
+		return err
+	}
+
+	// Apply the IAM policy if it is set
+	if pString, ok := d.GetOk("policy"); ok {
+		// The policy string is just a marshaled cloudresourcemanager.Policy.
+		// Unmarshal it to a struct.
+		var policy cloudresourcemanager.Policy
+		if err = json.Unmarshal([]byte(pString.(string)), &policy); err != nil {
+			return err
+		}
+
+		// Retrieve existing IAM policy from project. This will be merged
+		// with the policy defined here.
+		// TODO(evanbrown): Add an 'authoritative' flag that allows policy
+		// in manifest to overwrite existing policy.
+		p, err := getProjectIamPolicy(project, config)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Got existing bindings from project: %#v", p.Bindings)
+
+		// Merge the existing policy bindings with those defined in this manifest.
+		p.Bindings = mergeBindings(append(p.Bindings, policy.Bindings...))
+
+		// Apply the merged policy
+		log.Printf("[DEBUG] Setting new policy for project: %#v", p)
+		_, err = config.clientResourceManager.Projects.SetIamPolicy(project,
+			&cloudresourcemanager.SetIamPolicyRequest{Policy: p}).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error applying IAM policy for project %q: %s", project, err)
+		}
+	}
+	return nil
+}
+
+func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	// Confirm the project exists.
+	// TODO(evanbrown): Support project creation
+	p, err := config.clientResourceManager.Projects.Get(project).Do()
+	if err != nil {
+		if v, ok := err.(*googleapi.Error); ok && v.Code == http.StatusNotFound {
+			return fmt.Errorf("Project %q does not exist. The Google provider does not currently support new project creation.", project)
+		}
+		return fmt.Errorf("Error checking project %q: %s", project, err)
+	}
+
+	d.Set("number", strconv.FormatInt(int64(p.ProjectNumber), 10))
+	d.Set("name", p.Name)
+
+	return nil
+}
+
+func resourceGoogleProjectUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	// Policy has changed
+	if ok := d.HasChange("policy"); ok {
+		// The policy string is just a marshaled cloudresourcemanager.Policy.
+		// Unmarshal it to a struct that contains the old and new policies
+		oldPString, newPString := d.GetChange("policy")
+		var oldPolicy, newPolicy cloudresourcemanager.Policy
+		if err = json.Unmarshal([]byte(newPString.(string)), &newPolicy); err != nil {
+			return err
+		}
+		if err = json.Unmarshal([]byte(oldPString.(string)), &oldPolicy); err != nil {
+			return err
+		}
+
+		// Find any Roles and Members that were removed (i.e., those that are present
+		// in the old but absent in the new
+		oldMap := rolesToMembersMap(oldPolicy.Bindings)
+		newMap := rolesToMembersMap(newPolicy.Bindings)
+		deleted := make(map[string]string)
+
+		// Get each role and its associated members in the old state
+		for role, members := range oldMap {
+			// The role exists in the new state
+			if _, ok := newMap[role]; ok {
+				// Check each memeber
+				for member, _ := range members {
+					// Member does not exist in new state, so it was deleted
+					if _, ok = newMap[role][member]; !ok {
+						deleted[role] = member
+					}
+				}
+			} else {
+				// This indicates an entire role was deleted. Mark all members
+				// for delete.
+				for member, _ := range members {
+					deleted[role] = member
+				}
+			}
+		}
+		log.Printf("[DEBUG] Roles and Members to be deleted: %#v", deleted)
+
+		// Retrieve existing IAM policy from project. This will be merged
+		// with the policy in the current state
+		// TODO(evanbrown): Add an 'authoritative' flag that allows policy
+		// in manifest to overwrite existing policy.
+		p, err := getProjectIamPolicy(project, config)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Got existing bindings from project: %#v", p.Bindings)
+
+		// Merge existing policy with policy in the current state
+		log.Printf("[DEBUG] Merging new bindings from project: %#v", newPolicy.Bindings)
+		mergedBindings := mergeBindings(append(p.Bindings, newPolicy.Bindings...))
+
+		// Remove any roles and members that were explicitly deleted
+		mergedBindingsMap := rolesToMembersMap(mergedBindings)
+		for role, member := range deleted {
+			delete(mergedBindingsMap[role], member)
+		}
+
+		p.Bindings = rolesToMembersBinding(mergedBindingsMap)
+		log.Printf("[DEBUG] Setting new policy for project: %#v", p)
+
+		dump, _ := json.MarshalIndent(p.Bindings, " ", "  ")
+		log.Printf(string(dump))
+		_, err = config.clientResourceManager.Projects.SetIamPolicy(project,
+			&cloudresourcemanager.SetIamPolicyRequest{Policy: p}).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error applying IAM policy for project %q: %s", project, err)
+		}
+	}
+
+	return nil
+}
+
+func resourceGoogleProjectDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func getProjectIamPolicy(project string, config *Config) (*cloudresourcemanager.Policy, error) {
+	p, err := config.clientResourceManager.Projects.GetIamPolicy(project,
+		&cloudresourcemanager.GetIamPolicyRequest{}).Do()
+
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving IAM policy for project %q: %s", project, err)
+	}
+	return p, nil
+}
+
+// Convert a map of roles->members to a list of Binding
+func rolesToMembersBinding(m map[string]map[string]bool) []*cloudresourcemanager.Binding {
+	bindings := make([]*cloudresourcemanager.Binding, 0)
+	for role, members := range m {
+		b := cloudresourcemanager.Binding{
+			Role:    role,
+			Members: make([]string, 0),
+		}
+		for m, _ := range members {
+			b.Members = append(b.Members, m)
+		}
+		bindings = append(bindings, &b)
+	}
+	return bindings
+}
+
+// Map a role to a map of members, allowing easy merging of multiple bindings.
+func rolesToMembersMap(bindings []*cloudresourcemanager.Binding) map[string]map[string]bool {
+	bm := make(map[string]map[string]bool)
+	// Get each binding
+	for _, b := range bindings {
+		// Initialize members map
+		if _, ok := bm[b.Role]; !ok {
+			bm[b.Role] = make(map[string]bool)
+		}
+		// Get each member (user/principal) for the binding
+		for _, m := range b.Members {
+			// Add the member
+			bm[b.Role][m] = true
+		}
+	}
+	return bm
+}
+
+// Merge multiple Bindings such that Bindings with the same Role result in
+// a single Binding with combined Members
+func mergeBindings(bindings []*cloudresourcemanager.Binding) []*cloudresourcemanager.Binding {
+	bm := rolesToMembersMap(bindings)
+	rb := make([]*cloudresourcemanager.Binding, 0)
+
+	for role, members := range bm {
+		var b cloudresourcemanager.Binding
+		b.Role = role
+		b.Members = make([]string, 0)
+		for m, _ := range members {
+			b.Members = append(b.Members, m)
+		}
+		rb = append(rb, &b)
+	}
+
+	return rb
+}

--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -130,12 +130,27 @@ func resourceGoogleProjectUpdate(d *schema.ResourceData, meta interface{}) error
 	if ok := d.HasChange("policy"); ok {
 		// The policy string is just a marshaled cloudresourcemanager.Policy.
 		// Unmarshal it to a struct that contains the old and new policies
-		oldPString, newPString := d.GetChange("policy")
+		oldP, newP := d.GetChange("policy")
+		oldPString := oldP.(string)
+		newPString := newP.(string)
+
+		// JSON Unmarshaling would fail
+		if oldPString == "" {
+			oldPString = "{}"
+		}
+		if newPString == "" {
+			newPString = "{}"
+		}
+
+		oldPStringf, _ := json.MarshalIndent(oldPString, " ", "   ")
+		newPStringf, _ := json.MarshalIndent(newPString, " ", "   ")
+		log.Printf("[DEBUG]: Old policy: %v\nNew policy: %v", string(oldPStringf), string(newPStringf))
+
 		var oldPolicy, newPolicy cloudresourcemanager.Policy
-		if err = json.Unmarshal([]byte(newPString.(string)), &newPolicy); err != nil {
+		if err = json.Unmarshal([]byte(newPString), &newPolicy); err != nil {
 			return err
 		}
-		if err = json.Unmarshal([]byte(oldPString.(string)), &oldPolicy); err != nil {
+		if err = json.Unmarshal([]byte(oldPString), &oldPolicy); err != nil {
 			return err
 		}
 

--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -31,28 +31,20 @@ func resourceGoogleProject() *schema.Resource {
 		Delete: resourceGoogleProjectDelete,
 
 		Schema: map[string]*schema.Schema{
-			"project": &schema.Schema{
+			"id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
-			"policy": &schema.Schema{
+			"policy_data": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"number": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -77,7 +69,7 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Apply the IAM policy if it is set
-	if pString, ok := d.GetOk("policy"); ok {
+	if pString, ok := d.GetOk("policy_data"); ok {
 		// The policy string is just a marshaled cloudresourcemanager.Policy.
 		// Unmarshal it to a struct.
 		var policy cloudresourcemanager.Policy
@@ -116,6 +108,7 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	d.SetId(project)
 
 	// Confirm the project exists.
 	// TODO(evanbrown): Support project creation
@@ -141,10 +134,10 @@ func resourceGoogleProjectUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Policy has changed
-	if ok := d.HasChange("policy"); ok {
+	if ok := d.HasChange("policy_data"); ok {
 		// The policy string is just a marshaled cloudresourcemanager.Policy.
 		// Unmarshal it to a struct that contains the old and new policies
-		oldP, newP := d.GetChange("policy")
+		oldP, newP := d.GetChange("policy_data")
 		oldPString := oldP.(string)
 		newPString := newP.(string)
 

--- a/builtin/providers/google/resource_google_project_test.go
+++ b/builtin/providers/google/resource_google_project_test.go
@@ -133,9 +133,9 @@ func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes string, or
 
 		var projectP, policyP cloudresourcemanager.Policy
 		// The project should have a policy
-		ps, ok := project.Primary.Attributes["policy"]
+		ps, ok := project.Primary.Attributes["policy_data"]
 		if !ok {
-			return fmt.Errorf("Project resource %q did not have a 'policy' attribute", project.Primary.ID)
+			return fmt.Errorf("Project resource %q did not have a 'policy_data' attribute. Attributes were %#v", project.Primary.Attributes["id"], project.Primary.Attributes)
 		}
 		if err := json.Unmarshal([]byte(ps), &projectP); err != nil {
 			return err
@@ -146,9 +146,9 @@ func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes string, or
 		if !ok {
 			return fmt.Errorf("Not found: %s", policyRes)
 		}
-		ps, ok = policy.Primary.Attributes["policy"]
+		ps, ok = policy.Primary.Attributes["policy_data"]
 		if !ok {
-			return fmt.Errorf("Policy resource %q did not have a 'policy' attribute", policy.Primary.ID)
+			return fmt.Errorf("Data policy resource %q did not have a 'policy_data' attribute. Attributes were %#v", policy.Primary.Attributes["id"], project.Primary.Attributes)
 		}
 		if err := json.Unmarshal([]byte(ps), &policyP); err != nil {
 			return err
@@ -158,7 +158,6 @@ func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes string, or
 		if !reflect.DeepEqual(derefBindings(projectP.Bindings), derefBindings(policyP.Bindings)) {
 			return fmt.Errorf("Project and data source policies do not match: project policy is %+v, data resource policy is  %+v", derefBindings(projectP.Bindings), derefBindings(policyP.Bindings))
 		}
-		return nil
 
 		// Merge the project policy in Terrafomr state with the policy the project had before the config was applied
 		expected := make([]*cloudresourcemanager.Binding, 0)
@@ -446,13 +445,13 @@ func (b Binding) Less(i, j int) bool {
 
 var testAccGoogleProject_basic = `
 resource "google_project" "acceptance" {
-    project = "%v"
+    id = "%v"
 }`
 
 var testAccGoogleProject_policy1 = `
 resource "google_project" "acceptance" {
-    project = "%v"
-	policy = "${data.google_iam_policy.admin.policy}"
+    id = "%v"
+    policy_data = "${data.google_iam_policy.admin.policy_data}"
 }
 
 data "google_iam_policy" "admin" {

--- a/builtin/providers/google/resource_google_project_test.go
+++ b/builtin/providers/google/resource_google_project_test.go
@@ -1,25 +1,186 @@
 package google
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"
 )
 
-type Binding []*cloudresourcemanager.Binding
+var (
+	projectId = multiEnvSearch([]string{
+		"GOOGLE_PROJECT",
+		"GCLOUD_PROJECT",
+		"CLOUDSDK_CORE_PROJECT",
+	})
+)
 
-func (b Binding) Len() int {
-	return len(b)
+func multiEnvSearch(ks []string) string {
+	for _, k := range ks {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
-func (b Binding) Swap(i, j int) {
-	b[i], b[j] = b[j], b[i]
+// Test that a Project resource can be created and destroyed
+func TestAccGoogleProject_associate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccGoogleProject_basic, projectId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance"),
+				),
+			},
+		},
+	})
 }
 
-func (b Binding) Less(i, j int) bool {
-	return b[i].Role < b[j].Role
+// Test that a Project resource can be created, an IAM Policy
+// associated with it, and then destroyed
+func TestAccGoogleProject_iamPolicy1(t *testing.T) {
+	var policy *cloudresourcemanager.Policy
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGoogleProjectDestroy,
+		Steps: []resource.TestStep{
+			// First step inventories the project's existing IAM policy
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccGoogleProject_basic, projectId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(policy),
+				),
+			},
+			// Second step applies an IAM policy from a data source. The application
+			// merges policies, so we validate the expected state.
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccGoogleProject_policy1, projectId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance"),
+					testAccCheckGoogleProjectIamPolicyIsMerged("google_project.acceptance", "data.google_iam_policy.admin", policy),
+				),
+			},
+			// Finally, remove the custom IAM policy from config and apply, then
+			// confirm that the project is in its original state.
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccGoogleProject_basic, projectId),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleProjectDestroy(s *terraform.State) error {
+	return nil
+}
+
+// Retrieve the existing policy (if any) for a GCP Project
+func testAccGoogleProjectExistingPolicy(p *cloudresourcemanager.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		c := testAccProvider.Meta().(*Config)
+		var err error
+		p, err = getProjectIamPolicy(projectId, c)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve IAM Policy for project %q: %s", projectId, err)
+		}
+		if len(p.Bindings) == 0 {
+			return fmt.Errorf("Refuse to run test against project with zero IAM Bindings. This is likely an error in the test code that is not properly identifying the IAM policy of a project.")
+		}
+		return nil
+	}
+}
+
+func testAccCheckGoogleProjectExists(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmt.Errorf("Not found: %s", r)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if rs.Primary.ID != projectId {
+			return fmt.Errorf("Expected project %q to match ID %q in state", projectId, rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes string, original *cloudresourcemanager.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Get the project resource
+		project, ok := s.RootModule().Resources[projectRes]
+		if !ok {
+			return fmt.Errorf("Not found: %s", projectRes)
+		}
+		// The project ID should match the config's project ID
+		if project.Primary.ID != projectId {
+			return fmt.Errorf("Expected project %q to match ID %q in state", projectId, project.Primary.ID)
+		}
+
+		var projectP, policyP cloudresourcemanager.Policy
+		// The project should have a policy
+		ps, ok := project.Primary.Attributes["policy"]
+		if !ok {
+			return fmt.Errorf("Project resource %q did not have a 'policy' attribute", project.Primary.ID)
+		}
+		if err := json.Unmarshal([]byte(ps), &projectP); err != nil {
+			return err
+		}
+
+		// The data policy resource should have a policy
+		policy, ok := s.RootModule().Resources[policyRes]
+		if !ok {
+			return fmt.Errorf("Not found: %s", policyRes)
+		}
+		ps, ok = policy.Primary.Attributes["policy"]
+		if !ok {
+			return fmt.Errorf("Policy resource %q did not have a 'policy' attribute", policy.Primary.ID)
+		}
+		if err := json.Unmarshal([]byte(ps), &policyP); err != nil {
+			return err
+		}
+
+		// The bindings in both policies should be identical
+		if !reflect.DeepEqual(derefBindings(projectP.Bindings), derefBindings(policyP.Bindings)) {
+			return fmt.Errorf("Project and data source policies do not match: project policy is %+v, data resource policy is  %+v", derefBindings(projectP.Bindings), derefBindings(policyP.Bindings))
+		}
+		return nil
+
+		// Merge the project policy in Terrafomr state with the policy the project had before the config was applied
+		expected := make([]*cloudresourcemanager.Binding, 0)
+		expected = append(expected, original.Bindings...)
+		expected = append(expected, projectP.Bindings...)
+		expectedM := mergeBindings(expected)
+
+		// Retrieve the actual policy from the project
+		c := testAccProvider.Meta().(*Config)
+		actual, err := getProjectIamPolicy(projectId, c)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve IAM Policy for project %q: %s", projectId, err)
+		}
+		actualM := mergeBindings(actual.Bindings)
+
+		// The bindings should match, indicating the policy was successfully applied and merged
+		if !reflect.DeepEqual(derefBindings(actualM), derefBindings(expectedM)) {
+			return fmt.Errorf("Actual and expected project policies do not match: actual policy is %+v, expected policy is  %+v", derefBindings(actualM), derefBindings(expectedM))
+		}
+
+		return nil
+	}
 }
 
 func TestIamRolesToMembersBinding(t *testing.T) {
@@ -148,15 +309,6 @@ func TestIamRolesToMembersMap(t *testing.T) {
 	}
 }
 
-func derefBindings(b []*cloudresourcemanager.Binding) []cloudresourcemanager.Binding {
-	db := make([]cloudresourcemanager.Binding, len(b))
-
-	for i, v := range b {
-		db[i] = *v
-	}
-	return db
-}
-
 func TestIamMergeBindings(t *testing.T) {
 	table := []struct {
 		input  []*cloudresourcemanager.Binding
@@ -270,3 +422,52 @@ func TestIamMergeBindings(t *testing.T) {
 		}
 	}
 }
+
+func derefBindings(b []*cloudresourcemanager.Binding) []cloudresourcemanager.Binding {
+	db := make([]cloudresourcemanager.Binding, len(b))
+
+	for i, v := range b {
+		db[i] = *v
+	}
+	return db
+}
+
+type Binding []*cloudresourcemanager.Binding
+
+func (b Binding) Len() int {
+	return len(b)
+}
+func (b Binding) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+func (b Binding) Less(i, j int) bool {
+	return b[i].Role < b[j].Role
+}
+
+var testAccGoogleProject_basic = `
+resource "google_project" "acceptance" {
+    project = "%v"
+}`
+
+var testAccGoogleProject_policy1 = `
+resource "google_project" "acceptance" {
+    project = "%v"
+	policy = "${data.google_iam_policy.admin.policy}"
+}
+
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "user:evanbrown@google.com",
+    ]
+  }
+  binding {
+    role = "roles/compute.instanceAdmin"
+    members = [
+      "user:evanbrown@google.com",
+      "user:evandbrown@gmail.com",
+    ]
+  }
+
+}`

--- a/builtin/providers/google/resource_google_project_test.go
+++ b/builtin/providers/google/resource_google_project_test.go
@@ -1,0 +1,198 @@
+package google
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+type Binding []cloudresourcemanager.Binding
+
+func (b Binding) Len() int {
+	return len(b)
+}
+
+func (b Binding) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func (b Binding) Less(i, j int) bool {
+	return b[i].Role < b[j].Role
+}
+
+func TestIamMapRolesToMembers(t *testing.T) {
+	table := []struct {
+		input  []cloudresourcemanager.Binding
+		expect map[string]map[string]bool
+	}{
+		{
+			input: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+			},
+			expect: map[string]map[string]bool{
+				"role-1": map[string]bool{
+					"member-1": true,
+					"member-2": true,
+				},
+			},
+		},
+		{
+			input: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+						"member-1",
+						"member-2",
+					},
+				},
+			},
+			expect: map[string]map[string]bool{
+				"role-1": map[string]bool{
+					"member-1": true,
+					"member-2": true,
+				},
+			},
+		},
+		{
+			input: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+				},
+			},
+			expect: map[string]map[string]bool{
+				"role-1": map[string]bool{},
+			},
+		},
+	}
+
+	for _, test := range table {
+		got := mapRolesToMembers(test.input)
+		if !reflect.DeepEqual(got, test.expect) {
+			t.Errorf("got %+v, expected %+v", got, test.expect)
+		}
+	}
+}
+
+func TestIamMergeBindings(t *testing.T) {
+	table := []struct {
+		input  []cloudresourcemanager.Binding
+		expect []cloudresourcemanager.Binding
+	}{
+		{
+			input: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-3",
+					},
+				},
+			},
+			expect: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+						"member-3",
+					},
+				},
+			},
+		},
+		{
+			input: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-3",
+						"member-4",
+					},
+				},
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-2",
+						"member-1",
+					},
+				},
+				{
+					Role: "role-2",
+					Members: []string{
+						"member-1",
+					},
+				},
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-5",
+					},
+				},
+				{
+					Role: "role-3",
+					Members: []string{
+						"member-1",
+					},
+				},
+				{
+					Role: "role-2",
+					Members: []string{
+						"member-2",
+					},
+				},
+			},
+			expect: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+						"member-3",
+						"member-4",
+						"member-5",
+					},
+				},
+				{
+					Role: "role-2",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+				{
+					Role: "role-3",
+					Members: []string{
+						"member-1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range table {
+		got := mergeBindings(test.input)
+		sort.Sort(Binding(got))
+		for i, _ := range got {
+			sort.Strings(got[i].Members)
+		}
+
+		if !reflect.DeepEqual(got, test.expect) {
+			t.Errorf("\ngot %+v\nexpected %+v", got, test.expect)
+		}
+	}
+}

--- a/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-api.json
+++ b/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-api.json
@@ -1,0 +1,507 @@
+{
+ "kind": "discovery#restDescription",
+ "etag": "\"bRFOOrZKfO9LweMbPqu0kcu6De8/8EOgQpr1bAhvZ8Ay5woGZcfT03Y\"",
+ "discoveryVersion": "v1",
+ "id": "cloudresourcemanager:v1",
+ "name": "cloudresourcemanager",
+ "version": "v1",
+ "revision": "20160225",
+ "title": "Google Cloud Resource Manager API",
+ "description": "The Google Cloud Resource Manager API provides methods for creating, reading, and updating project metadata.",
+ "ownerDomain": "google.com",
+ "ownerName": "Google",
+ "icons": {
+  "x16": "http://www.google.com/images/icons/product/search-16.gif",
+  "x32": "http://www.google.com/images/icons/product/search-32.gif"
+ },
+ "documentationLink": "https://cloud.google.com/resource-manager",
+ "protocol": "rest",
+ "baseUrl": "https://cloudresourcemanager.googleapis.com/",
+ "basePath": "",
+ "rootUrl": "https://cloudresourcemanager.googleapis.com/",
+ "servicePath": "",
+ "batchPath": "batch",
+ "parameters": {
+  "access_token": {
+   "type": "string",
+   "description": "OAuth access token.",
+   "location": "query"
+  },
+  "alt": {
+   "type": "string",
+   "description": "Data format for response.",
+   "default": "json",
+   "enumDescriptions": [
+    "Responses with Content-Type of application/json",
+    "Media download with context-dependent Content-Type",
+    "Responses with Content-Type of application/x-protobuf"
+   ],
+   "location": "query"
+  },
+  "bearer_token": {
+   "type": "string",
+   "description": "OAuth bearer token.",
+   "location": "query"
+  },
+  "callback": {
+   "type": "string",
+   "description": "JSONP",
+   "location": "query"
+  },
+  "fields": {
+   "type": "string",
+   "description": "Selector specifying which fields to include in a partial response.",
+   "location": "query"
+  },
+  "key": {
+   "type": "string",
+   "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+   "location": "query"
+  },
+  "oauth_token": {
+   "type": "string",
+   "description": "OAuth 2.0 token for the current user.",
+   "location": "query"
+  },
+  "pp": {
+   "type": "boolean",
+   "description": "Pretty-print response.",
+   "default": "true",
+   "location": "query"
+  },
+  "prettyPrint": {
+   "type": "boolean",
+   "description": "Returns response with indentations and line breaks.",
+   "default": "true",
+   "location": "query"
+  },
+  "quotaUser": {
+   "type": "string",
+   "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+   "location": "query"
+  },
+  "upload_protocol": {
+   "type": "string",
+   "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+   "location": "query"
+  },
+  "uploadType": {
+   "type": "string",
+   "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+   "location": "query"
+  },
+  "$.xgafv": {
+   "type": "string",
+   "description": "V1 error format.",
+   "enumDescriptions": [
+    "v1 error format",
+    "v2 error format"
+   ],
+   "location": "query"
+  }
+ },
+ "auth": {
+  "oauth2": {
+   "scopes": {
+    "https://www.googleapis.com/auth/cloud-platform": {
+     "description": "View and manage your data across Google Cloud Platform services"
+    },
+    "https://www.googleapis.com/auth/cloud-platform.read-only": {
+     "description": "View your data across Google Cloud Platform services"
+    }
+   }
+  }
+ },
+ "schemas": {
+  "Project": {
+   "id": "Project",
+   "type": "object",
+   "description": "A Project is a high-level Google Cloud Platform entity. It is a container for ACLs, APIs, AppEngine Apps, VMs, and other Google Cloud Platform resources.",
+   "properties": {
+    "projectNumber": {
+     "type": "string",
+     "description": "The number uniquely identifying the project. Example: 415104041262 Read-only.",
+     "format": "int64"
+    },
+    "projectId": {
+     "type": "string",
+     "description": "The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: tokyo-rain-123 Read-only after creation."
+    },
+    "lifecycleState": {
+     "type": "string",
+     "description": "The Project lifecycle state. Read-only.",
+     "enum": [
+      "LIFECYCLE_STATE_UNSPECIFIED",
+      "ACTIVE",
+      "DELETE_REQUESTED",
+      "DELETE_IN_PROGRESS"
+     ]
+    },
+    "name": {
+     "type": "string",
+     "description": "The user-assigned name of the Project. It must be 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: My Project Read-write."
+    },
+    "createTime": {
+     "type": "string",
+     "description": "Creation time. Read-only."
+    },
+    "labels": {
+     "type": "object",
+     "description": "The labels associated with this Project. Label keys must be between 1 and 63 characters long and must conform to the following regular expression: \\[a-z\\](\\[-a-z0-9\\]*\\[a-z0-9\\])?. Label values must be between 0 and 63 characters long and must conform to the regular expression (\\[a-z\\](\\[-a-z0-9\\]*\\[a-z0-9\\])?)?. No more than 256 labels can be associated with a given resource. Clients should store labels in a representation such as JSON that does not depend on specific characters being disallowed. Example: \"environment\" : \"dev\" Read-write.",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "parent": {
+     "$ref": "ResourceId",
+     "description": "An optional reference to a parent Resource. The only supported parent type is \"organization\". Once set, the parent cannot be modified. Read-write."
+    }
+   }
+  },
+  "ResourceId": {
+   "id": "ResourceId",
+   "type": "object",
+   "description": "A container to reference an id for any resource type. A `resource` in Google Cloud Platform is a generic term for something you (a developer) may want to interact with through one of our API's. Some examples are an AppEngine app, a Compute Engine instance, a Cloud SQL database, and so on.",
+   "properties": {
+    "type": {
+     "type": "string",
+     "description": "Required field representing the resource type this id is for. At present, the only valid type is \"organization\"."
+    },
+    "id": {
+     "type": "string",
+     "description": "Required field for the type-specific id. This should correspond to the id used in the type-specific API's."
+    }
+   }
+  },
+  "ListProjectsResponse": {
+   "id": "ListProjectsResponse",
+   "type": "object",
+   "description": "A page of the response received from the ListProjects method. A paginated response where more pages are available has `next_page_token` set. This token can be used in a subsequent request to retrieve the next request page.",
+   "properties": {
+    "projects": {
+     "type": "array",
+     "description": "The list of Projects that matched the list filter. This list can be paginated.",
+     "items": {
+      "$ref": "Project"
+     }
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "Pagination token. If the result set is too large to fit in a single response, this token is returned. It encodes the position of the current result cursor. Feeding this value into a new list request with the `page_token` parameter gives the next page of the results. When `next_page_token` is not filled in, there is no next page and the list returned is the last page in the result set. Pagination tokens have a limited lifetime."
+    }
+   }
+  },
+  "Empty": {
+   "id": "Empty",
+   "type": "object",
+   "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); } The JSON representation for `Empty` is empty JSON object `{}`."
+  },
+  "UndeleteProjectRequest": {
+   "id": "UndeleteProjectRequest",
+   "type": "object",
+   "description": "The request sent to the UndeleteProject method."
+  },
+  "GetIamPolicyRequest": {
+   "id": "GetIamPolicyRequest",
+   "type": "object",
+   "description": "Request message for `GetIamPolicy` method."
+  },
+  "Policy": {
+   "id": "Policy",
+   "type": "object",
+   "description": "Defines an Identity and Access Management (IAM) policy. It is used to specify access control policies for Cloud Platform resources. A `Policy` consists of a list of `bindings`. A `Binding` binds a list of `members` to a `role`, where the members can be user accounts, Google groups, Google domains, and service accounts. A `role` is a named list of permissions defined by IAM. **Example** { \"bindings\": [ { \"role\": \"roles/owner\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-other-app@appspot.gserviceaccount.com\", ] }, { \"role\": \"roles/viewer\", \"members\": [\"user:sean@example.com\"] } ] } For a description of IAM and its features, see the [IAM developer's guide](https://cloud.google.com/iam).",
+   "properties": {
+    "version": {
+     "type": "integer",
+     "description": "Version of the `Policy`. The default version is 0.",
+     "format": "int32"
+    },
+    "bindings": {
+     "type": "array",
+     "description": "Associates a list of `members` to a `role`. Multiple `bindings` must not be specified for the same `role`. `bindings` with no members will result in an error.",
+     "items": {
+      "$ref": "Binding"
+     }
+    },
+    "etag": {
+     "type": "string",
+     "description": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. If no `etag` is provided in the call to `setIamPolicy`, then the existing policy is overwritten blindly.",
+     "format": "byte"
+    }
+   }
+  },
+  "Binding": {
+   "id": "Binding",
+   "type": "object",
+   "description": "Associates `members` with a `role`.",
+   "properties": {
+    "role": {
+     "type": "string",
+     "description": "Role that is assigned to `members`. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. Required"
+    },
+    "members": {
+     "type": "array",
+     "description": "Specifies the identities requesting access for a Cloud Platform resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@gmail.com` or `joe@example.com`. * `serviceAccount:{emailid}`: An email address that represents a service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: A Google Apps domain name that represents all the users of that domain. For example, `google.com` or `example.com`.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "SetIamPolicyRequest": {
+   "id": "SetIamPolicyRequest",
+   "type": "object",
+   "description": "Request message for `SetIamPolicy` method.",
+   "properties": {
+    "policy": {
+     "$ref": "Policy",
+     "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Cloud Platform services (such as Projects) might reject them."
+    }
+   }
+  },
+  "TestIamPermissionsRequest": {
+   "id": "TestIamPermissionsRequest",
+   "type": "object",
+   "description": "Request message for `TestIamPermissions` method.",
+   "properties": {
+    "permissions": {
+     "type": "array",
+     "description": "The set of permissions to check for the `resource`. Permissions with wildcards (such as '*' or 'storage.*') are not allowed. For more information see IAM Overview.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "TestIamPermissionsResponse": {
+   "id": "TestIamPermissionsResponse",
+   "type": "object",
+   "description": "Response message for `TestIamPermissions` method.",
+   "properties": {
+    "permissions": {
+     "type": "array",
+     "description": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  }
+ },
+ "resources": {
+  "projects": {
+   "methods": {
+    "get": {
+     "id": "cloudresourcemanager.projects.get",
+     "path": "v1/projects/{projectId}",
+     "httpMethod": "GET",
+     "description": "Retrieves the Project identified by the specified `project_id` (for example, `my-project-123`). The caller must have read permissions for this Project.",
+     "parameters": {
+      "projectId": {
+       "type": "string",
+       "description": "The Project ID (for example, `my-project-123`). Required.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "projectId"
+     ],
+     "response": {
+      "$ref": "Project"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only"
+     ]
+    },
+    "list": {
+     "id": "cloudresourcemanager.projects.list",
+     "path": "v1/projects",
+     "httpMethod": "GET",
+     "description": "Lists Projects that are visible to the user and satisfy the specified filter. This method returns Projects in an unspecified order. New Projects do not necessarily appear at the end of the list.",
+     "parameters": {
+      "pageToken": {
+       "type": "string",
+       "description": "A pagination token returned from a previous call to ListProjects that indicates from where listing should continue. Optional.",
+       "location": "query"
+      },
+      "pageSize": {
+       "type": "integer",
+       "description": "The maximum number of Projects to return in the response. The server can return fewer Projects than requested. If unspecified, server picks an appropriate default. Optional.",
+       "format": "int32",
+       "location": "query"
+      },
+      "filter": {
+       "type": "string",
+       "description": "An expression for filtering the results of the request. Filter rules are case insensitive. The fields eligible for filtering are: + `name` + `id` + labels.key where *key* is the name of a label Some examples of using labels as filters: |Filter|Description| |------|-----------| |name:*|The project has a name.| |name:Howl|The project's name is `Howl` or `howl`.| |name:HOWL|Equivalent to above.| |NAME:howl|Equivalent to above.| |labels.color:*|The project has the label `color`.| |labels.color:red|The project's label `color` has the value `red`.| |labels.color:red label.size:big|The project's label `color` has the value `red` and its label `size` has the value `big`. Optional.",
+       "location": "query"
+      }
+     },
+     "response": {
+      "$ref": "ListProjectsResponse"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only"
+     ]
+    },
+    "update": {
+     "id": "cloudresourcemanager.projects.update",
+     "path": "v1/projects/{projectId}",
+     "httpMethod": "PUT",
+     "description": "Updates the attributes of the Project identified by the specified `project_id` (for example, `my-project-123`). The caller must have modify permissions for this Project.",
+     "parameters": {
+      "projectId": {
+       "type": "string",
+       "description": "The project ID (for example, `my-project-123`). Required.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "projectId"
+     ],
+     "request": {
+      "$ref": "Project"
+     },
+     "response": {
+      "$ref": "Project"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform"
+     ]
+    },
+    "delete": {
+     "id": "cloudresourcemanager.projects.delete",
+     "path": "v1/projects/{projectId}",
+     "httpMethod": "DELETE",
+     "description": "Marks the Project identified by the specified `project_id` (for example, `my-project-123`) for deletion. This method will only affect the Project if the following criteria are met: + The Project does not have a billing account associated with it. + The Project has a lifecycle state of ACTIVE. This method changes the Project's lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts at an unspecified time, at which point the lifecycle state changes to DELETE_IN_PROGRESS. Until the deletion completes, you can check the lifecycle state checked by retrieving the Project with GetProject, and the Project remains visible to ListProjects. However, you cannot update the project. After the deletion completes, the Project is not retrievable by the GetProject and ListProjects methods. The caller must have modify permissions for this Project.",
+     "parameters": {
+      "projectId": {
+       "type": "string",
+       "description": "The Project ID (for example, `foo-bar-123`). Required.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "projectId"
+     ],
+     "response": {
+      "$ref": "Empty"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform"
+     ]
+    },
+    "undelete": {
+     "id": "cloudresourcemanager.projects.undelete",
+     "path": "v1/projects/{projectId}:undelete",
+     "httpMethod": "POST",
+     "description": "Restores the Project identified by the specified `project_id` (for example, `my-project-123`). You can only use this method for a Project that has a lifecycle state of DELETE_REQUESTED. After deletion starts, as indicated by a lifecycle state of DELETE_IN_PROGRESS, the Project cannot be restored. The caller must have modify permissions for this Project.",
+     "parameters": {
+      "projectId": {
+       "type": "string",
+       "description": "The project ID (for example, `foo-bar-123`). Required.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "projectId"
+     ],
+     "request": {
+      "$ref": "UndeleteProjectRequest"
+     },
+     "response": {
+      "$ref": "Empty"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform"
+     ]
+    },
+    "getIamPolicy": {
+     "id": "cloudresourcemanager.projects.getIamPolicy",
+     "path": "v1/projects/{resource}:getIamPolicy",
+     "httpMethod": "POST",
+     "description": "Returns the IAM access control policy for the specified Project. Permission is denied if the policy or the resource does not exist.",
+     "parameters": {
+      "resource": {
+       "type": "string",
+       "description": "REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "resource"
+     ],
+     "request": {
+      "$ref": "GetIamPolicyRequest"
+     },
+     "response": {
+      "$ref": "Policy"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only"
+     ]
+    },
+    "setIamPolicy": {
+     "id": "cloudresourcemanager.projects.setIamPolicy",
+     "path": "v1/projects/{resource}:setIamPolicy",
+     "httpMethod": "POST",
+     "description": "Sets the IAM access control policy for the specified Project. Replaces any existing policy. The following constraints apply when using `setIamPolicy()`: + Project currently supports only `user:{emailid}` and `serviceAccount:{emailid}` members in a `Binding` of a `Policy`. + To be added as an `owner`, a user must be invited via Cloud Platform console and must accept the invitation. + Members cannot be added to more than one role in the same policy. + There must be at least one owner who has accepted the Terms of Service (ToS) agreement in the policy. Calling `setIamPolicy()` to to remove the last ToS-accepted owner from the policy will fail. + Calling this method requires enabling the App Engine Admin API. Note: Removing service accounts from policies or changing their roles can render services completely inoperable. It is important to understand how the service account is being used before removing or updating its roles.",
+     "parameters": {
+      "resource": {
+       "type": "string",
+       "description": "REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "resource"
+     ],
+     "request": {
+      "$ref": "SetIamPolicyRequest"
+     },
+     "response": {
+      "$ref": "Policy"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform"
+     ]
+    },
+    "testIamPermissions": {
+     "id": "cloudresourcemanager.projects.testIamPermissions",
+     "path": "v1/projects/{resource}:testIamPermissions",
+     "httpMethod": "POST",
+     "description": "Returns permissions that a caller has on the specified Project.",
+     "parameters": {
+      "resource": {
+       "type": "string",
+       "description": "REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "resource"
+     ],
+     "request": {
+      "$ref": "TestIamPermissionsRequest"
+     },
+     "response": {
+      "$ref": "TestIamPermissionsResponse"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only"
+     ]
+    }
+   }
+  }
+ }
+}

--- a/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-gen.go
+++ b/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-gen.go
@@ -1,0 +1,1468 @@
+// Package cloudresourcemanager provides access to the Google Cloud Resource Manager API.
+//
+// See https://cloud.google.com/resource-manager
+//
+// Usage example:
+//
+//   import "google.golang.org/api/cloudresourcemanager/v1"
+//   ...
+//   cloudresourcemanagerService, err := cloudresourcemanager.New(oauthHttpClient)
+package cloudresourcemanager // import "google.golang.org/api/cloudresourcemanager/v1"
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	context "golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
+	gensupport "google.golang.org/api/gensupport"
+	googleapi "google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = gensupport.MarshalJSON
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Canceled
+var _ = ctxhttp.Do
+
+const apiId = "cloudresourcemanager:v1"
+const apiName = "cloudresourcemanager"
+const apiVersion = "v1"
+const basePath = "https://cloudresourcemanager.googleapis.com/"
+
+// OAuth2 scopes used by this API.
+const (
+	// View and manage your data across Google Cloud Platform services
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// View your data across Google Cloud Platform services
+	CloudPlatformReadOnlyScope = "https://www.googleapis.com/auth/cloud-platform.read-only"
+)
+
+func New(client *http.Client) (*Service, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &Service{client: client, BasePath: basePath}
+	s.Projects = NewProjectsService(s)
+	return s, nil
+}
+
+type Service struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	Projects *ProjectsService
+}
+
+func (s *Service) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewProjectsService(s *Service) *ProjectsService {
+	rs := &ProjectsService{s: s}
+	return rs
+}
+
+type ProjectsService struct {
+	s *Service
+}
+
+// Binding: Associates `members` with a `role`.
+type Binding struct {
+	// Members: Specifies the identities requesting access for a Cloud
+	// Platform resource. `members` can have the following values: *
+	// `allUsers`: A special identifier that represents anyone who is on the
+	// internet; with or without a Google account. *
+	// `allAuthenticatedUsers`: A special identifier that represents anyone
+	// who is authenticated with a Google account or a service account. *
+	// `user:{emailid}`: An email address that represents a specific Google
+	// account. For example, `alice@gmail.com` or `joe@example.com`. *
+	// `serviceAccount:{emailid}`: An email address that represents a
+	// service account. For example,
+	// `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An
+	// email address that represents a Google group. For example,
+	// `admins@example.com`. * `domain:{domain}`: A Google Apps domain name
+	// that represents all the users of that domain. For example,
+	// `google.com` or `example.com`.
+	Members []string `json:"members,omitempty"`
+
+	// Role: Role that is assigned to `members`. For example,
+	// `roles/viewer`, `roles/editor`, or `roles/owner`. Required
+	Role string `json:"role,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Members") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Binding) MarshalJSON() ([]byte, error) {
+	type noMethod Binding
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// Empty: A generic empty message that you can re-use to avoid defining
+// duplicated empty messages in your APIs. A typical example is to use
+// it as the request or the response type of an API method. For
+// instance: service Foo { rpc Bar(google.protobuf.Empty) returns
+// (google.protobuf.Empty); } The JSON representation for `Empty` is
+// empty JSON object `{}`.
+type Empty struct {
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+}
+
+// GetIamPolicyRequest: Request message for `GetIamPolicy` method.
+type GetIamPolicyRequest struct {
+}
+
+// ListProjectsResponse: A page of the response received from the
+// ListProjects method. A paginated response where more pages are
+// available has `next_page_token` set. This token can be used in a
+// subsequent request to retrieve the next request page.
+type ListProjectsResponse struct {
+	// NextPageToken: Pagination token. If the result set is too large to
+	// fit in a single response, this token is returned. It encodes the
+	// position of the current result cursor. Feeding this value into a new
+	// list request with the `page_token` parameter gives the next page of
+	// the results. When `next_page_token` is not filled in, there is no
+	// next page and the list returned is the last page in the result set.
+	// Pagination tokens have a limited lifetime.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// Projects: The list of Projects that matched the list filter. This
+	// list can be paginated.
+	Projects []*Project `json:"projects,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "NextPageToken") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *ListProjectsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListProjectsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// Policy: Defines an Identity and Access Management (IAM) policy. It is
+// used to specify access control policies for Cloud Platform resources.
+// A `Policy` consists of a list of `bindings`. A `Binding` binds a list
+// of `members` to a `role`, where the members can be user accounts,
+// Google groups, Google domains, and service accounts. A `role` is a
+// named list of permissions defined by IAM. **Example** { "bindings": [
+// { "role": "roles/owner", "members": [ "user:mike@example.com",
+// "group:admins@example.com", "domain:google.com",
+// "serviceAccount:my-other-app@appspot.gserviceaccount.com", ] }, {
+// "role": "roles/viewer", "members": ["user:sean@example.com"] } ] }
+// For a description of IAM and its features, see the [IAM developer's
+// guide](https://cloud.google.com/iam).
+type Policy struct {
+	// Bindings: Associates a list of `members` to a `role`. Multiple
+	// `bindings` must not be specified for the same `role`. `bindings` with
+	// no members will result in an error.
+	Bindings []*Binding `json:"bindings,omitempty"`
+
+	// Etag: `etag` is used for optimistic concurrency control as a way to
+	// help prevent simultaneous updates of a policy from overwriting each
+	// other. It is strongly suggested that systems make use of the `etag`
+	// in the read-modify-write cycle to perform policy updates in order to
+	// avoid race conditions: An `etag` is returned in the response to
+	// `getIamPolicy`, and systems are expected to put that etag in the
+	// request to `setIamPolicy` to ensure that their change will be applied
+	// to the same version of the policy. If no `etag` is provided in the
+	// call to `setIamPolicy`, then the existing policy is overwritten
+	// blindly.
+	Etag string `json:"etag,omitempty"`
+
+	// Version: Version of the `Policy`. The default version is 0.
+	Version int64 `json:"version,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Bindings") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Policy) MarshalJSON() ([]byte, error) {
+	type noMethod Policy
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// Project: A Project is a high-level Google Cloud Platform entity. It
+// is a container for ACLs, APIs, AppEngine Apps, VMs, and other Google
+// Cloud Platform resources.
+type Project struct {
+	// CreateTime: Creation time. Read-only.
+	CreateTime string `json:"createTime,omitempty"`
+
+	// Labels: The labels associated with this Project. Label keys must be
+	// between 1 and 63 characters long and must conform to the following
+	// regular expression: \[a-z\](\[-a-z0-9\]*\[a-z0-9\])?. Label values
+	// must be between 0 and 63 characters long and must conform to the
+	// regular expression (\[a-z\](\[-a-z0-9\]*\[a-z0-9\])?)?. No more than
+	// 256 labels can be associated with a given resource. Clients should
+	// store labels in a representation such as JSON that does not depend on
+	// specific characters being disallowed. Example: "environment" : "dev"
+	// Read-write.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// LifecycleState: The Project lifecycle state. Read-only.
+	//
+	// Possible values:
+	//   "LIFECYCLE_STATE_UNSPECIFIED"
+	//   "ACTIVE"
+	//   "DELETE_REQUESTED"
+	//   "DELETE_IN_PROGRESS"
+	LifecycleState string `json:"lifecycleState,omitempty"`
+
+	// Name: The user-assigned name of the Project. It must be 4 to 30
+	// characters. Allowed characters are: lowercase and uppercase letters,
+	// numbers, hyphen, single-quote, double-quote, space, and exclamation
+	// point. Example: My Project Read-write.
+	Name string `json:"name,omitempty"`
+
+	// Parent: An optional reference to a parent Resource. The only
+	// supported parent type is "organization". Once set, the parent cannot
+	// be modified. Read-write.
+	Parent *ResourceId `json:"parent,omitempty"`
+
+	// ProjectId: The unique, user-assigned ID of the Project. It must be 6
+	// to 30 lowercase letters, digits, or hyphens. It must start with a
+	// letter. Trailing hyphens are prohibited. Example: tokyo-rain-123
+	// Read-only after creation.
+	ProjectId string `json:"projectId,omitempty"`
+
+	// ProjectNumber: The number uniquely identifying the project. Example:
+	// 415104041262 Read-only.
+	ProjectNumber int64 `json:"projectNumber,omitempty,string"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "CreateTime") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Project) MarshalJSON() ([]byte, error) {
+	type noMethod Project
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// ResourceId: A container to reference an id for any resource type. A
+// `resource` in Google Cloud Platform is a generic term for something
+// you (a developer) may want to interact with through one of our API's.
+// Some examples are an AppEngine app, a Compute Engine instance, a
+// Cloud SQL database, and so on.
+type ResourceId struct {
+	// Id: Required field for the type-specific id. This should correspond
+	// to the id used in the type-specific API's.
+	Id string `json:"id,omitempty"`
+
+	// Type: Required field representing the resource type this id is for.
+	// At present, the only valid type is "organization".
+	Type string `json:"type,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Id") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *ResourceId) MarshalJSON() ([]byte, error) {
+	type noMethod ResourceId
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// SetIamPolicyRequest: Request message for `SetIamPolicy` method.
+type SetIamPolicyRequest struct {
+	// Policy: REQUIRED: The complete policy to be applied to the
+	// `resource`. The size of the policy is limited to a few 10s of KB. An
+	// empty policy is a valid policy but certain Cloud Platform services
+	// (such as Projects) might reject them.
+	Policy *Policy `json:"policy,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Policy") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SetIamPolicyRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SetIamPolicyRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// TestIamPermissionsRequest: Request message for `TestIamPermissions`
+// method.
+type TestIamPermissionsRequest struct {
+	// Permissions: The set of permissions to check for the `resource`.
+	// Permissions with wildcards (such as '*' or 'storage.*') are not
+	// allowed. For more information see IAM Overview.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsRequest) MarshalJSON() ([]byte, error) {
+	type noMethod TestIamPermissionsRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// TestIamPermissionsResponse: Response message for `TestIamPermissions`
+// method.
+type TestIamPermissionsResponse struct {
+	// Permissions: A subset of `TestPermissionsRequest.permissions` that
+	// the caller is allowed.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod TestIamPermissionsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// UndeleteProjectRequest: The request sent to the UndeleteProject
+// method.
+type UndeleteProjectRequest struct {
+}
+
+// method id "cloudresourcemanager.projects.delete":
+
+type ProjectsDeleteCall struct {
+	s          *Service
+	projectId  string
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+}
+
+// Delete: Marks the Project identified by the specified `project_id`
+// (for example, `my-project-123`) for deletion. This method will only
+// affect the Project if the following criteria are met: + The Project
+// does not have a billing account associated with it. + The Project has
+// a lifecycle state of ACTIVE. This method changes the Project's
+// lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts
+// at an unspecified time, at which point the lifecycle state changes to
+// DELETE_IN_PROGRESS. Until the deletion completes, you can check the
+// lifecycle state checked by retrieving the Project with GetProject,
+// and the Project remains visible to ListProjects. However, you cannot
+// update the project. After the deletion completes, the Project is not
+// retrievable by the GetProject and ListProjects methods. The caller
+// must have modify permissions for this Project.
+func (r *ProjectsService) Delete(projectId string) *ProjectsDeleteCall {
+	c := &ProjectsDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsDeleteCall) Fields(s ...googleapi.Field) *ProjectsDeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsDeleteCall) Context(ctx context.Context) *ProjectsDeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsDeleteCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.delete" call.
+// Exactly one of *Empty or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Empty.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsDeleteCall) Do(opts ...googleapi.CallOption) (*Empty, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Empty{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Marks the Project identified by the specified `project_id` (for example, `my-project-123`) for deletion. This method will only affect the Project if the following criteria are met: + The Project does not have a billing account associated with it. + The Project has a lifecycle state of ACTIVE. This method changes the Project's lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts at an unspecified time, at which point the lifecycle state changes to DELETE_IN_PROGRESS. Until the deletion completes, you can check the lifecycle state checked by retrieving the Project with GetProject, and the Project remains visible to ListProjects. However, you cannot update the project. After the deletion completes, the Project is not retrievable by the GetProject and ListProjects methods. The caller must have modify permissions for this Project.",
+	//   "httpMethod": "DELETE",
+	//   "id": "cloudresourcemanager.projects.delete",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "projectId": {
+	//       "description": "The Project ID (for example, `foo-bar-123`). Required.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}",
+	//   "response": {
+	//     "$ref": "Empty"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "cloudresourcemanager.projects.get":
+
+type ProjectsGetCall struct {
+	s            *Service
+	projectId    string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// Get: Retrieves the Project identified by the specified `project_id`
+// (for example, `my-project-123`). The caller must have read
+// permissions for this Project.
+func (r *ProjectsService) Get(projectId string) *ProjectsGetCall {
+	c := &ProjectsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsGetCall) Fields(s ...googleapi.Field) *ProjectsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsGetCall) IfNoneMatch(entityTag string) *ProjectsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsGetCall) Context(ctx context.Context) *ProjectsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsGetCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.get" call.
+// Exactly one of *Project or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Project.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsGetCall) Do(opts ...googleapi.CallOption) (*Project, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Project{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves the Project identified by the specified `project_id` (for example, `my-project-123`). The caller must have read permissions for this Project.",
+	//   "httpMethod": "GET",
+	//   "id": "cloudresourcemanager.projects.get",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "projectId": {
+	//       "description": "The Project ID (for example, `my-project-123`). Required.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}",
+	//   "response": {
+	//     "$ref": "Project"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only"
+	//   ]
+	// }
+
+}
+
+// method id "cloudresourcemanager.projects.getIamPolicy":
+
+type ProjectsGetIamPolicyCall struct {
+	s                   *Service
+	resource            string
+	getiampolicyrequest *GetIamPolicyRequest
+	urlParams_          gensupport.URLParams
+	ctx_                context.Context
+}
+
+// GetIamPolicy: Returns the IAM access control policy for the specified
+// Project. Permission is denied if the policy or the resource does not
+// exist.
+func (r *ProjectsService) GetIamPolicy(resource string, getiampolicyrequest *GetIamPolicyRequest) *ProjectsGetIamPolicyCall {
+	c := &ProjectsGetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.getiampolicyrequest = getiampolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsGetIamPolicyCall) Fields(s ...googleapi.Field) *ProjectsGetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsGetIamPolicyCall) Context(ctx context.Context) *ProjectsGetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsGetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.getiampolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{resource}:getIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.getIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsGetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns the IAM access control policy for the specified Project. Permission is denied if the policy or the resource does not exist.",
+	//   "httpMethod": "POST",
+	//   "id": "cloudresourcemanager.projects.getIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{resource}:getIamPolicy",
+	//   "request": {
+	//     "$ref": "GetIamPolicyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only"
+	//   ]
+	// }
+
+}
+
+// method id "cloudresourcemanager.projects.list":
+
+type ProjectsListCall struct {
+	s            *Service
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// List: Lists Projects that are visible to the user and satisfy the
+// specified filter. This method returns Projects in an unspecified
+// order. New Projects do not necessarily appear at the end of the list.
+func (r *ProjectsService) List() *ProjectsListCall {
+	c := &ProjectsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	return c
+}
+
+// Filter sets the optional parameter "filter": An expression for
+// filtering the results of the request. Filter rules are case
+// insensitive. The fields eligible for filtering are: + `name` + `id` +
+// labels.key where *key* is the name of a label Some examples of using
+// labels as filters: |Filter|Description| |------|-----------|
+// |name:*|The project has a name.| |name:Howl|The project's name is
+// `Howl` or `howl`.| |name:HOWL|Equivalent to above.|
+// |NAME:howl|Equivalent to above.| |labels.color:*|The project has the
+// label `color`.| |labels.color:red|The project's label `color` has the
+// value `red`.| |labels.color:red label.size:big|The project's label
+// `color` has the value `red` and its label `size` has the value `big`.
+func (c *ProjectsListCall) Filter(filter string) *ProjectsListCall {
+	c.urlParams_.Set("filter", filter)
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": The maximum number
+// of Projects to return in the response. The server can return fewer
+// Projects than requested. If unspecified, server picks an appropriate
+// default.
+func (c *ProjectsListCall) PageSize(pageSize int64) *ProjectsListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": A pagination token
+// returned from a previous call to ListProjects that indicates from
+// where listing should continue.
+func (c *ProjectsListCall) PageToken(pageToken string) *ProjectsListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsListCall) Fields(s ...googleapi.Field) *ProjectsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsListCall) IfNoneMatch(entityTag string) *ProjectsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsListCall) Context(ctx context.Context) *ProjectsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsListCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.SetOpaque(req.URL)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.list" call.
+// Exactly one of *ListProjectsResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListProjectsResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsListCall) Do(opts ...googleapi.CallOption) (*ListProjectsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListProjectsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists Projects that are visible to the user and satisfy the specified filter. This method returns Projects in an unspecified order. New Projects do not necessarily appear at the end of the list.",
+	//   "httpMethod": "GET",
+	//   "id": "cloudresourcemanager.projects.list",
+	//   "parameters": {
+	//     "filter": {
+	//       "description": "An expression for filtering the results of the request. Filter rules are case insensitive. The fields eligible for filtering are: + `name` + `id` + labels.key where *key* is the name of a label Some examples of using labels as filters: |Filter|Description| |------|-----------| |name:*|The project has a name.| |name:Howl|The project's name is `Howl` or `howl`.| |name:HOWL|Equivalent to above.| |NAME:howl|Equivalent to above.| |labels.color:*|The project has the label `color`.| |labels.color:red|The project's label `color` has the value `red`.| |labels.color:red label.size:big|The project's label `color` has the value `red` and its label `size` has the value `big`. Optional.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "The maximum number of Projects to return in the response. The server can return fewer Projects than requested. If unspecified, server picks an appropriate default. Optional.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "A pagination token returned from a previous call to ListProjects that indicates from where listing should continue. Optional.",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects",
+	//   "response": {
+	//     "$ref": "ListProjectsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsListCall) Pages(ctx context.Context, f func(*ListProjectsResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "cloudresourcemanager.projects.setIamPolicy":
+
+type ProjectsSetIamPolicyCall struct {
+	s                   *Service
+	resource            string
+	setiampolicyrequest *SetIamPolicyRequest
+	urlParams_          gensupport.URLParams
+	ctx_                context.Context
+}
+
+// SetIamPolicy: Sets the IAM access control policy for the specified
+// Project. Replaces any existing policy. The following constraints
+// apply when using `setIamPolicy()`: + Project currently supports only
+// `user:{emailid}` and `serviceAccount:{emailid}` members in a
+// `Binding` of a `Policy`. + To be added as an `owner`, a user must be
+// invited via Cloud Platform console and must accept the invitation. +
+// Members cannot be added to more than one role in the same policy. +
+// There must be at least one owner who has accepted the Terms of
+// Service (ToS) agreement in the policy. Calling `setIamPolicy()` to to
+// remove the last ToS-accepted owner from the policy will fail. +
+// Calling this method requires enabling the App Engine Admin API. Note:
+// Removing service accounts from policies or changing their roles can
+// render services completely inoperable. It is important to understand
+// how the service account is being used before removing or updating its
+// roles.
+func (r *ProjectsService) SetIamPolicy(resource string, setiampolicyrequest *SetIamPolicyRequest) *ProjectsSetIamPolicyCall {
+	c := &ProjectsSetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.setiampolicyrequest = setiampolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsSetIamPolicyCall) Fields(s ...googleapi.Field) *ProjectsSetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsSetIamPolicyCall) Context(ctx context.Context) *ProjectsSetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsSetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.setiampolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{resource}:setIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.setIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsSetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Sets the IAM access control policy for the specified Project. Replaces any existing policy. The following constraints apply when using `setIamPolicy()`: + Project currently supports only `user:{emailid}` and `serviceAccount:{emailid}` members in a `Binding` of a `Policy`. + To be added as an `owner`, a user must be invited via Cloud Platform console and must accept the invitation. + Members cannot be added to more than one role in the same policy. + There must be at least one owner who has accepted the Terms of Service (ToS) agreement in the policy. Calling `setIamPolicy()` to to remove the last ToS-accepted owner from the policy will fail. + Calling this method requires enabling the App Engine Admin API. Note: Removing service accounts from policies or changing their roles can render services completely inoperable. It is important to understand how the service account is being used before removing or updating its roles.",
+	//   "httpMethod": "POST",
+	//   "id": "cloudresourcemanager.projects.setIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{resource}:setIamPolicy",
+	//   "request": {
+	//     "$ref": "SetIamPolicyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "cloudresourcemanager.projects.testIamPermissions":
+
+type ProjectsTestIamPermissionsCall struct {
+	s                         *Service
+	resource                  string
+	testiampermissionsrequest *TestIamPermissionsRequest
+	urlParams_                gensupport.URLParams
+	ctx_                      context.Context
+}
+
+// TestIamPermissions: Returns permissions that a caller has on the
+// specified Project.
+func (r *ProjectsService) TestIamPermissions(resource string, testiampermissionsrequest *TestIamPermissionsRequest) *ProjectsTestIamPermissionsCall {
+	c := &ProjectsTestIamPermissionsCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.testiampermissionsrequest = testiampermissionsrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsTestIamPermissionsCall) Fields(s ...googleapi.Field) *ProjectsTestIamPermissionsCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsTestIamPermissionsCall) Context(ctx context.Context) *ProjectsTestIamPermissionsCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsTestIamPermissionsCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.testiampermissionsrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{resource}:testIamPermissions")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.testIamPermissions" call.
+// Exactly one of *TestIamPermissionsResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *TestIamPermissionsResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsTestIamPermissionsCall) Do(opts ...googleapi.CallOption) (*TestIamPermissionsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &TestIamPermissionsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns permissions that a caller has on the specified Project.",
+	//   "httpMethod": "POST",
+	//   "id": "cloudresourcemanager.projects.testIamPermissions",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{resource}:testIamPermissions",
+	//   "request": {
+	//     "$ref": "TestIamPermissionsRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "TestIamPermissionsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only"
+	//   ]
+	// }
+
+}
+
+// method id "cloudresourcemanager.projects.undelete":
+
+type ProjectsUndeleteCall struct {
+	s                      *Service
+	projectId              string
+	undeleteprojectrequest *UndeleteProjectRequest
+	urlParams_             gensupport.URLParams
+	ctx_                   context.Context
+}
+
+// Undelete: Restores the Project identified by the specified
+// `project_id` (for example, `my-project-123`). You can only use this
+// method for a Project that has a lifecycle state of DELETE_REQUESTED.
+// After deletion starts, as indicated by a lifecycle state of
+// DELETE_IN_PROGRESS, the Project cannot be restored. The caller must
+// have modify permissions for this Project.
+func (r *ProjectsService) Undelete(projectId string, undeleteprojectrequest *UndeleteProjectRequest) *ProjectsUndeleteCall {
+	c := &ProjectsUndeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.undeleteprojectrequest = undeleteprojectrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsUndeleteCall) Fields(s ...googleapi.Field) *ProjectsUndeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsUndeleteCall) Context(ctx context.Context) *ProjectsUndeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsUndeleteCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.undeleteprojectrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}:undelete")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.undelete" call.
+// Exactly one of *Empty or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Empty.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsUndeleteCall) Do(opts ...googleapi.CallOption) (*Empty, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Empty{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Restores the Project identified by the specified `project_id` (for example, `my-project-123`). You can only use this method for a Project that has a lifecycle state of DELETE_REQUESTED. After deletion starts, as indicated by a lifecycle state of DELETE_IN_PROGRESS, the Project cannot be restored. The caller must have modify permissions for this Project.",
+	//   "httpMethod": "POST",
+	//   "id": "cloudresourcemanager.projects.undelete",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "projectId": {
+	//       "description": "The project ID (for example, `foo-bar-123`). Required.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}:undelete",
+	//   "request": {
+	//     "$ref": "UndeleteProjectRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Empty"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "cloudresourcemanager.projects.update":
+
+type ProjectsUpdateCall struct {
+	s          *Service
+	projectId  string
+	project    *Project
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+}
+
+// Update: Updates the attributes of the Project identified by the
+// specified `project_id` (for example, `my-project-123`). The caller
+// must have modify permissions for this Project.
+func (r *ProjectsService) Update(projectId string, project *Project) *ProjectsUpdateCall {
+	c := &ProjectsUpdateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.project = project
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsUpdateCall) Fields(s ...googleapi.Field) *ProjectsUpdateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsUpdateCall) Context(ctx context.Context) *ProjectsUpdateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsUpdateCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.project)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "cloudresourcemanager.projects.update" call.
+// Exactly one of *Project or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Project.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsUpdateCall) Do(opts ...googleapi.CallOption) (*Project, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Project{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates the attributes of the Project identified by the specified `project_id` (for example, `my-project-123`). The caller must have modify permissions for this Project.",
+	//   "httpMethod": "PUT",
+	//   "id": "cloudresourcemanager.projects.update",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "projectId": {
+	//       "description": "The project ID (for example, `my-project-123`). Required.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}",
+	//   "request": {
+	//     "$ref": "Project"
+	//   },
+	//   "response": {
+	//     "$ref": "Project"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}

--- a/vendor/google.golang.org/api/iam/v1/iam-api.json
+++ b/vendor/google.golang.org/api/iam/v1/iam-api.json
@@ -1,0 +1,891 @@
+{
+ "kind": "discovery#restDescription",
+ "etag": "\"bRFOOrZKfO9LweMbPqu0kcu6De8/KGIJuBPLol6TqL9arf5YOmp-wQ0\"",
+ "discoveryVersion": "v1",
+ "id": "iam:v1",
+ "name": "iam",
+ "version": "v1",
+ "revision": "20160129",
+ "title": "Google Identity and Access Management API",
+ "description": "Manages identity and access control for Google Cloud Platform resources, including the creation of service accounts, which you can use to authenticate to Google and make API calls.",
+ "ownerDomain": "google.com",
+ "ownerName": "Google",
+ "icons": {
+  "x16": "http://www.google.com/images/icons/product/search-16.gif",
+  "x32": "http://www.google.com/images/icons/product/search-32.gif"
+ },
+ "documentationLink": "https://cloud.google.com/iam/",
+ "protocol": "rest",
+ "baseUrl": "https://iam.googleapis.com/",
+ "basePath": "",
+ "rootUrl": "https://iam.googleapis.com/",
+ "servicePath": "",
+ "batchPath": "batch",
+ "version_module": true,
+ "parameters": {
+  "access_token": {
+   "type": "string",
+   "description": "OAuth access token.",
+   "location": "query"
+  },
+  "alt": {
+   "type": "string",
+   "description": "Data format for response.",
+   "default": "json",
+   "enumDescriptions": [
+    "Responses with Content-Type of application/json",
+    "Media download with context-dependent Content-Type",
+    "Responses with Content-Type of application/x-protobuf"
+   ],
+   "location": "query"
+  },
+  "bearer_token": {
+   "type": "string",
+   "description": "OAuth bearer token.",
+   "location": "query"
+  },
+  "callback": {
+   "type": "string",
+   "description": "JSONP",
+   "location": "query"
+  },
+  "fields": {
+   "type": "string",
+   "description": "Selector specifying which fields to include in a partial response.",
+   "location": "query"
+  },
+  "key": {
+   "type": "string",
+   "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+   "location": "query"
+  },
+  "oauth_token": {
+   "type": "string",
+   "description": "OAuth 2.0 token for the current user.",
+   "location": "query"
+  },
+  "pp": {
+   "type": "boolean",
+   "description": "Pretty-print response.",
+   "default": "true",
+   "location": "query"
+  },
+  "prettyPrint": {
+   "type": "boolean",
+   "description": "Returns response with indentations and line breaks.",
+   "default": "true",
+   "location": "query"
+  },
+  "quotaUser": {
+   "type": "string",
+   "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+   "location": "query"
+  },
+  "upload_protocol": {
+   "type": "string",
+   "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+   "location": "query"
+  },
+  "uploadType": {
+   "type": "string",
+   "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+   "location": "query"
+  },
+  "$.xgafv": {
+   "type": "string",
+   "description": "V1 error format.",
+   "enumDescriptions": [
+    "v1 error format",
+    "v2 error format"
+   ],
+   "location": "query"
+  }
+ },
+ "auth": {
+  "oauth2": {
+   "scopes": {
+    "https://www.googleapis.com/auth/cloud-platform": {
+     "description": "View and manage your data across Google Cloud Platform services"
+    }
+   }
+  }
+ },
+ "schemas": {
+  "ListServiceAccountsResponse": {
+   "id": "ListServiceAccountsResponse",
+   "type": "object",
+   "description": "The service account list response.",
+   "properties": {
+    "accounts": {
+     "type": "array",
+     "description": "The list of matching service accounts.",
+     "items": {
+      "$ref": "ServiceAccount"
+     }
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "To retrieve the next page of results, set [ListServiceAccountsRequest.page_token] to this value."
+    }
+   }
+  },
+  "ServiceAccount": {
+   "id": "ServiceAccount",
+   "type": "object",
+   "description": "A service account in the Identity and Access Management API. To create a service account, you specify the project_id and account_id for the account. The account_id is unique within the project, and used to generate the service account email address and a stable unique id. All other methods can identify accounts using the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". In requests using '-' as a wildcard for the project, will infer the project from the account and the account value can be the email address or the unique_id of the service account. In responses the resource name will always be in the format \"projects/{project}/serviceAccounts/{email}\"."
+    },
+    "projectId": {
+     "type": "string",
+     "description": "@OutputOnly The id of the project that owns the service account."
+    },
+    "uniqueId": {
+     "type": "string",
+     "description": "@OutputOnly unique and stable id of the service account."
+    },
+    "email": {
+     "type": "string",
+     "description": "@OutputOnly Email address of the service account."
+    },
+    "displayName": {
+     "type": "string",
+     "description": "Optional. A user-specified description of the service account. Must be fewer than 100 UTF-8 bytes."
+    },
+    "etag": {
+     "type": "string",
+     "description": "Used to perform a consistent read-modify-write.",
+     "format": "byte"
+    },
+    "oauth2ClientId": {
+     "type": "string",
+     "description": "@OutputOnly. The OAuth2 client id for the service account. This is used in conjunction with the OAuth2 clientconfig API to make three legged OAuth2 (3LO) flows to access the data of Google users."
+    }
+   }
+  },
+  "CreateServiceAccountRequest": {
+   "id": "CreateServiceAccountRequest",
+   "type": "object",
+   "description": "The service account create request.",
+   "properties": {
+    "accountId": {
+     "type": "string",
+     "description": "Required. The account id that is used to generate the service account email address and a stable unique id. It is unique within a project, must be 1-63 characters long, and match the regular expression [a-z]([-a-z0-9]*[a-z0-9]) to comply with RFC1035."
+    },
+    "serviceAccount": {
+     "$ref": "ServiceAccount",
+     "description": "The ServiceAccount resource to create. Currently, only the following values are user assignable: display_name ."
+    }
+   }
+  },
+  "Empty": {
+   "id": "Empty",
+   "type": "object",
+   "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); } The JSON representation for `Empty` is empty JSON object `{}`."
+  },
+  "ListServiceAccountKeysResponse": {
+   "id": "ListServiceAccountKeysResponse",
+   "type": "object",
+   "description": "The service account keys list response.",
+   "properties": {
+    "keys": {
+     "type": "array",
+     "description": "The public keys for the service account.",
+     "items": {
+      "$ref": "ServiceAccountKey"
+     }
+    }
+   }
+  },
+  "ServiceAccountKey": {
+   "id": "ServiceAccountKey",
+   "type": "object",
+   "description": "Represents a service account key. A service account can have 0 or more key pairs. The private keys for these are not stored by Google. ServiceAccountKeys are immutable.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "The resource name of the service account key in the format \"projects/{project}/serviceAccounts/{email}/keys/{key}\"."
+    },
+    "privateKeyType": {
+     "type": "string",
+     "description": "The type of the private key.",
+     "enum": [
+      "TYPE_UNSPECIFIED",
+      "TYPE_PKCS12_FILE",
+      "TYPE_GOOGLE_CREDENTIALS_FILE"
+     ]
+    },
+    "privateKeyData": {
+     "type": "string",
+     "description": "The key data.",
+     "format": "byte"
+    },
+    "validAfterTime": {
+     "type": "string",
+     "description": "The key can be used after this timestamp."
+    },
+    "validBeforeTime": {
+     "type": "string",
+     "description": "The key can be used before this timestamp."
+    }
+   }
+  },
+  "CreateServiceAccountKeyRequest": {
+   "id": "CreateServiceAccountKeyRequest",
+   "type": "object",
+   "description": "The service account key create request.",
+   "properties": {
+    "privateKeyType": {
+     "type": "string",
+     "description": "The type of the key requested. GOOGLE_CREDENTIALS is the default key type.",
+     "enum": [
+      "TYPE_UNSPECIFIED",
+      "TYPE_PKCS12_FILE",
+      "TYPE_GOOGLE_CREDENTIALS_FILE"
+     ]
+    }
+   }
+  },
+  "SignBlobRequest": {
+   "id": "SignBlobRequest",
+   "type": "object",
+   "description": "The service account sign blob request.",
+   "properties": {
+    "bytesToSign": {
+     "type": "string",
+     "description": "The bytes to sign",
+     "format": "byte"
+    }
+   }
+  },
+  "SignBlobResponse": {
+   "id": "SignBlobResponse",
+   "type": "object",
+   "description": "The service account sign blob response.",
+   "properties": {
+    "keyId": {
+     "type": "string",
+     "description": "The id of the key used to sign the blob."
+    },
+    "signature": {
+     "type": "string",
+     "description": "The signed blob.",
+     "format": "byte"
+    }
+   }
+  },
+  "Policy": {
+   "id": "Policy",
+   "type": "object",
+   "description": "Defines an Identity and Access Management (IAM) policy. It is used to specify access control policies for Cloud Platform resources. A `Policy` consists of a list of `bindings`. A `Binding` binds a list of `members` to a `role`, where the members can be user accounts, Google groups, Google domains, and service accounts. A `role` is a named list of permissions defined by IAM. **Example** { \"bindings\": [ { \"role\": \"roles/owner\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-other-app@appspot.gserviceaccount.com\"] }, { \"role\": \"roles/viewer\", \"members\": [\"user:sean@example.com\"] } ] } For a description of IAM and its features, see the [IAM developer's guide](https://cloud.google.com/iam).",
+   "properties": {
+    "version": {
+     "type": "integer",
+     "description": "Version of the `Policy`. The default version is 0.",
+     "format": "int32"
+    },
+    "bindings": {
+     "type": "array",
+     "description": "Associates a list of `members` to a `role`. Multiple `bindings` must not be specified for the same `role`. `bindings` with no members will result in an error.",
+     "items": {
+      "$ref": "Binding"
+     }
+    },
+    "rules": {
+     "type": "array",
+     "items": {
+      "$ref": "Rule"
+     }
+    },
+    "etag": {
+     "type": "string",
+     "description": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. If no `etag` is provided in the call to `setIamPolicy`, then the existing policy is overwritten blindly.",
+     "format": "byte"
+    }
+   }
+  },
+  "Binding": {
+   "id": "Binding",
+   "type": "object",
+   "description": "Associates `members` with a `role`.",
+   "properties": {
+    "role": {
+     "type": "string",
+     "description": "Role that is assigned to `members`. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. Required"
+    },
+    "members": {
+     "type": "array",
+     "description": "Specifies the identities requesting access for a Cloud Platform resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@gmail.com` or `joe@example.com`. * `serviceAccount:{emailid}`: An email address that represents a service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: A Google Apps domain name that represents all the users of that domain. For example, `google.com` or `example.com`.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "Rule": {
+   "id": "Rule",
+   "type": "object",
+   "description": "A rule to be applied in a Policy.",
+   "properties": {
+    "description": {
+     "type": "string",
+     "description": "Human-readable description of the rule."
+    },
+    "permissions": {
+     "type": "array",
+     "description": "A permission is a string of form '..' (e.g., 'storage.buckets.list'). A value of '*' matches all permissions, and a verb part of '*' (e.g., 'storage.buckets.*') matches all verbs.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "action": {
+     "type": "string",
+     "description": "Required",
+     "enum": [
+      "NO_ACTION",
+      "ALLOW",
+      "ALLOW_WITH_LOG",
+      "DENY",
+      "DENY_WITH_LOG",
+      "LOG"
+     ]
+    },
+    "in": {
+     "type": "array",
+     "description": "The rule matches if the PRINCIPAL/AUTHORITY_SELECTOR is in this set of entries.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "notIn": {
+     "type": "array",
+     "description": "The rule matches if the PRINCIPAL/AUTHORITY_SELECTOR is not in this set of entries. The format for in and not_in entries is the same as for members in a Binding (see google/iam/v1/policy.proto).",
+     "items": {
+      "type": "string"
+     }
+    },
+    "conditions": {
+     "type": "array",
+     "description": "Additional restrictions that must be met",
+     "items": {
+      "$ref": "Condition"
+     }
+    },
+    "logConfig": {
+     "type": "array",
+     "description": "The config returned to callers of tech.iam.IAM.CheckPolicy for any entries that match the LOG action.",
+     "items": {
+      "$ref": "LogConfig"
+     }
+    }
+   }
+  },
+  "Condition": {
+   "id": "Condition",
+   "type": "object",
+   "description": "A condition to be met.",
+   "properties": {
+    "iam": {
+     "type": "string",
+     "description": "Trusted attributes supplied by the IAM system.",
+     "enum": [
+      "NO_ATTR",
+      "AUTHORITY",
+      "ATTRIBUTION"
+     ]
+    },
+    "sys": {
+     "type": "string",
+     "description": "Trusted attributes supplied by any service that owns resources and uses the IAM system for access control.",
+     "enum": [
+      "NO_ATTR",
+      "REGION",
+      "SERVICE",
+      "NAME",
+      "IP"
+     ]
+    },
+    "svc": {
+     "type": "string",
+     "description": "Trusted attributes discharged by the service."
+    },
+    "op": {
+     "type": "string",
+     "description": "An operator to apply the subject with.",
+     "enum": [
+      "NO_OP",
+      "EQUALS",
+      "NOT_EQUALS",
+      "IN",
+      "NOT_IN",
+      "DISCHARGED"
+     ]
+    },
+    "value": {
+     "type": "string",
+     "description": "The object of the condition. Exactly one of these must be set."
+    },
+    "values": {
+     "type": "array",
+     "description": "The objects of the condition. This is mutually exclusive with 'value'.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "LogConfig": {
+   "id": "LogConfig",
+   "type": "object",
+   "description": "Specifies what kind of log the caller must write Increment a streamz counter with the specified metric and field names. Metric names should start with a '/', generally be lowercase-only, and end in \"_count\". Field names should not contain an initial slash. The actual exported metric names will have \"/iam/policy\" prepended. Field names correspond to IAM request parameters and field values are their respective values. At present only \"iam_principal\", corresponding to IAMContext.principal, is supported. Examples: counter { metric: \"/debug_access_count\" field: \"iam_principal\" } ==\u003e increment counter /iam/policy/backend_debug_access_count {iam_principal=[value of IAMContext.principal]} At this time we do not support: * multiple field names (though this may be supported in the future) * decrementing the counter * incrementing it by anything other than 1",
+   "properties": {
+    "counter": {
+     "$ref": "CounterOptions",
+     "description": "Counter options."
+    },
+    "dataAccess": {
+     "$ref": "DataAccessOptions",
+     "description": "Data access options."
+    },
+    "cloudAudit": {
+     "$ref": "CloudAuditOptions",
+     "description": "Cloud audit options."
+    }
+   }
+  },
+  "CounterOptions": {
+   "id": "CounterOptions",
+   "type": "object",
+   "description": "Options for counters",
+   "properties": {
+    "metric": {
+     "type": "string",
+     "description": "The metric to update."
+    },
+    "field": {
+     "type": "string",
+     "description": "The field value to attribute."
+    }
+   }
+  },
+  "DataAccessOptions": {
+   "id": "DataAccessOptions",
+   "type": "object",
+   "description": "Write a Data Access (Gin) log"
+  },
+  "CloudAuditOptions": {
+   "id": "CloudAuditOptions",
+   "type": "object",
+   "description": "Write a Cloud Audit log"
+  },
+  "SetIamPolicyRequest": {
+   "id": "SetIamPolicyRequest",
+   "type": "object",
+   "description": "Request message for `SetIamPolicy` method.",
+   "properties": {
+    "policy": {
+     "$ref": "Policy",
+     "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Cloud Platform services (such as Projects) might reject them."
+    }
+   }
+  },
+  "TestIamPermissionsRequest": {
+   "id": "TestIamPermissionsRequest",
+   "type": "object",
+   "description": "Request message for `TestIamPermissions` method.",
+   "properties": {
+    "permissions": {
+     "type": "array",
+     "description": "The set of permissions to check for the `resource`. Permissions with wildcards (such as '*' or 'storage.*') are not allowed. For more information see IAM Overview.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "TestIamPermissionsResponse": {
+   "id": "TestIamPermissionsResponse",
+   "type": "object",
+   "description": "Response message for `TestIamPermissions` method.",
+   "properties": {
+    "permissions": {
+     "type": "array",
+     "description": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  }
+ },
+ "resources": {
+  "projects": {
+   "resources": {
+    "serviceAccounts": {
+     "methods": {
+      "list": {
+       "id": "iam.projects.serviceAccounts.list",
+       "path": "v1/{+name}/serviceAccounts",
+       "httpMethod": "GET",
+       "description": "Lists service accounts for a project.",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "Required. The resource name of the project associated with the service accounts, such as \"projects/123\"",
+         "required": true,
+         "pattern": "^projects/[^/]*$",
+         "location": "path"
+        },
+        "pageSize": {
+         "type": "integer",
+         "description": "Optional limit on the number of service accounts to include in the response. Further accounts can subsequently be obtained by including the [ListServiceAccountsResponse.next_page_token] in a subsequent request.",
+         "format": "int32",
+         "location": "query"
+        },
+        "pageToken": {
+         "type": "string",
+         "description": "Optional pagination token returned in an earlier [ListServiceAccountsResponse.next_page_token].",
+         "location": "query"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "response": {
+        "$ref": "ListServiceAccountsResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "get": {
+       "id": "iam.projects.serviceAccounts.get",
+       "path": "v1/{+name}",
+       "httpMethod": "GET",
+       "description": "Gets a ServiceAccount",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+         "required": true,
+         "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "response": {
+        "$ref": "ServiceAccount"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "create": {
+       "id": "iam.projects.serviceAccounts.create",
+       "path": "v1/{+name}/serviceAccounts",
+       "httpMethod": "POST",
+       "description": "Creates a service account and returns it.",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "Required. The resource name of the project associated with the service accounts, such as \"projects/123\"",
+         "required": true,
+         "pattern": "^projects/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "request": {
+        "$ref": "CreateServiceAccountRequest"
+       },
+       "response": {
+        "$ref": "ServiceAccount"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "update": {
+       "id": "iam.projects.serviceAccounts.update",
+       "path": "v1/{+name}",
+       "httpMethod": "PUT",
+       "description": "Updates a service account. Currently, only the following fields are updatable: 'display_name' . The 'etag' is mandatory.",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". In requests using '-' as a wildcard for the project, will infer the project from the account and the account value can be the email address or the unique_id of the service account. In responses the resource name will always be in the format \"projects/{project}/serviceAccounts/{email}\".",
+         "required": true,
+         "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "request": {
+        "$ref": "ServiceAccount"
+       },
+       "response": {
+        "$ref": "ServiceAccount"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "delete": {
+       "id": "iam.projects.serviceAccounts.delete",
+       "path": "v1/{+name}",
+       "httpMethod": "DELETE",
+       "description": "Deletes a service acount.",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+         "required": true,
+         "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "response": {
+        "$ref": "Empty"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "signBlob": {
+       "id": "iam.projects.serviceAccounts.signBlob",
+       "path": "v1/{+name}:signBlob",
+       "httpMethod": "POST",
+       "description": "Signs a blob using a service account.",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+         "required": true,
+         "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "request": {
+        "$ref": "SignBlobRequest"
+       },
+       "response": {
+        "$ref": "SignBlobResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "getIamPolicy": {
+       "id": "iam.projects.serviceAccounts.getIamPolicy",
+       "path": "v1/{+resource}:getIamPolicy",
+       "httpMethod": "POST",
+       "description": "Returns the IAM access control policy for specified IAM resource.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "response": {
+        "$ref": "Policy"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "setIamPolicy": {
+       "id": "iam.projects.serviceAccounts.setIamPolicy",
+       "path": "v1/{+resource}:setIamPolicy",
+       "httpMethod": "POST",
+       "description": "Sets the IAM access control policy for the specified IAM resource.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "request": {
+        "$ref": "SetIamPolicyRequest"
+       },
+       "response": {
+        "$ref": "Policy"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      },
+      "testIamPermissions": {
+       "id": "iam.projects.serviceAccounts.testIamPermissions",
+       "path": "v1/{+resource}:testIamPermissions",
+       "httpMethod": "POST",
+       "description": "Tests the specified permissions against the IAM access control policy for the specified IAM resource.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "request": {
+        "$ref": "TestIamPermissionsRequest"
+       },
+       "response": {
+        "$ref": "TestIamPermissionsResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+       ]
+      }
+     },
+     "resources": {
+      "keys": {
+       "methods": {
+        "list": {
+         "id": "iam.projects.serviceAccounts.keys.list",
+         "path": "v1/{+name}/keys",
+         "httpMethod": "GET",
+         "description": "Lists service account keys",
+         "parameters": {
+          "name": {
+           "type": "string",
+           "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+           "required": true,
+           "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+           "location": "path"
+          },
+          "keyTypes": {
+           "type": "string",
+           "description": "The type of keys the user wants to list. If empty, all key types are included in the response. Duplicate key types are not allowed.",
+           "enum": [
+            "KEY_TYPE_UNSPECIFIED",
+            "USER_MANAGED",
+            "SYSTEM_MANAGED"
+           ],
+           "repeated": true,
+           "location": "query"
+          }
+         },
+         "parameterOrder": [
+          "name"
+         ],
+         "response": {
+          "$ref": "ListServiceAccountKeysResponse"
+         },
+         "scopes": [
+          "https://www.googleapis.com/auth/cloud-platform"
+         ]
+        },
+        "get": {
+         "id": "iam.projects.serviceAccounts.keys.get",
+         "path": "v1/{+name}",
+         "httpMethod": "GET",
+         "description": "Gets the ServiceAccountKey by key id.",
+         "parameters": {
+          "name": {
+           "type": "string",
+           "description": "The resource name of the service account key in the format \"projects/{project}/serviceAccounts/{account}/keys/{key}\". Using '-' as a wildcard for the project will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+           "required": true,
+           "pattern": "^projects/[^/]*/serviceAccounts/[^/]*/keys/[^/]*$",
+           "location": "path"
+          }
+         },
+         "parameterOrder": [
+          "name"
+         ],
+         "response": {
+          "$ref": "ServiceAccountKey"
+         },
+         "scopes": [
+          "https://www.googleapis.com/auth/cloud-platform"
+         ]
+        },
+        "create": {
+         "id": "iam.projects.serviceAccounts.keys.create",
+         "path": "v1/{+name}/keys",
+         "httpMethod": "POST",
+         "description": "Creates a service account key and returns it.",
+         "parameters": {
+          "name": {
+           "type": "string",
+           "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+           "required": true,
+           "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+           "location": "path"
+          }
+         },
+         "parameterOrder": [
+          "name"
+         ],
+         "request": {
+          "$ref": "CreateServiceAccountKeyRequest"
+         },
+         "response": {
+          "$ref": "ServiceAccountKey"
+         },
+         "scopes": [
+          "https://www.googleapis.com/auth/cloud-platform"
+         ]
+        },
+        "delete": {
+         "id": "iam.projects.serviceAccounts.keys.delete",
+         "path": "v1/{+name}",
+         "httpMethod": "DELETE",
+         "description": "Deletes a service account key.",
+         "parameters": {
+          "name": {
+           "type": "string",
+           "description": "The resource name of the service account key in the format \"projects/{project}/serviceAccounts/{account}/keys/{key}\". Using '-' as a wildcard for the project will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+           "required": true,
+           "pattern": "^projects/[^/]*/serviceAccounts/[^/]*/keys/[^/]*$",
+           "location": "path"
+          }
+         },
+         "parameterOrder": [
+          "name"
+         ],
+         "response": {
+          "$ref": "Empty"
+         },
+         "scopes": [
+          "https://www.googleapis.com/auth/cloud-platform"
+         ]
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/vendor/google.golang.org/api/iam/v1/iam-gen.go
+++ b/vendor/google.golang.org/api/iam/v1/iam-gen.go
@@ -1,0 +1,2365 @@
+// Package iam provides access to the Google Identity and Access Management API.
+//
+// See https://cloud.google.com/iam/
+//
+// Usage example:
+//
+//   import "google.golang.org/api/iam/v1"
+//   ...
+//   iamService, err := iam.New(oauthHttpClient)
+package iam // import "google.golang.org/api/iam/v1"
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	context "golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
+	gensupport "google.golang.org/api/gensupport"
+	googleapi "google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = gensupport.MarshalJSON
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Canceled
+var _ = ctxhttp.Do
+
+const apiId = "iam:v1"
+const apiName = "iam"
+const apiVersion = "v1"
+const basePath = "https://iam.googleapis.com/"
+
+// OAuth2 scopes used by this API.
+const (
+	// View and manage your data across Google Cloud Platform services
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+)
+
+func New(client *http.Client) (*Service, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &Service{client: client, BasePath: basePath}
+	s.Projects = NewProjectsService(s)
+	return s, nil
+}
+
+type Service struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	Projects *ProjectsService
+}
+
+func (s *Service) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewProjectsService(s *Service) *ProjectsService {
+	rs := &ProjectsService{s: s}
+	rs.ServiceAccounts = NewProjectsServiceAccountsService(s)
+	return rs
+}
+
+type ProjectsService struct {
+	s *Service
+
+	ServiceAccounts *ProjectsServiceAccountsService
+}
+
+func NewProjectsServiceAccountsService(s *Service) *ProjectsServiceAccountsService {
+	rs := &ProjectsServiceAccountsService{s: s}
+	rs.Keys = NewProjectsServiceAccountsKeysService(s)
+	return rs
+}
+
+type ProjectsServiceAccountsService struct {
+	s *Service
+
+	Keys *ProjectsServiceAccountsKeysService
+}
+
+func NewProjectsServiceAccountsKeysService(s *Service) *ProjectsServiceAccountsKeysService {
+	rs := &ProjectsServiceAccountsKeysService{s: s}
+	return rs
+}
+
+type ProjectsServiceAccountsKeysService struct {
+	s *Service
+}
+
+// Binding: Associates `members` with a `role`.
+type Binding struct {
+	// Members: Specifies the identities requesting access for a Cloud
+	// Platform resource. `members` can have the following values: *
+	// `allUsers`: A special identifier that represents anyone who is on the
+	// internet; with or without a Google account. *
+	// `allAuthenticatedUsers`: A special identifier that represents anyone
+	// who is authenticated with a Google account or a service account. *
+	// `user:{emailid}`: An email address that represents a specific Google
+	// account. For example, `alice@gmail.com` or `joe@example.com`. *
+	// `serviceAccount:{emailid}`: An email address that represents a
+	// service account. For example,
+	// `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An
+	// email address that represents a Google group. For example,
+	// `admins@example.com`. * `domain:{domain}`: A Google Apps domain name
+	// that represents all the users of that domain. For example,
+	// `google.com` or `example.com`.
+	Members []string `json:"members,omitempty"`
+
+	// Role: Role that is assigned to `members`. For example,
+	// `roles/viewer`, `roles/editor`, or `roles/owner`. Required
+	Role string `json:"role,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Members") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Binding) MarshalJSON() ([]byte, error) {
+	type noMethod Binding
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// CloudAuditOptions: Write a Cloud Audit log
+type CloudAuditOptions struct {
+}
+
+// Condition: A condition to be met.
+type Condition struct {
+	// Iam: Trusted attributes supplied by the IAM system.
+	//
+	// Possible values:
+	//   "NO_ATTR"
+	//   "AUTHORITY"
+	//   "ATTRIBUTION"
+	Iam string `json:"iam,omitempty"`
+
+	// Op: An operator to apply the subject with.
+	//
+	// Possible values:
+	//   "NO_OP"
+	//   "EQUALS"
+	//   "NOT_EQUALS"
+	//   "IN"
+	//   "NOT_IN"
+	//   "DISCHARGED"
+	Op string `json:"op,omitempty"`
+
+	// Svc: Trusted attributes discharged by the service.
+	Svc string `json:"svc,omitempty"`
+
+	// Sys: Trusted attributes supplied by any service that owns resources
+	// and uses the IAM system for access control.
+	//
+	// Possible values:
+	//   "NO_ATTR"
+	//   "REGION"
+	//   "SERVICE"
+	//   "NAME"
+	//   "IP"
+	Sys string `json:"sys,omitempty"`
+
+	// Value: The object of the condition. Exactly one of these must be set.
+	Value string `json:"value,omitempty"`
+
+	// Values: The objects of the condition. This is mutually exclusive with
+	// 'value'.
+	Values []string `json:"values,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Iam") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Condition) MarshalJSON() ([]byte, error) {
+	type noMethod Condition
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// CounterOptions: Options for counters
+type CounterOptions struct {
+	// Field: The field value to attribute.
+	Field string `json:"field,omitempty"`
+
+	// Metric: The metric to update.
+	Metric string `json:"metric,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Field") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *CounterOptions) MarshalJSON() ([]byte, error) {
+	type noMethod CounterOptions
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// CreateServiceAccountKeyRequest: The service account key create
+// request.
+type CreateServiceAccountKeyRequest struct {
+	// PrivateKeyType: The type of the key requested. GOOGLE_CREDENTIALS is
+	// the default key type.
+	//
+	// Possible values:
+	//   "TYPE_UNSPECIFIED"
+	//   "TYPE_PKCS12_FILE"
+	//   "TYPE_GOOGLE_CREDENTIALS_FILE"
+	PrivateKeyType string `json:"privateKeyType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "PrivateKeyType") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *CreateServiceAccountKeyRequest) MarshalJSON() ([]byte, error) {
+	type noMethod CreateServiceAccountKeyRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// CreateServiceAccountRequest: The service account create request.
+type CreateServiceAccountRequest struct {
+	// AccountId: Required. The account id that is used to generate the
+	// service account email address and a stable unique id. It is unique
+	// within a project, must be 1-63 characters long, and match the regular
+	// expression [a-z]([-a-z0-9]*[a-z0-9]) to comply with RFC1035.
+	AccountId string `json:"accountId,omitempty"`
+
+	// ServiceAccount: The ServiceAccount resource to create. Currently,
+	// only the following values are user assignable: display_name .
+	ServiceAccount *ServiceAccount `json:"serviceAccount,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "AccountId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *CreateServiceAccountRequest) MarshalJSON() ([]byte, error) {
+	type noMethod CreateServiceAccountRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// DataAccessOptions: Write a Data Access (Gin) log
+type DataAccessOptions struct {
+}
+
+// Empty: A generic empty message that you can re-use to avoid defining
+// duplicated empty messages in your APIs. A typical example is to use
+// it as the request or the response type of an API method. For
+// instance: service Foo { rpc Bar(google.protobuf.Empty) returns
+// (google.protobuf.Empty); } The JSON representation for `Empty` is
+// empty JSON object `{}`.
+type Empty struct {
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+}
+
+// ListServiceAccountKeysResponse: The service account keys list
+// response.
+type ListServiceAccountKeysResponse struct {
+	// Keys: The public keys for the service account.
+	Keys []*ServiceAccountKey `json:"keys,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Keys") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *ListServiceAccountKeysResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListServiceAccountKeysResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// ListServiceAccountsResponse: The service account list response.
+type ListServiceAccountsResponse struct {
+	// Accounts: The list of matching service accounts.
+	Accounts []*ServiceAccount `json:"accounts,omitempty"`
+
+	// NextPageToken: To retrieve the next page of results, set
+	// [ListServiceAccountsRequest.page_token] to this value.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Accounts") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *ListServiceAccountsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListServiceAccountsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// LogConfig: Specifies what kind of log the caller must write Increment
+// a streamz counter with the specified metric and field names. Metric
+// names should start with a '/', generally be lowercase-only, and end
+// in "_count". Field names should not contain an initial slash. The
+// actual exported metric names will have "/iam/policy" prepended. Field
+// names correspond to IAM request parameters and field values are their
+// respective values. At present only "iam_principal", corresponding to
+// IAMContext.principal, is supported. Examples: counter { metric:
+// "/debug_access_count" field: "iam_principal" } ==> increment counter
+// /iam/policy/backend_debug_access_count {iam_principal=[value of
+// IAMContext.principal]} At this time we do not support: * multiple
+// field names (though this may be supported in the future) *
+// decrementing the counter * incrementing it by anything other than 1
+type LogConfig struct {
+	// CloudAudit: Cloud audit options.
+	CloudAudit *CloudAuditOptions `json:"cloudAudit,omitempty"`
+
+	// Counter: Counter options.
+	Counter *CounterOptions `json:"counter,omitempty"`
+
+	// DataAccess: Data access options.
+	DataAccess *DataAccessOptions `json:"dataAccess,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CloudAudit") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *LogConfig) MarshalJSON() ([]byte, error) {
+	type noMethod LogConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// Policy: Defines an Identity and Access Management (IAM) policy. It is
+// used to specify access control policies for Cloud Platform resources.
+// A `Policy` consists of a list of `bindings`. A `Binding` binds a list
+// of `members` to a `role`, where the members can be user accounts,
+// Google groups, Google domains, and service accounts. A `role` is a
+// named list of permissions defined by IAM. **Example** { "bindings": [
+// { "role": "roles/owner", "members": [ "user:mike@example.com",
+// "group:admins@example.com", "domain:google.com",
+// "serviceAccount:my-other-app@appspot.gserviceaccount.com"] }, {
+// "role": "roles/viewer", "members": ["user:sean@example.com"] } ] }
+// For a description of IAM and its features, see the [IAM developer's
+// guide](https://cloud.google.com/iam).
+type Policy struct {
+	// Bindings: Associates a list of `members` to a `role`. Multiple
+	// `bindings` must not be specified for the same `role`. `bindings` with
+	// no members will result in an error.
+	Bindings []*Binding `json:"bindings,omitempty"`
+
+	// Etag: `etag` is used for optimistic concurrency control as a way to
+	// help prevent simultaneous updates of a policy from overwriting each
+	// other. It is strongly suggested that systems make use of the `etag`
+	// in the read-modify-write cycle to perform policy updates in order to
+	// avoid race conditions: An `etag` is returned in the response to
+	// `getIamPolicy`, and systems are expected to put that etag in the
+	// request to `setIamPolicy` to ensure that their change will be applied
+	// to the same version of the policy. If no `etag` is provided in the
+	// call to `setIamPolicy`, then the existing policy is overwritten
+	// blindly.
+	Etag string `json:"etag,omitempty"`
+
+	Rules []*Rule `json:"rules,omitempty"`
+
+	// Version: Version of the `Policy`. The default version is 0.
+	Version int64 `json:"version,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Bindings") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Policy) MarshalJSON() ([]byte, error) {
+	type noMethod Policy
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// Rule: A rule to be applied in a Policy.
+type Rule struct {
+	// Action: Required
+	//
+	// Possible values:
+	//   "NO_ACTION"
+	//   "ALLOW"
+	//   "ALLOW_WITH_LOG"
+	//   "DENY"
+	//   "DENY_WITH_LOG"
+	//   "LOG"
+	Action string `json:"action,omitempty"`
+
+	// Conditions: Additional restrictions that must be met
+	Conditions []*Condition `json:"conditions,omitempty"`
+
+	// Description: Human-readable description of the rule.
+	Description string `json:"description,omitempty"`
+
+	// In: The rule matches if the PRINCIPAL/AUTHORITY_SELECTOR is in this
+	// set of entries.
+	In []string `json:"in,omitempty"`
+
+	// LogConfig: The config returned to callers of tech.iam.IAM.CheckPolicy
+	// for any entries that match the LOG action.
+	LogConfig []*LogConfig `json:"logConfig,omitempty"`
+
+	// NotIn: The rule matches if the PRINCIPAL/AUTHORITY_SELECTOR is not in
+	// this set of entries. The format for in and not_in entries is the same
+	// as for members in a Binding (see google/iam/v1/policy.proto).
+	NotIn []string `json:"notIn,omitempty"`
+
+	// Permissions: A permission is a string of form '..' (e.g.,
+	// 'storage.buckets.list'). A value of '*' matches all permissions, and
+	// a verb part of '*' (e.g., 'storage.buckets.*') matches all verbs.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Action") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *Rule) MarshalJSON() ([]byte, error) {
+	type noMethod Rule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// ServiceAccount: A service account in the Identity and Access
+// Management API. To create a service account, you specify the
+// project_id and account_id for the account. The account_id is unique
+// within the project, and used to generate the service account email
+// address and a stable unique id. All other methods can identify
+// accounts using the format
+// "projects/{project}/serviceAccounts/{account}". Using '-' as a
+// wildcard for the project, will infer the project from the account.
+// The account value can be the email address or the unique_id of the
+// service account.
+type ServiceAccount struct {
+	// DisplayName: Optional. A user-specified description of the service
+	// account. Must be fewer than 100 UTF-8 bytes.
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Email: @OutputOnly Email address of the service account.
+	Email string `json:"email,omitempty"`
+
+	// Etag: Used to perform a consistent read-modify-write.
+	Etag string `json:"etag,omitempty"`
+
+	// Name: The resource name of the service account in the format
+	// "projects/{project}/serviceAccounts/{account}". In requests using '-'
+	// as a wildcard for the project, will infer the project from the
+	// account and the account value can be the email address or the
+	// unique_id of the service account. In responses the resource name will
+	// always be in the format "projects/{project}/serviceAccounts/{email}".
+	Name string `json:"name,omitempty"`
+
+	// Oauth2ClientId: @OutputOnly. The OAuth2 client id for the service
+	// account. This is used in conjunction with the OAuth2 clientconfig API
+	// to make three legged OAuth2 (3LO) flows to access the data of Google
+	// users.
+	Oauth2ClientId string `json:"oauth2ClientId,omitempty"`
+
+	// ProjectId: @OutputOnly The id of the project that owns the service
+	// account.
+	ProjectId string `json:"projectId,omitempty"`
+
+	// UniqueId: @OutputOnly unique and stable id of the service account.
+	UniqueId string `json:"uniqueId,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "DisplayName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *ServiceAccount) MarshalJSON() ([]byte, error) {
+	type noMethod ServiceAccount
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// ServiceAccountKey: Represents a service account key. A service
+// account can have 0 or more key pairs. The private keys for these are
+// not stored by Google. ServiceAccountKeys are immutable.
+type ServiceAccountKey struct {
+	// Name: The resource name of the service account key in the format
+	// "projects/{project}/serviceAccounts/{email}/keys/{key}".
+	Name string `json:"name,omitempty"`
+
+	// PrivateKeyData: The key data.
+	PrivateKeyData string `json:"privateKeyData,omitempty"`
+
+	// PrivateKeyType: The type of the private key.
+	//
+	// Possible values:
+	//   "TYPE_UNSPECIFIED"
+	//   "TYPE_PKCS12_FILE"
+	//   "TYPE_GOOGLE_CREDENTIALS_FILE"
+	PrivateKeyType string `json:"privateKeyType,omitempty"`
+
+	// ValidAfterTime: The key can be used after this timestamp.
+	ValidAfterTime string `json:"validAfterTime,omitempty"`
+
+	// ValidBeforeTime: The key can be used before this timestamp.
+	ValidBeforeTime string `json:"validBeforeTime,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *ServiceAccountKey) MarshalJSON() ([]byte, error) {
+	type noMethod ServiceAccountKey
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// SetIamPolicyRequest: Request message for `SetIamPolicy` method.
+type SetIamPolicyRequest struct {
+	// Policy: REQUIRED: The complete policy to be applied to the
+	// `resource`. The size of the policy is limited to a few 10s of KB. An
+	// empty policy is a valid policy but certain Cloud Platform services
+	// (such as Projects) might reject them.
+	Policy *Policy `json:"policy,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Policy") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SetIamPolicyRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SetIamPolicyRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// SignBlobRequest: The service account sign blob request.
+type SignBlobRequest struct {
+	// BytesToSign: The bytes to sign
+	BytesToSign string `json:"bytesToSign,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "BytesToSign") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SignBlobRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SignBlobRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// SignBlobResponse: The service account sign blob response.
+type SignBlobResponse struct {
+	// KeyId: The id of the key used to sign the blob.
+	KeyId string `json:"keyId,omitempty"`
+
+	// Signature: The signed blob.
+	Signature string `json:"signature,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "KeyId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *SignBlobResponse) MarshalJSON() ([]byte, error) {
+	type noMethod SignBlobResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// TestIamPermissionsRequest: Request message for `TestIamPermissions`
+// method.
+type TestIamPermissionsRequest struct {
+	// Permissions: The set of permissions to check for the `resource`.
+	// Permissions with wildcards (such as '*' or 'storage.*') are not
+	// allowed. For more information see IAM Overview.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsRequest) MarshalJSON() ([]byte, error) {
+	type noMethod TestIamPermissionsRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// TestIamPermissionsResponse: Response message for `TestIamPermissions`
+// method.
+type TestIamPermissionsResponse struct {
+	// Permissions: A subset of `TestPermissionsRequest.permissions` that
+	// the caller is allowed.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod TestIamPermissionsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields)
+}
+
+// method id "iam.projects.serviceAccounts.create":
+
+type ProjectsServiceAccountsCreateCall struct {
+	s                           *Service
+	name                        string
+	createserviceaccountrequest *CreateServiceAccountRequest
+	urlParams_                  gensupport.URLParams
+	ctx_                        context.Context
+}
+
+// Create: Creates a service account and returns it.
+func (r *ProjectsServiceAccountsService) Create(name string, createserviceaccountrequest *CreateServiceAccountRequest) *ProjectsServiceAccountsCreateCall {
+	c := &ProjectsServiceAccountsCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	c.createserviceaccountrequest = createserviceaccountrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsCreateCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsCreateCall) Context(ctx context.Context) *ProjectsServiceAccountsCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsCreateCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.createserviceaccountrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}/serviceAccounts")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.create" call.
+// Exactly one of *ServiceAccount or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *ServiceAccount.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsCreateCall) Do(opts ...googleapi.CallOption) (*ServiceAccount, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ServiceAccount{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a service account and returns it.",
+	//   "httpMethod": "POST",
+	//   "id": "iam.projects.serviceAccounts.create",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "Required. The resource name of the project associated with the service accounts, such as \"projects/123\"",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}/serviceAccounts",
+	//   "request": {
+	//     "$ref": "CreateServiceAccountRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "ServiceAccount"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.delete":
+
+type ProjectsServiceAccountsDeleteCall struct {
+	s          *Service
+	name       string
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+}
+
+// Delete: Deletes a service acount.
+func (r *ProjectsServiceAccountsService) Delete(name string) *ProjectsServiceAccountsDeleteCall {
+	c := &ProjectsServiceAccountsDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsDeleteCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsDeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsDeleteCall) Context(ctx context.Context) *ProjectsServiceAccountsDeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsDeleteCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.delete" call.
+// Exactly one of *Empty or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Empty.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsServiceAccountsDeleteCall) Do(opts ...googleapi.CallOption) (*Empty, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Empty{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Deletes a service acount.",
+	//   "httpMethod": "DELETE",
+	//   "id": "iam.projects.serviceAccounts.delete",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "Empty"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.get":
+
+type ProjectsServiceAccountsGetCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// Get: Gets a ServiceAccount
+func (r *ProjectsServiceAccountsService) Get(name string) *ProjectsServiceAccountsGetCall {
+	c := &ProjectsServiceAccountsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsGetCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsServiceAccountsGetCall) IfNoneMatch(entityTag string) *ProjectsServiceAccountsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsGetCall) Context(ctx context.Context) *ProjectsServiceAccountsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsGetCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.get" call.
+// Exactly one of *ServiceAccount or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *ServiceAccount.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsGetCall) Do(opts ...googleapi.CallOption) (*ServiceAccount, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ServiceAccount{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets a ServiceAccount",
+	//   "httpMethod": "GET",
+	//   "id": "iam.projects.serviceAccounts.get",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "ServiceAccount"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.getIamPolicy":
+
+type ProjectsServiceAccountsGetIamPolicyCall struct {
+	s          *Service
+	resource   string
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+}
+
+// GetIamPolicy: Returns the IAM access control policy for specified IAM
+// resource.
+func (r *ProjectsServiceAccountsService) GetIamPolicy(resource string) *ProjectsServiceAccountsGetIamPolicyCall {
+	c := &ProjectsServiceAccountsGetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsGetIamPolicyCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsGetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsGetIamPolicyCall) Context(ctx context.Context) *ProjectsServiceAccountsGetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsGetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:getIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.getIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsServiceAccountsGetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns the IAM access control policy for specified IAM resource.",
+	//   "httpMethod": "POST",
+	//   "id": "iam.projects.serviceAccounts.getIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:getIamPolicy",
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.list":
+
+type ProjectsServiceAccountsListCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// List: Lists service accounts for a project.
+func (r *ProjectsServiceAccountsService) List(name string) *ProjectsServiceAccountsListCall {
+	c := &ProjectsServiceAccountsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": Optional limit on
+// the number of service accounts to include in the response. Further
+// accounts can subsequently be obtained by including the
+// [ListServiceAccountsResponse.next_page_token] in a subsequent
+// request.
+func (c *ProjectsServiceAccountsListCall) PageSize(pageSize int64) *ProjectsServiceAccountsListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": Optional
+// pagination token returned in an earlier
+// [ListServiceAccountsResponse.next_page_token].
+func (c *ProjectsServiceAccountsListCall) PageToken(pageToken string) *ProjectsServiceAccountsListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsListCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsServiceAccountsListCall) IfNoneMatch(entityTag string) *ProjectsServiceAccountsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsListCall) Context(ctx context.Context) *ProjectsServiceAccountsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsListCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}/serviceAccounts")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.list" call.
+// Exactly one of *ListServiceAccountsResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *ListServiceAccountsResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsListCall) Do(opts ...googleapi.CallOption) (*ListServiceAccountsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListServiceAccountsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists service accounts for a project.",
+	//   "httpMethod": "GET",
+	//   "id": "iam.projects.serviceAccounts.list",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "Required. The resource name of the project associated with the service accounts, such as \"projects/123\"",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "Optional limit on the number of service accounts to include in the response. Further accounts can subsequently be obtained by including the [ListServiceAccountsResponse.next_page_token] in a subsequent request.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "Optional pagination token returned in an earlier [ListServiceAccountsResponse.next_page_token].",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}/serviceAccounts",
+	//   "response": {
+	//     "$ref": "ListServiceAccountsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsServiceAccountsListCall) Pages(ctx context.Context, f func(*ListServiceAccountsResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "iam.projects.serviceAccounts.setIamPolicy":
+
+type ProjectsServiceAccountsSetIamPolicyCall struct {
+	s                   *Service
+	resource            string
+	setiampolicyrequest *SetIamPolicyRequest
+	urlParams_          gensupport.URLParams
+	ctx_                context.Context
+}
+
+// SetIamPolicy: Sets the IAM access control policy for the specified
+// IAM resource.
+func (r *ProjectsServiceAccountsService) SetIamPolicy(resource string, setiampolicyrequest *SetIamPolicyRequest) *ProjectsServiceAccountsSetIamPolicyCall {
+	c := &ProjectsServiceAccountsSetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.setiampolicyrequest = setiampolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsSetIamPolicyCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsSetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsSetIamPolicyCall) Context(ctx context.Context) *ProjectsServiceAccountsSetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsSetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.setiampolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:setIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.setIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsServiceAccountsSetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Sets the IAM access control policy for the specified IAM resource.",
+	//   "httpMethod": "POST",
+	//   "id": "iam.projects.serviceAccounts.setIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:setIamPolicy",
+	//   "request": {
+	//     "$ref": "SetIamPolicyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.signBlob":
+
+type ProjectsServiceAccountsSignBlobCall struct {
+	s               *Service
+	name            string
+	signblobrequest *SignBlobRequest
+	urlParams_      gensupport.URLParams
+	ctx_            context.Context
+}
+
+// SignBlob: Signs a blob using a service account.
+func (r *ProjectsServiceAccountsService) SignBlob(name string, signblobrequest *SignBlobRequest) *ProjectsServiceAccountsSignBlobCall {
+	c := &ProjectsServiceAccountsSignBlobCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	c.signblobrequest = signblobrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsSignBlobCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsSignBlobCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsSignBlobCall) Context(ctx context.Context) *ProjectsServiceAccountsSignBlobCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsSignBlobCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.signblobrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}:signBlob")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.signBlob" call.
+// Exactly one of *SignBlobResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *SignBlobResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsSignBlobCall) Do(opts ...googleapi.CallOption) (*SignBlobResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &SignBlobResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Signs a blob using a service account.",
+	//   "httpMethod": "POST",
+	//   "id": "iam.projects.serviceAccounts.signBlob",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}:signBlob",
+	//   "request": {
+	//     "$ref": "SignBlobRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "SignBlobResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.testIamPermissions":
+
+type ProjectsServiceAccountsTestIamPermissionsCall struct {
+	s                         *Service
+	resource                  string
+	testiampermissionsrequest *TestIamPermissionsRequest
+	urlParams_                gensupport.URLParams
+	ctx_                      context.Context
+}
+
+// TestIamPermissions: Tests the specified permissions against the IAM
+// access control policy for the specified IAM resource.
+func (r *ProjectsServiceAccountsService) TestIamPermissions(resource string, testiampermissionsrequest *TestIamPermissionsRequest) *ProjectsServiceAccountsTestIamPermissionsCall {
+	c := &ProjectsServiceAccountsTestIamPermissionsCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.testiampermissionsrequest = testiampermissionsrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsTestIamPermissionsCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsTestIamPermissionsCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsTestIamPermissionsCall) Context(ctx context.Context) *ProjectsServiceAccountsTestIamPermissionsCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsTestIamPermissionsCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.testiampermissionsrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:testIamPermissions")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.testIamPermissions" call.
+// Exactly one of *TestIamPermissionsResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *TestIamPermissionsResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsTestIamPermissionsCall) Do(opts ...googleapi.CallOption) (*TestIamPermissionsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &TestIamPermissionsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Tests the specified permissions against the IAM access control policy for the specified IAM resource.",
+	//   "httpMethod": "POST",
+	//   "id": "iam.projects.serviceAccounts.testIamPermissions",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:testIamPermissions",
+	//   "request": {
+	//     "$ref": "TestIamPermissionsRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "TestIamPermissionsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.update":
+
+type ProjectsServiceAccountsUpdateCall struct {
+	s              *Service
+	name           string
+	serviceaccount *ServiceAccount
+	urlParams_     gensupport.URLParams
+	ctx_           context.Context
+}
+
+// Update: Updates a service account. Currently, only the following
+// fields are updatable: 'display_name' . The 'etag' is mandatory.
+func (r *ProjectsServiceAccountsService) Update(name string, serviceaccount *ServiceAccount) *ProjectsServiceAccountsUpdateCall {
+	c := &ProjectsServiceAccountsUpdateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	c.serviceaccount = serviceaccount
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsUpdateCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsUpdateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsUpdateCall) Context(ctx context.Context) *ProjectsServiceAccountsUpdateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsUpdateCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.serviceaccount)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.update" call.
+// Exactly one of *ServiceAccount or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *ServiceAccount.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsUpdateCall) Do(opts ...googleapi.CallOption) (*ServiceAccount, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ServiceAccount{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates a service account. Currently, only the following fields are updatable: 'display_name' . The 'etag' is mandatory.",
+	//   "httpMethod": "PUT",
+	//   "id": "iam.projects.serviceAccounts.update",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". In requests using '-' as a wildcard for the project, will infer the project from the account and the account value can be the email address or the unique_id of the service account. In responses the resource name will always be in the format \"projects/{project}/serviceAccounts/{email}\".",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "request": {
+	//     "$ref": "ServiceAccount"
+	//   },
+	//   "response": {
+	//     "$ref": "ServiceAccount"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.keys.create":
+
+type ProjectsServiceAccountsKeysCreateCall struct {
+	s                              *Service
+	name                           string
+	createserviceaccountkeyrequest *CreateServiceAccountKeyRequest
+	urlParams_                     gensupport.URLParams
+	ctx_                           context.Context
+}
+
+// Create: Creates a service account key and returns it.
+func (r *ProjectsServiceAccountsKeysService) Create(name string, createserviceaccountkeyrequest *CreateServiceAccountKeyRequest) *ProjectsServiceAccountsKeysCreateCall {
+	c := &ProjectsServiceAccountsKeysCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	c.createserviceaccountkeyrequest = createserviceaccountkeyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsKeysCreateCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsKeysCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsKeysCreateCall) Context(ctx context.Context) *ProjectsServiceAccountsKeysCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsKeysCreateCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.createserviceaccountkeyrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}/keys")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.keys.create" call.
+// Exactly one of *ServiceAccountKey or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ServiceAccountKey.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsKeysCreateCall) Do(opts ...googleapi.CallOption) (*ServiceAccountKey, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ServiceAccountKey{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a service account key and returns it.",
+	//   "httpMethod": "POST",
+	//   "id": "iam.projects.serviceAccounts.keys.create",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}/keys",
+	//   "request": {
+	//     "$ref": "CreateServiceAccountKeyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "ServiceAccountKey"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.keys.delete":
+
+type ProjectsServiceAccountsKeysDeleteCall struct {
+	s          *Service
+	name       string
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+}
+
+// Delete: Deletes a service account key.
+func (r *ProjectsServiceAccountsKeysService) Delete(name string) *ProjectsServiceAccountsKeysDeleteCall {
+	c := &ProjectsServiceAccountsKeysDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsKeysDeleteCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsKeysDeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsKeysDeleteCall) Context(ctx context.Context) *ProjectsServiceAccountsKeysDeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsKeysDeleteCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.keys.delete" call.
+// Exactly one of *Empty or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Empty.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsServiceAccountsKeysDeleteCall) Do(opts ...googleapi.CallOption) (*Empty, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Empty{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Deletes a service account key.",
+	//   "httpMethod": "DELETE",
+	//   "id": "iam.projects.serviceAccounts.keys.delete",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource name of the service account key in the format \"projects/{project}/serviceAccounts/{account}/keys/{key}\". Using '-' as a wildcard for the project will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*/keys/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "Empty"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.keys.get":
+
+type ProjectsServiceAccountsKeysGetCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// Get: Gets the ServiceAccountKey by key id.
+func (r *ProjectsServiceAccountsKeysService) Get(name string) *ProjectsServiceAccountsKeysGetCall {
+	c := &ProjectsServiceAccountsKeysGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsKeysGetCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsKeysGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsServiceAccountsKeysGetCall) IfNoneMatch(entityTag string) *ProjectsServiceAccountsKeysGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsKeysGetCall) Context(ctx context.Context) *ProjectsServiceAccountsKeysGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsKeysGetCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.keys.get" call.
+// Exactly one of *ServiceAccountKey or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ServiceAccountKey.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsKeysGetCall) Do(opts ...googleapi.CallOption) (*ServiceAccountKey, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ServiceAccountKey{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets the ServiceAccountKey by key id.",
+	//   "httpMethod": "GET",
+	//   "id": "iam.projects.serviceAccounts.keys.get",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource name of the service account key in the format \"projects/{project}/serviceAccounts/{account}/keys/{key}\". Using '-' as a wildcard for the project will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*/keys/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "ServiceAccountKey"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "iam.projects.serviceAccounts.keys.list":
+
+type ProjectsServiceAccountsKeysListCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+}
+
+// List: Lists service account keys
+func (r *ProjectsServiceAccountsKeysService) List(name string) *ProjectsServiceAccountsKeysListCall {
+	c := &ProjectsServiceAccountsKeysListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// KeyTypes sets the optional parameter "keyTypes": The type of keys the
+// user wants to list. If empty, all key types are included in the
+// response. Duplicate key types are not allowed.
+//
+// Possible values:
+//   "KEY_TYPE_UNSPECIFIED"
+//   "USER_MANAGED"
+//   "SYSTEM_MANAGED"
+func (c *ProjectsServiceAccountsKeysListCall) KeyTypes(keyTypes ...string) *ProjectsServiceAccountsKeysListCall {
+	c.urlParams_.SetMulti("keyTypes", append([]string{}, keyTypes...))
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsServiceAccountsKeysListCall) Fields(s ...googleapi.Field) *ProjectsServiceAccountsKeysListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsServiceAccountsKeysListCall) IfNoneMatch(entityTag string) *ProjectsServiceAccountsKeysListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsServiceAccountsKeysListCall) Context(ctx context.Context) *ProjectsServiceAccountsKeysListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+func (c *ProjectsServiceAccountsKeysListCall) doRequest(alt string) (*http.Response, error) {
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}/keys")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	if c.ctx_ != nil {
+		return ctxhttp.Do(c.ctx_, c.s.client, req)
+	}
+	return c.s.client.Do(req)
+}
+
+// Do executes the "iam.projects.serviceAccounts.keys.list" call.
+// Exactly one of *ListServiceAccountKeysResponse or error will be
+// non-nil. Any non-2xx status code is an error. Response headers are in
+// either *ListServiceAccountKeysResponse.ServerResponse.Header or (if a
+// response was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsServiceAccountsKeysListCall) Do(opts ...googleapi.CallOption) (*ListServiceAccountKeysResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListServiceAccountKeysResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists service account keys",
+	//   "httpMethod": "GET",
+	//   "id": "iam.projects.serviceAccounts.keys.list",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "keyTypes": {
+	//       "description": "The type of keys the user wants to list. If empty, all key types are included in the response. Duplicate key types are not allowed.",
+	//       "enum": [
+	//         "KEY_TYPE_UNSPECIFIED",
+	//         "USER_MANAGED",
+	//         "SYSTEM_MANAGED"
+	//       ],
+	//       "location": "query",
+	//       "repeated": true,
+	//       "type": "string"
+	//     },
+	//     "name": {
+	//       "description": "The resource name of the service account in the format \"projects/{project}/serviceAccounts/{account}\". Using '-' as a wildcard for the project, will infer the project from the account. The account value can be the email address or the unique_id of the service account.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]*/serviceAccounts/[^/]*$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}/keys",
+	//   "response": {
+	//     "$ref": "ListServiceAccountKeysResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1993,6 +1993,12 @@
 			"revision": "5eaf0df67e70d6997a9fe0ed24383fa1b01638d3"
 		},
 		{
+			"checksumSHA1": "QDbbtubwRml+xdgIfNy/yC6Ff78=",
+			"path": "google.golang.org/api/cloudresourcemanager/v1",
+			"revision": "43c645d4bcf9251ced36c823a93b6d198764aae4",
+			"revisionTime": "2016-03-24T17:48:31Z"
+		},
+		{
 			"checksumSHA1": "K2ewXgyH/uLdvOdg2ad02Z6Jym0=",
 			"path": "google.golang.org/api/compute/v1",
 			"revision": "3f131f305a2ae45080e71fdb780128cc92e8745e",
@@ -2027,6 +2033,12 @@
 			"path": "google.golang.org/api/googleapi/internal/uritemplates",
 			"revision": "3f131f305a2ae45080e71fdb780128cc92e8745e",
 			"revisionTime": "2016-08-05T04:28:55Z"
+		},
+		{
+			"checksumSHA1": "NetCfFfklnz0sJXmRPIRJsPKV5Q=",
+			"path": "google.golang.org/api/iam/v1",
+			"revision": "43c645d4bcf9251ced36c823a93b6d198764aae4",
+			"revisionTime": "2016-03-24T17:48:31Z"
 		},
 		{
 			"checksumSHA1": "M7er6A8YuCmllh/cj/fZhHDEb3I=",

--- a/website/source/docs/providers/google/d/google_iam_policy.html.markdown
+++ b/website/source/docs/providers/google/d/google_iam_policy.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "google"
+page_title: "Google: google_iam_policy"
+sidebar_current: "docs-google-datasource-iam-policy"
+description: |-
+  Generates an IAM policy that can be referenced by other resources, applying
+  the policy to them.
+---
+
+# google\_iam\_policy
+
+Generates an IAM policy document that may be referenced by and applied to
+other Google Cloud Platform resources, such as the `google_project` resource.
+
+```
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/compute.instanceAdmin"
+    members = [
+      "serviceAccount:your-custom-sa@your-project.iam.gserviceaccount.com",
+    ]
+  }
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "user:evanbrown@google.com",
+    ]
+  }
+}
+```
+
+This data source is used to define IAM policies to apply to othe resources.
+Currently, defining a policy through a datasource and referencing that policy
+from another resource is the only way to apply an IAM policy to a resource.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `binding` (Required) - A nested configuration block (described below)
+  defining a binding to be included in the policy document. Multiple
+  `binding` arguments are supported.
+
+Each document configuration must have one or more `binding` blocks, which
+each accept the following arguments:
+
+* `role` (Required) - The role/permission that will be granted to the members.
+  See the [IAM Roles](https://cloud.google.com/compute/docs/access/iam) documentation for a complete list of roles.
+* `members` (Required) - An array of users/principals that will be granted
+  the privilege in the `role`. For a human user, prefix the user's e-mail
+  address with `user:` (e.g., `user:evandbrown@gmail.com`). For a service
+  account, prefix the service account e-mail address with `serviceAccount:`
+  (e.g., `serviceAccount:your-service-account@your-project.iam.gserviceaccount.com`).
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `policy_data` - The above bindings serialized in a format suitable for
+  referencing from a resource that supports IAM.

--- a/website/source/docs/providers/google/r/google_project.html.markdown
+++ b/website/source/docs/providers/google/r/google_project.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "google"
+page_title: "Google: google_project"
+sidebar_current: "docs-google-project"
+description: |-
+ Allows management of a Google Cloud Platform project. 
+---
+
+# google\_project
+
+Allows management of an existing Google Cloud Platform project, and is
+currently limited to adding or modifying the IAM Policy for the project.
+
+When adding a policy to a project, the policy will be merged with the
+project's existing policy. The policy is always specified in a
+`google_iam_policy` data source and referencd from the project's
+`policy_data` attribute.
+
+## Example Usage
+
+```js
+resource "google_project" "my-project" {
+    id = "your-project-id"
+    policy_data = "${data.google_iam_policy.admin.policy}"
+}
+
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "user:evandbrown@gmail.com",
+    ]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The project ID.
+    Changing this forces a new project to be referenced.
+
+* `policy` - (Optional) The `google_iam_policy` data source that represents
+    the IAM policy that will be applied to the project. The policy will be
+    merged with any existing policy applied to the project.
+
+    Changing this updates the policy.
+
+    Deleting this removes the policy, but leaves the original project policy
+    intact. If there are overlapping `binding` entries between the original
+    project policy and the data source policy, they will be removed.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `name` - The name of the project.
+
+* `number` - The numeric identifier of the project.


### PR DESCRIPTION
WIP: needs acceptance tests, more validation, and code review. 

This change adds a data source to allow declaring IAM policies, as well as a
 new resource to represent an existing GCP project. The project resource may reference an IAM policy, allowing a user to set project-wide permissions.

