### PR TITLE
docs/aws: Documentation Update for `aws_db_option_group`

### DIFF
--- a/website/source/docs/providers/aws/r/db_option_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_option_group.html.markdown
@@ -28,10 +28,10 @@ resource "aws_db_option_group" "bar" {
   option {
     option_name = "TDE"
   }
-
-  apply_immediately = true
 }
 ```
+
+~> **Note**: Any modifications to the `db_option_group` are set to happen immediately as we default to applying immediately.
 
 ## Argument Reference
 


### PR DESCRIPTION
Remove `apply_immediately` from the example and add a short note that we
apply_immediately by default

fixes #8421