### PR TITLE
[WIP] Adding reference to docs for supported ECDSA curves.

### DIFF
--- a/website/source/docs/providers/tls/r/private_key.html.md
+++ b/website/source/docs/providers/tls/r/private_key.html.md
@@ -42,7 +42,7 @@ RSA key in bits. Defaults to 2048.
 
 * `ecdsa_curve` - (Optional) When `algorithm` is "ECDSA", the name of the elliptic
 curve to use. May be any one of "P224", "P256", "P384" or "P521", with "P224" as the
-default.
+default.  **Some providers may not accept the default P224 curve.  See below for help**
 
 ## Attributes Reference
 
@@ -70,3 +70,10 @@ terraform taint tls_private_key.example
 ```
 
 A new key will then be generated on the next ``terraform apply``.
+
+## Provider-specific ECDSA Curve Information
+
+Certain providers (AWS, Microsoft Azure, Google Cloud, etc.) may only support
+certain ECDSA curves when generating your private key.  
+
+* `AWS` - Supports P256 and P384 ECDSA curves


### PR DESCRIPTION
**Relevant Terraform Version**:  All

I started this thread on the mailing list to discuss this issue but didn't get much attention, so I'm hoping that it's worth updating in the documentation:
[TLS provider -- ECDSA private key default value](https://groups.google.com/forum/#!topic/terraform-tool/JOjwJyD4iaw)

After using Terraform to provision some AWS infrastructure I found that defaulting to the P224 ECDSA curve for my TLS-provider private key (used for creating the certificate added to my ELB listener) would break my ability to log into my site.  Working with my company's AWS Solutions Architect I found that ELB only supports P256 and P384 curves.  It'd be great to include that type of information for AWS and other providers to help with using the TLS resources.

- I don't know if this is the right place for that information and don't use other cloud providers often enough to be able to help with Google, Azure, etc.