### PR TITLE
provider/rundeck) enable validation for multiple values in an array

### DIFF
--- a/builtin/providers/rundeck/util.go
+++ b/builtin/providers/rundeck/util.go
@@ -1,0 +1,25 @@
+package rundeck
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func validateValueFunc(values []string) schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (we []string, errors []error) {
+		value := v.(string)
+		valid := false
+		for _, role := range values {
+			if value == role {
+				valid = true
+				break
+			}
+		}
+
+		if !valid {
+			errors = append(errors, fmt.Errorf("%s is an invalid value for argument %s", value, k))
+		}
+		return
+	}
+}


### PR DESCRIPTION
Enable ValidateFunc, copied from another provider:

``` bash
            "rank_order": &schema.Schema{
                Type:         schema.TypeString,
                Optional:     true,
                Default:      "ascending",
                ValidateFunc: validateValueFunc([]string{"ascending", "descending"}),
            },
```

This will be used when rank_order is implemented, but can be used for other schema validations.
This one is handy to have.
