### PR TITLE
provider/aws: Add DiffSupressionFunc to `aws_elasticsearch_domain`, `aws_sqs_queue` and `aws_sns_topic`

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -22,9 +22,9 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"access_policies": &schema.Schema{
-				Type:      schema.TypeString,
-				StateFunc: normalizeJson,
-				Optional:  true,
+				Type:             schema.TypeString,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+				Optional:         true,
 			},
 			"advanced_options": &schema.Schema{
 				Type:     schema.TypeMap,

--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -46,9 +46,10 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ForceNew: false,
 			},
 			"policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 				StateFunc: func(v interface{}) string {
 					s, ok := v.(string)
 					if !ok || s == "" {

--- a/builtin/providers/aws/resource_aws_sns_topic_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/jen20/awspolicyequivalence"
 )
 
 func TestAccAWSSNSTopic_basic(t *testing.T) {
@@ -22,6 +24,26 @@ func TestAccAWSSNSTopic_basic(t *testing.T) {
 				Config: testAccAWSSNSTopicConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSNSTopic_policy(t *testing.T) {
+	rName := acctest.RandString(10)
+	expectedPolicy := `{"Statement":[{"Sid":"Stmt1445931846145","Effect":"Allow","Principal":{"AWS":"*"},"Action":"sns:Publish","Resource":"arn:aws:sns:us-west-2::example"}],"Version":"2012-10-17","Id":"Policy1445931846145"}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_sns_topic.test_topic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSNSTopicWithPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),
+					testAccCheckAWSNSTopicHasPolicy("aws_sns_topic.test_topic", expectedPolicy),
 				),
 			},
 		},
@@ -43,6 +65,56 @@ func TestAccAWSSNSTopic_withIAMRole(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSNSTopicHasPolicy(n string, expectedPolicyText string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Queue URL specified!")
+		}
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SNS topic with that ARN exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).snsconn
+
+		params := &sns.GetTopicAttributesInput{
+			TopicArn: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.GetTopicAttributes(params)
+		if err != nil {
+			return err
+		}
+
+		var actualPolicyText string
+		for k, v := range resp.Attributes {
+			if k == "Policy" {
+				actualPolicyText = *v
+				break
+			}
+		}
+
+		equivalent, err := awspolicy.PoliciesAreEquivalent(actualPolicyText, expectedPolicyText)
+		if err != nil {
+			return fmt.Errorf("Error testing policy equivalence: %s", err)
+		}
+		if !equivalent {
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
+				expectedPolicyText, actualPolicyText)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckAWSSNSTopicDestroy(s *terraform.State) error {
@@ -103,6 +175,31 @@ resource "aws_sns_topic" "test_topic" {
     name = "terraform-test-topic"
 }
 `
+
+func testAccAWSSNSTopicWithPolicy(r string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test_topic" {
+  name = "example-%s"
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Sid": "Stmt1445931846145",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+       },
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-west-2::example"
+    }
+  ],
+  "Version": "2012-10-17",
+  "Id": "Policy1445931846145"
+}
+EOF
+}
+`, r)
+}
 
 // Test for https://github.com/hashicorp/terraform/issues/3660
 const testAccAWSSNSTopicConfig_withIAMRole = `

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/url"
@@ -42,60 +40,48 @@ func resourceAwsSqsQueue() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"delay_seconds": &schema.Schema{
+			"delay_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  0,
 			},
-			"max_message_size": &schema.Schema{
+			"max_message_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  262144,
 			},
-			"message_retention_seconds": &schema.Schema{
+			"message_retention_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  345600,
 			},
-			"receive_wait_time_seconds": &schema.Schema{
+			"receive_wait_time_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  0,
 			},
-			"visibility_timeout_seconds": &schema.Schema{
+			"visibility_timeout_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  30,
 			},
-			"policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				StateFunc: func(v interface{}) string {
-					s, ok := v.(string)
-					if !ok || s == "" {
-						return ""
-					}
-					jsonb := []byte(s)
-					buffer := new(bytes.Buffer)
-					if err := json.Compact(buffer, jsonb); err != nil {
-						log.Printf("[WARN] Error compacting JSON for Policy in SNS Queue, using raw string: %s", err)
-						return s
-					}
-					return buffer.String()
-				},
+			"policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+				Computed:         true,
 			},
