### PR TITLE
Allow TypeList in provider Input

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -474,7 +474,7 @@ func (m schemaMap) Input(
 
 		var value interface{}
 		switch v.Type {
-		case TypeBool, TypeInt, TypeFloat, TypeSet:
+		case TypeBool, TypeInt, TypeFloat, TypeList, TypeSet:
 			continue
 		case TypeString:
 			value, err = m.inputString(input, k, v)


### PR DESCRIPTION
I was building a [shell](https://github.com/toddnni/terraform-provider-shell) provider where I used `TypeList` in provider input. Suprisingly, terraform will crash when provider is used

```
panic: Unknown type for input: 5
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: 
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: goroutine 51 [running]:
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: panic(0x9a3040, 0xc820230850)
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /usr/lib/go-1.6/src/runtime/panic.go:481 +0x3e6
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: github.com/hashicorp/terraform/helper/schema.schemaMap.Input(0xc820131a40, 0x7eff1f013098, 0xc820252158, 0xc820238810, 0xaaee00, 0x0, 0x0)
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /home/toniyl/golib/src/github.com/hashicorp/terraform/helper/schema/schema.go:482 +0x6bc
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: github.com/hashicorp/terraform/helper/schema.(*Provider).Input(0xc820131a10, 0x7eff1f013098, 0xc820252158, 0xc820238810, 0xc8202364e0, 0x0, 0x0)
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /home/toniyl/golib/src/github.com/hashicorp/terraform/helper/schema/provider.go:111 +0x4e
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Input(0xc82012f9e0, 0xc820230390, 0xc820230770, 0x0, 0x0)
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /home/toniyl/golib/src/github.com/hashicorp/terraform/plugin/resource_provider.go:408 +0x218
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: reflect.Value.call(0xa6a320, 0xb73788, 0x13, 0xba5ad0, 0x4, 0xc820243ee8, 0x3, 0x3, 0x0, 0x0, ...)
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /usr/lib/go-1.6/src/reflect/value.go:435 +0x120d
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: reflect.Value.Call(0xa6a320, 0xb73788, 0x13, 0xc820243ee8, 0x3, 0x3, 0x0, 0x0, 0x0)
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /usr/lib/go-1.6/src/reflect/value.go:303 +0xb1
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: net/rpc.(*service).call(0xc82022c3c0, 0xc82022c380, 0xc8202300c0, 0xc820246280, 0xc8202340c0, 0x971da0, 0xc820230390, 0x16, 0x971e00, 0xc820230770, ...)
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /usr/lib/go-1.6/src/net/rpc/server.go:383 +0x1c2
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell: created by net/rpc.(*Server).ServeCodec
2016/09/04 11:31:14 [DEBUG] plugin: terraform-provider-shell:   /usr/lib/go-1.6/src/net/rpc/server.go:477 +0x49d
...
```

I don't understand the issue or the schema code well, but I thought to give a shot, because the solution might be this simple. Provider started working and tests passed when I added `TypeList` in allowed types in `Input()` function. None of the existing builtin modules use `TypeList`. 
