### PR TITLE
provider/google: Support Import of 'google_compute_instance_group_manager'

### DIFF
--- a/builtin/providers/google/import_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/import_compute_instance_group_manager_test.go
@@ -1,0 +1,65 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccInstanceGroupManager_importBasic(t *testing.T) {
+	resourceName1 := "google_compute_instance_group_manager.igm-basic"
+	resourceName2 := "google_compute_instance_group_manager.igm-no-tp"
+	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceGroupManager_basic(template, target, igm1, igm2),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccInstanceGroupManager_importUpdate(t *testing.T) {
+	resourceName := "google_compute_instance_group_manager.igm-update"
+	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceGroupManager_update(template, target, igm),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"log"
 	"strings"
-
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
 )
 
 func resourceComputeInstanceGroupManager() *schema.Resource {
@@ -17,6 +16,9 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 		Read:   resourceComputeInstanceGroupManagerRead,
 		Update: resourceComputeInstanceGroupManagerUpdate,
 		Delete: resourceComputeInstanceGroupManagerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"base_instance_name": &schema.Schema{
@@ -80,6 +82,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"self_link": &schema.Schema{
@@ -184,6 +187,18 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 	return resourceComputeInstanceGroupManagerRead(d, meta)
 }
 
+func flattenNamedPorts(namedPorts []*compute.NamedPort) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(namedPorts))
+	for _, namedPort := range namedPorts {
+		namedPortMap := make(map[string]interface{})
+		namedPortMap["name"] = namedPort.Name
+		namedPortMap["port"] = namedPort.Port
+		result = append(result, namedPortMap)
+	}
+	return result
+
+}
+
 func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
@@ -192,26 +207,42 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	manager, err := config.clientCompute.InstanceGroupManagers.Get(
-		project, d.Get("zone").(string), d.Id()).Do()
+	region, err := getRegion(d, config)
 	if err != nil {
-		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
-			log.Printf("[WARN] Removing Instance Group Manager %q because it's gone", d.Get("name").(string))
-			// The resource doesn't exist anymore
-			d.SetId("")
-
-			return nil
-		}
-
-		return fmt.Errorf("Error reading instance group manager: %s", err)
+		return err
 	}
 
-	// Set computed fields
-	d.Set("named_port", manager.NamedPorts)
+	getInstanceGroupManager := func(zone string) (interface{}, error) {
+		return config.clientCompute.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
+	}
+
+	resource, err := getZonalResourceFromRegion(getInstanceGroupManager, region, config.clientCompute, project)
+	if err != nil {
+		return err
+	}
+	if resource == nil {
+		log.Printf("[WARN] Removing Instance Group Manager %q because it's gone", d.Get("name").(string))
+		// The resource doesn't exist anymore
+		d.SetId("")
+		return nil
+	}
+	manager := resource.(*compute.InstanceGroupManager)
+
+	zoneUrl := strings.Split(manager.Zone, "/")
+	d.Set("base_instance_name", manager.BaseInstanceName)
+	d.Set("instance_template", manager.InstanceTemplate)
+	d.Set("name", manager.Name)
+	d.Set("zone", zoneUrl[len(zoneUrl)-1])
+	d.Set("description", manager.Description)
+	d.Set("project", project)
+	d.Set("target_size", manager.TargetSize)
+	d.Set("target_pools", manager.TargetPools)
+	d.Set("named_port", flattenNamedPorts(manager.NamedPorts))
 	d.Set("fingerprint", manager.Fingerprint)
 	d.Set("instance_group", manager.InstanceGroup)
 	d.Set("target_size", manager.TargetSize)
 	d.Set("self_link", manager.SelfLink)
+	d.Set("update_strategy", "RESTART") //this field doesn't match the manager api, set to default value
 
 	return nil
 }
@@ -368,6 +399,12 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 
 	zone := d.Get("zone").(string)
 	op, err := config.clientCompute.InstanceGroupManagers.Delete(project, zone, d.Id()).Do()
+	attempt := 0
+	for err != nil && attempt < 20 {
+		attempt++
+		time.Sleep(2000 * time.Millisecond)
+		op, err = config.clientCompute.InstanceGroupManagers.Delete(project, zone, d.Id()).Do()
+	}
 	if err != nil {
 		return fmt.Errorf("Error deleting instance group manager: %s", err)
 	}

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -277,7 +277,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -331,7 +331,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -380,7 +380,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -411,7 +411,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -456,7 +456,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccInstanceGroupManager' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccInstanceGroupManager -timeout 120m
=== RUN   TestAccInstanceGroupManager_importBasic
--- PASS: TestAccInstanceGroupManager_importBasic (116.97s)
=== RUN   TestAccInstanceGroupManager_importUpdate
--- PASS: TestAccInstanceGroupManager_importUpdate (124.32s)
=== RUN   TestAccInstanceGroupManager_basic
--- PASS: TestAccInstanceGroupManager_basic (124.62s)
=== RUN   TestAccInstanceGroupManager_update
--- PASS: TestAccInstanceGroupManager_update (187.20s)
=== RUN   TestAccInstanceGroupManager_updateLifecycle
--- PASS: TestAccInstanceGroupManager_updateLifecycle (126.11s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google
679.274s
```
@lwander 