### PR TITLE
command: use bufio.ReadString instead of scanning to get spaces

### DIFF
--- a/command/ui_input.go
+++ b/command/ui_input.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/colorstring"
@@ -95,12 +96,13 @@ func (i *UIInput) Input(opts *terraform.InputOpts) (string, error) {
 	// interrupt this if we are interrupted (SIGINT)
 	result := make(chan string, 1)
 	go func() {
-		var line string
-		if _, err := fmt.Fscanln(r, &line); err != nil {
+		buf := bufio.NewReader(r)
+		line, err := buf.ReadString('\n')
+		if err != nil {
 			log.Printf("[ERR] UIInput scan err: %s", err)
 		}
 
-		result <- line
+		result <- strings.TrimRightFunc(line, unicode.IsSpace)
 	}()
 
 	select {

--- a/command/ui_input_test.go
+++ b/command/ui_input_test.go
@@ -26,3 +26,19 @@ func TestUIInputInput(t *testing.T) {
 		t.Fatalf("bad: %#v", v)
 	}
 }
+
+func TestUIInputInput_spaces(t *testing.T) {
+	i := &UIInput{
+		Reader: bytes.NewBufferString("foo bar\n"),
+		Writer: bytes.NewBuffer(nil),
+	}
+
+	v, err := i.Input(&terraform.InputOpts{})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if v != "foo bar" {
+		t.Fatalf("bad: %#v", v)
+	}
+}


### PR DESCRIPTION
Fixes #2628 

Surprised this hasn't bit more people! Turns out fmt's Scan functions break on spaces and I don't see a way around that. Luckily `bufio` has some nice functions reading up to a certain character. Added another test to verify.