### PR TITLE
command: more resilient HCL check for inputs

### DIFF
--- a/command/flag_kv_test.go
+++ b/command/flag_kv_test.go
@@ -134,14 +134,11 @@ func TestFlagTypedKV(t *testing.T) {
 			true,
 		},
 
-		/*
-			TODO: wait for HCL merge
-			{
-				"key=/path",
-				map[string]interface{}{"key": "/path"},
-				false,
-			},
-		*/
+		{
+			"key=/path",
+			map[string]interface{}{"key": "/path"},
+			false,
+		},
 
 		{
 			"key=1234.dkr.ecr.us-east-1.amazonaws.com/proj:abcdef",

--- a/command/flag_kv_test.go
+++ b/command/flag_kv_test.go
@@ -47,6 +47,12 @@ func TestFlagStringKV(t *testing.T) {
 			nil,
 			true,
 		},
+
+		{
+			"key=/path",
+			map[string]string{"key": "/path"},
+			false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -126,6 +132,21 @@ func TestFlagTypedKV(t *testing.T) {
 			`key={"hello" = "world", "foo" = "bar"}\nkey2="invalid"`,
 			nil,
 			true,
+		},
+
+		/*
+			TODO: wait for HCL merge
+			{
+				"key=/path",
+				map[string]interface{}{"key": "/path"},
+				false,
+			},
+		*/
+
+		{
+			"key=1234.dkr.ecr.us-east-1.amazonaws.com/proj:abcdef",
+			map[string]interface{}{"key": "1234.dkr.ecr.us-east-1.amazonaws.com/proj:abcdef"},
+			false,
 		},
 	}
 

--- a/vendor/github.com/hashicorp/hcl/README.md
+++ b/vendor/github.com/hashicorp/hcl/README.md
@@ -103,6 +103,16 @@ variable "ami" {
     description = "the AMI to use"
 }
 ```
+This would be equivalent to the following json:
+``` json
+{
+  "variable": {
+      "ami": {
+          "description": "the AMI to use"
+        }
+    }
+}
+```
 
 ## Thanks
 

--- a/vendor/github.com/hashicorp/hcl/hcl/ast/ast.go
+++ b/vendor/github.com/hashicorp/hcl/hcl/ast/ast.go
@@ -214,4 +214,5 @@ func (c *CommentGroup) Pos() token.Pos {
 // GoStringer
 //-------------------------------------------------------------------
 
-func (o *ObjectKey) GoString() string { return fmt.Sprintf("*%#v", *o) }
+func (o *ObjectKey) GoString() string  { return fmt.Sprintf("*%#v", *o) }
+func (o *ObjectList) GoString() string { return fmt.Sprintf("*%#v", *o) }

--- a/vendor/github.com/hashicorp/hcl/hcl/scanner/scanner.go
+++ b/vendor/github.com/hashicorp/hcl/hcl/scanner/scanner.go
@@ -224,6 +224,11 @@ func (s *Scanner) Scan() token.Token {
 func (s *Scanner) scanComment(ch rune) {
 	// single line comments
 	if ch == '#' || (ch == '/' && s.peek() != '*') {
+		if ch == '/' && s.peek() != '/' {
+			s.err("expected '/' for comment")
+			return
+		}
+
 		ch = s.next()
 		for ch != '\n' && ch >= 0 && ch != eof {
 			ch = s.next()

--- a/vendor/github.com/hashicorp/hcl/json/scanner/scanner.go
+++ b/vendor/github.com/hashicorp/hcl/json/scanner/scanner.go
@@ -296,7 +296,7 @@ func (s *Scanner) scanString() {
 			return
 		}
 
-		if ch == '"' && braces == 0 {
+		if ch == '"' {
 			break
 		}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1168,70 +1168,70 @@
 			"revision": "7e3c02b30806fa5779d3bdfc152ce4c6f40e7b38"
 		},
 		{
-			"checksumSHA1": "8E3sekKdBZ38W0UFwONoZb0txbE=",
+			"checksumSHA1": "fa9G5tEr4oJJc3vtgn/B0NWZXfA=",
 			"path": "github.com/hashicorp/hcl",
-			"revision": "bc40da04e8303cb7406e9ed1a2b742d636c5d960",
-			"revisionTime": "2016-08-22T16:37:30Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
-			"checksumSHA1": "IxyvRpCFeoJBGl2obLKJV7RCGjg=",
+			"checksumSHA1": "67DfevLBglV52Y2eAuhFc/xQni0=",
 			"path": "github.com/hashicorp/hcl/hcl/ast",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "5HVecyfmcTm6OTffEi6LGayQf5M=",
 			"path": "github.com/hashicorp/hcl/hcl/fmtcmd",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "l2oQxBsZRwn6eZjf+whXr8c9+8c=",
 			"path": "github.com/hashicorp/hcl/hcl/parser",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "CSmwxPOTz7GSpnWPF9aGkbVeR64=",
 			"path": "github.com/hashicorp/hcl/hcl/printer",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
-			"checksumSHA1": "vjhDQVlgHhdxml1V8/cj0vOe+j8=",
+			"checksumSHA1": "lgR7PSAZ0RtvAc9OCtCnNsF/x8g=",
 			"path": "github.com/hashicorp/hcl/hcl/scanner",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "JlZmnzqdmFFyb1+2afLyR3BOE/8=",
 			"path": "github.com/hashicorp/hcl/hcl/strconv",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "c6yprzj06ASwCo18TtbbNNBHljA=",
 			"path": "github.com/hashicorp/hcl/hcl/token",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "jQ45CCc1ed/nlV7bbSnx6z72q1M=",
 			"path": "github.com/hashicorp/hcl/json/parser",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
-			"checksumSHA1": "S1e0F9ZKSnqgOLfjDTYazRL28tA=",
+			"checksumSHA1": "YdvFsNOMSWMLnY6fcliWQa0O5Fw=",
 			"path": "github.com/hashicorp/hcl/json/scanner",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
 			"path": "github.com/hashicorp/hcl/json/token",
-			"revision": "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1",
-			"revisionTime": "2016-07-11T23:17:52Z"
+			"revision": "99df0eb941dd8ddbc83d3f3605a34f6a686ac85e",
+			"revisionTime": "2016-09-02T16:52:19Z"
 		},
 		{
 			"checksumSHA1": "OrnLOmhc0FcHYs02wtbu1siIsnM=",
@@ -1260,7 +1260,6 @@
 		},
 		{
 			"checksumSHA1": "jq2E42bB0kwKaerHXwJslUea4eM=",
-			"origin": "github.com/hashicorp/terraform/vendor/github.com/henrikhodne/go-librato/librato",
 			"path": "github.com/henrikhodne/go-librato/librato",
 			"revision": "6e9aa4b1a8a8b735ad14b4f1c9542ef183e82dc2",
 			"revisionTime": "2016-08-11T07:26:26Z"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/8044

This introduces a more resilient check when parsing variable values as HCL for determining if they were really HCL or not. Before, we simply checked error message (I kept this around although it may no longer be necessary). Now, I check for certain starting symbols ignoring whitespace:

  * `[` - List

  * `{` - Map

  * `"` - String

If it DOESN'T have one of those, we return as-is.

Existing tests pass. I want to double check with @jen20 if this is enough.

