### PR TITLE
provider/aws: Refresh `aws_lambda_event_source_mapping` from state when NotFound

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_event_source_mapping.go
+++ b/builtin/providers/aws/resource_aws_lambda_event_source_mapping.go
@@ -134,6 +134,12 @@ func resourceAwsLambdaEventSourceMappingRead(d *schema.ResourceData, meta interf
 
 	eventSourceMappingConfiguration, err := conn.GetEventSourceMapping(params)
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "ResourceNotFoundException" {
+			log.Printf("[DEBUG] Lambda event source mapping (%s) not found", d.Id())
+			d.SetId("")
+
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes #8375

When a Lambda or an associated Event Source Mapping has been removed via
the AWS Console, Terraform throws an error similar to the following:

```
Error refreshing state: 1 error(s) occurred:

* aws_lambda_event_source_mapping.dmp_enrichment_event_source_mapping:
* ResourceNotFoundException: The resource you requested does not exist.
    status code: 404, request id: a17c641d-6868-11e6-accf-3d0ea71934fa

```

the resource should be refreshed from the state when this happens so
that subsequent plans show it needs to be recreated

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_'
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/22 16:15:54 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSLambdaEventSourceMapping_ -timeout 120m
=== RUN   TestAccAWSLambdaEventSourceMapping_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_basic (120.81s)
=== RUN   TestAccAWSLambdaEventSourceMapping_disappears
--- PASS: TestAccAWSLambdaEventSourceMapping_disappears (104.08s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    224.914s
```