### PR TITLE
provisioner/chef: Fix provisioner failure "exited with non-zero exit status: 1"

### DIFF
--- a/builtin/provisioners/chef/windows_provisioner.go
+++ b/builtin/provisioners/chef/windows_provisioner.go
@@ -10,7 +10,7 @@ import (
 )
 
 const installScript = `
-$winver = [System.Environment]::OSVersion.Version | %% {"{0}.{1}" -f $_.Major,$_.Minor}
+$winver = [System.Environment]::OSVersion.Version | % {"{0}.{1}" -f $_.Major,$_.Minor}
 
 switch ($winver)
 {
@@ -72,7 +72,7 @@ func (p *Provisioner) windowsCreateConfigFiles(
 	}
 
 	if len(p.OhaiHints) > 0 {
-		// Make sure the hits directory exists
+		// Make sure the hints directory exists
 		hintsDir := path.Join(windowsConfDir, "ohai/hints")
 		cmd := fmt.Sprintf("cmd /c if not exist %q mkdir %q", hintsDir, hintsDir)
 		if err := p.runCommand(o, comm, cmd); err != nil {


### PR DESCRIPTION
The issue is discussed here [provisioner/chef: not installing chef on Windows #3769](https://github.com/hashicorp/terraform/issues/3769)

The chef provisioner fails very quickly:

aws_instance.tsdr (chef): Connected!
aws_instance.tsdr: Still creating... (5m19s elapsed)
...
aws_instance.tsdr: Still creating... (6m9s elapsed)
Error applying plan:
1 error(s) occurred:
Command "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Temp/ChefClient.ps1" exited with non-zero exit status: 1

I believe this is the reason the chef provisioner fails. I assume we want a for-each statement here so a single quote should be used. (also a misspelled word in a comment )

This is my provisioner statement. The runlist is empty at the moment for troubleshooting.

provisioner "chef" {
environment = "build"
server_url = "https://chef.xxx.org/organizations/mpetka"
ssl_verify_mode = "verify_none"
validation_client_name = "mpetka-validator"
validation_key = "${file("./mpetka-validator.pem")}"
node_name = "dr-tsdr-1"
run_list = [""]
log_to_file = "true"
skip_install = "false"
os_type = "windows"
client_options = [
"exit_status = disabled",
"log_location = win_evt",
"rest_timeout = 800"
]
connection {
type = "winrm"
user = "vagrant"
password = "${var.admin_password}"
timeout = "30m"
}
}

Here is the default powershell alias showing that the for-loop is aliased to the single percentage

Get-Alias -Definition ForEach-Object
CommandType                    Name           Definition
Alias                                      %                 ForEach-Object
Alias                                     foreach         ForEach-Object