### PR TITLE
provider/google: Use healthcheck names instead of urls when reading target pool

### DIFF
--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -362,6 +362,16 @@ func convertInstancesFromUrls(urls []string) []string {
 	return result
 }
 
+func convertHealthChecksFromUrls(urls []string) []string {
+	result := make([]string, 0, len(urls))
+	for _, url := range urls {
+		urlArray := strings.Split(url, "/")
+		healthCheck := fmt.Sprintf("%s", urlArray[len(urlArray)-1])
+		result = append(result, healthCheck)
+	}
+	return result
+}
+
 func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
@@ -394,7 +404,11 @@ func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("backup_pool", tpool.BackupPool)
 	d.Set("description", tpool.Description)
 	d.Set("failover_ratio", tpool.FailoverRatio)
-	d.Set("health_checks", tpool.HealthChecks)
+	if tpool.HealthChecks != nil {
+		d.Set("health_checks", convertHealthChecksFromUrls(tpool.HealthChecks))
+	} else {
+		d.Set("health_checks", nil)
+	}
 	if tpool.Instances != nil {
 		d.Set("instances", convertInstancesFromUrls(tpool.Instances))
 	} else {

--- a/builtin/providers/google/resource_compute_target_pool_test.go
+++ b/builtin/providers/google/resource_compute_target_pool_test.go
@@ -73,9 +73,17 @@ func testAccCheckComputeTargetPoolExists(n string) resource.TestCheckFunc {
 }
 
 var testAccComputeTargetPool_basic = fmt.Sprintf(`
+resource "google_compute_http_health_check" "foobar" {
+	name = "healthcheck-test-%s"
+	host = "example.com"
+}
+
 resource "google_compute_target_pool" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	instances = ["us-central1-a/foo", "us-central1-b/bar"]
 	name = "tpool-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
-}`, acctest.RandString(10))
+	health_checks = [
+		"${google_compute_http_health_check.foobar.name}"
+	]
+}`, acctest.RandString(10), acctest.RandString(10))


### PR DESCRIPTION
- Resolves #8488

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>