### PR TITLE
provider/archive: Converting to datasource.

### DIFF
--- a/builtin/providers/archive/data_source_archive_file.go
+++ b/builtin/providers/archive/data_source_archive_file.go
@@ -69,7 +69,7 @@ func dataSourceFileRead(d *schema.ResourceData, meta interface{}) error {
 	outputDirectory := path.Dir(outputPath)
 	if outputDirectory != "" {
 		if _, err := os.Stat(outputDirectory); err != nil {
-			if err := os.MkdirAll(outputDirectory, 0644); err != nil {
+			if err := os.MkdirAll(outputDirectory, 0755); err != nil {
 				return err
 			}
 		}

--- a/builtin/providers/archive/data_source_archive_file.go
+++ b/builtin/providers/archive/data_source_archive_file.go
@@ -69,7 +69,7 @@ func dataSourceFileRead(d *schema.ResourceData, meta interface{}) error {
 	outputDirectory := path.Dir(outputPath)
 	if outputDirectory != "" {
 		if _, err := os.Stat(outputDirectory); err != nil {
-			if err := os.MkdirAll(outputDirectory, 0777); err != nil {
+			if err := os.MkdirAll(outputDirectory, 0644); err != nil {
 				return err
 			}
 		}

--- a/builtin/providers/archive/data_source_archive_file.go
+++ b/builtin/providers/archive/data_source_archive_file.go
@@ -4,10 +4,11 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"io/ioutil"
 	"os"
 	"path"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func dataSourceFile() *schema.Resource {

--- a/builtin/providers/archive/data_source_archive_file_test.go
+++ b/builtin/providers/archive/data_source_archive_file_test.go
@@ -18,21 +18,21 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 				Config: testAccArchiveFileContentConfig,
 				Check: r.ComposeTestCheckFunc(
 					testAccArchiveFileExists("zip_file_acc_test.zip", &fileSize),
-					r.TestCheckResourceAttrPtr("archive_file.foo", "output_size", &fileSize),
+					r.TestCheckResourceAttrPtr("data.archive_file.foo", "output_size", &fileSize),
 				),
 			},
 			r.TestStep{
 				Config: testAccArchiveFileFileConfig,
 				Check: r.ComposeTestCheckFunc(
 					testAccArchiveFileExists("zip_file_acc_test.zip", &fileSize),
-					r.TestCheckResourceAttrPtr("archive_file.foo", "output_size", &fileSize),
+					r.TestCheckResourceAttrPtr("data.archive_file.foo", "output_size", &fileSize),
 				),
 			},
 			r.TestStep{
 				Config: testAccArchiveFileDirConfig,
 				Check: r.ComposeTestCheckFunc(
 					testAccArchiveFileExists("zip_file_acc_test.zip", &fileSize),
-					r.TestCheckResourceAttrPtr("archive_file.foo", "output_size", &fileSize),
+					r.TestCheckResourceAttrPtr("data.archive_file.foo", "output_size", &fileSize),
 				),
 			},
 			r.TestStep{

--- a/builtin/providers/archive/data_source_archive_file_test.go
+++ b/builtin/providers/archive/data_source_archive_file_test.go
@@ -13,9 +13,6 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 	var fileSize string
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
-		CheckDestroy: r.ComposeTestCheckFunc(
-			testAccArchiveFileMissing("zip_file_acc_test.zip"),
-		),
 		Steps: []r.TestStep{
 			r.TestStep{
 				Config: testAccArchiveFileContentConfig,
@@ -57,19 +54,6 @@ func testAccArchiveFileExists(filename string, fileSize *string) r.TestCheckFunc
 		}
 		*fileSize = fmt.Sprintf("%d", fi.Size())
 		return nil
-	}
-}
-
-func testAccArchiveFileMissing(filename string) r.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, err := os.Stat(filename)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		return fmt.Errorf("found file expected to be deleted: %s", filename)
 	}
 }
 

--- a/builtin/providers/archive/data_source_archive_file_test.go
+++ b/builtin/providers/archive/data_source_archive_file_test.go
@@ -74,7 +74,7 @@ func testAccArchiveFileMissing(filename string) r.TestCheckFunc {
 }
 
 var testAccArchiveFileContentConfig = `
-resource "archive_file" "foo" {
+data "archive_file" "foo" {
   type                    = "zip"
   source_content          = "This is some content"
   source_content_filename = "content.txt"
@@ -84,7 +84,7 @@ resource "archive_file" "foo" {
 
 var tmpDir = os.TempDir() + "/test"
 var testAccArchiveFileOutputPath = fmt.Sprintf(`
-resource "archive_file" "foo" {
+data "archive_file" "foo" {
   type                    = "zip"
   source_content          = "This is some content"
   source_content_filename = "content.txt"
@@ -93,7 +93,7 @@ resource "archive_file" "foo" {
 `, tmpDir)
 
 var testAccArchiveFileFileConfig = `
-resource "archive_file" "foo" {
+data "archive_file" "foo" {
   type        = "zip"
   source_file = "test-fixtures/test-file.txt"
   output_path = "zip_file_acc_test.zip"
@@ -101,7 +101,7 @@ resource "archive_file" "foo" {
 `
 
 var testAccArchiveFileDirConfig = `
-resource "archive_file" "foo" {
+data "archive_file" "foo" {
   type        = "zip"
   source_dir  = "test-fixtures/test-dir"
   output_path = "zip_file_acc_test.zip"

--- a/builtin/providers/archive/provider.go
+++ b/builtin/providers/archive/provider.go
@@ -7,10 +7,14 @@ import (
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
-		Schema: map[string]*schema.Schema{},
-
+		DataSourcesMap: map[string]*schema.Resource{
+			"archive_file": dataSourceFile(),
+		},
 		ResourcesMap: map[string]*schema.Resource{
-			"archive_file": resourceArchiveFile(),
+			"archive_file": schema.DataSourceResourceShim(
+				"archive_file",
+				dataSourceFile(),
+			),
 		},
 	}
 }

--- a/website/source/docs/providers/archive/d/archive_file.md
+++ b/website/source/docs/providers/archive/d/archive_file.md
@@ -1,7 +1,7 @@
 ---
 layout: "archive"
 page_title: "Archive: archive_file"
-sidebar_current: "docs-archive-resource-file"
+sidebar_current: "docs-archive-datasource-archive-file"
 description: |-
   Generates an archive from content, a file, or directory of files.
 ---
@@ -13,9 +13,9 @@ Generates an archive from content, a file, or directory of files.
 ## Example Usage
 
 ```
-resource "archive_file" "init" {
-    type = "zip"
-    source_content_filename = "${path.module}/init.tpl"
+data "archive_file" "init" {
+    type        = "zip"
+    source_file = "${path.module}/init.tpl"
     output_path = "${path.module}/files/init.zip"
 }
 ```
@@ -44,4 +44,7 @@ NOTE: One of `source_content_filename` (with `source_content`), `source_file`, o
 The following attributes are exported:
 
 * `output_size` - The size of the output archive file.
+
 * `output_sha` - The SHA1 checksum of output archive file.
+
+* `output_base64sha256` - The base64-encoded SHA256 checksum of output archive file.

--- a/website/source/layouts/archive.erb
+++ b/website/source/layouts/archive.erb
@@ -10,11 +10,11 @@
 					<a href="/docs/providers/archive/index.html">Archive Provider</a>
 				</li>
 
-				<li<%= sidebar_current(/^docs-archive-resource/) %>>
-					<a href="#">Resources</a>
+				<li<%= sidebar_current(/^docs-archive-datasource/) %>>
+					<a href="#">Data Sources</a>
 					<ul class="nav nav-visible">
-						<li<%= sidebar_current("docs-archive-resource-file") %>>
-							<a href="/docs/providers/archive/r/file.html">archive_file</a>
+						<li<%= sidebar_current("docs-archive-datasource-archive-file") %>>
+							<a href="/docs/providers/archive/d/archive_file.html">archive_file</a>
 						</li>
 					</ul>
 				</li>


### PR DESCRIPTION
Since the output file is always generated, you will get flapping between runs.

It makes sense to just convert to datasource and always generate a new archive file, but only show as new if sha of output file is different.