### PR TITLE
provider/aws: kms encryption resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -259,6 +259,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kinesis_stream":                           resourceAwsKinesisStream(),
 			"aws_kms_alias":                                resourceAwsKmsAlias(),
 			"aws_kms_key":                                  resourceAwsKmsKey(),
+			"aws_kms_key_encrypt":                          resourceAwsKmsKeyEncrypt(),
 			"aws_lambda_function":                          resourceAwsLambdaFunction(),
 			"aws_lambda_event_source_mapping":              resourceAwsLambdaEventSourceMapping(),
 			"aws_lambda_alias":                             resourceAwsLambdaAlias(),

--- a/builtin/providers/aws/resource_aws_kms_encrypt.go
+++ b/builtin/providers/aws/resource_aws_kms_encrypt.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+)
+
+func resourceAwsKmsKeyEncrypt() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsKmsKeyEncryptCreate,
+		Read:   resourceAwsKmsKeyEncryptRead,
+		Delete: resourceAwsKmsKeyEncryptDelete,
+
+		Schema: map[string]*schema.Schema{
+			"key_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"plaintext": &schema.Schema{
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+			"ciphertext_blob": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsKmsKeyEncryptRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsKmsKeyEncryptDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsKmsKeyEncryptCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kmsconn
+
+	req := &kms.EncryptInput{
+		KeyId:     aws.String(d.Get("key_id").(string)),
+		Plaintext: []byte(d.Get("plaintext").(string)),
+	}
+
+	log.Printf("[DEBUG] KMS encrypt for key: %s", d.Get("key_id").(string))
+
+	out, err := conn.Encrypt(req)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s-encrypted", d.Get("key_id").(string)))
+	d.Set("ciphertext_blob", base64.StdEncoding.EncodeToString((out.CiphertextBlob)))
+	return nil
+}

--- a/website/source/docs/providers/aws/r/kms_key_encrypt.html.markdown
+++ b/website/source/docs/providers/aws/r/kms_key_encrypt.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "aws"
+page_title: "AWS: aws_kms_key_encrypt"
+sidebar_current: "docs-aws-resource-kms-key-encrypt"
+description: |-
+  encrypts content for a KMS key
+---
+
+# aws\_kms\_key\_encrypt
+
+Encrypts content for an aws_kms_key.
+
+## Example Usage
+
+```
+resource "aws_kms_key" "oauth_config" {
+  description = "oauth config"
+  is_enabled = true
+}
+
+resource "aws_kms_key_encrypt" "oauth" {
+  key_id = "${aws_kms_key.oauth_config.key_id}"
+  plaintext = <<EOF
+{
+  "client_id": "e587dbae22222f55da22",
+  "client_secret": "8289575d00000ace55e1815ec13673955721b8a5"
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `key_id` - (Required) the KMS key to be used
+* `plaintext` - (Required) the plaintext content
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `plaintext_blob` - Base64 encoded ciphertext blob


### PR DESCRIPTION
this PR adds a KMS encryption resource, as a possible solution for #6133.

Example usage:

```
resource "aws_kms_key" "oauth_config" {
  description = "oauth config"
  is_enabled = true
}

resource "aws_kms_key_encrypt" "oauth" {
  key_id = "${aws_kms_key.oauth_config.key_id}"
  plaintext = <<EOF
{
  "client_id": "e587dbae22222f55da22",
  "client_secret": "8289575d00000ace55e1815ec13673955721b8a5"
}
EOF
}

output "kms_ciphertext_blob" {
  value = "${aws_kms_key_encrypt.oauth.ciphertext_blob}"
}
```

decrypt: 

```
$ echo base64-string | base64 -D > /tmp/s
$ aws --region eu-west-1 kms decrypt --ciphertext-blob fileb:///tmp/s --output text --query Plaintext | base64 -D
```

This can be used to inline kms `ciphertext_blobs` for e.g. cloud-init scripts.
no tests yet because this is mostly a discussion point for the issue mentioned above.
