### PR TITLE
provider/aws: query_string_cache_keys for CloudFront and require origin_access_identity in s3_origin_config complex structure

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -378,6 +378,9 @@ func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues
 	if v, ok := m["headers"]; ok {
 		fv.Headers = expandHeaders(v.([]interface{}))
 	}
+	if v, ok := m["query_string_cache_keys"]; ok {
+		fv.QueryStringCacheKeys = expandQueryStringCacheKeys(v.([]interface{}))
+	}
 	return fv
 }
 
@@ -389,6 +392,9 @@ func flattenForwardedValues(fv *cloudfront.ForwardedValues) map[string]interface
 	}
 	if fv.Headers != nil {
 		m["headers"] = flattenHeaders(fv.Headers)
+	}
+	if fv.QueryStringCacheKeys != nil {
+		m["query_string_cache_keys"] = flattenQueryStringCacheKeys(fv.QueryStringCacheKeys)
 	}
 	return m
 }
@@ -407,6 +413,11 @@ func forwardedValuesHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
+	if d, ok := m["query_string_cache_keys"]; ok {
+		for _, e := range sortInterfaceSlice(d.([]interface{})) {
+			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
+		}
+	}
 	return hashcode.String(buf.String())
 }
 
@@ -420,6 +431,20 @@ func expandHeaders(d []interface{}) *cloudfront.Headers {
 func flattenHeaders(h *cloudfront.Headers) []interface{} {
 	if h.Items != nil {
 		return flattenStringList(h.Items)
+	}
+	return []interface{}{}
+}
+
+func expandQueryStringCacheKeys(d []interface{}) *cloudfront.QueryStringCacheKeys {
+	return &cloudfront.QueryStringCacheKeys{
+		Quantity: aws.Int64(int64(len(d))),
+		Items:    expandStringList(d),
+	}
+}
+
+func flattenQueryStringCacheKeys(k *cloudfront.QueryStringCacheKeys) []interface{} {
+	if k.Items != nil {
+		return flattenStringList(k.Items)
 	}
 	return []interface{}{}
 }

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -46,14 +46,19 @@ func trustedSignersConf() []interface{} {
 
 func forwardedValuesConf() map[string]interface{} {
 	return map[string]interface{}{
-		"query_string": true,
-		"cookies":      schema.NewSet(cookiePreferenceHash, []interface{}{cookiePreferenceConf()}),
-		"headers":      headersConf(),
+		"query_string":            true,
+		"query_string_cache_keys": queryStringCacheKeysConf(),
+		"cookies":                 schema.NewSet(cookiePreferenceHash, []interface{}{cookiePreferenceConf()}),
+		"headers":                 headersConf(),
 	}
 }
 
 func headersConf() []interface{} {
 	return []interface{}{"X-Example1", "X-Example2"}
+}
+
+func queryStringCacheKeysConf() []interface{} {
+	return []interface{}{"foo", "bar"}
 }
 
 func cookiePreferenceConf() map[string]interface{} {
@@ -467,6 +472,27 @@ func TestCloudFrontStructure_flattenHeaders(t *testing.T) {
 	in := headersConf()
 	h := expandHeaders(in)
 	out := flattenHeaders(h)
+
+	if reflect.DeepEqual(in, out) != true {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestCloudFrontStructure_expandQueryStringCacheKeys(t *testing.T) {
+	data := queryStringCacheKeysConf()
+	k := expandQueryStringCacheKeys(data)
+	if *k.Quantity != 2 {
+		t.Fatalf("Expected Quantity to be 2, got %v", *k.Quantity)
+	}
+	if reflect.DeepEqual(k.Items, expandStringList(data)) != true {
+		t.Fatalf("Expected Items to be %v, got %v", data, k.Items)
+	}
+}
+
+func TestCloudFrontStructure_flattenQueryStringCacheKeys(t *testing.T) {
+	in := queryStringCacheKeysConf()
+	k := expandQueryStringCacheKeys(in)
+	out := flattenQueryStringCacheKeys(k)
 
 	if reflect.DeepEqual(in, out) != true {
 		t.Fatalf("Expected out to be %v, got %v", in, out)

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -87,6 +87,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Type:     schema.TypeBool,
 										Required: true,
 									},
+									"query_string_cache_keys": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
 								},
 							},
 						},
@@ -211,6 +216,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"query_string": &schema.Schema{
 										Type:     schema.TypeBool,
 										Required: true,
+									},
+									"query_string_cache_keys": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -358,8 +358,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"origin_access_identity": &schema.Schema{
 										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "",
+										Required: true,
 									},
 								},
 							},

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -196,6 +196,11 @@ of several sub-resources - these resources are laid out below.
   * `query_string` (Required) - Indicates whether you want CloudFront to forward
     query strings to the origin that is associated with this cache behavior.
 
+  * `query_string_cache_keys` (Optional) - When specified, along with a value of
+    `true` for `query_string`, all query strings are forwarded, however only the
+    query string keys listed in this argument are cached. When omitted with a
+    value of `true` for `query_string`, all query string keys are cached.
+
 ##### Cookies Arguments
 
   * `forward` (Required) - Specifies whether you want CloudFront to forward


### PR DESCRIPTION
I've combined these two commits because the tests won't pass without the first commit now (this is new, guessing in the last few days as I was messing with CloudFront a few days ago).

The second commit addresses #7930 by requiring `origin_access_identity` in `s3_origin_config`, if it's specified when creating a distribution. If it's not, then an origin access identity won't be used, but if the origin is S3 it will be configured as an S3 origin.
