### PR TITLE
provider/google: Fix panic and state migration for google_compute_firewall

### DIFF
--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -23,6 +23,7 @@ func resourceComputeFirewall() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		SchemaVersion: 1,
+		MigrateState:  resourceComputeFirewallMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/builtin/providers/google/resource_compute_firewall.go
+++ b/builtin/providers/google/resource_compute_firewall.go
@@ -26,29 +26,29 @@ func resourceComputeFirewall() *schema.Resource {
 		MigrateState:  resourceComputeFirewallMigrateState,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"network": &schema.Schema{
+			"network": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"allow": &schema.Schema{
+			"allow": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"protocol": &schema.Schema{
+						"protocol": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"ports": &schema.Schema{
+						"ports": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -58,38 +58,38 @@ func resourceComputeFirewall() *schema.Resource {
 				Set: resourceComputeFirewallAllowHash,
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"project": &schema.Schema{
+			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
 
-			"self_link": &schema.Schema{
+			"self_link": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"source_ranges": &schema.Schema{
+			"source_ranges": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
 
-			"source_tags": &schema.Schema{
+			"source_tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
 
-			"target_tags": &schema.Schema{
+			"target_tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},


### PR DESCRIPTION
This pull request fixes the issues reported against Terraform 0.7.1 whereby a state migration which never ran (because it wasn't hooked in) caused a panic because of uninitialized or incorrect structure use.

It also tidies up the code for `google_compute_firewall` to conform to the newer style without redundant type declarations.

Fixes #8345, Fixes #8341.