### PR TITLE
Increase aws_rds_cluster timeout to 40 minutes

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -274,7 +274,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 				Pending:    []string{"creating", "backing-up", "modifying"},
 				Target:     []string{"available"},
 				Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
-				Timeout:    15 * time.Minute,
+				Timeout:    40 * time.Minute,
 				MinTimeout: 3 * time.Second,
 				Delay:      30 * time.Second, // Wait 30 secs before starting
 			}


### PR DESCRIPTION
The timeout was increased to 40 minutes when creating a new cluster in https://github.com/hashicorp/terraform/pull/8052. However when creating a cluster from a snapshot the timeout is still 15 minutes. This has been increased to 40 minutes.