### PR TITLE
provider/aws: Change a few policy test docs to use heredoc format, to…

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_policy_test.go
@@ -111,7 +111,16 @@ resource "aws_iam_group" "group" {
 resource "aws_iam_group_policy" "foo" {
 	name = "foo_policy"
 	group = "${aws_iam_group.group.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
 }
 `
 

--- a/builtin/providers/aws/resource_aws_iam_role_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_policy_test.go
@@ -115,13 +115,36 @@ func testAccIAMRolePolicyConfig(role, policy1 string) string {
 resource "aws_iam_role" "role" {
 	name = "tf_test_role_%s"
 	path = "/"
-	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+	assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
 	name = "tf_test_policy_%s"
 	role = "${aws_iam_role.role.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
 }
 `, role, policy1)
 }
@@ -131,19 +154,51 @@ func testAccIAMRolePolicyConfigUpdate(role, policy1, policy2 string) string {
 resource "aws_iam_role" "role" {
 	name = "tf_test_role_%s"
 	path = "/"
-	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+	assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
 	name = "tf_test_policy_%s"
 	role = "${aws_iam_role.role.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
 }
 
 resource "aws_iam_role_policy" "bar" {
 	name = "tf_test_policy_2_%s"
 	role = "${aws_iam_role.role.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
 }
 `, role, policy1, policy2)
 }


### PR DESCRIPTION
… prevent regressions

It did a quick look and it seemed many of our tests only had in-line policies. I want to change some to use the `heredoc` to make sure we don't accidentally regress there 

ref https://github.com/hashicorp/terraform/pull/7617#issuecomment-238929779

```console
$ TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSIAM -timeout 120m
=== RUN   TestAccAWSIAMPolicyDocument
--- PASS: TestAccAWSIAMPolicyDocument (5.99s)
=== RUN   TestAccAWSIAMAccountPasswordPolicy_importBasic
--- PASS: TestAccAWSIAMAccountPasswordPolicy_importBasic (9.14s)
=== RUN   TestAccAWSIAMGroup_importBasic
--- PASS: TestAccAWSIAMGroup_importBasic (8.90s)
=== RUN   TestAccAWSIAMSamlProvider_importBasic
--- PASS: TestAccAWSIAMSamlProvider_importBasic (8.00s)
=== RUN   TestAccAWSIAMAccountPasswordPolicy_basic
--- PASS: TestAccAWSIAMAccountPasswordPolicy_basic (15.30s)
=== RUN   TestAccAWSIAMGroupPolicy_basic
--- PASS: TestAccAWSIAMGroupPolicy_basic (16.64s)
=== RUN   TestAccAWSIAMGroup_basic
--- PASS: TestAccAWSIAMGroup_basic (13.20s)
=== RUN   TestAccAWSIAMInstanceProfile_basic
--- PASS: TestAccAWSIAMInstanceProfile_basic (9.91s)
=== RUN   TestAccAWSIAMInstanceProfile_namePrefix
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (11.09s)
=== RUN   TestAccAWSIAMRolePolicy_basic
--- PASS: TestAccAWSIAMRolePolicy_basic (20.71s)
=== RUN   TestAccAWSIAMSamlProvider_basic
--- PASS: TestAccAWSIAMSamlProvider_basic (16.01s)
=== RUN   TestAccAWSIAMServerCertificate_basic
--- PASS: TestAccAWSIAMServerCertificate_basic (10.27s)
=== RUN   TestAccAWSIAMServerCertificate_name_prefix
--- PASS: TestAccAWSIAMServerCertificate_name_prefix (8.49s)
=== RUN   TestAccAWSIAMServerCertificate_disappears
--- PASS: TestAccAWSIAMServerCertificate_disappears (8.38s)
=== RUN   TestAccAWSIAMServerCertificate_file
--- PASS: TestAccAWSIAMServerCertificate_file (16.13s)
=== RUN   TestAccAWSIAMUserPolicy_basic
--- PASS: TestAccAWSIAMUserPolicy_basic (17.44s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	195.630s
Test:
```