### PR TITLE
changing AWS_SECURITY_TOKEN to AWS_SESSION_TOKEN

### DIFF
--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -60,7 +60,7 @@ provider "aws" {
 
 You can provide your credentials via `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, 
 environment variables, representing your AWS Access Key and AWS Secret Key, respectively.
-`AWS_DEFAULT_REGION` and `AWS_SECURITY_TOKEN` are also used, if applicable:
+`AWS_DEFAULT_REGION` and `AWS_SESSION_TOKEN` are also used, if applicable:
 
 ```
 provider "aws" {}


### PR DESCRIPTION
I noticed that Terraform is not (anymore) parsing the value of environment variable `AWS_SECURITY_TOKEN` (which was re-added in May 2015: https://github.com/hashicorp/terraform/pull/1785)

Example ENV:

```
AWS_SECURITY_TOKEN="FQo...vgU="
AWS_ACCESS_KEY_ID="A...A"
AWS_SECRET_ACCESS_KEY="I...t"
AWS_DEFAULT_REGION="eu-west-1"
```
This errors with messages akin to "AWS was not able to validate the provided access credentials".

Setting `AWS_SESSION_TOKEN` instead of `AWS_SECURITY_TOKEN` on the other hand works just fine and seems to be in line with what is suggested in the code: https://github.com/hashicorp/terraform/blob/d1ac7d3b2e1be2f32092275340f33a2d73f7b31a/vendor/github.com/aws/aws-sdk-go/aws/credentials/env_provider.go#L69, making this whole thing a documentation change.

Happy to provide test cases or additional insights though!