### PR TITLE
core: name_prefix names now start with a timestamp

### DIFF
--- a/helper/resource/id_test.go
+++ b/helper/resource/id_test.go
@@ -1,14 +1,18 @@
 package resource
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
 
+var allDigits = regexp.MustCompile(`^\d+$`)
+var allBase32 = regexp.MustCompile(`^[a-z234567]+$`)
+
 func TestUniqueId(t *testing.T) {
 	iterations := 10000
 	ids := make(map[string]struct{})
-	var id string
+	var id, lastId string
 	for i := 0; i < iterations; i++ {
 		id = UniqueId()
 
@@ -20,6 +24,28 @@ func TestUniqueId(t *testing.T) {
 			t.Fatalf("Unique ID didn't have terraform- prefix! %s", id)
 		}
 
+		rest := strings.TrimPrefix(id, "terraform-")
+
+		if len(rest) != 26 {
+			t.Fatalf("Post-prefix part has wrong length! %s", rest)
+		}
+
+		timestamp := rest[:23]
+		random := rest[23:]
+
+		if !allDigits.MatchString(timestamp) {
+			t.Fatalf("Timestamp not all digits! %s", timestamp)
+		}
+
+		if !allBase32.MatchString(random) {
+			t.Fatalf("Random part not all base32! %s", random)
+		}
+
+		if lastId != "" && lastId >= id {
+			t.Fatalf("IDs not ordered! %s vs %s", lastId, id)
+		}
+
 		ids[id] = struct{}{}
+		lastId = id
 	}
 }


### PR DESCRIPTION
This means that two resources created by the same rule during different
seconds will get names which sort in the order they are created.

The rest of the ID is still random base32 characters; we no longer set
the bit values that denote UUIDv4.

The length of the ID returned by PrefixedUniqueId is not changed by this
commit.

Fixes #8143.