### PR TITLE
provider/aws: Add reader_endpoint RDS Clusters (supersedes #8878)

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -443,6 +443,7 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", dbc.PreferredMaintenanceWindow)
 	d.Set("kms_key_id", dbc.KmsKeyId)
+	d.Set("reader_endpoint", dbc.ReaderEndpoint)
 
 	var vpcg []string
 	for _, g := range dbc.VpcSecurityGroups {

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -85,6 +85,11 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"reader_endpoint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"engine": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -30,6 +30,8 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 						"aws_rds_cluster.default", "storage_encrypted", "false"),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster.default", "db_cluster_parameter_group_name", "default.aurora5.6"),
+					resource.TestCheckResourceAttrSet(
+						"aws_rds_cluster.default", "reader_endpoint"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -94,6 +94,8 @@ The following attributes are exported:
 * `preferred_backup_window` - The backup window
 * `preferred_maintenance_window` - The maintenance window
 * `endpoint` - The DNS address of the RDS instance
+* `reader_endpoint` - A read-only endpoint for the Aurora cluster, automatically
+load-balanced across replicas
 * `engine` - The database engine
 * `engine_version` - The database engine version
 * `maintenance_window` - The instance maintenance window


### PR DESCRIPTION
Continues #8878 with some minor additions

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSCluster_basic -timeout 120m
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (176.54s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	176.565s
Test:
```