### PR TITLE
provider/aws: Add aws_alb_listener resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -153,6 +153,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"aws_alb":                                      resourceAwsAlb(),
+			"aws_alb_listener":                             resourceAwsAlbListener(),
 			"aws_alb_target_group":                         resourceAwsAlbTargetGroup(),
 			"aws_ami":                                      resourceAwsAmi(),
 			"aws_ami_copy":                                 resourceAwsAmiCopy(),

--- a/builtin/providers/aws/resource_aws_alb.go
+++ b/builtin/providers/aws/resource_aws_alb.go
@@ -22,6 +22,11 @@ func resourceAwsAlb() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -164,6 +169,7 @@ func resourceAwsAlbRead(d *schema.ResourceData, meta interface{}) error {
 
 	alb := describeResp.LoadBalancers[0]
 
+	d.Set("arn", alb.LoadBalancerArn)
 	d.Set("name", alb.LoadBalancerName)
 	d.Set("internal", (alb.Scheme != nil && *alb.Scheme == "internal"))
 	d.Set("security_groups", flattenStringList(alb.SecurityGroups))

--- a/builtin/providers/aws/resource_aws_alb_listener.go
+++ b/builtin/providers/aws/resource_aws_alb_listener.go
@@ -1,0 +1,261 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsAlbListener() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAlbListenerCreate,
+		Read:   resourceAwsAlbListenerRead,
+		Update: resourceAwsAlbListenerUpdate,
+		Delete: resourceAwsAlbListenerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"load_balancer_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"port": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validateAwsAlbListenerPort,
+			},
+
+			"protocol": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "HTTP",
+				StateFunc: func(v interface{}) string {
+					return strings.ToUpper(v.(string))
+				},
+				ValidateFunc: validateAwsAlbListenerProtocol,
+			},
+
+			"ssl_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"default_action": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_group_arn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateAwsAlbListenerDefaultActionType,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsAlbListenerCreate(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbv2conn
+
+	params := &elbv2.CreateListenerInput{
+		LoadBalancerArn: aws.String(d.Get("load_balancer_arn").(string)),
+		Port:            aws.Int64(int64(d.Get("port").(int))),
+		Protocol:        aws.String(d.Get("protocol").(string)),
+	}
+
+	if sslPolicy, ok := d.GetOk("ssl_policy"); ok {
+		params.SslPolicy = aws.String(sslPolicy.(string))
+	}
+
+	if certificateArn, ok := d.GetOk("certificate_arn"); ok {
+		params.Certificates = make([]*elbv2.Certificate, 1)
+		params.Certificates[0] = &elbv2.Certificate{
+			CertificateArn: aws.String(certificateArn.(string)),
+		}
+	}
+
+	if defaultActions := d.Get("default_action").([]interface{}); len(defaultActions) == 1 {
+		params.DefaultActions = make([]*elbv2.Action, len(defaultActions))
+
+		for i, defaultAction := range defaultActions {
+			defaultActionMap := defaultAction.(map[string]interface{})
+
+			params.DefaultActions[i] = &elbv2.Action{
+				TargetGroupArn: aws.String(defaultActionMap["target_group_arn"].(string)),
+				Type:           aws.String(defaultActionMap["type"].(string)),
+			}
+		}
+	}
+
+	resp, err := elbconn.CreateListener(params)
+	if err != nil {
+		return errwrap.Wrapf("Error creating ALB Listener: {{err}}", err)
+	}
+
+	if len(resp.Listeners) == 0 {
+		return errors.New("Error creating ALB Listener: no listeners returned in response")
+	}
+
+	d.SetId(*resp.Listeners[0].ListenerArn)
+
+	return resourceAwsAlbListenerRead(d, meta)
+}
+
+func resourceAwsAlbListenerRead(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbv2conn
+
+	resp, err := elbconn.DescribeListeners(&elbv2.DescribeListenersInput{
+		ListenerArns: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		if isListenerNotFound(err) {
+			log.Printf("[WARN] DescribeListeners - removing %s from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return errwrap.Wrapf("Error retrieving Listener: {{err}}", err)
+	}
+
+	if len(resp.Listeners) != 1 {
+		return fmt.Errorf("Error retrieving Listener %q", d.Id())
+	}
+
+	listener := resp.Listeners[0]
+
+	d.Set("arn", listener.ListenerArn)
+	d.Set("load_balancer_arn", listener.LoadBalancerArn)
+	d.Set("port", listener.Port)
+	d.Set("protocol", listener.Protocol)
+	d.Set("ssl_policy", listener.SslPolicy)
+
+	if listener.Certificates != nil && len(listener.Certificates) == 1 {
+		d.Set("certificate_arn", listener.Certificates[0].CertificateArn)
+	}
+
+	defaultActions := make([]map[string]interface{}, 0)
+	if listener.DefaultActions != nil && len(listener.DefaultActions) > 0 {
+		for _, defaultAction := range listener.DefaultActions {
+			action := map[string]interface{}{
+				"target_group_arn": *defaultAction.TargetGroupArn,
+				"type":             *defaultAction.Type,
+			}
+			defaultActions = append(defaultActions, action)
+		}
+	}
+	d.Set("default_action", defaultActions)
+
+	return nil
+}
+
+func resourceAwsAlbListenerUpdate(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbv2conn
+
+	params := &elbv2.ModifyListenerInput{
+		ListenerArn: aws.String(d.Id()),
+		Port:        aws.Int64(int64(d.Get("port").(int))),
+		Protocol:    aws.String(d.Get("protocol").(string)),
+	}
+
+	if sslPolicy, ok := d.GetOk("ssl_policy"); ok {
+		params.SslPolicy = aws.String(sslPolicy.(string))
+	}
+
+	if certificateArn, ok := d.GetOk("certificate_arn"); ok {
+		params.Certificates = make([]*elbv2.Certificate, 1)
+		params.Certificates[0] = &elbv2.Certificate{
+			CertificateArn: aws.String(certificateArn.(string)),
+		}
+	}
+
+	if defaultActions := d.Get("default_action").([]interface{}); len(defaultActions) == 1 {
+		params.DefaultActions = make([]*elbv2.Action, len(defaultActions))
+
+		for i, defaultAction := range defaultActions {
+			defaultActionMap := defaultAction.(map[string]interface{})
+
+			params.DefaultActions[i] = &elbv2.Action{
+				TargetGroupArn: aws.String(defaultActionMap["target_group_arn"].(string)),
+				Type:           aws.String(defaultActionMap["type"].(string)),
+			}
+		}
+	}
+
+	_, err := elbconn.ModifyListener(params)
+	if err != nil {
+		return errwrap.Wrapf("Error modifying ALB Listener: {{err}}", err)
+	}
+
+	return resourceAwsAlbListenerRead(d, meta)
+}
+
+func resourceAwsAlbListenerDelete(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbv2conn
+
+	_, err := elbconn.DeleteListener(&elbv2.DeleteListenerInput{
+		ListenerArn: aws.String(d.Id()),
+	})
+	if err != nil {
+		return errwrap.Wrapf("Error deleting Listener: {{err}}", err)
+	}
+
+	return nil
+}
+
+func validateAwsAlbListenerPort(v interface{}, k string) (ws []string, errors []error) {
+	port := v.(int)
+	if port < 1 || port > 65536 {
+		errors = append(errors, fmt.Errorf("%q must be a valid port number (1-65536)", k))
+	}
+	return
+}
+
+func validateAwsAlbListenerProtocol(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	if value == "http" || value == "https" {
+		return
+	}
+
+	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS"))
+	return
+}
+
+func validateAwsAlbListenerDefaultActionType(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	if value != "forward" {
+		errors = append(errors, fmt.Errorf("%q must have the value %q", k, "forward"))
+	}
+	return
+}
+
+func isListenerNotFound(err error) bool {
+	elberr, ok := err.(awserr.Error)
+	return ok && elberr.Code() == "ListenerNotFound"
+}

--- a/builtin/providers/aws/resource_aws_alb_listener_test.go
+++ b/builtin/providers/aws/resource_aws_alb_listener_test.go
@@ -1,0 +1,385 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSALBListener_basic(t *testing.T) {
+	var conf elbv2.Listener
+	albName := fmt.Sprintf("testlistener-basic-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_listener.front_end",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBListenerConfig_basic(albName, targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBListenerExists("aws_alb_listener.front_end", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "protocol", "HTTP"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "port", "80"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "default_action.0.target_group_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBListener_https(t *testing.T) {
+	var conf elbv2.Listener
+	albName := fmt.Sprintf("testlistener-https-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_listener.front_end",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBListenerConfig_https(albName, targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBListenerExists("aws_alb_listener.front_end", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "certificate_arn"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "ssl_policy", "ELBSecurityPolicy-2015-05"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSALBListenerExists(n string, res *elbv2.Listener) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Listener ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).elbv2conn
+
+		describe, err := conn.DescribeListeners(&elbv2.DescribeListenersInput{
+			ListenerArns: []*string{aws.String(rs.Primary.ID)},
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if len(describe.Listeners) != 1 ||
+			*describe.Listeners[0].ListenerArn != rs.Primary.ID {
+			return errors.New("Listener not found")
+		}
+
+		*res = *describe.Listeners[0]
+		return nil
+	}
+}
+
+func testAccCheckAWSALBListenerDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).elbv2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_alb_listener" {
+			continue
+		}
+
+		describe, err := conn.DescribeListeners(&elbv2.DescribeListenersInput{
+			ListenerArns: []*string{aws.String(rs.Primary.ID)},
+		})
+
+		if err == nil {
+			if len(describe.Listeners) != 0 &&
+				*describe.Listeners[0].ListenerArn == rs.Primary.ID {
+				return fmt.Errorf("Listener %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if isListenerNotFound(err) {
+			return nil
+		} else {
+			return errwrap.Wrapf("Unexpected error checking ALB Listener destroyed: {{err}}", err)
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSALBListenerConfig_basic(albName, targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_listener" "front_end" {
+   load_balancer_arn = "${aws_alb.alb_test.id}"
+   protocol = "HTTP"
+   port = "80"
+
+   default_action {
+     target_group_arn = "${aws_alb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_alb" "alb_test" {
+  name            = "%s"
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}`, albName, targetGroupName)
+}
+
+func testAccAWSALBListenerConfig_https(albName, targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_listener" "front_end" {
+   load_balancer_arn = "${aws_alb.alb_test.id}"
+   protocol = "HTTPS"
+   port = "443"
+   ssl_policy = "ELBSecurityPolicy-2015-05"
+   certificate_arn = "${aws_iam_server_certificate.test_cert.arn}"
+
+   default_action {
+     target_group_arn = "${aws_alb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_alb" "alb_test" {
+  name            = "%s"
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_iam_server_certificate" "test_cert" {
+  name = "terraform-test-cert-%d"
+  certificate_body = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDBjCCAe4CCQCGWwBmOiHQdTANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJB
+VTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0
+cyBQdHkgTHRkMB4XDTE2MDYyMTE2MzM0MVoXDTE3MDYyMTE2MzM0MVowRTELMAkG
+A1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0
+IFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AL+LFlsCJG5txZp4yuu+lQnuUrgBXRG+irQqcTXlV91Bp5hpmRIyhnGCtWxxDBUL
+xrh4WN3VV/0jDzKT976oLgOy3hj56Cdqf+JlZ1qgMN5bHB3mm3aVWnrnsLbBsfwZ
+SEbk3Kht/cE1nK2toNVW+rznS3m+eoV3Zn/DUNwGlZr42hGNs6ETn2jURY78ETqR
+mW47xvjf86eIo7vULHJaY6xyarPqkL8DZazOmvY06hUGvGwGBny7gugfXqDG+I8n
+cPBsGJGSAmHmVV8o0RCB9UjY+TvSMQRpEDoVlvyrGuglsD8to/4+7UcsuDGlRYN6
+jmIOC37mOi/jwRfWL1YUa4MCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAPDxTH0oQ
+JjKXoJgkmQxurB81RfnK/NrswJVzWbOv6ejcbhwh+/ZgJTMc15BrYcxU6vUW1V/i
+Z7APU0qJ0icECACML+a2fRI7YdLCTiPIOmY66HY8MZHAn3dGjU5TeiUflC0n0zkP
+mxKJe43kcYLNDItbfvUDo/GoxTXrC3EFVZyU0RhFzoVJdODlTHXMVFCzcbQEBrBJ
+xKdShCEc8nFMneZcGFeEU488ntZoWzzms8/QpYrKa5S0Sd7umEU2Kwu4HTkvUFg/
+CqDUFjhydXxYRsxXBBrEiLOE5BdtJR1sH/QHxIJe23C9iHI2nS1NbLziNEApLwC4
+GnSud83VUo9G9w==
+-----END CERTIFICATE-----
+EOF
+
+	private_key =  <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAv4sWWwIkbm3FmnjK676VCe5SuAFdEb6KtCpxNeVX3UGnmGmZ
+EjKGcYK1bHEMFQvGuHhY3dVX/SMPMpP3vqguA7LeGPnoJ2p/4mVnWqAw3lscHeab
+dpVaeuewtsGx/BlIRuTcqG39wTWcra2g1Vb6vOdLeb56hXdmf8NQ3AaVmvjaEY2z
+oROfaNRFjvwROpGZbjvG+N/zp4iju9QsclpjrHJqs+qQvwNlrM6a9jTqFQa8bAYG
+fLuC6B9eoMb4jydw8GwYkZICYeZVXyjREIH1SNj5O9IxBGkQOhWW/Ksa6CWwPy2j
+/j7tRyy4MaVFg3qOYg4LfuY6L+PBF9YvVhRrgwIDAQABAoIBAFqJ4h1Om+3e0WK8
+6h4YzdYN4ue7LUTv7hxPW4gASlH5cMDoWURywX3yLNN/dBiWom4b5NWmvJqY8dwU
+eSyTznxNFhJ0PjozaxOWnw4FXlQceOPhV2bsHgKudadNU1Y4lSN9lpe+tg2Xy+GE
+ituM66RTKCf502w3DioiJpx6OEkxuhrnsQAWNcGB0MnTukm2f+629V+04R5MT5V1
+nY+5Phx2BpHgYzWBKh6Px1puu7xFv5SMQda1ndlPIKb4cNp0yYn+1lHNjbOE7QL/
+oEpWgrauS5Zk/APK33v/p3wVYHrKocIFHlPiCW0uIJJLsOZDY8pQXpTlc+/xGLLy
+WBu4boECgYEA6xO+1UNh6ndJ3xGuNippH+ucTi/uq1+0tG1bd63v+75tn5l4LyY2
+CWHRaWVlVn+WnDslkQTJzFD68X+9M7Cc4oP6WnhTyPamG7HlGv5JxfFHTC9GOKmz
+sSc624BDmqYJ7Xzyhe5kc3iHzqG/L72ZF1aijZdrodQMSY1634UX6aECgYEA0Jdr
+cBPSN+mgmEY6ogN5h7sO5uNV3TQQtW2IslfWZn6JhSRF4Rf7IReng48CMy9ZhFBy
+Q7H2I1pDGjEC9gQHhgVfm+FyMSVqXfCHEW/97pvvu9ougHA0MhPep1twzTGrqg+K
+f3PLW8hVkGyCrTfWgbDlPsHgsocA/wTaQOheaqMCgYBat5z+WemQfQZh8kXDm2xE
+KD2Cota9BcsLkeQpdFNXWC6f167cqydRSZFx1fJchhJOKjkeFLX3hgzBY6VVLEPu
+2jWj8imLNTv3Fhiu6RD5NVppWRkFRuAUbmo1SPNN2+Oa5YwGCXB0a0Alip/oQYex
+zPogIB4mLlmrjNCtL4SB4QKBgCEHKMrZSJrz0irqS9RlanPUaZqjenAJE3A2xMNA
+Z0FZXdsIEEyA6JGn1i1dkoKaR7lMp5sSbZ/RZfiatBZSMwLEjQv4mYUwoHP5Ztma
++wEyDbaX6G8L1Sfsv3+OWgETkVPfHBXsNtH0mZ/BnrtgsQVeBh52wmZiPAUlNo26
+fWCzAoGBAJOjqovLelLWzyQGqPFx/MwuI56UFXd1CmFlCIvF2WxCFmk3tlExoCN1
+HqSpt92vsgYgV7+lAb4U7Uy/v012gwiU1LK+vyAE9geo3pTjG73BNzG4H547xtbY
+dg+Sd4Wjm89UQoUUoiIcstY7FPbqfBtYKfh4RYHAHV2BwDFqzZCM
+-----END RSA PRIVATE KEY-----
+EOF
+}
+`, albName, targetGroupName, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+}

--- a/builtin/providers/aws/resource_aws_alb_target_group.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group.go
@@ -25,6 +25,11 @@ func resourceAwsAlbTargetGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -206,6 +211,7 @@ func resourceAwsAlbTargetGroupRead(d *schema.ResourceData, meta interface{}) err
 
 	targetGroup := resp.TargetGroups[0]
 
+	d.Set("arn", targetGroup.TargetGroupArn)
 	d.Set("name", targetGroup.TargetGroupName)
 	d.Set("port", targetGroup.Port)
 	d.Set("protocol", targetGroup.Protocol)

--- a/builtin/providers/aws/resource_aws_alb_target_group_test.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_test.go
@@ -27,6 +27,7 @@ func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
@@ -64,6 +65,7 @@ func TestAccAWSALBTargetGroup_updateHealthCheck(t *testing.T) {
 				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
@@ -87,6 +89,7 @@ func TestAccAWSALBTargetGroup_updateHealthCheck(t *testing.T) {
 				Config: testAccAWSALBTargetGroupConfig_updateHealthCheck(targetGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),

--- a/builtin/providers/aws/resource_aws_alb_test.go
+++ b/builtin/providers/aws/resource_aws_alb_test.go
@@ -38,6 +38,7 @@ func TestAccAWSALB_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "vpc_id"),
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "zone_id"),
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "dns_name"),
+					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "arn"),
 				),
 			},
 		},
@@ -70,6 +71,7 @@ func TestAccAWSALB_accesslogs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "vpc_id"),
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "zone_id"),
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "dns_name"),
+					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "arn"),
 				),
 			},
 
