### PR TITLE
provider/aws: Refresh `aws_route` from state if `aws_route_table` not found

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -197,6 +197,11 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	route, err := findResourceRoute(conn, d.Get("route_table_id").(string), d.Get("destination_cidr_block").(string))
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidRouteTableID.NotFound" {
+			log.Printf("[WARN] AWS RouteTable not found. Removing Route from state")
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	resourceAwsRouteSetResourceData(d, route)


### PR DESCRIPTION
Fixes #5288
Fixes #8388

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRoute_'                                                  2 ↵
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/24 12:46:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRoute_ -timeout 120m
=== RUN   TestAccAWSRoute_basic
--- PASS: TestAccAWSRoute_basic (56.87s)
=== RUN   TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (88.89s)
=== RUN   TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (143.36s)
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (76.67s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	365.810s
```