### PR TITLE
Output 'destroy complete' when it's destroy (was: apply)

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -232,12 +232,19 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-		"[reset][bold][green]\n"+
-			"Apply complete! Resources: %d added, %d changed, %d destroyed.",
-		countHook.Added,
-		countHook.Changed,
-		countHook.Removed)))
+	if c.Destroy {
+		c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
+			"[reset][bold][green]\n"+
+				"Destroy complete! Resources: %d destroyed.",
+			countHook.Removed)))
+	} else {
+		c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
+			"[reset][bold][green]\n"+
+				"Apply complete! Resources: %d added, %d changed, %d destroyed.",
+			countHook.Added,
+			countHook.Changed,
+			countHook.Removed)))
+	}
 
 	if countHook.Added > 0 || countHook.Changed > 0 {
 		c.Ui.Output(c.Colorize().Color(fmt.Sprintf(


### PR DESCRIPTION
Previously the output from `terraform destroy` looked like this:

```
Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
```
even though destroy is (under the hood) basically `apply`, it may IMO cause unnecessary confusions for common users, hence this PR is changing it to

```
Destroy complete! Resources: 0 added, 0 changed, 1 destroyed.
```