### PR TITLE
provider/aws: allow numeric characters in RedshiftClusterDbName

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -750,9 +750,9 @@ func validateRedshiftClusterIdentifier(v interface{}, k string) (ws []string, er
 
 func validateRedshiftClusterDbName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[a-z]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9a-z]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only lowercase letters characters allowed in %q", k))
+			"only lowercase letters and numeric characters allowed in %q", k))
 	}
 	if len(value) > 64 {
 		errors = append(errors, fmt.Errorf(

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -319,7 +319,7 @@ func TestResourceAWSRedshiftClusterDbNameValidation(t *testing.T) {
 		},
 		{
 			Value:    "testing1",
-			ErrCount: 1,
+			ErrCount: 0,
 		},
 		{
 			Value:    "testing-",


### PR DESCRIPTION
Fixes #8177: `aws_redshift_cluster` does not allow digits in cluster database name