### PR TITLE
provider/aws: Stop `aws_instance` `source_dest_check` triggering an API call on each terraform run

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -597,24 +597,25 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.SetPartial("tags")
 	}
 
-	// SourceDestCheck can only be set on VPC instances
-	// AWS will return an error of InvalidParameterCombination if we attempt
-	// to modify the source_dest_check of an instance in EC2 Classic
-	log.Printf("[INFO] Modifying instance %s", d.Id())
-	_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-		InstanceId: aws.String(d.Id()),
-		SourceDestCheck: &ec2.AttributeBooleanValue{
-			Value: aws.Bool(d.Get("source_dest_check").(bool)),
-		},
-	})
-	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok {
-			// Toloerate InvalidParameterCombination error in Classic, otherwise
-			// return the error
-			if "InvalidParameterCombination" != ec2err.Code() {
-				return err
+	if d.HasChange("source_dest_check") || d.IsNewResource() {
+		// SourceDestCheck can only be set on VPC instances	// AWS will return an error of InvalidParameterCombination if we attempt
+		// to modify the source_dest_check of an instance in EC2 Classic
+		log.Printf("[INFO] Modifying `source_dest_check` on Instance %s", d.Id())
+		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
+			InstanceId: aws.String(d.Id()),
+			SourceDestCheck: &ec2.AttributeBooleanValue{
+				Value: aws.Bool(d.Get("source_dest_check").(bool)),
+			},
+		})
+		if err != nil {
+			if ec2err, ok := err.(awserr.Error); ok {
+				// Toloerate InvalidParameterCombination error in Classic, otherwise
+				// return the error
+				if "InvalidParameterCombination" != ec2err.Code() {
+					return err
+				}
+				log.Printf("[WARN] Attempted to modify SourceDestCheck on non VPC instance: %s", ec2err.Message())
 			}
-			log.Printf("[WARN] Attempted to modify SourceDestCheck on non VPC instance: %s", ec2err.Message())
 		}
 	}
 


### PR DESCRIPTION
Fixes #3550

The simple fix here was to check if the Resource was new (to set the
value the first time) then check it has changed each time

I was able to see from the TF log the following:

```
Config

resource "aws_vpc" "foo" {
	cidr_block = "10.10.0.0/16"
}

resource "aws_subnet" "foo" {
	cidr_block = "10.10.1.0/24"
	vpc_id = "${aws_vpc.foo.id}"
}

resource "aws_instance" "foo" {
	ami = "ami-4fccb37f"
	instance_type = "m1.small"
	subnet_id = "${aws_subnet.foo.id}"
	source_dest_check = false
        disable_api_termination = true
}
```

No longer caused any Modifying source_dest_check entries in the LOG

I'd like to leave this out of 0.7.2 so that we get a couple of acceptance test runs on this change!