### PR TITLE
Fix `state mv` with nested modules to work properly

### DIFF
--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -141,7 +141,8 @@ func (c *StateMvCommand) addableResult(results []*terraform.StateFilterResult) i
 		return result
 
 	case *terraform.ResourceState:
-		// If a module state then we should add the full list of modules
+		// If a resource state with more than one result, it has a multi-count
+		// and we need to add all of them.
 		result := []*terraform.ResourceState{v}
 		if len(results) > 1 {
 			for _, r := range results[1:] {

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -156,6 +156,11 @@ func (c *StateMvCommand) addableResult(results []*terraform.StateFilterResult) i
 			}
 		}
 
+		// If we only have one item, add it directly
+		if len(result) == 1 {
+			return result[0]
+		}
+
 		return result
 
 	default:

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -79,13 +79,16 @@ func (c *StateMvCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Get the item to add to the state
+	add := c.addableResult(results)
+
 	// Do the actual move
 	if err := stateFromReal.Remove(args[0]); err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateMv, err))
 		return 1
 	}
 
-	if err := stateToReal.Add(args[0], args[1], results[0].Value); err != nil {
+	if err := stateToReal.Add(args[0], args[1], add); err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateMv, err))
 		return 1
 	}
@@ -117,6 +120,29 @@ func (c *StateMvCommand) Run(args []string) int {
 	c.Ui.Output(fmt.Sprintf(
 		"Moved %s to %s", args[0], args[1]))
 	return 0
+}
+
+// addableResult takes the result from a filter operation and returns what to
+// call State.Add with. The reason we do this is beacuse in the module case
+// we must add the list of all modules returned versus just the root module.
+func (c *StateMvCommand) addableResult(results []*terraform.StateFilterResult) interface{} {
+	switch v := results[0].Value.(type) {
+	case *terraform.ModuleState:
+		// If a module state then we should add the full list of modules
+		result := []*terraform.ModuleState{v}
+		if len(results) > 1 {
+			for _, r := range results[1:] {
+				if ms, ok := r.Value.(*terraform.ModuleState); ok {
+					result = append(result, ms)
+				}
+			}
+		}
+
+		return result
+	default:
+		// By default just add the first result
+		return v
+	}
 }
 
 func (c *StateMvCommand) Help() string {

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -139,6 +139,25 @@ func (c *StateMvCommand) addableResult(results []*terraform.StateFilterResult) i
 		}
 
 		return result
+
+	case *terraform.ResourceState:
+		// If a module state then we should add the full list of modules
+		result := []*terraform.ResourceState{v}
+		if len(results) > 1 {
+			for _, r := range results[1:] {
+				rs, ok := r.Value.(*terraform.ResourceState)
+				if !ok {
+					continue
+				}
+
+				if rs.Type == v.Type {
+					result = append(result, rs)
+				}
+			}
+		}
+
+		return result
+
 	default:
 		// By default just add the first result
 		return v

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -327,6 +327,7 @@ test_instance.baz:
 `
 
 const testStateMvNestedModule_stateOut = `
+<no state>
 module.bar:
   <no state>
 module.bar.child1:

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -808,6 +808,12 @@ func (m *ModuleState) IsRoot() bool {
 	return reflect.DeepEqual(m.Path, rootModulePath)
 }
 
+// IsDescendent returns true if other is a descendent of this module.
+func (m *ModuleState) IsDescendent(other *ModuleState) bool {
+	i := len(m.Path)
+	return len(other.Path) > i && reflect.DeepEqual(other.Path[:i], m.Path)
+}
+
 // Orphans returns a list of keys of resources that are in the State
 // but aren't present in the configuration itself. Hence, these keys
 // represent the state of resources that are orphans.

