### PR TITLE
Correct the data source configuration example to be valid

### DIFF
--- a/website/source/docs/configuration/data-sources.html.md
+++ b/website/source/docs/configuration/data-sources.html.md
@@ -39,11 +39,15 @@ A data source configuration looks like the following:
 ```
 // Find the latest available AMI that is tagged with Component = web
 data "aws_ami" "web" {
-  state = "available"
-  tags = {
-    Component = "web"
+  filter {
+    name = "state"
+    values = ["available"]
   }
-  select = "latest"
+  filter {
+    name = "tag:Component"
+    values = ["web"]
+  }
+  most_recent = true
 }
 ```
 


### PR DESCRIPTION
According to https://www.terraform.io/docs/providers/aws/d/ami.html, the example given on https://www.terraform.io/docs/configuration/data-sources.html is incorrect.

I've edited it, please confirm that it's the correct way to do what is expected.