### PR TITLE
provider/aws: Refresh `aws_cloudwatch_event_target` from state on `ResourceNotFoundException`

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
@@ -112,6 +112,13 @@ func resourceAwsCloudWatchEventTargetRead(d *schema.ResourceData, meta interface
 				d.SetId("")
 				return nil
 			}
+
+			if awsErr.Code() == "ResourceNotFoundException" {
+				log.Printf("[WARN] CloudWatch Event Target (%q) not found. Removing it from state %q ", d.Id())
+				d.SetId("")
+				return nil
+			}
+
 		}
 		return err
 	}

--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target.go
@@ -114,7 +114,7 @@ func resourceAwsCloudWatchEventTargetRead(d *schema.ResourceData, meta interface
 			}
 
 			if awsErr.Code() == "ResourceNotFoundException" {
-				log.Printf("[WARN] CloudWatch Event Target (%q) not found. Removing it from state %q ", d.Id())
+				log.Printf("[WARN] CloudWatch Event Target (%q) not found. Removing it from state.", d.Id())
 				d.SetId("")
 				return nil
 			}


### PR DESCRIPTION
Fixes #6928

@radeksimko FYI :)

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudWatchEventTarget_'
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/24 12:59:14 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudWatchEventTarget_ -timeout 120m
=== RUN   TestAccAWSCloudWatchEventTarget_basic
--- PASS: TestAccAWSCloudWatchEventTarget_basic (39.44s)
=== RUN   TestAccAWSCloudWatchEventTarget_missingTargetId
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (23.18s)
=== RUN   TestAccAWSCloudWatchEventTarget_full
--- PASS: TestAccAWSCloudWatchEventTarget_full (104.07s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	166.707s
```