### PR TITLE
provider/aws: Expose ARN suffix on ALB

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_test.go
+++ b/builtin/providers/aws/resource_aws_alb_test.go
@@ -14,6 +14,37 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestALBCloudwatchSuffixFromARN(t *testing.T) {
+	cases := []struct {
+		name   string
+		arn    *string
+		suffix string
+	}{
+		{
+			name:   "valid suffix",
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:loadbalancer/app/my-alb/abc123`),
+			suffix: `app/my-alb/abc123`,
+		},
+		{
+			name:   "no suffix",
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:loadbalancer`),
+			suffix: ``,
+		},
+		{
+			name:   "nil ARN",
+			arn:    nil,
+			suffix: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		actual := albSuffixFromARN(tc.arn)
+		if actual != tc.suffix {
+			t.Fatalf("bad suffix: %q\nExpected: %s\n     Got: %s", tc.name, tc.suffix, actual)
+		}
+	}
+}
+
 func TestAccAWSALB_basic(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	albName := fmt.Sprintf("testaccawsalb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))

--- a/website/source/docs/providers/aws/r/alb.html.markdown
+++ b/website/source/docs/providers/aws/r/alb.html.markdown
@@ -59,11 +59,12 @@ Access Logs (`access_logs`) support the following:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The ARN of the load balancer (matches `arn`)
-* `arn` - The ARN of the load balancer (matches `id`)
-* `dns_name` - The DNS name of the load balancer
+* `id` - The ARN of the load balancer (matches `arn`).
+* `arn` - The ARN of the load balancer (matches `id`).
+* `arn_suffix` - The ARN suffix for use with CloudWatch Metrics.
+* `dns_name` - The DNS name of the load balancer.
 * `canonical_hosted_zone_id` - The canonical hosted zone ID of the load balancer.
-* `zone_id` - The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record)
+* `zone_id` - The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
 
 ## Import
 


### PR DESCRIPTION
When creating a CloudWatch Metric for an Application Load Balancer it is neccessary to use the suffix of the ARN as the reference to the load balancer. This commit exposes that as an attribute on the `aws_alb` resource to prevent the need to use regular expression substitution to make the reference.

Fixes #8808.