### PR TITLE
local-exec: the OS doesn't need to be ready

### DIFF
--- a/website/source/docs/provisioners/local-exec.html.markdown
+++ b/website/source/docs/provisioners/local-exec.html.markdown
@@ -13,6 +13,9 @@ is created. This invokes a process on the machine running Terraform, not on
 the resource. See the `remote-exec` [provisioner](/docs/provisioners/remote-exec.html)
 to run commands on the resource.
 
+Beware that even though the resource is fully created when the provisioner is run,
+it doesn't need to have finished booting or starting system services.
+
 ## Example usage
 
 ```


### PR DESCRIPTION
It is not obvious that the resource being created doesn't mean that the OS and system services such as sshd are ready (contrary to `remote-exec`). It is better to make that explicit and same developers like me some headache :-)

(See #2811, #2137)