### PR TITLE
[GH-1275] Support for AWS access via IAMs AssumeRole functionality

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	Profile       string
 	Token         string
 	Region        string
+	RoleArn       string
 	MaxRetries    int
 
 	AllowedAccountIds   []interface{}
@@ -150,7 +151,10 @@ func (c *Config) Client() (interface{}, error) {
 		client.region = c.Region
 
 		log.Println("[INFO] Building AWS auth structure")
-		creds := GetCredentials(c)
+		creds, err := GetCredentials(c)
+		if err != nil {
+			return nil, &multierror.Error{Errors: errs}
+		}
 		// Call Get to check for credential provider. If nothing found, we'll get an
 		// error, and we can present it nicely to the user
 		cp, err := creds.Get()

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -64,6 +64,13 @@ func Provider() terraform.ResourceProvider {
 				InputDefault: "us-east-1",
 			},
 
+			"role_arn": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["role_arn"],
+			},
+
 			"max_retries": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -351,6 +358,8 @@ func init() {
 		"profile": "The profile for API operations. If not set, the default profile\n" +
 			"created with `aws configure` will be used.",
 
+		"role_arn": "The role to be assumed using the supplied access_key and secret_key",
+
 		"shared_credentials_file": "The path to the shared credentials file. If not set\n" +
 			"this defaults to ~/.aws/credentials.",
 
@@ -402,6 +411,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		CredsFilename:           d.Get("shared_credentials_file").(string),
 		Token:                   d.Get("token").(string),
 		Region:                  d.Get("region").(string),
+		RoleArn:                 d.Get("role_arn").(string),
 		MaxRetries:              d.Get("max_retries").(int),
 		DynamoDBEndpoint:        d.Get("dynamodb_endpoint").(string),
 		KinesisEndpoint:         d.Get("kinesis_endpoint").(string),

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -60,7 +60,7 @@ func s3Factory(conf map[string]string) (Client, error) {
 	kmsKeyID := conf["kms_key_id"]
 
 	var errs []error
-	creds := terraformAws.GetCredentials(&terraformAws.Config{
+	creds, err := terraformAws.GetCredentials(&terraformAws.Config{
 		AccessKey:     conf["access_key"],
 		SecretKey:     conf["secret_key"],
 		Token:         conf["token"],
@@ -69,7 +69,7 @@ func s3Factory(conf map[string]string) (Client, error) {
 	})
 	// Call Get to check for credential provider. If nothing found, we'll get an
 	// error, and we can present it nicely to the user
-	_, err := creds.Get()
+	_, err = creds.Get()
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
 			errs = append(errs, fmt.Errorf(`No valid credential sources found for AWS S3 remote.

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -111,6 +111,19 @@ You can provide custom metadata API endpoint via `AWS_METADATA_ENDPOINT` variabl
 which expects the endpoint URL including the version
 and defaults to `http://169.254.169.254:80/latest`.
 
+###Assume role
+
+If provided with a role arn, terraform will attempt to assume this role
+using the supplied credentials.
+
+Usage:
+
+```
+provider "aws" {
+  role_arn = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported in the `provider` block:


### PR DESCRIPTION
This commit enables terraform to utilise the assume role functionality
of sts to execute commands with different privileges than the API
keys specified.

Feedback very much so welcome, this was thrown together as a quick hack.

Signed-off-by: Ian Duffy <ian@ianduffy.ie>