### PR TITLE
provider/aws: `aws_spot_fleet_request` was leaving orphaned instances running

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request_test.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request_test.go
@@ -403,7 +403,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -451,7 +454,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -499,7 +505,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -554,7 +563,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -625,7 +637,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -680,7 +695,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -745,7 +763,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -801,7 +822,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }
@@ -863,7 +887,10 @@ resource "aws_iam_role" "test-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "spotfleet.amazonaws.com"
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
       },
       "Action": "sts:AssumeRole"
     }


### PR DESCRIPTION
Each nightly build was leaving multiple instances running. The issue is
that the IAM role we were using didn't have access to Terminate the EC2
instances

The role was missing the ec2 principle