### PR TITLE
provider/aws: Refresh `aws_elasticsearch_domain` from state when RecordNotFoundException

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -256,6 +256,11 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 		DomainName: aws.String(d.Get("domain_name").(string)),
 	})
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "RecordNotFoundException" {
+			log.Printf("[INFO] ElasticSearch Domain %q not found", d.Get("domain_name").(string))
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes #3967

When an ElasticSearch domain has been deleted outside of Terraform, the
next Terraform operation would return the following:

```
* aws_elasticsearch_domain.curvelogic_es: ResourceNotFoundException:
* Domain not found: curvelogic-es
    status code: 409, request id: 6e4b2371-8e1a-11e5-bd07-7741b705d65c
```

We now refresh the resource from state when it is no longer found