### PR TITLE
provider/aws: Making `aws_alb_listener` ssl_policy to be Computed

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_listener.go
+++ b/builtin/providers/aws/resource_aws_alb_listener.go
@@ -54,6 +54,7 @@ func resourceAwsAlbListener() *schema.Resource {
 			"ssl_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"certificate_arn": {


### PR DESCRIPTION
Fixes #8612

The SSL Policy is optional - if you don't add it and create a HTTPS Alb
Listener, AWS will add the policy for you. Without being computed, we
would get a diff

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSALBListener_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/02 17:16:33 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSALBListener_
-timeout 120m
=== RUN   TestAccAWSALBListener_basic
--- PASS: TestAccAWSALBListener_basic (70.45s)
=== RUN   TestAccAWSALBListener_https
--- PASS: TestAccAWSALBListener_https (63.20s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    133.667s
```