### PR TITLE
provider/google: Changed instances to a computed property of 'google_compute_target_pool'

### DIFF
--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -55,6 +55,7 @@ func resourceComputeTargetPool() *schema.Resource {
 			"instances": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -396,6 +397,8 @@ func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("health_checks", tpool.HealthChecks)
 	if tpool.Instances != nil {
 		d.Set("instances", convertInstancesFromUrls(tpool.Instances))
+	} else {
+		d.Set("instances", nil)
 	}
 	d.Set("name", tpool.Name)
 	d.Set("region", regionUrl[len(regionUrl)-1])


### PR DESCRIPTION
Instances of a target pool must be computed in the case when an instance group manager is adding instances. This change makes the list of instances a computed property so that the instance group manager tests pass. @lwander 