### PR TITLE
provider/aws: AWS SpotFleet Requests now works with Subnets and AZs

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -25,6 +25,9 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 		Delete: resourceAwsSpotFleetRequestDelete,
 		Update: resourceAwsSpotFleetRequestUpdate,
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsSpotFleetRequestMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"iam_fleet_role": &schema.Schema{
 				Type:     schema.TypeString,
@@ -49,7 +52,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 						"associate_public_ip_address": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  true,
+							Default:  false,
 						},
 						"ebs_block_device": &schema.Schema{
 							Type:     schema.TypeSet,
@@ -192,7 +195,6 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
-						//									"network_interface_set"
 						"placement_group": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
@@ -202,12 +204,6 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 						"spot_price": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
-						},
-						"subnet_id": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
 							ForceNew: true,
 						},
 						"user_data": &schema.Schema{
@@ -229,9 +225,16 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"subnet_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
 						"availability_zone": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 					},
@@ -291,19 +294,16 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{}) (*ec2.SpotFleetLaunchSpecification, error) {
 	conn := meta.(*AWSClient).ec2conn
 
-	_, hasSubnet := d["subnet_id"]
-	_, hasAZ := d["availability_zone"]
-	if !hasAZ && !hasSubnet {
-		return nil, fmt.Errorf("LaunchSpecification must include a subnet_id or an availability_zone")
-	}
-
 	opts := &ec2.SpotFleetLaunchSpecification{
 		ImageId:      aws.String(d["ami"].(string)),
 		InstanceType: aws.String(d["instance_type"].(string)),
 		SpotPrice:    aws.String(d["spot_price"].(string)),
-		Placement: &ec2.SpotPlacement{
-			AvailabilityZone: aws.String(d["availability_zone"].(string)),
-		},
+	}
+
+	if v, ok := d["availability_zone"]; ok {
+		opts.Placement = &ec2.SpotPlacement{
+			AvailabilityZone: aws.String(v.(string)),
+		}
 	}
 
 	if v, ok := d["ebs_optimized"]; ok {
@@ -327,70 +327,6 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 			base64.StdEncoding.EncodeToString([]byte(v.(string))))
 	}
 
-	// check for non-default Subnet, and cast it to a String
-	subnet, hasSubnet := d["subnet_id"]
-	subnetID := subnet.(string)
-
-	var associatePublicIPAddress bool
-	if v, ok := d["associate_public_ip_address"]; ok {
-		associatePublicIPAddress = v.(bool)
-	}
-
-	var groups []*string
-	if v, ok := d["security_groups"]; ok {
-		// Security group names.
-		// For a nondefault VPC, you must use security group IDs instead.
-		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
-		sgs := v.(*schema.Set).List()
-		if len(sgs) > 0 && hasSubnet {
-			log.Printf("[WARN] Deprecated. Attempting to use 'security_groups' within a VPC instance. Use 'vpc_security_group_ids' instead.")
-		}
-		for _, v := range sgs {
-			str := v.(string)
-			groups = append(groups, aws.String(str))
-		}
-	}
-
-	if hasSubnet && associatePublicIPAddress {
-		// If we have a non-default VPC / Subnet specified, we can flag
-		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
-		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise
-		// you get: Network interfaces and an instance-level subnet ID may not be specified on the same request
-		// You also need to attach Security Groups to the NetworkInterface instead of the instance,
-		// to avoid: Network interfaces and an instance-level security groups may not be specified on
-		// the same request
-		ni := &ec2.InstanceNetworkInterfaceSpecification{
-			AssociatePublicIpAddress: aws.Bool(associatePublicIPAddress),
-			DeviceIndex:              aws.Int64(int64(0)),
-			SubnetId:                 aws.String(subnetID),
-			Groups:                   groups,
-		}
-
-		if v, ok := d["private_ip"]; ok {
-			ni.PrivateIpAddress = aws.String(v.(string))
-		}
-
-		if v := d["vpc_security_group_ids"].(*schema.Set); v.Len() > 0 {
-			for _, v := range v.List() {
-				ni.Groups = append(ni.Groups, aws.String(v.(string)))
-			}
-		}
-
-		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
-	} else {
-		if subnetID != "" {
-			opts.SubnetId = aws.String(subnetID)
-		}
-
-		if v, ok := d["vpc_security_group_ids"]; ok {
-			if s := v.(*schema.Set); s.Len() > 0 {
-				for _, v := range s.List() {
-					opts.SecurityGroups = append(opts.SecurityGroups, &ec2.GroupIdentifier{GroupId: aws.String(v.(string))})
-				}
-			}
-		}
-	}
-
 	if v, ok := d["key_name"]; ok {
 		opts.KeyName = aws.String(v.(string))
 	}
