### PR TITLE
Fixed typo in aws_elb_attachment website docs

### DIFF
--- a/website/source/docs/providers/aws/r/elb_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/elb_attachment.html.markdown
@@ -22,7 +22,7 @@ conflict and will overwrite attachments.
 # Create a new load balancer attachment
 resource "aws_elb_attachment" "baz" {
   elb      = "${aws_elb.bar.id}"
-  instance = ["${aws_instance.foo.id}"]
+  instance = "${aws_instance.foo.id}"
 }
 ```
 


### PR DESCRIPTION
The instance argument is a string and not a list.
It will give you an error if you try to define it as a list.