### PR TITLE
Support setting datacenter when using consul remote state

### DIFF
--- a/state/remote/consul.go
+++ b/state/remote/consul.go
@@ -24,6 +24,9 @@ func consulFactory(conf map[string]string) (Client, error) {
 	if scheme, ok := conf["scheme"]; ok && scheme != "" {
 		config.Scheme = scheme
 	}
+	if datacenter, ok := conf["datacenter"]; ok && datacenter != "" {
+		config.Datacenter = datacenter
+	}
 	if auth, ok := conf["http_auth"]; ok && auth != "" {
 		var username, password string
 		if strings.Contains(auth, ":") {

--- a/website/source/docs/state/remote/consul.html.md
+++ b/website/source/docs/state/remote/consul.html.md
@@ -44,5 +44,6 @@ The following configuration options / environment variables are supported:
  * `scheme` - (Optional) Specifies what protocol to use when talking to the given
    `address`, either `http` or `https`. SSL support can also be triggered
    by setting then environment variable `CONSUL_HTTP_SSL` to `true`.
+ * `datacenter` - (Optional) The datacenter to use. Defaults to that of the agent.
  * `http_auth` / `CONSUL_HTTP_AUTH` - (Optional) HTTP Basic Authentication credentials to be used when
    communicating with Consul, in the format of either `user` or `user:pass`.


### PR DESCRIPTION
Small change to allow setting datacenter when using consul remote state:

`terraform remote config -backend=consul -backend-config=path=some/path -backend-config=access_token=some-token -backend-config=datacenter=dc1`

This fixes #1614.