### PR TITLE
provider/aws: `aws_elasticache_replication_groups` only support Redis

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -42,7 +41,9 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		ForceNew: true,
 	}
 
-	resourceSchema["engine"].ValidateFunc = validateAwsElastiCacheReplicationGroupEngine
+	resourceSchema["engine"].Required = false
+	resourceSchema["engine"].Optional = true
+	resourceSchema["engine"].Default = "redis"
 
 	return &schema.Resource{
 		Create: resourceAwsElasticacheReplicationGroupCreate,
@@ -63,7 +64,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		ReplicationGroupDescription: aws.String(d.Get("replication_group_description").(string)),
 		AutomaticFailoverEnabled:    aws.Bool(d.Get("automatic_failover_enabled").(bool)),
 		CacheNodeType:               aws.String(d.Get("node_type").(string)),
-		Engine:                      aws.String(d.Get("engine").(string)),
+		Engine:                      aws.String(d.Get("engine").(string)), //this the only supported engine type
 		Port:                        aws.Int64(int64(d.Get("port").(int))),
 		NumCacheClusters:            aws.Int64(int64(d.Get("number_cache_clusters").(int))),
 		Tags:                        tags,
@@ -390,14 +391,6 @@ func cacheReplicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replic
 
 		return rg, *rg.Status, nil
 	}
-}
-
-func validateAwsElastiCacheReplicationGroupEngine(v interface{}, k string) (ws []string, errors []error) {
-	if strings.ToLower(v.(string)) != "redis" {
-		errors = append(errors, fmt.Errorf("The only acceptable Engine type when using Replication Groups is Redis"))
-	}
-
-	return
 }
 
 func validateAwsElastiCacheReplicationGroupId(v interface{}, k string) (ws []string, errors []error) {

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -394,6 +394,13 @@ func cacheReplicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replic
 	}
 }
 
+func validateAwsElastiCacheReplicationGroupEngine(v interface{}, k string) (ws []string, errors []error) {
+	if strings.ToLower(v.(string)) != "redis" {
+		errors = append(errors, fmt.Errorf("The only acceptable Engine type when using Replication Groups is Redis"))
+	}
+	return
+}
+
 func validateAwsElastiCacheReplicationGroupId(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if (len(value) < 1) || (len(value) > 20) {

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -64,7 +64,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		ReplicationGroupDescription: aws.String(d.Get("replication_group_description").(string)),
 		AutomaticFailoverEnabled:    aws.Bool(d.Get("automatic_failover_enabled").(bool)),
 		CacheNodeType:               aws.String(d.Get("node_type").(string)),
-		Engine:                      aws.String(d.Get("engine").(string)), //this the only supported engine type
+		Engine:                      aws.String(d.Get("engine").(string)),
 		Port:                        aws.Int64(int64(d.Get("port").(int))),
 		NumCacheClusters:            aws.Int64(int64(d.Get("number_cache_clusters").(int))),
 		Tags:                        tags,

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -44,6 +44,7 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 	resourceSchema["engine"].Required = false
 	resourceSchema["engine"].Optional = true
 	resourceSchema["engine"].Default = "redis"
+	resourceSchema["engine"].ValidateFunc = validateAwsElastiCacheReplicationGroupEngine
 
 	return &schema.Resource{
 		Create: resourceAwsElasticacheReplicationGroupCreate,

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -138,34 +138,6 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 	})
 }
 
-func TestResourceAWSElastiCacheReplicationGroupEngineValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "Redis",
-			ErrCount: 0,
-		},
-		{
-			Value:    "REDIS",
-			ErrCount: 0,
-		},
-		{
-			Value:    "memcached",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsElastiCacheReplicationGroupEngine(tc.Value, "aws_elasticache_replication_group_engine")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the ElastiCache Replication Group Engine to trigger a validation error")
-		}
-	}
-}
-
 func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -202,6 +174,34 @@ func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the ElastiCache Replication Group Id to trigger a validation error")
+		}
+	}
+}
+
+func TestResourceAWSElastiCacheReplicationGroupEngineValidation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "Redis",
+			ErrCount: 0,
+		},
+		{
+			Value:    "REDIS",
+			ErrCount: 0,
+		},
+		{
+			Value:    "memcached",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateAwsElastiCacheReplicationGroupEngine(tc.Value, "aws_elasticache_replication_group_engine")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the ElastiCache Replication Group Engine to trigger a validation error")
 		}
 	}
 }

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -138,6 +138,34 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 	})
 }
 
