### PR TITLE
provider/aws: Support Policy DiffSuppression in `aws_kms_key` policy

### DIFF
--- a/builtin/providers/aws/import_aws_kms_key_test.go
+++ b/builtin/providers/aws/import_aws_kms_key_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAWSKMSKey_importBasic(t *testing.T) {
+func TestAccAWSKmsKey_importBasic(t *testing.T) {
 	resourceName := "aws_kms_key.foo"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/aws/resource_aws_kms_key.go
+++ b/builtin/providers/aws/resource_aws_kms_key.go
@@ -52,10 +52,10 @@ func resourceAwsKmsKey() *schema.Resource {
 				},
 			},
 			"policy": &schema.Schema{
-				Type:      schema.TypeString,
-				Optional:  true,
-				Computed:  true,
-				StateFunc: normalizeJson,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"is_enabled": &schema.Schema{
 				Type:     schema.TypeBool,

--- a/builtin/providers/aws/resource_aws_kms_key_test.go
+++ b/builtin/providers/aws/resource_aws_kms_key_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/jen20/awspolicyequivalence"
 )
 
 func TestAccAWSKmsKey_basic(t *testing.T) {
@@ -19,16 +20,36 @@ func TestAccAWSKmsKey_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSKmsKey,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &keyBefore),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSKmsKey_removedPolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &keyAfter),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsKey_policy(t *testing.T) {
+	var key kms.KeyMetadata
+	expectedPolicyText := `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Sid":"Enable IAM User Permissions","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:*","Resource":"*"}]}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsKey,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &key),
+					testAccCheckAWSKmsKeyHasPolicy("aws_kms_key.foo", expectedPolicyText),
 				),
 			},
 		},
@@ -43,7 +64,7 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSKmsKey_enabledRotation,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsKeyExists("aws_kms_key.bar", &key1),
@@ -52,7 +73,7 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_kms_key.bar", "enable_key_rotation", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSKmsKey_disabled,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsKeyExists("aws_kms_key.bar", &key2),
@@ -61,7 +82,7 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_kms_key.bar", "enable_key_rotation", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSKmsKey_enabled,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsKeyExists("aws_kms_key.bar", &key3),
@@ -72,6 +93,42 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSKmsKeyHasPolicy(name string, expectedPolicyText string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No KMS Key ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).kmsconn
+
+		out, err := conn.GetKeyPolicy(&kms.GetKeyPolicyInput{
+			KeyId:      aws.String(rs.Primary.ID),
+			PolicyName: aws.String("default"),
+		})
+		if err != nil {
+			return err
+		}
+
+		actualPolicyText := *out.Policy
+
+		equivalent, err := awspolicy.PoliciesAreEquivalent(actualPolicyText, expectedPolicyText)
+		if err != nil {
+			return fmt.Errorf("Error testing policy equivalence: %s", err)
+		}
+		if !equivalent {
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
+				expectedPolicyText, actualPolicyText)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckAWSKmsKeyDestroy(s *terraform.State) error {


### PR DESCRIPTION
Fixes #7495

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSKmsKey_policy'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/06 10:44:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSKmsKey_policy
-timeout 120m
=== RUN   TestAccAWSKmsKey_importBasic
--- PASS: TestAccAWSKmsKey_importBasic (166.19s)
=== RUN   TestAccAWSKmsKey_basic
--- PASS: TestAccAWSKmsKey_basic (215.33s)
=== RUN   TestAccAWSKmsKey_policy
--- PASS: TestAccAWSKmsKey_policy (116.81s)
=== RUN   TestAccAWSKmsKey_isEnabled
--- PASS: TestAccAWSKmsKey_isEnabled (1008.31s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws
1689.957s
```