### PR TITLE
provider/librato: Refresh space from state when not found

### DIFF
--- a/builtin/providers/librato/resource_librato_space.go
+++ b/builtin/providers/librato/resource_librato_space.go
@@ -115,6 +115,11 @@ func resourceLibratoSpaceDelete(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[INFO] Deleting Space: %d", id)
 	_, err = client.Spaces.Delete(uint(id))
 	if err != nil {
+		if errResp, ok := err.(*librato.ErrorResponse); ok && errResp.Response.StatusCode == 404 {
+			log.Printf("Space %s not found", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error deleting space: %s", err)
 	}
 


### PR DESCRIPTION
The librator provider is sometimes throwing errors when trying to delete
a space that is already deleted. The nightly tests shows this error:

```
Error: Error applying: 1 error(s) occurred:

                * librato_space.foobar: Error deleting space: DELETE
                * https://metrics-api.librato.com/v1/spaces/236303: 404
                * Request errors: Not Found,.
```

The Delete func should be aware if the space cannot be deleted as it is
already deleted and not error on this usecase

```
% make testacc TEST=./builtin/providers/librato TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/01 09:24:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/librato -v -run=Test -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccLibratoAlert_Basic
--- PASS: TestAccLibratoAlert_Basic (1.52s)
=== RUN   TestAccLibratoAlert_Full
--- PASS: TestAccLibratoAlert_Full (2.89s)
=== RUN   TestAccLibratoAlert_Updated
--- PASS: TestAccLibratoAlert_Updated (1.76s)
=== RUN   TestAccLibratoService_Basic
--- PASS: TestAccLibratoService_Basic (2.09s)
=== RUN   TestAccLibratoService_Updated
--- PASS: TestAccLibratoService_Updated (2.73s)
=== RUN   TestAccLibratoSpaceChart_Basic
--- PASS: TestAccLibratoSpaceChart_Basic (5.08s)
=== RUN   TestAccLibratoSpaceChart_Full
--- PASS: TestAccLibratoSpaceChart_Full (13.06s)
=== RUN   TestAccLibratoSpaceChart_Updated
--- PASS: TestAccLibratoSpaceChart_Updated (5.90s)
=== RUN   TestAccLibratoSpace_Basic
--- PASS: TestAccLibratoSpace_Basic (4.29s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/librato       	39.321s
```