### PR TITLE
fix typo in local-exec provisioner documentation

### DIFF
--- a/website/source/docs/provisioners/local-exec.html.markdown
+++ b/website/source/docs/provisioners/local-exec.html.markdown
@@ -13,7 +13,7 @@ is created. This invokes a process on the machine running Terraform, not on
 the resource. See the `remote-exec` [provisioner](/docs/provisioners/remote-exec.html)
 to run commands on the resource.
 
-Note that even though the resource will be ifully created when the provisioner is run,
+Note that even though the resource will be fully created when the provisioner is run,
 there is no guarantee that it will be in an operable state - for example system services
 such as `sshd` may not be started yet on compute resources.
 


### PR DESCRIPTION
A recent edit to this doc added a minor typo. 