### PR TITLE
provider/aws: Support 'publish' attribute in lambda_function

### DIFF
--- a/builtin/providers/aws/import_aws_lambda_function_test.go
+++ b/builtin/providers/aws/import_aws_lambda_function_test.go
@@ -26,7 +26,7 @@ func TestAccAWSLambdaFunction_importLocalFile(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename"},
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -50,7 +50,7 @@ func TestAccAWSLambdaFunction_importLocalFile_VPC(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename"},
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -74,7 +74,7 @@ func TestAccAWSLambdaFunction_importS3(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"s3_bucket", "s3_key"},
+				ImportStateVerifyIgnore: []string{"s3_bucket", "s3_key", "publish"},
 			},
 		},
 	})

--- a/website/source/docs/providers/aws/r/lambda_function.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_function.html.markdown
@@ -56,6 +56,7 @@ resource "aws_lambda_function" "test_lambda" {
 * `memory_size` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
 * `runtime` - (Optional) Defaults to `nodejs`. See [Runtimes][6] for valid values.
 * `timeout` - (Optional) The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
+* `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `vpc_config` - (Optional) Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]
 * `source_code_hash` - (Optional) Used to trigger updates. This is only useful in conjuction with `filename`.
   The only useful value is `${base64sha256(file("file.zip"))}`.
@@ -70,6 +71,9 @@ resource "aws_lambda_function" "test_lambda" {
 ## Attributes Reference
 
 * `arn` - The Amazon Resource Name (ARN) identifying your Lambda Function.
+* `qualified_arn` - The Amazon Resource Name (ARN) identifying your Lambda Function Version
+  (if versioning is enabled via `publish = true`).
+* `version` - Latest published version of your Lambda Function
 * `last_modified` - The date this resource was last modified.
 * `source_code_hash` - Base64-encoded representation of raw SHA-256 sum of the zip file
   provided either via `filename` or `s3_*` parameters


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/6067

### Test plan
See https://github.com/hashicorp/terraform/pull/8652 first before running these tests and actually merging this PR.
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSLambdaFunction'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSLambdaFunction -timeout 120m
=== RUN   TestAccAWSLambdaFunction_importLocalFile
--- PASS: TestAccAWSLambdaFunction_importLocalFile (53.23s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (51.13s)
=== RUN   TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_importS3 (62.24s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (50.17s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (53.84s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (52.12s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (44.01s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (42.00s)
=== RUN   TestAccAWSLambdaFunction_s3Update
--- PASS: TestAccAWSLambdaFunction_s3Update (109.48s)
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (92.78s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	611.022s
```