### PR TITLE
provider/aws: Export AWS ELB service account ARN

### DIFF
--- a/builtin/providers/aws/data_source_aws_elb_service_account.go
+++ b/builtin/providers/aws/data_source_aws_elb_service_account.go
@@ -32,6 +32,10 @@ func dataSourceAwsElbServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -44,6 +48,9 @@ func dataSourceAwsElbServiceAccountRead(d *schema.ResourceData, meta interface{}
 
 	if accid, ok := elbAccountIdPerRegionMap[region]; ok {
 		d.SetId(accid)
+
+		d.Set("arn", "arn:aws:iam::"+accid+":root")
+
 		return nil
 	}
 

--- a/builtin/providers/aws/data_source_aws_elb_service_account_test.go
+++ b/builtin/providers/aws/data_source_aws_elb_service_account_test.go
@@ -15,12 +15,14 @@ func TestAccAWSElbServiceAccount_basic(t *testing.T) {
 				Config: testAccCheckAwsElbServiceAccountConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_elb_service_account.main", "id", "797873946194"),
+					resource.TestCheckResourceAttr("data.aws_elb_service_account.main", "arn", "arn:aws:iam::797873946194:root"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccCheckAwsElbServiceAccountExplicitRegionConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_elb_service_account.regional", "id", "156460612806"),
+					resource.TestCheckResourceAttr("data.aws_elb_service_account.regional", "arn", "arn:aws:iam::156460612806:root"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/d/elb_service_account.html.markdown
+++ b/website/source/docs/providers/aws/d/elb_service_account.html.markdown
@@ -68,3 +68,4 @@ resource "aws_elb" "bar" {
 ## Attributes Reference
 
 * `id` - The ID of the AWS ELB service account in the selected region.
+* `arn` - The ARN of the AWS ELB service account in the selected region.


### PR DESCRIPTION
I'm new to Go so please bear with me.

This PR exports the `arn` attribute for the AWS ELB service account data source.

While `id` is helpful, AWS will re-write plain IDs in policies to use the full ARN, generating spurious diffs. Perhaps that is better solved by changing the policy parser/differ, but I don't know how to do that...

I was unable to get `make test TEST=./builtin/providers/aws/` to work so I'm relying on CI or someone to tell me what's wrong, or how to test just this data source.