### PR TITLE
Documentation: explain the role of to_port in a security group rule when protocol is "icmp"

### DIFF
--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -92,7 +92,7 @@ The `ingress` block supports:
     EC2-Classic, or Group IDs if using a VPC.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this ingress rule.
-* `to_port` - (Required) The end range port.
+* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
 
 The `egress` block supports:
 
@@ -105,7 +105,7 @@ The `egress` block supports:
     EC2-Classic, or Group IDs if using a VPC.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this egress rule.
-* `to_port` - (Required) The end range port.
+* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
 
 ~> **NOTE on Egress rules:** By default, AWS creates an `ALLOW ALL` egress rule when creating a
 new Security Group inside of a VPC. When creating a new Security

--- a/website/source/docs/providers/aws/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group_rule.html.markdown
@@ -51,7 +51,7 @@ Only valid with `egress`.
      depending on the `type`. Cannot be specified with `cidr_blocks`.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this ingress rule.
-* `to_port` - (Required) The end range port.
+* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
 
 ## Usage with prefix list IDs
 


### PR DESCRIPTION
Security group rules overload "from_port" and "to_port" for ICMP.  The docs currently only specify what from_port does (the ICMP type) but not to_port. [This thread](https://github.com/hashicorp/terraform/issues/1313) explains that to_port is the ICMP code, so I've added that to the docs because it would have helped me set up my security group.

This is relevant to the current terraform version.