### PR TITLE
Fix typos in the aws_default_security_group docs

### DIFF
--- a/website/source/docs/providers/aws/r/default_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/default_security_group.html.markdown
@@ -84,8 +84,8 @@ resource "aws_default_security_group" "default" {
 ## Argument Reference
 
 The arguments of an `aws_default_security_group` differ slightly from `aws_security_group` 
-resources. Namely, the `name` arguement is computed, and the `name_prefix` attribute
-removed. The following arguements are still supported: 
+resources. Namely, the `name` argument is computed, and the `name_prefix` attribute
+removed. The following arguments are still supported: 
 
 * `description` - (Optional, Forces new resource) The security group description. Defaults to
   "Managed by Terraform". Cannot be "". __NOTE__: This field maps to the AWS
@@ -128,4 +128,4 @@ The following attributes are exported:
 * `ingress` - The ingress rules. See above for more.
 * `egress` - The egress rules. See above for more.
 
-[aws-default-security-groups]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/UserGuide/using-network-security.html#default-security-group
+[aws-default-security-groups]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#default-security-group


### PR DESCRIPTION
- "arguement" → "argument"
- link to the default AWS docs, not the fr_fr version