### PR TITLE
provider/google: instance template support for metadata_startup_script

### DIFF
--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -294,6 +294,8 @@ resource "google_compute_instance_template" "foobar" {
 		foo = "bar"
 	}
 
+	metadata_startup_script = "echo Hello"
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -52,6 +52,8 @@ resource "google_compute_instance_template" "foobar" {
     foo = "bar"
   }
 
+  metadata_startup_script = "echo hi > /test.txt"
+
   service_account {
     scopes = ["userinfo-email", "compute-ro", "storage-ro"]
   }
@@ -132,6 +134,11 @@ The following arguments are supported:
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within instances created from this template.
+
+* `metadata_startup_script` - (Optional) An alternative to using the
+    startup-script metadata key. This replaces the startup-script metadata key
+    on the created instance template and thus the two mechanisms are not allowed
+    to be used simultaneously.
 
 * `network_interface` - (Required) Networks to attach to instances created from
     this template. This can be specified multiple times for multiple networks.


### PR DESCRIPTION
Fixes #7827.

This pull updates the `google_compute_instance_template` resource to use the same metadata arguments and validation functions as the `google_compute_instance` resource. That being said, while this directly addresses the issue, I'm not sure it's the most graceful way of doing it for a couple of reasons.

For users with existing configuration, this will force them to migrate their:

``` hcl
metadata {
    startup-script = "echo hi > /test.txt"
}
```

to: 

``` hcl
metadata_startup_script = "echo hi > /test.txt"
```

This results in a plan that detects a change to the config and forces deletion and recreation of the template. If that template is in use by a `google_compute_instance_group_manager` resource, then the apply will fail as a template can't be deleted while in use. Then you'd need to taint the instance group which would delete and recreate all instances created by it.

Second, this change isn't strictly necessary. While it is good to have consistent configuration, functions, and validations where possible between the two resources, instance templates are more restrictive than instances. As an existing instance template can't be updated at all, any change of any metadata at all results in the above deletion and recreation scenario. The original reason as far as I can tell for splitting the main metadata apart from the startup script was that if the startup script changed, then the instance should be destroyed and recreated so that it can be re-run. This left the remaining metadata keys to be changed freely. As all metadata is treated the same here splitting the startup script out isn't really needed.

Perhaps a state migration would solve this? Or perhaps it's not worth the hassle and is simply a WONTFIX. Thoughts? :)
