### PR TITLE
Make consul provider settings truly optional

### DIFF
--- a/builtin/providers/consul/resource_provider.go
+++ b/builtin/providers/consul/resource_provider.go
@@ -23,36 +23,43 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"CONSUL_ADDRESS",
 					"CONSUL_HTTP_ADDR",
-				}, nil),
+				}, "localhost:8500"),
 			},
 
 			"scheme": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_SCHEME", nil),
+				Type:     schema.TypeString,
+				Optional: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"CONSUL_SCHEME",
+					"CONSUL_HTTP_SCHEME",
+				}, "http"),
 			},
 
 			"ca_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CA_FILE", nil),
+				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
 			},
 
 			"cert_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CERT_FILE", nil),
+				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
 			},
 
 			"key_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_KEY_FILE", nil),
+				DefaultFunc: schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
 			},
 
 			"token": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"CONSUL_TOKEN",
+					"CONSUL_HTTP_TOKEN",
+				}, ""),
 			},
 		},
 


### PR DESCRIPTION
Set default values of truly optional settings to empty strings rather than nil, since a nil value triggers prompts for the missing values.

Also:
* Set default Consul address to `localhost:8500`
* Set default scheme to `http`
* Accept `CONSUL_HTTP_SCHEME` for consistency with other env var names
* Actively read ACL token from env vars (vs leaving it to client lib)

Should fix issue #8499