### PR TITLE
vendor: Bump github.com/aws/aws-sdk-go to v1.4.10

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/Makefile
+++ b/vendor/github.com/aws/aws-sdk-go/Makefile
@@ -107,14 +107,12 @@ lint:
 	if [ "$$lint" != "" ] && [ "$$lint" != "skipping golint" ]; then exit 1; fi
 
 SDK_BASE_FOLDERS=$(shell ls -d */ | grep -v vendor | grep -v awsmigrate)
-ifneq (,$(findstring go1.5, ${SDK_GO_VERSION}))
-	GO_VET_CMD=go tool vet --all -shadow
+ifneq (,$(findstring go1.4, ${SDK_GO_VERSION}))
+	GO_VET_CMD=echo skipping go vet, ${SDK_GO_VERSION}
 else ifneq (,$(findstring go1.6, ${SDK_GO_VERSION}))
 	GO_VET_CMD=go tool vet --all -shadow -example=false
-else ifneq (,$(findstring devel, ${SDK_GO_VERSION}))
-	GO_VET_CMD=go tool vet --all -shadow -tests=false
 else
-	GO_VET_CMD=echo skipping go vet, ${SDK_GO_VERSION}
+	GO_VET_CMD=go tool vet --all -shadow
 endif
 
 vet:

