### PR TITLE
provider/azurerm: Reordering the checks after an Azure API Get

### DIFF
--- a/builtin/providers/azurerm/resource_arm_availability_set.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set.go
@@ -117,12 +117,12 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 	name := id.Path["availabilitySets"]
 
 	resp, err := availSetClient.Get(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Availability Set %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Availability Set %s: %s", name, err)
 	}
 
 	availSet := *resp.Properties

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
@@ -225,12 +225,12 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	log.Printf("[INFO] Trying to find the AzureRM CDN Endpoint %s (Profile: %s, RG: %s)", name, profileName, resGroup)
 	resp, err := cdnEndpointsClient.Get(name, profileName, resGroup)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure CDN Endpoint %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure CDN Endpoint %s: %s", name, err)
 	}
 
 	d.Set("name", resp.Name)

--- a/builtin/providers/azurerm/resource_arm_cdn_profile.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile.go
@@ -99,12 +99,12 @@ func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
 	name := id.Path["Profiles"]
 
 	resp, err := cdnProfilesClient.Get(name, resGroup)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure CDN Profile %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure CDN Profile %s: %s", name, err)
 	}
 
 	if resp.Sku != nil {

--- a/builtin/providers/azurerm/resource_arm_local_network_gateway.go
+++ b/builtin/providers/azurerm/resource_arm_local_network_gateway.go
@@ -2,9 +2,9 @@ package azurerm
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
-	"github.com/Azure/azure-sdk-for-go/core/http"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -110,12 +110,11 @@ func resourceArmLocalNetworkGatewayRead(d *schema.ResourceData, meta interface{}
 
 	resp, err := lnetClient.Get(resGroup, name)
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
-			d.SetId("")
-			return nil
-		}
-
 		return fmt.Errorf("Error reading the state of Azure ARM local network gateway '%s': %s", name, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", resp.Name)

--- a/builtin/providers/azurerm/resource_arm_local_network_gateway_test.go
+++ b/builtin/providers/azurerm/resource_arm_local_network_gateway_test.go
@@ -56,7 +56,6 @@ func testCheckAzureRMLocalNetworkGatewayExists(name string) resource.TestCheckFu
 			if resp.StatusCode == http.StatusNotFound {
 				return fmt.Errorf("Local network gateway '%s' (resource group '%s') does not exist on Azure.", localNetName, resGrp)
 			}
-
 			return fmt.Errorf("Error reading the state of local network gateway '%s'.", localNetName)
 		}
 

--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -245,12 +245,12 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	name := id.Path["networkInterfaces"]
 
 	resp, err := ifaceClient.Get(resGroup, name, "")
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Network Interface %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Network Interface %s: %s", name, err)
 	}
 
 	iface := *resp.Properties

--- a/builtin/providers/azurerm/resource_arm_network_security_group.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group.go
@@ -191,12 +191,12 @@ func resourceArmNetworkSecurityGroupRead(d *schema.ResourceData, meta interface{
 	name := id.Path["networkSecurityGroups"]
 
 	resp, err := secGroupClient.Get(resGroup, name, "")
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Network Security Group %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Network Security Group %s: %s", name, err)
 	}
 
 	if resp.Properties.SecurityRules != nil {

--- a/builtin/providers/azurerm/resource_arm_network_security_rule.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_rule.go
@@ -175,12 +175,12 @@ func resourceArmNetworkSecurityRuleRead(d *schema.ResourceData, meta interface{}
 	sgRuleName := id.Path["securityRules"]
 
 	resp, err := secRuleClient.Get(resGroup, networkSGName, sgRuleName)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Network Security Rule %s: %s", sgRuleName, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Network Security Rule %s: %s", sgRuleName, err)
 	}
 
 	d.Set("access", resp.Properties.Access)

--- a/builtin/providers/azurerm/resource_arm_public_ip.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip.go
@@ -165,12 +165,12 @@ func resourceArmPublicIpRead(d *schema.ResourceData, meta interface{}) error {
 	name := id.Path["publicIPAddresses"]
 
 	resp, err := publicIPClient.Get(resGroup, name, "")
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure public ip %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure public ip %s: %s", name, err)
 	}
 
 	d.Set("location", resp.Location)

--- a/builtin/providers/azurerm/resource_arm_route.go
+++ b/builtin/providers/azurerm/resource_arm_route.go
@@ -112,12 +112,12 @@ func resourceArmRouteRead(d *schema.ResourceData, meta interface{}) error {
 	routeName := id.Path["routes"]
 
 	resp, err := routesClient.Get(resGroup, rtName, routeName)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Route %s: %s", routeName, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Route %s: %s", routeName, err)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_route_table.go
+++ b/builtin/providers/azurerm/resource_arm_route_table.go
@@ -142,12 +142,12 @@ func resourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	name := id.Path["routeTables"]
 
 	resp, err := routeTablesClient.Get(resGroup, name, "")
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Route Table %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Route Table %s: %s", name, err)
 	}
 
 	if resp.Properties.Subnets != nil {

--- a/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
@@ -112,12 +112,12 @@ func resourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}
 	name := id.Path["namespaces"]
 
 	resp, err := namespaceClient.Get(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure ServiceBus Namespace %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure ServiceBus Namespace %s: %s", name, err)
 	}
 
 	d.Set("name", resp.Name)

