### PR TITLE
provider/google: Ignore source image for 'google_compute_instance_template'

### DIFF
--- a/builtin/providers/google/resource_compute_autoscaler_test.go
+++ b/builtin/providers/google/resource_compute_autoscaler_test.go
@@ -139,7 +139,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-7-wheezy-v20160301"
 		auto_delete = true
 		boot = true
 	}
@@ -196,7 +196,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-7-wheezy-v20160301"
 		auto_delete = true
 		boot = true
 	}

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -277,7 +277,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -331,7 +331,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -380,7 +380,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -411,7 +411,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}
@@ -456,7 +456,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-7-wheezy-v20160301"
 			auto_delete = true
 			boot = true
 		}


### PR DESCRIPTION
Changed source_image so that it is read from the schema if it exists and otherwise it is read from the google api. The source image can be supplied by family rather than a specific image, while the api always returns the specific image. This caused terraform to plan a new resource because the image names differ, even though they refer to the same image. Ignoring source_image entirely would cause import to fail, so I only ignore it when it has a value in the schema (which will never be true if we are importing the resource).