### PR TITLE
provider/aws: Remove unsafe ptr dereferencing from ECS/ECR

### DIFF
--- a/builtin/providers/aws/resource_aws_ecr_repository.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository.go
@@ -60,8 +60,8 @@ func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] ECR repository created: %q", *repository.RepositoryArn)
 
 	d.SetId(*repository.RepositoryName)
-	d.Set("arn", *repository.RepositoryArn)
-	d.Set("registry_id", *repository.RegistryId)
+	d.Set("arn", repository.RepositoryArn)
+	d.Set("registry_id", repository.RegistryId)
 
 	return resourceAwsEcrRepositoryRead(d, meta)
 }
@@ -86,8 +86,8 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Received repository %s", out)
 
 	d.SetId(*repository.RepositoryName)
-	d.Set("arn", *repository.RepositoryArn)
-	d.Set("registry_id", *repository.RegistryId)
+	d.Set("arn", repository.RepositoryArn)
+	d.Set("registry_id", repository.RegistryId)
 	d.Set("name", repository.RepositoryName)
 
 	repositoryUrl := buildRepositoryUrl(repository, meta.(*AWSClient).region)

--- a/builtin/providers/aws/resource_aws_ecr_repository_policy.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_policy.go
@@ -53,7 +53,7 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] ECR repository policy created: %s", *repositoryPolicy.RepositoryName)
 
 	d.SetId(*repositoryPolicy.RepositoryName)
-	d.Set("registry_id", *repositoryPolicy.RegistryId)
+	d.Set("registry_id", repositoryPolicy.RegistryId)
 
 	return resourceAwsEcrRepositoryPolicyRead(d, meta)
 }
@@ -84,7 +84,7 @@ func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}
 	repositoryPolicy := out
 
 	d.SetId(*repositoryPolicy.RepositoryName)
-	d.Set("registry_id", *repositoryPolicy.RegistryId)
+	d.Set("registry_id", repositoryPolicy.RegistryId)
 
 	return nil
 }
@@ -110,7 +110,7 @@ func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface
 	repositoryPolicy := *out
 
 	d.SetId(*repositoryPolicy.RepositoryName)
-	d.Set("registry_id", *repositoryPolicy.RegistryId)
+	d.Set("registry_id", repositoryPolicy.RegistryId)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_ecs_cluster.go
+++ b/builtin/providers/aws/resource_aws_ecs_cluster.go
@@ -43,7 +43,7 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] ECS cluster %s created", *out.Cluster.ClusterArn)
 
 	d.SetId(*out.Cluster.ClusterArn)
-	d.Set("name", *out.Cluster.ClusterName)
+	d.Set("name", out.Cluster.ClusterName)
 	return nil
 }
 

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -201,21 +201,21 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Received ECS service %s", service)
 
 	d.SetId(*service.ServiceArn)
-	d.Set("name", *service.ServiceName)
+	d.Set("name", service.ServiceName)
 
 	// Save task definition in the same format
 	if strings.HasPrefix(d.Get("task_definition").(string), "arn:aws:ecs:") {
-		d.Set("task_definition", *service.TaskDefinition)
+		d.Set("task_definition", service.TaskDefinition)
 	} else {
 		taskDefinition := buildFamilyAndRevisionFromARN(*service.TaskDefinition)
 		d.Set("task_definition", taskDefinition)
 	}
 
-	d.Set("desired_count", *service.DesiredCount)
+	d.Set("desired_count", service.DesiredCount)
 
 	// Save cluster in the same format
 	if strings.HasPrefix(d.Get("cluster").(string), "arn:aws:ecs:") {
-		d.Set("cluster", *service.ClusterArn)
+		d.Set("cluster", service.ClusterArn)
 	} else {
 		clusterARN := getNameFromARN(*service.ClusterArn)
 		d.Set("cluster", clusterARN)
@@ -224,7 +224,7 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	// Save IAM role in the same format
 	if service.RoleArn != nil {
 		if strings.HasPrefix(d.Get("iam_role").(string), "arn:aws:iam:") {
-			d.Set("iam_role", *service.RoleArn)
+			d.Set("iam_role", service.RoleArn)
 		} else {
 			roleARN := getNameFromARN(*service.RoleArn)
 			d.Set("iam_role", roleARN)
@@ -232,8 +232,8 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if service.DeploymentConfiguration != nil {
-		d.Set("deployment_maximum_percent", *service.DeploymentConfiguration.MaximumPercent)
-		d.Set("deployment_minimum_healthy_percent", *service.DeploymentConfiguration.MinimumHealthyPercent)
+		d.Set("deployment_maximum_percent", service.DeploymentConfiguration.MaximumPercent)
+		d.Set("deployment_minimum_healthy_percent", service.DeploymentConfiguration.MinimumHealthyPercent)
 	}
 
 	if service.LoadBalancers != nil {

--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -140,7 +140,7 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 		*taskDefinition.TaskDefinitionArn, *taskDefinition.Revision)
 
 	d.SetId(*taskDefinition.Family)
-	d.Set("arn", *taskDefinition.TaskDefinitionArn)
+	d.Set("arn", taskDefinition.TaskDefinitionArn)
 
 	return resourceAwsEcsTaskDefinitionRead(d, meta)
 }
@@ -160,9 +160,9 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	taskDefinition := out.TaskDefinition
 
 	d.SetId(*taskDefinition.Family)
-	d.Set("arn", *taskDefinition.TaskDefinitionArn)
-	d.Set("family", *taskDefinition.Family)
-	d.Set("revision", *taskDefinition.Revision)
+	d.Set("arn", taskDefinition.TaskDefinitionArn)
+	d.Set("family", taskDefinition.Family)
+	d.Set("revision", taskDefinition.Revision)
 	d.Set("container_definitions", taskDefinition.ContainerDefinitions)
 	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
 	d.Set("network_mode", taskDefinition.NetworkMode)


### PR DESCRIPTION
See full explanation & motivation in https://github.com/hashicorp/terraform/pull/8512#issue-173637160

### Test plan
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSEcs'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSEcs -timeout 120m
=== RUN   TestAccAWSEcsDataSource_ecsContainerDefinition
--- PASS: TestAccAWSEcsDataSource_ecsContainerDefinition (109.07s)
=== RUN   TestAccAWSEcsCluster_basic
--- PASS: TestAccAWSEcsCluster_basic (16.14s)
=== RUN   TestAccAWSEcsServiceWithARN
--- PASS: TestAccAWSEcsServiceWithARN (120.29s)
=== RUN   TestAccAWSEcsServiceWithFamilyAndRevision
--- PASS: TestAccAWSEcsServiceWithFamilyAndRevision (109.85s)
=== RUN   TestAccAWSEcsServiceWithRenamedCluster
--- PASS: TestAccAWSEcsServiceWithRenamedCluster (232.85s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (124.40s)
=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (117.27s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withLbChanges (234.16s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (119.98s)
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (129.50s)
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (27.26s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (16.08s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (149.09s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (18.15s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (17.81s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	1541.928s
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSEcr'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSEcr -timeout 120m
=== RUN   TestAccAWSEcrRepository_importBasic
--- PASS: TestAccAWSEcrRepository_importBasic (37.27s)
=== RUN   TestAccAWSEcrRepositoryPolicy_basic
--- PASS: TestAccAWSEcrRepositoryPolicy_basic (34.62s)
=== RUN   TestAccAWSEcrRepository_basic
--- PASS: TestAccAWSEcrRepository_basic (37.74s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	109.648s
```