### PR TITLE
typo consul catalog entry example

### DIFF
--- a/website/source/docs/providers/consul/r/catalog_entry.html.markdown
+++ b/website/source/docs/providers/consul/r/catalog_entry.html.markdown
@@ -15,7 +15,7 @@ Provides access to Catalog data in Consul. This can be used to define a node or 
 ```
 resource "consul_catalog_entry" "app" {
     address = "192.168.10.10"
-    name = "foobar"
+    node = "foobar"
     service = {
         address = "127.0.0.1"
         id = "redis1"


### PR DESCRIPTION
In the consul catalog entry example `name` was specified in the root of the resource rather than the key `node` which is the actual required key-name.