### PR TITLE
aws/docs: Add missing ssm link to the sidebar

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -843,6 +843,16 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current(/^docs-aws-resource-ssm/) %>>
+                    <a href="#">SSM Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-ssm-document") %>>
+                            <a href="/docs/providers/aws/r/ssm_document.html">aws_ssm_document</a>
+                        </li>
+
+                    </ul>
+                </li>
 
                 <li<%= sidebar_current(/^docs-aws-resource-sqs/) %>>
                     <a href="#">SQS Resources</a>


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform/pull/8460

cc @liamjbennett & @stack72 