### PR TITLE
provider/google: Fix acceptance test image reversion

### DIFF
--- a/builtin/providers/google/resource_compute_autoscaler_test.go
+++ b/builtin/providers/google/resource_compute_autoscaler_test.go
@@ -139,7 +139,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-7-wheezy-v20160301"
+		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
 	}
@@ -196,7 +196,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-7-wheezy-v20160301"
+		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
 	}

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -277,7 +277,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -331,7 +331,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -380,7 +380,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -411,7 +411,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}
@@ -456,7 +456,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-cloud/debian-7-wheezy-v20160301"
+			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
 		}


### PR DESCRIPTION
It looks like #8301, while fixing the test, reverted the images in those tests back to using Debian 7 instead of Debian 8 (#8307). This just fixes those so all Google images refer to the same Debian 8 image. Re-ran the acceptance tests for the Autoscaler and InstanceGroupManager to be sure everything is still well.

```
$ make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccAutoscaler_'
==> Checking that code complies with gofmt requirements...
/opt/gopath/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/20 19:59:15 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccAutoscaler_ -timeout 120m
=== RUN   TestAccAutoscaler_importBasic
--- PASS: TestAccAutoscaler_importBasic (117.25s)
=== RUN   TestAccAutoscaler_basic
--- PASS: TestAccAutoscaler_basic (113.67s)
=== RUN   TestAccAutoscaler_update
--- PASS: TestAccAutoscaler_update (229.13s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	460.072s
```
```
$ make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccInstanceGroupManager_'
==> Checking that code complies with gofmt requirements...
/opt/gopath/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/20 20:07:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccInstanceGroupManager_ -timeout 120m
=== RUN   TestAccInstanceGroupManager_importBasic
--- PASS: TestAccInstanceGroupManager_importBasic (212.30s)
=== RUN   TestAccInstanceGroupManager_importUpdate
--- PASS: TestAccInstanceGroupManager_importUpdate (97.48s)
=== RUN   TestAccInstanceGroupManager_basic
--- PASS: TestAccInstanceGroupManager_basic (97.37s)
=== RUN   TestAccInstanceGroupManager_update
--- PASS: TestAccInstanceGroupManager_update (166.55s)
=== RUN   TestAccInstanceGroupManager_updateLifecycle
--- PASS: TestAccInstanceGroupManager_updateLifecycle (158.30s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	732.018s
```