### PR TITLE
Fix error from copy/paste of another example

### DIFF
--- a/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
@@ -93,7 +93,7 @@ resource "aws_elasticsearch_domain" "test_cluster" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name = "terraform-kinesis-firehose-test-stream"
-  destination = "redshift"
+  destination = "elasticsearch"
   s3_configuration {
     role_arn = "${aws_iam_role.firehose_role.arn}"
     bucket_arn = "${aws_s3_bucket.bucket.arn}"


### PR DESCRIPTION
It looks like the Elasticsearch example was copied from the Redshift example, but the "destination" field wasn't updated.