### PR TITLE
Warn when plugins are locally overridden

### DIFF
--- a/config.go
+++ b/config.go
@@ -169,12 +169,18 @@ func (c1 *Config) Merge(c2 *Config) *Config {
 		result.Providers[k] = v
 	}
 	for k, v := range c2.Providers {
+		if v1, ok := c1.Providers[k]; ok {
+			log.Printf("[WARN] Local %s provider configuration '%s' overrides '%s'", k, v, v1)
+		}
 		result.Providers[k] = v
 	}
 	for k, v := range c1.Provisioners {
 		result.Provisioners[k] = v
 	}
 	for k, v := range c2.Provisioners {
+		if v1, ok := c1.Provisioners[k]; ok {
+			log.Printf("[WARN] Local %s provisioner configuration '%s' overrides '%s'", k, v, v1)
+		}
 		result.Provisioners[k] = v
 	}
 


### PR DESCRIPTION
It is currently very easy to miss that a provider/provisioner has a local override in your `.terraformrc`, leading to unexpected behaviour that can be difficult to debug as no information is output about the overrides.