### PR TITLE
Document credentials variable and env var for gcs remote state

### DIFF
--- a/website/source/docs/state/remote/gcs.html.md
+++ b/website/source/docs/state/remote/gcs.html.md
@@ -53,3 +53,4 @@ The following configuration options are supported:
 
  * `bucket` - (Required) The name of the GCS bucket
  * `path` - (Required) The path where to place/look for state file inside the bucket
+ * `credentials` / `GOOGLE_CREDENTIALS` - (Required) Google Cloud Platform account credentials in json format


### PR DESCRIPTION
Just added a line documenting the environment variable for credentials as it wasn't immediately clear how this is set.