### PR TITLE
core: add wildcard (match all) support to ignore_changes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -570,6 +570,15 @@ func (c *Config) Validate() error {
 				}
 			}
 		}
+
+		// Verify ignore_changes contains valid entries
+		for _, v := range r.Lifecycle.IgnoreChanges {
+			if strings.Contains(v, "*") && v != "*" {
+				errs = append(errs, fmt.Errorf(
+					"%s: ignore_changes does not support using a partial string "+
+						"together with a wildcard: %s", n, v))
+			}
+		}
 	}
 
 	for source, vs := range vars {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -244,6 +244,20 @@ func TestConfigValidate_dupResource(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_ignoreChanges(t *testing.T) {
+	c := testConfig(t, "validate-ignore-changes")
+	if err := c.Validate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestConfigValidate_ignoreChangesBad(t *testing.T) {
+	c := testConfig(t, "validate-ignore-changes-bad")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_moduleNameBad(t *testing.T) {
 	c := testConfig(t, "validate-module-name-bad")
 	if err := c.Validate(); err == nil {

--- a/config/test-fixtures/validate-ignore-changes-bad/main.tf
+++ b/config/test-fixtures/validate-ignore-changes-bad/main.tf
@@ -1,0 +1,21 @@
+variable "foo" {
+  default = "ami-abcd1234"
+}
+
+variable "bar" {
+  default = "t2.micro"
+}
+
+provider "aws" {
+  access_key = "foo"
+  secret_key = "bar"
+}
+
+resource aws_instance "web" {
+  ami           = "${var.foo}"
+  instance_type = "${var.bar}"
+
+  lifecycle {
+    ignore_changes = ["ami", "instance*"]
+  }
+}

--- a/config/test-fixtures/validate-ignore-changes/main.tf
+++ b/config/test-fixtures/validate-ignore-changes/main.tf
@@ -1,0 +1,21 @@
+variable "foo" {
+  default = "ami-abcd1234"
+}
+
+variable "bar" {
+  default = "t2.micro"
+}
+
+provider "aws" {
+  access_key = "foo"
+  secret_key = "bar"
+}
+
+resource aws_instance "web" {
+  ami           = "${var.foo}"
+  instance_type = "${var.bar}"
+
+  lifecycle {
+    ignore_changes = ["*"]
+  }
+}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -188,7 +188,7 @@ func (n *EvalDiff) processIgnoreChanges(diff *InstanceDiff) error {
 	ignorableAttrKeys := make(map[string]bool)
 	for _, ignoredKey := range ignoreChanges {
 		for k := range diff.CopyAttributes() {
-			if strings.HasPrefix(k, ignoredKey) {
+			if ignoredKey == "*" || strings.HasPrefix(k, ignoredKey) {
 				ignorableAttrKeys[k] = true
 			}
 		}

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1407,6 +1407,19 @@ aws_instance.foo:
   ami = ami-abcd1234
 `
 
+const testTerraformPlanIgnoreChangesWildcardStr = `
+DIFF:
+
+
+
+STATE:
+
+aws_instance.foo:
+  ID = bar
+  ami = ami-abcd1234
+  instance_type = t2.micro
+`
+
 const testTerraformPlanComputedValueInMap = `
 DIFF:
 

--- a/terraform/test-fixtures/apply-ignore-changes-wildcard/main.tf
+++ b/terraform/test-fixtures/apply-ignore-changes-wildcard/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+  required_field = "set"
+
+  lifecycle {
+    ignore_changes = ["*"]
+  }
+}

--- a/terraform/test-fixtures/plan-ignore-changes-wildcard/main.tf
+++ b/terraform/test-fixtures/plan-ignore-changes-wildcard/main.tf
@@ -1,0 +1,12 @@
+variable "foo" {}
+
+variable "bar" {}
+
+resource "aws_instance" "foo" {
+  ami           = "${var.foo}"
+  instance_type = "${var.bar}"
+
+  lifecycle {
+    ignore_changes = ["*"]
+  }
+}

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -83,6 +83,10 @@ include `create_before_destroy`. Referencing a resource that does not include
 ~> **NOTE on ignore\_changes:** Ignored attribute names can be matched by their
 name, not state ID. For example, if an `aws_route_table` has two routes defined
 and the `ignore_changes` list contains "route", both routes will be ignored.
+Additionally you can also use a single entry with a wildcard (e.g. `"*"`)
+which will match all attribute names. Using a partial string together with a
+wildcard (e.g. `"rout*"`) is **not** supported.
+
 
 -------------
 


### PR DESCRIPTION
One use case for supporting a wildcard feature like this, is for when you want to completely lock down a resource in an efficient way.

You can already protect it from being destroyed or recreated by using `prevent_destroy`, but if you also want to prevent it from being altered in any way after it has been initially created, you'll have to manually make sure you have included all the possible attributes that can be used (so not only the ones you have initially configured, but all attributes).

Of course it is much easier if in those cases you can just add a single entry with a `*` to "lock" the resource for all changes.