### PR TITLE
provider/archive support folders in output_path

### DIFF
--- a/builtin/providers/archive/resource_archive_file.go
+++ b/builtin/providers/archive/resource_archive_file.go
@@ -99,6 +99,15 @@ func resourceArchiveFileUpdate(d *schema.ResourceData, meta interface{}) error {
 	archiveType := d.Get("type").(string)
 	output_path := d.Get("output_path").(string)
 
+	outputDirectory := path.Dir(output_path)
+	if outputDirectory != "" {
+		if _, err := os.Stat(outputDirectory); err != nil {
+			if err := os.MkdirAll(outputDirectory, 755); err != nil {
+				return err
+			}
+		}
+	}
+
 	archiver := getArchiver(archiveType, output_path)
 	if archiver == nil {
 		return fmt.Errorf("archive type not supported: %s", archiveType)

--- a/builtin/providers/archive/resource_archive_file.go
+++ b/builtin/providers/archive/resource_archive_file.go
@@ -76,15 +76,15 @@ func resourceArchiveFileCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArchiveFileRead(d *schema.ResourceData, meta interface{}) error {
-	output_path := d.Get("output_path").(string)
-	fi, err := os.Stat(output_path)
+	outputPath := d.Get("output_path").(string)
+	fi, err := os.Stat(outputPath)
 	if os.IsNotExist(err) {
 		d.SetId("")
 		d.MarkNewResource()
 		return nil
 	}
 
-	sha, err := genFileSha1(output_path)
+	sha, err := genFileSha1(outputPath)
 	if err != nil {
 		return fmt.Errorf("could not generate file checksum sha: %s", err)
 	}
@@ -97,9 +97,9 @@ func resourceArchiveFileRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceArchiveFileUpdate(d *schema.ResourceData, meta interface{}) error {
 	archiveType := d.Get("type").(string)
-	output_path := d.Get("output_path").(string)
+	outputPath := d.Get("output_path").(string)
 
-	outputDirectory := path.Dir(output_path)
+	outputDirectory := path.Dir(outputPath)
 	if outputDirectory != "" {
 		if _, err := os.Stat(outputDirectory); err != nil {
 			if err := os.MkdirAll(outputDirectory, 755); err != nil {
@@ -108,7 +108,7 @@ func resourceArchiveFileUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	archiver := getArchiver(archiveType, output_path)
+	archiver := getArchiver(archiveType, outputPath)
 	if archiver == nil {
 		return fmt.Errorf("archive type not supported: %s", archiveType)
 	}
@@ -131,12 +131,12 @@ func resourceArchiveFileUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Generate archived file stats
-	fi, err := os.Stat(output_path)
+	fi, err := os.Stat(outputPath)
 	if err != nil {
 		return err
 	}
 
-	sha, err := genFileSha1(output_path)
+	sha, err := genFileSha1(outputPath)
 	if err != nil {
 		return fmt.Errorf("could not generate file checksum sha: %s", err)
 	}
@@ -148,21 +148,21 @@ func resourceArchiveFileUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArchiveFileDelete(d *schema.ResourceData, meta interface{}) error {
-	output_path := d.Get("output_path").(string)
-	if _, err := os.Stat(output_path); os.IsNotExist(err) {
+	outputPath := d.Get("output_path").(string)
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		return nil
 	}
 
-	if err := os.Remove(output_path); err != nil {
-		return fmt.Errorf("could not delete zip file %q: %s", output_path, err)
+	if err := os.Remove(outputPath); err != nil {
+		return fmt.Errorf("could not delete zip file %q: %s", outputPath, err)
 	}
 
 	return nil
 }
 
 func resourceArchiveFileExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	output_path := d.Get("output_path").(string)
-	_, err := os.Stat(output_path)
+	outputPath := d.Get("output_path").(string)
+	_, err := os.Stat(outputPath)
 	if os.IsNotExist(err) {
 		return false, nil
 	}

--- a/builtin/providers/archive/resource_archive_file_test.go
+++ b/builtin/providers/archive/resource_archive_file_test.go
@@ -2,10 +2,11 @@ package archive
 
 import (
 	"fmt"
-	r "github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"os"
 	"testing"
+
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccArchiveFile_Basic(t *testing.T) {
@@ -35,6 +36,12 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 				Check: r.ComposeTestCheckFunc(
 					testAccArchiveFileExists("zip_file_acc_test.zip", &fileSize),
 					r.TestCheckResourceAttrPtr("archive_file.foo", "output_size", &fileSize),
+				),
+			},
+			r.TestStep{
+				Config: testAccArchiveFileOutputPath,
+				Check: r.ComposeTestCheckFunc(
+					testAccArchiveFileExists("example/path/test.zip", &fileSize),
 				),
 			},
 		},
@@ -72,6 +79,15 @@ resource "archive_file" "foo" {
   source_content          = "This is some content"
   source_content_filename = "content.txt"
   output_path             = "zip_file_acc_test.zip"
+}
+`
+
+var testAccArchiveFileOutputPath = `
+resource "archive_file" "foo" {
+  type                    = "zip"
+  source_content          = "This is some content"
+  source_content_filename = "content.txt"
+  output_path             = "example/path/test.zip"
 }
 `
 


### PR DESCRIPTION
The `archive` provider right now relies on `FileInfo`s `Name()` function, which only returns the base name of the`output_path`, ignoring any folders:

```
type FileInfo interface {
        Name() string       // base name of the file
        Size() int64        // length in bytes for regular files; system-dependent for others
        Mode() FileMode     // file mode bits
        ModTime() time.Time // modification time
        IsDir() bool        // abbreviation for Mode().IsDir()
        Sys() interface{}   // underlying data source (can return nil)
}
```

this PR changes to use the `output_path` directly, allowing archives to be placed in subfolders:

before:

```
resource "archive_file" "foo" {
  type                    = "zip"
  source_content          = "This is some content"
  source_content_filename = "content.txt"
  output_path             = "example/path/test.zip"
}
```

throws error that `test.zip` could not be found

after: creates test.zip in `example/path`.