### PR TITLE
config: count can't be a SimpleVariable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -468,10 +468,15 @@ func (c *Config) Validate() error {
 					"%s: resource count can't reference resource variable: %s",
 					n,
 					v.FullKey()))
+			case *SimpleVariable:
+				errs = append(errs, fmt.Errorf(
+					"%s: resource count can't reference variable: %s",
+					n,
+					v.FullKey()))
 			case *UserVariable:
 				// Good
 			default:
-				panic("Unknown type in count var: " + n)
+				panic(fmt.Sprintf("Unknown type in count var in %s: %T", n, v))
 			}
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -216,6 +216,13 @@ func TestConfigValidate_countVarInvalid(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_countVarUnknown(t *testing.T) {
+	c := testConfig(t, "validate-count-var-unknown")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_dependsOnVar(t *testing.T) {
 	c := testConfig(t, "validate-depends-on-var")
 	if err := c.Validate(); err == nil {

--- a/config/test-fixtures/validate-count-var-unknown/main.tf
+++ b/config/test-fixtures/validate-count-var-unknown/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+    count = "${list}"
+}

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -6,6 +6,25 @@ import (
 	"testing"
 )
 
+func TestContext2Validate_badCount(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "validate-bad-count")
+	c := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	w, e := c.Validate()
+	if len(w) > 0 {
+		t.Fatalf("bad: %#v", w)
+	}
+	if len(e) == 0 {
+		t.Fatalf("bad: %#v", e)
+	}
+}
+
 func TestContext2Validate_badVar(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "validate-bad-var")

--- a/terraform/test-fixtures/validate-bad-count/main.tf
+++ b/terraform/test-fixtures/validate-bad-count/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  count = "${list}"
+}


### PR DESCRIPTION
Fixes #8185 

Easy fix here, we needed the `count` validation to check "SimpleVariable" types as well which are unprefixed variables like `list` (instead of `foo.list`).