### PR TITLE
provider/aws: Change vpc_id to id in documentation

### DIFF
--- a/website/source/docs/providers/aws/r/default_security_group.html.markdown
+++ b/website/source/docs/providers/aws/r/default_security_group.html.markdown
@@ -41,7 +41,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = "${aws_vpc.mainvpc.vpc_id}"
+  vpc_id = "${aws_vpc.mainvpc.id}"
 
   ingress {
     protocol  = -1


### PR DESCRIPTION
Fixes #8979