### PR TITLE
Allow count in data sources

### DIFF
--- a/builtin/providers/test/data_source.go
+++ b/builtin/providers/test/data_source.go
@@ -11,10 +11,20 @@ func testDataSource() *schema.Resource {
 		Read: testDataSourceRead,
 
 		Schema: map[string]*schema.Schema{
-			"list": &schema.Schema{
+			"list": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"input": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"output": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -23,6 +33,12 @@ func testDataSource() *schema.Resource {
 func testDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(time.Now().UTC().String())
 	d.Set("list", []interface{}{"one", "two", "three"})
+
+	if input, hasInput := d.GetOk("input"); hasInput {
+		d.Set("output", input)
+	} else {
+		d.Set("output", "some output")
+	}
 
 	return nil
 }

--- a/builtin/providers/test/data_source_test.go
+++ b/builtin/providers/test/data_source_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDataSource_dataSourceCount(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		CheckDestroy: func(s *terraform.State) error {
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: strings.TrimSpace(`
+data "test_data_source" "test" {
+  count = 3
+  input = "count-${count.index}"
+}
+
+resource "test_resource" "foo" {
+  required     = "yep"
+  required_map = {
+    key = "value"
+  }
+
+  list = ["${data.test_data_source.test.*.output}"]
+}
+				`),
+				Check: func(s *terraform.State) error {
+					res, hasRes := s.RootModule().Resources["test_resource.foo"]
+					if !hasRes {
+						return errors.New("No test_resource.foo in state")
+					}
+					if res.Primary.Attributes["list.#"] != "3" {
+						return errors.New("Wrong list.#, expected 3")
+					}
+					if res.Primary.Attributes["list.0"] != "count-0" {
+						return errors.New("Wrong list.0, expected count-0")
+					}
+					if res.Primary.Attributes["list.1"] != "count-1" {
+						return errors.New("Wrong list.0, expected count-1")
+					}
+					if res.Primary.Attributes["list.2"] != "count-2" {
+						return errors.New("Wrong list.0, expected count-2")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -97,6 +97,13 @@ func testResource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
+			"list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"list_of_map": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -552,3 +552,20 @@ func testConfig(t *testing.T, name string) *Config {
 
 	return c
 }
+
+func TestConfigDataCount(t *testing.T) {
+	c := testConfig(t, "data-count")
+	actual, err := c.Resources[0].Count()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if actual != 5 {
+		t.Fatalf("bad: %#v", actual)
+	}
+
+	// we need to make sure "count" has been removed from the RawConfig, since
+	// it's not a real key and won't validate.
+	if _, ok := c.Resources[0].RawConfig.Raw["count"]; ok {
+		t.Fatal("count key still exists in RawConfig")
+	}
+}

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -457,6 +457,7 @@ func loadDataResourcesHcl(list *ast.ObjectList) ([]*Resource, error) {
 		// Remove the fields we handle specially
 		delete(config, "depends_on")
 		delete(config, "provider")
+		delete(config, "count")
 
 		rawConfig, err := NewRawConfig(config)
 		if err != nil {

--- a/config/test-fixtures/data-count/main.tf
+++ b/config/test-fixtures/data-count/main.tf
@@ -1,0 +1,3 @@
+data "foo" "bar" {
+    count = 5
+}

--- a/terraform/test-fixtures/plan-computed-data-count/main.tf
+++ b/terraform/test-fixtures/plan-computed-data-count/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "foo" {
+  num     = "2"
+  compute = "foo"
+}
+
+data "aws_vpc" "bar" {
+  count = 3
+  foo = "${aws_instance.foo.foo}"
+}


### PR DESCRIPTION
Count worked in data sources, but the resource validation would fail due to the extra "count" key in the raw config. Make sure the HCL loader removes count.

Fixes #8527 