### PR TITLE
provider/aws: Increase route_table timeouts

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -110,7 +110,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: resourceAwsRouteTableStateRefreshFunc(conn, d.Id()),
-		Timeout: 1 * time.Minute,
+		Timeout: 2 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(
@@ -387,7 +387,7 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"ready"},
 		Target:  []string{},
 		Refresh: resourceAwsRouteTableStateRefreshFunc(conn, d.Id()),
-		Timeout: 1 * time.Minute,
+		Timeout: 2 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
It may take more than 1 minute

```
21:01:58 [vpc] aws_route_table.public: Refreshing state... (ID: rtb-d202deb4)
21:01:58 [vpc] aws_route_table_association.jce-public: Refreshing state... (ID: rtbassoc-248f4a5d)
21:02:00 [vpc] aws_route_table_association.jce-public: Destroying...
21:02:00 [vpc] aws_route_table_association.jce-public: Destruction complete
21:02:00 [vpc] aws_route_table.public: Destroying...
21:02:12 [vpc] aws_route_table.public: Still destroying... (10s elapsed)
21:02:22 [vpc] aws_route_table.public: Still destroying... (20s elapsed)
21:02:32 [vpc] aws_route_table.public: Still destroying... (30s elapsed)
21:02:40 [vpc] aws_route_table.public: Still destroying... (40s elapsed)
21:02:50 [vpc] aws_route_table.public: Still destroying... (50s elapsed)
21:03:00 [vpc] aws_route_table.public: Still destroying... (1m0s elapsed)
21:03:01 [vpc] Error applying plan:
21:03:01 [vpc] 
21:03:01 [vpc] 1 error(s) occurred:
21:03:01 [vpc] 
21:03:01 [vpc] * aws_route_table.public: Error waiting for route table (rtb-d202deb4) to become destroyed: timeout while waiting for state to become ''. last error: %!s(<nil>)
```
