### PR TITLE
provider/datadog: Allow `tags` to be configured for monitor resources.

### DIFF
--- a/builtin/providers/datadog/resource_datadog_monitor.go
+++ b/builtin/providers/datadog/resource_datadog_monitor.go
@@ -114,6 +114,15 @@ func resourceDatadogMonitor() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"tags": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					Elem: &schema.Schema{
+						Type: schema.TypeString},
+				},
+			},
 		},
 	}
 }
@@ -177,6 +186,14 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 		Name:    d.Get("name").(string),
 		Message: d.Get("message").(string),
 		Options: o,
+	}
+
+	if attr, ok := d.GetOk("tags"); ok {
+		s := make([]string, 0)
+		for k, v := range attr.(map[string]interface{}) {
+			s = append(s, fmt.Sprintf("%s:%s", k, v.(string)))
+		}
+		m.Tags = s
 	}
 
 	return &m
@@ -244,6 +261,7 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("escalation_message", m.Options.EscalationMessage)
 	d.Set("silenced", m.Options.Silenced)
 	d.Set("include_tags", m.Options.IncludeTags)
+	d.Set("tags", m.Tags)
 	d.Set("require_full_window", m.Options.RequireFullWindow)
 	d.Set("locked", m.Options.Locked)
 
@@ -269,6 +287,14 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 	if attr, ok := d.GetOk("query"); ok {
 		m.Query = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("tags"); ok {
+		s := make([]string, 0)
+		for k, v := range attr.(map[string]interface{}) {
+			s = append(s, fmt.Sprintf("%s:%s", k, v.(string)))
+		}
+		m.Tags = s
 	}
 
 	o := datadog.Options{}

--- a/builtin/providers/datadog/resource_datadog_monitor_test.go
+++ b/builtin/providers/datadog/resource_datadog_monitor_test.go
@@ -43,6 +43,10 @@ func TestAccDatadogMonitor_Basic(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.bar", "baz"),
 				),
 			},
 		},
@@ -89,6 +93,10 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.bar", "baz"),
 				),
 			},
 			resource.TestStep{
@@ -129,6 +137,10 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "true"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.baz", "qux"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.quux", "corge"),
 				),
 			},
 		},
@@ -211,6 +223,10 @@ resource "datadog_monitor" "foo" {
   include_tags = true
   require_full_window = true
   locked = false
+  tags {
+	"foo" = "bar"
+	"bar" = "baz"
+  }
 }
 `
 
@@ -240,6 +256,10 @@ resource "datadog_monitor" "foo" {
   locked = true
   silenced {
 	"*" = 0
+  }
+  tags {
+	"baz"  = "qux"
+	"quux" = "corge"
   }
 }
 `

--- a/website/source/docs/providers/datadog/r/monitor.html.markdown
+++ b/website/source/docs/providers/datadog/r/monitor.html.markdown
@@ -37,6 +37,10 @@ resource "datadog_monitor" "foo" {
   silenced {
     "*" = 0
   }
+  tags {
+    "foo" = "bar"
+    "bar" = "baz"
+  }
 }
 ```
 
@@ -78,6 +82,7 @@ The following arguments are supported:
     We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.
     Default: True for "on average", "at all times" and "in total" aggregation. False otherwise.
 * `locked` (Optional) A boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Defaults to False.
+* `tags` (Optional) A list of tags to associate with your monitor. This can help you categorize and filter monitors in the manage monitors page of the UI. Note: it's not currently possible to filter by these tags when querying via the API
     
     To mute the alert completely:
     


### PR DESCRIPTION
```
▶ make testacc TEST=./builtin/providers/datadog TESTARGS='-run=TestAccDatadogMonitor_Updated'
==> Checking that code complies with gofmt requirements...
/Users/ojongerius/gocode/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/18 16:48:17 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/datadog -v -run=TestAccDatadogMonitor_Updated -timeout 120m
=== RUN   TestAccDatadogMonitor_Updated
--- PASS: TestAccDatadogMonitor_Updated (86.91s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/datadog        86.925s
```
