### PR TITLE
provider/aws: Add support for `network_mode` to `aws_ecs_task_definition`

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -93,7 +93,7 @@ func validateAwsEcsTaskDefinitionNetworkMode(v interface{}, k string) (ws []stri
 	}
 
 	if _, ok := validTypes[value]; !ok {
-		errors = append(errors, fmt.Errorf("ECS Task Definition network_mode %q is invalid, must be %q, %q or %q", value, "bridge", "host", "none"))
+		errors = append(errors, fmt.Errorf("ECS Task Definition network_mode %q is invalid, must be `bridge`, `host` or `none`", value))
 	}
 	return
 }

--- a/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
@@ -52,7 +52,8 @@ The following arguments are supported:
 
 * `family` - (Required) The family, unique name for your task definition.
 * `container_definitions` - (Required) A list of container definitions in JSON format. See [AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html) for syntax. Note, you only need the containerDefinitions array, not the parent hash including the family and volumes keys.
-* `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. 
+* `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+* `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none` , `bridge` , and `host`.
 * `volume` - (Optional) A volume block. Volumes documented below.
 
 Volumes support the following:

--- a/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `family` - (Required) The family, unique name for your task definition.
 * `container_definitions` - (Required) A list of container definitions in JSON format. See [AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html) for syntax. Note, you only need the containerDefinitions array, not the parent hash including the family and volumes keys.
 * `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
-* `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none` , `bridge` , and `host`.
+* `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, and `host`.
 * `volume` - (Optional) A volume block. Volumes documented below.
 
 Volumes support the following:


### PR DESCRIPTION
Fixes #8281


```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcsTaskDefinition_'
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/22 18:12:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcsTaskDefinition_ -timeout 120m
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (29.02s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (16.75s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (147.77s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (19.49s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (19.52s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	232.588
```