### PR TITLE
Added missed link to sphere virtual disk

### DIFF
--- a/website/source/layouts/vsphere.erb
+++ b/website/source/layouts/vsphere.erb
@@ -22,6 +22,9 @@
             <li<%= sidebar_current("docs-vsphere-resource-file") %>>
               <a href="/docs/providers/vsphere/r/file.html">vsphere_file</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-resource-virtual-disk") %>>
+              <a href="/docs/providers/vsphere/r/virtual_disk.html">vsphere_virtual_disk</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
The link on web site for vsphere virtual disk was missed (https://www.terraform.io/docs/providers/vsphere/index.html)