--- a/vendor/github.com/aws/aws-sdk-go/aws/awsutil/path_value.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awsutil/path_value.go
@@ -106,8 +106,8 @@ func rValuesAtPath(v interface{}, path string, createPath, caseSensitive, nilTer
 
 		if indexStar || index != nil {
 			nextvals = []reflect.Value{}
-			for _, value := range values {
-				value := reflect.Indirect(value)
+			for _, valItem := range values {
+				value := reflect.Indirect(valItem)
 				if value.Kind() != reflect.Slice {
 					continue
 				}

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.4.7"
+const SDKVersion = "1.4.10"

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
 )
 
-const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2016_08_20"
+const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2016_09_07"
 
 // CreateCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the CreateCloudFrontOriginAccessIdentity operation. The "output" return
@@ -41,7 +41,7 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentityRequest(input *CreateCl
 	op := &request.Operation{
 		Name:       opCreateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront",
 	}
 
 	if input == nil {
@@ -61,7 +61,7 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentity(input *CreateCloudFron
 	return out, err
 }
 
-const opCreateDistribution = "CreateDistribution2016_08_20"
+const opCreateDistribution = "CreateDistribution2016_09_07"
 
 // CreateDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the CreateDistribution operation. The "output" return
@@ -89,7 +89,7 @@ func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (
 	op := &request.Operation{
 		Name:       opCreateDistribution,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/distribution",
+		HTTPPath:   "/2016-09-07/distribution",
 	}
 
 	if input == nil {
@@ -109,7 +109,7 @@ func (c *CloudFront) CreateDistribution(input *CreateDistributionInput) (*Create
 	return out, err
 }
 
-const opCreateDistributionWithTags = "CreateDistributionWithTags2016_08_20"
+const opCreateDistributionWithTags = "CreateDistributionWithTags2016_09_07"
 
 // CreateDistributionWithTagsRequest generates a "aws/request.Request" representing the
 // client's request for the CreateDistributionWithTags operation. The "output" return
@@ -137,7 +137,7 @@ func (c *CloudFront) CreateDistributionWithTagsRequest(input *CreateDistribution
 	op := &request.Operation{
 		Name:       opCreateDistributionWithTags,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/distribution?WithTags",
+		HTTPPath:   "/2016-09-07/distribution?WithTags",
 	}
 
 	if input == nil {
@@ -157,7 +157,7 @@ func (c *CloudFront) CreateDistributionWithTags(input *CreateDistributionWithTag
 	return out, err
 }
 
-const opCreateInvalidation = "CreateInvalidation2016_08_20"
+const opCreateInvalidation = "CreateInvalidation2016_09_07"
 
 // CreateInvalidationRequest generates a "aws/request.Request" representing the
 // client's request for the CreateInvalidation operation. The "output" return
@@ -185,7 +185,7 @@ func (c *CloudFront) CreateInvalidationRequest(input *CreateInvalidationInput) (
 	op := &request.Operation{
 		Name:       opCreateInvalidation,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/distribution/{DistributionId}/invalidation",
+		HTTPPath:   "/2016-09-07/distribution/{DistributionId}/invalidation",
 	}
 
 	if input == nil {
@@ -205,7 +205,7 @@ func (c *CloudFront) CreateInvalidation(input *CreateInvalidationInput) (*Create
 	return out, err
 }
 
-const opCreateStreamingDistribution = "CreateStreamingDistribution2016_08_20"
+const opCreateStreamingDistribution = "CreateStreamingDistribution2016_09_07"
 
 // CreateStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the CreateStreamingDistribution operation. The "output" return
@@ -233,7 +233,7 @@ func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDi
 	op := &request.Operation{
 		Name:       opCreateStreamingDistribution,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/streaming-distribution",
+		HTTPPath:   "/2016-09-07/streaming-distribution",
 	}
 
 	if input == nil {
@@ -253,7 +253,7 @@ func (c *CloudFront) CreateStreamingDistribution(input *CreateStreamingDistribut
 	return out, err
 }
 
-const opCreateStreamingDistributionWithTags = "CreateStreamingDistributionWithTags2016_08_20"
+const opCreateStreamingDistributionWithTags = "CreateStreamingDistributionWithTags2016_09_07"
 
 // CreateStreamingDistributionWithTagsRequest generates a "aws/request.Request" representing the
 // client's request for the CreateStreamingDistributionWithTags operation. The "output" return
@@ -281,7 +281,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTagsRequest(input *CreateStr
 	op := &request.Operation{
 		Name:       opCreateStreamingDistributionWithTags,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/streaming-distribution?WithTags",
+		HTTPPath:   "/2016-09-07/streaming-distribution?WithTags",
 	}
 
 	if input == nil {
@@ -301,7 +301,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTags(input *CreateStreamingD
 	return out, err
 }
 
-const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIdentity2016_08_20"
+const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIdentity2016_09_07"
 
 // DeleteCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteCloudFrontOriginAccessIdentity operation. The "output" return
@@ -329,7 +329,7 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentityRequest(input *DeleteCl
 	op := &request.Operation{
 		Name:       opDeleteCloudFrontOriginAccessIdentity,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}",
 	}
 
 	if input == nil {
@@ -351,7 +351,7 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentity(input *DeleteCloudFron
 	return out, err
 }
 
-const opDeleteDistribution = "DeleteDistribution2016_08_20"
+const opDeleteDistribution = "DeleteDistribution2016_09_07"
 
 // DeleteDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteDistribution operation. The "output" return
@@ -379,7 +379,7 @@ func (c *CloudFront) DeleteDistributionRequest(input *DeleteDistributionInput) (
 	op := &request.Operation{
 		Name:       opDeleteDistribution,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2016-08-20/distribution/{Id}",
+		HTTPPath:   "/2016-09-07/distribution/{Id}",
 	}
 
 	if input == nil {
@@ -401,7 +401,7 @@ func (c *CloudFront) DeleteDistribution(input *DeleteDistributionInput) (*Delete
 	return out, err
 }
 
-const opDeleteStreamingDistribution = "DeleteStreamingDistribution2016_08_20"
+const opDeleteStreamingDistribution = "DeleteStreamingDistribution2016_09_07"
 
 // DeleteStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteStreamingDistribution operation. The "output" return
@@ -429,7 +429,7 @@ func (c *CloudFront) DeleteStreamingDistributionRequest(input *DeleteStreamingDi
 	op := &request.Operation{
 		Name:       opDeleteStreamingDistribution,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}",
 	}
 
 	if input == nil {
@@ -451,7 +451,7 @@ func (c *CloudFront) DeleteStreamingDistribution(input *DeleteStreamingDistribut
 	return out, err
 }
 
-const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity2016_08_20"
+const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity2016_09_07"
 
 // GetCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the GetCloudFrontOriginAccessIdentity operation. The "output" return
@@ -479,7 +479,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityRequest(input *GetCloudFro
 	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentity,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}",
 	}
 
 	if input == nil {
@@ -499,7 +499,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentity(input *GetCloudFrontOrigi
 	return out, err
 }
 
-const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIdentityConfig2016_08_20"
+const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIdentityConfig2016_09_07"
 
 // GetCloudFrontOriginAccessIdentityConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetCloudFrontOriginAccessIdentityConfig operation. The "output" return
@@ -527,7 +527,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfigRequest(input *GetCl
 	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentityConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}/config",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}/config",
 	}
 
 	if input == nil {
@@ -547,7 +547,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfig(input *GetCloudFron
 	return out, err
 }
 
-const opGetDistribution = "GetDistribution2016_08_20"
+const opGetDistribution = "GetDistribution2016_09_07"
 
 // GetDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the GetDistribution operation. The "output" return
@@ -575,7 +575,7 @@ func (c *CloudFront) GetDistributionRequest(input *GetDistributionInput) (req *r
 	op := &request.Operation{
 		Name:       opGetDistribution,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{Id}",
+		HTTPPath:   "/2016-09-07/distribution/{Id}",
 	}
 
 	if input == nil {
@@ -595,7 +595,7 @@ func (c *CloudFront) GetDistribution(input *GetDistributionInput) (*GetDistribut
 	return out, err
 }
 
-const opGetDistributionConfig = "GetDistributionConfig2016_08_20"
+const opGetDistributionConfig = "GetDistributionConfig2016_09_07"
 
 // GetDistributionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetDistributionConfig operation. The "output" return
@@ -623,7 +623,7 @@ func (c *CloudFront) GetDistributionConfigRequest(input *GetDistributionConfigIn
 	op := &request.Operation{
 		Name:       opGetDistributionConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -643,7 +643,7 @@ func (c *CloudFront) GetDistributionConfig(input *GetDistributionConfigInput) (*
 	return out, err
 }
 
-const opGetInvalidation = "GetInvalidation2016_08_20"
+const opGetInvalidation = "GetInvalidation2016_09_07"
 
 // GetInvalidationRequest generates a "aws/request.Request" representing the
 // client's request for the GetInvalidation operation. The "output" return
@@ -671,7 +671,7 @@ func (c *CloudFront) GetInvalidationRequest(input *GetInvalidationInput) (req *r
 	op := &request.Operation{
 		Name:       opGetInvalidation,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{DistributionId}/invalidation/{Id}",
+		HTTPPath:   "/2016-09-07/distribution/{DistributionId}/invalidation/{Id}",
 	}
 
 	if input == nil {
@@ -691,7 +691,7 @@ func (c *CloudFront) GetInvalidation(input *GetInvalidationInput) (*GetInvalidat
 	return out, err
 }
 
-const opGetStreamingDistribution = "GetStreamingDistribution2016_08_20"
+const opGetStreamingDistribution = "GetStreamingDistribution2016_09_07"
 
 // GetStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the GetStreamingDistribution operation. The "output" return
@@ -719,7 +719,7 @@ func (c *CloudFront) GetStreamingDistributionRequest(input *GetStreamingDistribu
 	op := &request.Operation{
 		Name:       opGetStreamingDistribution,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}",
 	}
 
 	if input == nil {
@@ -739,7 +739,7 @@ func (c *CloudFront) GetStreamingDistribution(input *GetStreamingDistributionInp
 	return out, err
 }
 
-const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2016_08_20"
+const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2016_09_07"
 
 // GetStreamingDistributionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetStreamingDistributionConfig operation. The "output" return
@@ -767,7 +767,7 @@ func (c *CloudFront) GetStreamingDistributionConfigRequest(input *GetStreamingDi
 	op := &request.Operation{
 		Name:       opGetStreamingDistributionConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -787,7 +787,7 @@ func (c *CloudFront) GetStreamingDistributionConfig(input *GetStreamingDistribut
 	return out, err
 }
 
-const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdentities2016_08_20"
+const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdentities2016_09_07"
 
 // ListCloudFrontOriginAccessIdentitiesRequest generates a "aws/request.Request" representing the
 // client's request for the ListCloudFrontOriginAccessIdentities operation. The "output" return
@@ -815,7 +815,7 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesRequest(input *ListClou
 	op := &request.Operation{
 		Name:       opListCloudFrontOriginAccessIdentities,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"CloudFrontOriginAccessIdentityList.NextMarker"},
@@ -866,7 +866,7 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesPages(input *ListCloudF
 	})
 }
 
-const opListDistributions = "ListDistributions2016_08_20"
+const opListDistributions = "ListDistributions2016_09_07"
 
 // ListDistributionsRequest generates a "aws/request.Request" representing the
 // client's request for the ListDistributions operation. The "output" return
@@ -894,7 +894,7 @@ func (c *CloudFront) ListDistributionsRequest(input *ListDistributionsInput) (re
 	op := &request.Operation{
 		Name:       opListDistributions,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution",
+		HTTPPath:   "/2016-09-07/distribution",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"DistributionList.NextMarker"},
@@ -945,7 +945,7 @@ func (c *CloudFront) ListDistributionsPages(input *ListDistributionsInput, fn fu
 	})
 }
 
-const opListDistributionsByWebACLId = "ListDistributionsByWebACLId2016_08_20"
+const opListDistributionsByWebACLId = "ListDistributionsByWebACLId2016_09_07"
 
 // ListDistributionsByWebACLIdRequest generates a "aws/request.Request" representing the
 // client's request for the ListDistributionsByWebACLId operation. The "output" return
@@ -973,7 +973,7 @@ func (c *CloudFront) ListDistributionsByWebACLIdRequest(input *ListDistributions
 	op := &request.Operation{
 		Name:       opListDistributionsByWebACLId,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distributionsByWebACLId/{WebACLId}",
+		HTTPPath:   "/2016-09-07/distributionsByWebACLId/{WebACLId}",
 	}
 
 	if input == nil {
@@ -993,7 +993,7 @@ func (c *CloudFront) ListDistributionsByWebACLId(input *ListDistributionsByWebAC
 	return out, err
 }
 
-const opListInvalidations = "ListInvalidations2016_08_20"
+const opListInvalidations = "ListInvalidations2016_09_07"
 
 // ListInvalidationsRequest generates a "aws/request.Request" representing the
 // client's request for the ListInvalidations operation. The "output" return
@@ -1021,7 +1021,7 @@ func (c *CloudFront) ListInvalidationsRequest(input *ListInvalidationsInput) (re
 	op := &request.Operation{
 		Name:       opListInvalidations,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/distribution/{DistributionId}/invalidation",
+		HTTPPath:   "/2016-09-07/distribution/{DistributionId}/invalidation",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"InvalidationList.NextMarker"},
@@ -1072,7 +1072,7 @@ func (c *CloudFront) ListInvalidationsPages(input *ListInvalidationsInput, fn fu
 	})
 }
 
-const opListStreamingDistributions = "ListStreamingDistributions2016_08_20"
+const opListStreamingDistributions = "ListStreamingDistributions2016_09_07"
 
 // ListStreamingDistributionsRequest generates a "aws/request.Request" representing the
 // client's request for the ListStreamingDistributions operation. The "output" return
@@ -1100,7 +1100,7 @@ func (c *CloudFront) ListStreamingDistributionsRequest(input *ListStreamingDistr
 	op := &request.Operation{
 		Name:       opListStreamingDistributions,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/streaming-distribution",
+		HTTPPath:   "/2016-09-07/streaming-distribution",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"StreamingDistributionList.NextMarker"},
@@ -1151,7 +1151,7 @@ func (c *CloudFront) ListStreamingDistributionsPages(input *ListStreamingDistrib
 	})
 }
 
-const opListTagsForResource = "ListTagsForResource2016_08_20"
+const opListTagsForResource = "ListTagsForResource2016_09_07"
 
 // ListTagsForResourceRequest generates a "aws/request.Request" representing the
 // client's request for the ListTagsForResource operation. The "output" return
@@ -1179,7 +1179,7 @@ func (c *CloudFront) ListTagsForResourceRequest(input *ListTagsForResourceInput)
 	op := &request.Operation{
 		Name:       opListTagsForResource,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2016-08-20/tagging",
+		HTTPPath:   "/2016-09-07/tagging",
 	}
 
 	if input == nil {
@@ -1199,7 +1199,7 @@ func (c *CloudFront) ListTagsForResource(input *ListTagsForResourceInput) (*List
 	return out, err
 }
 
-const opTagResource = "TagResource2016_08_20"
+const opTagResource = "TagResource2016_09_07"
 
 // TagResourceRequest generates a "aws/request.Request" representing the
 // client's request for the TagResource operation. The "output" return
@@ -1227,7 +1227,7 @@ func (c *CloudFront) TagResourceRequest(input *TagResourceInput) (req *request.R
 	op := &request.Operation{
 		Name:       opTagResource,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/tagging?Operation=Tag",
+		HTTPPath:   "/2016-09-07/tagging?Operation=Tag",
 	}
 
 	if input == nil {
@@ -1249,7 +1249,7 @@ func (c *CloudFront) TagResource(input *TagResourceInput) (*TagResourceOutput, e
 	return out, err
 }
 
-const opUntagResource = "UntagResource2016_08_20"
+const opUntagResource = "UntagResource2016_09_07"
 
 // UntagResourceRequest generates a "aws/request.Request" representing the
 // client's request for the UntagResource operation. The "output" return
@@ -1277,7 +1277,7 @@ func (c *CloudFront) UntagResourceRequest(input *UntagResourceInput) (req *reque
 	op := &request.Operation{
 		Name:       opUntagResource,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2016-08-20/tagging?Operation=Untag",
+		HTTPPath:   "/2016-09-07/tagging?Operation=Untag",
 	}
 
 	if input == nil {
@@ -1299,7 +1299,7 @@ func (c *CloudFront) UntagResource(input *UntagResourceInput) (*UntagResourceOut
 	return out, err
 }
 
-const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIdentity2016_08_20"
+const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIdentity2016_09_07"
 
 // UpdateCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateCloudFrontOriginAccessIdentity operation. The "output" return
@@ -1327,7 +1327,7 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityRequest(input *UpdateCl
 	op := &request.Operation{
 		Name:       opUpdateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2016-08-20/origin-access-identity/cloudfront/{Id}/config",
+		HTTPPath:   "/2016-09-07/origin-access-identity/cloudfront/{Id}/config",
 	}
 
 	if input == nil {
@@ -1347,7 +1347,7 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentity(input *UpdateCloudFron
 	return out, err
 }
 
-const opUpdateDistribution = "UpdateDistribution2016_08_20"
+const opUpdateDistribution = "UpdateDistribution2016_09_07"
 
 // UpdateDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateDistribution operation. The "output" return
@@ -1375,7 +1375,7 @@ func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (
 	op := &request.Operation{
 		Name:       opUpdateDistribution,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2016-08-20/distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -1395,7 +1395,7 @@ func (c *CloudFront) UpdateDistribution(input *UpdateDistributionInput) (*Update
 	return out, err
 }
 
-const opUpdateStreamingDistribution = "UpdateStreamingDistribution2016_08_20"
+const opUpdateStreamingDistribution = "UpdateStreamingDistribution2016_09_07"
 
 // UpdateStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateStreamingDistribution operation. The "output" return
@@ -1423,7 +1423,7 @@ func (c *CloudFront) UpdateStreamingDistributionRequest(input *UpdateStreamingDi
 	op := &request.Operation{
 		Name:       opUpdateStreamingDistribution,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2016-08-20/streaming-distribution/{Id}/config",
+		HTTPPath:   "/2016-09-07/streaming-distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -2864,6 +2864,12 @@ type DistributionConfig struct {
 	// Whether the distribution is enabled to accept end user requests for content.
 	Enabled *bool `type:"boolean" required:"true"`
 
+	// (Optional) Specify the maximum HTTP version that you want viewers to use
+	// to communicate with CloudFront. The default value for new web distributions
+	// is http2. Viewers that don't support HTTP/2 will automatically use an earlier
+	// version.
+	HttpVersion *string `type:"string" enum:"HttpVersion"`
+
 	// A complex type that controls whether access logs are written for the distribution.
 	Logging *LoggingConfig `type:"structure"`
 
@@ -3074,6 +3080,11 @@ type DistributionSummary struct {
 
 	// Whether the distribution is enabled to accept end user requests for content.
 	Enabled *bool `type:"boolean" required:"true"`
+
+	// Specify the maximum HTTP version that you want viewers to use to communicate
+	// with CloudFront. The default value for new web distributions is http2. Viewers
+	// that don't support HTTP/2 will automatically use an earlier version.
+	HttpVersion *string `type:"string" required:"true" enum:"HttpVersion"`
 
 	// The identifier for the distribution. For example: EDFDVBD632BHDS5.
 	Id *string `type:"string" required:"true"`
@@ -5660,6 +5671,13 @@ const (
 	GeoRestrictionTypeWhitelist = "whitelist"
 	// @enum GeoRestrictionType
 	GeoRestrictionTypeNone = "none"
+)
+
+const (
+	// @enum HttpVersion
+	HttpVersionHttp11 = "http1.1"
+	// @enum HttpVersion
+	HttpVersionHttp2 = "http2"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/service.go
@@ -55,7 +55,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceName:   ServiceName,
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
-				APIVersion:    "2016-08-20",
+				APIVersion:    "2016-09-07",
 			},
 			handlers,
 		),

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -282,8 +282,10 @@ func (c *EC2) AssociateAddressRequest(input *AssociateAddressInput) (req *reques
 // Elastic IP address is already associated with a different instance or a network
 // interface, you get an error unless you allow reassociation.
 //
-// This is an idempotent operation. If you perform the operation more than
-// once, Amazon EC2 doesn't return an error.
+//  This is an idempotent operation. If you perform the operation more than
+// once, Amazon EC2 doesn't return an error, and you may be charged for each
+// time the Elastic IP address is remapped to the same instance. For more information,
+// see the Elastic IP Addresses section of Amazon EC2 Pricing (http://aws.amazon.com/ec2/pricing/).
 func (c *EC2) AssociateAddress(input *AssociateAddressInput) (*AssociateAddressOutput, error) {
 	req, out := c.AssociateAddressRequest(input)
 	err := req.Send()

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -3523,9 +3523,9 @@ func (c *RDS) DescribeSourceRegionsRequest(input *DescribeSourceRegionsInput) (r
 	return
 }
 
-// Returns a list that includes the status of each source AWS Region that the
-// current region can get a Read Replica or a DB snapshot from. This API action
-// supports pagination.
+// Returns a list of the source AWS regions where the current AWS region can
+// create a Read Replica or copy a DB snapshot from. This API action supports
+// pagination.
 func (c *RDS) DescribeSourceRegions(input *DescribeSourceRegionsInput) (*DescribeSourceRegionsOutput, error) {
 	req, out := c.DescribeSourceRegionsRequest(input)
 	err := req.Send()
@@ -6427,8 +6427,9 @@ type CreateDBInstanceInput struct {
 
 	// The name of the database engine to be used for this instance.
 	//
-	//  Valid Values: MySQL | mariadb | oracle-se1 | oracle-se | oracle-ee | sqlserver-ee
-	// | sqlserver-se | sqlserver-ex | sqlserver-web | postgres | aurora
+	//  Valid Values: mysql | mariadb | oracle-se1 | oracle-se2 | oracle-se | oracle-ee
+	// | sqlserver-ee | sqlserver-se | sqlserver-ex | sqlserver-web | postgres |
+	// aurora
 	//
 	// Not every database engine is available for every AWS region.
 	Engine *string `type:"string" required:"true"`
@@ -7740,6 +7741,19 @@ type DBCluster struct {
 	// Contains one or more identifiers of the Read Replicas associated with this
 	// DB cluster.
 	ReadReplicaIdentifiers []*string `locationNameList:"ReadReplicaIdentifier" type:"list"`
+
+	// The reader endpoint for the DB cluster. The reader endpoint for a DB cluster
+	// load-balances connections across the Aurora Replicas that are available in
+	// a DB cluster. As clients request new connections to the reader endpoint,
+	// Aurora distributes the connection requests among the Aurora Replicas in the
+	// DB cluster. This functionality can help balance your read workload across
+	// multiple Aurora Replicas in your DB cluster.
+	//
+	// If a failover occurs, and the Aurora Replica that you are connected to is
+	// promoted to be the primary instance, your connection will be dropped. To
+	// continue sending your read workload to other Aurora Replicas in the cluster,
+	// you can then recoonect to the reader endpoint.
+	ReaderEndpoint *string `type:"string"`
 
 	// Contains the identifier of the source DB cluster if this DB cluster is a
 	// Read Replica.
@@ -11714,11 +11728,11 @@ type DescribeSourceRegionsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	// The source region name, for example US West (Oregon).
+	// The source region name. For example, us-east-1.
 	//
 	// Constraints:
 	//
-	//   Must specify a valid AWS Region name, for example US West (Oregon).
+	//   Must specify a valid AWS Region name.
 	RegionName *string `type:"string"`
 }
 
@@ -12848,15 +12862,13 @@ type ModifyDBInstanceInput struct {
 	// Example: mySubnetGroup
 	DBSubnetGroupName *string `type:"string"`
 
-	// Specify the Active Directory Domain to move the instance to.
-	//
-	// The specified Active Directory Domain must be created prior to this operation.
-	// Currently only a SQL Server instance can be created in a Active Directory
-	// Domain.
+	// The Active Directory Domain to move the instance to. Specify none to remove
+	// the instance from its current domain. The domain must be created prior to
+	// this operation. Currently only a Microsoft SQL Server instance can be created
+	// in a Active Directory Domain.
 	Domain *string `type:"string"`
 
-	// Specify the name of the IAM role to be used when making API calls to the
-	// Directory Service.
+	// The name of the IAM role to use when making API calls to the Directory Service.
 	DomainIAMRoleName *string `type:"string"`
 
 	// The version number of the database engine to upgrade to. Changing this parameter

--- a/vendor/github.com/aws/aws-sdk-go/service/sns/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sns/api.go
@@ -3337,7 +3337,11 @@ type SetSMSAttributesInput struct {
 	// crossed. During that interval, if you continue to send SMS messages, you
 	// will incur costs that exceed your limit.
 	//
-	//   DeliveryStatusIAMRole – The ARN of the IAM role that allows Amazon SNS
+	//  By default, the spend limit is set to the maximum allowed by Amazon SNS.
+	// If you want to exceed the maximum, contact AWS Support (https://aws.amazon.com/premiumsupport/)
+	// or your AWS sales representative for a service limit increase.
+	//
+	//  DeliveryStatusIAMRole – The ARN of the IAM role that allows Amazon SNS
 	// to write logs about SMS deliveries in CloudWatch Logs. For each SMS message
 	// that you send, Amazon SNS writes a log that includes the message price, the
 	// success or failure status, the reason for failure (if the message failed),
@@ -3357,10 +3361,10 @@ type SetSMSAttributesInput struct {
 	//  DefaultSMSType – The type of SMS message that you will send by default.
 	// You can assign the following values:
 	//
-	//    Promotional – Noncritical messages, such as marketing messages. Amazon
-	// SNS optimizes the message delivery to incur the lowest cost.
+	//    Promotional – (Default) Noncritical messages, such as marketing messages.
+	// Amazon SNS optimizes the message delivery to incur the lowest cost.
 	//
-	//    Transactional – (Default) Critical messages that support customer transactions,
+	//    Transactional – Critical messages that support customer transactions,
 	// such as one-time passcodes for multi-factor authentication. Amazon SNS optimizes
 	// the message delivery to achieve the highest reliability.
 	//

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -345,572 +345,572 @@
 			"revision": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2"
 		},
 		{
-			"checksumSHA1": "UN8gKREzowlQIH6xM5GJVOBhDYM=",
+			"checksumSHA1": "kuw5W2UI5k2VXP9R34go1SBms9k=",
 			"path": "github.com/aws/aws-sdk-go",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
-			"checksumSHA1": "4pvpNLmTBs+Wdfn4BpgUpkMoHLs=",
+			"checksumSHA1": "Ex4zN+CcY/wtoDoK/penrVAxAok=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
-			"checksumSHA1": "ppmwInOtC5Mj/dBBWVxL0KPEI0I=",
+			"checksumSHA1": "+q4vdl3l1Wom8K1wfIpJ4jlFsbY=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "H/tMKHZU+Qka6RtYiGB50s2uA0s=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "gNWirlrTfSLbOe421hISBAhTqa4=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "dNZNaOPfBPnzE2CBnfhXXZ9g9jU=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "KQiUK/zr3mqnAXD7x/X55/iNme0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "4Ipx+5xN0gso+cENC2MHMWmQlR4=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "nCMd1XKjgV21bEl7J8VZFqTV8PE=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "U0SthWum+t9ACanK7SDJOg3dO6M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "NyUg1P8ZS/LHAAQAk/4C5O4X3og=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "44uohX3kLsfZHHOqunr+qJnSCdw=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "7lla+sckQeF18wORAGuU2fFMlp4=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "Bm6UrYb2QCzpYseLwwgw6aetgRc=",
 			"path": "github.com/aws/aws-sdk-go/private/endpoints",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "uNmSKXAF8B9HWEciW+iyUwZ99qQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "pNeF0Ey7TfBArH5LBQhKOQXQbLY=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "H9TymcQkQnXSXSVfjggiiS4bpzM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "isoix7lTx4qIq2zI2xFADtti5SI=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "5xzix1R8prUyWxgLnzUQoxTsfik=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "TW/7U+/8ormL7acf6z2rv2hDD+s=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "oUOTWZIpPJiGjc9p/hntdBDvS10=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "Y6Db2GGfGD9LPpcJIPj8vXE8BbQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "eUEkjyMPAuekKBE4ou+nM9tXEas=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "Eo9yODN5U99BK0pMzoqnBm7PCrY=",
 			"path": "github.com/aws/aws-sdk-go/private/waiter",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "DXwm+kmVCiuvvGCcUTeZD/L31Kk=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "WEwNL8ueG/6RTZOIDF/qu9EkwXo=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "MXY2nnlU3Qf4+6nTV4+GFxSD5Y4=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "vp/AYdsQnZtoPqtX86VsgmLIx1w=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
-			"checksumSHA1": "xWLF/7zgljbFtQypmR6+M9o9sTY=",
+			"checksumSHA1": "IBdkYM4/ts1B7FXcTrUk9KXPpcc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "eCFTaV9GKqv/UEzwRgFFUaFz098=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "G9CmCfw00Bjz0TtJsEnxGE6mv/0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "mWNJKpt18ASs9/RhnIjILcsGlng=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "sP/qEaDICVBV3rRw2sl759YI0iw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "p5a/DcdUvhTx0PCRR+/CRXk9g6c=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "N8Sgq+xG2vYJdKBikM3yQuIBZfs=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "i4hrcsFXLAQXzaxvWh6+BG8XcIU=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "y+pZPK8hcTDwq1zHuRduWE14flw=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
-			"checksumSHA1": "Unj4a0f5m6vhgXzIFjcgzWAcr3c=",
+			"checksumSHA1": "FiQmUvjtJfroyEr3dFUSChrpq08=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "d5x+dDz7zdrEYAGDM9XpYnSW3FE=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "CvZ+vaOolbfpAdOQPAuKDn4Mmt4=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "1vOgFGxLhjNe6BK3RJaV1OqisCs=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "rjSScNzMTvEHv7Lk5KcxDpNU5EE=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "RZF1yHtJhAqaMwbeAM/6BdLLavk=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "VAlXnW+WxxWRcCv4xsCoox2kgE0=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "qHuJHGUAuuizD9834MP3gVupfdo=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "YiNiSOILzSOaKB4JwdM4SDw7daM=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "DdsbJgngbL7Ce18ipxreRsf3lYo=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "MA6U/Vj0D00yihMHD6bXKyjtfeE=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "TtIAgZ+evpkKB5bBYCB69k0wZoU=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "B1EtgBrv//gYqA+Sp6a/SK2zLO4=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "dH2W7lR17dgn4a4OYiEzjpQH8hI=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "2n5/m0ClE4OyQRNdjfLwg+nSY3o=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "l6GbB/V5dPb3l+Nrb70wzyrYAgc=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "Qpi347xz5FIQISq73dZSdIf47AU=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "8F0/GisnAvgIBhNv36A8bitepQU=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
-			"checksumSHA1": "1qd0UaN3y1qEOuKCXjOvklfHp/c=",
+			"checksumSHA1": "Ku0+MrgKLUYYcaLd93bkLGNDgAk=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "SApEMc9VnHY0D10BAPcZKeFbj9k=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "Dw4DpBaYfuu+aQTlywfv1TCzHCg=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "imxJucuPrgaPRMPtAgsu+Y7soB4=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "o+bjuT6ycywUf+vXY9hYK4Z3okE=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "DW5kDRWLA2yAgYh9vsI+0uVqq/Q=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
-			"checksumSHA1": "Id0njZW0e+k+IyHfjH6VHhnawYc=",
+			"checksumSHA1": "QHuF2nb/DTz20LRh0rslFDzIm54=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "oLAlquYlQzgYFS9ochS/iQ9+uXY=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "Zw0GXDOn45IvrmAcCOlSHJMiljU=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "nH/itbdeFHpl4ysegdtgww9bFSA=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "V10Yi1cEBLqu6kjZl5vyItHDd6k=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "bc572378d109481c50d45d9dba4490d80386e98e",
-			"revisionTime": "2016-09-06T22:59:56Z",
-			"version": "v1.4.7",
-			"versionExact": "v1.4.7"
+			"revision": "ddfd17ec06eee10c24c5c474633273fd034afdda",
+			"revisionTime": "2016-09-15T22:45:27Z",
+			"version": "=v1.4.10",
+			"versionExact": "v1.4.10"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
```
govendor fetch github.com/aws/aws-sdk-go/...@=v1.4.10
```

This is mainly to support for the Aurora's `ReaderEndpoint` as discussed in https://github.com/aws/aws-sdk-go/issues/831