### PR TITLE
core: Check for attrV being nil before dereference

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -638,7 +638,9 @@ func (m schemaMap) diff(
 	}
 
 	for attrK, attrV := range unsupressedDiff.Attributes {
-		if schema.DiffSuppressFunc != nil && schema.DiffSuppressFunc(attrK, attrV.Old, attrV.New, d) {
+		if schema.DiffSuppressFunc != nil &&
+			attrV != nil &&
+			schema.DiffSuppressFunc(attrK, attrV.Old, attrV.New, d) {
 			continue
 		}
 


### PR DESCRIPTION
This can be an issue with unset computed fields.

Fixes #8815.