### PR TITLE
New users should know it's possible to save credentials outside of tf…

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -74,8 +74,8 @@ AWS access key and secret key, available from
 We're hardcoding them for now, but will extract these into
 variables later in the getting started guide.
 
-~>**Note**: If you simply leave out AWS credentials, Terraform will automatically search for saved API credentials (for example, in ~/.aws/credentials) or AIM instance profile credentials. This option is much cleaner for situations where tf files are checked into source control or where there is more than one admin user.
-See details [here] (https://aws.amazon.com/blogs/apn/terraform-beyond-the-basics-with-aws/). Not only do you NOT want AIM crdentials in source control, but you also want different IAM credentials for each admin user.
+~>**Note**: If you simply leave out AWS credentials, Terraform will automatically search for saved API credentials (for example, in ~/.aws/credentials) or IAM instance profile credentials. This option is much cleaner for situations where tf files are checked into source control or where there is more than one admin user.
+See details [here] (https://aws.amazon.com/blogs/apn/terraform-beyond-the-basics-with-aws/). Not only do you NOT want AIM credentials in source control, but you also want different IAM credentials for each admin user.
 
 This is a complete configuration that Terraform is ready to apply.
 The general structure should be intuitive and straightforward.

--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -74,6 +74,9 @@ AWS access key and secret key, available from
 We're hardcoding them for now, but will extract these into
 variables later in the getting started guide.
 
+~>**Note**: If you simply leave out AWS credentials, Terraform will automatically search for saved API credentials (for example, in ~/.aws/credentials) or AIM instance profile credentials. This option is much cleaner for situations where tf files are checked into source control or where there is more than one admin user.
+See details [here] (https://aws.amazon.com/blogs/apn/terraform-beyond-the-basics-with-aws/). Not only do you NOT want AIM crdentials in source control, but you also want different IAM credentials for each admin user.
+
 This is a complete configuration that Terraform is ready to apply.
 The general structure should be intuitive and straightforward.
 


### PR DESCRIPTION
… configs

Terraform will automatically search for AWS API credentials or Instance Profile Credentials. I wish I'd known that when I first read these docs.
Saving credentials outside of tf config files is a much better plan for situations where config files end up in source control and or where multiple people collaborate. Making this information available early will allow new users to set up a much more secure and robust plan for deploying terraform at scale and in production environments.