@@ -91,6 +93,7 @@ func TestAccAWSALB_accesslogs(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "access_logs.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "access_logs.0.bucket", bucketName),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "access_logs.0.prefix", "testAccAWSALBConfig_accessLogs"),
+					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "arn"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/alb.html.markdown
+++ b/website/source/docs/providers/aws/r/alb.html.markdown
@@ -56,7 +56,8 @@ Access Logs (`access_logs`) support the following:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The ARN of the load balancer
+* `id` - The ARN of the load balancer (matches `arn`)
+* `arn` - The ARN of the load balancer (matches `id`)
 * `dns_name` - The DNS name of the load balancer
 * `canonical_hosted_zone_id` - The canonical hosted zone ID of the load balancer.
 * `zone_id` - The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record)

--- a/website/source/docs/providers/aws/r/alb_listener.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_listener.html.markdown
@@ -23,14 +23,14 @@ resource "aws_alb_target_group" "front_end" {
 }
 
 resource "aws_alb_listener" "front_end" {
-   load_balancer_arn = "${aws_alb.front_end.id}"
+   load_balancer_arn = "${aws_alb.front_end.arn}"
    port = "443"
    protocol = "HTTPS"
    ssl_policy = "ELBSecurityPolicy-2015-05"
    certificate_arn = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
    
    default_action {
-     target_group_arn = "${aws_alb_target_group.front_end.id}"
+     target_group_arn = "${aws_alb_target_group.front_end.arn}"
      type = "forward"
    }
 }

