### PR TITLE
Allow use of protocol numbers for ah and esp

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -82,8 +82,6 @@ func protocolIntegers() map[string]int {
 	var protocolIntegers = make(map[string]int)
 	protocolIntegers = map[string]int{
 		// defined at https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-		"ah":   51,
-		"esp":  50,
 		"udp":  17,
 		"tcp":  6,
 		"icmp": 1,

--- a/website/source/docs/configuration/data-sources.html.md
+++ b/website/source/docs/configuration/data-sources.html.md
@@ -15,7 +15,7 @@ or defined by another separate Terraform configuration.
 
 [Providers](/docs/configuration/providers.html) are responsible in
 Terraform for defining and implementing data sources. Whereas
-a [resource](/docs/configuration/resource.html) causes Terraform
+a [resource](/docs/configuration/resources.html) causes Terraform
 to create and manage a new infrastructure component, data sources
 present read-only views into pre-existing data, or they compute
 new values on the fly within Terraform itself.

--- a/website/source/docs/providers/aws/r/security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group.html.markdown
@@ -87,7 +87,7 @@ The `ingress` block supports:
 * `cidr_blocks` - (Optional) List of CIDR blocks.
 * `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp")
 * `protocol` - (Required) The protocol. If you select a protocol of
-"-1", you must specify a "from_port" and "to_port" equal to 0.
+"-1", you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 * `security_groups` - (Optional) List of security group Group Names if using
     EC2-Classic, or Group IDs if using a VPC.
 * `self` - (Optional) If true, the security group itself will be added as
@@ -100,7 +100,7 @@ The `egress` block supports:
 * `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints)
 * `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp")
 * `protocol` - (Required) The protocol. If you select a protocol of
-"-1", you must specify a "from_port" and "to_port" equal to 0.
+"-1", you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 * `security_groups` - (Optional) List of security group Group Names if using
     EC2-Classic, or Group IDs if using a VPC.
 * `self` - (Optional) If true, the security group itself will be added as
@@ -156,7 +156,7 @@ The following attributes are exported:
 
 ## Import
 
-Security Groups can be imported using the `security group id`, e.g. 
+Security Groups can be imported using the `security group id`, e.g.
 
 ```
 $ terraform import aws_security_group.elb_sg sg-903004f8

--- a/website/source/docs/providers/aws/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group_rule.html.markdown
@@ -45,7 +45,7 @@ or `egress` (outbound).
 * `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints).
 Only valid with `egress`.
 * `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp").
-* `protocol` - (Required) The protocol.
+* `protocol` - (Required) The protocol. If not icmp, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 * `security_group_id` - (Required) The security group to apply this rule to.
 * `source_security_group_id` - (Optional) The security group id to allow access to/from,
      depending on the `type`. Cannot be specified with `cidr_blocks`.


### PR DESCRIPTION
It appears the aws sdk does not accept the protocol name for esp or ah. This fix allows the user to simply specify the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml) in their security group. 

This fix covers: https://github.com/hashicorp/terraform/issues/6888