### PR TITLE
Improvements for Scaleway machine creation

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -99,20 +99,6 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 	server.DynamicIPRequired = Bool(d.Get("dynamic_ip_required").(bool))
 	server.CommercialType = d.Get("type").(string)
 
-	arch := ""
-	if arch == "" {
-		server.CommercialType = strings.ToUpper(server.CommercialType)
-		switch server.CommercialType[:2] {
-		case "C1":
-			arch = "arm"
-		case "C2", "VC":
-			arch = "x86_64"
-		default:
-			log.Printf("[ERROR] %s wrong commercial type", server.CommercialType)
-			return errors.New("Wrong commercial type")
-		}
-	}
-
 	if bootscript, ok := d.GetOk("bootscript"); ok {
 		bootscript_id := bootscript.(string)
 

--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -100,7 +100,7 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 	server.CommercialType = d.Get("type").(string)
 
 	if bootscript, ok := d.GetOk("bootscript"); ok {
-		bootscript_id := bootscript.(string)
+		bootscript_id := String(bootscript.(string))
 
 		bootscripts, err := scaleway.GetBootscripts()
 		if err != nil {

--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -1,11 +1,9 @@
 package scaleway
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/scaleway/scaleway-cli/pkg/api"
@@ -100,7 +98,7 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 	server.CommercialType = d.Get("type").(string)
 
 	if bootscript, ok := d.GetOk("bootscript"); ok {
-		bootscript_id := String(bootscript.(string))
+		bootscript_id := bootscript.(string)
 
 		bootscripts, err := scaleway.GetBootscripts()
 		if err != nil {

--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -28,11 +28,12 @@ The following arguments are supported:
 * `name` - (Required) name of ARM server
 * `image` - (Required) base image of ARM server
 * `type` - (Required) type of ARM server
-* `bootscript` - (Optional) server bootscript
+* `bootscript` - (Optional) server bootscript, can be bootscript id or name. ex: "x86_64 4.5.7 docker \#4"
 * `tags` - (Optional) list of tags for server
 * `enable_ipv6` - (Optional) enable ipv6
 * `dynamic_ip_required` - (Optional) make server publicly available
 * `security_group` - (Optional) assign security group to server
+* `volumes` - (Optional) list of sizes (in GB) of extra volumes to create
 
 Field `name`, `type`, `tags`, `dynamic_ip_required`, `security_group` are editable.
 


### PR DESCRIPTION
- Add support for creating extra volumes during machine creation.
  Some machine types require extra volumes to be present when creating the machine.
- Add support for specifying a name of a bootscript instead of only id.
  Finding the ID of a bootscript is a big pain.
