### PR TITLE
provider/openstack: Fix documentation of openstack LBaaS resources

### DIFF
--- a/website/source/docs/providers/openstack/r/lb_listener_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_listener_v2.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "openstack"
-page_title: "OpenStack: openstack_lbaas_listener_v2"
+page_title: "OpenStack: openstack_lb_listener_v2"
 sidebar_current: "docs-openstack-resource-lbaas-listener-v2"
 description: |-
   Manages a V2 listener resource within OpenStack.
@@ -13,7 +13,7 @@ Manages a V2 listener resource within OpenStack.
 ## Example Usage
 
 ```
-resource "openstack_lbaas_listener_v2" "listener_1" {
+resource "openstack_lb_listener_v2" "listener_1" {
   protocol = "HTTP"
   protocol_port = 8080
   loadbalancer_id =  "d9415786-5f1a-428b-b35f-2f1523e146d2"

--- a/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
@@ -13,7 +13,7 @@ Manages a V2 loadbalancer resource within OpenStack.
 ## Example Usage
 
 ```
-resource "openstack_lbaas_loadbalancer_v2" "lb_1" {
+resource "openstack_lb_loadbalancer_v2" "lb_1" {
   vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
 }
 ```

--- a/website/source/docs/providers/openstack/r/lb_member_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_member_v2.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "openstack"
-page_title: "OpenStack: openstack_lbaas_member_v2"
+page_title: "OpenStack: openstack_lb_member_v2"
 sidebar_current: "docs-openstack-resource-lbaas-member-v2"
 description: |-
   Manages a V2 member resource within OpenStack.
@@ -13,7 +13,7 @@ Manages a V2 member resource within OpenStack.
 ## Example Usage
 
 ```
-resource "openstack_lbaas_member_v2" "member_1" {
+resource "openstack_lb_member_v2" "member_1" {
   address = "192.168.199.23"
   protocol_port = 8080
 }
@@ -30,6 +30,8 @@ The following arguments are supported:
 
 * `pool_id` - (Required) The id of the pool that this member will be
     assigned to.
+
+* `subnet_id` - (Required) The subnet in which to access the member
 
 * `name` - (Optional) Human-readable name for the member.
 

--- a/website/source/docs/providers/openstack/r/lb_member_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_member_v2.html.markdown
@@ -28,6 +28,9 @@ The following arguments are supported:
     `OS_REGION_NAME` environment variable is used. Changing this creates a new
     member.
 
+* `pool_id` - (Required) The id of the pool that this member will be
+    assigned to.
+
 * `name` - (Optional) Human-readable name for the member.
 
 * `tenant_id` - (Optional) Required for admins. The UUID of the tenant who owns

--- a/website/source/docs/providers/openstack/r/lb_monitor_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_monitor_v2.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "openstack"
-page_title: "OpenStack: openstack_lbaas_monitor_v2"
+page_title: "OpenStack: openstack_lb_monitor_v2"
 sidebar_current: "docs-openstack-resource-lbaas-monitor-v2"
 description: |-
   Manages a V2 monitor resource within OpenStack.
@@ -13,7 +13,7 @@ Manages a V2 monitor resource within OpenStack.
 ## Example Usage
 
 ```
-resource "openstack_lbaas_monitor_v2" "monitor_1" {
+resource "openstack_lb_monitor_v2" "monitor_1" {
   type = "PING"
   delay = 20
   timeout = 10

--- a/website/source/docs/providers/openstack/r/lb_pool_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_pool_v2.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "openstack"
-page_title: "OpenStack: openstack_lbaas_pool_v2"
+page_title: "OpenStack: openstack_lb_pool_v2"
 sidebar_current: "docs-openstack-resource-lbaas-pool-v2"
 description: |-
   Manages a V2 pool resource within OpenStack.
@@ -13,7 +13,7 @@ Manages a V2 pool resource within OpenStack.
 ## Example Usage
 
 ```
-resource "openstack_lbaas_pool_v2" "pool_1" {
+resource "openstack_lb_pool_v2" "pool_1" {
   protocol = "ProtocolHTTP"
   lb_method = "LBMethodRoundRobin"
   listener_id =  "d9415786-5f1a-428b-b35f-2f1523e146d2"

--- a/website/source/docs/providers/openstack/r/lb_pool_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_pool_v2.html.markdown
@@ -15,7 +15,7 @@ Manages a V2 pool resource within OpenStack.
 ```
 resource "openstack_lb_pool_v2" "pool_1" {
   protocol = "ProtocolHTTP"
-  lb_method = "LBMethodRoundRobin"
+  lb_method = "ROUND_ROBIN"
   listener_id =  "d9415786-5f1a-428b-b35f-2f1523e146d2"
   persistence {
       type          = "HTTP_COOKIE"
@@ -52,10 +52,9 @@ The following arguments are supported:
     will be associated with. Changing this creates a new pool.
 	Note:  One of LoadbalancerID or ListenerID must be provided.
 
-* `lb_method` - (Required) The algorithm used to distribute load between the
-    members of the pool. The current specification supports
-    LBMethodRoundRobin, LBMethodLeastConnections and LBMethodSourceIp as valid
-    values for this attribute.
+* `lb_method` - (Required) The load balancing algorithm to
+    distribute traffic to the pool's members. Must be one of
+    ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
 
 * `persistence` - Omit this field to prevent session persistence.  Indicates
     whether connections in the same session will be processed by the same Pool


### PR DESCRIPTION
For unknown reason all resource names are wrong and some pieces were missing like pool_id for lb_member_v2.
