### PR TITLE
provider/github: Remove unsafe ptr dereferencing

### DIFF
--- a/builtin/providers/github/resource_github_membership.go
+++ b/builtin/providers/github/resource_github_membership.go
@@ -53,11 +53,9 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) erro
 		d.SetId("")
 		return nil
 	}
-	username := membership.User.Login
-	roleName := membership.Role
 
-	d.Set("username", *username)
-	d.Set("role", *roleName)
+	d.Set("username", membership.User.Login)
+	d.Set("role", membership.Role)
 	return nil
 }
 


### PR DESCRIPTION
This is to prevent crashes as we've seen elsewhere, e.g. https://github.com/hashicorp/terraform/pull/8466

This is the first PR of many to remove any obvious and most visible anti-patterns used across all providers.

[`ResourceData.Set()` is capable of safe dereferencing](https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_data.go#L156-L166) - i.e. `nil` checking and even though the developer _should_ know when a certain field/variable could contain `nil`, it is still slightly better to end up in situation of unexpectedly empty field rather than a crash.

A small, naive `guru` + `jq` snippet of code used to find suspect lines/resources/providers:
https://gist.github.com/radeksimko/1a1a230647d3580c64a9dd66143e9e3b