### PR TITLE
provider/statuscake: Add support for contact-group id in statuscake test

### DIFF
--- a/builtin/providers/statuscake/resource_statuscaketest.go
+++ b/builtin/providers/statuscake/resource_statuscaketest.go
@@ -53,6 +53,10 @@ func resourceStatusCakeTest() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"contact_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -150,6 +154,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("timeout"); ok {
 		test.Timeout = v.(int)
+	}
+	if v, ok := d.GetOk("contact_id"); ok {
+		test.ContactID = v.(int)
 	}
 	return test
 }

--- a/builtin/providers/statuscake/resource_statuscaketest_test.go
+++ b/builtin/providers/statuscake/resource_statuscaketest_test.go
@@ -49,6 +49,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					testAccTestCheckExists("statuscake_test.google", &test),
 					resource.TestCheckResourceAttr("statuscake_test.google", "check_rate", "500"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "paused", "true"),
+					resource.TestCheckResourceAttr("statuscake_test.google", "contact_id", "23456"),
 				),
 			},
 		},
@@ -97,19 +98,21 @@ func testAccTestCheckDestroy(test *statuscake.Test) resource.TestCheckFunc {
 
 const testAccTestConfig_basic = `
 resource "statuscake_test" "google" {
-  website_name = "google.com"
-  website_url = "www.google.com"
-  test_type = "HTTP"
-  check_rate = 300
+	website_name = "google.com"
+	website_url = "www.google.com"
+	test_type = "HTTP"
+	check_rate = 300
+	contact_id = 12345
 }
 `
 
 const testAccTestConfig_update = `
 resource "statuscake_test" "google" {
-  website_name = "google.com"
-  website_url = "www.google.com"
-  test_type = "HTTP"
-  check_rate = 500
-  paused = true
+	website_name = "google.com"
+	website_url = "www.google.com"
+	test_type = "HTTP"
+	check_rate = 500
+	paused = true
+	contact_id = 23456
 }
 `


### PR DESCRIPTION
Solves https://github.com/hashicorp/terraform/issues/8416

Adds 1 new parameter: 
- `contact_id`

This will be used to link a statuscake test resource to an existing contact group, further work is required for managing a statuscake contact group resource.

