### PR TITLE
provider/azurerm: Fixes for azurerm subnet properties

### DIFF
--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -151,6 +151,12 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+  if resp.Properties.RouteTable == nil {
+    d.Set("route_table_id", nil)
+  } else {
+    d.Set("route_table_id", *resp.Properties.RouteTable.ID)
+  }
+
 	return nil
 }
 

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -151,6 +151,8 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+  d.Set("address_prefix", *resp.Properties.AddressPrefix)
+
   if resp.Properties.RouteTable == nil {
     d.Set("route_table_id", nil)
   } else {

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -44,13 +44,11 @@ func resourceArmSubnet() *schema.Resource {
 			"network_security_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"route_table_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"ip_configurations": {

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -151,13 +151,19 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-  d.Set("address_prefix", *resp.Properties.AddressPrefix)
+	d.Set("address_prefix", *resp.Properties.AddressPrefix)
 
-  if resp.Properties.RouteTable == nil {
-    d.Set("route_table_id", nil)
-  } else {
-    d.Set("route_table_id", *resp.Properties.RouteTable.ID)
-  }
+	if resp.Properties.RouteTable == nil {
+		d.Set("route_table_id", nil)
+	} else {
+		d.Set("route_table_id", *resp.Properties.RouteTable.ID)
+	}
+
+	if resp.Properties.NetworkSecurityGroup == nil {
+		d.Set("network_security_group_id", nil)
+	} else {
+		d.Set("network_security_group_id", *resp.Properties.NetworkSecurityGroup.ID)
+	}
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMSubnet_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri)
+	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -147,10 +147,24 @@ resource "azurerm_virtual_network" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
+resource "azurerm_network_security_group" "test" {
+    name = "acctestNSG%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_route_table" "test" {
+    name = "acctestRT%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
 resource "azurerm_subnet" "test" {
     name = "acctestsubnet%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     virtual_network_name = "${azurerm_virtual_network.test.name}"
     address_prefix = "10.0.2.0/24"
+    network_security_group_id  = "${azurerm_network_security_group.test.id}"
+    route_table_id = "${azurerm_route_table.test.id}"
 }
 `

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -30,6 +30,38 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSubnet_update(t *testing.T) {
+
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSubnet_update, ri, ri, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_subnet.test", "network_security_group_id", ""),
+					resource.TestCheckResourceAttr(
+						"azurerm_subnet.test", "route_table_id", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMSubnet_disappears(t *testing.T) {
 
 	ri := acctest.RandInt()
@@ -166,5 +198,40 @@ resource "azurerm_subnet" "test" {
     address_prefix = "10.0.2.0/24"
     network_security_group_id  = "${azurerm_network_security_group.test.id}"
     route_table_id = "${azurerm_route_table.test.id}"
+}
+`
+
+var testAccAzureRMSubnet_update = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctestvirtnet%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_network_security_group" "test" {
+    name = "acctestNSG%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_route_table" "test" {
+    name = "acctestRT%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctestsubnet%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+    network_security_group_id  = ""
+    route_table_id = ""
 }
 `


### PR DESCRIPTION
Partially fixes GH-8227

So far this implements the setting of address range, route table association and network security group association for azurerm subnet resource.

There is still failure when going from a set resource to none for route tables and nsg, e.g.

```
resource "azurerm_subnet" "test" {
    name = "testsubnet"
    resource_group_name = "${azurerm_resource_group.test.name}"
    virtual_network_name = "${azurerm_virtual_network.test.name}"
    address_prefix = "10.0.1.0/24"
    route_table_id = "${azurerm_route_table.test.id}"
    network_security_group_id = "${azurerm_network_security_group.test.id}"
}
```
to 
```
resource "azurerm_subnet" "test" {
    name = "testsubnet"
    resource_group_name = "${azurerm_resource_group.test.name}"
    virtual_network_name = "${azurerm_virtual_network.test.name}"
    address_prefix = "10.0.1.0/24"
    route_table_id = ""
    network_security_group_id = ""
}
```