### PR TITLE
docs/aws: Fixing the  size documentation to be GiBs not GBs

### DIFF
--- a/website/source/docs/providers/aws/r/ebs_volume.html.md
+++ b/website/source/docs/providers/aws/r/ebs_volume.html.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `availability_zone` - (Required) The AZ where the EBS volume will exist.
 * `encrypted` - (Optional) If true, the disk will be encrypted.
 * `iops` - (Optional) The amount of IOPS to provision for the disk.
-* `size` - (Optional) The size of the drive in GB.
+* `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `type` - (Optional) The type of EBS volume. Can be "standard", "gp2", "io1", or "st1" (Default: "standard").
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true


### PR DESCRIPTION
Fixes #8198 