### PR TITLE
state/remote: Officially Support local backend

### DIFF
--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -32,7 +32,7 @@ func TestState_complexOutputs(t *testing.T) {
 			{
 				Config: testAccState_complexOutputs,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStateValue("terraform_remote_state.foo", "backend", "_local"),
+					testAccCheckStateValue("terraform_remote_state.foo", "backend", "local"),
 					testAccCheckStateValue("terraform_remote_state.foo", "config.path", "./test-fixtures/complex_outputs.tfstate"),
 					testAccCheckStateValue("terraform_remote_state.foo", "computed_set.#", "2"),
 					testAccCheckStateValue("terraform_remote_state.foo", `map.%`, "2"),
@@ -65,7 +65,7 @@ func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
 
 const testAccState_basic = `
 data "terraform_remote_state" "foo" {
-	backend = "_local"
+	backend = "local"
 
 	config {
 		path = "./test-fixtures/basic.tfstate"
@@ -74,7 +74,7 @@ data "terraform_remote_state" "foo" {
 
 const testAccState_complexOutputs = `
 resource "terraform_remote_state" "foo" {
-	backend = "_local"
+	backend = "local"
 
 	config {
 		path = "./test-fixtures/complex_outputs.tfstate"

--- a/state/remote/remote.go
+++ b/state/remote/remote.go
@@ -36,16 +36,14 @@ func NewClient(t string, conf map[string]string) (Client, error) {
 // BuiltinClients is the list of built-in clients that can be used with
 // NewClient.
 var BuiltinClients = map[string]Factory{
+	"artifactory": artifactoryFactory,
 	"atlas":       atlasFactory,
 	"azure":       azureFactory,
 	"consul":      consulFactory,
 	"etcd":        etcdFactory,
 	"gcs":         gcsFactory,
 	"http":        httpFactory,
+	"local":       fileFactory,
 	"s3":          s3Factory,
 	"swift":       swiftFactory,
-	"artifactory": artifactoryFactory,
-
-	// This is used for development purposes only.
-	"_local": fileFactory,
 }

--- a/website/source/docs/state/remote/local.html.md
+++ b/website/source/docs/state/remote/local.html.md
@@ -1,0 +1,36 @@
+---
+layout: "remotestate"
+page_title: "Remote State Backend: local"
+sidebar_current: "docs-state-remote-local"
+description: |-
+  Remote state stored using the local file system.
+---
+
+# local
+
+Remote state backend that uses the local file system.
+
+## Example Usage
+
+```
+terraform remote config \
+    -backend=local \
+    -backend-config="path=/path/to/terraform.tfstate"
+```
+
+## Example Reference
+
+```
+data "terraform_remote_state" "foo" {
+    backend = "local"
+    config {
+        path = "${path.module}/../../terraform.tfstate"
+    }
+}
+```
+
+## Configuration variables
+
+The following configuration options are supported:
+
+ * `path` - (Required) The path to the `tfstate` file.

--- a/website/source/layouts/remotestate.erb
+++ b/website/source/layouts/remotestate.erb
@@ -34,6 +34,9 @@
                 <li<%= sidebar_current("docs-state-remote-http") %>>
                   <a href="/docs/state/remote/http.html">http</a>
                 </li>
+                <li<%= sidebar_current("docs-state-remote-local") %>>
+                  <a href="/docs/state/remote/local.html">local</a>
+                </li>
                 <li<%= sidebar_current("docs-state-remote-s3") %>>
                   <a href="/docs/state/remote/s3.html">s3</a>
                 </li>


### PR DESCRIPTION
This is a rework of pull request #6213 submitted by @joshuaspence, adjusted to work with the remote state data source. We also add a deprecation warning for people using the unsupported API, and retain the ability to refer to "_local" as well as "local" for users in a mixed version environment.

Fixes #3618, reworks #6213.