### PR TITLE
provider/google: Allow custom Compute Engine service account in instance template

### DIFF
--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -272,12 +272,14 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 
 			"service_account": &schema.Schema{
 				Type:     schema.TypeList,
+				MaxItems: 1,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"email": &schema.Schema{
 							Type:     schema.TypeString,
+							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
@@ -543,8 +545,13 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 			scopes = append(scopes, canonicalizeServiceScope(scope))
 		}
 
+		email := "default"
+		if v := d.Get(prefix + ".email"); v != nil {
+			email = v.(string)
+		}
+
 		serviceAccount := &compute.ServiceAccount{
-			Email:  "default",
+			Email:  "email",
 			Scopes: scopes,
 		}
 

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -551,7 +551,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		}
 
 		serviceAccount := &compute.ServiceAccount{
-			Email:  "email",
+			Email:  email,
 			Scopes: scopes,
 		}
 

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 * `scheduling` - (Optional) The scheduling strategy to use. More details about
     this configuration option are detailed below.
 
-* `service_account` - (Optional) Service account to attach to the instance.
+* `service_account` - (Optional) Service account to attach to the instance. Structure is documented below.
 
 * `tags` - (Optional) Tags to attach to the instance.
 
@@ -213,6 +213,9 @@ The `access_config` block supports:
     network ip. If not given, one will be generated.
 
 The `service_account` block supports:
+
+* `email` - (Optional) The service account e-mail address. If not given, the
+    default Google Compute Engine service account is used.
 
 * `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
     short names are supported.


### PR DESCRIPTION
To expand upon the work done in #7991 by @evandbrown these commits allows an operator to specify the e-mail address of a service account to use with a Google Compute Engine instance **template**. If no service account e-mail is provided, the default service account is used.