### PR TITLE
Support CloudWatch logging with Kinesis Firehose

### DIFF
--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -135,6 +135,22 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
+						"log_enabled": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
+						"log_group_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"log_stream_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -321,6 +337,11 @@ func createS3Config(d *schema.ResourceData) *firehose.S3DestinationConfiguration
 			IntervalInSeconds: aws.Int64(int64(s3["buffer_interval"].(int))),
 			SizeInMBs:         aws.Int64(int64(s3["buffer_size"].(int))),
 		},
+		CloudWatchLoggingOptions: &firehose.CloudWatchLoggingOptions{
+			Enabled:       aws.Bool(s3["log_enabled"].(bool)),
+			LogGroupName:  aws.String(s3["log_group_name"].(string)),
+			LogStreamName: aws.String(s3["log_stream_name"].(string)),
+		},
 		Prefix:                  extractPrefixConfiguration(s3),
 		CompressionFormat:       aws.String(s3["compression_format"].(string)),
 		EncryptionConfiguration: extractEncryptionConfiguration(s3),
@@ -336,6 +357,11 @@ func updateS3Config(d *schema.ResourceData) *firehose.S3DestinationUpdate {
 		BufferingHints: &firehose.BufferingHints{
 			IntervalInSeconds: aws.Int64((int64)(s3["buffer_interval"].(int))),
 			SizeInMBs:         aws.Int64((int64)(s3["buffer_size"].(int))),
+		},
+		CloudWatchLoggingOptions: &firehose.CloudWatchLoggingOptions{
+			Enabled:       aws.Bool(s3["log_enabled"].(bool)),
+			LogGroupName:  aws.String(s3["log_group_name"].(string)),
+			LogStreamName: aws.String(s3["log_stream_name"].(string)),
 		},
 		Prefix:                  extractPrefixConfiguration(s3),
 		CompressionFormat:       aws.String(s3["compression_format"].(string)),

--- a/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/source/docs/providers/aws/r/kinesis_firehose_delivery_stream.html.markdown
@@ -137,6 +137,9 @@ The `s3_configuration` object supports the following:
 * `compression_format` - (Optional) The compression format. If no value is specified, the default is UNCOMPRESSED. Other supported values are GZIP, ZIP & Snappy. If the destination is redshift you cannot use ZIP or Snappy.
 * `kms_key_arn` - (Optional) If set, the stream will encrypt data using the key in KMS, otherwise, no encryption will
 be used.
+* `log_enabled` - (Optional) Enables or disables CloudWatch logging. The default value is false.
+* `log_group_name` - (Optional) The CloudWatch group name for logging. This value is required if `log_enabled` is true.
+* `log_stream_name` - (Optional) The CloudWatch log stream name for logging. This value is required if `log_stream_name` is true.
 
 The `redshift_configuration` object supports the following:
 


### PR DESCRIPTION
Add support for configuring CloudWatch logging with Kinesis Firehose as per http://docs.aws.amazon.com/firehose/latest/APIReference/API_CreateDeliveryStream.html