--- a/builtin/providers/azurerm/resource_arm_storage_account.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account.go
@@ -256,12 +256,11 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 	resp, err := client.GetProperties(resGroup, name)
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
-			d.SetId("")
-			return nil
-		}
-
 		return fmt.Errorf("Error reading the state of AzureRM Storage Account %q: %s", name, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
 	}
 
 	keys, err := client.ListKeys(resGroup, name)

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -131,12 +131,13 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	name := id.Path["subnets"]
 
 	resp, err := subnetClient.Get(resGroup, vnetName, name, "")
+
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Subnet %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Subnet %s: %s", name, err)
 	}
 
 	if resp.Properties.IPConfigurations != nil && len(*resp.Properties.IPConfigurations) > 0 {

--- a/builtin/providers/azurerm/resource_arm_template_deployment.go
+++ b/builtin/providers/azurerm/resource_arm_template_deployment.go
@@ -143,13 +143,14 @@ func resourceArmTemplateDeploymentRead(d *schema.ResourceData, meta interface{})
 	}
 
 	resp, err := deployClient.Get(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure RM Template Deployment %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure RM Template Deployment %s: %s", name, err)
-	}
+
 	var outputs map[string]string
 	if resp.Properties.Outputs != nil && len(*resp.Properties.Outputs) > 0 {
 		outputs = make(map[string]string)

--- a/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint.go
@@ -152,13 +152,14 @@ func resourceArmTrafficManagerEndpointRead(d *schema.ResourceData, meta interfac
 	name := id.Path[endpointType]
 
 	resp, err := client.Get(resGroup, profileName, endpointType, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on TrafficManager Endpoint %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on TrafficManager Endpoint %s: %s", name, err)
-	}
+
 	endpoint := *resp.Properties
 
 	d.Set("name", resp.Name)

--- a/builtin/providers/azurerm/resource_arm_traffic_manager_profile.go
+++ b/builtin/providers/azurerm/resource_arm_traffic_manager_profile.go
@@ -150,13 +150,14 @@ func resourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interface
 	name := id.Path["trafficManagerProfiles"]
 
 	resp, err := client.Get(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Traffic Manager Profile %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Traffic Manager Profile %s: %s", name, err)
-	}
+
 	profile := *resp.Properties
 
 	// update appropriate values

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -485,12 +485,13 @@ func resourceArmVirtualMachineRead(d *schema.ResourceData, meta interface{}) err
 	name := id.Path["virtualMachines"]
 
 	resp, err := vmClient.Get(resGroup, name, "")
+
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Virtual Machine %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Virtual Machine %s: %s", name, err)
 	}
 
 	if resp.Plan != nil {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -431,13 +431,13 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 	name := id.Path["virtualMachineScaleSets"]
 
 	resp, err := vmScaleSetClient.Get(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Virtual Machine Scale Set %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		log.Printf("[INFO] AzureRM Virtual Machine Scale Set (%s) Not Found. Removing from State", name)
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Virtual Machine Scale Set %s: %s", name, err)
 	}
 
 	d.Set("location", resp.Location)

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -132,12 +132,12 @@ func resourceArmVirtualNetworkRead(d *schema.ResourceData, meta interface{}) err
 	name := id.Path["virtualNetworks"]
 
 	resp, err := vnetClient.Get(resGroup, name, "")
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure virtual network %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure virtual network %s: %s", name, err)
 	}
 	vnet := *resp.Properties
 

--- a/builtin/providers/azurerm/resource_arm_virtual_network_peering.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network_peering.go
@@ -123,13 +123,14 @@ func resourceArmVirtualNetworkPeeringRead(d *schema.ResourceData, meta interface
 	name := id.Path["virtualNetworkPeerings"]
 
 	resp, err := client.Get(resGroup, vnetName, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure virtual network peering %s: %s", name, err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure virtual network peering %s: %s", name, err)
-	}
+
 	peer := *resp.Properties
 
 	// update appropriate values


### PR DESCRIPTION
We are receiving suggestions of a panic as follows:

```
2016/09/01 07:21:55 [DEBUG] plugin: terraform: panic: runtime error: invalid memory address or nil pointer dereference
2016/09/01 07:21:55 [DEBUG] plugin: terraform: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xa3170f]
2016/09/01 07:21:55 [DEBUG] plugin: terraform:
2016/09/01 07:21:55 [DEBUG] plugin: terraform: goroutine 114 [running]:
2016/09/01 07:21:55 [DEBUG] plugin: terraform: panic(0x27f4e60, 0xc4200100e0)
2016/09/01 07:21:55 [DEBUG] plugin: terraform: 	/opt/go/src/runtime/panic.go:500 +0x1a1
2016/09/01 07:21:55 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/azurerm.resourceArmVirtualMachineRead(0xc4206d8060, 0x2995620, 0xc4204d0000, 0x0, 0x17)
2016/09/01 07:21:55 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/azurerm/resource_arm_virtual_machine.go:488 +0x1ff
2016/09/01 07:21:55 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc420017a40, 0xc42040c780, 0x2995620, 0xc4204d0000, 0xc42019c990, 0x1, 0x0)
```

This is because the code is as follows:

```
resp, err := client.Get(resGroup, vnetName, name)
if resp.StatusCode == http.StatusNotFound {
	d.SetId("")
	return nil
}
if err != nil {
	return fmt.Errorf("Error making Read request on Azure virtual network peering %s: %s", name, err)
}
```

When a request throws an error, the response object isn't valid. Therefore, we need to flip that code to check the error first

```
resp, err := client.Get(resGroup, vnetName, name)
if err != nil {
	return fmt.Errorf("Error making Read request on Azure virtual network peering %s: %s", name, err)
}
if resp.StatusCode == http.StatusNotFound {
	d.SetId("")
	return nil
}
```