### PR TITLE
provider/aws: adds the ability to apply tags to spot request instances

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -269,6 +269,8 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsSpotInstanceRequestUpdate(d *schema.ResourceData, meta interface{}) error {
+	// call read to ensure we have the spot_instance_id populated as this is required for the tags
+	resourceAwsSpotInstanceRequestRead(d, meta)
 	conn := meta.(*AWSClient).ec2conn
 
 	d.Partial(true)

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -2,11 +2,17 @@ package aws
 
 import (
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	spotRequestIDPrefix        = "sir-"
+	spotRequestSpotInstance_ID = "spot_instance_id"
 )
 
 // tagsSchema returns the schema to use for tags.
@@ -58,6 +64,33 @@ func setElbV2Tags(conn *elbv2.ELBV2, d *schema.ResourceData) error {
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags"
 func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
+	var err error
+
+	id := d.Id()
+
+	// Check for a Spot Instance Requests as it requires special
+	// handeling, the tagging process will tag the spot request it self
+	// as its id is stored in d.Id(), to tag the instance the spot
+	// request creates we need to use the the instance id which is stored
+	// under key 'spot_instance_id'
+	if strings.Contains(id, spotRequestIDPrefix) {
+		spotInstID := d.Get(spotRequestSpotInstance_ID).(string)
+		err = setTagsActual(conn, d, spotInstID)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = setTagsActual(conn, d, id)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setTagsActual(conn *ec2.EC2, d *schema.ResourceData, id string) error {
 	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})
@@ -66,9 +99,9 @@ func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 
 		// Set tags
 		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %#v from %s", remove, d.Id())
+			log.Printf("[DEBUG] Removing tags: %#v from %s", remove, id)
 			_, err := conn.DeleteTags(&ec2.DeleteTagsInput{
-				Resources: []*string{aws.String(d.Id())},
+				Resources: []*string{aws.String(id)},
 				Tags:      remove,
 			})
 			if err != nil {
@@ -76,9 +109,9 @@ func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 			}
 		}
 		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %s for %s", create, d.Id())
+			log.Printf("[DEBUG] Creating tags: %s for %s", create, id)
 			_, err := conn.CreateTags(&ec2.CreateTagsInput{
-				Resources: []*string{aws.String(d.Id())},
+				Resources: []*string{aws.String(id)},
 				Tags:      create,
 			})
 			if err != nil {

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -10,11 +10,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-const (
-	spotRequestIDPrefix        = "sir-"
-	spotRequestSpotInstance_ID = "spot_instance_id"
-)
-
 // tagsSchema returns the schema to use for tags.
 //
 func tagsSchema() *schema.Schema {
@@ -69,12 +64,12 @@ func setTags(conn *ec2.EC2, d *schema.ResourceData) error {
 	id := d.Id()
 
 	// Check for a Spot Instance Requests as it requires special
-	// handeling, the tagging process will tag the spot request it self
+	// handling, the tagging process will tag the spot request it self
 	// as its id is stored in d.Id(), to tag the instance the spot
 	// request creates we need to use the the instance id which is stored
 	// under key 'spot_instance_id'
-	if strings.Contains(id, spotRequestIDPrefix) {
-		spotInstID := d.Get(spotRequestSpotInstance_ID).(string)
+	if strings.Contains(id, "sir-") {
+		spotInstID := d.Get("spot_instance_id").(string)
 		err = setTagsActual(conn, d, spotInstID)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #3263

adds the ability to tag instances that are created by spot instance requests
