### PR TITLE
provider/aws: Handle missing EFS mount target in aws_efs_mount_target.

### DIFF
--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -102,6 +102,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.SetId(*mt.MountTargetId)
+	log.Printf("[INFO] EFS mount target ID: %s", d.Id())
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"creating"},

--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -76,7 +76,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 	// So we make it fail by calling 1 request per AZ at a time.
 	az, err := getAzFromSubnetId(subnetId, meta.(*AWSClient).ec2conn)
 	if err != nil {
-		return fmt.Errorf("Failed getting AZ from subnet ID (%s): %s", subnetId, err)
+		return fmt.Errorf("Failed getting Availability Zone from subnet ID (%s): %s", subnetId, err)
 	}
 	mtKey := "efs-mt-" + fsId + "-" + az
 	awsMutexKV.Lock(mtKey)
@@ -114,8 +114,8 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 				return nil, "error", err
 			}
 
-			if len(resp.MountTargets) < 1 {
-				return nil, "error", fmt.Errorf("EFS mount target %q not found", d.Id())
+			if resp.MountTargets != nil && len(resp.MountTargets) < 1 {
+				return nil, "error", fmt.Errorf("EFS mount target %q could not be found.", d.Id())
 			}
 
 			mt := resp.MountTargets[0]
@@ -161,11 +161,19 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 		MountTargetId: aws.String(d.Id()),
 	})
 	if err != nil {
-		return err
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "MountTargetNotFound" {
+			// The EFS mount target could not be found,
+			// which would indicate that it might be
+			// already deleted.
+			log.Printf("[WARN] EFS mount target %q could not be found.", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading EFS mount target %s: %s", d.Id(), err)
 	}
 
-	if len(resp.MountTargets) < 1 {
-		return fmt.Errorf("EFS mount target %q not found", d.Id())
+	if resp.MountTargets != nil && len(resp.MountTargets) < 1 {
+		return fmt.Errorf("EFS mount target %q could not be found.", d.Id())
 	}
 
 	mt := resp.MountTargets[0]
@@ -173,10 +181,10 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] Found EFS mount target: %#v", mt)
 
 	d.SetId(*mt.MountTargetId)
-	d.Set("file_system_id", *mt.FileSystemId)
-	d.Set("ip_address", *mt.IpAddress)
-	d.Set("subnet_id", *mt.SubnetId)
-	d.Set("network_interface_id", *mt.NetworkInterfaceId)
+	d.Set("file_system_id", mt.FileSystemId)
+	d.Set("ip_address", mt.IpAddress)
+	d.Set("subnet_id", mt.SubnetId)
+	d.Set("network_interface_id", mt.NetworkInterfaceId)
 
 	sgResp, err := conn.DescribeMountTargetSecurityGroups(&efs.DescribeMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String(d.Id()),
@@ -185,15 +193,22 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	d.Set("security_groups", schema.NewSet(schema.HashString, flattenStringList(sgResp.SecurityGroups)))
+	err = d.Set("security_groups", schema.NewSet(schema.HashString, flattenStringList(sgResp.SecurityGroups)))
+	if err != nil {
+		return err
+	}
 
 	// DNS name per http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html
 	az, err := getAzFromSubnetId(*mt.SubnetId, meta.(*AWSClient).ec2conn)
 	if err != nil {
-		return fmt.Errorf("Failed getting AZ from subnet ID (%s): %s", *mt.SubnetId, err)
+		return fmt.Errorf("Failed getting Availability Zone from subnet ID (%s): %s", *mt.SubnetId, err)
 	}
+
 	region := meta.(*AWSClient).region
-	d.Set("dns_name", fmt.Sprintf("%s.%s.efs.%s.amazonaws.com", az, *mt.FileSystemId, region))
+	err = d.Set("dns_name", fmt.Sprintf("%s.%s.efs.%s.amazonaws.com", az, *mt.FileSystemId, region))
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -207,8 +222,8 @@ func getAzFromSubnetId(subnetId string, conn *ec2.EC2) (string, error) {
 		return "", err
 	}
 
-	if len(out.Subnets) != 1 {
-		return "", fmt.Errorf("Expected exactly 1 subnet returned for %q", subnetId)
+	if l := len(out.Subnets); l != 1 {
+		return "", fmt.Errorf("Expected exactly 1 subnet returned for %q, got: %d", subnetId, l)
 	}
 
 	return *out.Subnets[0].AvailabilityZone, nil
@@ -245,7 +260,7 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 				return nil, "error", awsErr
 			}
 
-			if len(resp.MountTargets) < 1 {
+			if resp.MountTargets != nil && len(resp.MountTargets) < 1 {
 				return nil, "", nil
 			}
 
@@ -261,7 +276,7 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for EFS mount target (%q) to delete: %q",
+		return fmt.Errorf("Error waiting for EFS mount target (%q) to delete: %s",
 			d.Id(), err.Error())
 	}
 

--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -205,7 +205,7 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	region := meta.(*AWSClient).region
-	err = d.Set("dns_name", fmt.Sprintf("%s.%s.efs.%s.amazonaws.com", az, *mt.FileSystemId, region))
+	err = d.Set("dns_name", resourceAwsEfsMountTargetDnsName(az, *mt.FileSystemId, region))
 	if err != nil {
 		return err
 	}
@@ -283,4 +283,8 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] EFS mount target %q deleted.", d.Id())
 
 	return nil
+}
+
+func resourceAwsEfsMountTargetDnsName(az, fileSystemId, region string) string {
+	return fmt.Sprintf("%s.%s.efs.%s.amazonaws.com", az, fileSystemId, region)
 }

--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -114,7 +114,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 				return nil, "error", err
 			}
 
