### PR TITLE
provider/aws: Validate `aws_iam_policy_attachment` Name parameter to stop being empty

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_policy_attachment.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment.go
@@ -25,6 +25,14 @@ func resourceAwsIamPolicyAttachment() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if value == "" {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be an empty string", k))
+					}
+					return
+				},
 			},
 			"users": &schema.Schema{
 				Type:     schema.TypeSet,

--- a/builtin/providers/aws/resource_aws_iam_policy_attachment.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_attachment.go
@@ -26,8 +26,7 @@ func resourceAwsIamPolicyAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if value == "" {
+					if v.(string) == "" {
 						errors = append(errors, fmt.Errorf(
 							"%q cannot be an empty string", k))
 					}

--- a/website/source/docs/providers/aws/r/iam_policy_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy_attachment.html.markdown
@@ -42,7 +42,7 @@ resource "aws_iam_policy_attachment" "test-attach" {
 
 The following arguments are supported:
 
-* `name` 		(Required) - The name of the policy.
+* `name` 		(Required) - The name of the policy. This cannot be an empty string.
 * `users`		(Optional) - The user(s) the policy should be applied to
 * `roles`		(Optional) - The role(s) the policy should be applied to
 * `groups`		(Optional) - The group(s) the policy should be applied to


### PR DESCRIPTION
Fixes #8368

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSPolicyAttachment_'
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/24 11:46:01 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSPolicyAttachment_ -timeout 120m
=== RUN   TestAccAWSPolicyAttachment_basic
--- PASS: TestAccAWSPolicyAttachment_basic (44.67s)
=== RUN   TestAccAWSPolicyAttachment_paginatedEntities
--- PASS: TestAccAWSPolicyAttachment_paginatedEntities (161.68s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    206.379s
```