### PR TITLE
provider/aws: Added a cluster_address attribute to aws elasticache.

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -170,6 +170,11 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		Computed: true,
 	}
 
+	resourceSchema["cluster_address"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+
 	resourceSchema["replication_group_id"] = &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
@@ -348,6 +353,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 		if c.ConfigurationEndpoint != nil {
 			d.Set("port", c.ConfigurationEndpoint.Port)
 			d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", *c.ConfigurationEndpoint.Address, *c.ConfigurationEndpoint.Port)))
+			d.Set("cluster_address", aws.String(fmt.Sprintf("%s", *c.ConfigurationEndpoint.Address)))
 		}
 
 		if c.ReplicationGroupId != nil {

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticache/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticache/api.go
@@ -2572,6 +2572,9 @@ type CacheCluster struct {
 	// node.
 	ConfigurationEndpoint *Endpoint `type:"structure"`
 
+	// The DNS name of the cache cluster without the port appended.
+	ClusterAddress *string `type:"string"`
+
 	// The name of the cache engine (memcached or redis) to be used for this cache
 	// cluster.
 	Engine *string `type:"string"`


### PR DESCRIPTION
Added the cluster address as a separate attribute to the configuration endpoint. When using the configuration endpoint in conjunction with route 53 it was appending the cluster address with the port and invalidating the route 53 record.

When using the AWS elasticache client you can specify the cluster address and use Auto discovery, Terraform currently doesn't support this as you have to either specify the cache nodes or manually edit the route 53 record. 
https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ClientConfig.AutoDiscovery.html

There is a requirement of the aws elasticache client when using a CNAME to reference the elasticache cluster address, it requires the CNAME to include .cfg. which informs the client that it is a cluster and to treat it as such.
