### PR TITLE
vSphere Provider: Fix #8253

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -1053,6 +1053,9 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 						}
 						if gatewaySetting != "" {
 							deviceID, err := strconv.Atoi(route.Gateway.Device)
+							if len(networkInterfaces) == 1 {
+								deviceID = 0
+							}
 							if err != nil {
 								log.Printf("[WARN] error at processing %s of device id %#v: %#v", gatewaySetting, route.Gateway.Device, err)
 							} else {


### PR DESCRIPTION
Body:
If we only have one networkInterface, deviceID should be 0 to ensure that it selects the first element of the networkInterfaces array.

I don't have a development vSphere environment handy for running tests and have only used it with one configuration, hence the WIP.