@@ -401,6 +337,51 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 			return nil, err
 		}
 		opts.WeightedCapacity = aws.Float64(wc)
+	}
+
+	var groups []*string
+	if v, ok := d["security_groups"]; ok {
+		sgs := v.(*schema.Set).List()
+		for _, v := range sgs {
+			str := v.(string)
+			groups = append(groups, aws.String(str))
+		}
+	}
+
+	var groupIds []*string
+	if v, ok := d["vpc_security_group_ids"]; ok {
+		if s := v.(*schema.Set); s.Len() > 0 {
+			for _, v := range s.List() {
+				opts.SecurityGroups = append(opts.SecurityGroups, &ec2.GroupIdentifier{GroupId: aws.String(v.(string))})
+				groupIds = append(groupIds, aws.String(v.(string)))
+			}
+		}
+	}
+
+	subnetId, hasSubnetId := d["subnet_id"]
+	if hasSubnetId {
+		opts.SubnetId = aws.String(subnetId.(string))
+	}
+
+	associatePublicIpAddress, hasPublicIpAddress := d["associate_public_ip_address"]
+	if hasPublicIpAddress && associatePublicIpAddress.(bool) == true && hasSubnetId {
+
+		// If we have a non-default VPC / Subnet specified, we can flag
+		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
+		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise
+		// you get: Network interfaces and an instance-level subnet ID may not be specified on the same request
+		// You also need to attach Security Groups to the NetworkInterface instead of the instance,
+		// to avoid: Network interfaces and an instance-level security groups may not be specified on
+		// the same request
+		ni := &ec2.InstanceNetworkInterfaceSpecification{
+			AssociatePublicIpAddress: aws.Bool(true),
+			DeviceIndex:              aws.Int64(int64(0)),
+			SubnetId:                 aws.String(subnetId.(string)),
+			Groups:                   groupIds,
+		}
+
+		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
+		opts.SubnetId = aws.String("")
 	}
 
 	blockDevices, err := readSpotFleetBlockDeviceMappingsFromConfig(d, conn)
@@ -617,7 +598,50 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 
 	d.SetId(*resp.SpotFleetRequestId)
 
+	log.Printf("[INFO] Spot Fleet Request ID: %s", d.Id())
+	log.Println("[INFO] Waiting for Spot Fleet Request to be active")
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"submitted"},
+		Target:     []string{"active"},
+		Refresh:    resourceAwsSpotFleetRequestStateRefreshFunc(d, meta),
+		Timeout:    10 * time.Minute,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
 	return resourceAwsSpotFleetRequestRead(d, meta)
+}
+
+func resourceAwsSpotFleetRequestStateRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		conn := meta.(*AWSClient).ec2conn
+		req := &ec2.DescribeSpotFleetRequestsInput{
+			SpotFleetRequestIds: []*string{aws.String(d.Id())},
+		}
+		resp, err := conn.DescribeSpotFleetRequests(req)
+
+		if err != nil {
+			log.Printf("Error on retrieving Spot Fleet Request when waiting: %s", err)
+			return nil, "", nil
+		}
+
+		if resp == nil {
+			return nil, "", nil
+		}
+
+		if len(resp.SpotFleetRequestConfigs) == 0 {
+			return nil, "", nil
+		}
+
+		spotFleetRequest := resp.SpotFleetRequestConfigs[0]
+
+		return spotFleetRequest, *spotFleetRequest.SpotFleetRequestState, nil
+	}
 }
 
 func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) error {
@@ -773,7 +797,7 @@ func launchSpecToMap(
 	}
 
 	if l.WeightedCapacity != nil {
-		m["weighted_capacity"] = fmt.Sprintf("%.3f", aws.Float64Value(l.WeightedCapacity))
+		m["weighted_capacity"] = floatToString(*l.WeightedCapacity)
 	}
 
 	// m["security_groups"] = securityGroupsToSet(l.SecutiryGroups)
@@ -941,9 +965,10 @@ func hashLaunchSpecification(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["ami"].(string)))
-	if m["availability_zone"] != nil && m["availability_zone"] != "" {
+	if m["availability_zone"] != "" {
 		buf.WriteString(fmt.Sprintf("%s-", m["availability_zone"].(string)))
-	} else if m["subnet_id"] != nil && m["subnet_id"] != "" {
+	}
+	if m["subnet_id"] != "" {
 		buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
 	}
 	buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
@@ -958,4 +983,8 @@ func hashEbsBlockDevice(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["snapshot_id"].(string)))
 	return hashcode.String(buf.String())
