### PR TITLE
provider/aws: VPC ID, Port, Protocol and Name change on aws_alb_target_group will ForceNew resource

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group.go
@@ -33,23 +33,27 @@ func resourceAwsAlbTargetGroup() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"port": {
 				Type:         schema.TypeInt,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validateAwsAlbTargetGroupPort,
 			},
 
 			"protocol": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validateAwsAlbTargetGroupProtocol,
 			},
 
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"deregistration_delay": {

--- a/builtin/providers/aws/resource_aws_alb_target_group_test.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_test.go
@@ -51,6 +51,117 @@ func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSALBTargetGroup_changeNameForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupNameBefore := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	targetGroupNameAfter := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupNameBefore),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupNameBefore),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupNameAfter),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupNameAfter),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_changeProtocolForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTP"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_changePortForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "442"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_changeVpcForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSALBTargetGroup_tags(t *testing.T) {
 	var conf elbv2.TargetGroup
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -206,6 +317,131 @@ func testAccCheckAWSALBTargetGroupDestroy(s *terraform.State) error {
 }
 
 func testAccAWSALBTargetGroupConfig_basic(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 442
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.test2.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.10.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName string) string {
 	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
   name = "%s"
   port = 443

--- a/website/source/docs/providers/aws/r/alb_target_group.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_target_group.html.markdown
@@ -31,10 +31,10 @@ resource "aws_vpc" "main" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the target group.
-* `port` - (Required) The port on which targets receive traffic, unless overridden when registering a specific target.
-* `protocol` - (Required) The protocol to use for routing traffic to the targets.
-* `vpc_id` - (Required) The identifier of the VPC in which to create the target group.
+* `name` - (Required) The name of the target group. 
+* `port` - (Required) The port on which targets receive traffic, unless overridden when registering a specific target. 
+* `protocol` - (Required) The protocol to use for routing traffic to the targets. 
+* `vpc_id` - (Required) The identifier of the VPC in which to create the target group. 
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds. 
 * `stickiness` - (Optional) A Stickiness block. Stickiness blocks are documented below.
 * `health_check` - (Optional) A Health Check block. Health Check blocks are documented below.


### PR DESCRIPTION
Fixes #8741

The modify-target-group doesn't allow changes to name, port, protocol or
vpc_id - therefore, they should all be ForceNew: true

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSALBTargetGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/22 16:04:29 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSALBTargetGroup_ -timeout 120m
=== RUN   TestAccAWSALBTargetGroup_basic
--- PASS: TestAccAWSALBTargetGroup_basic (50.66s)
=== RUN   TestAccAWSALBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (84.48s)
=== RUN   TestAccAWSALBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (95.89s)
=== RUN   TestAccAWSALBTargetGroup_changePortForceNew
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (85.77s)
=== RUN   TestAccAWSALBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (85.00s)
=== RUN   TestAccAWSALBTargetGroup_tags
--- PASS: TestAccAWSALBTargetGroup_tags (88.11s)
=== RUN   TestAccAWSALBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (82.15s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    572.083s
```