### PR TITLE
provider/aws: Fix. Adjust create and destroy timeout in aws_vpn_gateway_attachment.

### DIFF
--- a/builtin/providers/aws/resource_aws_vpn_gateway_attachment.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway_attachment.go
@@ -59,9 +59,9 @@ func resourceAwsVpnGatewayAttachmentCreate(d *schema.ResourceData, meta interfac
 		Pending:    []string{"detached", "attaching"},
 		Target:     []string{"attached"},
 		Refresh:    vpnGatewayAttachmentStateRefresh(conn, vpcId, vgwId),
-		Timeout:    5 * time.Minute,
+		Timeout:    15 * time.Minute,
 		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+		MinTimeout: 5 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
@@ -151,9 +151,9 @@ func resourceAwsVpnGatewayAttachmentDelete(d *schema.ResourceData, meta interfac
 		Pending:    []string{"attached", "detaching"},
 		Target:     []string{"detached"},
 		Refresh:    vpnGatewayAttachmentStateRefresh(conn, vpcId, vgwId),
-		Timeout:    5 * time.Minute,
+		Timeout:    15 * time.Minute,
 		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+		MinTimeout: 5 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()


### PR DESCRIPTION
This commit increases the timeout, delay and minimum timeout values in
order to resolve a timeout potentially occurring when the VPC gateway
is being attached or detached.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>