### PR TITLE
[WIP] provider/aws: Strip trailing dot from the hosted zone name.

### DIFF
--- a/builtin/providers/aws/import_aws_route53_zone_test.go
+++ b/builtin/providers/aws/import_aws_route53_zone_test.go
@@ -22,7 +22,7 @@ func TestAccAWSRoute53Zone_importBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"name", "force_destroy"},
 			},
 		},
 	})

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -30,6 +30,9 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					return strings.TrimSuffix(v.(string), ".")
+				},
 			},
 
 			"comment": &schema.Schema{


### PR DESCRIPTION
This commit removes the trailing dot from the name of the hosted zone allowing
for resource to be imported regardless of whether the name as the trailing dot
or not.

As per the DNS standard, the trailing dot is usually required to denote the
fully-qualified domain name and/or zone name, but Route53 always treats given
zone name as fully-qualified, therefore we can afford to support name without
the trailing dot.

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
