### PR TITLE
provider/aws: Add API Gateway Client Certificate

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -169,6 +169,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_api_gateway_api_key":                      resourceAwsApiGatewayApiKey(),
 			"aws_api_gateway_authorizer":                   resourceAwsApiGatewayAuthorizer(),
 			"aws_api_gateway_base_path_mapping":            resourceAwsApiGatewayBasePathMapping(),
+			"aws_api_gateway_client_certificate":           resourceAwsApiGatewayClientCertificate(),
 			"aws_api_gateway_deployment":                   resourceAwsApiGatewayDeployment(),
 			"aws_api_gateway_domain_name":                  resourceAwsApiGatewayDomainName(),
 			"aws_api_gateway_integration":                  resourceAwsApiGatewayIntegration(),

--- a/builtin/providers/aws/resource_aws_api_gateway_client_certificate.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_client_certificate.go
@@ -1,0 +1,125 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsApiGatewayClientCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsApiGatewayClientCertificateCreate,
+		Read:   resourceAwsApiGatewayClientCertificateRead,
+		Update: resourceAwsApiGatewayClientCertificateUpdate,
+		Delete: resourceAwsApiGatewayClientCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"created_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expiration_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pem_encoded_certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsApiGatewayClientCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	input := apigateway.GenerateClientCertificateInput{}
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+	log.Printf("[DEBUG] Generating API Gateway Client Certificate: %s", input)
+	out, err := conn.GenerateClientCertificate(&input)
+	if err != nil {
+		return fmt.Errorf("Failed to generate client certificate: %s", err)
+	}
+
+	d.SetId(*out.ClientCertificateId)
+
+	return resourceAwsApiGatewayClientCertificateRead(d, meta)
+}
+
+func resourceAwsApiGatewayClientCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	input := apigateway.GetClientCertificateInput{
+		ClientCertificateId: aws.String(d.Id()),
+	}
+	out, err := conn.GetClientCertificate(&input)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+			log.Printf("[WARN] API Gateway Client Certificate %s not found, removing", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	log.Printf("[DEBUG] Received API Gateway Client Certificate: %s", out)
+
+	d.Set("description", out.Description)
+	d.Set("created_date", out.CreatedDate)
+	d.Set("expiration_date", out.ExpirationDate)
+	d.Set("pem_encoded_certificate", out.PemEncodedCertificate)
+
+	return nil
+}
+
+func resourceAwsApiGatewayClientCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	operations := make([]*apigateway.PatchOperation, 0)
+	if d.HasChange("description") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/description"),
+			Value: aws.String(d.Get("description").(string)),
+		})
+	}
+
+	input := apigateway.UpdateClientCertificateInput{
+		ClientCertificateId: aws.String(d.Id()),
+		PatchOperations:     operations,
+	}
+
+	log.Printf("[DEBUG] Updating API Gateway Client Certificate: %s", input)
+	_, err := conn.UpdateClientCertificate(&input)
+	if err != nil {
+		return fmt.Errorf("Updating API Gateway Client Certificate failed: %s", err)
+	}
+
+	return resourceAwsApiGatewayClientCertificateRead(d, meta)
+}
+
+func resourceAwsApiGatewayClientCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+	log.Printf("[DEBUG] Deleting API Gateway Client Certificate: %s", d.Id())
+	input := apigateway.DeleteClientCertificateInput{
+		ClientCertificateId: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteClientCertificate(&input)
+	if err != nil {
+		return fmt.Errorf("Deleting API Gateway Client Certificate failed: %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_api_gateway_client_certificate_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_client_certificate_test.go
@@ -1,0 +1,128 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSAPIGatewayClientCertificate_basic(t *testing.T) {
+	var conf apigateway.ClientCertificate
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayClientCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayClientCertificateConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayClientCertificateExists("aws_api_gateway_client_certificate.cow", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_client_certificate.cow", "description", "Hello from TF acceptance test"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayClientCertificateConfig_basic_updated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayClientCertificateExists("aws_api_gateway_client_certificate.cow", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_client_certificate.cow", "description", "Hello from TF acceptance test - updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayClientCertificate_importBasic(t *testing.T) {
+	resourceName := "aws_api_gateway_client_certificate.cow"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayClientCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayClientCertificateConfig_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAPIGatewayClientCertificateExists(n string, res *apigateway.ClientCertificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway Client Certificate ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+		req := &apigateway.GetClientCertificateInput{
+			ClientCertificateId: aws.String(rs.Primary.ID),
+		}
+		out, err := conn.GetClientCertificate(req)
+		if err != nil {
+			return err
+		}
+
+		*res = *out
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayClientCertificateDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_api_gateway_client_certificate" {
+			continue
+		}
+
+		req := &apigateway.GetClientCertificateInput{
+			ClientCertificateId: aws.String(rs.Primary.ID),
+		}
+		out, err := conn.GetClientCertificate(req)
+		if err == nil {
+			return fmt.Errorf("API Gateway Client Certificate still exists: %s", out)
+		}
+
+		awsErr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if awsErr.Code() != "NotFoundException" {
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+const testAccAWSAPIGatewayClientCertificateConfig_basic = `
+resource "aws_api_gateway_client_certificate" "cow" {
+  description = "Hello from TF acceptance test"
+}
+`
+
+const testAccAWSAPIGatewayClientCertificateConfig_basic_updated = `
+resource "aws_api_gateway_client_certificate" "cow" {
+  description = "Hello from TF acceptance test - updated"
+}
+`

--- a/website/source/docs/providers/aws/r/api_gateway_client_certificate.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_client_certificate.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_client_certificate"
+sidebar_current: "docs-aws-resource-api-gateway-client-certificate"
+description: |-
+  Provides an API Gateway Client Certificate.
+---
+
+# aws\_api\_gateway\_client\_certificate
+
+Provides an API Gateway Client Certificate.
+
+## Example Usage
+
+```
+resource "aws_api_gateway_client_certificate" "demo" {
+  description = "My client certificate"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) The description of the client certificate.
+
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The identifier of the client certificate.
+* `created_date` - The date when the client certificate was created.
+* `expiration_date` - The date when the client certificate will expire.
+* `pem_encoded_certificate` - The PEM-encoded public key of the client certificate.
+
+## Import
+
+API Gateway Client Certificates can be imported using the id, e.g.
+
+```
+$ terraform import aws_api_gateway_client_certificate.demo ab1cqe
+```

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -62,6 +62,9 @@
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-base-path-mapping") %>>
                             <a href="/docs/providers/aws/r/api_gateway_base_path_mapping.html">aws_api_gateway_base_path_mapping</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-api-gateway-client-certificate") %>>
+                            <a href="/docs/providers/aws/r/api_gateway_client_certificate.html">aws_api_gateway_client_certificate</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-deployment") %>>
                             <a href="/docs/providers/aws/r/api_gateway_deployment.html">aws_api_gateway_deployment</a>
                         </li>


### PR DESCRIPTION
This would be useful for an upcoming API Gateway Stage PR so that we can test these resources together.

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSAPIGatewayClientCertificate'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSAPIGatewayClientCertificate -timeout 120m
=== RUN   TestAccAWSAPIGatewayClientCertificate_basic
--- PASS: TestAccAWSAPIGatewayClientCertificate_basic (28.37s)
=== RUN   TestAccAWSAPIGatewayClientCertificate_importBasic
--- PASS: TestAccAWSAPIGatewayClientCertificate_importBasic (16.67s)
PASS
ok     	github.com/hashicorp/terraform/builtin/providers/aws   	45.065s
```