### PR TITLE
provider/template: Added single part support to datasource cloudinit template.

### DIFF
--- a/builtin/providers/template/datasource_cloudinit_config_test.go
+++ b/builtin/providers/template/datasource_cloudinit_config_test.go
@@ -52,6 +52,17 @@ func TestRender(t *testing.T) {
 			}`,
 			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDARY--\r\n",
 		},
+		{
+			`data "template_cloudinit_config" "foo" {
+				single_part = true
+				base64_encode = false
+				gzip = false
+				part {
+					content      = "baz"
+				}
+			}`,
+			"baz",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/builtin/providers/template/datasource_cloudinit_config_test.go
+++ b/builtin/providers/template/datasource_cloudinit_config_test.go
@@ -1,16 +1,26 @@
 package template
 
 import (
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"strings"
 	"testing"
 
 	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
+type TestCloudInitData struct {
+	ResourceBlock string
+	Expected      string
+	Base64        bool
+	Gzip          bool
+}
+
 func TestRender(t *testing.T) {
-	testCases := []struct {
-		ResourceBlock string
-		Expected      string
-	}{
+	testCases := []TestCloudInitData{
 		{
 			`data "template_cloudinit_config" "foo" {
 				gzip = false
@@ -22,6 +32,8 @@ func TestRender(t *testing.T) {
 				}
 			}`,
 			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n",
+			false,
+			false,
 		},
 		{
 			`data "template_cloudinit_config" "foo" {
@@ -35,6 +47,8 @@ func TestRender(t *testing.T) {
 				}
 			}`,
 			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Disposition: attachment; filename=\"foobar.sh\"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n",
+			false,
+			false,
 		},
 		{
 			`data "template_cloudinit_config" "foo" {
@@ -51,6 +65,8 @@ func TestRender(t *testing.T) {
 				}
 			}`,
 			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDARY--\r\n",
+			false,
+			false,
 		},
 		{
 			`data "template_cloudinit_config" "foo" {
@@ -62,6 +78,47 @@ func TestRender(t *testing.T) {
 				}
 			}`,
 			"baz",
+			false,
+			false,
+		},
+		{
+			`data "template_cloudinit_config" "foo" {
+				single_part = true
+				base64_encode = true
+				gzip = false
+				part {
+					content      = "baz"
+				}
+			}`,
+			"baz",
+			true,
+			false,
+		},
+		{
+			`data "template_cloudinit_config" "foo" {
+				single_part = true
+				base64_encode = true
+				gzip = true
+				part {
+					content      = "baz"
+				}
+			}`,
+			"baz",
+			true,
+			true,
+		},
+		{
+			`data "template_cloudinit_config" "foo" {
+				single_part = true
+				base64_encode = false
+				gzip = true
+				part {
+					content      = "baz"
+				}
+			}`,
+			"baz",
+			false,
+			true,
 		},
 	}
 
@@ -71,12 +128,60 @@ func TestRender(t *testing.T) {
 			Steps: []r.TestStep{
 				r.TestStep{
 					Config: tt.ResourceBlock,
-					Check: r.ComposeTestCheckFunc(
-						r.TestCheckResourceAttr("data.template_cloudinit_config.foo", "rendered", tt.Expected),
-					),
+					Check:  testCheckResourceAttrEncoded("data.template_cloudinit_config.foo", "rendered", tt.Expected, tt.Base64, tt.Gzip),
 				},
 			},
 		})
+	}
+}
+
+func testCheckResourceAttrEncoded(name string, key string, value string, base64_decode bool, gzip_decode bool) r.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		is := rs.Primary
+		if is == nil {
+			return fmt.Errorf("No primary instance: %s", name)
+		}
+
+		var result string
+
+		if base64_decode {
+			temp, err := base64.StdEncoding.DecodeString(is.Attributes[key])
+			if err != nil {
+				return fmt.Errorf("Unable to decode base64 string")
+			}
+			result = string(temp)
+		} else {
+			result = is.Attributes[key]
+		}
+
+		if gzip_decode {
+			gzipReader, err := gzip.NewReader(strings.NewReader(result))
+			if err != nil {
+				return fmt.Errorf("Unable to decompress gzip string")
+			}
+			gzipReader.Close()
+			temp, err := ioutil.ReadAll(gzipReader)
+			if err != nil {
+				return fmt.Errorf("Unable read data from gzip reader")
+			}
+			result = string(temp)
+		}
+
+		if result != value {
+			return fmt.Errorf(
+				"%s: Attribute '%s' expected %#v, got %#v",
+				name,
+				key,
+				value,
+				result)
+		}
+
+		return nil
 	}
 }
 

--- a/website/source/docs/providers/template/d/cloudinit_config.html.markdown
+++ b/website/source/docs/providers/template/d/cloudinit_config.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
 
 * `base64_encode` - (Optional) Base64 encoding of the rendered output. Default to `true`
 
+* `single_part` - (Optional) Use first part as plain single part. Raises an error when multiple parts defined. Default to `false`
+
 * `part` - (Required) One may specify this many times, this creates a fragment of the rendered cloud-init config file. The order of the parts is maintained in the configuration is maintained in the rendered template.
 
 The `part` block supports:


### PR DESCRIPTION
Some implementations from cloud-init does not support multi parts (e.g. coreos-cloudinit).
