### PR TITLE
provider/azurerm: Setting the AzureRM SDK to an explicit version

### DIFF
--- a/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
@@ -3,11 +3,19 @@ package azure
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 const (
 	activeDirectoryAPIVersion = "1.0"
 )
+
+var environments = map[string]Environment{
+	"AZURECHINACLOUD":        ChinaCloud,
+	"AZUREGERMANCLOUD":       GermanCloud,
+	"AZUREPUBLICCLOUD":       PublicCloud,
+	"AZUREUSGOVERNMENTCLOUD": USGovernmentCloud,
+}
 
 // Environment represents a set of endpoints for each of Azure's Clouds.
 type Environment struct {
@@ -52,7 +60,7 @@ var (
 		ManagementPortalURL:       "https://manage.windowsazure.us/",
 		PublishSettingsURL:        "https://manage.windowsazure.us/publishsettings/index",
 		ServiceManagementEndpoint: "https://management.core.usgovcloudapi.net/",
-		ResourceManagerEndpoint:   "https://management.usgovcloudapi.net",
+		ResourceManagerEndpoint:   "https://management.usgovcloudapi.net/",
 		ActiveDirectoryEndpoint:   "https://login.microsoftonline.com/",
 		GalleryEndpoint:           "https://gallery.usgovcloudapi.net/",
 		KeyVaultEndpoint:          "https://vault.usgovcloudapi.net/",
@@ -87,8 +95,8 @@ var (
 		Name:                      "AzureGermanCloud",
 		ManagementPortalURL:       "http://portal.microsoftazure.de/",
 		PublishSettingsURL:        "https://manage.microsoftazure.de/publishsettings/index",
-		ServiceManagementEndpoint: "https://management.core.cloudapi.de",
-		ResourceManagerEndpoint:   "https://management.microsoftazure.de",
+		ServiceManagementEndpoint: "https://management.core.cloudapi.de/",
+		ResourceManagerEndpoint:   "https://management.microsoftazure.de/",
 		ActiveDirectoryEndpoint:   "https://login.microsoftonline.de/",
 		GalleryEndpoint:           "https://gallery.cloudapi.de/",
 		KeyVaultEndpoint:          "https://vault.microsoftazure.de/",
@@ -100,6 +108,16 @@ var (
 		ServiceBusEndpointSuffix:  "servicebus.cloudapi.de",
 	}
 )
+
+// EnvironmentFromName returns an Environment based on the common name specified
+func EnvironmentFromName(name string) (Environment, error) {
+	name = strings.ToUpper(name)
+	env, ok := environments[name]
+	if !ok {
+		return env, fmt.Errorf("autorest/azure: There is no cloud environment matching the name %q", name)
+	}
+	return env, nil
+}
 
 // OAuthConfigForTenant returns an OAuthConfig with tenant specific urls
 func (env Environment) OAuthConfigForTenant(tenantID string) (*OAuthConfig, error) {

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -20,9 +20,6 @@ const (
 
 	// DefaultRetryAttempts is number of attempts for retry status codes (5xx).
 	DefaultRetryAttempts = 3
-
-	// DefaultRetryDuration is a resonable delay for retry.
-	defaultRetryInterval = 30 * time.Second
 )
 
 var statusCodesForRetry = []int{
@@ -130,6 +127,9 @@ type Client struct {
 	// RetryAttempts sets the default number of retry attempts for client.
 	RetryAttempts int
 
+	// RetryDuration sets the delay duration for retries.
+	RetryDuration time.Duration
+
 	// UserAgent, if not empty, will be set as the HTTP User-Agent header on all requests sent
 	// through the Do method.
 	UserAgent string
@@ -144,6 +144,7 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDelay:    DefaultPollingDelay,
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
+		RetryDuration:   30 * time.Second,
 		UserAgent:       ua,
 	}
 }
@@ -163,7 +164,7 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 		return nil, NewErrorWithError(err, "autorest/Client", "Do", nil, "Preparing request failed")
 	}
 	resp, err := SendWithSender(c.sender(), r,
-		DoRetryForStatusCodes(c.RetryAttempts, defaultRetryInterval, statusCodesForRetry...))
+		DoRetryForStatusCodes(c.RetryAttempts, c.RetryDuration, statusCodesForRetry...))
 	Respond(resp,
 		c.ByInspecting())
 	return resp, err

--- a/vendor/github.com/Azure/go-autorest/autorest/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/utility.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"reflect"
 	"sort"
 	"strings"
 )
