### PR TITLE
provider/aws Fix import errors when aws_route has VPC endpoint

### DIFF
--- a/builtin/providers/aws/import_aws_route_table.go
+++ b/builtin/providers/aws/import_aws_route_table.go
@@ -43,9 +43,10 @@ func resourceAwsRouteTableImportState(
 			// Minimal data for route
 			d := subResource.Data(nil)
 			d.SetType("aws_route")
-			d.Set("route_table_id", id)
 			d.Set("destination_cidr_block", route.DestinationCidrBlock)
+			d.Set("destination_prefix_list_id", route.DestinationPrefixListId)
 			d.SetId(routeIDHash(d, route))
+			d.Set("route_table_id", id)
 			results = append(results, d)
 		}
 	}

--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -359,7 +359,11 @@ func resourceAwsRouteExists(d *schema.ResourceData, meta interface{}) (bool, err
 
 // Create an ID for a route
 func routeIDHash(d *schema.ResourceData, r *ec2.Route) string {
-	return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationCidrBlock))
+	dest := r.DestinationCidrBlock
+	if dest == nil {
+		dest = r.DestinationPrefixListId
+	}
+	return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*dest))
 }
 
 // Helper: retrieve a route


### PR DESCRIPTION
Fixes #8225

If an imported aws_route contains a PrefixListId entry the RouteHashID function
no longer throws a nil pointer reference.