### PR TITLE
provider/digitalocean: trim whitespace from ssh key

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -34,6 +35,9 @@ func resourceDigitalOceanSSHKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.TrimSpace(val.(string))
+				},
 			},
 
 			"fingerprint": &schema.Schema{

--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanSSHKey_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_ssh_key.foobar", "name", "foobar"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_ssh_key.foobar", "public_key", testAccValidPublicKey),
+						"digitalocean_ssh_key.foobar", "public_key", strings.TrimSpace(testAccValidPublicKey)),
 				),
 			},
 		},
@@ -111,6 +111,5 @@ resource "digitalocean_ssh_key" "foobar" {
     public_key = "%s"
 }`, testAccValidPublicKey)
 
-var testAccValidPublicKey = strings.TrimSpace(`
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
-`)
+var testAccValidPublicKey = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/7889

whitespace is trimmed from `public_key` when retrieving from the DigitalOcean API, resulting in the resource being recreated every run.