### PR TITLE
command: remove value restriction when overriding

### DIFF
--- a/command/flag_kv.go
+++ b/command/flag_kv.go
@@ -158,9 +158,10 @@ func parseVarFlagAsHCL(input string) (string, interface{}, error) {
 		return "", nil, fmt.Errorf("Cannot parse value for variable %s (%q) as valid HCL: %s", probablyName, input, err)
 	}
 
-	// Cover cases such as key=
+	// Cover cases in which the value is either empty or does not start with a
+	// letter, e.g. paths.
 	if len(decoded) == 0 {
-		return probablyName, "", nil
+		return probablyName, input[idx+1:], nil
 	}
 
 	if len(decoded) > 1 {

--- a/command/flag_kv_test.go
+++ b/command/flag_kv_test.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"flag"
-	"github.com/davecgh/go-spew/spew"
 	"io/ioutil"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 func TestFlagStringKV_impl(t *testing.T) {
@@ -46,6 +47,12 @@ func TestFlagStringKV(t *testing.T) {
 			"key",
 			nil,
 			true,
+		},
+
+		{
+			"key=/path",
+			map[string]string{"key": "/path"},
+			false,
 		},
 	}
 
@@ -126,6 +133,12 @@ func TestFlagTypedKV(t *testing.T) {
 			`key={"hello" = "world", "foo" = "bar"}\nkey2="invalid"`,
 			nil,
 			true,
+		},
+
+		{
+			"key=/path",
+			map[string]interface{}{"key": "/path"},
+			false,
 		},
 	}
 


### PR DESCRIPTION
Remove the restriction of not accepting certain strings as values when
overriding variables using the `-var` flag. This allows values to be
accepted even if they do not start with a letter, e.g. paths.

This fixes #8477.