### PR TITLE
docs/aws: Update  documentation example to remove \ from bucket prefix

### DIFF
--- a/website/source/docs/providers/aws/r/cloudtrail.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudtrail.html.markdown
@@ -15,7 +15,7 @@ Provides a CloudTrail resource.
 resource "aws_cloudtrail" "foobar" {
     name = "tf-trail-foobar"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
-    s3_key_prefix = "/prefix"
+    s3_key_prefix = "prefix"
     include_global_service_events = false
 }
 


### PR DESCRIPTION
Fixes #8287