### PR TITLE
core: allow overriding data dir with $TF_DATA_DIR

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -14,6 +14,10 @@ var test bool = false
 // DefaultDataDir is the default directory for storing local data.
 const DefaultDataDir = ".terraform"
 
+// DataDirEnvVar is the name of the environment variable that can be used to
+// override the data directory.
+const DataDirEnvVar = "TF_DATA_DIR"
+
 // DefaultStateFilename is the default filename used for the state file.
 const DefaultStateFilename = "terraform.tfstate"
 

--- a/command/init.go
+++ b/command/init.go
@@ -57,7 +57,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	// Set the state out path to be the path requested for the module
 	// to be copied. This ensures any remote states gets setup in the
-	// proper directory.
+	// proper directory. This overrides $TF_DATA_DIR!
 	c.Meta.dataDir = filepath.Join(path, DefaultDataDir)
 
 	source := args[0]

--- a/command/meta.go
+++ b/command/meta.go
@@ -109,7 +109,7 @@ func (m *Meta) Context(copts contextOpts) (*terraform.Context, bool, error) {
 		f.Close()
 		if err == nil {
 			// Setup our state
-			state, statePath, err := StateFromPlan(m.statePath, m.stateOutPath, plan)
+			state, statePath, err := StateFromPlan(m.statePath, m.stateOutPath, m.DataDir(), plan)
 			if err != nil {
 				return nil, false, fmt.Errorf("Error loading plan: %s", err)
 			}
@@ -179,12 +179,13 @@ func (m *Meta) Context(copts contextOpts) (*terraform.Context, bool, error) {
 
 // DataDir returns the directory where local data will be stored.
 func (m *Meta) DataDir() string {
-	dataDir := DefaultDataDir
 	if m.dataDir != "" {
-		dataDir = m.dataDir
+		return m.dataDir
 	}
-
-	return dataDir
+	if envVar := os.Getenv(DataDirEnvVar); envVar != "" {
+		return envVar
+	}
+	return DefaultDataDir
 }
 
 const (

--- a/command/push.go
+++ b/command/push.go
@@ -202,6 +202,9 @@ func (c *PushCommand) Run(args []string) int {
 
 	// Build the archiving options, which includes everything it can
 	// by default according to VCS rules but forcing the data directory.
+	// Note that we always use DefaultDataDir here, ignoring $TF_DATA_DIR,
+	// because this is defining the structure of the archive we send rather
+	// than the place we find the files locally.
 	archiveOpts := &archive.ArchiveOpts{
 		VCS: archiveVCS,
 		Extra: map[string]string{

--- a/command/state.go
+++ b/command/state.go
@@ -169,7 +169,7 @@ func State(opts *StateOpts) (*StateResult, error) {
 
 // StateFromPlan gets our state from the plan.
 func StateFromPlan(
-	localPath, outPath string,
+	localPath, outPath, dataDir string,
 	plan *terraform.Plan) (state.State, string, error) {
 	var result state.State
 	resultPath := localPath
@@ -179,7 +179,7 @@ func StateFromPlan(
 
 		// It looks like we have a remote state in the plan, so
 		// we have to initialize that.
-		resultPath = filepath.Join(DefaultDataDir, DefaultStateFilename)
+		resultPath = filepath.Join(dataDir, DefaultStateFilename)
 		result, err = remoteState(plan.State, resultPath, false)
 		if err != nil {
 			return nil, "", err

--- a/website/source/docs/configuration/environment-variables.html.md
+++ b/website/source/docs/configuration/environment-variables.html.md
@@ -8,6 +8,10 @@ description: |-
 
 # Environment Variables
 
+## TF_DATA_DIR
+
+This specifies the name of the directory where Terraform stores metadata files such as module sources and remote state files by default, overriding the default of `.terraform`.
+
 ## TF_LOG
 
 If set to any value, enables detailed logs to appear on stderr which is useful for debugging. For example:


### PR DESCRIPTION
Fixes #4487.

Note: I don't use Atlas so I was unable to confirm my suspicions about how `push` works.

I also don't use `terraform init` so I wasn't sure if it made sense to change the code there.  `$TF_DATA_DIR` could be either a relative or an absolute path, and if it's an absolute path it doesn't really make sense to combine it with the path given on the command line.  (We use it as a relative path.)
