### PR TITLE
provider/aws: Set aws_alb security_groups computed

### DIFF
--- a/builtin/providers/aws/resource_aws_alb.go
+++ b/builtin/providers/aws/resource_aws_alb.go
@@ -39,6 +39,7 @@ func resourceAwsAlb() *schema.Resource {
 			"security_groups": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 				ForceNew: true,
 				Optional: true,
 				Set:      schema.HashString,


### PR DESCRIPTION
This commit fixes #8264 by making the `security_groups` attribute on `aws_alb` resources computed, allowing the default security group assigned by AWS to not generate perpetual plans forcing new resources.

Part of #8137.