### PR TITLE
provider/aws: Add AWS Billing & Cost Management service account

### DIFF
--- a/builtin/providers/aws/data_source_aws_billing_service_account.go
+++ b/builtin/providers/aws/data_source_aws_billing_service_account.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/schema"
 )
 

--- a/builtin/providers/aws/data_source_aws_billing_service_account.go
+++ b/builtin/providers/aws/data_source_aws_billing_service_account.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+  "fmt"
+
+  "github.com/hashicorp/terraform/helper/schema"
+)
+
+// See http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-getting-started.html#step-2
+var billingAccountId = "386209384616"
+
+func dataSourceAwsBillingServiceAccount() *schema.Resource {
+  return &schema.Resource{
+    Read: dataSourceAwsBillingServiceAccountRead,
+
+    Schema: map[string]*schema.Schema{
+      "arn": &schema.Schema{
+        Type:     schema.TypeString,
+        Computed: true,
+      },
+    },
+  }
+}
+
+func dataSourceAwsBillingServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
+  d.SetId(billingAccountId)
+
+  d.Set("arn", "arn:aws:iam::"+billingAccountId+":root")
+
+  return nil
+}

--- a/builtin/providers/aws/data_source_aws_billing_service_account.go
+++ b/builtin/providers/aws/data_source_aws_billing_service_account.go
@@ -1,31 +1,31 @@
 package aws
 
 import (
-  "fmt"
+	"fmt"
 
-  "github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 // See http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-getting-started.html#step-2
 var billingAccountId = "386209384616"
 
 func dataSourceAwsBillingServiceAccount() *schema.Resource {
-  return &schema.Resource{
-    Read: dataSourceAwsBillingServiceAccountRead,
+	return &schema.Resource{
+		Read: dataSourceAwsBillingServiceAccountRead,
 
-    Schema: map[string]*schema.Schema{
-      "arn": &schema.Schema{
-        Type:     schema.TypeString,
-        Computed: true,
-      },
-    },
-  }
+		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
 }
 
 func dataSourceAwsBillingServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
-  d.SetId(billingAccountId)
+	d.SetId(billingAccountId)
 
-  d.Set("arn", "arn:aws:iam::"+billingAccountId+":root")
+	d.Set("arn", "arn:aws:iam::"+billingAccountId+":root")
 
-  return nil
+	return nil
 }

--- a/builtin/providers/aws/data_source_aws_billing_service_account_test.go
+++ b/builtin/providers/aws/data_source_aws_billing_service_account_test.go
@@ -1,25 +1,25 @@
 package aws
 
 import (
-  "testing"
+	"testing"
 
-  "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSBillingServiceAccount_basic(t *testing.T) {
-  resource.Test(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    Steps: []resource.TestStep{
-      resource.TestStep{
-        Config: testAccCheckAwsBillingServiceAccountConfig,
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "id", "386209384616"),
-          resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "arn", "arn:aws:iam::386209384616:root"),
-        ),
-      }
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsBillingServiceAccountConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "id", "386209384616"),
+					resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "arn", "arn:aws:iam::386209384616:root"),
+				),
+			},
+		},
+	})
 }
 
 const testAccCheckAwsBillingServiceAccountConfig = `

--- a/builtin/providers/aws/data_source_aws_billing_service_account_test.go
+++ b/builtin/providers/aws/data_source_aws_billing_service_account_test.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+  "testing"
+
+  "github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSBillingServiceAccount_basic(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:  func() { testAccPreCheck(t) },
+    Providers: testAccProviders,
+    Steps: []resource.TestStep{
+      resource.TestStep{
+        Config: testAccCheckAwsBillingServiceAccountConfig,
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "id", "386209384616"),
+          resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "arn", "arn:aws:iam::386209384616:root"),
+        ),
+      }
+    },
+  })
+}
+
+const testAccCheckAwsBillingServiceAccountConfig = `
+data "aws_billing_service_account" "main" { }
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -145,6 +145,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"aws_ami":                      dataSourceAwsAmi(),
 			"aws_availability_zones":       dataSourceAwsAvailabilityZones(),
+			"aws_billing_service_account":  dataSourceAwsBillingServiceAccount(),
 			"aws_caller_identity":          dataSourceAwsCallerIdentity(),
 			"aws_cloudformation_stack":     dataSourceAwsCloudFormationStack(),
 			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),

--- a/website/source/docs/providers/aws/d/billing_service_account.markdown
+++ b/website/source/docs/providers/aws/d/billing_service_account.markdown
@@ -1,0 +1,60 @@
+---
+layout: "aws"
+page_title: "AWS: aws_billing_service_account"
+sidebar_current: "docs-aws-datasource-billing-service-account"
+description: |-
+  Get AWS Billing Service Account
+---
+
+# aws\_billing\_service\_account
+
+Use this data source to get the Account ID of the [AWS Billing and Cost Management Service Account](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-getting-started.html#step-2) for the purpose of whitelisting in S3 bucket policy.
+
+## Example Usage
+
+```
+data "aws_billing_service_account" "main" { }
+
+resource "aws_s3_bucket" "billing_logs" {
+    bucket = "my-billing-tf-test-bucket"
+    acl = "private"
+    policy = <<POLICY
+{
+  "Id": "Policy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetBucketAcl", "s3:GetBucketPolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket",
+      "Principal": {
+        "AWS": [
+          "${data.aws_billing_service_account.main.id}"
+        ]
+      }
+    },
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/AWSLogs/*",
+      "Principal": {
+        "AWS": [
+          "${data.aws_billing_service_account.main.id}"
+        ]
+      }
+    }
+  ]
+}
+POLICY
+}
+```
+
+
+## Attributes Reference
+
+* `id` - The ID of the AWS billing service account.
+* `arn` - The ARN of the AWS billing service account.


### PR DESCRIPTION
This adds a very simple data source for the AWS Billing & Cost Management account magic number.

Used to allow AWS to dump detailed billing reports into an S3 bucket you control.

http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-getting-started.html#step-2

I'm basing my work off #8221.

As in my first contribution attempt in #8700, I'm new to Go and working blind as I haven't been able to build or test this code. I'm hoping someone who knows what they're doing can check and modify this as needed.

