### PR TITLE
Vagrantfile improvement (apt-get)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ SRCROOT="/opt/go"
 SRCPATH="/opt/gopath"
 
 # Get the ARCH
-ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
+ARCH="$(uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|')"
 
 # Install Prereq Packages
 export DEBIAN_PRIORITY=critical
@@ -24,12 +24,12 @@ echo "Installing prerequisites ..."
 apt-get install ${APT_OPTS} build-essential curl git-core libpcre3-dev mercurial pkg-config zip >/dev/null
 
 # Install Go
-cd /tmp
-wget --quiet https://storage.googleapis.com/golang/go${GOVERSION}.linux-${ARCH}.tar.gz
-tar -xvf go${GOVERSION}.linux-${ARCH}.tar.gz
-mv go $SRCROOT
-chmod 775 $SRCROOT
-chown vagrant:vagrant $SRCROOT
+echo "Downloading go (${GOVERSION}) ..."
+wget -P /tmp --quiet "https://storage.googleapis.com/golang/go${GOVERSION}.linux-${ARCH}.tar.gz"
+echo "Setting up go (${GOVERSION}) ..."
+tar -C /opt -xf "/tmp/go${GOVERSION}.linux-${ARCH}.tar.gz"
+chmod 775 "$SRCROOT"
+chown vagrant:vagrant "$SRCROOT"
 
 # Setup the GOPATH; even though the shared folder spec gives the working
 # directory the right user/group, we need to set it properly on the

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,44 +13,43 @@ SRCPATH="/opt/gopath"
 ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
 
 # Install Prereq Packages
-sudo apt-get update
-sudo apt-get upgrade -y
-sudo apt-get install -y build-essential curl git-core libpcre3-dev mercurial pkg-config zip
+apt-get update
+apt-get upgrade -y
+apt-get install -y build-essential curl git-core libpcre3-dev mercurial pkg-config zip >/dev/null
 
 # Install Go
 cd /tmp
 wget --quiet https://storage.googleapis.com/golang/go${GOVERSION}.linux-${ARCH}.tar.gz
 tar -xvf go${GOVERSION}.linux-${ARCH}.tar.gz
-sudo mv go $SRCROOT
-sudo chmod 775 $SRCROOT
-sudo chown vagrant:vagrant $SRCROOT
+mv go $SRCROOT
+chmod 775 $SRCROOT
+chown vagrant:vagrant $SRCROOT
 
 # Setup the GOPATH; even though the shared folder spec gives the working
 # directory the right user/group, we need to set it properly on the
 # parent path to allow subsequent "go get" commands to work.
-sudo mkdir -p $SRCPATH
-sudo chown -R vagrant:vagrant $SRCPATH 2>/dev/null || true
+mkdir -p "$SRCPATH"
+chown -R vagrant:vagrant "$SRCPATH" 2>/dev/null || true
 # ^^ silencing errors here because we expect this to fail for the shared folder
 
-cat <<EOF >/tmp/gopath.sh
+install -m0755 /dev/stdin /etc/profile.d/gopath.sh <<EOF
 export GOPATH="$SRCPATH"
 export GOROOT="$SRCROOT"
 export PATH="$SRCROOT/bin:$SRCPATH/bin:\$PATH"
 EOF
-cat <<EOF >>~/.bashrc
 
+install -m0644 /dev/stdin /home/vagrant/.bashrc <<EOF
 ## After login, change to terraform directory
 cd /opt/gopath/src/github.com/hashicorp/terraform
 EOF
-sudo mv /tmp/gopath.sh /etc/profile.d/gopath.sh
-sudo chmod 0755 /etc/profile.d/gopath.sh
+
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "bento/ubuntu-14.04"
   config.vm.hostname = "terraform"
 
-  config.vm.provision "shell", inline: $script, privileged: false
+  config.vm.provision "shell", inline: $script
   config.vm.synced_folder '.', '/opt/gopath/src/github.com/hashicorp/terraform'
 
   ["vmware_fusion", "vmware_workstation"].each do |p|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,8 @@ export GOROOT="$SRCROOT"
 export PATH="$SRCROOT/bin:$SRCPATH/bin:\$PATH"
 EOF
 
-install -m0644 /dev/stdin /home/vagrant/.bashrc <<EOF
+cat >>/home/vagrant/.bashrc <<EOF
+
 ## After login, change to terraform directory
 cd /opt/gopath/src/github.com/hashicorp/terraform
 EOF

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,9 +13,15 @@ SRCPATH="/opt/gopath"
 ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
 
 # Install Prereq Packages
-apt-get update
-apt-get upgrade -y
-apt-get install -y build-essential curl git-core libpcre3-dev mercurial pkg-config zip >/dev/null
+export DEBIAN_PRIORITY=critical
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+APT_OPTS="--yes --force-yes --no-install-suggests --no-install-recommends"
+echo "Upgrading packages ..."
+apt-get update ${APT_OPTS} >/dev/null
+apt-get upgrade ${APT_OPTS} >/dev/null
+echo "Installing prerequisites ..."
+apt-get install ${APT_OPTS} build-essential curl git-core libpcre3-dev mercurial pkg-config zip >/dev/null
 
 # Install Go
 cd /tmp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "bento/ubuntu-14.04"
   config.vm.hostname = "terraform"
 
-  config.vm.provision "shell", inline: $script
+  config.vm.provision "prepare-shell", type: "shell", inline: "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile", privileged: false
+  config.vm.provision "initial-setup", type: "shell", inline: $script
   config.vm.synced_folder '.', '/opt/gopath/src/github.com/hashicorp/terraform'
 
   ["vmware_fusion", "vmware_workstation"].each do |p|


### PR DESCRIPTION
This pull does the following:

- runs `apt-get` in non-interactive mode, to prevent errors with `dpkg-preconfigure` while `apt-get upgrade`
- do not install *recommended* packages automatically, to prevents the unnecessary install of X11