### PR TITLE
provider/aws: Support Import aws_elasticache_cluster

### DIFF
--- a/builtin/providers/aws/import_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/import_aws_elasticache_cluster_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSElasticacheCluster_importBasic(t *testing.T) {
+	resourceName := "aws_elasticache_cluster.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheClusterConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/import_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/import_aws_elasticache_cluster_test.go
@@ -1,12 +1,17 @@
 package aws
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSElasticacheCluster_importBasic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	resourceName := "aws_elasticache_cluster.bar"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -200,6 +200,9 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		Read:   resourceAwsElasticacheClusterRead,
 		Update: resourceAwsElasticacheClusterUpdate,
 		Delete: resourceAwsElasticacheClusterDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: resourceSchema,
 	}

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -48,6 +48,7 @@ To make a resource importable, please see the
 * aws_eip
 * aws_elastic_beanstalk_application
 * aws_elastic_beanstalk_environment
+* aws_elasticache_cluster
 * aws_elasticache_parameter_group
 * aws_elasticache_subnet_group
 * aws_elb
@@ -149,4 +150,3 @@ To make a resource importable, please see the
 * triton_key
 * triton_machine
 * triton_vlan
-

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -119,3 +119,12 @@ The following attributes are exported:
 
 [1]: https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html
 [2]: https://docs.aws.amazon.com/fr_fr/AmazonElastiCache/latest/UserGuide/Clusters.Modify.html
+
+
+## Import
+
+ElastiCache Clusters can be imported using the `cluster_id`, e.g.
+
+```
+$ terraform import aws_elasticache_cluster.my_cluster my_cluster
+```


### PR DESCRIPTION
Add support for importing AWS ElastiCache clusters.

### Testing with newly compiled binary:
```
$ terraform import aws_elasticache_cluster.my_cluster my_cluster
aws_elasticache_cluster.my_cluster: Importing from ID "my_cluster"...
aws_elasticache_cluster.my_cluster: Import complete!
  Imported aws_elasticache_cluster (ID: my_cluster)
aws_elasticache_cluster.my_cluster: Refreshing state... (ID: my_cluster)

Import success! The resources imported are shown above. These are
now in your Terraform state. Import does not currently generate
configuration, so you must do this next. If you do not create configuration
for the above resources, then the next `terraform plan` will mark
them for destruction.
```


### Results in this `terraform.tfstate` file:
```json
{
    "version": 3,
    "terraform_version": "0.7.1",
    "serial": 0,
    "lineage": "67b45360-d9a2-4fdb-8ae4-1d1cc41d1dfa",
    "modules": [
        {
            "path": [
                "root"
            ],
            "outputs": {},
            "resources": {
                "aws_elasticache_cluster.my_cluster": {
                    "type": "aws_elasticache_cluster",
                    "depends_on": [],
                    "primary": {
                        "id": "my_cluster",
                        "attributes": {
                            "availability_zone": "us-east-1a",
                            "cache_nodes.#": "1",
                            "cache_nodes.0.address": "XXXXXXXXXX",
                            "cache_nodes.0.availability_zone": "us-east-1a",
                            "cache_nodes.0.id": "0001",
                            "cache_nodes.0.port": "6379",
                            "cluster_id": "my_cluster",
                            "engine": "redis",
                            "engine_version": "2.8.22",
                            "id": "my_cluster",
                            "maintenance_window": "sun:09:00-sun:10:00",
                            "node_type": "cache.t2.micro",
                            "num_cache_nodes": "1",
                            "security_group_names.#": "0",
                            "snapshot_retention_limit": "0",
                            "snapshot_window": "",
                            "subnet_group_name": "my_cluster",
                            "tags.%": "0"
                        },
                        "meta": {},
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "aws"
                }
            },
            "depends_on": []
        }
    ]
}
```