### PR TITLE
provider/scaleway: fix security_group_rule identification

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_security_group_rule.go
+++ b/builtin/providers/scaleway/resource_scaleway_security_group_rule.go
@@ -89,8 +89,16 @@ func resourceScalewaySecurityGroupRuleCreate(d *schema.ResourceData, m interface
 		return err
 	}
 
+	matches := func(rule api.ScalewaySecurityGroupRule) bool {
+		return rule.Action == req.Action &&
+			rule.Direction == req.Direction &&
+			rule.IPRange == req.IPRange &&
+			rule.Protocol == req.Protocol &&
+			rule.DestPortFrom == req.DestPortFrom
+	}
+
 	for _, rule := range resp.Rules {
-		if rule.Action == req.Action && rule.Direction == req.Direction && rule.IPRange == req.IPRange && rule.Protocol == req.Protocol {
+		if matches(rule) {
 			d.SetId(rule.ID)
 			break
 		}

--- a/builtin/providers/scaleway/resource_scaleway_security_group_rule_test.go
+++ b/builtin/providers/scaleway/resource_scaleway_security_group_rule_test.go
@@ -21,10 +21,16 @@ func TestAccScalewaySecurityGroupRule_Basic(t *testing.T) {
 				Config: testAccCheckScalewaySecurityGroupRuleConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewaySecurityGroupsExists("scaleway_security_group.base", &group),
-					resource.TestCheckResourceAttr("scaleway_security_group_rule.http", "action", "drop"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.http", "action", "accept"),
 					resource.TestCheckResourceAttr("scaleway_security_group_rule.http", "direction", "inbound"),
 					resource.TestCheckResourceAttr("scaleway_security_group_rule.http", "ip_range", "0.0.0.0/0"),
 					resource.TestCheckResourceAttr("scaleway_security_group_rule.http", "protocol", "TCP"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.http", "port", "80"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.https", "action", "accept"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.https", "direction", "inbound"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.https", "ip_range", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.https", "protocol", "TCP"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.https", "port", "443"),
 					testAccCheckScalewaySecurityGroupRuleExists("scaleway_security_group_rule.http", &group),
 					testAccCheckScalewaySecurityGroupRuleAttributes("scaleway_security_group_rule.http", &group),
 				),
@@ -93,7 +99,7 @@ func testAccCheckScalewaySecurityGroupRuleAttributes(n string, group *api.Scalew
 			return err
 		}
 
-		if rule.Rules.Action != "drop" {
+		if rule.Rules.Action != "accept" {
 			return fmt.Errorf("Wrong rule action")
 		}
 		if rule.Rules.Direction != "inbound" {
@@ -149,10 +155,20 @@ resource "scaleway_security_group" "base" {
 resource "scaleway_security_group_rule" "http" {
   security_group = "${scaleway_security_group.base.id}"
 
-  action = "drop"
+  action = "accept"
   direction = "inbound"
   ip_range = "0.0.0.0/0"
   protocol = "TCP"
   port = 80
+}
+
+resource "scaleway_security_group_rule" "https" {
+  security_group = "${scaleway_security_group.base.id}"
+
+  action = "accept"
+  direction = "inbound"
+  ip_range = "0.0.0.0/0"
+  protocol = "TCP"
+  port = 443
 }
 `


### PR DESCRIPTION
this PR fixes a bug in the scaleway `security_group_rule`: when storing the ID of a security group rule, the check to identify the rule was wrong.

before:

```
rule.Action == req.Action &&
			rule.Direction == req.Direction &&
			rule.IPRange == req.IPRange &&
			rule.Protocol == req.Protocol
```

after:

```
rule.Action == req.Action &&
			rule.Direction == req.Direction &&
			rule.IPRange == req.IPRange &&
			rule.Protocol == req.Protocol &&
			rule.DestPortFrom == req.DestPortFrom
```

this would result in terraform not properly identifying correct rules, thus not setting up security group rules properly.

see https://github.com/hashicorp/terraform/pull/7784#issuecomment-244754720 for a report (thanks @sheerun)

I've updated the tests to show the problem, and fix it accordingly:

```
make testacc TEST=./builtin/providers/scaleway TESTARGS='-run=TestAccScalewaySecurityGroupRule_Basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/05 16:33:12 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScalewaySecurityGroupRule_Basic -timeout 120m
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (3.71s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/scaleway	3.725s
```