### PR TITLE
[WIP] core: plan only includes first map when resource references a var containing a list of maps

### DIFF
--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -206,9 +206,18 @@ func (c *ResourceConfig) get(
 					return nil, false
 				}
 				if i >= int64(cv.Len()) {
-					return nil, false
+					if int64(cv.Len()) == 1 {
+						if val, ok := cv.Index(0).Interface().(string); ok && strings.HasPrefix(val, "${") {
+							// This happens when the resource reference a list of maps var.
+							// On the first pass, the variable has not been interpolated.
+							current = val
+						}
+					} else {
+						return nil, false
+					}
+				} else {
+					current = cv.Index(int(i)).Interface()
 				}
-				current = cv.Index(int(i)).Interface()
 			}
 		case reflect.String:
 			// This happens when map keys contain "." and have a common

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -149,6 +149,25 @@ func TestResourceConfigGet(t *testing.T) {
 			Key:   "mapname.0.listkey.0.key",
 			Value: 3,
 		},
+		 // Reference list of maps variable
+		//{
+		//	Vars:  map[string]string{
+		//		"listofmaps": `[
+		//		{
+		//			name = "map1"
+		//			foo = "bar1"
+		//		},
+		//		{
+		//			name = "map2"
+		//			"foo = "bar2"
+		//		}]`,
+		//	},
+		//	Config: map[string]interface{}{
+		//		"listofmapsref": "${var.listofmaps}",
+		//	},
+		//	Key:   "listofmapsref.1",
+		//	Value: "${var.listofmaps}",
+		//},
 		// FIXME: this is ambiguous, and matches the nested map
 		//        leaving here to catch this behaviour if it changes.
 		{

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -149,7 +149,7 @@ func TestResourceConfigGet(t *testing.T) {
 			Key:   "mapname.0.listkey.0.key",
 			Value: 3,
 		},
-		 // Reference list of maps variable
+		// Reference list of maps variable
 		//{
 		//	Vars:  map[string]string{
 		//		"listofmaps": `[


### PR DESCRIPTION
When referencing a list of maps variable from a resource, only 
the first list element is included the plan.

Consider the following config:

``` hcl
variable "app_config" {
  type = "list"

  default = [
    {
      foo = "bar"
      baz = "bam"
    },
    {
      foo = "bar"
      baz = "bam"
    },
  ]
}

resource "heroku_app" "interpolated" {
  name   = "my-cool-app"
  region = "us"

  config_vars = ["${var.app_config}"]
}
```

The `plan` output shows the following:

```
+ heroku_app.interpolated                                                                                                                                                              
    all_config_vars.%: "<computed>"                                                                                                                                                    
    config_vars.#:     "2"                                                                                                                                                             
    config_vars.0.%:   "2"                                                                                                                                                             
    config_vars.0.baz: "bam"                                                                                                                                                           
    config_vars.0.foo: "bar"                                                                                                                                                           
    git_url:           "<computed>"                                                                                                                                                    
    heroku_hostname:   "<computed>"                                                                                                                                                    
    name:              "my-cool-app"                                                                                                                                                   
    region:            "us"                                                                                                                                                            
    stack:             "<computed>"                                                                                                                                                    
    web_url:           "<computed>" 
```

Notice the `config_vars.#` correctly indicates there should be 2 elements, but only `config_vars.0` is shown.

If the same resources is defined with an embedded list of maps, the plan output shows both elements:

``` hcl
resource "heroku_app" "embedded" {
  name   = "my-cool-app"
  region = "us"

  config_vars = [
    {
      foo = "bar"
      baz = "bam"
    },
    {
      foo = "bar"
      baz = "bam"
    },
  ]
}
```

**Plan Output**

```
+ heroku_app.embedded                                                                                                                                                                  
    all_config_vars.%:     "<computed>"                                                                                                                                                
    config_vars.#:         "2"                                                                                                                                                         
    config_vars.0.%:       "4"                                                                                                                                                         
    config_vars.0.fqdn:    "ms1.pri.awstest.internal"                                                                                                                                  
    config_vars.0.name:    "ms1"                                                                                                                                                       
    config_vars.0.primary: "1"                                                                                                                                                         
    config_vars.0.subnet:  "sub1"                                                                                                                                                      
    config_vars.1.%:       "4"                                                                                                                                                         
    config_vars.1.fqdn:    "ms2.pri.awstest.internal"                                                                                                                                  
    config_vars.1.name:    "ms2"                                                                                                                                                       
    config_vars.1.primary: "0"                                                                                                                                                         
    config_vars.1.subnet:  "sub2"                                                                                                                                                      
    git_url:               "<computed>"                                                                                                                                                
    heroku_hostname:       "<computed>"                                                                                                                                                
    name:                  "my-cool-app"                                                                                                                                               
    region:                "us"                                                                                                                                                        
    stack:                 "<computed>"                                                                                                                                                
    web_url:               "<computed>" 
```

This PR fixes the interpolated config.

I'm not very familiar with the core of Terraform so there may be a better way / place to fix this issue.
Also, I'm looking for advice on how to add a test for this case. 
You'll see in `resource_test.go` my attempt at adding a test (which does not work).

Also, I'm not actually trying to use the heroku resource in this way. I chose it to demonstrate this problem because it's `config_vars` attribute accepts a list of maps and invalid / missing heroku credentials doesn't prevent `terraform plan` from running. I'm actually trying to use this pattern with a custom terraform provider.
