### PR TITLE
config: variable names and outputs must be unique

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -239,6 +239,12 @@ func (c *Config) Validate() error {
 	vars := c.InterpolatedVariables()
 	varMap := make(map[string]*Variable)
 	for _, v := range c.Variables {
+		if _, ok := varMap[v.Name]; ok {
+			errs = append(errs, fmt.Errorf(
+				"Variable '%s': duplicate found. Variable names must be unique.",
+				v.Name))
+		}
+
 		varMap[v.Name] = v
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -447,6 +447,13 @@ func TestConfigValidate_varDefaultInterpolate(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_varDup(t *testing.T) {
+	c := testConfig(t, "validate-var-dup")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_varMultiExactNonSlice(t *testing.T) {
 	c := testConfig(t, "validate-var-multi-exact-non-slice")
 	if err := c.Validate(); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -300,6 +300,13 @@ func TestConfigValidate_outputBadField(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_outputDuplicate(t *testing.T) {
+	c := testConfig(t, "validate-output-dup")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_pathVar(t *testing.T) {
 	c := testConfig(t, "validate-path-var")
 	if err := c.Validate(); err != nil {

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -29,6 +29,7 @@ func (t *hclConfigurable) Config() (*Config, error) {
 	}
 
 	type hclVariable struct {
+		Name         string `hcl:",key"`
 		Default      interface{}
 		Description  string
 		DeclaredType string   `hcl:"type"`
@@ -36,7 +37,7 @@ func (t *hclConfigurable) Config() (*Config, error) {
 	}
 
 	var rawConfig struct {
-		Variable map[string]*hclVariable
+		Variable []*hclVariable
 	}
 
 	// Top-level item should be the object list
@@ -56,7 +57,7 @@ func (t *hclConfigurable) Config() (*Config, error) {
 	config := new(Config)
 	if len(rawConfig.Variable) > 0 {
 		config.Variables = make([]*Variable, 0, len(rawConfig.Variable))
-		for k, v := range rawConfig.Variable {
+		for _, v := range rawConfig.Variable {
 			// Defaults turn into a slice of map[string]interface{} and
 			// we need to make sure to convert that down into the
 			// proper type for Config.
@@ -72,7 +73,7 @@ func (t *hclConfigurable) Config() (*Config, error) {
 			}
 
 			newVar := &Variable{
-				Name:         k,
+				Name:         v.Name,
 				DeclaredType: v.DeclaredType,
 				Default:      v.Default,
 				Description:  v.Description,

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -446,6 +446,22 @@ func TestLoadDir_override(t *testing.T) {
 	}
 }
 
+func TestLoadDir_overrideVar(t *testing.T) {
+	c, err := LoadDir(filepath.Join(fixtureDir, "dir-override-var"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	actual := variablesStr(c.Variables)
+	if actual != strings.TrimSpace(dirOverrideVarsVariablesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestLoadFile_mismatchedVariableTypes(t *testing.T) {
 	_, err := LoadFile(filepath.Join(fixtureDir, "variable-mismatched-type.tf"))
 	if err == nil {
@@ -919,6 +935,12 @@ data.do.simple (x1)
 const dirOverrideVariablesStr = `
 foo
   bar
+  bar
+`
+
+const dirOverrideVarsVariablesStr = `
+foo
+  baz
   bar
 `
 

--- a/config/test-fixtures/dir-override-var/main.tf
+++ b/config/test-fixtures/dir-override-var/main.tf
@@ -1,0 +1,4 @@
+variable "foo" {
+    default = "bar"
+    description = "bar"
+}

--- a/config/test-fixtures/dir-override-var/main_override.tf
+++ b/config/test-fixtures/dir-override-var/main_override.tf
@@ -1,0 +1,3 @@
+variable "foo" {
+    default = "baz"
+}

--- a/config/test-fixtures/validate-output-dup/main.tf
+++ b/config/test-fixtures/validate-output-dup/main.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "web" {
+}
+
+output "ip" {
+  value = "foo"
+}
+
+output "ip" {
+  value = "bar"
+}

--- a/config/test-fixtures/validate-var-default/main.tf
+++ b/config/test-fixtures/validate-var-default/main.tf
@@ -2,7 +2,7 @@ variable "foo" {
   default = "bar"
 }
 
-variable "foo" {
+variable "foo2" {
   default = {
     foo = "bar"
   }

--- a/config/test-fixtures/validate-var-dup/main.tf
+++ b/config/test-fixtures/validate-var-dup/main.tf
@@ -1,0 +1,2 @@
+variable "foo" {}
+variable "foo" {}


### PR DESCRIPTION
Fixes #5052 
Fixes #5144

This adds new config validation to verify output names and variable names are unique.