### PR TITLE
docs: Note envvars for Datadog configuration

### DIFF
--- a/website/source/docs/providers/datadog/index.html.markdown
+++ b/website/source/docs/providers/datadog/index.html.markdown
@@ -38,6 +38,6 @@ resource "datadog_timeboard" "default" {
 
 The following arguments are supported:
 
-* `api_key` - (Required) Datadog API key
-* `app_key` - (Required) Datadog APP key
+* `api_key` - (Required) Datadog API key. This can also be set via the `DATADOG_API_KEY` environment variable.
+* `app_key` - (Required) Datadog APP key. This can also be set via the `DATADOG_APP_KEY` environment variable.
 


### PR DESCRIPTION
This is a minor annoyance but useful for configuring the Datadog provider without having to look up the correct variables in code.