### PR TITLE
provider/scaleway: Document ports in security group rules properly

### DIFF
--- a/website/source/docs/providers/scaleway/index.html.markdown
+++ b/website/source/docs/providers/scaleway/index.html.markdown
@@ -60,7 +60,7 @@ resource "scaleway_security_group_rule" "http_accept" {
   direction = "inbound"
   ip_range = "0.0.0.0/0"
   protocol = "TCP"
-  dest_port_from = 80
+  port = 80
 }
 
 resource "scaleway_security_group_rule" "https_accept" {
@@ -70,7 +70,7 @@ resource "scaleway_security_group_rule" "https_accept" {
   direction = "inbound"
   ip_range = "0.0.0.0/0"
   protocol = "TCP"
-  dest_port_from = 443
+  port = 443
 }
 
 ```

--- a/website/source/docs/providers/scaleway/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/scaleway/r/security_group_rule.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `protocol` - (Required) protocol of rule (`ICMP`, `TCP`, `UDP`)
 * `port` - (Optional) port of the rule
 
-Field `action`, `direction`, `ip_range`, `protocol`, `port` are editable.
+Fields `action`, `direction`, `ip_range`, `protocol`, `port` are editable.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/scaleway/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/scaleway/r/security_group_rule.html.markdown
@@ -26,7 +26,7 @@ resource "scaleway_security_group_rule" "smtp_drop_1" {
   direction = "inbound"
   ip_range = "0.0.0.0/0"
   protocol = "TCP"
-  dest_port_from = 25
+  port = 25
 }
 
 ```
@@ -39,10 +39,9 @@ The following arguments are supported:
 * `direction` - (Required) direction of rule (`inbound`, `outbound`)
 * `ip_range` - (Required) ip_range of rule
 * `protocol` - (Required) protocol of rule (`ICMP`, `TCP`, `UDP`)
-* `dest_port_from` - (Optional) port range from
-* `dest_port_to` - (Optional) port from to
+* `port` - (Optional) port of the rule
 
-Field `action`, `direction`, `ip_range`, `protocol`, `dest_port_from`, `dest_port_to` are editable.
+Field `action`, `direction`, `ip_range`, `protocol`, `port` are editable.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The documentation appears to have been written following the [Scaleway API](https://developer.scaleway.com/#security-groups-manage-rules-post). However this is not how the resource is actually implemented in the current version ([code](https://github.com/hashicorp/terraform/blob/9f314a3c29944885a9d61e54eb62e363d9a64c23/builtin/providers/scaleway/resource_scaleway_security_group_rule.go#L75) and [tests](https://github.com/hashicorp/terraform/blob/9f314a3c29944885a9d61e54eb62e363d9a64c23/builtin/providers/scaleway/resource_scaleway_security_group_rule_test.go#L156)).