### PR TITLE
provider/google: Support Import of 'google_compute_forwarding_rule'

### DIFF
--- a/builtin/providers/google/import_compute_forwarding_rule_test.go
+++ b/builtin/providers/google/import_compute_forwarding_rule_test.go
@@ -1,0 +1,32 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeForwardingRule_importBasic(t *testing.T) {
+	resourceName := "google_compute_forwarding_rule.foobar"
+	poolName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	ruleName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeForwardingRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeForwardingRule_basic(poolName, ruleName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -15,6 +15,9 @@ func resourceComputeForwardingRule() *schema.Resource {
 		Read:   resourceComputeForwardingRuleRead,
 		Delete: resourceComputeForwardingRuleDelete,
 		Update: resourceComputeForwardingRuleUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -59,12 +62,14 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"self_link": &schema.Schema{
@@ -179,10 +184,15 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}
 
+	d.Set("name", frule.Name)
+	d.Set("target", frule.Target)
+	d.Set("description", frule.Description)
+	d.Set("port_range", frule.PortRange)
+	d.Set("project", project)
+	d.Set("region", region)
 	d.Set("ip_address", frule.IPAddress)
 	d.Set("ip_protocol", frule.IPProtocol)
 	d.Set("self_link", frule.SelfLink)
-
 	return nil
 }
 


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccComputeForwardingRule_' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeForwardingRule_ -timeout 120m
=== RUN   TestAccComputeForwardingRule_importBasic
--- PASS: TestAccComputeForwardingRule_importBasic (51.57s)
=== RUN   TestAccComputeForwardingRule_basic
--- PASS: TestAccComputeForwardingRule_basic (50.95s)
=== RUN   TestAccComputeForwardingRule_ip
--- PASS: TestAccComputeForwardingRule_ip (51.09s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	
153.665s
```
@lwander 