### PR TITLE
provider/aws: Prevent crash on account ID validation

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -232,7 +232,7 @@ func (c *Config) Client() (interface{}, error) {
 
 	authErr := c.ValidateAccountId(client.accountid)
 	if authErr != nil {
-		return nil, err
+		return nil, authErr
 	}
 
 	client.apigateway = apigateway.New(sess)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/8729

Introduced in https://github.com/hashicorp/terraform/pull/8638

### Test plan
```hcl
provider "aws" {
  region = "us-west-2"
  allowed_account_ids = ["invalid"]
}
```
expected output:
```
Error refreshing state: 1 error(s) occurred:

* Account ID not allowed (123456789012)
```