### PR TITLE
adding locks

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -755,10 +755,19 @@ func (r *RemoteState) deepcopy() *RemoteState {
 }
 
 func (r *RemoteState) Empty() bool {
-	return r == nil || r.Type == ""
+	if r == nil {
+		return true
+	}
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Type == ""
 }
 
 func (r *RemoteState) Equals(other *RemoteState) bool {
+	r.Lock()
+	defer r.Unlock()
+
 	if r.Type != other.Type {
 		return false
 	}

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -886,6 +886,9 @@ func (s *ModuleState) Unlock() { s.mu.Unlock() }
 
 // Equal tests whether one module state is equal to another.
 func (m *ModuleState) Equal(other *ModuleState) bool {
+	m.Lock()
+	defer m.Unlock()
+
 	// Paths must be equal
 	if !reflect.DeepEqual(m.Path, other.Path) {
 		return false
@@ -934,11 +937,16 @@ func (m *ModuleState) Equal(other *ModuleState) bool {
 
 // IsRoot says whether or not this module diff is for the root module.
 func (m *ModuleState) IsRoot() bool {
+	m.Lock()
+	defer m.Unlock()
 	return reflect.DeepEqual(m.Path, rootModulePath)
 }
 
 // IsDescendent returns true if other is a descendent of this module.
 func (m *ModuleState) IsDescendent(other *ModuleState) bool {
+	m.Lock()
+	defer m.Unlock()
+
 	i := len(m.Path)
 	return len(other.Path) > i && reflect.DeepEqual(other.Path[:i], m.Path)
 }
@@ -947,6 +955,9 @@ func (m *ModuleState) IsDescendent(other *ModuleState) bool {
 // but aren't present in the configuration itself. Hence, these keys
 // represent the state of resources that are orphans.
 func (m *ModuleState) Orphans(c *config.Config) []string {
+	m.Lock()
+	defer m.Unlock()
+
 	keys := make(map[string]struct{})
 	for k, _ := range m.Resources {
 		keys[k] = struct{}{}
@@ -1028,6 +1039,9 @@ func (m *ModuleState) deepcopy() *ModuleState {
 
 // prune is used to remove any resources that are no longer required
 func (m *ModuleState) prune() {
+	m.Lock()
+	defer m.Unlock()
+
 	for k, v := range m.Resources {
 		v.prune()
 
@@ -1050,6 +1064,9 @@ func (m *ModuleState) sort() {
 }
 
 func (m *ModuleState) String() string {
+	m.Lock()
+	defer m.Unlock()
+
 	var buf bytes.Buffer
 
 	if len(m.Resources) == 0 {

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -128,6 +128,11 @@ func (s *State) children(path []string) []*ModuleState {
 func (s *State) AddModule(path []string) *ModuleState {
 	s.Lock()
 	defer s.Unlock()
+
+	return s.addModule(path)
+}
+
+func (s *State) addModule(path []string) *ModuleState {
 	// check if the module exists first
 	m := s.moduleByPath(path)
 	if m != nil {
@@ -616,10 +621,10 @@ func (s *State) init() {
 	if s.Version == 0 {
 		s.Version = StateVersion
 	}
-	if s.ModuleByPath(rootModulePath) == nil {
-		s.AddModule(rootModulePath)
+	if s.moduleByPath(rootModulePath) == nil {
+		s.addModule(rootModulePath)
 	}
-	s.EnsureHasLineage()
+	s.ensureHasLineage()
 
 	for _, mod := range s.Modules {
 		mod.init()
@@ -634,6 +639,10 @@ func (s *State) EnsureHasLineage() {
 	s.Lock()
 	defer s.Unlock()
 
+	s.ensureHasLineage()
+}
+
+func (s *State) ensureHasLineage() {
 	if s.Lineage == "" {
 		s.Lineage = uuid.NewV4().String()
 		log.Printf("[DEBUG] New state was assigned lineage %q\n", s.Lineage)
@@ -648,6 +657,10 @@ func (s *State) AddModuleState(mod *ModuleState) {
 	s.Lock()
 	defer s.Unlock()
 
+	s.addModuleState(mod)
+}
+
+func (s *State) addModuleState(mod *ModuleState) {
 	for i, m := range s.Modules {
 		if reflect.DeepEqual(m.Path, mod.Path) {
 			s.Modules[i] = mod

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -814,6 +814,8 @@ func (s *OutputState) Equal(other *OutputState) bool {
 	if s == nil || other == nil {
 		return false
 	}
+	s.Lock()
+	defer s.Unlock()
 
 	if s.Type != other.Type {
 		return false


### PR DESCRIPTION
I don't see an easy way out of the concurrency issues without a major refactor. This PR aims to be an intermediate step which will add locks around all concurrently accessed data structures used in the graph walks. This isn't necessarily going to make managing the current code easier, but it will hopefully make it more correct. 

The first round of changes will add locks to all exported methods of the various State and Diff structs. If these methods need to be called while holding a lock, we delegate the functionality to a matching private method that does not acquire the mutex. This will provide a pattern to follow, so that we can always ensure that all access is done through a mutex.
