### PR TITLE
provider/aws: Add JSON validation to the aws_s3_bucket_policy resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_policy.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_policy.go
@@ -29,6 +29,7 @@ func resourceAwsS3BucketPolicy() *schema.Resource {
 			"policy": {
 				Type:             schema.TypeString,
 				Required:         true,
+				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 		},


### PR DESCRIPTION
This commit adds support for new helper function which is used to
normalise and validate JSON string.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>