### PR TITLE
provider/aws: API Gateway Custom Authorizer

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_authorizer.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_authorizer.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -200,7 +201,11 @@ func resourceAwsApiGatewayAuthorizerDelete(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Deleting API Gateway Authorizer: %s", input)
 	_, err := conn.DeleteAuthorizer(&input)
 	if err != nil {
-		return fmt.Errorf("Deleting API Gateway Authorizer failed: %s", err)
+		// XXX: Figure out a way to delete the method that depends on the authorizer first
+		// otherwise the authorizer will be dangling until the API is deleted
+		if !strings.Contains(err.Error(), "ConflictException") {
+			return fmt.Errorf("Deleting API Gateway Authorizer failed: %s", err)
+		}
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_api_gateway_method.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method.go
@@ -46,6 +46,11 @@ func resourceAwsApiGatewayMethod() *schema.Resource {
 				Required: true,
 			},
 
+			"authorizer_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"api_key_required": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -107,6 +112,7 @@ func resourceAwsApiGatewayMethodCreate(d *schema.ResourceData, meta interface{})
 		RequestModels:     aws.StringMap(models),
 		RequestParameters: aws.BoolMap(parameters),
 		ApiKeyRequired:    aws.Bool(d.Get("api_key_required").(bool)),
+		AuthorizerId:      aws.String(d.Get("authorizer_id").(string)),
 	})
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Method: %s", err)

--- a/builtin/providers/aws/resource_aws_api_gateway_method_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,12 +45,51 @@ func TestAccAWSAPIGatewayMethod_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayMethod_customauthorizer(t *testing.T) {
+	var conf apigateway.Method
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayMethodConfigWithCustomAuthorizer,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodExists("aws_api_gateway_method.test", &conf),
+					testAccCheckAWSAPIGatewayMethodAttributes(&conf),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_method.test", "http_method", "GET"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_method.test", "authorization", "CUSTOM"),
+					resource.TestMatchResourceAttr(
+						"aws_api_gateway_method.test", "authorizer_id", regexp.MustCompile("^[a-z0-9]{6}$")),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_method.test", "request_models.application/json", "Error"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayMethodConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodExists("aws_api_gateway_method.test", &conf),
+					testAccCheckAWSAPIGatewayMethodAttributesUpdate(&conf),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_method.test", "authorization", "NONE"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_method.test", "authorizer_id", ""),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAPIGatewayMethodAttributes(conf *apigateway.Method) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *conf.HttpMethod != "GET" {
 			return fmt.Errorf("Wrong HttpMethod: %q", *conf.HttpMethod)
 		}
