### PR TITLE
docs/remote_state: Update docs to use data instead of resource

### DIFF
--- a/website/source/docs/state/remote/artifactory.html.md
+++ b/website/source/docs/state/remote/artifactory.html.md
@@ -31,7 +31,7 @@ terraform remote config \
 ## Example Referencing
 
 ```
-resource "terraform_remote_state" "foo" {
+data "terraform_remote_state" "foo" {
 	backend = "artifactory"
 	config {
 		username = "SheldonCooper"

--- a/website/source/docs/state/remote/atlas.html.md
+++ b/website/source/docs/state/remote/atlas.html.md
@@ -25,7 +25,7 @@ terraform remote config \
 ## Example Referencing
 
 ```
-resource "terraform_remote_state" "foo" {
+data "terraform_remote_state" "foo" {
 	backend = "atlas"
 	config {
 		name = "bigbang/example"

--- a/website/source/docs/state/remote/consul.html.md
+++ b/website/source/docs/state/remote/consul.html.md
@@ -25,7 +25,7 @@ terraform remote config \
 ## Example Referencing
 
 ```
-resource "terraform_remote_state" "foo" {
+data "terraform_remote_state" "foo" {
 	backend = "consul"
 	config {
 		path = "full/path"

--- a/website/source/docs/state/remote/etcd.html.md
+++ b/website/source/docs/state/remote/etcd.html.md
@@ -22,7 +22,7 @@ terraform remote config \
 ## Example Referencing
 
 ```
-resource "terraform_remote_state" "foo" {
+data "terraform_remote_state" "foo" {
 	backend = "etcd"
 	config {
 		path = "path/to/terraform.tfstate"

--- a/website/source/docs/state/remote/http.html.md
+++ b/website/source/docs/state/remote/http.html.md
@@ -23,7 +23,7 @@ terraform remote config \
 ## Example Referencing
 
 ```
-resource "terraform_remote_state" "foo" {
+data "terraform_remote_state" "foo" {
 	backend = "http"
 	config {
 		address = "http://my.rest.api.com"

--- a/website/source/docs/state/remote/s3.html.md
+++ b/website/source/docs/state/remote/s3.html.md
@@ -31,7 +31,7 @@ terraform remote config \
 ## Example Referencing
 
 ```
-resource "terraform_remote_state" "foo" {
+data "terraform_remote_state" "foo" {
 	backend = "s3"
 	config {
 		bucket = "terraform-state-prod"

--- a/website/source/docs/state/remote/swift.html.md
+++ b/website/source/docs/state/remote/swift.html.md
@@ -21,7 +21,7 @@ terraform remote config \
 ## Example Referencing
 
 ```
-resource "terraform_remote_state" "foo" {
+data "terraform_remote_state" "foo" {
 	backend = "swift"
 	config {
 		path = "random/path"


### PR DESCRIPTION
I noticed that a lot of the new `remote_state` backends were still using a resource instead of a data source.