### PR TITLE
provider/aws: Fix Lambda acceptance tests

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -258,26 +258,20 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", "tf_acc_lambda_name_s3_unversioned", &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_s3_unversioned"),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, "tf_acc_lambda_name_s3_unversioned"),
-					testAccCheckAwsLambdaSourceCodeHash(&conf, "un6qF9S9hKvXbWwJ6m2EYaVCWjcr0PCZWiTV3h4zB0I="),
+					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
 			resource.TestStep{
-				ExpectNonEmptyPlan: true,
 				PreConfig: func() {
 					// Upload 2nd version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile)
 				},
 				Config: genAWSLambdaFunctionConfig_s3_unversioned(bucketName, key2, path),
-			},
-			// Extra step because of missing ComputedWhen
-			// See https://github.com/hashicorp/terraform/pull/4846 & https://github.com/hashicorp/terraform/pull/5330
-			resource.TestStep{
-				Config: genAWSLambdaFunctionConfig_s3_unversioned(bucketName, key2, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", "tf_acc_lambda_name_s3_unversioned", &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_s3_unversioned"),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, "tf_acc_lambda_name_s3_unversioned"),
-					testAccCheckAwsLambdaSourceCodeHash(&conf, "Y5Jf4Si63UDy1wKNfPs+U56ZL0NxsieKPt9EwRl4GQM="),
+					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
 		},


### PR DESCRIPTION
Hash changes related to https://github.com/hashicorp/terraform/pull/8258

`ExpectNonEmptyPlan` was never actually necessary in this particular case as there's no extra interpolation necessary (unlike in versioned bucket that needs to generate the VersionId and basically re-interpolate). I assume it was just copy-paste error which was unnoticed in #6860

cc @alexef @apparentlymart 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSLambdaFunction_s3Update_unversioned'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSLambdaFunction_s3Update_unversioned -timeout 120m
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (92.26s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	92.282s
```