### PR TITLE
provider/aws: Add aws_account_id data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_caller_identity.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity.go
@@ -1,0 +1,40 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCallerIdentity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCallerIdentityRead,
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient)
+
+	log.Printf("[DEBUG] Reading Caller Identity.")
+	d.SetId(time.Now().UTC().String())
+
+	if client.accountid == "" {
+		log.Println("[DEBUG] No Account ID available, failing")
+		return fmt.Errorf("No AWS Account ID is available to the provider. Please ensure that\n" +
+			"skip_requesting_account_id is not set on the AWS provider.")
+	}
+
+	log.Printf("[DEBUG] Setting AWS Account ID to %s.", client.accountid)
+	d.Set("account_id", meta.(*AWSClient).accountid)
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_caller_identity_test.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity_test.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCallerIdentity_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsCallerIdentityConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCallerIdentityAccountId("data.aws_caller_identity.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find AccountID resource: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Account Id resource ID not set.")
+		}
+
+		expected := testAccProvider.Meta().(*AWSClient).accountid
+		if rs.Primary.Attributes["account_id"] != expected {
+			return fmt.Errorf("Incorrect Account ID: expected %q, got %q", expected, rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckAwsCallerIdentityConfig_basic = `
+data "aws_caller_identity" "current" { }
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -142,6 +142,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"aws_ami":                      dataSourceAwsAmi(),
 			"aws_availability_zones":       dataSourceAwsAvailabilityZones(),
+			"aws_caller_identity":          dataSourceAwsCallerIdentity(),
 			"aws_iam_policy_document":      dataSourceAwsIamPolicyDocument(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
 			"aws_s3_bucket_object":         dataSourceAwsS3BucketObject(),

--- a/website/source/docs/providers/aws/d/caller_identity.html.markdown
+++ b/website/source/docs/providers/aws/d/caller_identity.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "aws"
+page_title: "AWS: aws_caller_identity"
+sidebar_current: "docs-aws-datasource-caller-identity"
+description: |-
+  Get information about the identity of the caller for the provider
+  connection to AWS.
+---
+
+# aws\_caller\_identity
+
+Use this data source to get the access to the effective Account ID in
+which Terraform is working.
+
+~> **NOTE on `aws_caller_identity`:** - an Account ID is only available
+if `skip_requesting_account_id` is not set on the AWS provider. In such
+cases, the data source will return an error.
+
+## Example Usage
+
+```
+data "aws_caller_identity" "current" { }
+
+output "account_id" {
+  value = "${data.aws_caller_identity.current.account_id}"
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+`account_id` is set to the ID of the AWS account. 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -13,11 +13,15 @@
                 <li<%= sidebar_current(/^docs-aws-datasource/) %>>
                 <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+
                         <li<%= sidebar_current("docs-aws-datasource-ami") %>>
                             <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-availability-zones") %>>
                             <a href="/docs/providers/aws/d/availability_zones.html">aws_availability_zones</a>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-datasource-caller-identity") %>>
+                          <a href="/docs/providers/aws/d/caller_identity.html">aws_caller_identity</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-ecs-container-definition") %>>
                             <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>


### PR DESCRIPTION
This data source provides access during configuration to the ID of the AWS account for the connection to AWS. It is primarily useful for interpolating into policy documents, for example when creating the policy for an ELB or ALB access log bucket.

This will need revisiting and further testing once the work for AssumeRole is integrated.