### PR TITLE
Make terraform get to download an URL only once

### DIFF
--- a/command/module_storage.go
+++ b/command/module_storage.go
@@ -2,10 +2,14 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/mitchellh/cli"
 )
+
+// map to store all already downloaded URLs
+var storedModules = make(map[string]string)
 
 // uiModuleStorage implements module.Storage and is just a proxy to output
 // to the UI any Get operations.
@@ -24,6 +28,32 @@ func (s *uiModuleStorage) Get(key string, source string, update bool) error {
 		updateStr = " (update)"
 	}
 
-	s.Ui.Output(fmt.Sprintf("Get: %s%s", source, updateStr))
-	return s.Storage.Get(key, source, update)
+	if strings.Hasprefix(source, "file") {
+		s.Ui.Output(fmt.Sprintf("Get: %s%s", source, updateStr))
+		return s.Storage.Get(key, source, update)
+	} else if storedModules[source] == "" {
+		storedModules[source] = key
+		s.Ui.Output(fmt.Sprintf("Get: %s%s storemap %+v", source, updateStr, storedModules))
+		return s.Storage.Get(key, source, update)
+	} else {
+		downloadedPath := storedModules[source]
+		downloadedPathURL := fmtfileURL(downloadedPath)
+		s.Ui.Output(fmt.Sprintf("Get: %s%s storemap %+v", downloadedPathURL, updateStr, storedModules))
+		return s.Storage.Get(key, downloadedPathURL, update)
+	}
+
+}
+
+func fmtFileURL(path string) string {
+	if runtime.GOOS == "windows" {
+		// Make sure we're using "/" on Windows. URLs are "/"-based.
+		path = filepath.ToSlash(path)
+		return fmt.Sprintf("file://%s", path)
+	}
+
+	// Make sure that we don't start with "/" since we add that below.
+	if path[0] == '/' {
+		path = path[1:]
+	}
+	return fmt.Sprintf("file:///%s", path)
 }


### PR DESCRIPTION
We have use cases where the same terraform module via git is invoked n - number of times (sometimes in the range of 100). git-cloning them 100s of times makes terraform get too slow. This PR attempts to clone once and link to the downloaded file URL other times.

Building with this and testing seems to make terraform get work fine but there seems to be a problem with plan. I guess work around for this would be to store this info in a file and read that as well when module is loaded.

But before that any advice on how to solve this better or if there are any alternative approaches to this which might work better would be great.