-			if resp.MountTargets != nil && len(resp.MountTargets) < 1 {
+			if hasEmptyMountTargets(resp) {
 				return nil, "error", fmt.Errorf("EFS mount target %q could not be found.", d.Id())
 			}
 
@@ -172,7 +172,7 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error reading EFS mount target %s: %s", d.Id(), err)
 	}
 
-	if resp.MountTargets != nil && len(resp.MountTargets) < 1 {
+	if hasEmptyMountTargets(resp) {
 		return fmt.Errorf("EFS mount target %q could not be found.", d.Id())
 	}
 
@@ -260,7 +260,7 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 				return nil, "error", awsErr
 			}
 
-			if resp.MountTargets != nil && len(resp.MountTargets) < 1 {
+			if hasEmptyMountTargets(resp) {
 				return nil, "", nil
 			}
 
@@ -287,4 +287,11 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 
 func resourceAwsEfsMountTargetDnsName(az, fileSystemId, region string) string {
 	return fmt.Sprintf("%s.%s.efs.%s.amazonaws.com", az, fileSystemId, region)
+}
+
+func hasEmptyMountTargets(mto *efs.DescribeMountTargetsOutput) bool {
+	if mto != nil && len(mto.MountTargets) > 0 {
+		return false
+	}
+	return true
 }

--- a/builtin/providers/aws/resource_aws_efs_mount_target_test.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target_test.go
@@ -68,6 +68,28 @@ func TestResourceAWSEFSMountTarget_mountTargetDnsName(t *testing.T) {
 	}
 }
 
