### PR TITLE
provider/aws: Add aws_sqs_queue_policy

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -325,6 +325,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_spot_instance_request":                    resourceAwsSpotInstanceRequest(),
 			"aws_spot_fleet_request":                       resourceAwsSpotFleetRequest(),
 			"aws_sqs_queue":                                resourceAwsSqsQueue(),
+			"aws_sqs_queue_policy":                         resourceAwsSqsQueuePolicy(),
 			"aws_sns_topic":                                resourceAwsSnsTopic(),
 			"aws_sns_topic_policy":                         resourceAwsSnsTopicPolicy(),
 			"aws_sns_topic_subscription":                   resourceAwsSnsTopicSubscription(),

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -75,6 +75,7 @@ func resourceAwsSqsQueue() *schema.Resource {
 			"policy": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				StateFunc: func(v interface{}) string {
 					s, ok := v.(string)
 					if !ok || s == "" {

--- a/builtin/providers/aws/resource_aws_sqs_queue_policy.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_policy.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSqsQueuePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSqsQueuePolicyUpsert,
+		Read:   resourceAwsSqsQueuePolicyRead,
+		Update: resourceAwsSqsQueuePolicyUpsert,
+		Delete: resourceAwsSqsQueuePolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"queue_url": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy": &schema.Schema{
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+		},
+	}
+}
+
+func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+	url := d.Get("queue_url").(string)
+
+	_, err := conn.SetQueueAttributes(&sqs.SetQueueAttributesInput{
+		QueueUrl: aws.String(url),
+		Attributes: aws.StringMap(map[string]string{
+			"Policy": d.Get("policy").(string),
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("Error updating SQS attributes: %s", err)
+	}
+
+	d.SetId("sqs-policy-" + url)
+
+	return resourceAwsSqsQueuePolicyRead(d, meta)
+}
+
+func resourceAwsSqsQueuePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+	url := d.Get("queue_url").(string)
+	out, err := conn.GetQueueAttributes(&sqs.GetQueueAttributesInput{
+		QueueUrl:       aws.String(url),
+		AttributeNames: []*string{aws.String("Policy")},
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AWS.SimpleQueueService.NonExistentQueue" {
+			log.Printf("[WARN] SQS Queue (%s) not found", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	if out == nil {
+		return fmt.Errorf("Received empty response for SQS queue %s", d.Id())
+	}
+
+	policy, ok := out.Attributes["Policy"]
+	if !ok {
+		return fmt.Errorf("SQS Queue policy not found for %s", d.Id())
+	}
+
+	d.Set("policy", policy)
+
+	return nil
+}
+
+func resourceAwsSqsQueuePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+
+	url := d.Get("queue_url").(string)
+	log.Printf("[DEBUG] Deleting SQS Queue Policy of %s", url)
+	_, err := conn.SetQueueAttributes(&sqs.SetQueueAttributesInput{
+		QueueUrl: aws.String(url),
+		Attributes: aws.StringMap(map[string]string{
+			"Policy": "",
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting SQS Queue policy: %s", err)
+	}
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_sqs_queue_policy_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_policy_test.go
@@ -1,0 +1,63 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSQSPolicyConfig_basic(queueName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.q"),
+					resource.TestMatchResourceAttr("aws_sqs_queue_policy.test", "policy",
+						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSSQSPolicyConfig_basic(r string) string {
+	return fmt.Sprintf(testAccAWSSQSPolicyConfig_basic_tpl, r)
+}
+
+const testAccAWSSQSPolicyConfig_basic_tpl = `
+resource "aws_sqs_queue" "q" {
+  name = "%s"
+}
+
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = "${aws_sqs_queue.q.id}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "sqspolicy",
+  "Statement": [
+    {
+      "Sid": "First",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "${aws_sqs_queue.q.arn}",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "${aws_sqs_queue.q.arn}"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}
+`

--- a/website/source/docs/providers/aws/r/sqs_queue_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/sqs_queue_policy.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "aws"
+page_title: "AWS: aws_sqs_queue_policy"
+sidebar_current: "docs-aws-resource-sqs-queue-policy"
+description: |-
+  Provides a SQS Queue Policy resource.
+---
+
+# aws\_sqs\_queue\_policy
+
+Allows you to set a policy of an SQS Queue
+while referencing ARN of the queue within the policy.
+
+## Example Usage
+
+```
+resource "aws_sqs_queue" "q" {
+  name = "examplequeue"
+}
+
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = "${aws_sqs_queue.q.id}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "sqspolicy",
+  "Statement": [
+    {
+      "Sid": "First",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "${aws_sqs_queue.q.arn}",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "${aws_sqs_queue.q.arn}"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `queue_url` - (Required) The URL of the SNS Queue to which to attach the policy
+* `policy` - (Required) The JSON policy for the SQS queue

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -880,6 +880,10 @@
                             <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-sqs-queue-policy") %>>
+                            <a href="/docs/providers/aws/r/sqs_queue_policy.html">aws_sqs_queue_policy</a>
+                        </li>
+
                     </ul>
                 </li>
 


### PR DESCRIPTION
This may conflict with https://github.com/hashicorp/terraform/pull/8650 so it's probably best to merge that one 1st and then let me rebase this PR.

### Test plan
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSSQSQueuePolicy'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSSQSQueuePolicy -timeout 120m
=== RUN   TestAccAWSSQSQueuePolicy_basic
--- PASS: TestAccAWSSQSQueuePolicy_basic (30.99s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	31.006s
```