### PR TITLE
command/meta: validate config right away

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
@@ -27,7 +28,11 @@ const DefaultBackupExtension = ".backup"
 const DefaultParallelism = 10
 
 func validateContext(ctx *terraform.Context, ui cli.Ui) bool {
-	if ws, es := ctx.Validate(); len(ws) > 0 || len(es) > 0 {
+	log.Println("[INFO] Validating the context...")
+	ws, es := ctx.Validate()
+	log.Printf("[INFO] Validation result: %d warnings, %d errors", len(ws), len(es))
+
+	if len(ws) > 0 || len(es) > 0 {
 		ui.Output(
 			"There are warnings and/or errors related to your configuration. Please\n" +
 				"fix these before continuing.\n")

--- a/command/meta.go
+++ b/command/meta.go
@@ -165,6 +165,11 @@ func (m *Meta) Context(copts contextOpts) (*terraform.Context, bool, error) {
 		return nil, false, fmt.Errorf("Error downloading modules: %s", err)
 	}
 
+	// Validate the module right away
+	if err := mod.Validate(); err != nil {
+		return nil, false, err
+	}
+
 	opts.Module = mod
 	opts.Parallelism = copts.Parallelism
 	opts.State = state.State()

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -395,6 +395,31 @@ func TestPlan_statePast(t *testing.T) {
 	}
 }
 
+func TestPlan_validate(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.Chdir(testFixturePath("plan-invalid")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Chdir(cwd)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &PlanCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
 func TestPlan_vars(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -396,6 +396,10 @@ func TestPlan_statePast(t *testing.T) {
 }
 
 func TestPlan_validate(t *testing.T) {
+	// This is triggered by not asking for input so we have to set this to false
+	test = false
+	defer func() { test = true }()
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -417,6 +421,11 @@ func TestPlan_validate(t *testing.T) {
 	args := []string{}
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	actual := ui.ErrorWriter.String()
+	if !strings.Contains(actual, "can't reference") {
+		t.Fatalf("bad: %s", actual)
 	}
 }
 

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -765,8 +765,7 @@ func pushTFVars() []atlas.TFVar {
 	return []atlas.TFVar{
 		{"bar", "foo", false},
 		{"baz", `{
-  A      = "a"
-  interp = "${file("t.txt")}"
+  A = "a"
 }`, true},
 		{"fob", `["a", "quotes \"in\" quotes"]`, true},
 		{"foo", "bar", false},

--- a/command/test-fixtures/plan-invalid/main.tf
+++ b/command/test-fixtures/plan-invalid/main.tf
@@ -1,0 +1,7 @@
+resource "test_instance" "foo" {
+    count = 5
+}
+
+resource "test_instance" "bar" {
+    count = "${length(test_instance.foo.*.id)}"
+}

--- a/command/test-fixtures/push-tfvars/main.tf
+++ b/command/test-fixtures/push-tfvars/main.tf
@@ -7,7 +7,6 @@ variable "baz" {
 
   default = {
     "A"    = "a"
-    interp = "${file("t.txt")}"
   }
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -195,6 +195,13 @@ func TestConfigValidate_countResourceVar(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_countResourceVarMulti(t *testing.T) {
+	c := testConfig(t, "validate-count-resource-var-multi")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_countUserVar(t *testing.T) {
 	c := testConfig(t, "validate-count-user-var")
 	if err := c.Validate(); err != nil {

--- a/config/test-fixtures/validate-count-resource-var-multi/main.tf
+++ b/config/test-fixtures/validate-count-resource-var-multi/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "foo" {}
+
+resource "aws_instance" "web" {
+    count = "${length(aws_instance.foo.*.bar)}"
+}


### PR DESCRIPTION
Fixes #8524 

We were running `Input` before ever validating the configuration. This makes sense because `Context.Validate` require vars be set before running. However, we should always validate the configuration itself before doing anything else to catch issues like the above that is fixed.

This caught some errors in the tests I had to fix which should've never worked, you can't have interpolated defaults in variables for example.