### PR TITLE
Allow specifying ldflags via env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ vet:
 # generate runs `go generate` to build the dynamically generated
 # source files.
 generate:
-	@which stringer ; if [ $$? -ne 0 ]; then \
+	@which stringer > /dev/null; if [ $$? -ne 0 ]; then \
 	  go get -u golang.org/x/tools/cmd/stringer; \
 	fi
 	go generate $$(go list ./... | grep -v /terraform/vendor/)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,8 @@ fi
 # instruct gox to build statically linked binaries
 export CGO_ENABLED=0
 
-LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}"
+# Allow LD_FLAGS to be appended during development compilations
+LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} $LD_FLAGS"
 # In relase mode we don't want debug information in the binary
 if [[ -n "${TF_RELEASE}" ]]; then
     LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -s -w"


### PR DESCRIPTION
Allows specifying `LD_FLAGS` during development builds.

```
$ LD_FLAGS="-linkmode=external" make dev
```

Since the version of DTrace on macOS Sierra (On the public beta's at least) has been updated, this allows DTrace to run on Terraform during development/debugging.

```
$ sudo dtrace -n 'pid$target::main.main:entry' -c "terraform apply"
dtrace: description 'pid$target::main.main:entry' matched 1 probe

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

foo = bar
dtrace: pid 23096 has exited
CPU     ID                    FUNCTION:NAME
  2 265673                  main.main:entry
```

Also redirects the `@which stringer` command inside the `generate` Makefile target to `/dev/null` so we stop echoing the path to the `stringer` binary on every call to `generate`.