### PR TITLE
providers/template: template_file supports floating point math

### DIFF
--- a/builtin/providers/template/datasource_template_file.go
+++ b/builtin/providers/template/datasource_template_file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/hil"
@@ -116,9 +117,20 @@ func execute(s string, vars map[string]interface{}) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("unexpected type for variable %q: %T", k, v)
 		}
+
+		// Store the defaults (string and value)
+		var val interface{} = s
+		typ := ast.TypeString
+
+		// If we can parse a float, then use that
+		if v, err := strconv.ParseFloat(s, 64); err == nil {
+			val = v
+			typ = ast.TypeFloat
+		}
+
 		varmap[k] = ast.Variable{
-			Value: s,
-			Type:  ast.TypeString,
+			Value: val,
+			Type:  typ,
 		}
 	}
 

--- a/builtin/providers/template/datasource_template_file_test.go
+++ b/builtin/providers/template/datasource_template_file_test.go
@@ -26,6 +26,8 @@ func TestTemplateRendering(t *testing.T) {
 		{`{a="foo"}`, `$${a}`, `foo`},
 		{`{a="hello"}`, `$${replace(a, "ello", "i")}`, `hi`},
 		{`{}`, `${1+2+3}`, `6`},
+		{`{a=1, b=2}`, `$${a+b}`, `3`},
+		{`{a=0.1, b=0.2}`, `$${0+((a+b)*10)}`, `3`},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
Fixes #7887 

This adds a special case to detect numbers as floating point variables and converts them to floats. This allows floating point math to work.