+func TestResourceAWSEFSMountTarget_hasEmptyMountTargets(t *testing.T) {
+	mto := &efs.DescribeMountTargetsOutput{
+		MountTargets: []*efs.MountTargetDescription{},
+	}
+
+	var actual bool
+
+	actual = hasEmptyMountTargets(mto)
+	if !actual {
+		t.Fatalf("Expected return value to be true, got %t", actual)
+	}
+
+	// Add an empty mount target.
+	mto.MountTargets = append(mto.MountTargets, &efs.MountTargetDescription{})
+
+	actual = hasEmptyMountTargets(mto)
+	if actual {
+		t.Fatalf("Expected return value to be false, got %t", actual)
+	}
+
+}
+
 func testAccCheckEfsMountTargetDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).efsconn
 	for _, rs := range s.RootModule().Resources {

--- a/builtin/providers/aws/resource_aws_efs_mount_target_test.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -14,6 +15,8 @@ import (
 )
 
 func TestAccAWSEFSMountTarget_basic(t *testing.T) {
+	var mount efs.MountTargetDescription
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -24,6 +27,7 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsMountTarget(
 						"aws_efs_mount_target.alpha",
+						&mount,
 					),
 					resource.TestMatchResourceAttr(
 						"aws_efs_mount_target.alpha",
@@ -37,6 +41,7 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsMountTarget(
 						"aws_efs_mount_target.alpha",
+						&mount,
 					),
 					resource.TestMatchResourceAttr(
 						"aws_efs_mount_target.alpha",
@@ -45,6 +50,7 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 					),
 					testAccCheckEfsMountTarget(
 						"aws_efs_mount_target.beta",
+						&mount,
 					),
 					resource.TestMatchResourceAttr(
 						"aws_efs_mount_target.beta",
@@ -52,6 +58,29 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 						regexp.MustCompile("^us-west-2b.[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSMountTarget_disappears(t *testing.T) {
+	var mount efs.MountTargetDescription
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEFSMountTargetConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsMountTarget(
+						"aws_efs_mount_target.alpha",
+						&mount,
+					),
+					testAccAWSEFSMountTargetDisappears(&mount),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -115,7 +144,7 @@ func testAccCheckEfsMountTargetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckEfsMountTarget(resourceID string) resource.TestCheckFunc {
+func testAccCheckEfsMountTarget(resourceID string, mount *efs.MountTargetDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceID]
 		if !ok {
@@ -144,13 +173,54 @@ func testAccCheckEfsMountTarget(resourceID string) resource.TestCheckFunc {
 				*mt.MountTargets[0].MountTargetId, fs.Primary.ID)
 		}
 
+		*mount = *mt.MountTargets[0]
+
 		return nil
 	}
 }
 
+func testAccAWSEFSMountTargetDisappears(mount *efs.MountTargetDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).efsconn
+
+		_, err := conn.DeleteMountTarget(&efs.DeleteMountTargetInput{
+			MountTargetId: mount.MountTargetId,
+		})
+
+		if err != nil {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "MountTargetNotFound" {
+				return nil
+			}
+			return err
+		}
+
+		return resource.Retry(3*time.Minute, func() *resource.RetryError {
+			resp, err := conn.DescribeMountTargets(&efs.DescribeMountTargetsInput{
+				MountTargetId: mount.MountTargetId,
+			})
+			if err != nil {
+				if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "MountTargetNotFound" {
+					return nil
+				}
+				return resource.NonRetryableError(
+					fmt.Errorf("Error reading EFS mount target: %s", err))
+			}
+			if resp.MountTargets == nil || len(resp.MountTargets) < 1 {
+				return nil
+			}
+			if *resp.MountTargets[0].LifeCycleState == "deleted" {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf(
+				"Waiting for EFS mount target: %s", mount.MountTargetId))
+		})
+	}
+
+}
+
 const testAccAWSEFSMountTargetConfig = `
 resource "aws_efs_file_system" "foo" {
-	reference_name = "radeksimko"
+	creation_token = "radeksimko"
 }
 
 resource "aws_efs_mount_target" "alpha" {
@@ -171,7 +241,7 @@ resource "aws_subnet" "alpha" {
 
 const testAccAWSEFSMountTargetConfigModified = `
 resource "aws_efs_file_system" "foo" {
-	reference_name = "radeksimko"
+	creation_token = "radeksimko"
 }
 
 resource "aws_efs_mount_target" "alpha" {

--- a/builtin/providers/aws/resource_aws_efs_mount_target_test.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target_test.go
@@ -57,6 +57,17 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 	})
 }
 
+func TestResourceAWSEFSMountTarget_mountTargetDnsName(t *testing.T) {
+	actual := resourceAwsEfsMountTargetDnsName("non-existant-1c",
+		"fs-123456ab", "non-existant-1")
+
+	expected := "non-existant-1c.fs-123456ab.efs.non-existant-1.amazonaws.com"
+	if actual != expected {
+		t.Fatalf("Expected EFS mount target DNS name to be %s, got %s",
+			expected, actual)
+	}
+}
+
 func testAccCheckEfsMountTargetDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).efsconn
 	for _, rs := range s.RootModule().Resources {


### PR DESCRIPTION
This commit resolves issue where the EFS mount target would be already
deleted (e.g. it was deleted outside of Terraform, etc.). Also, correct
how values are begin set in the ReadFunc to avoid nil pointer dereference.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>