### PR TITLE
provider/aws: Retry resourceAwsLaunchConfigurationCreate

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -481,6 +481,9 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 				if strings.Contains(awsErr.Message(), "Invalid IamInstanceProfile") {
 					return resource.RetryableError(err)
 				}
+				if strings.Contains(awsErr.Message(), "You are not authorized to perform this operation") {
+					return resource.RetryableError(err)
+				}
 			}
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
Retry `resourceAwsLaunchConfigurationCreate` if instance profile hasn't propagated. Fixes the issue addressed in #7198.

I am not sure if I should add acceptance tests.