### PR TITLE
provider/aws: don't use deprecated argument in EFS filesystem example

### DIFF
--- a/website/source/docs/providers/aws/r/efs_file_system.html.markdown
+++ b/website/source/docs/providers/aws/r/efs_file_system.html.markdown
@@ -14,7 +14,7 @@ Provides an Elastic File System (EFS) resource.
 
 ```
 resource "aws_efs_file_system" "foo" {
-  reference_name = "my-product"
+  creation_token = "my-product"
   tags {
     Name = "MyProduct"
   }


### PR DESCRIPTION
Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>