### PR TITLE
command/push: fix tests to be vcs=false GH-8478

### DIFF
--- a/command/push_test.go
+++ b/command/push_test.go
@@ -107,6 +107,7 @@ func TestPush_noUploadModules(t *testing.T) {
 	defer os.Remove(testStateFileRemote(t, s))
 
 	args := []string{
+		"-vcs=false",
 		"-name=mitchellh/tf-test",
 		"-upload-modules=false",
 		path,
@@ -115,9 +116,14 @@ func TestPush_noUploadModules(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
+	// NOTE: The duplicates below are not ideal but are how things work
+	// currently due to how we manually add the files to the archive. This
+	// is definitely a "bug" we can fix in the future.
 	actual := testArchiveStr(t, archivePath)
 	expected := []string{
 		".terraform/",
+		".terraform/",
+		".terraform/terraform.tfstate",
 		".terraform/terraform.tfstate",
 		"child/",
 		"child/main.tf",


### PR DESCRIPTION
Fixes #8478 

This introduces the `-vcs=false` flag to the command to disable VCS mode. This exposed some weird buggy behavior where double entries are inserted into the archive. This isn't an actual problem though since it'll still extract properly at the expense of disk space. We can fix that in the future.