### PR TITLE
provider/aws: Add `aws_ecs_task_definition` datasource to allow services to track the latest revision

### DIFF
--- a/builtin/providers/aws/data_source_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/data_source_aws_ecs_task_definition.go
@@ -1,0 +1,71 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEcsTaskDefinition() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEcsTaskDefinitionRead,
+
+		Schema: map[string]*schema.Schema{
+			"task_definition": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// Computed values.
+			"family": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"revision": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"task_role_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecsconn
+
+	desc, err := conn.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(d.Get("task_definition").(string)),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	taskDefinition := *desc.TaskDefinition
+
+	d.SetId(aws.StringValue(taskDefinition.TaskDefinitionArn))
+	d.Set("family", aws.StringValue(taskDefinition.Family))
+	d.Set("network_mode", aws.StringValue(taskDefinition.NetworkMode))
+	d.Set("revision", aws.Int64Value(taskDefinition.Revision))
+	d.Set("status", aws.StringValue(taskDefinition.Status))
+	d.Set("task_role_arn", aws.StringValue(taskDefinition.TaskRoleArn))
+
+	if d.Id() == "" {
+		return fmt.Errorf("task definition %q not found", d.Get("task_definition").(string))
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_ecs_task_definition_test.go
+++ b/builtin/providers/aws/data_source_aws_ecs_task_definition_test.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSEcsDataSource_ecsTaskDefinition(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsEcsTaskDefinitionDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "id", regexp.MustCompile("^arn:aws:ecs:us-west-2:[0-9]{12}:task-definition/mongodb:[1-9]*[0-9]$")),
+					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "family", "mongodb"),
+					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "network_mode", "bridge"),
+					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "revision", regexp.MustCompile("^[1-9]*[0-9]$")),
+					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "status", "ACTIVE"),
+					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "task_role_arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/mongo_role$")),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAwsEcsTaskDefinitionDataSourceConfig = `
+resource "aws_iam_role" "mongo_role" {
+    name = "mongo_role"
+    assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_ecs_task_definition" "mongo" {
+  family = "mongodb"
+  task_role_arn = "${aws_iam_role.mongo_role.arn}"
+  network_mode = "bridge"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "environment": [{
+      "name": "SECRET",
+      "value": "KEY"
+    }],
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "memoryReservation": 64,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+data "aws_ecs_task_definition" "mongo" {
+  task_definition = "${aws_ecs_task_definition.mongo.family}"
+}
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -155,6 +155,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ebs_snapshot":             dataSourceAwsEbsSnapshot(),
 			"aws_ebs_volume":               dataSourceAwsEbsVolume(),
 			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),
+			"aws_ecs_task_definition":      dataSourceAwsEcsTaskDefinition(),
 			"aws_eip":                      dataSourceAwsEip(),
 			"aws_elb_hosted_zone_id":       dataSourceAwsElbHostedZoneId(),
 			"aws_elb_service_account":      dataSourceAwsElbServiceAccount(),

--- a/website/source/docs/providers/aws/d/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/d/ecs_task_definition.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ecs_task_definition"
+sidebar_current: "docs-aws-datasource-ecs-task-definition"
+description: |-
+    Provides details about an ecs task definition
+---
+
+# aws\_ecs\_task\_definition
+
+The ECS task definition data source allows access to details of
+a specific AWS ECS task definition.
+
+
+## Example Usage
+
+```
+# Simply specify the family to find the latest ACTIVE revision in that family.
+data "aws_ecs_task_definition" "mongo" {
+  task_definition = "${aws_ecs_task_definition.mongo.family}"
+}
+
+resource "aws_ecs_cluster" "foo" {
+  name = "foo"
+}
+
+resource "aws_ecs_task_definition" "mongo" {
+  family = "mongodb"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "environment": [{
+      "name": "SECRET",
+      "value": "KEY"
+    }],
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "memoryReservation": 64,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "mongo" {
+  name = "mongo"
+  cluster = "${aws_ecs_cluster.foo.id}"
+  desired_count = 2
+
+  # Track the latest ACTIVE revision
+  task_definition = "${aws_ecs_task_definition.mongo.family}:${max("${aws_ecs_task_definition.mongo.revision}", "${data.aws_ecs_task_definition.mongo.revision}")}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `task_definition` - (Required) The family for the latest ACTIVE revision, family and revision (family:revision) for a specific revision in the family, the ARN of the task definition to access to.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `family` - The family of this task definition
+* `network_mode` - The Docker networking mode to use for the containers in this task.
+* `revision` - The revision of this task definition
+* `status` - The status of this task definition
+* `task_role_arn` - The ARN of the IAM role that containers in this task can assume

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -47,6 +47,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ecs-container-definition") %>>
                             <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-ecs-task-definition") %>>
+                            <a href="/docs/providers/aws/d/ecs_task_definition.html">aws_ecs_task_definition</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-elb-hosted-zone-id") %>>
                             <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
                         </li>


### PR DESCRIPTION
Implements #8449 

This PR contains the following:
- New datasource `aws_ecs_task_definition`
- ~~New interpolation function `max`~~ (added in #9692)
- The corresponding unit tests and acceptance tests
- The corresponding documentation updates

See #8449 for the detailed explanation of the why.
