### PR TITLE
build: Exclude darwin/arm from OS/Arch targets

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,6 +17,7 @@ GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
+XC_EXCLUDE_OSARCH="!darwin/arm"
 
 # Delete the old dir
 echo "==> Removing old directory..."
@@ -49,6 +50,7 @@ echo "==> Building..."
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
+    -osarch="${XC_EXCLUDE_OSARCH}" \
     -ldflags "${LD_FLAGS}" \
     -output "pkg/{{.OS}}_{{.Arch}}/terraform" \
     .


### PR DESCRIPTION
Fixes #8365