### PR TITLE
Fix typo in OpenStack LBaaSv2 pool resource

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_pool_v2.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v2.go
@@ -50,7 +50,7 @@ func resourcePoolV2() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if value != "lTCP" && value != "HTTP" && value != "HTTPS" {
+					if value != "TCP" && value != "HTTP" && value != "HTTPS" {
 						errors = append(errors, fmt.Errorf(
 							"Only 'TCP', 'HTTP', and 'HTTPS' are supported values for 'protocol'"))
 					}


### PR DESCRIPTION
This PR fixes a typo which prevents creating an OpenStack LBaaSv2 TCP pool.

```
resource "openstack_lb_pool_v2" "lb1_pool_1" {
  protocol    = "TCP"
  lb_method   = "ROUND_ROBIN"
  listener_id =  "${openstack_lb_listener_v2.listener_1.id}"
}
```

```
Errors:
  * openstack_lb_pool_v2.lb1_pool_1: Only 'TCP', 'HTTP', and 'HTTPS' are supported values for 'protocol'
```