### PR TITLE
provider/aws: Update VPC Peering connect accept/request attributes (supersedes #8338)

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -134,21 +134,17 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	// When the VPC Peering Connection is pending acceptance,
 	// the details about accepter and/or requester peering
 	// options would not be included in the response.
-	if _, ok := d.GetOk("accepter"); ok {
-		if pc.AccepterVpcInfo.PeeringOptions != nil {
-			err = d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
-			if err != nil {
-				return err
-			}
+	if pc.AccepterVpcInfo != nil && pc.AccepterVpcInfo.PeeringOptions != nil {
+		err := d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
+		if err != nil {
+			return err
 		}
 	}
 
-	if _, ok := d.GetOk("requester"); ok {
-		if pc.RequesterVpcInfo.PeeringOptions != nil {
-			err = d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
-			if err != nil {
-				return err
-			}
+	if pc.RequesterVpcInfo != nil && pc.RequesterVpcInfo.PeeringOptions != nil {
+		err := d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
+		if err != nil {
+			return err
 		}
 	}
 
@@ -294,6 +290,7 @@ func vpcPeeringConnectionOptionsSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
+		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -288,7 +288,7 @@ func resourceAwsVPCPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) r
 
 func vpcPeeringConnectionOptionsSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Optional: true,
 		Computed: true,
 		MaxItems: 1,

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -126,34 +126,28 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] VPC Peering Connection response: %#v", pc)
 
-	d.Set("accept_status", *pc.Status.Code)
+	d.Set("accept_status", pc.Status.Code)
+	d.Set("peer_owner_id", pc.AccepterVpcInfo.OwnerId)
+	d.Set("peer_vpc_id", pc.AccepterVpcInfo.VpcId)
+	d.Set("vpc_id", pc.RequesterVpcInfo.VpcId)
 
 	// When the VPC Peering Connection is pending acceptance,
 	// the details about accepter and/or requester peering
 	// options would not be included in the response.
-	if pc.AccepterVpcInfo != nil {
-		d.Set("peer_owner_id", *pc.AccepterVpcInfo.OwnerId)
-		d.Set("peer_vpc_id", *pc.AccepterVpcInfo.VpcId)
-
-		if _, ok := d.GetOk("accepter"); ok {
-			if pc.AccepterVpcInfo.PeeringOptions != nil {
-				err = d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
-				if err != nil {
-					return err
-				}
+	if _, ok := d.GetOk("accepter"); ok {
+		if pc.AccepterVpcInfo.PeeringOptions != nil {
+			err = d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
+			if err != nil {
+				return err
 			}
 		}
 	}
 
-	if pc.RequesterVpcInfo != nil {
-		d.Set("vpc_id", *pc.RequesterVpcInfo.VpcId)
-
-		if _, ok := d.GetOk("requester"); ok {
-			if pc.RequesterVpcInfo.PeeringOptions != nil {
-				err = d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
-				if err != nil {
-					return err
-				}
+	if _, ok := d.GetOk("requester"); ok {
+		if pc.RequesterVpcInfo.PeeringOptions != nil {
+			err = d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -67,7 +68,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 
 	resp, err := conn.CreateVpcPeeringConnection(createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating VPC Peering Connection: %s", err)
+		return errwrap.Wrapf("Error creating VPC Peering Connection: {{err}}", err)
 	}
 
 	// Get the ID and store it
@@ -239,7 +240,7 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if err := resourceVPCPeeringConnectionOptionsModify(d, meta); err != nil {
-			return fmt.Errorf("Error modifying VPC Peering Connection options: %s", err)
+			return errwrap.Wrapf("Error modifying VPC Peering Connection options: {{err}}", err)
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -137,14 +137,14 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	if pc.AccepterVpcInfo != nil && pc.AccepterVpcInfo.PeeringOptions != nil {
 		err := d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
 		if err != nil {
-			return err
+			log.Printf("[ERR] Error setting VPC Peering connection accepter information: %s", err)
 		}
 	}
 
 	if pc.RequesterVpcInfo != nil && pc.RequesterVpcInfo.PeeringOptions != nil {
 		err := d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
 		if err != nil {
-			return err
+			log.Printf("[ERR] Error setting VPC Peering connection requester information: %s", err)
 		}
 	}
 
@@ -180,16 +180,16 @@ func resourceVPCPeeringConnectionOptionsModify(d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("accepter"); ok {
-		if s := v.([]interface{}); len(s) > 0 {
-			modifyOpts.AccepterPeeringConnectionOptions = expandPeeringOptions(
-				s[0].(map[string]interface{}))
+		if s := v.(*schema.Set); len(s.List()) > 0 {
+			co := s.List()[0].(map[string]interface{})
+			modifyOpts.AccepterPeeringConnectionOptions = expandPeeringOptions(co)
 		}
 	}
 
 	if v, ok := d.GetOk("requester"); ok {
-		if s := v.([]interface{}); len(s) > 0 {
-			modifyOpts.RequesterPeeringConnectionOptions = expandPeeringOptions(
-				s[0].(map[string]interface{}))
+		if s := v.(*schema.Set); len(s.List()) > 0 {
+			co := s.List()[0].(map[string]interface{})
+			modifyOpts.RequesterPeeringConnectionOptions = expandPeeringOptions(co)
 		}
 	}
 
@@ -297,17 +297,17 @@ func vpcPeeringConnectionOptionsSchema() *schema.Schema {
 				"allow_remote_vpc_dns_resolution": &schema.Schema{
 					Type:     schema.TypeBool,
 					Optional: true,
-					Computed: true,
+					Default:  false,
 				},
 				"allow_classic_link_to_remote_vpc": &schema.Schema{
 					Type:     schema.TypeBool,
 					Optional: true,
-					Computed: true,
+					Default:  false,
 				},
 				"allow_vpc_to_remote_classic_link": &schema.Schema{
 					Type:     schema.TypeBool,
 					Optional: true,
-					Computed: true,
+					Default:  false,
 				},
 			},
 		},

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection_test.go
@@ -161,7 +161,7 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 						"accepter.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc_peering_connection.foo",
-						"accepter.0.allow_remote_vpc_dns_resolution", "true"),
+						"accepter.1102046665.allow_remote_vpc_dns_resolution", "true"),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						"aws_vpc_peering_connection.foo", "accepter",
 						&ec2.VpcPeeringConnectionOptionsDescription{
@@ -174,10 +174,10 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 						"requester.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc_peering_connection.foo",
-						"requester.0.allow_classic_link_to_remote_vpc", "true"),
+						"requester.41753983.allow_classic_link_to_remote_vpc", "true"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc_peering_connection.foo",
-						"requester.0.allow_vpc_to_remote_classic_link", "true"),
+						"requester.41753983.allow_vpc_to_remote_classic_link", "true"),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						"aws_vpc_peering_connection.foo", "requester",
 						&ec2.VpcPeeringConnectionOptionsDescription{
@@ -201,7 +201,7 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 						"accepter.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc_peering_connection.foo",
-						"accepter.0.allow_remote_vpc_dns_resolution", "true"),
+						"accepter.1102046665.allow_remote_vpc_dns_resolution", "true"),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						"aws_vpc_peering_connection.foo", "accepter",
 						&ec2.VpcPeeringConnectionOptionsDescription{

--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -67,6 +67,11 @@ resource "aws_vpc" "bar" {
 
 ## Argument Reference
 
+-> **Note:** Modifying the VPC Peering Connection options requires peering to be active. An automatic activation
+can be done using the [`auto_accept`](vpc_peering.html#auto_accept) attribute. Alternatively, the VPC Peering
+Connection has to be made active manually using other means. See [notes](vpc_peering.html#notes) below for
+more information.
+
 The following arguments are supported:
 
 * `peer_owner_id` - (Required) The AWS account ID of the owner of the peer VPC.


### PR DESCRIPTION
This PR continues #8338 by reading the peering options regardless if present.
I'm currently seeing a diff on `accepter` though so this is a WIP