### PR TITLE
provider/aws: change to snapshot_identifier should force new aws_db_instance

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -265,6 +265,7 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: false,
 				Optional: true,
+				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 


### PR DESCRIPTION
Fixes #8793

When a new snapshot_identifier has been specified, aws_db_instance did
nothing. We cannot modify this value should it should be forcenew

We have no tests for restoring from snapshot so i checked the basic test
to make sure all works as expected:

```
% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestAccAWSDBInstance_basic'
% 1 ↵ ✚
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/22 16:37:14 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDBInstance_basic -timeout 120m
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (505.37s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    505.392s
```