### PR TITLE
Add missing json attribute to documentation for aws_iam_policy_document

### DIFF
--- a/website/source/docs/providers/aws/r/cloudfront_origin_access_identity.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_origin_access_identity.html.markdown
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "s3_policy" {
 
 aws_s3_bucket "bucket" {
   ...
-  policy = "${data.aws_iam_policy_document.s3_policy}"
+  policy = "${data.aws_iam_policy_document.s3_policy.json}"
 }
 ```
 


### PR DESCRIPTION
Fixes `data variables must be four parts: data.TYPE.NAME.ATTR` error.