### PR TITLE
provider/aws: Do not set empty string to state for `aws_vpn_gateway` availability zone

### DIFF
--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -94,7 +94,10 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		d.Set("vpc_id", *vpnAttachment.VpcId)
 	}
-	d.Set("availability_zone", vpnGateway.AvailabilityZone)
+
+	if vpnGateway.AvailabilityZone != nil && *vpnGateway.AvailabilityZone != "" {
+		d.Set("availability_zone", vpnGateway.AvailabilityZone)
+	}
 	d.Set("tags", tagsToMap(vpnGateway.Tags))
 
 	return nil

--- a/builtin/providers/aws/resource_aws_vpn_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway_test.go
@@ -58,6 +58,26 @@ func TestAccAWSVpnGateway_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSVpnGateway_withAvailabilityZoneSetToState(t *testing.T) {
+	var v ec2.VpnGateway
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpnGatewayConfigWithAZ,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpnGatewayExists("aws_vpn_gateway.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_vpn_gateway.foo", "availability_zone", "us-west-2a"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSVpnGateway_disappears(t *testing.T) {
 	var v ec2.VpnGateway
 
@@ -433,5 +453,16 @@ resource "aws_vpn_gateway" "foo" {
 
 resource "aws_vpn_gateway" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
+}
+`
+
+const testAccVpnGatewayConfigWithAZ = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpn_gateway" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+	availability_zone = "us-west-2a"
 }
 `


### PR DESCRIPTION
Fixes #4752

According to the AWS Documentation, when `describing-vpn-gateways`

```
AvailabilityZone -> (string)
The Availability Zone where the virtual private gateway was created, if applicable. This field may be empty or not returned.
```

Therefore, if we pass an availability zone as part of vpn gateway, then it may come back as an empty string. If we set this empty string back to state, then the next plan will look as follows:

```
-/+ aws_vpn_gateway.vpn_gateway
    availability_zone: "" => "us-west-2a" (forces new resource)
    tags.%:            "1" => "1"
    tags.Name:         "vpn-us-west-2" => "vpn-us-west-2"
    vpc_id:            "vpc-1e9da47a" => "vpc-1e9da47a"

Plan: 1 to add, 0 to change, 1 to destroy.
```

If the availability_zone comes back from AWS as an empty string, then we should not set it to state to avoid forcing a new resource for the user

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpnGateway_withAvailabilityZoneSetToState'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/03 17:10:57 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnGateway_withAvailabilityZoneSetToState -timeout 120m
=== RUN   TestAccAWSVpnGateway_withAvailabilityZoneSetToState
--- FAIL: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (36.11s)
       	testing.go:265: Step 0 error: Check failed: Check 2/2 error: aws_vpn_gateway.foo: Attribute 'availability_zone' expected "us-west-2a", got ""
FAIL
exit status 1
FAIL   	github.com/hashicorp/terraform/builtin/providers/aws   	36.130s
make: *** [testacc] Error 1
[stacko@Pauls-MacBook-Pro:~/Code/go/src/github.com/hashicorp/terraform on master]
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpnGateway_withAvailabilityZoneSetToState'                                                                                       2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/03 17:12:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnGateway_withAvailabilityZoneSetToState -timeout 120m
=== RUN   TestAccAWSVpnGateway_withAvailabilityZoneSetToState
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (46.50s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	46.517s
```