### PR TITLE
provider/aws: Add Primary Endpoint Address attribute for `aws_elasticache_replication_group`

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -42,6 +42,11 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		ForceNew: true,
 	}
 
+	resourceSchema["primary_endpoint_address"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+
 	resourceSchema["engine"].Required = false
 	resourceSchema["engine"].Optional = true
 	resourceSchema["engine"].Default = "redis"
@@ -214,6 +219,8 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		d.Set("maintenance_window", c.PreferredMaintenanceWindow)
 		d.Set("snapshot_window", c.SnapshotWindow)
 		d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
+
+		d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
 
 	}
 

--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -31,7 +31,7 @@ resource "aws_elasticache_replication_group" "bar" {
 
 The following arguments are supported:
 
-* `replication_group_id` – (Required) The replication group identifier. This parameter is stored as a lowercase string.
+* `replication_group_id` – (Required) The replication group identifier.
 * `replication_group_description` – (Required) A user-created description for the replication group.
 * `number_cache_clusters` - (Required) The number of cache clusters this replication group will have.
  If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource
@@ -67,3 +67,4 @@ Please note that setting a `snapshot_retention_limit` is not supported on cache.
 The following attributes are exported:
 
 * `id` - The ID of the ElastiCache Replication Group
+* `primary_endpoint_address` - The Address of the Primary Node in the replication group. Doesn't include the port.


### PR DESCRIPTION
Fixes #8377

Now we can output the endpoint of the primary

```
resource "aws_elasticache_replication_group" "bar" {
    replication_group_id = "tf-11111"
    replication_group_description = "test description"
    node_type = "cache.m1.small"
    number_cache_clusters = 2
    port = 6379
    parameter_group_name = "default.redis2.8"
    apply_immediately = true
}

output "primary_endpoint_address" {
  value = "${aws_elasticache_replication_group.bar.primary_endpoint_address}"
}
```

This gives us:

```
% terraform apply
...................
aws_elasticache_replication_group.bar: Creation complete

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

primary_endpoint_address = tf-11111.d5jx4z.ng.0001.use1.cache.amazonaws.com
```

This was the addition of a computed field only so the basic test still works as expected:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_basic'                        ✹
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/22 17:11:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticacheReplicationGroup_basic -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (741.71s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	741.735s
```