### PR TITLE
Add a way to avoid panicwrap when debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,11 @@ func main() {
 func realMain() int {
 	var wrapConfig panicwrap.WrapConfig
 
+	// don't re-exec terraform as a child process for easier debugging
+	if os.Getenv("TF_FORK") == "0" {
+		return wrappedMain()
+	}
+
 	if !panicwrap.Wrapped(&wrapConfig) {
 		// Determine where logs should go in general (requested by the user)
 		logWriter, err := logging.LogOutput()


### PR DESCRIPTION
When trying to use a debugger, you don't want the terraform to run in a
new child process. Setting TF_FORK=0 will skip panicwrap and continue
running the program in the current process. This will also give direct
access to log output, and stdout.

Fixes #8795 