### PR TITLE
provider/aws: `aws_elasticache_replication_group_id` validation change

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -404,9 +404,9 @@ func validateAwsElastiCacheReplicationGroupEngine(v interface{}, k string) (ws [
 
 func validateAwsElastiCacheReplicationGroupId(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if (len(value) < 1) || (len(value) > 20) {
+	if (len(value) < 1) || (len(value) > 16) {
 		errors = append(errors, fmt.Errorf(
-			"%q must contain from 1 to 20 alphanumeric characters or hyphens", k))
+			"%q must contain from 1 to 16 alphanumeric characters or hyphens", k))
 	}
 	if !regexp.MustCompile(`^[0-9a-zA-Z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -164,7 +164,7 @@ func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(65),
+			Value:    randomString(17),
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
Fixes #8379 

The AWS documentation tells us the following:

```
--replication-group-id (string)

The replication group identifier. This parameter is stored as a
lowercase string.
Constraints:
A name must contain from *1 to 20* alphanumeric characters or hyphens.
The first character must be a letter.
A name cannot end with a hyphen or contain two consecutive hyphens.
```

This is not correct and is causing users errors:

```
* aws_elasticache_replication_group.bar: Error creating Elasticache
* Replication Group: InvalidParameterValue: Replication group id should
* be no more than 16 characters.
    status code: 400, request id:
```

Tuning the Validation from 20 to 16 characters to avoid user issues