### PR TITLE
provider/aws: Add JSON validation to the aws_sqs_queue_policy resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_sqs_queue_policy.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_policy.go
@@ -27,6 +27,7 @@ func resourceAwsSqsQueuePolicy() *schema.Resource {
 			"policy": &schema.Schema{
 				Type:             schema.TypeString,
 				Required:         true,
+				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 		},


### PR DESCRIPTION
This commit adds support for new helper function which is used to
normalise and validate JSON string.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>