### PR TITLE
provider/archiver fix test output path breaking other tests

### DIFF
--- a/builtin/providers/archive/resource_archive_file.go
+++ b/builtin/providers/archive/resource_archive_file.go
@@ -102,7 +102,7 @@ func resourceArchiveFileUpdate(d *schema.ResourceData, meta interface{}) error {
 	outputDirectory := path.Dir(outputPath)
 	if outputDirectory != "" {
 		if _, err := os.Stat(outputDirectory); err != nil {
-			if err := os.MkdirAll(outputDirectory, 755); err != nil {
+			if err := os.MkdirAll(outputDirectory, 0777); err != nil {
 				return err
 			}
 		}

--- a/builtin/providers/archive/resource_archive_file_test.go
+++ b/builtin/providers/archive/resource_archive_file_test.go
@@ -41,7 +41,7 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 			r.TestStep{
 				Config: testAccArchiveFileOutputPath,
 				Check: r.ComposeTestCheckFunc(
-					testAccArchiveFileExists("example/path/test.zip", &fileSize),
+					testAccArchiveFileExists(fmt.Sprintf("%s/test.zip", tmpDir), &fileSize),
 				),
 			},
 		},
@@ -82,14 +82,15 @@ resource "archive_file" "foo" {
 }
 `
 
-var testAccArchiveFileOutputPath = `
+var tmpDir = os.TempDir() + "/test"
+var testAccArchiveFileOutputPath = fmt.Sprintf(`
 resource "archive_file" "foo" {
   type                    = "zip"
   source_content          = "This is some content"
   source_content_filename = "content.txt"
-  output_path             = "example/path/test.zip"
+  output_path             = "%s/test.zip"
 }
-`
+`, tmpDir)
 
 var testAccArchiveFileFileConfig = `
 resource "archive_file" "foo" {


### PR DESCRIPTION
This PR addresses a bug which I introduced in #8278.

ping @stack72 