### PR TITLE
provider/aws: aws_autoscaling_policy fails when setting scaling_adjustment to 0 for SimpleScaling

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_policy.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_policy.go
@@ -220,7 +220,7 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 
 	//if policy_type=="SimpleScaling" then scaling_adjustment is required and 0 is allowed
 	if v, ok := d.GetOk("scaling_adjustment"); ok || *params.PolicyType == "SimpleScaling" {
-		params.EstimatedInstanceWarmup = aws.Int64(int64(v.(int)))
+		params.ScalingAdjustment = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("step_adjustment"); ok {

--- a/builtin/providers/aws/resource_aws_autoscaling_policy.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_policy.go
@@ -218,8 +218,11 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 		params.PolicyType = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("scaling_adjustment"); ok {
-		params.ScalingAdjustment = aws.Int64(int64(v.(int)))
+	//if policy_type=="SimpleScaling" then scaling_adjustment is required and 0 is allowed
+	if *params.PolicyType == "SimpleScaling" {
+		params.ScalingAdjustment = aws.Int64(int64(d.Get("scaling_adjustment").(int)))
+	} else if v, ok := d.GetOk("scaling_adjustment"); ok {
+		params.EstimatedInstanceWarmup = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("step_adjustment"); ok {

--- a/builtin/providers/aws/resource_aws_autoscaling_policy.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_policy.go
@@ -219,9 +219,7 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 	}
 
 	//if policy_type=="SimpleScaling" then scaling_adjustment is required and 0 is allowed
-	if *params.PolicyType == "SimpleScaling" {
-		params.ScalingAdjustment = aws.Int64(int64(d.Get("scaling_adjustment").(int)))
-	} else if v, ok := d.GetOk("scaling_adjustment"); ok {
+	if v, ok := d.GetOk("scaling_adjustment"); ok || *params.PolicyType == "SimpleScaling" {
 		params.EstimatedInstanceWarmup = aws.Int64(int64(v.(int)))
 	}
 


### PR DESCRIPTION
Terraform 0.7.3 incorrectly handles setting `scaling_adjustment=0` when using `policy_type = "SimpleScaling"` although this is allowed in the AWS CLI and Console for all 3 adjustment_types.

The following terraform configuration:
```
resource "aws_autoscaling_policy" "ok" {
    name = "terraform-test-ok"
    scaling_adjustment = 0
    adjustment_type = "ExactCapacity"
    cooldown = 300
    autoscaling_group_name = "${aws_autoscaling_group.main.name}"
}
```
will return the error:
```
* aws_autoscaling_policy.foobar_simple: Error putting scaling policy: ValidationError: Scaling increment must be specified for a SimpleScaling policy
			status code: 400, request id: 0a983458-7c7a-11e6-b90d-c986fdc05768
```

This is due to the current provider using the GetOk function which doesn't set the value if equal to 0.  This PR changes this behavior by using the Get function when the policy_type="SimpleScaling", and falls back to using GetOk when the policy_type isn't.

Below are the acceptance test results.
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AccAWSAutoscalingPolicy_SimpleScalingStepAdjustment'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/16 21:18:59 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=AccAWSAutoscalingPolicy_SimpleScalingStepAdjustment -timeout 120m
=== RUN   TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (43.07s)
PASS
ok  	github.com/dennis-bsi/terraform/builtin/providers/aws	43.098s
```