### PR TITLE
provider/aws: DataSource for RedShift Account ID

### DIFF
--- a/builtin/providers/aws/data_source_aws_redshift_service_account.go
+++ b/builtin/providers/aws/data_source_aws_redshift_service_account.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// See http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging
+var redshiftServiceAccountPerRegionMap = map[string]string{
+	"us-east-1":      "193672423079",
+	"us-west-1":      "262260360010",
+	"us-west-2":      "902366379725",
+	"ap-south-1":     "865932855811",
+	"ap-northeast-2": "760740231472",
+	"ap-southeast-1": "361669875840",
+	"ap-southeast-2": "762762565011",
+	"ap-northeast-1": "404641285394",
+	"eu-central-1":   "053454850223",
+	"eu-west-1":      "210876761215",
+}
+
+func dataSourceAwsRedshiftServiceAccount() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRedshiftServiceAccountRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsRedshiftServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
+	region := meta.(*AWSClient).region
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+	}
+
+	if accid, ok := redshiftServiceAccountPerRegionMap[region]; ok {
+		d.SetId(accid)
+		return nil
+	}
+
+	return fmt.Errorf("Unknown region (%q)", region)
+}

--- a/builtin/providers/aws/data_source_aws_redshift_service_account_test.go
+++ b/builtin/providers/aws/data_source_aws_redshift_service_account_test.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSRedshiftServiceAccount_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsRedshiftServiceAccountConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_redshift_service_account.main", "id", "902366379725"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "id", "210876761215"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAwsRedshiftServiceAccountConfig = `
+data "aws_redshift_service_account" "main" { }
+`
+
+const testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig = `
+data "aws_redshift_service_account" "regional" {
+	region = "eu-west-1"
+}
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -143,11 +143,12 @@ func Provider() terraform.ResourceProvider {
 			"aws_ami":                      dataSourceAwsAmi(),
 			"aws_availability_zones":       dataSourceAwsAvailabilityZones(),
 			"aws_caller_identity":          dataSourceAwsCallerIdentity(),
+			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),
 			"aws_elb_account_id":           dataSourceAwsElbAccountId(),
 			"aws_iam_policy_document":      dataSourceAwsIamPolicyDocument(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
+			"aws_redshift_service_account": dataSourceAwsRedshiftServiceAccount(),
 			"aws_s3_bucket_object":         dataSourceAwsS3BucketObject(),
-			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/source/docs/providers/aws/d/redshift_service_account.html.markdown
+++ b/website/source/docs/providers/aws/d/redshift_service_account.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: aws_redshift_account_id"
+sidebar_current: "docs-aws-datasource-redshift-account-id"
+description: |-
+  Get AWS Redshift Service Account ID for storing audit data in S3.
+---
+
+# aws\_redshift\_service\_account
+
+Use this data source to get the Service Account ID of the [AWS Redshift Account](http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging)
+in a given region for the purpose of allowing Redshift to store audit data in S3.
+
+## Example Usage
+
+```
+data "aws_redshift_service_account" "main" { }
+
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-redshift-logging-test-bucket"
+	force_destroy = true
+	policy = <<EOF
+{
+	"Version": "2008-10-17",
+	"Statement": [
+		{
+        			"Sid": "Put bucket policy needed for audit logging",
+        			"Effect": "Allow",
+        			"Principal": {
+        				"AWS": "arn:aws:iam:${data.aws_redshift_account_id.main.id}:user/logs"
+        			},
+        			"Action": "s3:PutObject",
+        			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
+        		},
+        		{
+        			"Sid": "Get bucket policy needed for audit logging ",
+        			"Effect": "Allow",
+        			"Principal": {
+        				"AWS": "arn:aws:iam:${data.aws_redshift_account_id.main.id}:user/logs"
+        			},
+        			"Action": "s3:GetBucketAcl",
+        			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket"
+        		}
+	]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) Name of the Region whose Redshift account id is desired. If not specified, default's to the region from the AWS provider configuration.
+
+
+## Attributes Reference
+
+* `id` - The ID of the Redshift service Account in the selected region.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -35,6 +35,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ip_ranges") %>>
                             <a href="/docs/providers/aws/d/ip_ranges.html">aws_ip_ranges</a>
                         </li>
+                      <li<%= sidebar_current("docs-aws-datasource-redshift-account-id") %>>
+                        <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_servcice_account</a>
+                      </li>
                         <li<%= sidebar_current("docs-aws-datasource-s3-bucket-object") %>>
                             <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
                         </li>


### PR DESCRIPTION
When you need to enable monitoring for Redshift, you need to create the
correct policy in the bucket for logging. This needs to have the
Redshift Account ID for a given region. This data source provides a
handy lookup for this

http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging

```
% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestAccAWSRedshiftServiceAccount_basic'         2 ↵ ✹ ✭
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/16 14:39:35 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSRedshiftServiceAccount_basic -timeout 120m
=== RUN   TestAccAWSRedshiftServiceAccount_basic
--- PASS: TestAccAWSRedshiftServiceAccount_basic (19.47s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    19.483s
```