### PR TITLE
provider/fastly: Change error text on findService

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -1519,7 +1519,7 @@ func findService(id string, meta interface{}) (*gofastly.Service, error) {
 
 	l, err := conn.ListServices(&gofastly.ListServicesInput{})
 	if err != nil {
-		return nil, fmt.Errorf("[WARN] Error listing services when deleting Fastly Service (%s): %s", id, err)
+		return nil, fmt.Errorf("[WARN] Error listing services (%s): %s", id, err)
 	}
 
 	for _, s := range l {


### PR DESCRIPTION
This PR changes error message on `findService` function on [resource_fastly_service_v1.go](https://github.com/hashicorp/terraform/blob/master/builtin/providers/fastly/resource_fastly_service_v1.go) file.

I was performing `terraform plan` locally and got this error, like this:

```
* fastly_service_v1.REDACTED: [WARN] Error listing services when deleting Fastly Service (REDACTED): 401 - Unauthorized
Message: Provided credentials are missing or invalid
```

I was misinformed by the message, because I thought Terraform actually tried to delete my (production) services. I looked into resource_fastly_service_v1.go and found out that it's an error message printed at `findService` function, which doesn't do any destructive action by itself.