### PR TITLE
Correct spelling of the word certificate

### DIFF
--- a/website/source/docs/providers/tls/r/locally_signed_cert.html.md
+++ b/website/source/docs/providers/tls/r/locally_signed_cert.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # tls\_locally\_signed\_cert
 
-Generates a TLS ceritifcate using a *Certificate Signing Request* (CSR) and
+Generates a TLS certificate using a *Certificate Signing Request* (CSR) and
 signs it with a provided certificate authority (CA) private key.
 
 Locally-signed certificates are generally only trusted by client software when


### PR DESCRIPTION
This is a minor typo that I noticed while working on something else.  Breaking it out into its own commit to make it easier to merge.