### PR TITLE
provider/aws: Add support for TargetGroups to AutoScaling Groups

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -169,6 +169,13 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 				Default:  false,
 			},
 
+			"target_group_arns": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"tag": autoscalingTagsSchema(),
 		},
 	}
@@ -272,6 +279,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
+	log.Printf("\n***\nASG: %s\n\n***\n", g)
 	d.Set("availability_zones", flattenStringList(g.AvailabilityZones))
 	d.Set("default_cooldown", g.DefaultCooldown)
 	d.Set("desired_capacity", g.DesiredCapacity)
@@ -279,6 +287,21 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("health_check_type", g.HealthCheckType)
 	d.Set("launch_configuration", g.LaunchConfigurationName)
 	d.Set("load_balancers", flattenStringList(g.LoadBalancerNames))
+	if g.TargetGroupARNs != nil {
+		log.Printf("\n***\nTarget groups:\n")
+		for i, t := range g.TargetGroupARNs {
+			log.Printf("\t%d: %s\n", i, *t)
+		}
+	}
+	log.Printf("\n@@@\nTarget groups: \n%s\n\n@@@\n", g.TargetGroupARNs)
+	if err := d.Set("target_group_arns", flattenStringList(g.TargetGroupARNs)); err != nil {
+		log.Printf("\n@@@\nERROR setting target groups: %s\n@@@\n", err)
+	} else {
+		log.Printf("\n@@@\nYay set tga\n@@@\n@@@")
+		for i, t := range flattenStringList(g.TargetGroupARNs) {
+			log.Printf("\t%d: %s\n", i, t.(string))
+		}
+	}
 	d.Set("min_size", g.MinSize)
 	d.Set("max_size", g.MaxSize)
 	d.Set("placement_group", g.PlacementGroup)
@@ -418,6 +441,42 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 			})
 			if err != nil {
 				return fmt.Errorf("[WARN] Error updating Load Balancers for AutoScaling Group (%s), error: %s", d.Id(), err)
+			}
+		}
+	}
+
+	if d.HasChange("target_group_arns") {
+
+		o, n := d.GetChange("target_group_arns")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+		remove := expandStringList(os.Difference(ns).List())
+		add := expandStringList(ns.Difference(os).List())
+
+		if len(remove) > 0 {
+			_, err := conn.DetachLoadBalancerTargetGroups(&autoscaling.DetachLoadBalancerTargetGroupsInput{
+				AutoScalingGroupName: aws.String(d.Id()),
+				TargetGroupARNs:      remove,
+			})
+			if err != nil {
+				return fmt.Errorf("[WARN] Error updating Load Balancers Target Groups for AutoScaling Group (%s), error: %s", d.Id(), err)
+			}
+		}
+
+		if len(add) > 0 {
+			_, err := conn.AttachLoadBalancerTargetGroups(&autoscaling.AttachLoadBalancerTargetGroupsInput{
+				AutoScalingGroupName: aws.String(d.Id()),
+				TargetGroupARNs:      add,
+			})
+			if err != nil {
+				return fmt.Errorf("[WARN] Error updating Load Balancers Target Groups for AutoScaling Group (%s), error: %s", d.Id(), err)
 			}
 		}
 	}

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -283,7 +283,6 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	log.Printf("\n***\nASG: %s\n\n***\n", g)
 	d.Set("availability_zones", flattenStringList(g.AvailabilityZones))
 	d.Set("default_cooldown", g.DefaultCooldown)
 	d.Set("desired_capacity", g.DesiredCapacity)

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -67,6 +67,8 @@ The following arguments are supported:
 * `load_balancers` (Optional) A list of load balancer names to add to the autoscaling
    group names.
 * `vpc_zone_identifier` (Optional) A list of subnet IDs to launch resources in.
+* `target_group_arns` (Optional) A list of `aws_target_group` ARNs, for use with
+Application Load Balancing
 * `termination_policies` (Optional) A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default`.
 * `tag` (Optional) A list of tag blocks. Tags documented below.
 * `placement_group` (Optional) The name of the placement group into which you'll launch your instances, if any.
@@ -114,6 +116,8 @@ The following attributes are exported:
 * `vpc_zone_identifier` (Optional) - The VPC zone identifier
 * `load_balancers` (Optional) The load balancer names associated with the
    autoscaling group.
+* `target_group_arns` (Optional) list of Target Group ARNs that apply to this
+AutoScaling Group
 
 ~> **NOTE:** When using `ELB` as the health_check_type, `health_check_grace_period` is required.
 


### PR DESCRIPTION
Adds support for the new `aws_alb_target_group` to our existing `aws_autoscaling_group`

Includes: 

- [x] Tests
- [x] Implementation 
- [x] Docs

~~Docs coming..~~

Tests passing:

```
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (85.38s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	85.396s
```