### PR TITLE
Replaces remaining AWS_SECURITY_TOKEN with AWS_SESSION_TOKEN

### DIFF
--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -154,7 +154,7 @@ The following arguments are supported in the `provider` block:
   If this is not set and a profile is specified, ~/.aws/credentials will be used.
 
 * `token` - (Optional) Use this to set an MFA token. It can also be sourced
-  from the `AWS_SECURITY_TOKEN` environment variable.
+  from the `AWS_SESSION_TOKEN` environment variable.
 
 * `max_retries` - (Optional) This is the maximum number of times an API call is
   being retried in case requests are being throttled or experience transient failures.

--- a/website/source/docs/state/remote/s3.html.md
+++ b/website/source/docs/state/remote/s3.html.md
@@ -58,4 +58,4 @@ The following configuration options / environment variables are supported:
  * `kms_key_id` - (Optional) The ARN of a KMS Key to use for encrypting the state.
  * `profile` - (Optional) This is the AWS profile name as set in the shared credentials file.
  * `shared_credentials_file`  - (Optional) This is the path to the shared credentials file. If this is not set and a profile is specified, ~/.aws/credentials will be used.
- * `token` - (Optional) Use this to set an MFA token. It can also be sourced from the `AWS_SECURITY_TOKEN` environment variable.
+ * `token` - (Optional) Use this to set an MFA token. It can also be sourced from the `AWS_SESSION_TOKEN` environment variable.


### PR DESCRIPTION
Following up on https://github.com/hashicorp/terraform/pull/8816, I noticed another two references to `AWS_SECURITY_TOKEN` that should really be `AWS_SESSION_TOKEN`. 

I think this change results in less conflicting docs.

Wondering if this should also be mentioned in the `CHANGELOG.md`?