### PR TITLE
config: JSON resource keys with only one item load properly GH-5140

### DIFF
--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -327,6 +327,22 @@ func TestLoadJSONBasic(t *testing.T) {
 	}
 }
 
+func TestLoadFileBasic_jsonNoName(t *testing.T) {
+	c, err := LoadFile(filepath.Join(fixtureDir, "resource-no-name.tf.json"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	actual := resourcesStr(c.Resources)
+	if actual != strings.TrimSpace(basicJsonNoNameResourcesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestLoadFile_variables(t *testing.T) {
 	c, err := LoadFile(filepath.Join(fixtureDir, "variables.tf"))
 	if err != nil {
@@ -835,6 +851,11 @@ baz (map)
 foo
   bar
   bar
+`
+
+const basicJsonNoNameResourcesStr = `
+aws_security_group.allow_external_http_https (x1)
+  tags
 `
 
 const dirBasicOutputsStr = `

--- a/config/test-fixtures/resource-no-name.tf.json
+++ b/config/test-fixtures/resource-no-name.tf.json
@@ -1,0 +1,11 @@
+{
+  "resource" : {
+    "aws_security_group" : {
+      "allow_external_http_https" : {
+        "tags" : {
+          "Name" : "allow_external_http_https"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #5140 

When a resource has only a single key set, the HCL parser treats that
key as part of the overall set of object keys. This isn't valid since
we expect resources to have exactly two keys. In this scenario, we have
to "unwrap" the keys back into a set of objects.

Details are in the comment in the changeset.