### PR TITLE
aws_iam_instance_profile: Restrict example perms

### DIFF
--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -27,7 +27,9 @@ resource "aws_iam_role" "role" {
     "Statement": [
         {
             "Action": "sts:AssumeRole",
-            "Principal": {"AWS": "*"},
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
             "Effect": "Allow",
             "Sid": ""
         }


### PR DESCRIPTION
In this example, principal "AWS": "*" tells IAM that any user in the world can assume that role as long as they know the account ID + role name. 

In my testing, "Service": "ec2.amazonaws.com" is sufficiently permissive to allow the instance_profile to work without allowing global accesses.