+func TestResourceAWSElastiCacheReplicationGroupEngineValidation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "Redis",
+			ErrCount: 0,
+		},
+		{
+			Value:    "REDIS",
+			ErrCount: 0,
+		},
+		{
+			Value:    "memcached",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateAwsElastiCacheReplicationGroupEngine(tc.Value, "aws_elasticache_replication_group_engine")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the ElastiCache Replication Group Engine to trigger a validation error")
+		}
+	}
+}
+
 func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 	cases := []struct {
 		Value    string

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -178,34 +178,6 @@ func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 	}
 }
 
-func TestResourceAWSElastiCacheReplicationGroupEngineValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "Redis",
-			ErrCount: 0,
-		},
-		{
-			Value:    "REDIS",
-			ErrCount: 0,
-		},
-		{
-			Value:    "memcached",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsElastiCacheReplicationGroupEngine(tc.Value, "aws_elasticache_replication_group_engine")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the ElastiCache Replication Group Engine to trigger a validation error")
-		}
-	}
-}
-
 func testAccCheckAWSElasticacheReplicationGroupExists(n string, v *elasticache.ReplicationGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -284,7 +256,6 @@ resource "aws_elasticache_security_group" "bar" {
 resource "aws_elasticache_replication_group" "bar" {
     replication_group_id = "tf-%s"
     replication_group_description = "test description"
-    engine = "redis"
     node_type = "cache.m1.small"
     number_cache_clusters = 2
     port = 6379
@@ -319,7 +290,6 @@ resource "aws_elasticache_security_group" "bar" {
 resource "aws_elasticache_replication_group" "bar" {
     replication_group_id = "tf-%s"
     replication_group_description = "updated description"
-    engine = "redis"
     node_type = "cache.m1.small"
     number_cache_clusters = 2
     port = 6379
@@ -354,7 +324,6 @@ resource "aws_elasticache_security_group" "bar" {
 resource "aws_elasticache_replication_group" "bar" {
     replication_group_id = "tf-%s"
     replication_group_description = "updated description"
-    engine = "redis"
     node_type = "cache.m1.medium"
     number_cache_clusters = 2
     port = 6379
@@ -404,7 +373,6 @@ resource "aws_elasticache_replication_group" "bar" {
     replication_group_description = "test description"
     node_type = "cache.m1.small"
     number_cache_clusters = 1
-    engine = "redis"
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
     security_group_ids = ["${aws_security_group.bar.id}"]
@@ -466,7 +434,6 @@ resource "aws_elasticache_replication_group" "bar" {
     replication_group_description = "test description"
     node_type = "cache.m1.small"
     number_cache_clusters = 2
-    engine = "redis"
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
     security_group_ids = ["${aws_security_group.bar.id}"]

--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -20,7 +20,6 @@ resource "aws_elasticache_replication_group" "bar" {
   replication_group_description = "test description"
   node_type                     = "cache.m1.small"
   number_cache_clusters         = 2
-  engine                        = "redis"
   port                          = 6379
   parameter_group_name          = "default.redis2.8"
   availability_zones            = ["us-west-2a", "us-west-2b"]
@@ -34,17 +33,16 @@ The following arguments are supported:
 
 * `replication_group_id` – (Required) The replication group identifier. This parameter is stored as a lowercase string.
 * `replication_group_description` – (Required) A user-created description for the replication group.
-* `number_cache_clusters` - (Required) The number of cache clusters this replication group will initially have.
+* `number_cache_clusters` - (Required) The number of cache clusters this replication group will have.
  If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource
 * `node_type` - (Required) The compute and memory capacity of the nodes in the node group.
-* `engine` - (Required) The name of the cache engine to be used for the cache clusters in this replication group. The only valid value is Redis.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. Defaults to `false`.
 * `availability_zones` - (Optional) A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important.
 * `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group.
 * `parameter_group_name` - (Optional) The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.
 * `subnet_group_name` - (Optional) The name of the cache subnet group to be used for the replication group.
 * `security_group_names` - (Optional) A list of cache security group names to associate with this replication group.
-* `security_group_ids` - (Optional) One or more Amazon VPC security groups associated with this replication group.
+* `security_group_ids` - (Optional) One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud 
 * `snapshot_arns` – (Optional) A single-element string list containing an
 Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3.
 Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`


### PR DESCRIPTION
therefore, making our users add `engine = redis` to the configuration
felt wasted

test runs still work without the user needing to set an engine :)

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_basic'
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/18 20:02:04 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticacheReplicationGroup_basic -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (778.72s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	778.745s
```