### PR TITLE
provider/aws: Update ElasticTranscoder to allow empty notifications, removing notifications, etc

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/builtin/providers/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -233,18 +233,23 @@ func expandETNotifications(d *schema.ResourceData) *elastictranscoder.Notificati
 		return nil
 	}
 
-	s := set.(*schema.Set)
-	if s == nil || s.Len() == 0 {
+	s := set.(*schema.Set).List()
+	if s == nil || len(s) == 0 {
 		return nil
 	}
 
-	m := s.List()[0].(map[string]interface{})
+	if s[0] == nil {
+		log.Printf("[ERR] First element of Notifications set is nil")
+		return nil
+	}
+
+	rN := s[0].(map[string]interface{})
 
 	return &elastictranscoder.Notifications{
-		Completed:   getStringPtr(m, "completed"),
-		Error:       getStringPtr(m, "error"),
-		Progressing: getStringPtr(m, "progressing"),
-		Warning:     getStringPtr(m, "warning"),
+		Completed:   aws.String(rN["completed"].(string)),
+		Error:       aws.String(rN["error"].(string)),
+		Progressing: aws.String(rN["progressing"].(string)),
+		Warning:     aws.String(rN["warning"].(string)),
 	}
 }
 

--- a/website/source/docs/providers/aws/r/elastic_transcoder_pipeline.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_transcoder_pipeline.html.markdown
@@ -66,20 +66,21 @@ The `content_config_permissions` object supports the following:
 
 
 The `notifications` object supports the following:
+
 * `completed` - The topic ARN for the Amazon SNS topic that you want to notify when Elastic Transcoder has finished processing a job in this pipeline.
 * `error` - The topic ARN for the Amazon SNS topic that you want to notify when Elastic Transcoder encounters an error condition while processing a job in this pipeline.
 * `progressing` - The topic ARN for the Amazon Simple Notification Service (Amazon SNS) topic that you want to notify when Elastic Transcoder has started to process a job in this pipeline.
 * `warning` - The topic ARN for the Amazon SNS topic that you want to notify when Elastic Transcoder encounters a warning condition while processing a job in this pipeline.
 
-The thumbnail_config object specifies information about the Amazon S3 bucket in
+The `thumbnail_config` object specifies information about the Amazon S3 bucket in
 which you want Elastic Transcoder to save thumbnail files: which bucket to use,
 which users you want to have access to the files, the type of access you want
 users to have, and the storage class that you want to assign to the files. If
-you specify values for ContentConfig, you must also specify values for
-ThumbnailConfig even if you don't want to create thumbnails. (You control
+you specify values for `content_config`, you must also specify values for
+`thumbnail_config` even if you don't want to create thumbnails. (You control
 whether to create thumbnails when you create a job. For more information, see
 ThumbnailPattern in the topic Create Job.) If you specify values for
-ContentConfig and ThumbnailConfig, omit the OutputBucket object.
+`content_config` and `thumbnail_config`, omit the OutputBucket object.
 
 The `thumbnail_config` object supports the following:
 


### PR DESCRIPTION
Allows users to supply empty (`""`) notifications for ElasticTranscoder, which amounts to unsetting them.

The current implementation doesn't allow you to remove any previously set ones, or omit any at all.

Adds acceptance test `TestAccAWSElasticTranscoderPipeline_notifications` which will fail on `master`. 

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticTranscoderPipeline_ -timeout 120m
=== RUN   TestAccAWSElasticTranscoderPipeline_basic
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (24.10s)
=== RUN   TestAccAWSElasticTranscoderPipeline_notifications
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (35.44s) <-- new 
=== RUN   TestAccAWSElasticTranscoderPipeline_withContentConfig
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (35.36s)
=== RUN   TestAccAWSElasticTranscoderPipeline_withPermissions
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (22.11s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	117.039s
Test:
```

Fixes #8163