### PR TITLE
provider/aws: add local name filter to aws_ami datasource

### DIFF
--- a/builtin/providers/aws/data_source_aws_ami.go
+++ b/builtin/providers/aws/data_source_aws_ami.go
@@ -44,7 +44,7 @@ func dataSourceAwsAmi() *schema.Resource {
 					},
 				},
 			},
-			"local_name_filter": &schema.Schema{
+			"name_regex": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -212,11 +212,11 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 
 	executableUsers, executableUsersOk := d.GetOk("executable_users")
 	filters, filtersOk := d.GetOk("filter")
-	localNameFilter, localNameFilterOk := d.GetOk("local_name_filter")
+	nameRegex, nameRegexOk := d.GetOk("name_regex")
 	owners, ownersOk := d.GetOk("owners")
 
-	if executableUsersOk == false && filtersOk == false && localNameFilterOk == false && ownersOk == false {
-		return fmt.Errorf("One of executable_users, filters, local_name_filter, or owners must be assigned")
+	if executableUsersOk == false && filtersOk == false && nameRegexOk == false && ownersOk == false {
+		return fmt.Errorf("One of executable_users, filters, name_regex, or owners must be assigned")
 	}
 
 	params := &ec2.DescribeImagesInput{}
@@ -236,8 +236,8 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var filteredImages []*ec2.Image
-	if localNameFilterOk == true {
-		r := regexp.MustCompile(localNameFilter.(string))
+	if nameRegexOk == true {
+		r := regexp.MustCompile(nameRegex.(string))
 		for _, image := range resp.Images {
 			if r.MatchString(*image.Name) == true {
 				filteredImages = append(filteredImages, image)

--- a/builtin/providers/aws/data_source_aws_ami_test.go
+++ b/builtin/providers/aws/data_source_aws_ami_test.go
@@ -139,6 +139,22 @@ func TestAccAWSAmiDataSource_owners(t *testing.T) {
 	})
 }
 
+func TestAccAWSAmiDataSource_localNameFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsAmiDataSourceLocalNameFilterConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAmiDataSourceID("data.aws_ami.local_filtered_ami"),
+					resource.TestMatchResourceAttr("data.aws_ami.local_filtered_ami", "image_id", regexp.MustCompile("^ami-")),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsAmiDataSourceDestroy(s *terraform.State) error {
 	return nil
 }
@@ -243,5 +259,18 @@ const testAccCheckAwsAmiDataSourceOwnersConfig = `
 data "aws_ami" "amazon_ami" {
 	most_recent = true
 	owners = ["amazon"]
+}
+`
+
+// Testing local_name_filter parameter
+const testAccCheckAwsAmiDataSourceLocalNameFilterConfig = `
+data "aws_ami" "local_filtered_ami" {
+	most_recent = true
+	owners = ["amazon"]
+	filter {
+		name = "name"
+		values = ["amzn-ami-*"]
+	}
+	local_name_filter = "^amzn-ami-\\d{3}[5].*-ecs-optimized"
 }
 `

--- a/builtin/providers/aws/data_source_aws_ami_test.go
+++ b/builtin/providers/aws/data_source_aws_ami_test.go
@@ -145,10 +145,10 @@ func TestAccAWSAmiDataSource_localNameFilter(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckAwsAmiDataSourceLocalNameFilterConfig,
+				Config: testAccCheckAwsAmiDataSourceNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAmiDataSourceID("data.aws_ami.local_filtered_ami"),
-					resource.TestMatchResourceAttr("data.aws_ami.local_filtered_ami", "image_id", regexp.MustCompile("^ami-")),
+					testAccCheckAwsAmiDataSourceID("data.aws_ami.name_regex_filtered_ami"),
+					resource.TestMatchResourceAttr("data.aws_ami.name_regex_filtered_ami", "image_id", regexp.MustCompile("^ami-")),
 				),
 			},
 		},
@@ -262,15 +262,15 @@ data "aws_ami" "amazon_ami" {
 }
 `
 
-// Testing local_name_filter parameter
-const testAccCheckAwsAmiDataSourceLocalNameFilterConfig = `
-data "aws_ami" "local_filtered_ami" {
+// Testing name_regex parameter
+const testAccCheckAwsAmiDataSourceNameRegexConfig = `
+data "aws_ami" "name_regex_filtered_ami" {
 	most_recent = true
 	owners = ["amazon"]
 	filter {
 		name = "name"
 		values = ["amzn-ami-*"]
 	}
-	local_name_filter = "^amzn-ami-\\d{3}[5].*-ecs-optimized"
+	name_regex = "^amzn-ami-\\d{3}[5].*-ecs-optimized"
 }
 `

--- a/website/source/docs/providers/aws/d/ami.html.markdown
+++ b/website/source/docs/providers/aws/d/ami.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws\_ami
 
-Use this data source to get the ID of a registered AMI for use in other 
+Use this data source to get the ID of a registered AMI for use in other
 resources.
 
 ## Example Usage
@@ -25,6 +25,7 @@ data "aws_ami" "nat_ami" {
     name = "name"
     values = ["amzn-ami-vpc-nat*"]
   }
+  local_name_filter = "^myami-\\d{3}"
   owners = ["self"]
 }
 ```
@@ -40,6 +41,9 @@ recent AMI.
 * `filter` - (Optional) One or more name/value pairs to filter off of. There are
 several valid keys, for a full reference, check out
 [describe-images in the AWS CLI reference][1].
+
+* `local_name_filter` - (Optional) A regex string to apply to the AMI list returned
+by AWS. This allows more advanced filtering not supported from the AWS API.
 
 * `owners` - (Optional) Limit search to specific AMI owners. Valid items are the numeric
 account ID, `amazon`, or `self`.

--- a/website/source/docs/providers/aws/d/ami.html.markdown
+++ b/website/source/docs/providers/aws/d/ami.html.markdown
@@ -25,7 +25,7 @@ data "aws_ami" "nat_ami" {
     name = "name"
     values = ["amzn-ami-vpc-nat*"]
   }
-  local_name_filter = "^myami-\\d{3}"
+  name_regex = "^myami-\\d{3}"
   owners = ["self"]
 }
 ```
@@ -42,13 +42,17 @@ recent AMI.
 several valid keys, for a full reference, check out
 [describe-images in the AWS CLI reference][1].
 
-* `local_name_filter` - (Optional) A regex string to apply to the AMI list returned
-by AWS. This allows more advanced filtering not supported from the AWS API.
-
 * `owners` - (Optional) Limit search to specific AMI owners. Valid items are the numeric
 account ID, `amazon`, or `self`.
 
-~> **NOTE:** At least one of `executable_users`, `filter`, or `owners` must be specified.
+* `name_regex` - (Optional) A regex string to apply to the AMI list returned
+by AWS. This allows more advanced filtering not supported from the AWS API. This
+filtering is done locally on what AWS returns, and could have a performance
+impact if the result is large. It is recommended to combine this with other
+options to narrow down the list AWS returns.
+
+~> **NOTE:** At least one of `executable_users`, `filter`, `owners`, or
+`name_regex` must be specified.
 
 ~> **NOTE:** If more or less than a single match is returned by the search,
 Terraform will fail. Ensure that your search is specific enough to return


### PR DESCRIPTION
In cases where the filters provided by AWS against the name of an AMI are not
sufficient, allow adding a "local_name_filter" which is a regex that is used
to filter the AMIs returned by amazon.

I am not able to actually run the tests at the moment, but I did want to get some feedback if this idea would be welcome. I personally have run into this issue, where I can't get the correct AMI's to return without doing additional processing on the list returned by Amazon.