### PR TITLE
provider/azurerm: Fix. Correct a typo in the error message.

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -159,7 +159,7 @@ func registerProviderWithSubscription(providerName string, client *riviera.Clien
 	}
 
 	if !response.IsSuccessful() {
-		return fmt.Errorf("Credentials for acessing the Azure Resource Manager API are likely " +
+		return fmt.Errorf("Credentials for accessing the Azure Resource Manager API are likely " +
 			"to be incorrect, or\n  the service principal does not have permission to use " +
 			"the Azure Service Management\n  API.")
 	}


### PR DESCRIPTION
This comment corrects a simple typo in the error message issued when the
credentials are not working and/or do not offer access to AzureRM, etc.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>