### PR TITLE
provider/aws: Add validation for master_password in aws_redshift_cluster

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -56,8 +56,9 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			},
 
 			"master_password": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateRedshiftClusterMasterPassword,
 			},
 
 			"cluster_security_groups": &schema.Schema{
@@ -796,6 +797,26 @@ func validateRedshiftClusterMasterUsername(v interface{}, k string) (ws []string
 	}
 	if len(value) > 128 {
 		errors = append(errors, fmt.Errorf("%q cannot be more than 128 characters", k))
+	}
+	return
+}
+
+func validateRedshiftClusterMasterPassword(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^.*[a-z].*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain at least one lowercase letter", k))
+	}
+	if !regexp.MustCompile(`^.*[A-Z].*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain at least one uppercase letter", k))
+	}
+	if !regexp.MustCompile(`^.*[0-9].*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain at least one number", k))
+	}
+	if len(value) < 8 {
+		errors = append(errors, fmt.Errorf("%q must be more than 8 characters", k))
 	}
 	return
 }

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -816,7 +816,7 @@ func validateRedshiftClusterMasterPassword(v interface{}, k string) (ws []string
 			"%q must contain at least one number", k))
 	}
 	if len(value) < 8 {
-		errors = append(errors, fmt.Errorf("%q must be more than 8 characters", k))
+		errors = append(errors, fmt.Errorf("%q must be at least 8 characters", k))
 	}
 	return
 }

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -436,9 +436,7 @@ func TestResourceAWSRedshiftClusterMasterPasswordValidation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		fmt.Printf("Test Case Value: %s\n", tc.Value)
 		_, errors := validateRedshiftClusterMasterPassword(tc.Value, "aws_redshift_cluster_master_password")
-		fmt.Printf("Expected: %d and found %d\n", tc.ErrCount, len(errors))
 
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the Redshift Cluster master_password to trigger a validation error")

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -408,6 +408,44 @@ func TestResourceAWSRedshiftClusterMasterUsernameValidation(t *testing.T) {
 	}
 }
 
+func TestResourceAWSRedshiftClusterMasterPasswordValidation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "1TESTING",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1testing",
+			ErrCount: 1,
+		},
+		{
+			Value:    "TestTest",
+			ErrCount: 1,
+		},
+		{
+			Value:    "T3st",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1Testing",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		fmt.Printf("Test Case Value: %s\n", tc.Value)
+		_, errors := validateRedshiftClusterMasterPassword(tc.Value, "aws_redshift_cluster_master_password")
+		fmt.Printf("Expected: %d and found %d\n", tc.ErrCount, len(errors))
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Redshift Cluster master_password to trigger a validation error")
+		}
+	}
+}
+
 var testAccAWSRedshiftClusterConfig_updateNodeCount = `
 resource "aws_redshift_cluster" "default" {
   cluster_identifier = "tf-redshift-cluster-%d"


### PR DESCRIPTION
The master password in redshift must be: at least 8 chars and contain at least one uppercase letter, one lowercase letter, and one number.

Adds validation to the `master_password` argument of the `aws_redshift_cluster` resource.