### PR TITLE
schema: Return all validation errors together from InternalValidate

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -69,24 +70,25 @@ func (p *Provider) InternalValidate() error {
 		return errors.New("provider is nil")
 	}
 
+	var validationErrors error
 	sm := schemaMap(p.Schema)
 	if err := sm.InternalValidate(sm); err != nil {
-		return err
+		validationErrors = multierror.Append(validationErrors, err)
 	}
 
 	for k, r := range p.ResourcesMap {
 		if err := r.InternalValidate(nil, true); err != nil {
-			return fmt.Errorf("resource %s: %s", k, err)
+			validationErrors = multierror.Append(validationErrors, fmt.Errorf("resource %s: %s", k, err))
 		}
 	}
 
 	for k, r := range p.DataSourcesMap {
 		if err := r.InternalValidate(nil, false); err != nil {
-			return fmt.Errorf("data source %s: %s", k, err)
+			validationErrors = multierror.Append(validationErrors, fmt.Errorf("data source %s: %s", k, err))
 		}
 	}
 
-	return nil
+	return validationErrors
 }
 
 // Meta returns the metadata associated with this provider that was


### PR DESCRIPTION
This can be helpful for any developers making changes in existing providers/resources/data sources or creating new ones.

Previously we were returning the first validation error which lead to the (IMO boring & slow) workflow _"fix, run tests again, rinse & repeat"_.

Now the developer should be able to fix all errors at once.