### PR TITLE
Clean up whitespace in `aws_appautoscaling_policy` docs

### DIFF
--- a/website/source/docs/providers/aws/r/appautoscaling_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/appautoscaling_policy.html.markdown
@@ -14,18 +14,18 @@ Provides an Application AutoScaling Policy resource.
 ```
 resource "aws_appautoscaling_policy" "down" {
   name = "scale-down"
-	service_namespace = "ecs"
-	resource_id = "service/ecsclustername/servicename"
-	scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace = "ecs"
+  resource_id = "service/ecsclustername/servicename"
+  scalable_dimension = "ecs:service:DesiredCount"
 
-	adjustment_type = "ChangeInCapacity"
-	cooldown = 60
-	metric_aggregation_type = "Maximum"
+  adjustment_type = "ChangeInCapacity"
+  cooldown = 60
+  metric_aggregation_type = "Maximum"
 
-	step_adjustment {
+  step_adjustment {
     metric_interval_lower_bound = 0
-		scaling_adjustment = -1
-	}
+    scaling_adjustment = -1
+  }
   depends_on = ["aws_appautoscaling_target.target"]
 }
 ```


### PR DESCRIPTION
The whitespace in the documentation for `aws_appautoscaling_policy` was very confusing.  I believe it was due to a mix up of tabs and spaces.  It's much prettier and easier to read now.