### PR TITLE
config/module: use source as part of key

### DIFF
--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -170,7 +170,7 @@ func (t *Tree) Load(s getter.Storage, mode GetMode) error {
 
 		// Get the directory where this module is so we can load it
 		key := strings.Join(path, ".")
-		key = "root." + key
+		key = fmt.Sprintf("root.%s-%s", key, source)
 		dir, ok, err := getStorage(s, key, source, mode)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #3070 

Ehhh, couldn't find a really great way to test this without embedding a git repo which I didn't want to do here. I view this as sort of a stop-gap solution anyways as we do a bigger plan around how modules should be stored on disk.

This is **kind of** backwards incompatible in that after updating you'll have to run `terraform get` again. I don't think that is very disruptive but happy to talk about it.