### PR TITLE
Waiting for 'terminated' on aws instance destroy is slow and unnecessary

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1142,8 +1142,8 @@ func awsTerminateInstance(conn *ec2.EC2, id string) error {
 	log.Printf("[DEBUG] Waiting for instance (%s) to become terminated", id)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"pending", "running", "shutting-down", "stopped", "stopping"},
-		Target:     []string{"terminated"},
+		Pending:    []string{"pending", "running", "stopped", "stopping"},
+		Target:     []string{"shutting-down", "terminated"},
 		Refresh:    InstanceStateRefreshFunc(conn, id),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,


### PR DESCRIPTION
This changes the destroy behavior of the aws instance resource to shutting-down instead of terminated. It has sped up my development cycle significantly. Some terraform destroys were taking upwards of ten minutes before this patch. Please consider merging, as this should likely be the default behavior.