### PR TITLE
provider/aws: Add JSON validation to the aws_sns_topic_policy resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic_policy.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_policy.go
@@ -30,6 +30,7 @@ func resourceAwsSnsTopicPolicy() *schema.Resource {
 			"policy": {
 				Type:             schema.TypeString,
 				Required:         true,
+				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 		},


### PR DESCRIPTION
This commit adds support for new helper function which is used to
normalise and validate JSON string.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>