### PR TITLE
provider/aws: CloudFront meta-PR

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -378,6 +378,9 @@ func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues
 	if v, ok := m["headers"]; ok {
 		fv.Headers = expandHeaders(v.([]interface{}))
 	}
+	if v, ok := m["query_string_cache_keys"]; ok {
+		fv.QueryStringCacheKeys = expandQueryStringCacheKeys(v.([]interface{}))
+	}
 	return fv
 }
 
@@ -389,6 +392,9 @@ func flattenForwardedValues(fv *cloudfront.ForwardedValues) map[string]interface
 	}
 	if fv.Headers != nil {
 		m["headers"] = flattenHeaders(fv.Headers)
+	}
+	if fv.QueryStringCacheKeys != nil {
+		m["query_string_cache_keys"] = flattenQueryStringCacheKeys(fv.QueryStringCacheKeys)
 	}
 	return m
 }
@@ -407,6 +413,11 @@ func forwardedValuesHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
+	if d, ok := m["query_string_cache_keys"]; ok {
+		for _, e := range sortInterfaceSlice(d.([]interface{})) {
+			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
+		}
+	}
 	return hashcode.String(buf.String())
 }
 
@@ -420,6 +431,20 @@ func expandHeaders(d []interface{}) *cloudfront.Headers {
 func flattenHeaders(h *cloudfront.Headers) []interface{} {
 	if h.Items != nil {
 		return flattenStringList(h.Items)
+	}
+	return []interface{}{}
+}
+
+func expandQueryStringCacheKeys(d []interface{}) *cloudfront.QueryStringCacheKeys {
+	return &cloudfront.QueryStringCacheKeys{
+		Quantity: aws.Int64(int64(len(d))),
+		Items:    expandStringList(d),
+	}
+}
+
+func flattenQueryStringCacheKeys(k *cloudfront.QueryStringCacheKeys) []interface{} {
+	if k.Items != nil {
+		return flattenStringList(k.Items)
 	}
 	return []interface{}{}
 }

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -46,6 +46,7 @@ func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionCo
 		CustomErrorResponses: expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
 		DefaultCacheBehavior: expandDefaultCacheBehavior(d.Get("default_cache_behavior").(*schema.Set).List()[0].(map[string]interface{})),
 		Enabled:              aws.Bool(d.Get("enabled").(bool)),
+		HttpVersion:          aws.String(d.Get("http_version").(string)),
 		Origins:              expandOrigins(d.Get("origin").(*schema.Set)),
 		PriceClass:           aws.String(d.Get("price_class").(string)),
 	}
@@ -121,6 +122,9 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 	}
 	if distributionConfig.DefaultRootObject != nil {
 		d.Set("default_root_object", distributionConfig.DefaultRootObject)
+	}
+	if distributionConfig.HttpVersion != nil {
+		d.Set("http_version", distributionConfig.HttpVersion)
 	}
 	if distributionConfig.WebACLId != nil {
 		d.Set("web_acl_id", distributionConfig.WebACLId)

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -46,14 +46,19 @@ func trustedSignersConf() []interface{} {
 
 func forwardedValuesConf() map[string]interface{} {
 	return map[string]interface{}{
-		"query_string": true,
-		"cookies":      schema.NewSet(cookiePreferenceHash, []interface{}{cookiePreferenceConf()}),
-		"headers":      headersConf(),
+		"query_string":            true,
+		"query_string_cache_keys": queryStringCacheKeysConf(),
+		"cookies":                 schema.NewSet(cookiePreferenceHash, []interface{}{cookiePreferenceConf()}),
+		"headers":                 headersConf(),
 	}
 }
 
 func headersConf() []interface{} {
 	return []interface{}{"X-Example1", "X-Example2"}
+}
+
+func queryStringCacheKeysConf() []interface{} {
+	return []interface{}{"foo", "bar"}
 }
 
 func cookiePreferenceConf() map[string]interface{} {
@@ -467,6 +472,27 @@ func TestCloudFrontStructure_flattenHeaders(t *testing.T) {
 	in := headersConf()
 	h := expandHeaders(in)
 	out := flattenHeaders(h)
+
+	if reflect.DeepEqual(in, out) != true {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestCloudFrontStructure_expandQueryStringCacheKeys(t *testing.T) {
+	data := queryStringCacheKeysConf()
+	k := expandQueryStringCacheKeys(data)
+	if *k.Quantity != 2 {
+		t.Fatalf("Expected Quantity to be 2, got %v", *k.Quantity)
+	}
+	if reflect.DeepEqual(k.Items, expandStringList(data)) != true {
+		t.Fatalf("Expected Items to be %v, got %v", data, k.Items)
+	}
+}
+
+func TestCloudFrontStructure_flattenQueryStringCacheKeys(t *testing.T) {
+	in := queryStringCacheKeysConf()
+	k := expandQueryStringCacheKeys(in)
+	out := flattenQueryStringCacheKeys(k)
 
 	if reflect.DeepEqual(in, out) != true {
 		t.Fatalf("Expected out to be %v, got %v", in, out)

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -87,6 +87,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Type:     schema.TypeBool,
 										Required: true,
 									},
+									"query_string_cache_keys": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
 								},
 							},
 						},
@@ -211,6 +216,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"query_string": &schema.Schema{
 										Type:     schema.TypeBool,
 										Required: true,
+									},
+									"query_string_cache_keys": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -260,6 +261,12 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 			"enabled": &schema.Schema{
 				Type:     schema.TypeBool,
 				Required: true,
+			},
+			"http_version": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "http2",
+				ValidateFunc: validateHTTP,
 			},
 			"logging_config": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -617,4 +624,21 @@ func resourceAwsCloudFrontWebDistributionStateRefreshFunc(id string, meta interf
 
 		return resp.Distribution, *resp.Distribution.Status, nil
 	}
+}
+
+// validateHTTP ensures that the http_version resource parameter is
+// correct.
+func validateHTTP(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	found := false
+	for _, w := range []string{"http1.1", "http2"} {
+		if value == w {
+			found = true
+		}
+	}
+	if found == false {
+		errors = append(errors, fmt.Errorf(
+			"HTTP version parameter must be one of http1.1 or http2"))
+	}
+	return
 }

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -358,8 +358,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"origin_access_identity": &schema.Schema{
 										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "",
+										Required: true,
 									},
 								},
 							},

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -110,6 +110,30 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 	})
 }
 
