### PR TITLE
providers/aws: Check error from resourceAwsRoute53RecordBuildSet and return err if set

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -271,7 +272,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 
 	respRaw, err := changeRoute53RecordSet(conn, req)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("[ERR]: Error building changeset: {{err}}", err)
 	}
 
 	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -270,6 +270,9 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		zone, *rec.Name, req)
 
 	respRaw, err := changeRoute53RecordSet(conn, req)
+	if err != nil {
+		return err
+	}
 
 	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo
 


### PR DESCRIPTION
This should address the possible panic reported in https://github.com/hashicorp/terraform/issues/8393. I have not been able to reproduce firsthand, I see the possibilities. 