### PR TITLE
provider/aws: Fix issue updating Elastic Beanstalk Environment variables

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -239,6 +239,13 @@ func TestAccAWSBeanstalkEnv_basic_settings_update(t *testing.T) {
 				),
 			},
 			resource.TestStep{
+				Config: testAccBeanstalkEnvConfig_settings_update(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccVerifyBeanstalkConfig(&app, []string{"TF_LOG", "TF_SOME_VAR"}),
+				),
+			},
+			resource.TestStep{
 				Config: testAccBeanstalkEnvConfig_empty_settings(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
@@ -504,6 +511,61 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "TF_SOME_VAR"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:scheduledaction"
+    resource  = "ScheduledAction01"
+    name      = "MinSize"
+    value     = 2
+  }
+
+  setting {
+    namespace = "aws:autoscaling:scheduledaction"
+    resource  = "ScheduledAction01"
+    name      = "MaxSize"
+    value     = 3
+  }
+
+  setting {
+    namespace = "aws:autoscaling:scheduledaction"
+    resource  = "ScheduledAction01"
+    name      = "StartTime"
+    value     = "2016-07-28T04:07:02Z"
+  }
+}`, r, r)
+}
+
+func testAccBeanstalkEnvConfig_settings_update(r int) string {
+	return fmt.Sprintf(`
+resource "aws_elastic_beanstalk_application" "tftest" {
+  name = "tf-test-name-%d"
+  description = "tf-test-desc"
+}
+
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name                = "tf-test-name-%d"
+  application         = "${aws_elastic_beanstalk_application.tftest.name}"
+  solution_stack_name = "64bit Amazon Linux running Python"
+
+        wait_for_ready_timeout = "15m"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "TF_LOG"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "TF_SOME_VAR"
+    value     = "false"
+  }
+
+	  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "TF_SOME_NEW_VAR"
     value     = "true"
   }
 


### PR DESCRIPTION
There is a bug in how `aws_beanstalk_environment` handles updating environment variables, specifically when modifying more than a single one. When more than one is _modified_, a replace operation should occur. Because of how Beanstalk handles things, we don't do our normal _remove all these_ then _add all these_, as we normally do. 

There is logic in place to handle this, but the test case was too simple and did not test modifying a variable, only adding or deleting. When _modifying_, we need to essentially do a  `PUT`. Due to an error in the logic, modifying a variable resulted sending the new value while also telling the Service to remove it completely. 

This PR changes the logic to remove items that are both being added and deleted from the slice of items to remove, instead of trying to build up a new set of removals. I've also modified an existing test to verify the behavior. 

Fixes https://github.com/hashicorp/terraform/issues/8742