### PR TITLE
provider/azurerm: support Diagnostics Profile

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -213,6 +213,34 @@ func resourceArmVirtualMachine() *schema.Resource {
 				Default:  false,
 			},
 
+			"diagnostics_profile": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"boot_diagnostics": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+
+									"storage_uri": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"os_profile": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -425,6 +453,11 @@ func resourceArmVirtualMachineCreate(d *schema.ResourceData, meta interface{}) e
 		StorageProfile: &storageProfile,
 	}
 
+	if _, ok := d.GetOk("diagnostics_profile"); ok {
+		diagnosticsProfile := expandAzureRmVirtualMachineDiagnosticsProfile(d)
+		properties.DiagnosticsProfile = &diagnosticsProfile
+	}
+
 	osProfile, err := expandAzureRmVirtualMachineOsProfile(d)
 	if err != nil {
 		return err
@@ -540,6 +573,12 @@ func resourceArmVirtualMachineRead(d *schema.ResourceData, meta interface{}) err
 	if resp.Properties.OsProfile.Secrets != nil {
 		if err := d.Set("os_profile_secrets", flattenAzureRmVirtualMachineOsProfileSecrets(resp.Properties.OsProfile.Secrets)); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting Virtual Machine Storage OS Profile Secrets: %#v", err)
+		}
+	}
+
+	if resp.Properties.DiagnosticsProfile != nil {
+		if err := d.Set("diagnostics_profile", flattenAzureRmVirtualMachineDiagnosticsProfile(resp.Properties.DiagnosticsProfile)); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting Virtual Machine Diagnostics Profile: %#v", err)
 		}
 	}
 
@@ -709,6 +748,16 @@ func flattenAzureRmVirtualMachineImageReference(image *compute.ImageReference) [
 	}
 
 	return []interface{}{result}
+}
+
+func flattenAzureRmVirtualMachineDiagnosticsProfile(profile *compute.DiagnosticsProfile) map[string]interface{} {
+	result := make(map[string]interface{})
+	bootDiagnostics := make(map[string]interface{})
+	bootDiagnostics["enabled"] = *profile.BootDiagnostics.Enabled
+	bootDiagnostics["storage_uri"] = *profile.BootDiagnostics.StorageURI
+	result["boot_diagnostics"] = bootDiagnostics
+
+	return result
 }
 
 func flattenAzureRmVirtualMachineNetworkInterfaces(profile *compute.NetworkProfile) []string {
@@ -1088,6 +1137,22 @@ func expandAzureRmVirtualMachineDataDisk(d *schema.ResourceData) ([]compute.Data
 	}
 
 	return data_disks, nil
+}
+
+func expandAzureRmVirtualMachineDiagnosticsProfile(d *schema.ResourceData) compute.DiagnosticsProfile {
+	diagnosticsProfiles := d.Get("diagnostics_profile").(*schema.Set).List()
+	diagnosticsProfile := diagnosticsProfiles[0].(map[string]interface{})
+	bootDiagnosticses := diagnosticsProfile["boot_diagnostics"].(*schema.Set).List()
+	bootDiagnostics := bootDiagnosticses[0].(map[string]interface{})
+	enabled := bootDiagnostics["enabled"].(bool)
+	storageURI := bootDiagnostics["storage_uri"].(string)
+
+	return compute.DiagnosticsProfile{
+		BootDiagnostics: &compute.BootDiagnostics{
+			Enabled:    &enabled,
+			StorageURI: &storageURI,
+		},
+	}
 }
 
 func expandAzureRmVirtualMachineImageReference(d *schema.ResourceData) (*compute.ImageReference, error) {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -159,6 +159,25 @@ func TestAccAzureRMVirtualMachine_windowsUnattendedConfig(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachine_diagnosticsProfile(t *testing.T) {
+	var vm compute.VirtualMachine
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachine_diagnosticsProfile, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test", &vm),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachine_winRMConfig(t *testing.T) {
 	var vm compute.VirtualMachine
 	ri := acctest.RandInt()
@@ -1154,7 +1173,100 @@ resource "azurerm_virtual_machine" "test" {
             content = "<FirstLogonCommands><SynchronousCommand><CommandLine>shutdown /r /t 0 /c \"initial reboot\"</CommandLine><Description>reboot</Description><Order>1</Order></SynchronousCommand></FirstLogonCommands>"
         }
     }
+
+    diagnostics_profile {
+        boot_diagnostics {
+            enabled = true
+            storage_uri = "${azurerm_storage_account.test.primary_blob_endpoint}"
+        }
+    }
 }
+`
+
+var testAccAzureRMVirtualMachine_diagnosticsProfile = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+        name = "testconfiguration1"
+        subnet_id = "${azurerm_subnet.test.id}"
+        private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accsa%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine" "test" {
+    name = "acctvm-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    network_interface_ids = ["${azurerm_network_interface.test.id}"]
+    vm_size = "Standard_A0"
+
+    storage_image_reference {
+	publisher = "MicrosoftWindowsServer"
+	offer = "WindowsServer"
+	sku = "2012-Datacenter"
+	version = "latest"
+    }
+
+    storage_os_disk {
+        name = "myosdisk1"
+        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+        caching = "ReadWrite"
+        create_option = "FromImage"
+    }
+
+    os_profile {
+	computer_name = "winhost01"
+	admin_username = "testadmin"
+	admin_password = "Password1234!"
+    }
+
+    os_profile_windows_config {
+        winrm {
+	  protocol = "http"
+        }
+    }
+}
+
 `
 
 var testAccAzureRMVirtualMachine_winRMConfig = `

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -207,6 +207,7 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 * `plan` - (Optional) A plan block as documented below.
 * `availability_set_id` - (Optional) The Id of the Availablity Set in which to create the virtual machine
+  `diagnostics_profile` - (Optional) A Diagnostics Profile block as referenced below.
 * `vm_size` - (Required) Specifies the [size of the virtual machine](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-size-specs/).
 * `storage_image_reference` - (Optional) A Storage Image Reference block as documented below.
 * `storage_os_disk` - (Required) A Storage OS Disk block as referenced below.
@@ -227,6 +228,15 @@ For more information on the different example configurations, please check out t
 * `name` - (Required) Specifies the name of the image from the marketplace.
 * `publisher` - (Optional) Specifies the publisher of the image.
 * `product` - (Optional) Specifies the product of the image from the marketplace.
+
+`diagnostics_profile` supports the following:
+
+* `boot_diagnostics`: (Required) A Boot Diagnostics block as documented below.
+
+`boot_diagnostics` supports the following:
+
+* `enabled`: (Required) Whether to enable boot diagnostics for the virtual machine.
+* `storage_uri`: (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
 
 `storage_image_reference` supports the following:
 


### PR DESCRIPTION
Add support for a diagnostics profile, which allows boot diagnostics to be enabled on a virtual machine.