### PR TITLE
provider/google: Support Import of 'google_resource_http_health_check'

### DIFF
--- a/builtin/providers/google/import_compute_http_health_check_test.go
+++ b/builtin/providers/google/import_compute_http_health_check_test.go
@@ -1,0 +1,28 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeHttpHealthCheck_importBasic(t *testing.T) {
+	resourceName := "google_compute_http_health_check.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHttpHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHttpHealthCheck_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_compute_http_health_check.go
+++ b/builtin/providers/google/resource_compute_http_health_check.go
@@ -15,6 +15,9 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 		Read:   resourceComputeHttpHealthCheckRead,
 		Delete: resourceComputeHttpHealthCheckDelete,
 		Update: resourceComputeHttpHealthCheckUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -55,6 +58,7 @@ func resourceComputeHttpHealthCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"request_path": &schema.Schema{
@@ -220,11 +224,14 @@ func resourceComputeHttpHealthCheckRead(d *schema.ResourceData, meta interface{}
 	d.Set("host", hchk.Host)
 	d.Set("request_path", hchk.RequestPath)
 	d.Set("check_interval_sec", hchk.CheckIntervalSec)
-	d.Set("health_threshold", hchk.HealthyThreshold)
+	d.Set("healthy_threshold", hchk.HealthyThreshold)
 	d.Set("port", hchk.Port)
 	d.Set("timeout_sec", hchk.TimeoutSec)
 	d.Set("unhealthy_threshold", hchk.UnhealthyThreshold)
 	d.Set("self_link", hchk.SelfLink)
+	d.Set("name", hchk.Name)
+	d.Set("description", hchk.Description)
+	d.Set("project", project)
 
 	return nil
 }


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccComputeHttpHealthCheck_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeHttpHealthCheck_ -timeout 120m
=== RUN   TestAccComputeHttpHealthCheck_importBasic
--- PASS: TestAccComputeHttpHealthCheck_importBasic (26.32s)
=== RUN   TestAccComputeHttpHealthCheck_basic
--- PASS: TestAccComputeHttpHealthCheck_basic (26.29s)
=== RUN   TestAccComputeHttpHealthCheck_update
--- PASS: TestAccComputeHttpHealthCheck_update (51.75s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	
104.416s
```
@lwander 