### PR TITLE
mysql_user pre-5.7.6 compat (fixes GH-8230)

### DIFF
--- a/builtin/providers/mysql/provider.go
+++ b/builtin/providers/mysql/provider.go
@@ -2,13 +2,22 @@ package mysql
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
-	mysqlc "github.com/ziutek/mymysql/thrsafe"
+	mysqlc "github.com/ziutek/mymysql/mysql"
+	mysqlts "github.com/ziutek/mymysql/thrsafe"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+type providerConfiguration struct {
+	Conn         mysqlc.Conn
+	VersionMajor uint
+	VersionMinor uint
+	VersionPatch uint
+}
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
@@ -69,21 +78,65 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		proto = "unix"
 	}
 
-	// mysqlc is the thread-safe implementation of mymysql, so we can
+	// mysqlts is the thread-safe implementation of mymysql, so we can
 	// safely re-use the same connection between multiple parallel
 	// operations.
-	conn := mysqlc.New(proto, "", endpoint, username, password)
+	conn := mysqlts.New(proto, "", endpoint, username, password)
 
 	err := conn.Connect()
 	if err != nil {
 		return nil, err
 	}
 
-	return conn, nil
+	major, minor, patch, err := mysqlVersion(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &providerConfiguration{
+		Conn:         conn,
+		VersionMajor: major,
+		VersionMinor: minor,
+		VersionPatch: patch,
+	}, nil
 }
 
 var identQuoteReplacer = strings.NewReplacer("`", "``")
 
 func quoteIdentifier(in string) string {
 	return fmt.Sprintf("`%s`", identQuoteReplacer.Replace(in))
+}
+
+func mysqlVersion(conn mysqlc.Conn) (uint, uint, uint, error) {
+	rows, _, err := conn.Query("SELECT VERSION()")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if len(rows) == 0 {
+		return 0, 0, 0, fmt.Errorf("SELECT VERSION() returned an empty set")
+	}
+
+	versionString := rows[0].Str(0)
+	version := strings.Split(versionString, ".")
+	invalidVersionErr := fmt.Errorf("Invalid major.minor.patch in %q", versionString)
+	if len(version) != 3 {
+		return 0, 0, 0, invalidVersionErr
+	}
+
+	major, err := strconv.ParseUint(version[0], 10, 32)
+	if err != nil {
+		return 0, 0, 0, invalidVersionErr
+	}
+
+	minor, err := strconv.ParseUint(version[1], 10, 32)
+	if err != nil {
+		return 0, 0, 0, invalidVersionErr
+	}
+
+	patch, err := strconv.ParseUint(version[2], 10, 32)
+	if err != nil {
+		return 0, 0, 0, invalidVersionErr
+	}
+
+	return uint(major), uint(minor), uint(patch), nil
 }

--- a/builtin/providers/mysql/resource_database.go
+++ b/builtin/providers/mysql/resource_database.go
@@ -43,7 +43,7 @@ func resourceDatabase() *schema.Resource {
 }
 
 func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	stmtSQL := databaseConfigSQL("CREATE", d)
 	log.Println("Executing statement:", stmtSQL)
@@ -59,7 +59,7 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	stmtSQL := databaseConfigSQL("ALTER", d)
 	log.Println("Executing statement:", stmtSQL)
@@ -73,7 +73,7 @@ func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	// This is kinda flimsy-feeling, since it depends on the formatting
 	// of the SHOW CREATE DATABASE output... but this data doesn't seem
@@ -124,7 +124,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteDatabase(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	name := d.Id()
 	stmtSQL := "DROP DATABASE " + quoteIdentifier(name)

--- a/builtin/providers/mysql/resource_database_test.go
+++ b/builtin/providers/mysql/resource_database_test.go
@@ -39,7 +39,7 @@ func testAccDatabaseCheck(rn string, name *string) resource.TestCheckFunc {
 			return fmt.Errorf("database id not set")
 		}
 
-		conn := testAccProvider.Meta().(mysqlc.Conn)
+		conn := testAccProvider.Meta().(*providerConfiguration).Conn
 		rows, _, err := conn.Query("SHOW CREATE DATABASE terraform_acceptance_test")
 		if err != nil {
 			return fmt.Errorf("error reading database: %s", err)
@@ -66,7 +66,7 @@ func testAccDatabaseCheck(rn string, name *string) resource.TestCheckFunc {
 
 func testAccDatabaseCheckDestroy(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(mysqlc.Conn)
+		conn := testAccProvider.Meta().(*providerConfiguration).Conn
 
 		_, _, err := conn.Query("SHOW CREATE DATABASE terraform_acceptance_test")
 		if err == nil {

--- a/builtin/providers/mysql/resource_grant.go
+++ b/builtin/providers/mysql/resource_grant.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"strings"
 
-	mysqlc "github.com/ziutek/mymysql/mysql"
-
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -56,7 +54,7 @@ func resourceGrant() *schema.Resource {
 }
 
 func CreateGrant(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	// create a comma-delimited string of privileges
 	var privileges string
@@ -95,7 +93,7 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.* FROM '%s'@'%s'",
 		d.Get("database").(string),

--- a/builtin/providers/mysql/resource_grant_test.go
+++ b/builtin/providers/mysql/resource_grant_test.go
@@ -47,7 +47,7 @@ func testAccPrivilegeExists(rn string, privilege string) resource.TestCheckFunc 
 		user := userhost[0]
 		host := userhost[1]
 
-		conn := testAccProvider.Meta().(mysqlc.Conn)
+		conn := testAccProvider.Meta().(*providerConfiguration).Conn
 		stmtSQL := fmt.Sprintf("SHOW GRANTS for '%s'@'%s'", user, host)
 		log.Println("Executing statement:", stmtSQL)
 		rows, _, err := conn.Query(stmtSQL)
@@ -77,7 +77,7 @@ func testAccPrivilegeExists(rn string, privilege string) resource.TestCheckFunc 
 }
 
 func testAccGrantCheckDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(mysqlc.Conn)
+	conn := testAccProvider.Meta().(*providerConfiguration).Conn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mysql_grant" {

--- a/builtin/providers/mysql/resource_user.go
+++ b/builtin/providers/mysql/resource_user.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	mysqlc "github.com/ziutek/mymysql/mysql"
-
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -40,7 +38,7 @@ func resourceUser() *schema.Resource {
 }
 
 func CreateUser(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	stmtSQL := fmt.Sprintf("CREATE USER '%s'@'%s'",
 		d.Get("user").(string),
@@ -64,17 +62,29 @@ func CreateUser(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateUser(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conf := meta.(*providerConfiguration)
 
 	if d.HasChange("password") {
 		_, newpw := d.GetChange("password")
-		stmtSQL := fmt.Sprintf("ALTER USER '%s'@'%s' IDENTIFIED BY '%s'",
-			d.Get("user").(string),
-			d.Get("host").(string),
-			newpw.(string))
+		var stmtSQL string
+
+		/* ALTER USER syntax introduced in MySQL 5.7.6 deprecates SET PASSWORD (GH-8230) */
+		if conf.VersionMajor > 5 ||
+			(conf.VersionMajor == 5 && conf.VersionMinor > 7) ||
+			(conf.VersionMajor == 5 && conf.VersionMinor == 7 && conf.VersionPatch >= 6) {
+			stmtSQL = fmt.Sprintf("ALTER USER '%s'@'%s' IDENTIFIED BY '%s'",
+				d.Get("user").(string),
+				d.Get("host").(string),
+				newpw.(string))
+		} else {
+			stmtSQL = fmt.Sprintf("SET PASSWORD FOR '%s'@'%s' = PASSWORD('%s')",
+				d.Get("user").(string),
+				d.Get("host").(string),
+				newpw.(string))
+		}
 
 		log.Println("Executing query:", stmtSQL)
-		_, _, err := conn.Query(stmtSQL)
+		_, _, err := conf.Conn.Query(stmtSQL)
 		if err != nil {
 			return err
 		}
@@ -89,7 +99,7 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteUser(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(mysqlc.Conn)
+	conn := meta.(*providerConfiguration).Conn
 
 	stmtSQL := fmt.Sprintf("DROP USER '%s'@'%s'",
 		d.Get("user").(string),


### PR DESCRIPTION
As described in GH-8230, `mysql_user` isn't compatible with MySQL versions < 5.7.6. This PR adds a conditional based on the version string reported by MySQL, and a test that covers this scenario.