### PR TITLE
provider/datadog: Docs updates

### DIFF
--- a/website/source/docs/providers/datadog/r/monitor.html.markdown
+++ b/website/source/docs/providers/datadog/r/monitor.html.markdown
@@ -101,3 +101,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - ID of the Datadog monitor
+
+## Import
+
+Monitors can be imported using their numeric ID, e.g.
+
+```
+$ terraform import datadog_monitor.bytes_received_localhost 2081
+```

--- a/website/source/layouts/datadog.erb
+++ b/website/source/layouts/datadog.erb
@@ -3,25 +3,27 @@
 		<div class="docs-sidebar hidden-print affix-top" role="complementary">
 			<ul class="nav docs-sidenav">
 				<li<%= sidebar_current("docs-home") %>>
-				<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
-                </li>
+					<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
+				</li>
 
 				<li<%= sidebar_current("docs-datadog-index") %>>
-				<a href="/docs/providers/datadog/index.html">Datadog Provider</a>
-                </li>
+					<a href="/docs/providers/datadog/index.html">Datadog Provider</a>
+				</li>
 
 				<li<%= sidebar_current(/^docs-datadog-resource/) %>>
-				<a href="#">Resources</a>
-                <ul class="nav nav-visible">
-                    <li<%= sidebar_current("docs-datadog-resource-monitor") %>>
-					<a href="/docs/providers/datadog/r/monitor.html">datadog_monitor</a>
-                    <a href="/docs/providers/datadog/r/timeboard.html">datadog_timeboard</a>
-                    </li>
-				</ul>
+					<a href="#">Resources</a>
+					<ul class="nav nav-visible">
+						<li<%= sidebar_current("docs-datadog-resource-monitor") %>>
+							<a href="/docs/providers/datadog/r/monitor.html">datadog_monitor</a>
+						</li>
+						<li<%= sidebar_current("docs-datadog-resource-timeboard") %>>
+							<a href="/docs/providers/datadog/r/timeboard.html">datadog_timeboard</a>
+						</li>
+					</ul>
 				</li>
 			</ul>
 		</div>
 	<% end %>
 
 	<%= yield %>
-	<% end %>
+<% end %>


### PR DESCRIPTION
Document the import support for `datadog_monitor` merged in #8324, and fix the sidebar highlighting of currently selected resource.