### PR TITLE
provider/aws: Wait for Spot Fleet to drain before removing from state

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -975,8 +975,6 @@ func resourceAwsSpotFleetRequestDelete(d *schema.ResourceData, meta interface{})
 		return resource.RetryableError(
 			fmt.Errorf("fleet still has (%d) running instances", len(resp.ActiveInstances)))
 	})
-
-	return nil
 }
 
 func hashEphemeralBlockDevice(v interface{}) int {

--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -954,7 +954,7 @@ func resourceAwsSpotFleetRequestDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	if !found {
-		return fmt.Errorf("[ERR] Spot Fleet request (%s) was not found to be successfully canceled, dangling may resources exit", d.Id())
+		return fmt.Errorf("[ERR] Spot Fleet request (%s) was not found to be successfully canceled, dangling resources may exit", d.Id())
 	}
 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {

--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -936,7 +936,7 @@ func resourceAwsSpotFleetRequestDelete(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Cancelling spot fleet request: %s", d.Id())
-	_, err := conn.CancelSpotFleetRequests(&ec2.CancelSpotFleetRequestsInput{
+	resp, err := conn.CancelSpotFleetRequests(&ec2.CancelSpotFleetRequestsInput{
 		SpotFleetRequestIds: []*string{aws.String(d.Id())},
 		TerminateInstances:  aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
 	})
@@ -944,6 +944,37 @@ func resourceAwsSpotFleetRequestDelete(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return fmt.Errorf("Error cancelling spot request (%s): %s", d.Id(), err)
 	}
+
+	// check response successfulFleetRequestSet to make sure our request was canceled
+	var found bool
+	for _, s := range resp.SuccessfulFleetRequests {
+		if *s.SpotFleetRequestId == d.Id() {
+			found = true
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("[ERR] Spot Fleet request (%s) was not found to be successfully canceled, dangling may resources exit", d.Id())
+	}
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err := conn.DescribeSpotFleetInstances(&ec2.DescribeSpotFleetInstancesInput{
+			SpotFleetRequestId: aws.String(d.Id()),
+		})
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if len(resp.ActiveInstances) == 0 {
+			log.Printf("[DEBUG] Active instance count is 0 for Spot Fleet Request (%s), removing", d.Id())
+			return nil
+		}
+
+		log.Printf("[DEBUG] Active instance count in Spot Fleet Request (%s): %d", d.Id(), len(resp.ActiveInstances))
+
+		return resource.RetryableError(
+			fmt.Errorf("fleet still has (%d) running instances", len(resp.ActiveInstances)))
+	})
 
 	return nil
 }


### PR DESCRIPTION
Ensures the spot fleet is drained before reporting successful destroy
and moving on. We found our nightly acc. tests were leaking Spot Instances (specifically `TestAccAWSSpotFleetRequest_withWeightedCapacity`), and on investigation found that on `DELETE`, `aws_spot_fleet` was not waiting for the included instances to terminate before moving on. 

The problem then appears because Terraform moves on and destroys the IAM role that was being used by the Spot Fleet Request. By the time EC2 gets around to attempting to destroy the request and it's instances, the IAM role has been destroyed, so then we get a failure in the Spot Request. By then, Terraform has likely already exited (or is at least considered it's job done there).

This PR waits for the instances to drain before moving on. Unfortunately the `ActiveInstances` attribute is documented to "possibly be out of date". In my findings it lags about 2 minutes behind.

Alternative I tried simply checking the spot fleet status and looping until we go from `cancelled_terminating` to `cancelled`, however, I found that transition takes upwards of 10 some minutes after all the instances are terminated. 

Unfortunately (still), there exists an edge case in our tests where EC2 is lagging behind in fulfilling the request, such that when we try to destroy it we have zero `ActiveInstances`, so we think things are fine. I'm open to ideas on how to fix that, but in the meantime I believe this PR is still a good idea and will prevent `TestAccAWSSpotFleetRequest_withWeightedCapacity` from leaking ~90% of the time. 