### PR TITLE
Update Vagrantfile to use Go 1.7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $script = <<SCRIPT
-GOVERSION="1.6"
+GOVERSION="1.7"
 SRCROOT="/opt/go"
 SRCPATH="/opt/gopath"
 
@@ -37,9 +37,13 @@ export GOPATH="$SRCPATH"
 export GOROOT="$SRCROOT"
 export PATH="$SRCROOT/bin:$SRCPATH/bin:\$PATH"
 EOF
+cat <<EOF >>~/.bashrc
+
+## After login, change to terraform directory
+cd /opt/gopath/src/github.com/hashicorp/terraform
+EOF
 sudo mv /tmp/gopath.sh /etc/profile.d/gopath.sh
 sudo chmod 0755 /etc/profile.d/gopath.sh
-source /etc/profile.d/gopath.sh
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
Knocking on [58e4a58](https://github.com/hashicorp/terraform/commit/58e4a5809960475a216fde32d11d1db77533eb43) and #8211, I updated the Vagrantfile to use Go 1.7. Tested a full build, and it passed.

I also added a bit to the .bashrc to change to the shared Terraform code directory on `vagrant ssh`, and removed the `source` from the end of the provisioning script as it's a noop.

I had attempted to update this to use Ubuntu 16.04 LTS, but there seems to be an issue with the bento box and the parallels provisioner on the vagrant side, so I just left it at 14.04 for now.