### PR TITLE
provider/aws: Add aws_default_route_table resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -262,6 +262,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_nat_gateway":                              resourceAwsNatGateway(),
 			"aws_network_acl":                              resourceAwsNetworkAcl(),
 			"aws_default_network_acl":                      resourceAwsDefaultNetworkAcl(),
+			"aws_default_route_table":                      resourceAwsDefaultRouteTable(),
 			"aws_network_acl_rule":                         resourceAwsNetworkAclRule(),
 			"aws_network_interface":                        resourceAwsNetworkInterface(),
 			"aws_opsworks_application":                     resourceAwsOpsworksApplication(),

--- a/builtin/providers/aws/resource_aws_default_route_table.go
+++ b/builtin/providers/aws/resource_aws_default_route_table.go
@@ -1,0 +1,245 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDefaultRouteTable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDefaultRouteTableCreate,
+		Read:   resourceAwsDefaultRouteTableRead,
+		Update: resourceAwsRouteTableUpdate,
+		Delete: resourceAwsDefaultRouteTableDelete,
+
+		Schema: map[string]*schema.Schema{
+			"default_route_table_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"propagating_vgws": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"route": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr_block": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"gateway_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"instance_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"nat_gateway_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"vpc_peering_connection_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"network_interface_id": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Set: resourceAwsRouteTableHash,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsDefaultRouteTableCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	filter1 := &ec2.Filter{
+		Name:   aws.String("association.main"),
+		Values: []*string{aws.String("true")},
+	}
+	filter2 := &ec2.Filter{
+		Name:   aws.String("vpc-id"),
+		Values: []*string{aws.String(d.Get("vpc_id").(string))},
+	}
+
+	findOpts := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{filter1, filter2},
+	}
+
+	resp, err := conn.DescribeRouteTables(findOpts)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.RouteTables) < 1 || resp.RouteTables[0] == nil {
+		return fmt.Errorf("Default Route table not found")
+	}
+
+	rt := resp.RouteTables[0]
+
+	// The Default Route Table for a VPC can change, so use a Resource UniqueID
+	// for the ID here.
+	d.SetId(resource.UniqueId())
+	d.Set("default_route_table_id", rt.RouteTableId)
+	d.Set("vpc_id", rt.VpcId)
+
+	// revoke all default and pre-existing routes on the default route table.
+	// In the UPDATE method, we'll apply only the rules in the configuration.
+	log.Printf("[DEBUG] Revoking default routes for Default Route Table for %s", d.Id())
+	if err := revokeAllRouteTableRules(*rt.RouteTableId, meta); err != nil {
+		return err
+	}
+
+	return resourceAwsRouteTableUpdate(d, meta)
+}
+
+func resourceAwsDefaultRouteTableRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	filter1 := &ec2.Filter{
+		Name:   aws.String("association.main"),
+		Values: []*string{aws.String("true")},
+	}
+	filter2 := &ec2.Filter{
+		Name:   aws.String("vpc-id"),
+		Values: []*string{aws.String(d.Get("vpc_id").(string))},
+	}
+
+	findOpts := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{filter1, filter2},
+	}
+
+	resp, err := conn.DescribeRouteTables(findOpts)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.RouteTables) < 1 || resp.RouteTables[0] == nil {
+		return fmt.Errorf("Default Route table not found")
+	}
+
+	rt := resp.RouteTables[0]
+	d.Set("default_route_table_id", rt.RouteTableId)
+
+	propagatingVGWs := make([]string, 0, len(rt.PropagatingVgws))
+	for _, vgw := range rt.PropagatingVgws {
+		propagatingVGWs = append(propagatingVGWs, *vgw.GatewayId)
+	}
+	d.Set("propagating_vgws", propagatingVGWs)
+
+	// Create an empty schema.Set to hold all routes
+	route := &schema.Set{F: resourceAwsRouteTableHash}
+
+	// Loop through the routes and add them to the set
+	for _, r := range rt.Routes {
+		if r.GatewayId != nil && *r.GatewayId == "local" {
+			continue
+		}
+
+		if r.Origin != nil && *r.Origin == "EnableVgwRoutePropagation" {
+			continue
+		}
+
+		if r.DestinationPrefixListId != nil {
+			// Skipping because VPC endpoint routes are handled separately
+			// See aws_vpc_endpoint
+			continue
+		}
+
+		m := make(map[string]interface{})
+
+		if r.DestinationCidrBlock != nil {
+			m["cidr_block"] = *r.DestinationCidrBlock
+		}
+		if r.GatewayId != nil {
+			m["gateway_id"] = *r.GatewayId
+		}
+		if r.NatGatewayId != nil {
+			m["nat_gateway_id"] = *r.NatGatewayId
+		}
+		if r.InstanceId != nil {
+			m["instance_id"] = *r.InstanceId
+		}
+		if r.VpcPeeringConnectionId != nil {
+			m["vpc_peering_connection_id"] = *r.VpcPeeringConnectionId
+		}
+		if r.NetworkInterfaceId != nil {
+			m["network_interface_id"] = *r.NetworkInterfaceId
+		}
+
+		route.Add(m)
+	}
+	d.Set("route", route)
+
+	// Tags
+	d.Set("tags", tagsToMap(rt.Tags))
+
+	return nil
+}
+
+func resourceAwsDefaultRouteTableDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy Default Route Table. Terraform will remove this resource from the state file, however resources may remain.")
+	d.SetId("")
+	return nil
+}
+
+// revokeAllRouteTableRules revoke all ingress and egress rules that the Default
+// Network ACL currently has
+func revokeAllRouteTableRules(netaclId string, meta interface{}) error {
+	// conn := meta.(*AWSClient).ec2conn
+	log.Printf("\n***\nrevokeAllRouteTableRules\n***\n")
+
+	// Disable the propagation as it no longer exists in the config
+	// log.Printf(
+	// 	"[INFO] Deleting VGW propagation from %s: %s",
+	// 	d.Id(), id)
+	// _, err := conn.DisableVgwRoutePropagation(&ec2.DisableVgwRoutePropagationInput{
+	// 	RouteTableId: aws.String(d.Id()),
+	// 	GatewayId:    aws.String(id),
+	// })
+
+	// // Delete the route as it no longer exists in the config
+	// log.Printf(
+	// 	"[INFO] Deleting route from %s: %s",
+	// 	d.Id(), m["cidr_block"].(string))
+	// _, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
+	// 	RouteTableId:         aws.String(d.Id()),
+	// 	DestinationCidrBlock: aws.String(m["cidr_block"].(string)),
+	// })
+	// if err != nil {
+	// 	return err
+	// }
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_default_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_default_route_table_test.go
@@ -1,0 +1,259 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
+	var v ec2.RouteTable
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_default_route_table.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDefaultRouteTableConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(
+						"aws_default_route_table.foo", &v),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDefaultRouteTableDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_default_route_table" {
+			continue
+		}
+
+		// Try to find the resource
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			RouteTableIds: []*string{aws.String(rs.Primary.ID)},
+		})
+		if err == nil {
+			if len(resp.RouteTables) > 0 {
+				return fmt.Errorf("still exist.")
+			}
+
+			return nil
+		}
+
+		// Verify the error is what we want
+		ec2err, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if ec2err.Code() != "InvalidRouteTableID.NotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDefaultRouteTableExists(n string, v *ec2.RouteTable) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		resp, err := conn.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			RouteTableIds: []*string{aws.String(rs.Primary.ID)},
+		})
+		if err != nil {
+			return err
+		}
+		if len(resp.RouteTables) == 0 {
+			return fmt.Errorf("RouteTable not found")
+		}
+
+		*v = *resp.RouteTables[0]
+
+		return nil
+	}
+}
+
+const testAccDefaultRouteTableConfig = `
+resource "aws_vpc" "foo" {
+  cidr_block           = "10.1.0.0/16"
+  enable_dns_hostnames = true
+
+  tags {
+    Name = "tf-default-route-table-test"
+  }
+}
+
+resource "aws_default_route_table" "foo" {
+  default_route_table_id = "${aws_vpc.foo.default_route_table_id}"
+
+  route {
+    cidr_block = "10.0.1.0/32"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
+
+  tags {
+    Name = "tf-default-route-table-test"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.foo.id}"
+
+  tags {
+    Name = "tf-default-route-table-test"
+  }
+}`
+
+const testAccDefaultRouteTableConfigChange = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_internet_gateway" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	route {
+		cidr_block = "10.3.0.0/16"
+		gateway_id = "${aws_internet_gateway.foo.id}"
+	}
+
+	route {
+		cidr_block = "10.4.0.0/16"
+		gateway_id = "${aws_internet_gateway.foo.id}"
+	}
+}
+`
+
+const testAccDefaultRouteTableConfigInstance = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "foo" {
+	cidr_block = "10.1.1.0/24"
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_instance" "foo" {
+	# us-west-2
+	ami = "ami-4fccb37f"
+	instance_type = "m1.small"
+	subnet_id = "${aws_subnet.foo.id}"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	route {
+		cidr_block = "10.2.0.0/16"
+		instance_id = "${aws_instance.foo.id}"
+	}
+}
+`
+
+const testAccDefaultRouteTableConfigTags = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		foo = "bar"
+	}
+}
+`
+
+const testAccDefaultRouteTableConfigTagsUpdate = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		bar = "baz"
+	}
+}
+`
+
+// VPC Peering connections are prefixed with pcx
+// This test requires an ENV var, AWS_ACCOUNT_ID, with a valid AWS Account ID
+func testAccDefaultRouteTableVpcPeeringConfig(acc string) string {
+	cfg := `resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_internet_gateway" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_vpc" "bar" {
+	cidr_block = "10.3.0.0/16"
+}
+
+resource "aws_internet_gateway" "bar" {
+	vpc_id = "${aws_vpc.bar.id}"
+}
+
+resource "aws_vpc_peering_connection" "foo" {
+		vpc_id = "${aws_vpc.foo.id}"
+		peer_vpc_id = "${aws_vpc.bar.id}"
+		peer_owner_id = "%s"
+		tags {
+			foo = "bar"
+		}
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	route {
+		cidr_block = "10.2.0.0/16"
+		vpc_peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
+	}
+}
+`
+	return fmt.Sprintf(cfg, acc)
+}
+
+const testAccDefaultRouteTableVgwRoutePropagationConfig = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpn_gateway" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	propagating_vgws = ["${aws_vpn_gateway.foo.id}"]
+}
+`

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -26,6 +26,8 @@ func TestAccAWSVpc_basic(t *testing.T) {
 					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
+					resource.TestCheckResourceAttrSet(
+						"aws_vpc.foo", "default_route_table_id"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/default_route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/default_route_table.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "aws"
+page_title: "AWS: aws_default_route_table"
+sidebar_current: "docs-aws-resource-default-route-table|"
+description: |-
+  Provides a resource to manage a Default VPC Routing Table.
+---
+
+# aws\_default\_route\_table
+
+Provides a resource to manage a Default VPC Routing Table.
+
+Each VPC created in AWS comes with a Default Route Table that can be managed, but not
+destroyed. **This is an advanced resource**, and has special caveats to be aware
+of when using it. Please read this document in its entirety before using this
+resource.
+
+The `aws_default_route_table` behaves differently from normal resources, in that
+Terraform does not _create_ this resource, but instead attempts to "adopt" it
+into management. We can do this because each VPC created has a Default Route
+Table that cannot be destroyed, and is created with a single route.
+
+When Terraform first adopts the Default Route Table, it **immediately removes all
+defined routes**. It then proceeds to create any routes specified in the 
+configuration. This step is required so that only the routes specified in the 
+configuration present in the Default Route Table.
+
+For more information about Route Tables, see the AWS Documentation on 
+[Route Tables][aws-route-tables].
+
+For more information about managing normal Route Tables in Terraform, see our
+documentation on [aws_route_table][tf-route-tables].
+
+~> **NOTE on Route Tables and Routes:** Terraform currently
+provides both a standalone [Route resource](route.html) and a Route Table resource with routes
+defined in-line. At this time you cannot use a Route Table with in-line routes
+in conjunction with any Route resources. Doing so will cause
+a conflict of rule settings and will overwrite routes.
+
+## Example usage with tags:
+
+```
+resource "aws_route_table" "r" {
+    default_route_table_id = "${aws_vpc.foo.default_route_table_id}"
+    route {
+        ...
+    }
+
+	tags {
+		Name = "default table"
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `default_route_table_id` - (Required) The ID of the Default Routing Table.
+* `route` - (Optional) A list of route objects. Their keys are documented below.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+* `propagating_vgws` - (Optional) A list of virtual gateways for propagation.
+
+Each route supports the following:
+
+* `cidr_block` - (Required) The CIDR block of the route.
+* `gateway_id` - (Optional) The Internet Gateway ID.
+* `nat_gateway_id` - (Optional) The NAT Gateway ID.
+* `instance_id` - (Optional) The EC2 instance ID.
+* `vpc_peering_connection_id` - (Optional) The VPC Peering ID.
+* `network_interface_id` - (Optional) The ID of the elastic network interface (eni) to use.
+
+Each route must contain either a `gateway_id`, an `instance_id`, a `nat_gateway_id`, a
+`vpc_peering_connection_id` or a `network_interface_id`. Note that the default route, mapping
+the VPC's CIDR block to "local", is created implicitly and cannot be specified.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the routing table
+
+
+[aws-route-tables]: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html#Route_Replacing_Main_Table
+[tf-route-tables]: /docs/providers/aws/r/route_table.html

--- a/website/source/docs/providers/aws/r/default_route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/default_route_table.html.markdown
@@ -13,7 +13,9 @@ Provides a resource to manage a Default VPC Routing Table.
 Each VPC created in AWS comes with a Default Route Table that can be managed, but not
 destroyed. **This is an advanced resource**, and has special caveats to be aware
 of when using it. Please read this document in its entirety before using this
-resource.
+resource. It is recommened you **do not** use both `aws_default_route_table` to
+manage the default route table **and** use the `aws_main_route_table_association`,
+due to possible conflict in routes.
 
 The `aws_default_route_table` behaves differently from normal resources, in that
 Terraform does not _create_ this resource, but instead attempts to "adopt" it
@@ -37,10 +39,11 @@ defined in-line. At this time you cannot use a Route Table with in-line routes
 in conjunction with any Route resources. Doing so will cause
 a conflict of rule settings and will overwrite routes.
 
+
 ## Example usage with tags:
 
 ```
-resource "aws_route_table" "r" {
+resource "aws_default_route_table" "r" {
     default_route_table_id = "${aws_vpc.foo.default_route_table_id}"
     route {
         ...

--- a/website/source/docs/providers/aws/r/vpc.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc.html.markdown
@@ -61,6 +61,7 @@ The following attributes are exported:
      [`aws_main_route_table_association`](/docs/providers/aws/r/main_route_table_assoc.html).
 * `default_network_acl_id` - The ID of the network ACL created by default on VPC creation
 * `default_security_group_id` - The ID of the security group created by default on VPC creation
+* `default_security_group_id` - The ID of the route table created by default on VPC creation
 
 
 [1]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/UserGuide/vpc-classiclink.html

--- a/website/source/docs/providers/aws/r/vpc.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc.html.markdown
@@ -61,7 +61,7 @@ The following attributes are exported:
      [`aws_main_route_table_association`](/docs/providers/aws/r/main_route_table_assoc.html).
 * `default_network_acl_id` - The ID of the network ACL created by default on VPC creation
 * `default_security_group_id` - The ID of the security group created by default on VPC creation
-* `default_security_group_id` - The ID of the route table created by default on VPC creation
+* `default_route_table_id` - The ID of the route table created by default on VPC creation
 
 
 [1]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/UserGuide/vpc-classiclink.html

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -846,6 +846,10 @@
                             <a href="/docs/providers/aws/r/default_network_acl.html">aws_default_network_acl</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-default-route-table") %>>
+                            <a href="/docs/providers/aws/r/default_route_table.html">aws_default_route_table</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-flow-log") %>>
                             <a href="/docs/providers/aws/r/flow_log.html">aws_flow_log</a>
                         </li>


### PR DESCRIPTION
Adds a resource to manage the default route table that comes with every VPC. 
This is an advanced resource with caveats mentioned in the documentation. 

Part of #6093