### PR TITLE
provider/aws: Terraform fails during Redshift delete if FinalSnapshot is being taken.

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -670,7 +670,7 @@ func resourceAwsRedshiftClusterDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"available", "creating", "deleting", "rebooting", "resizing", "renaming"},
+		Pending:    []string{"available", "creating", "deleting", "rebooting", "resizing", "renaming", "final-snapshot"},
 		Target:     []string{"destroyed"},
 		Refresh:    resourceAwsRedshiftClusterStateRefreshFunc(d, meta),
 		Timeout:    40 * time.Minute,


### PR DESCRIPTION
When deleting a RedShift cluster with FinalSnapshot set to true, terraform fails when the cluster's status changes to final-snapshot.  This PR simply adds `final-snapshot` as a valid pending state during the delete.

This run was using 0.7.0 on Atlas/Terraform Enterprise
```
aws_redshift_cluster.main: Destroying...
module.us_west_2.opsdata_private_bucket.aws_s3_bucket.main: Modifications complete
Error applying plan:

1 error(s) occurred:

* aws_redshift_cluster.main: [ERROR] Error deleting Redshift Cluster (warehouse): unexpected state 'final-snapshot', wanted target 'destroyed'. last error: %!s(<nil>)
```