+}
+
+func floatToString(input float64) string {
+	return strconv.FormatFloat(input, 'f', 0, 64)
 }

--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -797,7 +797,7 @@ func launchSpecToMap(
 	}
 
 	if l.WeightedCapacity != nil {
-		m["weighted_capacity"] = floatToString(*l.WeightedCapacity)
+		m["weighted_capacity"] = strconv.FormatFloat(*l.WeightedCapacity, 'f', 0, 64)
 	}
 
 	// m["security_groups"] = securityGroupsToSet(l.SecutiryGroups)
@@ -983,8 +983,4 @@ func hashEbsBlockDevice(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["snapshot_id"].(string)))
 	return hashcode.String(buf.String())
-}
-
-func floatToString(input float64) string {
-	return strconv.FormatFloat(input, 'f', 0, 64)
 }

--- a/builtin/providers/aws/resource_aws_spot_fleet_request_migrate.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request_migrate.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsSpotFleetRequestMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Spot Fleet Request State v0; migrating to v1")
+		return migrateSpotFleetRequestV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateSpotFleetRequestV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty Spot Fleet Request State; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	is.Attributes["associate_public_ip_address"] = "false"
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/aws/resource_aws_spot_fleet_request_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request_migrate_test.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSSpotFleetRequestMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			ID:           "some_id",
+			Attributes: map[string]string{
+				"associate_public_ip_address": "true",
+			},
+			Expected: "false",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsSpotFleetRequestMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.Attributes["associate_public_ip_address"] != tc.Expected {
+			t.Fatalf("bad Spot Fleet Request Migrate: %s\n\n expected: %s", is.Attributes["associate_public_ip_address"], tc.Expected)
+		}
+	}
+}

--- a/website/source/docs/providers/aws/r/spot_fleet_request.html.markdown
+++ b/website/source/docs/providers/aws/r/spot_fleet_request.html.markdown
@@ -42,6 +42,31 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 }
 ```
 
+~> **NOTE:** Terraform does not support the functionality where multiple `subnet_id` or `availability_zone` parameters can be specified in the same 
+launch configuration block. If you want to specify multiple values, then separate launch configuration blocks should be used:
+
+```
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "arn:aws:iam::12345678:role/spot-fleet"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = "2019-11-04T20:44:20Z"
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-d06a90b0"
+        key_name = "my-key"
+        availability_zone = "us-west-2a"
+    }
+    launch_specification {
+        instance_type = "m3.large"
+        ami = "ami-d06a90b0"
+        key_name = "my-key"
+        availability_zone = "us-west-2a"
+    }
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+```
+
 ## Argument Reference
 
 Most of these arguments directly correspond to the


### PR DESCRIPTION
Fixes #8150 
Fixes #8203 

Also added a complete set of tests that reflect all of the use cases
that Amazon document
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-examples.html

It is important to note there that Terraform will be suggesting that
users create multiple launch configurations rather than AWS's version of
combing values into CSV based parameters. This will ensure that we are
able to enforce the correct state

Also note that `associate_public_ip_address` now defaults to `false` - a migration has been
included in this PR to migration users of this functionality. This needs
to be noted in the changelog. The last part of changing functionality
here is waiting for the state of the request to become `active`. Before
we get to this state, we cannot guarantee that Amazon have accepted the
request or it could have failed validation.

```
% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestAccAWSSpotFleetRequest_'
% 2 ↵
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/22 15:44:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSSpotFleetRequest_ -timeout 120m
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (133.90s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (76.67s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (75.22s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (96.95s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (74.44s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (97.82s)
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (76.22s)
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (79.81s)
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (77.15s)
=== RUN   TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName
--- PASS: TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    788.184s
```