### PR TITLE
[WIP] provider/aws: Allow `aws_rds_instance` to upgrade the major version

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -837,6 +837,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("engine_version") {
 		d.SetPartial("engine_version")
 		req.EngineVersion = aws.String(d.Get("engine_version").(string))
+		req.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
 		requestUpdate = true
 	}
 	if d.HasChange("backup_window") {

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -19,6 +19,8 @@ phase because a modification has not yet taken place. You can use the
 `apply_immediately` flag to instruct the service to apply the change immediately
 (see documentation below).
 
+When upgrading the major version of an engine, `allow_major_version_upgrade` must be set to `true`
+
 ~> **Note:** using `apply_immediately` can result in a
 brief downtime as the server reboots. See the AWS Docs on [RDS Maintenance][2]
 for more information.


### PR DESCRIPTION
Fixes #8468

If a user wished to bump the `engine_version` of an RDS instance,
Terraform was not sending `allow_major_version_upgrade` to the API
*unless* that value also changed at the same time. This caused the
following error from RDS API:

```
* aws_db_instance.bar: Error modifying DB Instance
* tf-20160825101420910562798obb: InvalidParameterCombination: The
* AllowMajorVersionUpgrade flag must be present when upgrading to a new
* major version.
    status code: 400, request id: 20e36364-6ab0-11e6-b794-51f12f4135f1
```

This change will always send the `allow_major_version_upgrade` flag to
the API when the `engine_version` changes.

This still relies on the user setting the correct value i.e. if they are
upgrading from postgres 0.4.7 -> 9.5.2 then the config will need to set
the `allow_major_version_upgrade` flag to be `true`

Test Results:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBInstance_'                                               ✹
==> Checking that code complies with gofmt requirements...
/Users/stacko/Code/go/bin/stringer
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/08/25 12:29:44 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBInstance_ -timeout 120m
=== RUN   TestAccAWSDBInstance_importBasic
--- PASS: TestAccAWSDBInstance_importBasic (676.05s)
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (565.33s)
=== RUN   TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_kmsKey (838.52s)
=== RUN   TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_optionGroup (706.67s)
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (1030.00s)
=== RUN   TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_portUpdate (698.09s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	4514.683s
```