### PR TITLE
provider/aws: Fix importing of EIP by IP address

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"time"
 
@@ -172,6 +173,13 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("domain", address.Domain)
+
+	// confirm we have an Allocation ID for our ID
+	// Allows users to import with IP address and not just allocation id
+	if net.ParseIP(id) != nil {
+		log.Printf("[DEBUG] Re-assigning EIP ID (%s) to it's Allocation ID (%s)", d.Id(), *address.AllocationId)
+		d.SetId(*address.AllocationId)
+	}
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -174,8 +174,8 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("domain", address.Domain)
 
-	// confirm we have an Allocation ID for our ID
-	// Allows users to import with IP address and not just allocation id
+	// Force ID to be an Allocation ID if we're on a VPC
+	// This allows users to import the EIP based on the IP if they are in a VPC
 	if *address.Domain == "vpc" && net.ParseIP(id) != nil {
 		log.Printf("[DEBUG] Re-assigning EIP ID (%s) to it's Allocation ID (%s)", d.Id(), *address.AllocationId)
 		d.SetId(*address.AllocationId)

--- a/website/source/docs/providers/aws/r/eip.html.markdown
+++ b/website/source/docs/providers/aws/r/eip.html.markdown
@@ -107,4 +107,13 @@ The following attributes are exported:
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
 
+
+## Import
+
+EIPs can be imported using their Allocation ID, e.g.
+
+```
+$ terraform import aws_eip.bar eipalloc-00a10e96
+```
+
 [1]: https://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_AssociateAddress.html

--- a/website/source/docs/providers/aws/r/eip.html.markdown
+++ b/website/source/docs/providers/aws/r/eip.html.markdown
@@ -110,10 +110,16 @@ The following attributes are exported:
 
 ## Import
 
-EIPs can be imported using their Allocation ID, e.g.
+EIPs in a VPC can be imported using their Allocation ID, e.g.
 
 ```
 $ terraform import aws_eip.bar eipalloc-00a10e96
+```
+
+EIPs in EC2 Classic can be imported using their Public IP, e.g.
+
+```
+$ terraform import aws_eip.bar 52.0.0.0
 ```
 
 [1]: https://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_AssociateAddress.html


### PR DESCRIPTION
Allow users to import EIP resources by IP even if they are in a VPC. Users should use the allocation id to import when using a VPC, but this is possible either way.

~~EIPs are meant to be imported by their allocation id, however, importing
by their EIP *appears* to work because this API actually accepts IP
lookup, despite the [documentation asking for the allocation id](http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_DescribeAddresses.html).~~

Here we:

- update docs on how to import EIPs and provide an example
- fix case if user imported by IP, to switch to using the alloc id for
the resource id **when in a VPC**

~~I chose not to document that looking up by IP is a method of import,
because the AWS  API docs do not explicitly say that looking up by IP is
OK, so I'd rather not encourage users to do so, so long as the AWS API doesn't explicitly say it's OK.~~

~~Alternatively, we could choose to not support IP imports and parse the resource ID and reject it (remove from
state with error/warning) if it doesn't match the `eipalloc-*` format. I thought this was a bit better UX, as some users may just think the IP is OK to import on, and maybe it should be.~~

**Update:** Importing by IP is the only way EC2 Classic users can import, ignore the strike through content above

Fixes #8962 

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEIP -timeout 120m
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (140.31s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (8.17s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (169.95s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (32.44s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (31.58s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (124.87s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    507.351s
Test:
```