### PR TITLE
provider/aws: Add JSON validation to the aws_sqs_queue resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -73,13 +73,18 @@ func resourceAwsSqsQueue() *schema.Resource {
 			"policy": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 				Computed:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"redrive_policy": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				StateFunc: normalizeJson,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateJsonString,
+				StateFunc: func(v interface{}) string {
+					json, _ := normalizeJsonString(v)
+					return json
+				},
 			},
 			"arn": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This commit adds support for new helper function which is used to
normalise and validate JSON string.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>