-		if *conf.AuthorizationType != "NONE" {
+		if *conf.AuthorizationType != "NONE" && *conf.AuthorizationType != "CUSTOM" {
 			return fmt.Errorf("Wrong Authorization: %q", *conf.AuthorizationType)
 		}
 
@@ -153,6 +193,106 @@ func testAccCheckAWSAPIGatewayMethodDestroy(s *terraform.State) error {
 
 	return nil
 }
+
+const testAccAWSAPIGatewayMethodConfigWithCustomAuthorizer = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+}
+
+resource "aws_iam_role" "invocation_role" {
+  name = "tf_acc_api_gateway_auth_invocation_role"
+  path = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "apigateway.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "invocation_policy" {
+  name = "default"
+  role = "${aws_iam_role.invocation_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "lambda:InvokeFunction",
+      "Effect": "Allow",
+      "Resource": "${aws_lambda_function.authorizer.arn}"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "tf_acc_iam_for_lambda_api_gateway_authorizer"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "authorizer" {
+  filename = "test-fixtures/lambdatest.zip"
+  source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
+  function_name = "tf_acc_api_gateway_authorizer"
+  role = "${aws_iam_role.iam_for_lambda.arn}"
+  handler = "exports.example"
+}
+
+resource "aws_api_gateway_authorizer" "test" {
+  name = "tf-acc-test-authorizer"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  authorizer_uri = "arn:aws:apigateway:region:lambda:path/2015-03-31/functions/${aws_lambda_function.authorizer.arn}/invocations"
+  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  path_part = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "GET"
+  authorization = "CUSTOM"
+  authorizer_id = "${aws_api_gateway_authorizer.test.id}"
+
+  request_models = {
+    "application/json" = "Error"
+  }
+
+  request_parameters = {
+    "method.request.header.Content-Type" = false
+	  "method.request.querystring.page" = true
+  }
+}
+`
 
 const testAccAWSAPIGatewayMethodConfig = `
 resource "aws_api_gateway_rest_api" "test" {

--- a/builtin/providers/aws/resource_aws_api_gateway_method_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_method_test.go
@@ -196,7 +196,7 @@ func testAccCheckAWSAPIGatewayMethodDestroy(s *terraform.State) error {
 
 const testAccAWSAPIGatewayMethodConfigWithCustomAuthorizer = `
 resource "aws_api_gateway_rest_api" "test" {
-  name = "test"
+  name = "tf-acc-test-custom-auth"
 }
 
 resource "aws_iam_role" "invocation_role" {

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -39,7 +39,8 @@ The following arguments are supported:
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
 * `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
-* `authorization` - (Required) The type of authorization used for the method
+* `authorization` - (Required) The type of authorization used for the method (`NONE`, `CUSTOM`)
+* `authorizer_id` - (Optional) The authorizer id to be used when the authorization is `CUSTOM`
 * `api_key_required` - (Optional) Specify if the method requires an API key
 * `request_models` - (Optional) A map of the API models used for the request's content type
   where key is the content type (e.g. `application/json`)


### PR DESCRIPTION
Replaces https://github.com/hashicorp/terraform/pull/6731

Thanks @johnjelinek for most of the work here. I just added a few missing bits.

### Test plan
One test may _actually_ fail until https://github.com/hashicorp/terraform/pull/8533 is merged.

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSAPIGateway'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSAPIGateway -timeout 120m
=== RUN   TestAccAWSAPIGatewayAccount_importBasic
--- PASS: TestAccAWSAPIGatewayAccount_importBasic (16.81s)
=== RUN   TestAccAWSAPIGatewayApiKey_importBasic
--- PASS: TestAccAWSAPIGatewayApiKey_importBasic (43.76s)
=== RUN   TestAccAWSAPIGatewayAccount_basic
--- PASS: TestAccAWSAPIGatewayAccount_basic (120.88s)
=== RUN   TestAccAWSAPIGatewayApiKey_basic
--- PASS: TestAccAWSAPIGatewayApiKey_basic (42.53s)
=== RUN   TestAccAWSAPIGatewayAuthorizer_basic
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (52.22s)
=== RUN   TestAccAWSAPIGatewayBasePath_basic
--- PASS: TestAccAWSAPIGatewayBasePath_basic (40.37s)
=== RUN   TestAccAWSAPIGatewayDeployment_basic
--- PASS: TestAccAWSAPIGatewayDeployment_basic (37.23s)
=== RUN   TestAccAWSAPIGatewayDomainName_basic
--- PASS: TestAccAWSAPIGatewayDomainName_basic (20.89s)
=== RUN   TestAccAWSAPIGatewayIntegrationResponse_basic
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (58.66s)
=== RUN   TestAccAWSAPIGatewayIntegration_basic
--- PASS: TestAccAWSAPIGatewayIntegration_basic (48.09s)
=== RUN   TestAccAWSAPIGatewayMethodResponse_basic
--- PASS: TestAccAWSAPIGatewayMethodResponse_basic (55.87s)
=== RUN   TestAccAWSAPIGatewayMethod_basic
--- PASS: TestAccAWSAPIGatewayMethod_basic (43.93s)
=== RUN   TestAccAWSAPIGatewayMethod_customauthorizer
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (59.41s)
=== RUN   TestAccAWSAPIGatewayModel_basic
--- PASS: TestAccAWSAPIGatewayModel_basic (24.93s)
=== RUN   TestAccAWSAPIGatewayResource_basic
--- PASS: TestAccAWSAPIGatewayResource_basic (29.13s)
=== RUN   TestAccAWSAPIGatewayRestApi_basic
--- PASS: TestAccAWSAPIGatewayRestApi_basic (43.80s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	738.540s
```