@@ -104,6 +105,22 @@ func ensureValueString(value interface{}) string {
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+// MapToValues method converts map[string]interface{} to url.Values.
+func MapToValues(m map[string]interface{}) url.Values {
+	v := url.Values{}
+	for key, value := range m {
+		x := reflect.ValueOf(value)
+		if x.Kind() == reflect.Array || x.Kind() == reflect.Slice {
+			for i := 0; i < x.Len(); i++ {
+				v.Add(key, ensureValueString(x.Index(i)))
+			}
+		} else {
+			v.Add(key, ensureValueString(value))
+		}
+	}
+	return v
 }
 
 // String method converts interface v to string. If interface is a list, it

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,194 +7,250 @@
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/cdn",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "88TAbW2kN6NighEaL9X8IKNp3Go=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/compute",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "AdWY+YN439QSBtAFqG/dIV93J38=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/network",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "EdND5GRzWDkSwl18UVWJJgsnOG4=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/resources/resources",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "iFV4QVdtS6bx3fNhjDAyS/Eiw+Y=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/scheduler",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "jskb+xe0vrZayq7Iu9yyJXo+Kmc=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/servicebus",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "jh7wjswBwwVeY/P8wtqtqBR58y4=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/storage",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "PLyDrzfgTsbkk7HsuJxbj8QmTC4=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/trafficmanager",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "Q+0Zz0iylSKMck4JhYc8XR83i8M=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/core/http",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "F2fqk+OPM3drSkK0G6So5ASayyA=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/core/tls",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "SGOuRzxuQpJChBvq6SsNojKvcKw=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "TcQ6KXoBkvUhCYeggJ/bwcz+QaQ=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/affinitygroup",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "HfjyhRfmKBsVgWLTOfWVcxe8Z88=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/hostedservice",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "4otMhU6xZ41HfmiGZFYtV93GdcI=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/location",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "hxivwm3D13cqFGOlOS3q8HD7DN0=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/networksecuritygroup",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "2USoeYg8k1tA1QNLRByEnP/asqs=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/osimage",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "hzwziaU5QlMlFcFPdbEmW18oV3Y=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/sql",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "YoAhDE0X6hSFuPpXbpfqcTC0Zvw=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/storageservice",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "6xEiZL4a9rr5YbnY0RdzuzhEF1Q=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualmachine",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "xcBM3zQtfcE3VHNBACJJGEesCBI=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualmachinedisk",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "0bfdkDZ2JFV7bol6GQFfC0g+lP4=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualmachineimage",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "IhjDqm84VDVSIoHyiGvUzuljG3s=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualnetwork",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "+ykSkHo40/f6VK6/zXDqzF8Lh14=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/vmutils",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "w1X4Sxcdx4WhCqVZdPWoUuMPn9U=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/storage",
 			"revision": "bfc5b4af08f3d3745d908af36b7ed5b9060f0258",
-			"revisionTime": "2016-08-11T22:07:13Z"
+			"revisionTime": "2016-08-11T22:07:13Z",
+			"version": "v3.2.0-beta",
+			"versionExact": "v3.2.0-beta"
 		},
 		{
-			"checksumSHA1": "pi00alAztMy9MGxJmvg9qC+tsGk=",
+			"checksumSHA1": "eVSHe6GIHj9/ziFrQLZ1SC7Nn6k=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest",
-			"revision": "9c64b6583716b13caa7f85398c3331229c38f168",
-			"revisionTime": "2016-06-28T23:39:30Z"
+			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
+			"revisionTime": "2016-08-11T21:24:34Z",
+			"version": "v7.1.0",
+			"versionExact": "v7.1.0"
 		},
 		{
-			"checksumSHA1": "wP+cCq8z17Raoq9PndkX4J17W2w=",
+			"checksumSHA1": "z8FwqeLK0Pluo7FYC5k2MVBoils=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest/azure",
-			"revision": "9c64b6583716b13caa7f85398c3331229c38f168",
-			"revisionTime": "2016-06-28T23:39:30Z"
+			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
+			"revisionTime": "2016-08-11T21:24:34Z",
+			"version": "v7.1.0",
+			"versionExact": "v7.1.0"
 		},
 		{
 			"checksumSHA1": "q4bSpJ5t571H3ny1PwIgTn6g75E=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest/date",
-			"revision": "9c64b6583716b13caa7f85398c3331229c38f168",
-			"revisionTime": "2016-06-28T23:39:30Z"
+			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
+			"revisionTime": "2016-08-11T21:24:34Z",
+			"version": "v7.1.0",
+			"versionExact": "v7.1.0"
 		},
 		{
 			"checksumSHA1": "Ev8qCsbFjDlMlX0N2tYAhYQFpUc=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest/to",
-			"revision": "9c64b6583716b13caa7f85398c3331229c38f168",
-			"revisionTime": "2016-06-28T23:39:30Z"
+			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
+			"revisionTime": "2016-08-11T21:24:34Z",
+			"version": "v7.1.0",
+			"versionExact": "v7.1.0"
 		},
 		{
 			"comment": "0.0.2-27-gedd0930",


### PR DESCRIPTION
We tended to use master which isn't the best idea. Also set Go Autorest
to the correct version (7.1.0)

This will happen after the release of Terraform 0.7.1 so we can get some acceptance test coverage 