### PR TITLE
provider/aws: Remove unsafe ptr dereferencing [A-C]*

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -76,7 +76,7 @@ func resourceAwsApiGatewayDomainNameCreate(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(*domainName.DomainName)
-	d.Set("cloudfront_domain_name", *domainName.DistributionDomainName)
+	d.Set("cloudfront_domain_name", domainName.DistributionDomainName)
 	d.Set("cloudfront_zone_id", cloudFrontRoute53ZoneID)
 
 	return resourceAwsApiGatewayDomainNameRead(d, meta)

--- a/builtin/providers/aws/resource_aws_cloudtrail.go
+++ b/builtin/providers/aws/resource_aws_cloudtrail.go
@@ -122,7 +122,7 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] CloudTrail created: %s", t)
 
-	d.Set("arn", *t.TrailARN)
+	d.Set("arn", t.TrailARN)
 	d.SetId(*t.Name)
 
 	// AWS CloudTrail sets newly-created trails to false.

--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -76,11 +76,11 @@ func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[DEBUG] Found Log Group: %#v", *lg)
 
-	d.Set("arn", *lg.Arn)
-	d.Set("name", *lg.LogGroupName)
+	d.Set("arn", lg.Arn)
+	d.Set("name", lg.LogGroupName)
 
 	if lg.RetentionInDays != nil {
-		d.Set("retention_in_days", *lg.RetentionInDays)
+		d.Set("retention_in_days", lg.RetentionInDays)
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_codecommit_repository.go
+++ b/builtin/providers/aws/resource_aws_codecommit_repository.go
@@ -93,10 +93,10 @@ func resourceAwsCodeCommitRepositoryCreate(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(d.Get("repository_name").(string))
-	d.Set("repository_id", *out.RepositoryMetadata.RepositoryId)
-	d.Set("arn", *out.RepositoryMetadata.Arn)
-	d.Set("clone_url_http", *out.RepositoryMetadata.CloneUrlHttp)
-	d.Set("clone_url_ssh", *out.RepositoryMetadata.CloneUrlSsh)
+	d.Set("repository_id", out.RepositoryMetadata.RepositoryId)
+	d.Set("arn", out.RepositoryMetadata.Arn)
+	d.Set("clone_url_http", out.RepositoryMetadata.CloneUrlHttp)
+	d.Set("clone_url_ssh", out.RepositoryMetadata.CloneUrlSsh)
 
 	return resourceAwsCodeCommitRepositoryUpdate(d, meta)
 }
@@ -133,14 +133,14 @@ func resourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error reading CodeCommit Repository: %s", err.Error())
 	}
 
-	d.Set("repository_id", *out.RepositoryMetadata.RepositoryId)
-	d.Set("arn", *out.RepositoryMetadata.Arn)
-	d.Set("clone_url_http", *out.RepositoryMetadata.CloneUrlHttp)
-	d.Set("clone_url_ssh", *out.RepositoryMetadata.CloneUrlSsh)
+	d.Set("repository_id", out.RepositoryMetadata.RepositoryId)
+	d.Set("arn", out.RepositoryMetadata.Arn)
+	d.Set("clone_url_http", out.RepositoryMetadata.CloneUrlHttp)
+	d.Set("clone_url_ssh", out.RepositoryMetadata.CloneUrlSsh)
 
 	if _, ok := d.GetOk("default_branch"); ok {
 		if out.RepositoryMetadata.DefaultBranch != nil {
-			d.Set("default_branch", *out.RepositoryMetadata.DefaultBranch)
+			d.Set("default_branch", out.RepositoryMetadata.DefaultBranch)
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_codedeploy_app.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_app.go
@@ -78,7 +78,7 @@ func resourceAwsCodeDeployAppRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	d.Set("name", *resp.Application.ApplicationName)
+	d.Set("name", resp.Application.ApplicationName)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -247,11 +247,11 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	d.Set("app_name", *resp.DeploymentGroupInfo.ApplicationName)
+	d.Set("app_name", resp.DeploymentGroupInfo.ApplicationName)
 	d.Set("autoscaling_groups", resp.DeploymentGroupInfo.AutoScalingGroups)
-	d.Set("deployment_config_name", *resp.DeploymentGroupInfo.DeploymentConfigName)
-	d.Set("deployment_group_name", *resp.DeploymentGroupInfo.DeploymentGroupName)
-	d.Set("service_role_arn", *resp.DeploymentGroupInfo.ServiceRoleArn)
+	d.Set("deployment_config_name", resp.DeploymentGroupInfo.DeploymentConfigName)
+	d.Set("deployment_group_name", resp.DeploymentGroupInfo.DeploymentGroupName)
+	d.Set("service_role_arn", resp.DeploymentGroupInfo.ServiceRoleArn)
 	if err := d.Set("ec2_tag_filter", ec2TagFiltersToMap(resp.DeploymentGroupInfo.Ec2TagFilters)); err != nil {
 		return err
 	}


### PR DESCRIPTION
See full explanation & motivation in https://github.com/hashicorp/terraform/pull/8512#issue-173637160

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run="AWS(APIGatewayDomainName|CloudTrail|CloudWatchLogGroup|CodeCommitRepository|CodeDeployApp|CodeDeployDeploymentGroup)"'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run="AWS(APIGatewayDomainName|CloudTrail|CloudWatchLogGroup|CodeCommitRepository|CodeDeployApp|CodeDeployDeploymentGroup)" -timeout 120m
=== RUN   TestAccAWSCloudTrail_importBasic
--- PASS: TestAccAWSCloudTrail_importBasic (70.02s)
=== RUN   TestAccAWSCloudWatchLogGroup_importBasic
--- PASS: TestAccAWSCloudWatchLogGroup_importBasic (18.06s)
=== RUN   TestAccAWSAPIGatewayDomainName_basic
--- PASS: TestAccAWSAPIGatewayDomainName_basic (19.96s)
=== RUN   TestAccAWSCloudTrail_basic
--- PASS: TestAccAWSCloudTrail_basic (107.62s)
=== RUN   TestAccAWSCloudTrail_enable_logging
--- PASS: TestAccAWSCloudTrail_enable_logging (147.01s)
=== RUN   TestAccAWSCloudTrail_is_multi_region
--- PASS: TestAccAWSCloudTrail_is_multi_region (140.15s)
=== RUN   TestAccAWSCloudTrail_logValidation
--- PASS: TestAccAWSCloudTrail_logValidation (100.66s)
=== RUN   TestAccAWSCloudTrail_tags
--- PASS: TestAccAWSCloudTrail_tags (158.60s)
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (17.04s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (35.15s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (21.04s)
=== RUN   TestAccAWSCloudWatchLogGroup_disappears
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (15.81s)
=== RUN   TestAccAWSCodeCommitRepository_basic
--- PASS: TestAccAWSCodeCommitRepository_basic (16.16s)
=== RUN   TestAccAWSCodeCommitRepository_withChanges
--- PASS: TestAccAWSCodeCommitRepository_withChanges (26.61s)
=== RUN   TestAccAWSCodeCommitRepository_create_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_default_branch (18.56s)
=== RUN   TestAccAWSCodeCommitRepository_create_and_update_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_and_update_default_branch (27.35s)
=== RUN   TestAccAWSCodeDeployApp_basic
--- PASS: TestAccAWSCodeDeployApp_basic (27.28s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (44.59s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (35.21s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_disappears
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (29.13s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (45.48s)
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (49.91s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	1171.446s
```