### PR TITLE
provider/aws: Add JSON validation to the aws_s3_bucket resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -471,10 +472,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 					return err
 				}
 			} else {
-				policy, _ := normalizeJsonString(*v)
-				if err := d.Set("policy", policy); err != nil {
-					return err
+				policy, err := normalizeJsonString(*v)
+				if err != nil {
+					return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
 				}
+				d.Set("policy", policy)
 			}
 		}
 	}

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -48,6 +48,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 			"policy": &schema.Schema{
 				Type:             schema.TypeString,
 				Optional:         true,
+				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 
@@ -110,9 +111,13 @@ func resourceAwsS3Bucket() *schema.Resource {
 						},
 
 						"routing_rules": &schema.Schema{
-							Type:      schema.TypeString,
-							Optional:  true,
-							StateFunc: normalizeJson,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateJsonString,
+							StateFunc: func(v interface{}) string {
+								json, _ := normalizeJsonString(v)
+								return json
+							},
 						},
 					},
 				},
@@ -465,8 +470,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 				if err := d.Set("policy", ""); err != nil {
 					return err
 				}
-			} else if err := d.Set("policy", normalizeJson(*v)); err != nil {
-				return err
+			} else {
+				policy, _ := normalizeJsonString(*v)
+				if err := d.Set("policy", policy); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This commit adds support for new helper function which is used to
normalise and validate JSON string.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>