--- a/website/source/docs/providers/aws/r/alb_listener.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_listener.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "aws"
+page_title: "AWS: aws_alb_listener"
+sidebar_current: "docs-aws-resource-alb-listener"
+description: |-
+  Provides an Application Load Balancer Listener resource.
+---
+
+# aws\_alb\_listener
+
+Provides an Application Load Balancer Listener resource.
+
+## Example Usage
+
+```
+# Create a new load balancer
+resource "aws_alb" "front_end" {
+  # Other parameters...
+}
+
+resource "aws_alb_target_group" "front_end" {
+  # Other parameters...
+}
+
+resource "aws_alb_listener" "front_end" {
+   load_balancer_arn = "${aws_alb.front_end.id}"
+   port = "443"
+   protocol = "HTTPS"
+   ssl_policy = "ELBSecurityPolicy-2015-05"
+   certificate_arn = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+   
+   default_action {
+     target_group_arn = "${aws_alb_target_group.front_end.id}"
+     type = "forward"
+   }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `load_balancer_arn` - (Required, Forces New Resource) The ARN of the load balancer.
+* `port` - (Required) The port on which the load balancer is listening.
+* `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `HTTP` and `HTTPS`. Defaults to `HTTP`.
+* `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`. The only valid value is currently `ELBSecurityPolicy-2015-05`.
+* `certificate_arn` - (Optional) The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS.
+* `default_action` - (Required) An Action block. Action blocks are documented below.
+
+Action Blocks (for `default_action`) support the following:
+
+* `target_group_arn` - (Required) The ARN of the Target Group to which to route traffic.
+* `type` - (Required) The type of routing action. The only valid value is `forward`.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The ARN of the listener (matches `arn`)
+* `arn` - The ARN of the listener (matches `id`)
+
+## Import
+
+Listeners can be imported using their ARN, e.g.
+
+```
+$ terraform import aws_alb_listener.front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener/app/front-end-alb/8e4497da625e2d8a/9ab28ade35828f96
+```

--- a/website/source/docs/providers/aws/r/alb_target_group.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_target_group.html.markdown
@@ -49,7 +49,8 @@ Health Check Blocks (`health_check`) support the following:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The ARN of the target group.
+* `id` - The ARN of the Target Group (matches `arn`)
+* `arn` - The ARN of the Target Group (matches `id`)
 
 ## Import
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -214,9 +214,13 @@
                             <a href="/docs/providers/aws/r/alb.html">aws_alb</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-alb-listener") %>>
+                            <a href="/docs/providers/aws/r/alb_listener.html">aws_alb_listener</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-alb-target-group") %>>
                             <a href="/docs/providers/aws/r/alb_target_group.html">aws_alb_target_group</a>
-			</li>
+                        </li>
 
                         <li<%= sidebar_current("docs-aws-resource-ami") %>>
                             <a href="/docs/providers/aws/r/ami.html">aws_ami</a>


### PR DESCRIPTION
This commit adds the `aws_alb_listener` resource and associated acceptance tests and documentation.

This is part of a series of pull requests in order to implement #8137.