### PR TITLE
provider/aws: Support `snapshot_name` for ElastiCache Cluster and Replication Groups

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -126,6 +126,10 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		params.SnapshotWindow = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("snapshot_name"); ok {
+		params.SnapshotName = aws.String(v.(string))
+	}
+
 	resp, err := conn.CreateReplicationGroup(params)
 	if err != nil {
 		return fmt.Errorf("Error creating Elasticache Replication Group: %s", err)
@@ -133,7 +137,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 
 	d.SetId(*resp.ReplicationGroup.ReplicationGroupId)
 
-	pending := []string{"creating", "modifying"}
+	pending := []string{"creating", "modifying", "restoring"}
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
 		Target:     []string{"available"},

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -85,6 +85,8 @@ names to associate with this cache cluster
 Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3.
 Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
 
+* `snapshot_name` - (Optional) The name of a snapshot from which to restore data into the new node group.  Changing the `snapshot_name` forces a new resource. 
+
 * `snapshot_window` - (Optional, Redis only) The daily time range (in UTC) during which ElastiCache will
 begin taking a daily snapshot of your cache cluster. Example: 05:00-09:00
 

--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -31,7 +31,7 @@ resource "aws_elasticache_replication_group" "bar" {
 
 The following arguments are supported:
 
-* `replication_group_id` – (Required) The replication group identifier.
+* `replication_group_id` – (Required) The replication group identifier. This parameter is stored as a lowercase string.
 * `replication_group_description` – (Required) A user-created description for the replication group.
 * `number_cache_clusters` - (Required) The number of cache clusters this replication group will have.
  If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `snapshot_arns` – (Optional) A single-element string list containing an
 Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3.
 Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
+* `snapshot_name` - (Optional) The name of a snapshot from which to restore data into the new node group. Changing the `snapshot_name` forces a new resource. 
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance
 on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).
 The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`
@@ -67,4 +68,3 @@ Please note that setting a `snapshot_retention_limit` is not supported on cache.
 The following attributes are exported:
 
 * `id` - The ID of the ElastiCache Replication Group
-* `primary_endpoint_address` - The Address of the Primary Node in the replication group. Doesn't include the port.


### PR DESCRIPTION
In order to be able to restore a named snapshot as ElastiCache Cluster
or a Replication Group, the `snapshot_name` parameter was needed to be
passed. Changing the `snapshot_name` will force a new resource to be
created

```
ElastiCache Cluster Tests

% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheCluster_'
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/23 17:29:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticacheCluster_ -timeout 120m
=== RUN   TestAccAWSElasticacheCluster_basic
--- PASS: TestAccAWSElasticacheCluster_basic (343.08s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (893.79s)
=== RUN   TestAccAWSElasticacheCluster_decreasingCacheNodes
--- PASS: TestAccAWSElasticacheCluster_decreasingCacheNodes (892.92s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (521.85s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (620.22s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	3271.902s
```

```
ElastiCache Replication Group Tests

% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheReplication'                                                                                                              ✹
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/23 17:43:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticacheReplication -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (849.70s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (797.11s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1568.24s)
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (640.13s)
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1079.49s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	4934.703s
```
