### PR TITLE
Fix segmentation fault in "aws_api_gateway_base_path_mapping" resource

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_base_path_mapping.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_base_path_mapping.go
@@ -101,9 +101,9 @@ func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error reading Gateway base path mapping: %s", err)
 	}
 
-	d.Set("base_path", *mapping.BasePath)
-	d.Set("api_id", *mapping.RestApiId)
-	d.Set("stage_name", *mapping.Stage)
+	d.Set("base_path", mapping.BasePath)
+	d.Set("api_id", mapping.RestApiId)
+	d.Set("stage_name", mapping.Stage)
 
 	return nil
 }


### PR DESCRIPTION
It is possible for the `mapping.BasePath`, `mapping.RestApiId`, and
`mapping.Stage` to be nil when they have not been set for the
mapping.[1]  When this occurs a nil pointer is dereferenced and terraform
segmentation faults.

Here we remove the blind derefrences and trust in the behaviour of
(*ResourceData).Set() to handle the nil pointer safely.

[1] https://github.com/hashicorp/terraform/blob/master/vendor/github.com/aws/aws-sdk-go/service/apigateway/api.go#L4892-L4904