### PR TITLE
[WIP] provider/aws: fix option updates to beanstalk

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -235,14 +235,14 @@ func TestAccAWSBeanstalkEnv_basic_settings_update(t *testing.T) {
 				Config: testAccBeanstalkEnvConfig_settings(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					testAccVerifyBeanstalkConfig(&app, []string{"TF_LOG", "TF_SOME_VAR"}),
+					testAccVerifyBeanstalkConfig(&app, []string{"ENV_STATIC", "ENV_UPDATE"}),
 				),
 			},
 			resource.TestStep{
 				Config: testAccBeanstalkEnvConfig_settings_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					testAccVerifyBeanstalkConfig(&app, []string{"TF_LOG", "TF_SOME_VAR"}),
+					testAccVerifyBeanstalkConfig(&app, []string{"ENV_STATIC", "ENV_UPDATE"}),
 				),
 			},
 			resource.TestStep{
@@ -280,7 +280,7 @@ func testAccVerifyBeanstalkConfig(env *elasticbeanstalk.EnvironmentDescription, 
 		cs := resp.ConfigurationSettings[0]
 
 		var foundEnvs []string
-		testStrings := []string{"TF_LOG", "TF_SOME_VAR"}
+		testStrings := []string{"ENV_STATIC", "ENV_UPDATE"}
 		for _, os := range cs.OptionSettings {
 			for _, k := range testStrings {
 				if *os.OptionName == k {
@@ -504,13 +504,19 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "TF_LOG"
+    name      = "ENV_STATIC"
     value     = "true"
   }
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "TF_SOME_VAR"
+    name      = "ENV_UPDATE"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "ENV_REMOVE"
     value     = "true"
   }
 
@@ -553,19 +559,19 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "TF_LOG"
+    name      = "ENV_STATIC"
     value     = "true"
   }
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "TF_SOME_VAR"
+    name      = "ENV_UPDATE"
     value     = "false"
   }
 
-	  setting {
+  setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "TF_SOME_NEW_VAR"
+    name      = "ENV_ADD"
     value     = "true"
   }
 


### PR DESCRIPTION
Before upgrading to v0.7.3 I was seeing the issue where, when you update elasticbeanstalk settings, the result is that the setting gets removed rather than updated. I was seeing this only with environment variables, but the issue may apply to all types of settings.

After upgrading to v0.7.4, this fix that was released https://github.com/hashicorp/terraform/pull/8848 that addresses the issue. However, because it is modifying the slice it is iterating over, you get a `slice bounds out of range` panic.

I've modified the logic to track which "removals" are actually updates, and not adding them to the set of options to remove. This seems to work in my manual testing. 

I tried to modify the test for this but I couldn't figure out how to run it. Never programmed in go before so not really sure how to run it, any help welcome! Running `make test` appears to pass but I'm not confident it is actually running.