### PR TITLE
provider/google: Update Acceptance Tests to use Debian 8

### DIFF
--- a/builtin/providers/google/resource_compute_autoscaler_test.go
+++ b/builtin/providers/google/resource_compute_autoscaler_test.go
@@ -139,7 +139,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-7-wheezy-v20160301"
+		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
 	}
@@ -196,7 +196,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-7-wheezy-v20160301"
+		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
 	}

--- a/builtin/providers/google/resource_compute_backend_service_test.go
+++ b/builtin/providers/google/resource_compute_backend_service_test.go
@@ -277,7 +277,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-7-wheezy-v20160301"
+    source_image = "debian-8-jessie-v20160803"
     auto_delete  = true
     boot         = true
   }

--- a/builtin/providers/google/resource_compute_disk_test.go
+++ b/builtin/providers/google/resource_compute_disk_test.go
@@ -81,7 +81,7 @@ func testAccComputeDisk_basic(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-7-wheezy-v20160301"
+	image = "debian-8-jessie-v20160803"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -277,7 +277,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-7-wheezy-v20160301"
+			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -331,7 +331,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-7-wheezy-v20160301"
+			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -380,7 +380,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-7-wheezy-v20160301"
+			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -411,7 +411,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-7-wheezy-v20160301"
+			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -456,7 +456,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-7-wheezy-v20160301"
+			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}

--- a/builtin/providers/google/resource_compute_instance_group_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_test.go
@@ -190,7 +190,7 @@ func testAccComputeInstanceGroup_basic(instance string) string {
 		zone = "us-central1-c"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -238,7 +238,7 @@ func testAccComputeInstanceGroup_update(instance string) string {
 		count = 1
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -273,7 +273,7 @@ func testAccComputeInstanceGroup_update2(instance string) string {
 		count = 3
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -26,7 +26,7 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateTag(&instanceTemplate, "foo"),
 					testAccCheckComputeInstanceTemplateMetadata(&instanceTemplate, "foo", "bar"),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20160301", true, true),
+					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 				),
 			},
 		},
@@ -66,7 +66,7 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20160301", true, true),
+					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
 				),
 			},
@@ -276,7 +276,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-7-wheezy-v20160301"
+		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
 	}
@@ -310,7 +310,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-7-wheezy-v20160301"
+		source_image = "debian-8-jessie-v20160803"
 	}
 
 	network_interface {
@@ -328,7 +328,7 @@ resource "google_compute_instance_template" "foobar" {
 var testAccComputeInstanceTemplate_disks = fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "instancet-test-%s"
-	image = "debian-7-wheezy-v20160301"
+	image = "debian-8-jessie-v20160803"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -339,7 +339,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-7-wheezy-v20160301"
+		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 100
 		boot = true
@@ -372,7 +372,7 @@ func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 		machine_type = "n1-standard-1"
 
 		disk {
-			source_image = "debian-7-wheezy-v20160211"
+			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			disk_size_gb = 10
 			boot = true
@@ -407,7 +407,7 @@ resource "google_compute_instance_template" "foobar" {
 	region = "us-central1"
 
 	disk {
-		source_image = "debian-7-wheezy-v20160211"
+		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true

--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -649,7 +649,7 @@ func testAccComputeInstance_basic_deprecated_network(instance string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network {
@@ -671,7 +671,7 @@ func testAccComputeInstance_update_deprecated_network(instance string) string {
 		tags = ["baz"]
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network {
@@ -694,7 +694,7 @@ func testAccComputeInstance_basic(instance string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -743,7 +743,7 @@ func testAccComputeInstance_basic3(instance string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			image = "debian-cloud/debian-7-wheezy-v20160301"
+			image = "debian-cloud/debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -791,7 +791,7 @@ func testAccComputeInstance_basic5(instance string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20160301"
+			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -816,7 +816,7 @@ func testAccComputeInstance_forceNewAndChangeMetadata(instance string) string {
 		tags = ["baz"]
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -840,7 +840,7 @@ func testAccComputeInstance_update(instance string) string {
 		tags = ["baz"]
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -867,7 +867,7 @@ func testAccComputeInstance_ip(ip, instance string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -898,7 +898,7 @@ func testAccComputeInstance_disks(disk, instance string, autodelete bool) string
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		disk {
@@ -924,7 +924,7 @@ func testAccComputeInstance_local_ssd(instance string) string {
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		disk {
@@ -947,7 +947,7 @@ func testAccComputeInstance_service_account(instance string) string {
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -972,7 +972,7 @@ func testAccComputeInstance_scheduling(instance string) string {
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -997,7 +997,7 @@ func testAccComputeInstance_subnet_auto(instance string) string {
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -1028,7 +1028,7 @@ func testAccComputeInstance_subnet_custom(instance string) string {
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -1056,7 +1056,7 @@ func testAccComputeInstance_address_auto(instance string) string {
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {
@@ -1084,7 +1084,7 @@ func testAccComputeInstance_address_custom(instance, address string) string {
 		zone = "us-central1-a"
 
 		disk {
-			image = "debian-7-wheezy-v20160301"
+			image = "debian-8-jessie-v20160803"
 		}
 
 		network_interface {

--- a/website/source/docs/providers/google/r/compute_autoscaler.html.markdown
+++ b/website/source/docs/providers/google/r/compute_autoscaler.html.markdown
@@ -29,7 +29,7 @@ resource "google_compute_instance_template" "foobar" {
   tags = ["foo", "bar"]
 
   disk {
-    source_image = "debian-cloud/debian-7-wheezy-v20160301"
+    source_image = "debian-cloud/debian-8"
   }
 
   network_interface {

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -45,7 +45,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-7-wheezy-v20160301"
+    source_image = "debian-cloud/debian-8"
     auto_delete  = true
     boot         = true
   }

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -25,7 +25,7 @@ resource "google_compute_instance" "default" {
   tags = ["foo", "bar"]
 
   disk {
-    image = "debian-7-wheezy-v20160301"
+    image = "debian-cloud/debian-8"
   }
 
   // Local SSD disk

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -32,7 +32,7 @@ resource "google_compute_instance_template" "foobar" {
 
   // Create a new boot disk from an image
   disk {
-    source_image = "debian-7-wheezy-v20160301"
+    source_image = "debian-cloud/debian-8"
     auto_delete = true
     boot = true
   }

--- a/website/source/docs/providers/google/r/dns_record_set.markdown
+++ b/website/source/docs/providers/google/r/dns_record_set.markdown
@@ -21,7 +21,7 @@ resource "google_compute_instance" "frontend" {
   zone         = "us-central1-b"
 
   disk {
-    image = "debian-7-wheezy-v20160301"
+    image = "debian-cloud/debian-8"
   }
 
   network_interface {


### PR DESCRIPTION
Debian 7 is no longer an official supported image in GCE, so updating Acceptance Tests and Documentation to use the most recent Debian 8 image.

While doing this, discovered a bug in the Autoscaler Test that was causing it to fail. Details [here](https://github.com/hashicorp/terraform/pull/8307#commitcomment-18698853).