### PR TITLE
Add note to use Server-Defined-Cipher-Order

### DIFF
--- a/website/source/docs/providers/aws/r/lb_ssl_negotiation_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/lb_ssl_negotiation_policy.html.markdown
@@ -76,6 +76,8 @@ balancer.
 
 To set your attributes, please see the [AWS Elastic Load Balancing Developer Guide](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-security-policy-table.html) for a listing of the supported SSL protocols, SSL options, and SSL ciphers.
 
+~> **NOTE:** The AWS documentation references Server Order Preference, which the AWS Elastic Load Balancing API refers to as `Server-Defined-Cipher-Order`. If you wish to set Server Order Preference, use this value instead.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
The Terraform documentation, rather correctly, refers to a list of options
you can pass to an Elastic Load Balancer from the AWS documentation. All but
one of these options works; 'Server Order Preference' doesn't work, because
the API refers to it as 'Server-Defined-Cipher-Order'.

Add a note to explain this, at least as a temporary solution.

Fixes #8340.