### PR TITLE
Fix inconsistent results with self interpolation

### DIFF
--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -48,6 +48,18 @@ func NewRawConfig(raw map[string]interface{}) (*RawConfig, error) {
 	return result, nil
 }
 
+// RawMap returns a copy of the RawConfig.Raw map.
+func (r *RawConfig) RawMap() map[string]interface{} {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	m := make(map[string]interface{})
+	for k, v := range r.Raw {
+		m[k] = v
+	}
+	return m
+}
+
 // Copy returns a copy of this RawConfig, uninterpolated.
 func (r *RawConfig) Copy() *RawConfig {
 	r.lock.Lock()
@@ -192,6 +204,9 @@ func (r *RawConfig) Merge(other *RawConfig) *RawConfig {
 }
 
 func (r *RawConfig) init() error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	r.config = r.Raw
 	r.Interpolations = nil
 	r.Variables = nil
@@ -261,6 +276,8 @@ func (r *RawConfig) merge(r2 *RawConfig) *RawConfig {
 // UnknownKeys returns the keys of the configuration that are unknown
 // because they had interpolated variables that must be computed.
 func (r *RawConfig) UnknownKeys() []string {
+	r.lock.Lock()
+	defer r.lock.Unlock()
 	return r.unknownKeys
 }
 

--- a/config/raw_config_test.go
+++ b/config/raw_config_test.go
@@ -342,3 +342,27 @@ func TestRawConfig_implGob(t *testing.T) {
 	var _ gob.GobDecoder = new(RawConfig)
 	var _ gob.GobEncoder = new(RawConfig)
 }
+
+// verify that RawMap returns a identical copy
+func TestNewRawConfig_rawMap(t *testing.T) {
+	raw := map[string]interface{}{
+		"foo": "${var.bar}",
+		"bar": `${file("boom.txt")}`,
+	}
+
+	rc, err := NewRawConfig(raw)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	rawCopy := rc.RawMap()
+	if !reflect.DeepEqual(raw, rawCopy) {
+		t.Fatalf("bad: %#v", rawCopy)
+	}
+
+	// make sure they aren't the same map
+	raw["test"] = "value"
+	if reflect.DeepEqual(raw, rawCopy) {
+		t.Fatal("RawMap() didn't return a copy")
+	}
+}

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -239,6 +239,6 @@ func (c *ResourceConfig) interpolateForce() {
 	}
 
 	c.ComputedKeys = c.raw.UnknownKeys()
-	c.Raw = c.raw.Raw
+	c.Raw = c.raw.RawMap()
 	c.Config = c.raw.Config()
 }


### PR DESCRIPTION
Due to a race in interpolateForce(), a reference to self could return
inconsistent results.