### PR TITLE
aws: Add elb_account_id data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_elb_account_id.go
+++ b/builtin/providers/aws/data_source_aws_elb_account_id.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// See http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
+var elbAccountIdPerRegionMap = map[string]string{
+	"ap-northeast-1": "582318560864",
+	"ap-northeast-2": "600734575887",
+	"ap-south-1":     "718504428378",
+	"ap-southeast-1": "114774131450",
+	"ap-southeast-2": "783225319266",
+	"cn-north-1":     "638102146993",
+	"eu-central-1":   "054676820928",
+	"eu-west-1":      "156460612806",
+	"sa-east-1":      "507241528517",
+	"us-east-1":      "127311923021",
+	"us-gov-west":    "048591011584",
+	"us-west-1":      "027434742980",
+	"us-west-2":      "797873946194",
+}
+
+func dataSourceAwsElbAccountId() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsElbAccountIdRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsElbAccountIdRead(d *schema.ResourceData, meta interface{}) error {
+	region := meta.(*AWSClient).region
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+	}
+
+	if accid, ok := elbAccountIdPerRegionMap[region]; ok {
+		d.SetId(accid)
+		return nil
+	}
+
+	return fmt.Errorf("Unknown region (%q)", region)
+}

--- a/builtin/providers/aws/data_source_aws_elb_account_id_test.go
+++ b/builtin/providers/aws/data_source_aws_elb_account_id_test.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSElbAccountId_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsElbAccountIdConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_elb_account_id.main", "id", "797873946194"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckAwsElbAccountIdExplicitRegionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_elb_account_id.regional", "id", "156460612806"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAwsElbAccountIdConfig = `
+data "aws_elb_account_id" "main" { }
+`
+
+const testAccCheckAwsElbAccountIdExplicitRegionConfig = `
+data "aws_elb_account_id" "regional" {
+	region = "eu-west-1"
+}
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -143,6 +143,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ami":                      dataSourceAwsAmi(),
 			"aws_availability_zones":       dataSourceAwsAvailabilityZones(),
 			"aws_caller_identity":          dataSourceAwsCallerIdentity(),
+			"aws_elb_account_id":           dataSourceAwsElbAccountId(),
 			"aws_iam_policy_document":      dataSourceAwsIamPolicyDocument(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
 			"aws_s3_bucket_object":         dataSourceAwsS3BucketObject(),

--- a/website/source/docs/providers/aws/d/elb_account_id.html.markdown
+++ b/website/source/docs/providers/aws/d/elb_account_id.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elb_account_id"
+sidebar_current: "docs-aws-datasource-elb-account-id"
+description: |-
+  Get AWS Elastic Load Balancing Account ID
+---
+
+# aws\_elb\_account\_id
+
+Use this data source to get the Account ID of the [AWS Elastic Load Balancing Account](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy)
+in a given region for the purpose of whitelisting in S3 bucket policy.
+
+## Example Usage
+
+```
+data "aws_elb_account_id" "main" { }
+
+resource "aws_s3_bucket" "elb_logs" {
+    bucket = "my-elb-tf-test-bucket"
+    acl = "private"
+    policy = <<POLICY
+{
+  "Id": "Policy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::my-elb-tf-test-bucket/AWSLogs/*",
+      "Principal": {
+        "AWS": [
+          "${data.aws_elb_account_id.main.id}"
+        ]
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_elb" "bar" {
+  name = "my-foobar-terraform-elb"
+  availability_zones = ["us-west-2a"]
+
+  access_logs {
+    bucket = "${aws_s3_bucket.elb_logs.bucket}"
+    interval = 5
+  }
+
+  listener {
+    instance_port = 8000
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) Region of a given AWS ELB Account
+
+
+## Attributes Reference
+
+* `id` - Account ID

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -26,6 +26,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ecs-container-definition") %>>
                             <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-elb-account-id") %>>
+                            <a href="/docs/providers/aws/d/elb_account_id.html">aws_elb_account_id</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-iam-policy-document") %>>
                             <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
                         </li>


### PR DESCRIPTION
I'm not sure if data source is the right place for such static lookup, but I can't think of a better place right now.

http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy