### PR TITLE
provider/aws: Support import of `aws_s3_bucket`

### DIFF
--- a/builtin/providers/aws/import_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/import_aws_s3_bucket_test.go
@@ -1,0 +1,32 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSS3Bucket_importBasic(t *testing.T) {
+	resourceName := "aws_s3_bucket.bucket"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketConfig(rInt),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -23,6 +23,9 @@ func resourceAwsS3Bucket() *schema.Resource {
 		Read:   resourceAwsS3BucketRead,
 		Update: resourceAwsS3BucketUpdate,
 		Delete: resourceAwsS3BucketDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"bucket": &schema.Schema{

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -249,3 +249,11 @@ The following attributes are exported:
 * `region` - The AWS region this bucket resides in.
 * `website_endpoint` - The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 * `website_domain` - The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+
+## Import
+
+S3 bucket can be imported using the `bucket`, e.g. 
+
+```
+$ terraform import aws_s3_bucket.bucket bucket-name
+```


### PR DESCRIPTION
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3Bucket_importBasic'                                                                                                                
==> Checking that code complies with gofmt requirements...
/home/kazunori/repos/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/18 00:31:44 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3Bucket_importBasic -timeout 120m
=== RUN   TestAccAWSS3Bucket_importBasic
--- PASS: TestAccAWSS3Bucket_importBasic (26.66s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    26.681s
```