-			"redrive_policy": &schema.Schema{
+			"redrive_policy": {
 				Type:      schema.TypeString,
 				Optional:  true,
 				StateFunc: normalizeJson,
 			},
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/jen20/awspolicyequivalence"
 )
 
 func TestAccAWSSQSQueue_basic(t *testing.T) {
@@ -19,22 +20,45 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSSQSConfigWithOverrides(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithOverrides("aws_sqs_queue.queue"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_policy(t *testing.T) {
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(5))
+
+	expectedPolicyText := fmt.Sprintf(
+		`{"Version": "2012-10-17","Id": "sqspolicy","Statement":[{"Sid": "Stmt1451501026839","Effect": "Allow","Principal":"*","Action":"sqs:SendMessage","Resource":"arn:aws:sqs:us-west-2:470663696735:%s","Condition":{"ArnEquals":{"aws:SourceArn":"arn:aws:sns:us-west-2:470663696735:%s"}}}]}`,
+		topicName, queueName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfig_PolicyFormat(topicName, queueName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSQSHasPolicy("aws_sqs_queue.test-email-events", expectedPolicyText),
 				),
 			},
 		},
@@ -47,7 +71,7 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSSQSConfigWithRedrive(acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.my_dead_letter_queue"),
@@ -59,13 +83,15 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 
 // Tests formatting and compacting of Policy, Redrive json
 func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(5))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSSQSConfig_PolicyFormat,
+			{
+				Config: testAccAWSSQSConfig_PolicyFormat(topicName, queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithOverrides("aws_sqs_queue.test-email-events"),
 				),
@@ -99,6 +125,48 @@ func testAccCheckAWSSQSQueueDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+func testAccCheckAWSQSHasPolicy(n string, expectedPolicyText string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Queue URL specified!")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sqsconn
+
+		params := &sqs.GetQueueAttributesInput{
+			QueueUrl:       aws.String(rs.Primary.ID),
+			AttributeNames: []*string{aws.String("Policy")},
+		}
+		resp, err := conn.GetQueueAttributes(params)
+		if err != nil {
+			return err
+		}
+
+		var actualPolicyText string
+		for k, v := range resp.Attributes {
+			if k == "Policy" {
+				actualPolicyText = *v
+				break
+			}
+		}
+
+		equivalent, err := awspolicy.PoliciesAreEquivalent(actualPolicyText, expectedPolicyText)
+		if err != nil {
+			return fmt.Errorf("Error testing policy equivalence: %s", err)
+		}
+		if !equivalent {
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
+				expectedPolicyText, actualPolicyText)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckAWSSQSExistsWithDefaults(n string) resource.TestCheckFunc {
@@ -242,13 +310,14 @@ resource "aws_sqs_queue" "my_dead_letter_queue" {
 `, name, name)
 }
 
-const testAccAWSSQSConfig_PolicyFormat = `
+func testAccAWSSQSConfig_PolicyFormat(queue, topic string) string {
+	return fmt.Sprintf(`
 variable "sns_name" {
-  default = "tf-test-name-2"
+  default = "%s"
 }
 
 variable "sqs_name" {
-  default = "tf-test-sqs-name-2"
+  default = "%s"
 }
 
 resource "aws_sns_topic" "test_topic" {
@@ -291,4 +360,5 @@ resource "aws_sns_topic_subscription" "test_queue_target" {
   protocol  = "sqs"
   endpoint  = "${aws_sqs_queue.test-email-events.arn}"
 }
-`
+`, topic, queue)
+}


### PR DESCRIPTION
```
SQS Queue Tests:

% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestAccAWSSQSQueue_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/04 12:05:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSQSQueue_
-timeout 120m
=== RUN   TestAccAWSSQSQueue_importBasic
--- PASS: TestAccAWSSQSQueue_importBasic (25.30s)
=== RUN   TestAccAWSSQSQueue_basic
--- PASS: TestAccAWSSQSQueue_basic (52.62s)
=== RUN   TestAccAWSSQSQueue_redrivePolicy
--- PASS: TestAccAWSSQSQueue_redrivePolicy (32.70s)
=== RUN   TestAccAWSSQSQueue_Policybasic
--- PASS: TestAccAWSSQSQueue_Policybasic (35.66s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    146.292s
```

```
SNS Topic Tests:

% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestAccAWSSNSTopic_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/04 12:10:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSNSTopic_
-timeout 120m
=== RUN   TestAccAWSSNSTopic_importBasic
--- PASS: TestAccAWSSNSTopic_importBasic (18.84s)
=== RUN   TestAccAWSSNSTopic_basic
--- PASS: TestAccAWSSNSTopic_basic (19.47s)
=== RUN   TestAccAWSSNSTopic_withIAMRole
--- PASS: TestAccAWSSNSTopic_withIAMRole (35.61s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    73.942s
```