+// TestAccAWSCloudFrontDistribution_HTTP11Config runs an
+// aws_cloudfront_distribution acceptance test with the HTTP version set to
+// 1.1.
+//
+// If you are testing manually and can't wait for deletion, set the
+// TF_TEST_CLOUDFRONT_RETAIN environment variable.
+func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCloudFrontDistributionHTTP11Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExistence(
+						"aws_cloudfront_distribution.http_1_1",
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -479,6 +503,54 @@ resource "aws_cloudfront_distribution" "no_optional_items" {
 		default_ttl = 3600
 		max_ttl = 86400
 	}
+	restrictions {
+		geo_restriction {
+			restriction_type = "whitelist"
+			locations = [ "US", "CA", "GB", "DE" ]
+		}
+	}
+	viewer_certificate {
+		cloudfront_default_certificate = true
+	}
+	%s
+}
+`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), testAccAWSCloudFrontDistributionRetainConfig())
+
+var testAccAWSCloudFrontDistributionHTTP11Config = fmt.Sprintf(`
+variable rand_id {
+	default = %d
+}
+
+resource "aws_cloudfront_distribution" "http_1_1" {
+	origin {
+		domain_name = "www.example.com"
+		origin_id = "myCustomOrigin"
+		custom_origin_config {
+			http_port = 80
+			https_port = 443
+			origin_protocol_policy = "http-only"
+			origin_ssl_protocols = [ "SSLv3", "TLSv1" ]
+		}
+	}
+	enabled = true
+	comment = "Some comment"
+	default_cache_behavior {
+		allowed_methods = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
+		cached_methods = [ "GET", "HEAD" ]
+		target_origin_id = "myCustomOrigin"
+		smooth_streaming = false
+		forwarded_values {
+			query_string = false
+			cookies {
+				forward = "all"
+			}
+		}
+		viewer_protocol_policy = "allow-all"
+		min_ttl = 0
+		default_ttl = 3600
+		max_ttl = 86400
+	}
+	http_version = "http1.1"
 	restrictions {
 		geo_restriction {
 			restriction_type = "whitelist"

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.4.7"
+const SDKVersion = "1.4.8"

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
 )
 
-const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2016_08_20"
+const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2016_09_07"
 
 // CreateCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the CreateCloudFrontOriginAccessIdentity operation. The "output" return
@@ -41,7 +41,7 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentityRequest(input *CreateCl
 	op := &request.Operation{
 		Name:       opCreateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront",
 	}
 
 	if input == nil {
@@ -61,7 +61,7 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentity(input *CreateCloudFron
 	return out, err
 }
 
-const opCreateDistribution = "CreateDistribution2016_08_20"
+const opCreateDistribution = "CreateDistribution2016_09_07"
 
 // CreateDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the CreateDistribution operation. The "output" return
@@ -89,7 +89,7 @@ func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (
 	op := &request.Operation{
 		Name:       opCreateDistribution,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/distribution",
+		HTTPPath:   "/2016-09-07/distribution",
 	}
 
 	if input == nil {
@@ -109,7 +109,7 @@ func (c *CloudFront) CreateDistribution(input *CreateDistributionInput) (*Create
 	return out, err
 }
 
-const opCreateDistributionWithTags = "CreateDistributionWithTags2016_08_20"
+const opCreateDistributionWithTags = "CreateDistributionWithTags2016_09_07"
 
 // CreateDistributionWithTagsRequest generates a "aws/request.Request" representing the
 // client's request for the CreateDistributionWithTags operation. The "output" return
@@ -137,7 +137,7 @@ func (c *CloudFront) CreateDistributionWithTagsRequest(input *CreateDistribution
 	op := &request.Operation{
 		Name:       opCreateDistributionWithTags,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/distribution?WithTags",
+		HTTPPath:   "/2016-09-07/distribution?WithTags",
 	}
 
 	if input == nil {
@@ -157,7 +157,7 @@ func (c *CloudFront) CreateDistributionWithTags(input *CreateDistributionWithTag
 	return out, err
 }
 
-const opCreateInvalidation = "CreateInvalidation2016_08_20"
+const opCreateInvalidation = "CreateInvalidation2016_09_07"
 
 // CreateInvalidationRequest generates a "aws/request.Request" representing the
 // client's request for the CreateInvalidation operation. The "output" return
@@ -185,7 +185,7 @@ func (c *CloudFront) CreateInvalidationRequest(input *CreateInvalidationInput) (
 	op := &request.Operation{
 		Name:       opCreateInvalidation,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/distribution/{DistributionId}/invalidation",
+		HTTPPath:   "/2016-09-07/distribution/{DistributionId}/invalidation",
 	}
 
 	if input == nil {
@@ -205,7 +205,7 @@ func (c *CloudFront) CreateInvalidation(input *CreateInvalidationInput) (*Create
 	return out, err
 }
 
-const opCreateStreamingDistribution = "CreateStreamingDistribution2016_08_20"
+const opCreateStreamingDistribution = "CreateStreamingDistribution2016_09_07"
 
 // CreateStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the CreateStreamingDistribution operation. The "output" return
@@ -233,7 +233,7 @@ func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDi
 	op := &request.Operation{
 		Name:       opCreateStreamingDistribution,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/streaming-distribution",
+		HTTPPath:   "/2016-09-07/streaming-distribution",
 	}
 
 	if input == nil {
@@ -253,7 +253,7 @@ func (c *CloudFront) CreateStreamingDistribution(input *CreateStreamingDistribut
 	return out, err
 }
 
-const opCreateStreamingDistributionWithTags = "CreateStreamingDistributionWithTags2016_08_20"
+const opCreateStreamingDistributionWithTags = "CreateStreamingDistributionWithTags2016_09_07"
 
 // CreateStreamingDistributionWithTagsRequest generates a "aws/request.Request" representing the
 // client's request for the CreateStreamingDistributionWithTags operation. The "output" return
@@ -281,7 +281,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTagsRequest(input *CreateStr
 	op := &request.Operation{
 		Name:       opCreateStreamingDistributionWithTags,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/streaming-distribution?WithTags",
+		HTTPPath:   "/2016-09-07/streaming-distribution?WithTags",
 	}
 
 	if input == nil {
@@ -301,7 +301,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTags(input *CreateStreamingD
 	return out, err
 }
 
-const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIdentity2016_08_20"
+const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIdentity2016_09_07"
 
 // DeleteCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteCloudFrontOriginAccessIdentity operation. The "output" return
@@ -329,7 +329,7 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentityRequest(input *DeleteCl
 	op := &request.Operation{
 		Name:       opDeleteCloudFrontOriginAccessIdentity,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}",
 	}
 
 	if input == nil {
@@ -351,7 +351,7 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentity(input *DeleteCloudFron
 	return out, err
 }
 
-const opDeleteDistribution = "DeleteDistribution2016_08_20"
+const opDeleteDistribution = "DeleteDistribution2016_09_07"
 
 // DeleteDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteDistribution operation. The "output" return
@@ -379,7 +379,7 @@ func (c *CloudFront) DeleteDistributionRequest(input *DeleteDistributionInput) (
 	op := &request.Operation{
 		Name:       opDeleteDistribution,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2016-08-20/distribution/{Id}",
+		HTTPPath:   "/2016-09-07/distribution/{Id}",
 	}
 
 	if input == nil {
@@ -401,7 +401,7 @@ func (c *CloudFront) DeleteDistribution(input *DeleteDistributionInput) (*Delete
 	return out, err
 }
 
-const opDeleteStreamingDistribution = "DeleteStreamingDistribution2016_08_20"
+const opDeleteStreamingDistribution = "DeleteStreamingDistribution2016_09_07"
 
 // DeleteStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteStreamingDistribution operation. The "output" return
@@ -429,7 +429,7 @@ func (c *CloudFront) DeleteStreamingDistributionRequest(input *DeleteStreamingDi
 	op := &request.Operation{
 		Name:       opDeleteStreamingDistribution,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}",
 	}
 
 	if input == nil {
@@ -451,7 +451,7 @@ func (c *CloudFront) DeleteStreamingDistribution(input *DeleteStreamingDistribut
 	return out, err
 }
 
-const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity2016_08_20"
+const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity2016_09_07"
 
 // GetCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the GetCloudFrontOriginAccessIdentity operation. The "output" return
@@ -479,7 +479,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityRequest(input *GetCloudFro
 	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentity,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}",
 	}
 
 	if input == nil {
@@ -499,7 +499,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentity(input *GetCloudFrontOrigi
 	return out, err
 }
 
-const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIdentityConfig2016_08_20"
+const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIdentityConfig2016_09_07"
 
 // GetCloudFrontOriginAccessIdentityConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetCloudFrontOriginAccessIdentityConfig operation. The "output" return
@@ -527,7 +527,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfigRequest(input *GetCl
 	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentityConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}/config",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}/config",
 	}
 
 	if input == nil {
@@ -547,7 +547,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfig(input *GetCloudFron
 	return out, err
 }
 
-const opGetDistribution = "GetDistribution2016_08_20"
+const opGetDistribution = "GetDistribution2016_09_07"
 
 // GetDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the GetDistribution operation. The "output" return
@@ -575,7 +575,7 @@ func (c *CloudFront) GetDistributionRequest(input *GetDistributionInput) (req *r
 	op := &request.Operation{
 		Name:       opGetDistribution,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{Id}",
+		HTTPPath:   "/2016-09-07/distribution/{Id}",
 	}
 
 	if input == nil {
@@ -595,7 +595,7 @@ func (c *CloudFront) GetDistribution(input *GetDistributionInput) (*GetDistribut
 	return out, err
 }
 
-const opGetDistributionConfig = "GetDistributionConfig2016_08_20"
+const opGetDistributionConfig = "GetDistributionConfig2016_09_07"
 
 // GetDistributionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetDistributionConfig operation. The "output" return
@@ -623,7 +623,7 @@ func (c *CloudFront) GetDistributionConfigRequest(input *GetDistributionConfigIn
 	op := &request.Operation{
 		Name:       opGetDistributionConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -643,7 +643,7 @@ func (c *CloudFront) GetDistributionConfig(input *GetDistributionConfigInput) (*
 	return out, err
 }
 
-const opGetInvalidation = "GetInvalidation2016_08_20"
+const opGetInvalidation = "GetInvalidation2016_09_07"
 
 // GetInvalidationRequest generates a "aws/request.Request" representing the
 // client's request for the GetInvalidation operation. The "output" return
@@ -671,7 +671,7 @@ func (c *CloudFront) GetInvalidationRequest(input *GetInvalidationInput) (req *r
 	op := &request.Operation{
 		Name:       opGetInvalidation,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{DistributionId}/invalidation/{Id}",
+		HTTPPath:   "/2016-09-07/distribution/{DistributionId}/invalidation/{Id}",
 	}
 
 	if input == nil {
@@ -691,7 +691,7 @@ func (c *CloudFront) GetInvalidation(input *GetInvalidationInput) (*GetInvalidat
 	return out, err
 }
 
-const opGetStreamingDistribution = "GetStreamingDistribution2016_08_20"
+const opGetStreamingDistribution = "GetStreamingDistribution2016_09_07"
 
 // GetStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the GetStreamingDistribution operation. The "output" return
@@ -719,7 +719,7 @@ func (c *CloudFront) GetStreamingDistributionRequest(input *GetStreamingDistribu
 	op := &request.Operation{
 		Name:       opGetStreamingDistribution,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}",
 	}
 
 	if input == nil {
@@ -739,7 +739,7 @@ func (c *CloudFront) GetStreamingDistribution(input *GetStreamingDistributionInp
 	return out, err
 }
 
-const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2016_08_20"
+const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2016_09_07"
 
 // GetStreamingDistributionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetStreamingDistributionConfig operation. The "output" return
@@ -767,7 +767,7 @@ func (c *CloudFront) GetStreamingDistributionConfigRequest(input *GetStreamingDi
 	op := &request.Operation{
 		Name:       opGetStreamingDistributionConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -787,7 +787,7 @@ func (c *CloudFront) GetStreamingDistributionConfig(input *GetStreamingDistribut
 	return out, err
 }
 
-const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdentities2016_08_20"
+const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdentities2016_09_07"
 
 // ListCloudFrontOriginAccessIdentitiesRequest generates a "aws/request.Request" representing the
 // client's request for the ListCloudFrontOriginAccessIdentities operation. The "output" return
@@ -815,7 +815,7 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesRequest(input *ListClou
 	op := &request.Operation{
 		Name:       opListCloudFrontOriginAccessIdentities,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"CloudFrontOriginAccessIdentityList.NextMarker"},
@@ -866,7 +866,7 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesPages(input *ListCloudF
 	})
 }
 
-const opListDistributions = "ListDistributions2016_08_20"
+const opListDistributions = "ListDistributions2016_09_07"
 
 // ListDistributionsRequest generates a "aws/request.Request" representing the
 // client's request for the ListDistributions operation. The "output" return
@@ -894,7 +894,7 @@ func (c *CloudFront) ListDistributionsRequest(input *ListDistributionsInput) (re
 	op := &request.Operation{
 		Name:       opListDistributions,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution",
+		HTTPPath:   "/2016-09-07/distribution",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"DistributionList.NextMarker"},
@@ -945,7 +945,7 @@ func (c *CloudFront) ListDistributionsPages(input *ListDistributionsInput, fn fu
 	})
 }
 
-const opListDistributionsByWebACLId = "ListDistributionsByWebACLId2016_08_20"
+const opListDistributionsByWebACLId = "ListDistributionsByWebACLId2016_09_07"
 
 // ListDistributionsByWebACLIdRequest generates a "aws/request.Request" representing the
 // client's request for the ListDistributionsByWebACLId operation. The "output" return
@@ -973,7 +973,7 @@ func (c *CloudFront) ListDistributionsByWebACLIdRequest(input *ListDistributions
 	op := &request.Operation{
 		Name:       opListDistributionsByWebACLId,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distributionsByWebACLId/{WebACLId}",
+		HTTPPath:   "/2016-09-07/distributionsByWebACLId/{WebACLId}",
 	}
 
 	if input == nil {
@@ -993,7 +993,7 @@ func (c *CloudFront) ListDistributionsByWebACLId(input *ListDistributionsByWebAC
 	return out, err
 }
 
-const opListInvalidations = "ListInvalidations2016_08_20"
+const opListInvalidations = "ListInvalidations2016_09_07"
 
 // ListInvalidationsRequest generates a "aws/request.Request" representing the
 // client's request for the ListInvalidations operation. The "output" return
@@ -1021,7 +1021,7 @@ func (c *CloudFront) ListInvalidationsRequest(input *ListInvalidationsInput) (re
 	op := &request.Operation{
 		Name:       opListInvalidations,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{DistributionId}/invalidation",
+		HTTPPath:   "/2016-09-07/distribution/{DistributionId}/invalidation",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"InvalidationList.NextMarker"},
@@ -1072,7 +1072,7 @@ func (c *CloudFront) ListInvalidationsPages(input *ListInvalidationsInput, fn fu
 	})
 }
 
-const opListStreamingDistributions = "ListStreamingDistributions2016_08_20"
+const opListStreamingDistributions = "ListStreamingDistributions2016_09_07"
 
 // ListStreamingDistributionsRequest generates a "aws/request.Request" representing the
 // client's request for the ListStreamingDistributions operation. The "output" return
@@ -1100,7 +1100,7 @@ func (c *CloudFront) ListStreamingDistributionsRequest(input *ListStreamingDistr
 	op := &request.Operation{
 		Name:       opListStreamingDistributions,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/streaming-distribution",
+		HTTPPath:   "/2016-09-07/streaming-distribution",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"StreamingDistributionList.NextMarker"},
@@ -1151,7 +1151,7 @@ func (c *CloudFront) ListStreamingDistributionsPages(input *ListStreamingDistrib
 	})
 }
 
-const opListTagsForResource = "ListTagsForResource2016_08_20"
+const opListTagsForResource = "ListTagsForResource2016_09_07"
 
 // ListTagsForResourceRequest generates a "aws/request.Request" representing the
 // client's request for the ListTagsForResource operation. The "output" return
@@ -1179,7 +1179,7 @@ func (c *CloudFront) ListTagsForResourceRequest(input *ListTagsForResourceInput)
 	op := &request.Operation{
 		Name:       opListTagsForResource,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/tagging",
+		HTTPPath:   "/2016-09-07/tagging",
 	}
 
 	if input == nil {
@@ -1199,7 +1199,7 @@ func (c *CloudFront) ListTagsForResource(input *ListTagsForResourceInput) (*List
 	return out, err
 }
 
-const opTagResource = "TagResource2016_08_20"
+const opTagResource = "TagResource2016_09_07"
 
 // TagResourceRequest generates a "aws/request.Request" representing the
 // client's request for the TagResource operation. The "output" return
@@ -1227,7 +1227,7 @@ func (c *CloudFront) TagResourceRequest(input *TagResourceInput) (req *request.R
 	op := &request.Operation{
 		Name:       opTagResource,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/tagging?Operation=Tag",
+		HTTPPath:   "/2016-09-07/tagging?Operation=Tag",
 	}
 
 	if input == nil {
@@ -1249,7 +1249,7 @@ func (c *CloudFront) TagResource(input *TagResourceInput) (*TagResourceOutput, e
 	return out, err
 }
 
-const opUntagResource = "UntagResource2016_08_20"
+const opUntagResource = "UntagResource2016_09_07"
 
 // UntagResourceRequest generates a "aws/request.Request" representing the
 // client's request for the UntagResource operation. The "output" return
@@ -1277,7 +1277,7 @@ func (c *CloudFront) UntagResourceRequest(input *UntagResourceInput) (req *reque
 	op := &request.Operation{
 		Name:       opUntagResource,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/tagging?Operation=Untag",
+		HTTPPath:   "/2016-09-07/tagging?Operation=Untag",
 	}
 
 	if input == nil {
@@ -1299,7 +1299,7 @@ func (c *CloudFront) UntagResource(input *UntagResourceInput) (*UntagResourceOut
 	return out, err
 }
 
-const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIdentity2016_08_20"
+const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIdentity2016_09_07"
 
 // UpdateCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateCloudFrontOriginAccessIdentity operation. The "output" return
@@ -1327,7 +1327,7 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityRequest(input *UpdateCl
 	op := &request.Operation{
 		Name:       opUpdateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}/config",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}/config",
 	}
 
 	if input == nil {
@@ -1347,7 +1347,7 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentity(input *UpdateCloudFron
 	return out, err
 }
 
-const opUpdateDistribution = "UpdateDistribution2016_08_20"
+const opUpdateDistribution = "UpdateDistribution2016_09_07"
 
 // UpdateDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateDistribution operation. The "output" return
@@ -1375,7 +1375,7 @@ func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (
 	op := &request.Operation{
 		Name:       opUpdateDistribution,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2016-08-20/distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -1395,7 +1395,7 @@ func (c *CloudFront) UpdateDistribution(input *UpdateDistributionInput) (*Update
 	return out, err
 }
 
-const opUpdateStreamingDistribution = "UpdateStreamingDistribution2016_08_20"
+const opUpdateStreamingDistribution = "UpdateStreamingDistribution2016_09_07"
 
 // UpdateStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateStreamingDistribution operation. The "output" return
@@ -1423,7 +1423,7 @@ func (c *CloudFront) UpdateStreamingDistributionRequest(input *UpdateStreamingDi
 	op := &request.Operation{
 		Name:       opUpdateStreamingDistribution,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -2864,6 +2864,12 @@ type DistributionConfig struct {
 	// Whether the distribution is enabled to accept end user requests for content.
 	Enabled *bool `type:"boolean" required:"true"`
 
+	// (Optional) Specify the maximum HTTP version that you want viewers to use
+	// to communicate with CloudFront. The default value for new web distributions
+	// is http2. Viewers that don't support HTTP/2 will automatically use an earlier
+	// version.
+	HttpVersion *string `type:"string" enum:"HttpVersion"`
+
 	// A complex type that controls whether access logs are written for the distribution.
 	Logging *LoggingConfig `type:"structure"`
 
@@ -3074,6 +3080,11 @@ type DistributionSummary struct {
 
 	// Whether the distribution is enabled to accept end user requests for content.
 	Enabled *bool `type:"boolean" required:"true"`
+
+	// Specify the maximum HTTP version that you want viewers to use to communicate
+	// with CloudFront. The default value for new web distributions is http2. Viewers
+	// that don't support HTTP/2 will automatically use an earlier version.
+	HttpVersion *string `type:"string" required:"true" enum:"HttpVersion"`
 
 	// The identifier for the distribution. For example: EDFDVBD632BHDS5.
 	Id *string `type:"string" required:"true"`
@@ -5660,6 +5671,13 @@ const (
 	GeoRestrictionTypeWhitelist = "whitelist"
 	// @enum GeoRestrictionType
 	GeoRestrictionTypeNone = "none"
+)
+
+const (
+	// @enum HttpVersion
+	HttpVersionHttp11 = "http1.1"
+	// @enum HttpVersion
+	HttpVersionHttp2 = "http2"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/service.go
@@ -55,7 +55,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceName:   ServiceName,
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
-				APIVersion:    "2016-08-20",
+				APIVersion:    "2016-09-07",
 			},
 			handlers,
 		),

--- a/vendor/github.com/aws/aws-sdk-go/service/sns/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sns/api.go
@@ -3337,7 +3337,11 @@ type SetSMSAttributesInput struct {
 	// crossed. During that interval, if you continue to send SMS messages, you
 	// will incur costs that exceed your limit.
 	//
-	//   DeliveryStatusIAMRole – The ARN of the IAM role that allows Amazon SNS
+	//  By default, the spend limit is set to the maximum allowed by Amazon SNS.
+	// If you want to exceed the maximum, contact AWS Support (https://aws.amazon.com/premiumsupport/)
+	// or your AWS sales representative for a service limit increase.
+	//
+	//  DeliveryStatusIAMRole – The ARN of the IAM role that allows Amazon SNS
 	// to write logs about SMS deliveries in CloudWatch Logs. For each SMS message
 	// that you send, Amazon SNS writes a log that includes the message price, the
 	// success or failure status, the reason for failure (if the message failed),
@@ -3357,10 +3361,10 @@ type SetSMSAttributesInput struct {
 	//  DefaultSMSType – The type of SMS message that you will send by default.
 	// You can assign the following values:
 	//
-	//    Promotional – Noncritical messages, such as marketing messages. Amazon
-	// SNS optimizes the message delivery to incur the lowest cost.
+	//    Promotional – (Default) Noncritical messages, such as marketing messages.
+	// Amazon SNS optimizes the message delivery to incur the lowest cost.
 	//
-	//    Transactional – (Default) Critical messages that support customer transactions,
+	//    Transactional – Critical messages that support customer transactions,
 	// such as one-time passcodes for multi-factor authentication. Amazon SNS optimizes
 	// the message delivery to achieve the highest reliability.
 	//

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -347,560 +347,560 @@
 		{
 			"checksumSHA1": "UN8gKREzowlQIH6xM5GJVOBhDYM=",
 			"path": "github.com/aws/aws-sdk-go",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
-			"checksumSHA1": "4pvpNLmTBs+Wdfn4BpgUpkMoHLs=",
+			"checksumSHA1": "ZjseNd/AQukVRV7YONYPweD1FxQ=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "ppmwInOtC5Mj/dBBWVxL0KPEI0I=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "H/tMKHZU+Qka6RtYiGB50s2uA0s=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "gNWirlrTfSLbOe421hISBAhTqa4=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "dNZNaOPfBPnzE2CBnfhXXZ9g9jU=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "KQiUK/zr3mqnAXD7x/X55/iNme0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "4Ipx+5xN0gso+cENC2MHMWmQlR4=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "nCMd1XKjgV21bEl7J8VZFqTV8PE=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "U0SthWum+t9ACanK7SDJOg3dO6M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "NyUg1P8ZS/LHAAQAk/4C5O4X3og=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "44uohX3kLsfZHHOqunr+qJnSCdw=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "7lla+sckQeF18wORAGuU2fFMlp4=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Bm6UrYb2QCzpYseLwwgw6aetgRc=",
 			"path": "github.com/aws/aws-sdk-go/private/endpoints",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "uNmSKXAF8B9HWEciW+iyUwZ99qQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "pNeF0Ey7TfBArH5LBQhKOQXQbLY=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "H9TymcQkQnXSXSVfjggiiS4bpzM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "isoix7lTx4qIq2zI2xFADtti5SI=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "5xzix1R8prUyWxgLnzUQoxTsfik=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "TW/7U+/8ormL7acf6z2rv2hDD+s=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "oUOTWZIpPJiGjc9p/hntdBDvS10=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Y6Db2GGfGD9LPpcJIPj8vXE8BbQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "eUEkjyMPAuekKBE4ou+nM9tXEas=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Eo9yODN5U99BK0pMzoqnBm7PCrY=",
 			"path": "github.com/aws/aws-sdk-go/private/waiter",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "DXwm+kmVCiuvvGCcUTeZD/L31Kk=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "WEwNL8ueG/6RTZOIDF/qu9EkwXo=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "MXY2nnlU3Qf4+6nTV4+GFxSD5Y4=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "vp/AYdsQnZtoPqtX86VsgmLIx1w=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
-			"checksumSHA1": "xWLF/7zgljbFtQypmR6+M9o9sTY=",
+			"checksumSHA1": "IBdkYM4/ts1B7FXcTrUk9KXPpcc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "eCFTaV9GKqv/UEzwRgFFUaFz098=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "G9CmCfw00Bjz0TtJsEnxGE6mv/0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "mWNJKpt18ASs9/RhnIjILcsGlng=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "sP/qEaDICVBV3rRw2sl759YI0iw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "p5a/DcdUvhTx0PCRR+/CRXk9g6c=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "N8Sgq+xG2vYJdKBikM3yQuIBZfs=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "i4hrcsFXLAQXzaxvWh6+BG8XcIU=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "y+pZPK8hcTDwq1zHuRduWE14flw=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Unj4a0f5m6vhgXzIFjcgzWAcr3c=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "d5x+dDz7zdrEYAGDM9XpYnSW3FE=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "CvZ+vaOolbfpAdOQPAuKDn4Mmt4=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "1vOgFGxLhjNe6BK3RJaV1OqisCs=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "rjSScNzMTvEHv7Lk5KcxDpNU5EE=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "RZF1yHtJhAqaMwbeAM/6BdLLavk=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "VAlXnW+WxxWRcCv4xsCoox2kgE0=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "qHuJHGUAuuizD9834MP3gVupfdo=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "YiNiSOILzSOaKB4JwdM4SDw7daM=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "DdsbJgngbL7Ce18ipxreRsf3lYo=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "MA6U/Vj0D00yihMHD6bXKyjtfeE=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "TtIAgZ+evpkKB5bBYCB69k0wZoU=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "B1EtgBrv//gYqA+Sp6a/SK2zLO4=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "dH2W7lR17dgn4a4OYiEzjpQH8hI=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "2n5/m0ClE4OyQRNdjfLwg+nSY3o=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "l6GbB/V5dPb3l+Nrb70wzyrYAgc=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Qpi347xz5FIQISq73dZSdIf47AU=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "8F0/GisnAvgIBhNv36A8bitepQU=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "1qd0UaN3y1qEOuKCXjOvklfHp/c=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "SApEMc9VnHY0D10BAPcZKeFbj9k=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Dw4DpBaYfuu+aQTlywfv1TCzHCg=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "imxJucuPrgaPRMPtAgsu+Y7soB4=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "o+bjuT6ycywUf+vXY9hYK4Z3okE=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "DW5kDRWLA2yAgYh9vsI+0uVqq/Q=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
-			"checksumSHA1": "Id0njZW0e+k+IyHfjH6VHhnawYc=",
+			"checksumSHA1": "QHuF2nb/DTz20LRh0rslFDzIm54=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "oLAlquYlQzgYFS9ochS/iQ9+uXY=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "Zw0GXDOn45IvrmAcCOlSHJMiljU=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},
 		{
 			"checksumSHA1": "nH/itbdeFHpl4ysegdtgww9bFSA=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
+			"revision": "2c129c11a732646f1411de34ad4833f50503f344",
+			"revisionTime": "2016-09-08T20:31:30Z",
 			"version": "v1.4.7",
 			"versionExact": "v1.4.7"
 		},

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -110,6 +110,10 @@ of several sub-resources - these resources are laid out below.
   * `enabled` (Required) - Whether the distribution is enabled to accept end
     user requests for content.
 
+  * `http_version` (Optional) - The maximum HTTP version to support on the
+    distribution. Allowed values are `http1.1` and `http2`. The default is
+    `http2`.
+
   * `logging_config` (Optional) - The [logging
     configuration](#logging-config-arguments) that controls how logs are written
     to your distribution (maximum one).

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -196,6 +196,11 @@ of several sub-resources - these resources are laid out below.
   * `query_string` (Required) - Indicates whether you want CloudFront to forward
     query strings to the origin that is associated with this cache behavior.
 
+  * `query_string_cache_keys` (Optional) - When specified, along with a value of
+    `true` for `query_string`, all query strings are forwarded, however only the
+    query string keys listed in this argument are cached. When omitted with a
+    value of `true` for `query_string`, all query string keys are cached.
+
 ##### Cookies Arguments
 
   * `forward` (Required) - Specifies whether you want CloudFront to forward


### PR DESCRIPTION
Most of these commits were already referenced in #8770, but I'm going to close that one in the spirit of branch naming. Again these would be different PR's if `QueryStringCacheKeys` was not a breaking issue.

The commits:

 * Add `query_string_cache_keys` to allow for selective caching of CloudFront keys (and ensure that  tests do not break)
 * Ensure that `origin_access_identity` is a required value within the `s3_config` block (should fix #7930)
 * Add HTTP/2 support via the `http_version` parameter (feature request #8730)
