### PR TITLE
provider/aws: Fix crash when reading VPC Peering Connection options.

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -126,34 +126,28 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] VPC Peering Connection response: %#v", pc)
 
-	d.Set("accept_status", *pc.Status.Code)
+	d.Set("accept_status", pc.Status.Code)
+	d.Set("peer_owner_id", pc.AccepterVpcInfo.OwnerId)
+	d.Set("peer_vpc_id", pc.AccepterVpcInfo.VpcId)
+	d.Set("vpc_id", pc.RequesterVpcInfo.VpcId)
 
 	// When the VPC Peering Connection is pending acceptance,
 	// the details about accepter and/or requester peering
 	// options would not be included in the response.
-	if pc.AccepterVpcInfo != nil {
-		d.Set("peer_owner_id", *pc.AccepterVpcInfo.OwnerId)
-		d.Set("peer_vpc_id", *pc.AccepterVpcInfo.VpcId)
-
-		if _, ok := d.GetOk("accepter"); ok {
-			if pc.AccepterVpcInfo.PeeringOptions != nil {
-				err = d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
-				if err != nil {
-					return err
-				}
+	if _, ok := d.GetOk("accepter"); ok {
+		if pc.AccepterVpcInfo.PeeringOptions != nil {
+			err = d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
+			if err != nil {
+				return err
 			}
 		}
 	}
 
-	if pc.RequesterVpcInfo != nil {
-		d.Set("vpc_id", *pc.RequesterVpcInfo.VpcId)
-
-		if _, ok := d.GetOk("requester"); ok {
-			if pc.RequesterVpcInfo.PeeringOptions != nil {
-				err = d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
-				if err != nil {
-					return err
-				}
+	if _, ok := d.GetOk("requester"); ok {
+		if pc.RequesterVpcInfo.PeeringOptions != nil {
+			err = d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -67,6 +67,11 @@ resource "aws_vpc" "bar" {
 
 ## Argument Reference
 
+-> **Note:** Modifying the VPC Peering Connection options requires peering to be active. An automatic activation
+can be done using the [`auto_accept`](vpc_peering.html#auto_accept) attribute. Alternatively, the VPC Peering
+Connection has to be made active manually using other means. See [notes](vpc_peering.html#notes) below for
+more information.
+
 The following arguments are supported:
 
 * `peer_owner_id` - (Required) The AWS account ID of the owner of the peer VPC.


### PR DESCRIPTION
This resolves the issue introduced in #8310.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>