### PR TITLE
[WIP] Partial Apply for Computed Provider Configuration

### DIFF
--- a/terraform/deferrals.go
+++ b/terraform/deferrals.go
@@ -1,0 +1,101 @@
+package terraform
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Deferrals represents a set of nodes whose evaluation is deferred to a later
+// run of Terraform.
+//
+// This set is populated by both the "validate" and "plan" walks, as we discover
+// situations where the configuration is not yet sufficiently complete to form
+// a complete graph.
+//
+// The deferral set is used during graph construction to suppress any deferred
+// nodes along with any other nodes that depend on them. Thus nodes deferred during
+// "validate" are skipped during all subsequent phases, and nodes deferred during
+// "plan" are skipped during apply.
+type Deferrals struct {
+	Modules []*ModuleDeferrals
+}
+
+func NewDeferrals() *Deferrals {
+	return &Deferrals{
+		Modules: []*ModuleDeferrals{},
+	}
+}
+
+func (d *Deferrals) ModuleByPath(path []string) *ModuleDeferrals {
+	if d == nil {
+		return nil
+	}
+	for _, mod := range d.Modules {
+		if mod.Path == nil {
+			panic("missing module path")
+		}
+		if reflect.DeepEqual(mod.Path, path) {
+			return mod
+		}
+	}
+	return nil
+}
+
+func (d *Deferrals) AddModule(path []string) *ModuleDeferrals {
+	m := &ModuleDeferrals{
+		Path: path,
+
+		Providers: map[string]string{},
+		Resources: map[string]string{},
+	}
+	d.Modules = append(d.Modules, m)
+	return m
+}
+
+func (d *Deferrals) Empty() bool {
+	if d == nil {
+		return true
+	}
+
+	for _, md := range d.Modules {
+		if len(md.Providers)+len(md.Resources) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// ModuleDeferrals is the set of deferrals for a particular module. It represents
+// part of a full set of deferred nodes within a Deferrals instance.
+type ModuleDeferrals struct {
+	Path []string
+
+	// This "set" is actually represented as a map for each deferrable node type,
+	// whose key is a type-specific identifier and whose value is an English-language
+	// reason for why the node is deferred.
+
+	Providers map[string]string
+	Resources map[string]string
+}
+
+func (md *ModuleDeferrals) ModuleDisplayPrefix() string {
+	if len(md.Path) == 1 && md.Path[0] == "root" {
+		return ""
+	}
+
+	return fmt.Sprintf("module.%s.", strings.Join(md.Path[1:], ".module."))
+}
+
+func (md *ModuleDeferrals) DeferProvider(name string, reason string) {
+	md.Providers[name] = reason
+}
+
+func (md *ModuleDeferrals) DeferResource(name string, reason string) {
+	md.Resources[name] = reason
+}
+
+func (md *ModuleDeferrals) ProviderIsDeferred(name string) bool {
+	_, deferred := md.Providers[name]
+	return deferred
+}

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -70,6 +70,10 @@ type EvalContext interface {
 	// the second parameter is merged with any previous call.
 	SetVariables(string, map[string]interface{})
 
+	// Deferrals returns the set of currently-deferred nodes as well
+	// as the lock that should be used to modify that set.
+	Deferrals() (*Deferrals, *sync.RWMutex)
+
 	// Diff returns the global diff as well as the lock that should
 	// be used to modify that diff.
 	Diff() (*Diff, *sync.RWMutex)

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -36,6 +36,8 @@ type BuiltinEvalContext struct {
 	Provisioners        map[string]ResourceProvisionerFactory
 	ProvisionerCache    map[string]ResourceProvisioner
 	ProvisionerLock     *sync.Mutex
+	DeferralsValue      *Deferrals
+	DeferralsLock       *sync.RWMutex
 	DiffValue           *Diff
 	DiffLock            *sync.RWMutex
 	StateValue          *State
@@ -330,6 +332,10 @@ func (ctx *BuiltinEvalContext) SetVariables(n string, vs map[string]interface{})
 	for k, v := range vs {
 		vars[k] = v
 	}
+}
+
+func (ctx *BuiltinEvalContext) Deferrals() (*Deferrals, *sync.RWMutex) {
+	return ctx.DeferralsValue, ctx.DeferralsLock
 }
 
 func (ctx *BuiltinEvalContext) Diff() (*Diff, *sync.RWMutex) {

--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/config"
 )
@@ -84,12 +85,33 @@ func (n *EvalCloseProvider) Eval(ctx EvalContext) (interface{}, error) {
 
 // EvalGetProvider is an EvalNode implementation that retrieves an already
 // initialized provider instance for the given name.
+//
+// Will abort evaluation of the current node if the named provider is
+// deferred, under the assumption that this node will itself be deferred
+// on subsequent walks and to prevent interating with an uninitalized
+// provider.
 type EvalGetProvider struct {
 	Name   string
 	Output *ResourceProvider
 }
 
 func (n *EvalGetProvider) Eval(ctx EvalContext) (interface{}, error) {
+
+	deferrals, lock := ctx.Deferrals()
+
+	// Lock the deferrals to prevent concurrent modifications
+	lock.Lock()
+	defer lock.Unlock()
+
+	modDeferrals := deferrals.ModuleByPath(ctx.Path())
+	if modDeferrals != nil && modDeferrals.ProviderIsDeferred(n.Name) {
+		// If the provider we need is deferred, abort our own
+		// evaluation on this walk. We too will be deferred on the
+		// *next* walk, due to depending on a deferred provider.
+		log.Printf("[DEBUG] EvalGetProvider exiting early due to deferred provider %q\n", n.Name)
+		return nil, EvalEarlyExitError{}
+	}
+
 	result := ctx.Provider(n.Name)
 	if result == nil {
 		return nil, fmt.Errorf("provider %s not initialized", n.Name)
@@ -142,4 +164,48 @@ func (n *EvalInputProvider) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	return nil, nil
+}
+
+// EvalDeferComputedProvider defers the given provider if the given configuration
+// contains unresolved interpolations.
+//
+// If the provider is deferred then this node will terminate further evaluation of
+// the provider, so any subsequent EvalNodes will not be visited.
+type EvalDeferComputedProvider struct {
+	Name   string
+	Config **ResourceConfig
+}
+
+// TODO: test
+func (n *EvalDeferComputedProvider) Eval(ctx EvalContext) (interface{}, error) {
+	deferrals, lock := ctx.Deferrals()
+
+	config := *n.Config
+	computed := config.ComputedKeys != nil && len(config.ComputedKeys) > 0
+
+	if !computed {
+		return true, nil
+	}
+
+	// Lock the deferrals to prevent concurrent modifications
+	lock.Lock()
+	defer lock.Unlock()
+
+	modDeferrals := deferrals.ModuleByPath(ctx.Path())
+	if modDeferrals == nil {
+		modDeferrals = deferrals.AddModule(ctx.Path())
+	}
+
+	// We'll take the first computed key to give some context to the
+	// reason message. This is arbitrary, but most providers don't have
+	// lots of configuration attributes so it should usually be sufficient
+	// to help the user understand what's going on.
+	keyForReason := config.ComputedKeys[0]
+	valueForReason, _ := config.GetRaw(keyForReason)
+
+	reason := fmt.Sprintf("%q not yet resolvable: %s", keyForReason, valueForReason)
+	modDeferrals.DeferProvider(n.Name, reason)
+
+	log.Printf("[DEBUG] Deferring provider %q: %s\n", n.Name, reason)
+	return true, EvalEarlyExitError{}
 }

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -57,6 +57,9 @@ type BuiltinGraphBuilder struct {
 	// Root is the root module of the graph to build.
 	Root *module.Tree
 
+	// Deferrals is the set of nodes that are to be deferred.
+	Deferrals *Deferrals
+
 	// Diff is the diff. The proper module diffs will be looked up.
 	Diff *Diff
 

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -149,6 +149,9 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 			// their dependencies.
 			&TargetsTransformer{Targets: b.Targets, Destroy: b.Destroy},
 
+			// Supresses any nodes that are in the deferrals set.
+			&DeferralsTransformer{Deferrals: b.Deferrals, Destroy: b.Destroy},
+
 			// Prune the providers. This must happen only once because flattened
 			// modules might depend on empty providers.
 			&PruneProviderTransformer{},

--- a/terraform/graph_dot.go
+++ b/terraform/graph_dot.go
@@ -102,7 +102,8 @@ func graphDotSubgraph(
 	for _, v := range toDraw {
 		dn := v.(GraphNodeDotter)
 		nodeName := graphDotNodeName(modName, v)
-		sg.AddNode(dn.DotNode(nodeName, opts))
+		dotNode := dn.DotNode(nodeName, opts)
+		sg.AddNode(dotNode)
 
 		// Draw all the edges from this vertex to other nodes
 		targets := dag.AsVertexList(g.DownEdges(v))
@@ -113,10 +114,19 @@ func graphDotSubgraph(
 				continue
 			}
 
+			// If our node has a color set then the edge inherits
+			// that color. The initial purpose of this is to show
+			// edges to deferred nodes (rendered in gray) as
+			// deferred themselves.
+			edgeAttrs := map[string]string{}
+			if dotNode.Attrs["color"] != "" {
+				edgeAttrs["color"] = dotNode.Attrs["color"]
+			}
+
 			if err := sg.AddEdgeBetween(
 				graphDotNodeName(modName, v),
 				graphDotNodeName(modName, target),
-				map[string]string{}); err != nil {
+				edgeAttrs); err != nil {
 				return err
 			}
 		}

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -76,6 +76,8 @@ func (w *ContextGraphWalker) EnterPath(path []string) EvalContext {
 		Provisioners:        w.Context.provisioners,
 		ProvisionerCache:    w.provisionerCache,
 		ProvisionerLock:     &w.provisionerLock,
+		DeferralsValue:      w.Context.deferrals,
+		DeferralsLock:       &w.Context.deferralsLock,
 		DiffValue:           w.Context.diff,
 		DiffLock:            &w.Context.diffLock,
 		StateValue:          w.Context.state,

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -21,11 +21,12 @@ func init() {
 // Plan represents a single Terraform execution plan, which contains
 // all the information necessary to make an infrastructure change.
 type Plan struct {
-	Diff    *Diff
-	Module  *module.Tree
-	State   *State
-	Vars    map[string]interface{}
-	Targets []string
+	Diff      *Diff
+	Module    *module.Tree
+	State     *State
+	Vars      map[string]interface{}
+	Targets   []string
+	Deferrals *Deferrals
 
 	once sync.Once
 }
@@ -39,6 +40,7 @@ func (p *Plan) Context(opts *ContextOpts) (*Context, error) {
 	opts.Module = p.Module
 	opts.State = p.State
 	opts.Targets = p.Targets
+	opts.Deferrals = p.Deferrals
 
 	opts.Variables = make(map[string]interface{})
 	for k, v := range p.Vars {

--- a/terraform/transform_deferrals.go
+++ b/terraform/transform_deferrals.go
@@ -1,0 +1,125 @@
+package terraform
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/dag"
+	"github.com/hashicorp/terraform/dot"
+)
+
+// DeferralsTransformer is a GraphTransformer that finds the nodes in the current
+// deferrals set and replaces them with a placeholder node to prevent evaluation.
+// It also applies the same transformation to any dependencies of the deferred nodes.
+//
+// The deferral set is constructed during the Refresh and Plan walks, so only during
+// the Apply walk is it guaranteed that dependencies of deferrals will not be evaluated.
+type DeferralsTransformer struct {
+
+	// The deferrals to consider when transforming the graph.
+	Deferrals *Deferrals
+
+	// Set to true when we're in a `terraform destroy` or a
+	// `terraform plan -destroy`
+	Destroy bool
+}
+
+func (t *DeferralsTransformer) Transform(g *Graph) error {
+	deferred, err := t.selectDeferredNodes(g, t.Deferrals)
+	if err != nil {
+		return err
+	}
+
+	for _, nI := range deferred.List() {
+		n := nI.(dag.Vertex)
+
+		// Rather than removing the node entirely, we instead wrap it in a
+		// placeholder node so that it's impotent but still visible in
+		// "terraform graph".
+		log.Printf("[TRACE] Suppressing deferred node %q\n", dag.VertexName(n))
+
+		placeholder := &graphNodeDeferred{n}
+		g.Replace(n, placeholder)
+	}
+
+	return nil
+}
+
+func (t *DeferralsTransformer) selectDeferredNodes(g *Graph, deferrals *Deferrals) (*dag.Set, error) {
+	deferred := new(dag.Set)
+
+	modDeferrals := deferrals.ModuleByPath(g.Path)
+	if modDeferrals == nil {
+		// No deferrals for this module.
+		return deferred, nil
+	}
+
+	addToSet := func(node dag.Vertex) error {
+		deferred.Add(node)
+
+		var deps *dag.Set
+		var err error
+		if t.Destroy {
+			// Walk direction is reversed when destroying
+			deps, err = g.Ancestors(node)
+		} else {
+			deps, err = g.Descendents(node)
+		}
+		if err != nil {
+			return err
+		}
+
+		for _, d := range deps.List() {
+			deferred.Add(d)
+		}
+
+		return nil
+	}
+
+	for _, v := range g.Vertices() {
+		if pn, ok := v.(GraphNodeProvider); ok {
+			if modDeferrals.ProviderIsDeferred(pn.ProviderName()) {
+				err := addToSet(v)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		// TODO: Resource deferrals.
+		// This might require a new node interface to get the module-local resource
+		// name for us to use to match.
+	}
+
+	return deferred, nil
+}
+
+type graphNodeDeferred struct {
+	DeferredNode dag.Vertex
+}
+
+func (n *graphNodeDeferred) Name() string {
+	return dag.VertexName(n.DeferredNode)
+}
+
+func (n *graphNodeDeferred) DotOrigin() bool {
+	if nd, ok := n.DeferredNode.(GraphNodeDotOrigin); ok {
+		return nd.DotOrigin()
+	} else {
+		return false
+	}
+}
+
+func (n *graphNodeDeferred) DotNode(name string, opts *GraphDotOpts) *dot.Node {
+	var node *dot.Node
+
+	if nd, ok := n.DeferredNode.(GraphNodeDotter); ok {
+		node = nd.DotNode(name, opts)
+	} else {
+		return nil
+	}
+
+	// Deferred nodes appear in grey in the graph
+	node.Attrs["color"] = "gray"
+	node.Attrs["fontcolor"] = "gray"
+
+	return node
+}


### PR DESCRIPTION
> **This is not yet ready to merge, but the code here so far is functional and so I'm posting it for a general design review before I proceed any further with polish, tests, docs, etc.**

This is an implementation of the "partial apply" concept proposed in #4149, along with a first use for this concept: deferring instantiation of providers with computed configurations.

As an example of what this is about, consider the following configuration:

``` hcl
data "docker_registry_image" "consul" {
  name = "consul"
}

resource "docker_image" "consul" {
  name         = "${data.docker_registry_image.consul.name}"
  pull_trigger = "${data.docker_registry_image.consul.sha256_digest}"
}

resource "docker_container" "consul" {
  name  = "consul-for-terraform-testing"
  image = "${docker_image.consul.latest}"

  env = [
    "CONSUL_BIND_INTERFACE=eth0",
    "CONSUL_CLIENT_INTERFACE=eth0",
  ]

  provisioner "local-exec" {
    # this script polls the consul kv API until it returns a 200 OK status,
    # working around the fact that Terraform can't tell when the consul
    # server has finished bootstrapping.
    command = "./wait-for-consul"
  }
}

provider "consul" {
  address = "${docker_container.consul.ip_address}:8500"
}

resource "consul_key_prefix" "test" {
  path_prefix = "test/"

  subkeys = {
    hi = "world"
  }
}
```

This configuration is an example of what I've come to refer to as a "multi-layer" Terraform configuration. In this case, the layers are Docker, which is being used to start up a Consul server, and Consul itself.

In Terraform _today_, this configuration is problematic in two situations:
- On initial run from an empty state, Terraform will attempt to instantiate the `consul` provider during the Plan phase, when the `address` argument is not yet resolvable. This causes the `consul` provider to use the literal string `${docker_container.consul.ip_address}:8500` as its Consul address, which fails.
- Once this stack has been created, If the docker container is deleted outside of Terraform, on the next Refresh pass Terraform will correctly detect that the container is gone, but it will then fail trying to refresh `consul_key_prefix.test`.

In both of these situations, Terraform _today_ requires the use of `-target=docker_container.consul` on the first run in order to help Terraform understand how to apply the configuration in multiple steps.

The _partial apply_ mechanism added here allows Terraform to automatically recognize when the configuration must be applied across multiple passes, and to guide the user through the necessary steps while automatically excluding the parts of the configuration that are not ready to be planned.

---

Since this is a UX change, let's walk through the user experience when applying the above configuration, so we can see how this plays out in practice.

The first step is the same as usual:

```
$ terraform plan -input=false -out=tfplan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

data.docker_registry_image.consul: Refreshing state...
docker_image.consul: Refreshing state... (ID: b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5consul)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Your plan was also saved to the path below. Call the "apply" subcommand
with this plan file and Terraform will exactly execute this execution
plan.

Path: tfplan

+ docker_container.consul
    bridge:           "<computed>"
    env.#:            "2"
    env.2438063316:   "CONSUL_BIND_INTERFACE=eth0"
    env.852711472:    "CONSUL_CLIENT_INTERFACE=eth0"
    gateway:          "<computed>"
    image:            "b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5"
    ip_address:       "<computed>"
    ip_prefix_length: "<computed>"
    log_driver:       "json-file"
    must_run:         "true"
    name:             "consul-for-terraform-testing"
    restart:          "no"


Terraform is not able to apply this configuration in a single step. The plan
above will partially apply the configuration, after which you can run
"terraform plan" again to plan the next set of changes to converge on the
state given in your configuration.

The following resources are being deferred:
- all from provider consul:
    "address" not yet resolvable: ${docker_container.consul.ip_address}:8500


Plan: 1 to add, 0 to change, 0 to destroy.
```

On the first run, Terraform detects that the `consul` provider configuration cannot yet be evaluated and so defers all resources belonging to that provider. It produces a plan containing the maximal set of changes that _can_ be applied, and explains to the user why the rest cannot be applied yet.

If desired, we can use `terraform graph tfplan` to get a more detailed understanding of what's going on with this plan, with deferred nodes and edges de-emphasized:

![graph](https://cloud.githubusercontent.com/assets/20180/18036772/149c5ba2-6d29-11e6-93df-5d002e8f089c.gif)

We can now apply the plan:

```
$ terraform apply tfplan
docker_container.consul: Creating...
  bridge:           "" => "<computed>"
  env.#:            "" => "2"
  env.2438063316:   "" => "CONSUL_BIND_INTERFACE=eth0"
  env.852711472:    "" => "CONSUL_CLIENT_INTERFACE=eth0"
  gateway:          "" => "<computed>"
  image:            "" => "b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5"
  ip_address:       "" => "<computed>"
  ip_prefix_length: "" => "<computed>"
  log_driver:       "" => "json-file"
  must_run:         "" => "true"
  name:             "" => "consul-for-terraform-testing"
  restart:          "" => "no"
docker_container.consul: Provisioning with 'local-exec'...
docker_container.consul (local-exec): Executing: /bin/sh -c "./wait-for-consul"
docker_container.consul: Creation complete

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate

This plan has only partially applied the configuration.
Run 'terraform plan' again now to plan the next set of changes to converge
on the desired state.
```

Terraform has now applied the subset of the configuration that it said it would, but reminds the user at the end of the output that this wasn't the whole configuration and that we need to iterate again.

So we repeat the first step:

```
$ terraform plan -input=false -out=tfplan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

data.docker_registry_image.consul: Refreshing state...
docker_image.consul: Refreshing state... (ID: b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5consul)
docker_container.consul: Refreshing state... (ID: a7baccf3aec1676fd549c1b36e9aac1f1e8a8a1e902bba4756d1be9863ce5207)
consul_key_prefix.test: Refreshing state... (ID: test/)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Your plan was also saved to the path below. Call the "apply" subcommand
with this plan file and Terraform will exactly execute this execution
plan.

Path: tfplan

~ consul_key_prefix.test
    subkeys.%:  "0" => "1"
    subkeys.hi: "" => "world"


Plan: 0 to add, 1 to change, 0 to destroy.
```

Now Terraform can successfully plan the `consul_key_prefix.test` resource, because the `consul` provider has a completely-resolved configuration. Nothing is deferred this time, so this looks like the plan output we're used to.

We can now apply this second plan:

```
$ terraform apply tfplan
consul_key_prefix.test: Modifying...
  subkeys.%:  "0" => "1"
  subkeys.hi: "" => "world"
consul_key_prefix.test: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate
```

As promised, the `consul_key_prefix` resource is created, and Terraform completes successfully. The state now matches the configuration, as we can find out by running the plan one more time:

```
$ terraform plan -input=false -out=tfplan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

data.docker_registry_image.consul: Refreshing state...
docker_image.consul: Refreshing state... (ID: b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5consul)
docker_container.consul: Refreshing state... (ID: a7baccf3aec1676fd549c1b36e9aac1f1e8a8a1e902bba4756d1be9863ce5207)
consul_key_prefix.test: Refreshing state... (ID: test/)

No changes. Infrastructure is up-to-date. This means that Terraform
could not detect any differences between your configuration and
the real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```

In most situations, this is where we'd stay... we'll leave the consul server running, and subsequent runs might update the keys under our prefix but we won't mess with that Docker container much.

However, let's consider what happens in the situation where that docker container gets deleted outside of Terraform's view for some reason:

```
$ docker stop consul-for-terraform-testing
$ docker rm consul-for-terraform-testing
```

Next time we run Terraform:

```
$ terraform plan -input=false -out=tfplan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

data.docker_registry_image.consul: Refreshing state...
docker_image.consul: Refreshing state... (ID: b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5consul)
docker_container.consul: Refreshing state... (ID: a7baccf3aec1676fd549c1b36e9aac1f1e8a8a1e902bba4756d1be9863ce5207)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Your plan was also saved to the path below. Call the "apply" subcommand
with this plan file and Terraform will exactly execute this execution
plan.

Path: tfplan

+ docker_container.consul
    bridge:           "<computed>"
    env.#:            "2"
    env.2438063316:   "CONSUL_BIND_INTERFACE=eth0"
    env.852711472:    "CONSUL_CLIENT_INTERFACE=eth0"
    gateway:          "<computed>"
    image:            "b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5"
    ip_address:       "<computed>"
    ip_prefix_length: "<computed>"
    log_driver:       "json-file"
    must_run:         "true"
    name:             "consul-for-terraform-testing"
    restart:          "no"


Terraform is not able to apply this configuration in a single step. The plan
above will partially apply the configuration, after which you can run
"terraform plan" again to plan the next set of changes to converge on the
state given in your configuration.

The following resources are being deferred:
- all from provider consul:
    "address" not yet resolvable: ${docker_container.consul.ip_address}:8500


Plan: 1 to add, 0 to change, 0 to destroy.
```

During the Refresh walk, Terraform detected that the Docker container was deleted. Later in the walk, it detected that the `consul` provider's configuration is back to being unresolvable again, since we no longer have a docker container instance. Thus Terraform defers dealing with the resources from that provider, since it's not safe nor reasonable to make plans about those resources if we aren't able to refresh them.

This time, just to illustrate an alternative, more cavalier workflow, we'll ignore the plan file that was created and just run `terraform apply` with no arguments:

```
$ terraform apply -input=false
data.docker_registry_image.consul: Refreshing state...
docker_image.consul: Refreshing state... (ID: b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5consul)
docker_container.consul: Refreshing state... (ID: a7baccf3aec1676fd549c1b36e9aac1f1e8a8a1e902bba4756d1be9863ce5207)
docker_container.consul: Creating...
  bridge:           "" => "<computed>"
  env.#:            "" => "2"
  env.2438063316:   "" => "CONSUL_BIND_INTERFACE=eth0"
  env.852711472:    "" => "CONSUL_CLIENT_INTERFACE=eth0"
  gateway:          "" => "<computed>"
  image:            "" => "b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5"
  ip_address:       "" => "<computed>"
  ip_prefix_length: "" => "<computed>"
  log_driver:       "" => "json-file"
  must_run:         "" => "true"
  name:             "" => "consul-for-terraform-testing"
  restart:          "" => "no"
docker_container.consul: Provisioning with 'local-exec'...
docker_container.consul (local-exec): Executing: /bin/sh -c "./wait-for-consul"
docker_container.consul: Creation complete
data.docker_registry_image.consul: Refreshing state...
docker_image.consul: Refreshing state... (ID: b04f6ab77bb82ae613256022c560002956eed1076c761410513b5e8421534fa5consul)
docker_container.consul: Refreshing state... (ID: ba0dcebc925cb42f4faff9507b99e41f17b1faa776ba780dfa7cf660803c9d50)
consul_key_prefix.test: Refreshing state... (ID: test/)
consul_key_prefix.test: Modifying...
  subkeys.%:  "0" => "1"
  subkeys.hi: "" => "world"
consul_key_prefix.test: Modifications complete

Apply complete! Resources: 1 added, 1 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate
```

A bare `terraform apply` behaves a little differently. Since the user doesn't care to view and approve the plan before proceeding, we just automatically run multiple plan/apply passes until we reach either an error or a success with no deferrals. In this case Terraform just "does what I mean", and doesn't trouble me with thinking about the fact that it takes multiple passes to reach this state. Certainly this approach is not recommended for production, but it provides a simpler path for those still learning/experimenting.

---
# How it works

There are several parts to the problem here:
- Detecting that a provider needs to be deferred.
- Detecting and transforming deferred nodes in the graph, including propagation of deferrals to dependent nodes.
- UX/workflow changes to support this.

The detection of deferrals happens during the _refresh_ and _plan_ phases. It needs to be done in two parts because each part detects different situations:
- Refresh: Provider depends on a resource that either hasn't been created yet or that an earlier `Read` has discovered has been deleted outside of Terraform.
- Plan: Provider depends on a resource that is being replaced due to a change to an argument that has `ForceNew` set.

During each of these walks, a deferred provider is skipped but its resources are still visited. Thus we must gracefully handle this during evaluation, by doing an _early exit_ from the evaluation if we try to retrieve a deferred provider.

Once a provider is deferred by one walk, it is automatically deferred for all _subsequent_ walks. That is,  a provider deferred during refresh cannot become un-deferred during a subsequent plan if both of these walks are happening during a single run. The rationale for this design is that unless the user specifically disabled refresh with `-refresh=false` we should not attempt to plan resources whose states may be stale.

On subsequent walks, the graph is transformed such that deferred nodes are replaced with no-op placeholder nodes. These nodes do nothing during evaluation, but allow the deferred nodes to be seen in the `terraform graph` output. This transformation operates under a similar principle to how the `-target` argument is handled, but inverted since deferrals are conceptually "anti-targets", excluding particular nodes.

The deferrals that are present at the end of the Plan walk are recorded in the plan so they can propagate into a subsequent run of `terraform apply` against that plan.

The UX changes are then implemented in terms of the above:
- For `terraform plan`, an additional note is added to the end of the plan output if there are deferrals recorded in the plan.
- For `terraform apply {planfile}`, an additional note is added to the end of the output when the plan contains deferrals, to remind the user that they need to run `terraform plan` again to see the next step.
- For `terraform apply` with no arguments, this is treated as if the user were repeatedly running `terraform plan -out=tfplan` and `terraform apply tfplan` until either there are no more deferrals or until an error occurs.
