### PR TITLE
terraform: prefix destroy resources with module path [GH-2767]

### DIFF
--- a/terraform/test-fixtures/apply-destroy-module-resource-prefix/child/main.tf
+++ b/terraform/test-fixtures/apply-destroy-module-resource-prefix/child/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "foo" {}

--- a/terraform/test-fixtures/apply-destroy-module-resource-prefix/main.tf
+++ b/terraform/test-fixtures/apply-destroy-module-resource-prefix/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+    source = "./child"
+}

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -896,6 +896,9 @@ func (n *graphNodeExpandedResourceDestroy) EvalTree() EvalNode {
 					Then: EvalNoop{},
 				},
 
+				// Load the instance info so we have the module path set
+				&EvalInstanceInfo{Info: info},
+
 				&EvalGetProvider{
 					Name:   n.ProvidedBy()[0],
 					Output: &provider,


### PR DESCRIPTION
Fixes #2767 

On destroy nodes we weren't populating the path for the instance info so the output wasn't showing it. This adds that and a test.