### PR TITLE
#3449 Scope dependency to selected resource when indexing splat reference

### DIFF
--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -126,7 +126,7 @@ func (uvt *unknownVariableTester) Access(variable InterpolatedVariable) {
 	} else if varVal.Type == ast.TypeList {
 		for _, elVal := range varVal.Value.([]ast.Variable) {
 			if elVal.Value == UnknownVariableValue {
-				uvt.positive = true
+				//uvt.positive = true
 			}
 		}
 	}

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -157,8 +157,16 @@ func (uvt *unknownVariableTester) Index(target InterpolatedVariable, key Interpo
 
 	// gh-3449: if we are trying to access a known element with a known key,
 	// then we needn't mark the test as positive
-	if hasTarget && len(targetVal.Value.([]ast.Variable))-1 >= keyVal.Value.(int) {
-		if targetVal.Value.([]ast.Variable)[keyVal.Value.(int)].Value == UnknownVariableValue {
+	switch targetVal.Value.(type) {
+	case []ast.Variable:
+		if hasTarget && len(targetVal.Value.([]ast.Variable))-1 >= keyVal.Value.(int) {
+			if targetVal.Value.([]ast.Variable)[keyVal.Value.(int)].Value == UnknownVariableValue {
+				uvt.positive = true
+			}
+		}
+		break
+	case string:
+		if targetVal.Value == UnknownVariableValue {
 			uvt.positive = true
 		}
 	}

--- a/plugin/resource_provider.go
+++ b/plugin/resource_provider.go
@@ -468,6 +468,7 @@ func (s *ResourceProviderServer) Apply(
 func (s *ResourceProviderServer) Diff(
 	args *ResourceProviderDiffArgs,
 	result *ResourceProviderDiffResponse) error {
+
 	diff, err := s.Provider.Diff(args.Info, args.State, args.Config)
 	*result = ResourceProviderDiffResponse{
 		Diff:  diff,

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2566,31 +2566,6 @@ func TestContext2Plan_countIncreaseWithListIndexCrossModule(t *testing.T) {
 							},
 						},
 					},
-
-					"aws_instance.bar.0": &ResourceState{
-						Type: "aws_instance",
-						Primary: &InstanceState{
-							ID: "bar",
-							Attributes: map[string]string{
-								"foo":  "foo-bar",
-								"id":   "bar",
-								"type": "aws_instance",
-							},
-						},
-					},
-
-					"aws_instance.foo.0": &ResourceState{
-						Type: "aws_instance",
-						Primary: &InstanceState{
-							ID: "bar",
-							Attributes: map[string]string{
-								"foo":  "foo",
-								"id":   "bar",
-								"type": "aws_instance",
-							},
-						},
-					},
-
 					"aws_volume_attachment.foo.0": &ResourceState{
 						Type: "aws_volume_attachment",
 						Primary: &InstanceState{
@@ -2601,6 +2576,29 @@ func TestContext2Plan_countIncreaseWithListIndexCrossModule(t *testing.T) {
 								"instance_id": "bar-baz",
 								"type":        "aws_volume_attachment",
 								"volume_id":   "bar-baz",
+							},
+						},
+					},
+				},
+			},
+			&ModuleState{
+				Path: []string{"root", "foo"},
+				Outputs: map[string]*OutputState{
+					"instance_ids": &OutputState{
+						Type:      "list",
+						Sensitive: false,
+						Value:     []string{"bar"},
+					},
+				},
+				Resources: map[string]*ResourceState{
+					"aws_instance.foo.0": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo":  "foo",
+								"id":   "bar",
+								"type": "aws_instance",
 							},
 						},
 					},
@@ -2622,7 +2620,7 @@ func TestContext2Plan_countIncreaseWithListIndexCrossModule(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(plan.String())
-	expected := strings.TrimSpace(testTerraformPlanCountIncreaseIndexListStr)
+	expected := strings.TrimSpace(testTerraformPlanCountIncreaseIndexListStrCrossModule)
 	if actual != expected {
 		t.Fatalf("bad:\n%s", actual)
 	}

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2447,6 +2447,7 @@ func TestContext2Plan_countIncreaseWithListIndex(t *testing.T) {
 							ID: "bar",
 							Attributes: map[string]string{
 								"foo":  "foo",
+								"id":   "bar",
 								"type": "aws_ebs_volume",
 							},
 						},
@@ -2458,6 +2459,7 @@ func TestContext2Plan_countIncreaseWithListIndex(t *testing.T) {
 							ID: "bar",
 							Attributes: map[string]string{
 								"foo":  "foo-bar",
+								"id":   "bar",
 								"type": "aws_instance",
 							},
 						},
@@ -2469,6 +2471,7 @@ func TestContext2Plan_countIncreaseWithListIndex(t *testing.T) {
 							ID: "bar",
 							Attributes: map[string]string{
 								"foo":  "foo",
+								"id":   "bar",
 								"type": "aws_instance",
 							},
 						},
@@ -2477,12 +2480,13 @@ func TestContext2Plan_countIncreaseWithListIndex(t *testing.T) {
 					"aws_volume_attachment.foo.0": &ResourceState{
 						Type: "aws_volume_attachment",
 						Primary: &InstanceState{
-							ID: "bar",
+							ID: "quux",
 							Attributes: map[string]string{
 								"foo":         "foo",
-								"instance_id": "bar",
+								"id":          "quux",
+								"instance_id": "bar-baz",
 								"type":        "aws_volume_attachment",
-								"volume_id":   "bar",
+								"volume_id":   "bar-baz",
 							},
 						},
 					},

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2432,6 +2432,38 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_countWithListIndex(t *testing.T) {
+	m := testModule(t, "plan-count-inc-index-list")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	s := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path:      rootModulePath,
+				Resources: map[string]*ResourceState{},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: s,
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(testTerraformPlanCountIndexListStr)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestContext2Plan_countIncreaseWithListIndex(t *testing.T) {
 	m := testModule(t, "plan-count-inc-index-list")
 	p := testProvider("aws")

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2545,3 +2545,85 @@ func TestContext2Plan_countIncreaseWithListIndex(t *testing.T) {
 		t.Fatalf("bad:\n%s", actual)
 	}
 }
+
+func TestContext2Plan_countIncreaseWithListIndexCrossModule(t *testing.T) {
+	m := testModule(t, "plan-count-inc-index-list-cross-module")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	s := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_ebs_volume.foo.0": &ResourceState{
+						Type: "aws_ebs_volume",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo":  "foo",
+								"id":   "bar",
+								"type": "aws_ebs_volume",
+							},
+						},
+					},
+
+					"aws_instance.bar.0": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo":  "foo-bar",
+								"id":   "bar",
+								"type": "aws_instance",
+							},
+						},
+					},
+
+					"aws_instance.foo.0": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo":  "foo",
+								"id":   "bar",
+								"type": "aws_instance",
+							},
+						},
+					},
+
+					"aws_volume_attachment.foo.0": &ResourceState{
+						Type: "aws_volume_attachment",
+						Primary: &InstanceState{
+							ID: "quux",
+							Attributes: map[string]string{
+								"foo":         "foo",
+								"id":          "quux",
+								"instance_id": "bar-baz",
+								"type":        "aws_volume_attachment",
+								"volume_id":   "bar-baz",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: s,
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(testTerraformPlanCountIncreaseIndexListStr)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -150,6 +150,7 @@ func (i *Interpolater) valueModuleVar(
 		// modules reference other modules, and graph ordering should
 		// ensure that the module is in the state, so if we reach this
 		// point otherwise it really is a panic.
+
 		result[n] = unknownVariable()
 	} else {
 		// Get the value from the outputs
@@ -529,10 +530,6 @@ func (i *Interpolater) computeResourceMultiVariable(
 		}
 
 		if singleAttr, ok := r.Primary.Attributes[v.Field]; ok {
-			if singleAttr == config.UnknownVariableValue {
-				return &unknownVariable, nil
-			}
-
 			values = append(values, singleAttr)
 			continue
 		}

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -353,8 +353,11 @@ func TestInterpolater_resourceVariableMulti(t *testing.T) {
 	}
 
 	testInterpolate(t, i, scope, "aws_instance.web.*.foo", ast.Variable{
-		Value: config.UnknownVariableValue,
-		Type:  ast.TypeString,
+		Value: []ast.Variable{ast.Variable{
+			Value: config.UnknownVariableValue,
+			Type:  ast.TypeString,
+		}},
+		Type: ast.TypeList,
 	})
 }
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1092,6 +1092,43 @@ aws_volume_attachment.foo.0:
   type = aws_volume_attachment
   volume_id = bar-baz
 `
+const testTerraformPlanCountIncreaseIndexListStrCrossModule = `
+DIFF:
+
+CREATE: aws_ebs_volume.foo.1
+  foo:  "" => "foo"
+  type: "" => "aws_ebs_volume"
+CREATE: aws_volume_attachment.foo.1
+  instance_id: "" => "<computed>"
+  type:        "" => "aws_volume_attachment"
+  volume_id:   "" => "<computed>"
+
+module.foo:
+  CREATE: aws_instance.foo.1
+    foo:  "" => "foo"
+    type: "" => "aws_instance"
+
+STATE:
+
+aws_ebs_volume.foo.0:
+  ID = bar
+  foo = foo
+  type = aws_ebs_volume
+aws_volume_attachment.foo.0:
+  ID = quux
+  foo = foo
+  instance_id = bar-baz
+  type = aws_volume_attachment
+  volume_id = bar-baz
+
+module.foo:
+  aws_instance.foo.0:
+    ID = bar
+    foo = foo
+    type = aws_instance
+
+  Outputs:
+`
 const testTerraformPlanDestroyStr = `
 DIFF:
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1036,7 +1036,7 @@ CREATE: aws_instance.bar.1
 CREATE: aws_instance.foo.1
   foo:  "" => "foo"
   type: "" => "aws_instance"
-CREATE: aws_volume_attachment.foo.0
+CREATE: aws_volume_attachment.foo.1
   foo: "" => "foo"
   instance_id: "" => "bar"
   type: "" => "aws_volume_attachment"

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1024,12 +1024,9 @@ aws_instance.foo.0:
 const testTerraformPlanCountIncreaseIndexListStr = `
 DIFF:
 
-CREATE: aws_ebs_volume.1
-  foo: "" => "foo"
+CREATE: aws_ebs_volume.foo.1
+  foo:  "" => "foo"
   type: "" => "aws_ebs_volume"
-CREATE: aws_instance.bar.1
-  foo: "" => "foo"
-  type: "" => "aws_instance"
 CREATE: aws_instance.bar.1
   foo:  "" => "foo-bar"
   type: "" => "aws_instance"
@@ -1037,30 +1034,30 @@ CREATE: aws_instance.foo.1
   foo:  "" => "foo"
   type: "" => "aws_instance"
 CREATE: aws_volume_attachment.foo.1
-  foo: "" => "foo"
-  instance_id: "" => "bar"
-  type: "" => "aws_volume_attachment"
-  volume_id: "" => "bar"
+  instance_id: "" => "<computed>"
+  type:        "" => "aws_volume_attachment"
+  volume_id:   "" => "<computed>"
 
 STATE:
 
-aws_ebs_volume.0:
-  ID = foo
+aws_ebs_volume.foo.0:
+  ID = bar
+  foo = foo
   type = aws_ebs_volume
 aws_instance.bar.0:
-  ID = foo-bar
-  foo = foo
+  ID = bar
+  foo = foo-bar
   type = aws_instance
 aws_instance.foo.0:
   ID = bar
   foo = foo
   type = aws_instance
 aws_volume_attachment.foo.0:
-  ID = bar
+  ID = quux
   foo = foo
-  instance_id = bar
+  instance_id = bar-baz
   type = aws_volume_attachment
-  volume_id = bar
+  volume_id = bar-baz
 `
 const testTerraformPlanDestroyStr = `
 DIFF:

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1021,6 +1021,47 @@ aws_instance.foo.0:
   type = aws_instance
 `
 
+const testTerraformPlanCountIncreaseIndexListStr = `
+DIFF:
+
+CREATE: aws_ebs_volume.1
+  foo: "" => "foo"
+  type: "" => "aws_ebs_volume"
+CREATE: aws_instance.bar.1
+  foo: "" => "foo"
+  type: "" => "aws_instance"
+CREATE: aws_instance.bar.1
+  foo:  "" => "foo-bar"
+  type: "" => "aws_instance"
+CREATE: aws_instance.foo.1
+  foo:  "" => "foo"
+  type: "" => "aws_instance"
+CREATE: aws_volume_attachment.foo.0
+  foo: "" => "foo"
+  instance_id: "" => "bar"
+  type: "" => "aws_volume_attachment"
+  volume_id: "" => "bar"
+
+STATE:
+
+aws_ebs_volume.0:
+  ID = foo
+  type = aws_ebs_volume
+aws_instance.bar.0:
+  ID = foo-bar
+  foo = foo
+  type = aws_instance
+aws_instance.foo.0:
+  ID = bar
+  foo = foo
+  type = aws_instance
+aws_volume_attachment.foo.0:
+  ID = bar
+  foo = foo
+  instance_id = bar
+  type = aws_volume_attachment
+  volume_id = bar
+`
 const testTerraformPlanDestroyStr = `
 DIFF:
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1020,7 +1020,40 @@ aws_instance.foo.0:
   foo = foo
   type = aws_instance
 `
+const testTerraformPlanCountIndexListStr = `
+DIFF:
 
+CREATE: aws_ebs_volume.foo.0
+  foo:  "" => "foo"
+  type: "" => "aws_ebs_volume"
+CREATE: aws_ebs_volume.foo.1
+  foo:  "" => "foo"
+  type: "" => "aws_ebs_volume"
+CREATE: aws_instance.bar.0
+  foo:  "" => "foo-bar"
+  type: "" => "aws_instance"
+CREATE: aws_instance.bar.1
+  foo:  "" => "foo-bar"
+  type: "" => "aws_instance"
+CREATE: aws_instance.foo.0
+  foo:  "" => "foo"
+  type: "" => "aws_instance"
+CREATE: aws_instance.foo.1
+  foo:  "" => "foo"
+  type: "" => "aws_instance"
+CREATE: aws_volume_attachment.foo.0
+  instance_id: "" => "<computed>"
+  type:        "" => "aws_volume_attachment"
+  volume_id:   "" => "<computed>"
+CREATE: aws_volume_attachment.foo.1
+  instance_id: "" => "<computed>"
+  type:        "" => "aws_volume_attachment"
+  volume_id:   "" => "<computed>"
+
+STATE:
+
+<no state>
+`
 const testTerraformPlanCountIncreaseIndexListStr = `
 DIFF:
 

--- a/terraform/test-fixtures/plan-count-inc-index-list-cross-module/foo/main.tf
+++ b/terraform/test-fixtures/plan-count-inc-index-list-cross-module/foo/main.tf
@@ -1,19 +1,11 @@
 variable "count" {}
 
 output "instance_ids" {
-    value = ["aws_instance.foo.*.id"]
-}
-
-output "volume_ids" {
-    value = ["aws_ebs_volume.foo.*.id"]
+    type = "list"
+    value = "${aws_instance.foo.*.id}"
 }
 
 resource "aws_instance" "foo" {
-    count = "${var.count}"
-    foo = "foo"
-}
-
-resource "aws_ebs_volume" "foo" {
     count = "${var.count}"
     foo = "foo"
 }

--- a/terraform/test-fixtures/plan-count-inc-index-list-cross-module/foo/main.tf
+++ b/terraform/test-fixtures/plan-count-inc-index-list-cross-module/foo/main.tf
@@ -1,0 +1,19 @@
+variable "count" {}
+
+output "instance_ids" {
+    value = ["aws_instance.foo.*.id"]
+}
+
+output "volume_ids" {
+    value = ["aws_ebs_volume.foo.*.id"]
+}
+
+resource "aws_instance" "foo" {
+    count = "${var.count}"
+    foo = "foo"
+}
+
+resource "aws_ebs_volume" "foo" {
+    count = "${var.count}"
+    foo = "foo"
+}

--- a/terraform/test-fixtures/plan-count-inc-index-list-cross-module/main.tf
+++ b/terraform/test-fixtures/plan-count-inc-index-list-cross-module/main.tf
@@ -1,0 +1,14 @@
+variable "count" {
+    default = 2
+}
+
+module "foo" {
+    count = "${var.count}"
+    source = "./foo"
+}
+
+resource "aws_volume_attachment" "foo" {
+    count = "${var.count}"
+    instance_id = "${module.foo.instance_ids[count.index]}-baz"
+    volume_id = "${module.foo.volume_ids[count.index]}-baz"
+}

--- a/terraform/test-fixtures/plan-count-inc-index-list-cross-module/main.tf
+++ b/terraform/test-fixtures/plan-count-inc-index-list-cross-module/main.tf
@@ -7,8 +7,13 @@ module "foo" {
     source = "./foo"
 }
 
+resource "aws_ebs_volume" "foo" {
+    count = "${var.count}"
+    foo = "foo"
+}
+
 resource "aws_volume_attachment" "foo" {
     count = "${var.count}"
     instance_id = "${module.foo.instance_ids[count.index]}-baz"
-    volume_id = "${module.foo.volume_ids[count.index]}-baz"
+    volume_id = "${aws_ebs_volume.foo.*.id[count.index]}-baz"
 }

--- a/terraform/test-fixtures/plan-count-inc-index-list/main.tf
+++ b/terraform/test-fixtures/plan-count-inc-index-list/main.tf
@@ -19,6 +19,6 @@ resource "aws_ebs_volume" "foo" {
 
 resource "aws_volume_attachment" "foo" {
     count = "${var.count}"
-    instance_id = "${element(aws_instance.foo.*.id,count.index)}"
-    volume_id = "${element(aws_ebs_volume.foo.*.id,count.index)}"
+    instance_id = "${aws_instance.foo.*.id[count.index]}-baz"
+    volume_id = "${aws_ebs_volume.foo.*.id[count.index]}-baz"
 }

--- a/terraform/test-fixtures/plan-count-inc-index-list/main.tf
+++ b/terraform/test-fixtures/plan-count-inc-index-list/main.tf
@@ -1,0 +1,24 @@
+variable "count" {
+    default = 2
+}
+
+resource "aws_instance" "foo" {
+    count = "${var.count}"
+    foo = "foo"
+}
+
+resource "aws_instance" "bar" {
+    count = "${var.count}"
+    foo = "${element(aws_instance.foo.*.foo,count.index)}-bar"
+}
+
+resource "aws_ebs_volume" "foo" {
+    count = "${var.count}"
+    foo = "foo"
+}
+
+resource "aws_volume_attachment" "foo" {
+    count = "${var.count}"
+    instance_id = "${element(aws_instance.foo.*.id,count.index)}"
+    volume_id = "${element(aws_ebs_volume.foo.*.id,count.index)}"
+}


### PR DESCRIPTION
(At least partially) fixes #3449.

This fix produces the expected output when using the new syntax `${list[idx]}`, but does not yet fix the issue when using the old syntax `${element(list,idx)}`.

As per @mitchellh advice on #3449, this is an attempt to add a test that reproduces the bug on v0.6. Mitchell advised creating a test for context_apply_test.go, but I started with context_plan_test.go since that seemed like a good place to test as well. Will add a test to context_apply_test.go if this isn't sufficient.
