### PR TITLE
provider/azurerm: Terraform Plan errors when created resources disappear

### DIFF
--- a/builtin/providers/azurerm/resource_arm_availability_set.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set.go
@@ -118,11 +118,11 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := availSetClient.Get(resGroup, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Availability Set %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	availSet := *resp.Properties

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
@@ -226,11 +226,11 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[INFO] Trying to find the AzureRM CDN Endpoint %s (Profile: %s, RG: %s)", name, profileName, resGroup)
 	resp, err := cdnEndpointsClient.Get(name, profileName, resGroup)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure CDN Endpoint %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("name", resp.Name)

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
@@ -29,6 +29,27 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCdnEndpoint_disappears(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
+					testCheckAzureRMCdnEndpointDisappears("azurerm_cdn_endpoint.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMCdnEndpoint_withTags(t *testing.T) {
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTags, ri, ri, ri)
@@ -90,6 +111,32 @@ func testCheckAzureRMCdnEndpointExists(name string) resource.TestCheckFunc {
 
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Bad: CDN Endpoint %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMCdnEndpointDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		profileName := rs.Primary.Attributes["profile_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient
+
+		_, err := conn.DeleteIfExists(name, profileName, resourceGroup, make(chan struct{}))
+		if err != nil {
+			return fmt.Errorf("Bad: Delete on cdnEndpointsClient: %s", err)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_cdn_profile.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile.go
@@ -100,11 +100,11 @@ func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := cdnProfilesClient.Get(name, resGroup)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure CDN Profile %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	if resp.Sku != nil {

--- a/builtin/providers/azurerm/resource_arm_local_network_gateway.go
+++ b/builtin/providers/azurerm/resource_arm_local_network_gateway.go
@@ -110,11 +110,11 @@ func resourceArmLocalNetworkGatewayRead(d *schema.ResourceData, meta interface{}
 
 	resp, err := lnetClient.Get(resGroup, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading the state of Azure ARM local network gateway '%s': %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("name", resp.Name)

--- a/builtin/providers/azurerm/resource_arm_local_network_gateway_test.go
+++ b/builtin/providers/azurerm/resource_arm_local_network_gateway_test.go
@@ -29,6 +29,28 @@ func TestAccAzureRMLocalNetworkGateway_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLocalNetworkGateway_disappears(t *testing.T) {
+	name := "azurerm_local_network_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(name),
+					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(name, "address_space.0", "127.0.0.0/8"),
+					testCheckAzureRMLocalNetworkGatewayDisappears(name),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 // testCheckAzureRMLocalNetworkGatewayExists returns the resurce.TestCheckFunc
 // which checks whether or not the expected local network gateway exists both
 // in the schema, and on Azure.
@@ -57,6 +79,37 @@ func testCheckAzureRMLocalNetworkGatewayExists(name string) resource.TestCheckFu
 				return fmt.Errorf("Local network gateway '%s' (resource group '%s') does not exist on Azure.", localNetName, resGrp)
 			}
 			return fmt.Errorf("Error reading the state of local network gateway '%s'.", localNetName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLocalNetworkGatewayDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// first check within the schema for the local network gateway:
+		res, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Local network gateway '%s' not found.", name)
+		}
+
+		// then, extract the name and the resource group:
+		id, err := parseAzureResourceID(res.Primary.ID)
+		if err != nil {
+			return err
+		}
+		localNetName := id.Path["localNetworkGateways"]
+		resGrp := id.ResourceGroup
+
+		// and finally, check that it exists on Azure:
+		lnetClient := testAccProvider.Meta().(*ArmClient).localNetConnClient
+
+		resp, err := lnetClient.Delete(resGrp, localNetName, make(chan struct{}))
+		if err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("Local network gateway '%s' (resource group '%s') does not exist on Azure.", localNetName, resGrp)
+			}
+			return fmt.Errorf("Error deleting the state of local network gateway '%s'.", localNetName)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -246,11 +246,11 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 
 	resp, err := ifaceClient.Get(resGroup, name, "")
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Network Interface %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	iface := *resp.Properties

--- a/builtin/providers/azurerm/resource_arm_network_security_group.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group.go
@@ -192,11 +192,11 @@ func resourceArmNetworkSecurityGroupRead(d *schema.ResourceData, meta interface{
 
 	resp, err := secGroupClient.Get(resGroup, name, "")
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Network Security Group %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	if resp.Properties.SecurityRules != nil {

--- a/builtin/providers/azurerm/resource_arm_network_security_rule.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_rule.go
@@ -176,11 +176,11 @@ func resourceArmNetworkSecurityRuleRead(d *schema.ResourceData, meta interface{}
 
 	resp, err := secRuleClient.Get(resGroup, networkSGName, sgRuleName)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Network Security Rule %s: %s", sgRuleName, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("access", resp.Properties.Access)

--- a/builtin/providers/azurerm/resource_arm_public_ip.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip.go
@@ -166,11 +166,11 @@ func resourceArmPublicIpRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := publicIPClient.Get(resGroup, name, "")
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure public ip %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("location", resp.Location)

--- a/builtin/providers/azurerm/resource_arm_public_ip_test.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip_test.go
@@ -98,6 +98,28 @@ func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPublicIpStatic_disappears(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+					testCheckAzureRMPublicIpDisappears("azurerm_public_ip.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMPublicIpStatic_idleTimeout(t *testing.T) {
 
 	ri := acctest.RandInt()
@@ -234,6 +256,31 @@ func testCheckAzureRMPublicIpExists(name string) resource.TestCheckFunc {
 
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Bad: Public IP %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMPublicIpDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		publicIpName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for public ip: %s", publicIpName)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).publicIPClient
+
+		_, err := conn.Delete(resourceGroup, publicIpName, make(chan struct{}))
+		if err != nil {
+			return fmt.Errorf("Bad: Delete on publicIPClient: %s", err)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_route.go
+++ b/builtin/providers/azurerm/resource_arm_route.go
@@ -113,11 +113,11 @@ func resourceArmRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := routesClient.Get(resGroup, rtName, routeName)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Route %s: %s", routeName, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_route_table.go
+++ b/builtin/providers/azurerm/resource_arm_route_table.go
@@ -143,11 +143,11 @@ func resourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := routeTablesClient.Get(resGroup, name, "")
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Route Table %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	if resp.Properties.Subnets != nil {

--- a/builtin/providers/azurerm/resource_arm_route_test.go
+++ b/builtin/providers/azurerm/resource_arm_route_test.go
@@ -30,6 +30,28 @@ func TestAccAzureRMRoute_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMRoute_disappears(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMRoute_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRouteExists("azurerm_route.test"),
+					testCheckAzureRMRouteDisappears("azurerm_route.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMRoute_multipleRoutes(t *testing.T) {
 
 	ri := acctest.RandInt()
@@ -82,6 +104,32 @@ func testCheckAzureRMRouteExists(name string) resource.TestCheckFunc {
 
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Bad: Route %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMRouteDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		rtName := rs.Primary.Attributes["route_table_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for route: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).routesClient
+
+		_, err := conn.Delete(resourceGroup, rtName, name, make(chan struct{}))
+		if err != nil {
+			return fmt.Errorf("Bad: Delete on routesClient: %s", err)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_storage_account.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account.go
@@ -256,11 +256,11 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 	resp, err := client.GetProperties(resGroup, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading the state of AzureRM Storage Account %q: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	keys, err := client.ListKeys(resGroup, name)

--- a/builtin/providers/azurerm/resource_arm_storage_blob_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob_test.go
@@ -163,6 +163,28 @@ func TestAccAzureRMStorageBlob_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageBlob_basic, ri, rs)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageBlobExists("azurerm_storage_blob.test"),
+					testCheckAzureRMStorageBlobDisappears("azurerm_storage_blob.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMStorageBlobBlock_source(t *testing.T) {
 	ri := acctest.RandInt()
 	rs1 := strings.ToLower(acctest.RandString(11))
@@ -324,6 +346,40 @@ func testCheckAzureRMStorageBlobExists(name string) resource.TestCheckFunc {
 
 		if !exists {
 			return fmt.Errorf("Bad: Storage Blob %q (storage container: %q) does not exist", name, storageContainerName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMStorageBlobDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		storageAccountName := rs.Primary.Attributes["storage_account_name"]
+		storageContainerName := rs.Primary.Attributes["storage_container_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
+		}
+
+		armClient := testAccProvider.Meta().(*ArmClient)
+		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(resourceGroup, storageAccountName)
+		if err != nil {
+			return err
+		}
+		if !accountExists {
+			return fmt.Errorf("Bad: Storage Account %q does not exist", storageAccountName)
+		}
+
+		_, err = blobClient.DeleteBlobIfExists(storageContainerName, name, map[string]string{})
+		if err != nil {
+			return err
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -133,11 +133,11 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := subnetClient.Get(resGroup, vnetName, name, "")
 
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Subnet %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	if resp.Properties.IPConfigurations != nil && len(*resp.Properties.IPConfigurations) > 0 {

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -30,6 +30,28 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSubnet_disappears(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+					testCheckAzureRMSubnetDisappears("azurerm_subnet.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -54,6 +76,32 @@ func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
 
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMSubnetDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		vnetName := rs.Primary.Attributes["virtual_network_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).subnetClient
+
+		_, err := conn.Delete(resourceGroup, vnetName, name, make(chan struct{}))
+		if err != nil {
+			return fmt.Errorf("Bad: Delete on subnetClient: %s", err)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_template_deployment.go
+++ b/builtin/providers/azurerm/resource_arm_template_deployment.go
@@ -144,11 +144,11 @@ func resourceArmTemplateDeploymentRead(d *schema.ResourceData, meta interface{})
 
 	resp, err := deployClient.Get(resGroup, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure RM Template Deployment %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	var outputs map[string]string

--- a/builtin/providers/azurerm/resource_arm_template_deployment_test.go
+++ b/builtin/providers/azurerm/resource_arm_template_deployment_test.go
@@ -29,6 +29,26 @@ func TestAccAzureRMTemplateDeployment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMTemplateDeployment_disappears(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_basicExample, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMTemplateDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMTemplateDeploymentExists("azurerm_template_deployment.test"),
+					testCheckAzureRMTemplateDeploymentDisappears("azurerm_template_deployment.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMTemplateDeployment_withParams(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_withParams, ri, ri, ri)
@@ -87,6 +107,31 @@ func testCheckAzureRMTemplateDeploymentExists(name string) resource.TestCheckFun
 
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Bad: TemplateDeployment %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMTemplateDeploymentDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).deploymentsClient
+
+		_, err := conn.Delete(resourceGroup, name, make(chan struct{}))
+		if err != nil {
+			return fmt.Errorf("Bad: Delete on deploymentsClient: %s", err)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint.go
@@ -153,11 +153,11 @@ func resourceArmTrafficManagerEndpointRead(d *schema.ResourceData, meta interfac
 
 	resp, err := client.Get(resGroup, profileName, endpointType, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on TrafficManager Endpoint %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	endpoint := *resp.Properties

--- a/builtin/providers/azurerm/resource_arm_traffic_manager_profile.go
+++ b/builtin/providers/azurerm/resource_arm_traffic_manager_profile.go
@@ -151,11 +151,11 @@ func resourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interface
 
 	resp, err := client.Get(resGroup, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Traffic Manager Profile %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	profile := *resp.Properties

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -520,11 +520,11 @@ func resourceArmVirtualMachineRead(d *schema.ResourceData, meta interface{}) err
 	resp, err := vmClient.Get(resGroup, name, "")
 
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Virtual Machine %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	if resp.Plan != nil {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -432,12 +432,12 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 
 	resp, err := vmScaleSetClient.Get(resGroup, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			log.Printf("[INFO] AzureRM Virtual Machine Scale Set (%s) Not Found. Removing from State", name)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure Virtual Machine Scale Set %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		log.Printf("[INFO] AzureRM Virtual Machine Scale Set (%s) Not Found. Removing from State", name)
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("location", resp.Location)

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -28,6 +28,26 @@ func TestAccAzureRMVirtualMachineScaleSet_basicLinux(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineScaleSet_basicLinux_disappears(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basicLinux, ri, ri, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+					testCheckAzureRMVirtualMachineScaleSetDisappears("azurerm_virtual_machine_scale_set.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 //func TestAccAzureRMVirtualMachineScaleSet_basicWindowsMachine(t *testing.T) {
 //	ri := acctest.RandInt()
 //	rs := acctest.RandString(6)
@@ -70,6 +90,31 @@ func testCheckAzureRMVirtualMachineScaleSetExists(name string) resource.TestChec
 
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Bad: VirtualMachineScaleSet %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMVirtualMachineScaleSetDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for virtual machine: scale set %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).vmScaleSetClient
+
+		_, err := conn.Delete(resourceGroup, name, make(chan struct{}))
+		if err != nil {
+			return fmt.Errorf("Bad: Delete on vmScaleSetClient: %s", err)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -133,12 +133,13 @@ func resourceArmVirtualNetworkRead(d *schema.ResourceData, meta interface{}) err
 
 	resp, err := vnetClient.Get(resGroup, name, "")
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure virtual network %s: %s", name, err)
 	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
-	}
+
 	vnet := *resp.Properties
 
 	// update appropriate values

--- a/builtin/providers/azurerm/resource_arm_virtual_network_peering.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network_peering.go
@@ -124,11 +124,11 @@ func resourceArmVirtualNetworkPeeringRead(d *schema.ResourceData, meta interface
 
 	resp, err := client.Get(resGroup, vnetName, name)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Azure virtual network peering %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	peer := *resp.Properties


### PR DESCRIPTION
Terraform can't plan correctly when a VM is manually removed from Azure. The vmClient() API call returns an error for 404 return. ~~This is different to subnetClient() which doesn't error for 404 returns.~~ subnetClient() also errors the same way. This may be a consistent problem across the provider.

**To Reproduce:**
1. `Apply` a plan to create a VM (example is below)
2. Manually delete a VM
3. Try to `Plan`. Terraform shows the following error
```
Error refreshing state: 1 error(s) occurred:

* azurerm_virtual_machine.test: Error making Read request on Azure Virtual Machine acctvm: compute.VirtualMachinesClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.Compute/virtualMachines/acctvm' under resource group 'acctestrg' was not found."
```

**Terraform HCL**
```
resource "azurerm_resource_group" "test" {
    name = "acctestrg"
    location = "West US"
}

resource "azurerm_virtual_network" "test" {
    name = "acctvn"
    address_space = ["10.0.0.0/16"]
    location = "West US"
    resource_group_name = "${azurerm_resource_group.test.name}"
}

resource "azurerm_subnet" "test" {
    name = "acctsub"
    resource_group_name = "${azurerm_resource_group.test.name}"
    virtual_network_name = "${azurerm_virtual_network.test.name}"
    address_prefix = "10.0.2.0/24"
}

resource "azurerm_network_interface" "test" {
    name = "acctni"
    location = "West US"
    resource_group_name = "${azurerm_resource_group.test.name}"

    ip_configuration {
        name = "testconfiguration1"
        subnet_id = "${azurerm_subnet.test.id}"
        private_ip_address_allocation = "dynamic"
    }
}

resource "azurerm_storage_account" "test" {
    name = "accsa"
    resource_group_name = "${azurerm_resource_group.test.name}"
    location = "westus"
    account_type = "Standard_LRS"

    tags {
        environment = "staging"
    }
}

resource "azurerm_storage_container" "test" {
    name = "vhds"
    resource_group_name = "${azurerm_resource_group.test.name}"
    storage_account_name = "${azurerm_storage_account.test.name}"
    container_access_type = "private"
}

resource "azurerm_virtual_machine" "test" {
    name = "acctvm"
    location = "West US"
    resource_group_name = "${azurerm_resource_group.test.name}"
    network_interface_ids = ["${azurerm_network_interface.test.id}"]
    vm_size = "Standard_A0"

    storage_image_reference {
        publisher = "Canonical"
        offer = "UbuntuServer"
        sku = "14.04.2-LTS"
        version = "latest"
    }

    storage_os_disk {
        name = "myosdisk1"
        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
        caching = "ReadWrite"
        create_option = "FromImage"
    }

    os_profile {
        computer_name = "hostname"
        admin_username = "testadmin"
        admin_password = "Password1234!"
    }

    os_profile_linux_config {
        disable_password_authentication = false
    }

    tags {
        environment = "staging"
    }
}
```