### PR TITLE
[WIP] provider/aws: aws_route53_zone should recreate when vpc_id removed

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -40,10 +40,10 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			},
 
 			"vpc_id": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"delegation_set_id"},
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "",
 			},
 
 			"vpc_region": &schema.Schema{
@@ -59,10 +59,10 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			},
 
 			"delegation_set_id": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"vpc_id"},
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 
 			"name_servers": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -167,6 +167,9 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		if err := d.Set("name_servers", ns); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting name servers for: %s, error: %#v", d.Id(), err)
 		}
+
+		d.Set("vpc_id", "")
+		d.Set("vpc_region", "")
 	} else {
 		ns, err := getNameServers(d.Id(), d.Get("name").(string), r53)
 		if err != nil {

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -491,6 +491,7 @@ resource "aws_vpc" "main" {
 
 resource "aws_route53_zone" "main" {
 	name = "hashicorp.com."
+
 }
 `
 

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/config"
 )
 
@@ -44,8 +45,8 @@ func (n *EvalCompareDiff) Eval(ctx EvalContext) (interface{}, error) {
 	if same, reason := one.Same(two); !same {
 		log.Printf("[ERROR] %s: diffs didn't match", n.Info.Id)
 		log.Printf("[ERROR] %s: reason: %s", n.Info.Id, reason)
-		log.Printf("[ERROR] %s: diff one: %#v", n.Info.Id, one)
-		log.Printf("[ERROR] %s: diff two: %#v", n.Info.Id, two)
+		log.Printf("[ERROR] %s: diff one: %s", n.Info.Id, spew.Sdump(one))
+		log.Printf("[ERROR] %s: diff two: %s", n.Info.Id, spew.Sdump(two))
 		return nil, fmt.Errorf(
 			"%s: diffs didn't match during apply. This is a bug with "+
 				"Terraform and should be reported as a GitHub Issue.\n"+
@@ -55,12 +56,12 @@ func (n *EvalCompareDiff) Eval(ctx EvalContext) (interface{}, error) {
 				"    Terraform Version: %s\n"+
 				"    Resource ID: %s\n"+
 				"    Mismatch reason: %s\n"+
-				"    Diff One (usually from plan): %#v\n"+
-				"    Diff Two (usually from apply): %#v\n"+
+				"    Diff One (usually from plan):  %s\n"+
+				"    Diff Two (usually from apply): %s\n"+
 				"\n"+
 				"Also include as much context as you can about your config, state, "+
 				"and the steps you performed to trigger this error.\n",
-			n.Info.Id, Version, n.Info.Id, reason, one, two)
+			n.Info.Id, Version, n.Info.Id, reason, spew.Sdump(one), spew.Sdump(two))
 	}
 
 	return nil, nil


### PR DESCRIPTION
Fixes #8676

In order to make this work, I had to remove the `conflicts_with` from vpc_id and make it computed: true

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRoute53Zone_'                                                                          ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/22 14:43:00 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRoute53Zone_ -timeout 120m
=== RUN   TestAccAWSRoute53Zone_importBasic
--- PASS: TestAccAWSRoute53Zone_importBasic (49.59s)
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (50.62s)
=== RUN   TestAccAWSRoute53Zone_forceDestroy
--- PASS: TestAccAWSRoute53Zone_forceDestroy (410.54s)
=== RUN   TestAccAWSRoute53Zone_updateComment
--- PASS: TestAccAWSRoute53Zone_updateComment (62.10s)
=== RUN   TestAccAWSRoute53Zone_private_basic
--- PASS: TestAccAWSRoute53Zone_private_basic (88.21s)
=== RUN   TestAccAWSRoute53Zone_private_region
--- PASS: TestAccAWSRoute53Zone_private_region (81.34s)
=== RUN   TestAccAWSRoute53Zone_privateToPublic
--- PASS: TestAccAWSRoute53Zone_privateToPublic (110.95s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    843.153s
```
