### PR TITLE
provider/google: Support Import of 'google_compute_autoscaler'

### DIFF
--- a/builtin/providers/google/import_compute_autoscaler_test.go
+++ b/builtin/providers/google/import_compute_autoscaler_test.go
@@ -1,0 +1,28 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAutoscaler_importBasic(t *testing.T) {
+	resourceName := "google_compute_autoscaler.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAutoscalerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAutoscaler_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -3,10 +3,13 @@ package google
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/pathorcontents"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -194,4 +197,28 @@ func getProject(d *schema.ResourceData, config *Config) (string, error) {
 		return "", fmt.Errorf("%q: required field is not set", "project")
 	}
 	return res.(string), nil
+}
+
+func getZonalResourceFromRegion(getResource func(string) (interface{}, error), region string, compute *compute.Service, project string) (interface{}, error) {
+	zoneList, err := compute.Zones.List(project).Do()
+	if err != nil {
+		return nil, err
+	}
+	var resource interface{}
+	for _, zone := range zoneList.Items {
+		if strings.Contains(zone.Name, region) {
+			resource, err = getResource(zone.Name)
+			if err != nil {
+				if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+					// Resource was not found in this zone
+					continue
+				}
+				return nil, fmt.Errorf("Error reading Resource: %s", err)
+			}
+			// Resource was found
+			return resource, nil
+		}
+	}
+	// Resource does not exist in this region
+	return nil, nil
 }

--- a/builtin/providers/google/resource_compute_autoscaler_test.go
+++ b/builtin/providers/google/resource_compute_autoscaler_test.go
@@ -179,7 +179,7 @@ resource "google_compute_autoscaler" "foobar" {
 	target = "${google_compute_instance_group_manager.foobar.self_link}"
 	autoscaling_policy = {
 		max_replicas = 5
-		min_replicas = 0
+		min_replicas = 1
 		cooldown_period = 60
 		cpu_utilization = {
 			target = 0.5
@@ -236,7 +236,7 @@ resource "google_compute_autoscaler" "foobar" {
 	target = "${google_compute_instance_group_manager.foobar.self_link}"
 	autoscaling_policy = {
 		max_replicas = 10
-		min_replicas = 0
+		min_replicas = 1
 		cooldown_period = 60
 		cpu_utilization = {
 			target = 0.5


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccAutoscaler_' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/google -v 
-run=TestAccAutoscaler -timeout 120m
=== RUN   TestAccAutoscaler_importBasic
--- PASS: TestAccAutoscaler_importBasic (141.11s)
=== RUN   TestAccAutoscaler_basic
--- PASS: TestAccAutoscaler_basic (130.14s)
=== RUN   TestAccAutoscaler_update
--- PASS: TestAccAutoscaler_update (260.09s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	
531.411s
```

@lwander 