### PR TITLE
provider/aws: Set `apply_method` to state in `aws_db_parameter_group`

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -66,14 +66,6 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "immediate",
-							// this parameter is not actually state, but a
-							// meta-parameter describing how the RDS API call
-							// to modify the parameter group should be made.
-							// Future reads of the resource from AWS don't tell
-							// us what we used for apply_method previously, so
-							// by squashing state to an empty string we avoid
-							// needing to do an update for every future run.
-							StateFunc: func(interface{}) string { return "" },
 						},
 					},
 				},

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -290,6 +290,45 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBParameterGroup_withApplyMethod(t *testing.T) {
+	var v rds.DBParameterGroup
+
+	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBParameterGroupConfigWithApplyMethod(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "name", groupName),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "parameter.2421266705.apply_method", "immediate"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						"aws_db_parameter_group.bar", "parameter.2478663599.apply_method", "pending-reboot"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 	var v rds.DBParameterGroup
 
@@ -463,6 +502,26 @@ resource "aws_db_parameter_group" "bar" {
 	parameter{
 	  name = "character_set_results"
 	  value = "utf8"
+	}
+	tags {
+		foo = "bar"
+	}
+}`, n)
+}
+
+func testAccAWSDBParameterGroupConfigWithApplyMethod(n string) string {
+	return fmt.Sprintf(`
+resource "aws_db_parameter_group" "bar" {
+	name = "%s"
+	family = "mysql5.6"
+	parameter {
+	  name = "character_set_server"
+	  value = "utf8"
+	}
+	parameter {
+	  name = "character_set_client"
+	  value = "utf8"
+	  apply_method = "pending-reboot"
 	}
 	tags {
 		foo = "bar"

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -650,6 +650,10 @@ func flattenParameters(list []*rds.Parameter) []map[string]interface{} {
 			if i.ParameterValue != nil {
 				r["value"] = strings.ToLower(*i.ParameterValue)
 			}
+			if i.ApplyMethod != nil {
+				r["apply_method"] = strings.ToLower(*i.ApplyMethod)
+			}
+
 			result = append(result, r)
 		}
 	}


### PR DESCRIPTION
Fixes #8593

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBParameterGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/01 13:04:22 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDBParameterGroup_ -timeout 120m
=== RUN   TestAccAWSDBParameterGroup_importBasic
--- PASS: TestAccAWSDBParameterGroup_importBasic (27.03s)
=== RUN   TestAccAWSDBParameterGroup_limit
--- PASS: TestAccAWSDBParameterGroup_limit (48.54s)
=== RUN   TestAccAWSDBParameterGroup_basic
--- PASS: TestAccAWSDBParameterGroup_basic (46.29s)
=== RUN   TestAccAWSDBParameterGroup_Only
--- PASS: TestAccAWSDBParameterGroup_Only (23.57s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    145.445s
```