### PR TITLE
Rancher provider

### DIFF
--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -144,7 +144,12 @@ func (client *Client) GetEnvironmentById(id string) (e *Environment, err error) 
 }
 
 func (client *Client) DeleteEnvironmentById(id string) (err error) {
-	err = client.newRequest("DELETE", fmt.Sprintf("/projects/%s", id), nil)
+	req, err := client.newRequest("DELETE", fmt.Sprintf("/projects/%s", id), nil)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Http.Do(req)
 	return
 }
 

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -122,22 +122,22 @@ func (client *Client) CreateEnvironment(env Environment) (string, error) {
 	}
 }
 
-func (client *Client) GetEnvironmentById(id string) (Environment, error) {
+func (client *Client) GetEnvironmentById(id string) (e Environment, err error) {
 	req, err := client.newRequest("GET", fmt.Sprintf("/projects/%s", id), nil)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	resp, err := client.Http.Do(req)
 	if err != nil {
-		return nil, err
+		return
 	}
 	defer resp.Body.Close()
 
 	env := new(Environment)
 	err = json.NewDecoder(resp.Body).Decode(env)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	return env, nil

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -178,7 +178,7 @@ func (client *Client) EnvironmentExists(name string) (bool, error) {
 		return "", fmt.Errorf("Failed to list environments looking for %s", name)
 	}
 
-	for _, e := range envs {
+	for _, e := range envs.Environments {
 		if e.Name == name {
 			return true, nil
 		}

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -144,7 +144,7 @@ func (client *Client) GetEnvironmentById(id string) (e *Environment, err error) 
 }
 
 func (client *Client) DeleteEnvironmentById(id string) (err error) {
-	req, err := client.newRequest("DELETE", fmt.Sprintf("/projects/%s", id), nil)
+	err = client.newRequest("DELETE", fmt.Sprintf("/projects/%s", id), nil)
 	return
 }
 

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -143,9 +143,9 @@ func (client *Client) GetEnvironmentById(id string) (e *Environment, err error) 
 	return env, nil
 }
 
-func (client *Client) DeleteEnvironmentById(id string) error {
-	// TODO implement
-	return nil
+func (client *Client) DeleteEnvironmentById(id string) (err error) {
+	req, err := client.newRequest("DELETE", fmt.Sprintf("/projects/%s", id), nil)
+	return
 }
 
 func (client *Client) EnvironmentExists(name string) (bool, error) {

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -92,8 +92,8 @@ type EnvironmentMember struct {
 }
 
 type PortRange struct {
-	StarPort int `json:"startPort"`
-	EndPort  int `json:"endPort"`
+	StartPort int `json:"startPort"`
+	EndPort   int `json:"endPort"`
 }
 
 func (client *Client) CreateEnvironment(env Environment) (string, error) {

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -122,7 +122,7 @@ func (client *Client) CreateEnvironment(env Environment) (string, error) {
 	}
 }
 
-func (client *Client) GetEnvironmentById(id string) (e Environment, err error) {
+func (client *Client) GetEnvironmentById(id string) (e *Environment, err error) {
 	req, err := client.newRequest("GET", fmt.Sprintf("/projects/%s", id), nil)
 	if err != nil {
 		return

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -216,7 +216,7 @@ func (client *Client) GetRegistrationToken(id string) (token RegistrationToken, 
 
 	tokens := new(RegistrationTokens)
 	if err = json.NewDecoder(resp.Body).Decode(tokens); err != nil {
-		return false, fmt.Errorf("Failed to list registration tokens for environment %s", id)
+		return token, fmt.Errorf("Failed to list registration tokens for environment %s", id)
 	}
 
 	for _, t := range tokens.Tokens {

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -147,3 +147,8 @@ func (client *Client) DeleteEnvironmentById(id string) error {
 	// TODO implement
 	return nil
 }
+
+func (client *Client) EnvironmentExists(name string) (bool, error) {
+	// TODO implement
+	return true, nil
+}

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -1,0 +1,38 @@
+package rancher
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// Client struct holding connection string
+type Client struct {
+	ServerUrl  string
+	AccessKey  string
+	SecretKey  string
+	ApiVersion int
+	Http       *http.Client
+}
+
+// NewClient returns a new Rancher client
+func NewClient(serverUrl string, accessKey string, secretKey string) (*Client, error) {
+	client := Client{
+		ServerUrl: serverUrl,
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+		Http:      cleanhttp.DefaultClient(),
+	}
+	var err error
+	client.ApiVersion, err = client.detectApiVersion()
+	if err != nil {
+		return nil, err
+	}
+	return &client, nil
+}
+
+// Detects the API version in use on the server
+// TODO: implement that
+func (client *Client) detectApiVersion() (int, error) {
+	return 1, nil
+}

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -160,22 +160,22 @@ func (client *Client) DeleteEnvironmentById(id string) (err error) {
 func (client *Client) EnvironmentExists(name string) (bool, error) {
 	req, err := client.newRequest("GET", "/projects", nil)
 	if err != nil {
-		return
+		return false, err
 	}
 
 	resp, err := client.Http.Do(req)
 	if err != nil {
-		return "", err
+		return false, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 && resp.StatusCode != 201 {
-		return "", fmt.Errorf("Error checking environment: %s", name)
+		return false, fmt.Errorf("Error checking environment: %s", name)
 	}
 
 	envs := new(Environments)
 	if err = json.NewDecoder(resp.Body).Decode(envs); err != nil {
-		return "", fmt.Errorf("Failed to list environments looking for %s", name)
+		return false, fmt.Errorf("Failed to list environments looking for %s", name)
 	}
 
 	for _, e := range envs.Environments {

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -142,3 +142,8 @@ func (client *Client) GetEnvironmentById(id string) (e *Environment, err error) 
 
 	return env, nil
 }
+
+func (client *Client) DeleteEnvironmentById(id string) error {
+	// TODO implement
+	return nil
+}

--- a/builtin/providers/rancher/client.go
+++ b/builtin/providers/rancher/client.go
@@ -110,7 +110,7 @@ func (client *Client) CreateEnvironment(env Environment) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 && resp.StatusCode != 204 {
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
 		return "", fmt.Errorf("Error creating environment: %s", env.Name)
 	} else {
 		newEnv := new(Environment)

--- a/builtin/providers/rancher/config.go
+++ b/builtin/providers/rancher/config.go
@@ -1,0 +1,26 @@
+package rancher
+
+import (
+	"fmt"
+	"log"
+)
+
+// Config - provider config
+type Config struct {
+	ServerUrl string
+	AccessKey string
+	SecretKey string
+}
+
+// Client returns a new client for accessing PowerDNS
+func (c *Config) Client() (*Client, error) {
+	client, err := NewClient(c.ServerUrl, c.ApiKey)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error setting up PowerDNS client: %s", err)
+	}
+
+	log.Printf("[INFO] PowerDNS Client configured for server %s", c.ServerUrl)
+
+	return client, nil
+}

--- a/builtin/providers/rancher/config.go
+++ b/builtin/providers/rancher/config.go
@@ -14,7 +14,7 @@ type Config struct {
 
 // Client returns a new client for accessing PowerDNS
 func (c *Config) Client() (*Client, error) {
-	client, err := NewClient(c.ServerUrl, c.ApiKey)
+	client, err := NewClient(c.ServerUrl, c.AccessKey, c.SecretKey)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up PowerDNS client: %s", err)

--- a/builtin/providers/rancher/provider.go
+++ b/builtin/providers/rancher/provider.go
@@ -30,7 +30,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
-		resourcesmap: map[string]*schema.resource{},
+		resourcesmap: map[string]*schema.Resource{
+			"rancher_environment": resourceRancherEnvironment(),
+		},
 
 		configurefunc: providerconfigure,
 	}

--- a/builtin/providers/rancher/provider.go
+++ b/builtin/providers/rancher/provider.go
@@ -1,0 +1,52 @@
+package rancher
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"server_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("RANCHER_URL", nil),
+				Description: "Rancher server URL",
+			},
+			"access_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("RANCHER_ACCESS_KEY", nil),
+				Description: "Rancher API access key",
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("RANCHER_SECRET_KEY", nil),
+				Description: "Rancher API secret key",
+			},
+		},
+
+		resourcesmap: map[string]*schema.resource{},
+
+		configurefunc: providerconfigure,
+	}
+}
+
+func providerConfigure(data *schema.ResourceData) (interface{}, error) {
+	config := Config{
+		ServerUrl: data.Get("server_url").(string),
+		AccessKey: data.Get("access_key").(string),
+		SecretKey: data.Get("secret_key").(string),
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return nil, fmt.Errorf("Error initializing Postgresql client: %s", err)
+	}
+
+	return client, nil
+}

--- a/builtin/providers/rancher/provider.go
+++ b/builtin/providers/rancher/provider.go
@@ -30,11 +30,11 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
-		resourcesmap: map[string]*schema.Resource{
+		ResourcesMap: map[string]*schema.Resource{
 			"rancher_environment": resourceRancherEnvironment(),
 		},
 
-		configurefunc: providerconfigure,
+		ConfigureFunc: providerConfigure,
 	}
 }
 

--- a/builtin/providers/rancher/provider_test.go
+++ b/builtin/providers/rancher/provider_test.go
@@ -1,0 +1,43 @@
+package rancher
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"powerdns": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProviderImpl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("RANCHER_URL"); v == "" {
+		t.Fatal("RANCHER_URL must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("RANCHER_ACCESS_KEY"); v == "" {
+		t.Fatal("RANCHER_ACCESS_KEY must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("RANCHER_SECRET_KEY"); v == "" {
+		t.Fatal("RANCHER_SECRET_KEY must be set for acceptance tests")
+	}
+}

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -165,7 +165,7 @@ func resourceRancherEnvironmentDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceRancherEnvironmentExists(d *schema.ResourceData, meta interface{}) error {
+func resourceRancherEnvironmentExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	name := d.Get("name").(string)
 
 	log.Printf("[INFO] Checking existence of Rancher Environment: %s", name)

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -102,9 +102,10 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 		env.Kubernetes = v.(bool)
 	}
 
-	if v, ok := d.GetOk("members"); ok {
-		//	Members:     []EnvironmentMember{},
-	}
+	// TODO: members
+	//if v, ok := d.GetOk("members"); ok {
+	//	Members:     []EnvironmentMember{},
+	//}
 
 	if v, ok := d.GetOk("mesos"); ok {
 		env.Mesos = v.(bool)
@@ -144,7 +145,8 @@ func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) er
 	client := meta.(*Client)
 
 	log.Printf("[DEBUG] Reading Rancher Environment: %s", d.Id())
-	env, err := client.GetEnvironmentById(d.Id())
+	// DO something with retrieved env?
+	_, err := client.GetEnvironmentById(d.Id())
 	if err != nil {
 		return fmt.Errorf("Couldn't fetch Rancher Environment: %s", err)
 	}

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -1,0 +1,181 @@
+package rancher
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRancherEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRancherEnvironmentCreate,
+		Read:   resourceRancherEnvironmentRead,
+		Delete: resourceRancherEnvironmentDelete,
+		Exists: resourceRancherEnvironmentExists,
+
+		// http://docs.rancher.com/rancher/v1.2/en/api/api-resources/project/
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+
+			"kubernetes": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"members": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"mesos": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"public_dns": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"services_port_range": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					"start_port": &schema.Schema{
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+
+					"end_port": &schema.Schema{
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+				},
+			},
+
+			"swarm": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"virtual_machine": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	env := Environment{
+		Name: d.Get("name").(string),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		env.Description = v.(string)
+	}
+
+	if v, ok := d.GetOk("kubernetes"); ok {
+		env.Kubernetes = v.(bool)
+	}
+
+	if v, ok := d.GetOk("members"); ok {
+		//	Members:     []EnvironmentMember{},
+	}
+
+	if v, ok := d.GetOk("mesos"); ok {
+		env.Mesos = v.(bool)
+	}
+
+	if v, ok := d.GetOk("public_dns"); ok {
+		env.PublicDNS = v.(bool)
+	}
+
+	if v, ok := d.GetOk("services_port_range"); ok {
+		portRange := v.(map[string]int)
+		env.ServicesPortRange = PortRange{
+			StartPort: portRange["start_port"],
+			EndPort:   portRange["end_port"],
+		}
+	}
+
+	if v, ok := d.GetOk("swarm"); ok {
+		env.Swarm = v.(bool)
+	}
+
+	if v, ok := d.GetOk("virtual_machine"); ok {
+		env.VirtualMachine = v.(bool)
+	}
+
+	log.Printf("[DEBUG] Creating Rancher Environment: %#v", env)
+	id, err := client.CreateEnvironment(env)
+	if err != nil {
+		return fmt.Errorf("Failed to create Rancher Environment: %s", err)
+	}
+
+	d.SetId(id)
+	return resourceRancherEnvironmentRead(d, meta)
+}
+
+func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	log.Printf("[DEBUG] Reading Rancher Environment: %s", d.Id())
+	env, err := client.GetEnvironmentById(d.Id())
+	if err != nil {
+		return fmt.Errorf("Couldn't fetch Rancher Environment: %s", err)
+	}
+
+	// Set stuff here?
+
+	return nil
+}
+
+func resourceRancherEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	log.Printf("[INFO] Deleting Rancher Environment: %s", d.Id())
+	err := client.DeleteEnvironementByID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("Error deleting Rancher Environment: %s", err)
+	}
+
+	return nil
+}
+
+func resourceRancherEnvironmentExists(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Checking existence of Rancher Environment: %s", name)
+
+	client := meta.(*Client)
+	exists, err := client.EnvironmentExists(name)
+
+	if err != nil {
+		return false, fmt.Errorf("Error checking Rancher Environment: %s", err)
+	} else {
+		return exists, nil
+	}
+}

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -158,7 +158,7 @@ func resourceRancherEnvironmentDelete(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*Client)
 
 	log.Printf("[INFO] Deleting Rancher Environment: %s", d.Id())
-	err := client.DeleteEnvironementByID(d.Id())
+	err := client.DeleteEnvironmentByID(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("Error deleting Rancher Environment: %s", err)

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -155,12 +155,6 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(id)
-	token, err := client.GetRegistrationToken(id)
-	if err != nil {
-		return err
-	}
-	d.Set("registration_token", token.Token)
-	d.Set("registration_url", token.RegistrationUrl)
 
 	return resourceRancherEnvironmentRead(d, meta)
 }
@@ -175,7 +169,12 @@ func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Couldn't fetch Rancher Environment: %s", err)
 	}
 
-	// Set stuff here?
+	token, err := client.GetRegistrationToken(d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("registration_token", token.Token)
+	d.Set("registration_url", token.RegistrationUrl)
 
 	return nil
 }

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -19,7 +19,7 @@ func resourceRancherEnvironment() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
+				ForceNew: true,
 			},
 
 			"kubernetes": {
@@ -31,7 +31,7 @@ func resourceRancherEnvironment() *schema.Resource {
 			"members": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: false,
+				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -158,7 +158,7 @@ func resourceRancherEnvironmentDelete(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*Client)
 
 	log.Printf("[INFO] Deleting Rancher Environment: %s", d.Id())
-	err := client.DeleteEnvironmentByID(d.Id())
+	err := client.DeleteEnvironmentById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("Error deleting Rancher Environment: %s", err)

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -115,12 +115,19 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 		env.PublicDNS = v.(bool)
 	}
 
+	portRange := make(map[string]int)
 	if v, ok := d.GetOk("services_port_range"); ok {
-		portRange := v.(map[string]int)
-		env.ServicesPortRange = PortRange{
-			StartPort: portRange["start_port"],
-			EndPort:   portRange["end_port"],
+		portRange = v.(map[string]int)
+	} else {
+		// Default values
+		portRange = map[string]int{
+			"start_port": 49153,
+			"end_port":   65535,
 		}
+	}
+	env.ServicesPortRange = PortRange{
+		StartPort: portRange["start_port"],
+		EndPort:   portRange["end_port"],
 	}
 
 	if v, ok := d.GetOk("swarm"); ok {

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -83,6 +83,16 @@ func resourceRancherEnvironment() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"registration_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"registration_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -145,6 +155,13 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(id)
+	token, err := client.GetRegistrationToken(id)
+	if err != nil {
+		return err
+	}
+	d.Set("registration_token", token.Token)
+	d.Set("registration_url", token.RegistrationUrl)
+
 	return resourceRancherEnvironmentRead(d, meta)
 }
 

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -58,14 +58,16 @@ func resourceRancherEnvironment() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
-					"start_port": &schema.Schema{
-						Type:     schema.TypeInt,
-						Required: true,
-					},
+					Schema: map[string]*schema.Schema{
+						"start_port": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+						},
 
-					"end_port": &schema.Schema{
-						Type:     schema.TypeInt,
-						Required: true,
+						"end_port": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+						},
 					},
 				},
 			},

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -18,7 +18,7 @@ func resourceRancherEnvironment() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -39,6 +39,7 @@ import (
 	postgresqlprovider "github.com/hashicorp/terraform/builtin/providers/postgresql"
 	powerdnsprovider "github.com/hashicorp/terraform/builtin/providers/powerdns"
 	rabbitmqprovider "github.com/hashicorp/terraform/builtin/providers/rabbitmq"
+	rancherprovider "github.com/hashicorp/terraform/builtin/providers/rancher"
 	randomprovider "github.com/hashicorp/terraform/builtin/providers/random"
 	rundeckprovider "github.com/hashicorp/terraform/builtin/providers/rundeck"
 	scalewayprovider "github.com/hashicorp/terraform/builtin/providers/scaleway"
@@ -95,6 +96,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"postgresql":   postgresqlprovider.Provider,
 	"powerdns":     powerdnsprovider.Provider,
 	"rabbitmq":     rabbitmqprovider.Provider,
+	"rancher":      rancherprovider.Provider,
 	"random":       randomprovider.Provider,
 	"rundeck":      rundeckprovider.Provider,
 	"scaleway":     scalewayprovider.Provider,


### PR DESCRIPTION
This new Rancher provider comes with a `rancher_environment` resource type:

```
resource "rancher_environment" "new_test" {
  name = "new_test"
  description = "My new test env"
}

output "env_id" {
  value = "${rancher_environment.new_test.id}"
}

output "registration_url" {
  value = "${rancher_environment.new_test.registration_url}"
}

output "registration_token" {
  value = "${rancher_environment.new_test.registration_token}"
}
```


I plan to add more resource types later.