### PR TITLE
provider/google: Support Import of 'google_compute_target_pool'

### DIFF
--- a/builtin/providers/google/import_compute_target_pool_test.go
+++ b/builtin/providers/google/import_compute_target_pool_test.go
@@ -1,0 +1,28 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeTargetPool_importBasic(t *testing.T) {
+	resourceName := "google_compute_target_pool.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeTargetPoolDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeTargetPool_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccComputeTargetPool_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeTargetPool_ -timeout 120m
=== RUN   TestAccComputeTargetPool_importBasic
--- PASS: TestAccComputeTargetPool_importBasic (26.24s)
=== RUN   TestAccComputeTargetPool_basic
--- PASS: TestAccComputeTargetPool_basic (25.94s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	
52.240s
```
@lwander 