### PR TITLE
provider/aws: Allow `aws_alb` to have the name auto-generated

### DIFF
--- a/builtin/providers/aws/resource_aws_alb.go
+++ b/builtin/providers/aws/resource_aws_alb.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -28,8 +29,17 @@ func resourceAwsAlb() *schema.Resource {
 			},
 
 			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateElbName,
+			},
+
+			"name_prefix": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateElbName,
 			},
@@ -111,8 +121,18 @@ func resourceAwsAlb() *schema.Resource {
 func resourceAwsAlbCreate(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
+	var name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		name = resource.PrefixedUniqueId(v.(string))
+	} else {
+		name = resource.PrefixedUniqueId("tf-lb-")
+	}
+	d.Set("name", name)
+
 	elbOpts := &elbv2.CreateLoadBalancerInput{
-		Name: aws.String(d.Get("name").(string)),
+		Name: aws.String(name),
 		Tags: tagsFromMapELBv2(d.Get("tags").(map[string]interface{})),
 	}
 

--- a/builtin/providers/aws/resource_aws_alb_test.go
+++ b/builtin/providers/aws/resource_aws_alb_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -39,6 +40,48 @@ func TestAccAWSALB_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "zone_id"),
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "dns_name"),
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALB_generatedName(t *testing.T) {
+	var conf elbv2.LoadBalancer
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb.alb_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBConfig_generatedName(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALB_namePrefix(t *testing.T) {
+	var conf elbv2.LoadBalancer
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb.alb_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBConfig_namePrefix(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "name"),
+					resource.TestMatchResourceAttr("aws_alb.alb_test", "name",
+						regexp.MustCompile("^tf-lb")),
 				),
 			},
 		},
@@ -291,6 +334,141 @@ resource "aws_security_group" "alb_test" {
     TestName = "TestAccAWSALB_basic"
   }
 }`, albName)
+}
+
+func testAccAWSALBConfig_generatedName() string {
+	return fmt.Sprintf(`
+resource "aws_alb" "alb_test" {
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}`)
+}
+
+func testAccAWSALBConfig_namePrefix() string {
+	return fmt.Sprintf(`
+resource "aws_alb" "alb_test" {
+  name_prefix     = "tf-lb"
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}`)
 }
 func testAccAWSALBConfig_updatedTags(albName string) string {
 	return fmt.Sprintf(`resource "aws_alb" "alb_test" {

--- a/website/source/docs/providers/aws/r/alb.html.markdown
+++ b/website/source/docs/providers/aws/r/alb.html.markdown
@@ -37,8 +37,10 @@ resource "aws_alb" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the ALB. This name must be unique within your AWS account, can have a maximum of 
-32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen.
+* `name` - (Optional) The name of the ALB. This name must be unique within your AWS account, can have a maximum of 32 characters, 
+must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, 
+Terraform will autogenerate a name beginning with `tf-lb`.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `internal` - (Optional) If true, the ALB will be internal.
 * `security_groups` - (Optional) A list of security group IDs to assign to the ELB.
 * `access_logs` - (Optional) An Access Logs block. Access Logs documented below.


### PR DESCRIPTION
In order to satisify scenarios where a lifecycle is block is used, we
would need the AWS ALB name field to be autogenerated. We follow the
same work as AWS ELB, we allow either a name-prefix or we automatically assign a prefix of `tf-lb`

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSALB_'                                                                                                                            2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/08 12:43:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSALB_ -timeout 120m
=== RUN   TestAccAWSALB_basic
--- PASS: TestAccAWSALB_basic (79.81s)
=== RUN   TestAccAWSALB_generatedName
--- PASS: TestAccAWSALB_generatedName (93.81s)
=== RUN   TestAccAWSALB_namePrefix
--- PASS: TestAccAWSALB_namePrefix (73.48s)
=== RUN   TestAccAWSALB_tags
--- PASS: TestAccAWSALB_tags (181.32s)
=== RUN   TestAccAWSALB_noSecurityGroup
--- PASS: TestAccAWSALB_noSecurityGroup (66.03s)
=== RUN   TestAccAWSALB_accesslogs
--- PASS: TestAccAWSALB_accesslogs (130.82s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	625.285s
```