--- a/terraform/state_add.go
+++ b/terraform/state_add.go
@@ -131,7 +131,7 @@ func stateAddFunc_Module_Module(s *State, fromAddr, addr *ResourceAddress, raw i
 		// It is! Strip the leading prefix and attach that to our address
 		extra := item.Path[len(src.Path)+1:]
 		addrCopy := addr.Copy()
-		addrCopy.Path = append(addrCopy.Path, extra)
+		addrCopy.Path = append(addrCopy.Path, extra...)
 
 		// Add it
 		s.Add(fromAddr.String(), addrCopy.String(), item)

--- a/terraform/state_add.go
+++ b/terraform/state_add.go
@@ -162,7 +162,7 @@ func stateAddFunc_Resource_Resource(s *State, fromAddr, addr *ResourceAddress, r
 
 		// If there is an index, this is an error since we can't assign
 		// a set of resources to a single index
-		if addr.Index >= 0 {
+		if addr.Index >= 0 && len(list) > 1 {
 			return fmt.Errorf(
 				"multiple resources can't be moved to a single index: "+
 					"%s => %s", fromAddr, addr)

--- a/terraform/state_add.go
+++ b/terraform/state_add.go
@@ -160,6 +160,14 @@ func stateAddFunc_Resource_Resource(s *State, fromAddr, addr *ResourceAddress, r
 			return fmt.Errorf("resource move with no value to: %s", addr)
 		}
 
+		// If there is an index, this is an error since we can't assign
+		// a set of resources to a single index
+		if addr.Index >= 0 {
+			return fmt.Errorf(
+				"multiple resources can't be moved to a single index: "+
+					"%s => %s", fromAddr, addr)
+		}
+
 		// Add each with a specific index
 		for i, rs := range list {
 			addrCopy := addr.Copy()

--- a/terraform/state_add.go
+++ b/terraform/state_add.go
@@ -129,7 +129,7 @@ func stateAddFunc_Module_Module(s *State, fromAddr, addr *ResourceAddress, raw i
 		}
 
 		// It is! Strip the leading prefix and attach that to our address
-		extra := item.Path[len(src.Path)+1:]
+		extra := item.Path[len(src.Path):]
 		addrCopy := addr.Copy()
 		addrCopy.Path = append(addrCopy.Path, extra...)
 

--- a/terraform/state_add_test.go
+++ b/terraform/state_add_test.go
@@ -231,7 +231,7 @@ func TestStateAdd(t *testing.T) {
 
 				// Should be ignored
 				&ModuleState{
-					Path: []string{"root", "bar", "child2"},
+					Path: []string{"root", "baz", "child2"},
 					Resources: map[string]*ResourceState{
 						"test_instance.foo": &ResourceState{
 							Type: "test_instance",
@@ -246,6 +246,11 @@ func TestStateAdd(t *testing.T) {
 			&State{},
 			&State{
 				Modules: []*ModuleState{
+					&ModuleState{
+						Path:      []string{"root", "bar"},
+						Resources: map[string]*ResourceState{},
+					},
+
 					&ModuleState{
 						Path: []string{"root", "bar", "child1"},
 						Resources: map[string]*ResourceState{
@@ -499,8 +504,8 @@ func TestStateAdd(t *testing.T) {
 
 		// Verify equality
 		if !tc.One.Equal(tc.Two) {
-			t.Fatalf("Bad: %s\n\n%#v\n\n%#v", k, tc.One, tc.Two)
-			//t.Fatalf("Bad: %s\n\n%s\n\n%s", k, tc.One.String(), tc.Two.String())
+			//t.Fatalf("Bad: %s\n\n%#v\n\n%#v", k, tc.One, tc.Two)
+			t.Fatalf("Bad: %s\n\n%s\n\n%s", k, tc.One.String(), tc.Two.String())
 		}
 	}
 }

--- a/terraform/state_add_test.go
+++ b/terraform/state_add_test.go
@@ -201,7 +201,7 @@ func TestStateAdd(t *testing.T) {
 
 			[]*ModuleState{
 				&ModuleState{
-					Path:      rootModulePath,
+					Path:      []string{"root", "foo"},
 					Resources: map[string]*ResourceState{},
 				},
 

--- a/terraform/state_add_test.go
+++ b/terraform/state_add_test.go
@@ -371,6 +371,51 @@ func TestStateAdd(t *testing.T) {
 			},
 		},
 
+		"ResourceState with count unspecified => Resource Addr (new)": {
+			false,
+			"aws_instance.bar",
+			"aws_instance.foo",
+			[]*ResourceState{
+				&ResourceState{
+					Type: "test_instance",
+					Primary: &InstanceState{
+						ID: "foo",
+					},
+				},
+
+				&ResourceState{
+					Type: "test_instance",
+					Primary: &InstanceState{
+						ID: "bar",
+					},
+				},
+			},
+
+			&State{},
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: []string{"root"},
+						Resources: map[string]*ResourceState{
+							"aws_instance.foo.0": &ResourceState{
+								Type: "test_instance",
+								Primary: &InstanceState{
+									ID: "foo",
+								},
+							},
+
+							"aws_instance.foo.1": &ResourceState{
+								Type: "test_instance",
+								Primary: &InstanceState{
+									ID: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
 		"ResourceState => Resource Addr (existing)": {
 			true,
 			"aws_instance.bar",

--- a/terraform/state_add_test.go
+++ b/terraform/state_add_test.go
@@ -194,6 +194,85 @@ func TestStateAdd(t *testing.T) {
 			nil,
 		},
 
+		"ModuleState with children => Module Addr (new)": {
+			false,
+			"module.foo",
+			"module.bar",
+
+			[]*ModuleState{
+				&ModuleState{
+					Path:      rootModulePath,
+					Resources: map[string]*ResourceState{},
+				},
+
+				&ModuleState{
+					Path: []string{"root", "foo", "child1"},
+					Resources: map[string]*ResourceState{
+						"test_instance.foo": &ResourceState{
+							Type: "test_instance",
+							Primary: &InstanceState{
+								ID: "foo",
+							},
+						},
+					},
+				},
+
+				&ModuleState{
+					Path: []string{"root", "foo", "child2"},
+					Resources: map[string]*ResourceState{
+						"test_instance.foo": &ResourceState{
+							Type: "test_instance",
+							Primary: &InstanceState{
+								ID: "foo",
+							},
+						},
+					},
+				},
+
+				// Should be ignored
+				&ModuleState{
+					Path: []string{"root", "bar", "child2"},
+					Resources: map[string]*ResourceState{
+						"test_instance.foo": &ResourceState{
+							Type: "test_instance",
+							Primary: &InstanceState{
+								ID: "foo",
+							},
+						},
+					},
+				},
+			},
+
+			&State{},
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: []string{"root", "bar", "child1"},
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Type: "test_instance",
+								Primary: &InstanceState{
+									ID: "foo",
+								},
+							},
+						},
+					},
+
+					&ModuleState{
+						Path: []string{"root", "bar", "child2"},
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Type: "test_instance",
+								Primary: &InstanceState{
+									ID: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
 		"ResourceState => Resource Addr (new)": {
 			false,
 			"aws_instance.bar",

--- a/terraform/state_add_test.go
+++ b/terraform/state_add_test.go
@@ -416,6 +416,30 @@ func TestStateAdd(t *testing.T) {
 			},
 		},
 
+		"ResourceState with count unspecified => Resource Addr (new with count)": {
+			true,
+			"aws_instance.bar",
+			"aws_instance.foo[0]",
+			[]*ResourceState{
+				&ResourceState{
+					Type: "test_instance",
+					Primary: &InstanceState{
+						ID: "foo",
+					},
+				},
+
+				&ResourceState{
+					Type: "test_instance",
+					Primary: &InstanceState{
+						ID: "bar",
+					},
+				},
+			},
+
+			&State{},
+			nil,
+		},
+
 		"ResourceState => Resource Addr (existing)": {
 			true,
 			"aws_instance.bar",

--- a/terraform/state_add_test.go
+++ b/terraform/state_add_test.go
@@ -440,6 +440,66 @@ func TestStateAdd(t *testing.T) {
 			nil,
 		},
 
+		"ResourceState with single count unspecified => Resource Addr (new with count)": {
+			false,
+			"aws_instance.bar",
+			"aws_instance.foo[0]",
+			[]*ResourceState{
+				&ResourceState{
+					Type: "test_instance",
+					Primary: &InstanceState{
+						ID: "foo",
+					},
+				},
+			},
+
+			&State{},
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: []string{"root"},
+						Resources: map[string]*ResourceState{
+							"aws_instance.foo.0": &ResourceState{
+								Type: "test_instance",
+								Primary: &InstanceState{
+									ID: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"ResourceState => Resource Addr (new with count)": {
+			false,
+			"aws_instance.bar",
+			"aws_instance.foo[0]",
+			&ResourceState{
+				Type: "test_instance",
+				Primary: &InstanceState{
+					ID: "foo",
+				},
+			},
+
+			&State{},
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: []string{"root"},
+						Resources: map[string]*ResourceState{
+							"aws_instance.foo.0": &ResourceState{
+								Type: "test_instance",
+								Primary: &InstanceState{
+									ID: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
 		"ResourceState => Resource Addr (existing)": {
 			true,
 			"aws_instance.bar",

--- a/terraform/state_filter_test.go
+++ b/terraform/state_filter_test.go
@@ -93,6 +93,19 @@ func TestStateFilterFilter(t *testing.T) {
 			},
 		},
 
+		"no count index": {
+			"complete.tfstate",
+			[]string{"module.consul.aws_instance.consul-green"},
+			[]string{
+				"*terraform.ResourceState: module.consul.aws_instance.consul-green[0]",
+				"*terraform.InstanceState: module.consul.aws_instance.consul-green[0]",
+				"*terraform.ResourceState: module.consul.aws_instance.consul-green[1]",
+				"*terraform.InstanceState: module.consul.aws_instance.consul-green[1]",
+				"*terraform.ResourceState: module.consul.aws_instance.consul-green[2]",
+				"*terraform.InstanceState: module.consul.aws_instance.consul-green[2]",
+			},
+		},
+
 		"nested modules": {
 			"nested-modules.tfstate",
 			[]string{"module.outer"},

--- a/terraform/state_filter_test.go
+++ b/terraform/state_filter_test.go
@@ -92,6 +92,20 @@ func TestStateFilterFilter(t *testing.T) {
 				"*terraform.InstanceState: module.consul.aws_instance.consul-green[0]",
 			},
 		},
+
+		"nested modules": {
+			"nested-modules.tfstate",
+			[]string{"module.outer"},
+			[]string{
+				"*terraform.ModuleState: module.outer",
+				"*terraform.ModuleState: module.outer.module.child1",
+				"*terraform.ResourceState: module.outer.module.child1.aws_instance.foo",
+				"*terraform.InstanceState: module.outer.module.child1.aws_instance.foo",
+				"*terraform.ModuleState: module.outer.module.child2",
+				"*terraform.ResourceState: module.outer.module.child2.aws_instance.foo",
+				"*terraform.InstanceState: module.outer.module.child2.aws_instance.foo",
+			},
+		},
 	}
 
 	for n, tc := range cases {

--- a/terraform/test-fixtures/state-filter/nested-modules.tfstate
+++ b/terraform/test-fixtures/state-filter/nested-modules.tfstate
@@ -1,0 +1,47 @@
+{
+    "version": 1,
+    "serial": 12,
+    "modules": [
+        {
+            "path": [
+                "root",
+                "outer"
+            ],
+            "resources": {}
+        },
+        {
+            "path": [
+                "root",
+                "outer",
+                "child1"
+            ],
+            "resources": {
+                "aws_instance.foo": {
+                    "type": "aws_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "1",
+                        "attributes": {}
+                    }
+                }
+            }
+        },
+        {
+            "path": [
+                "root",
+                "outer",
+                "child2"
+            ],
+            "resources": {
+                "aws_instance.foo": {
+                    "type": "aws_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "1",
+                        "attributes": {}
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #8263 
Fixes #7797

We were only adding the first result of searching for what to move. This works for every result type except modules since nested modules aren't nested within the ModuleState but alongside each other with longer paths. Rather than do a BIG refactor on nesting module states (which probably isn't right anyways), I modified `State.Add` and `StateMvCommand` to understand this limitation.

