### PR TITLE
provider/aws: Restore ah/esp protocol support for Network ACLs

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -82,8 +82,8 @@ func protocolIntegers() map[string]int {
 	var protocolIntegers = make(map[string]int)
 	protocolIntegers = map[string]int{
 		// defined at https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-                "ah":   51,
-                "esp":  50,
+		"ah":   51,
+		"esp":  50,
 		"udp":  17,
 		"tcp":  6,
 		"icmp": 1,

--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -82,6 +82,8 @@ func protocolIntegers() map[string]int {
 	var protocolIntegers = make(map[string]int)
 	protocolIntegers = map[string]int{
 		// defined at https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+                "ah":   51,
+                "esp":  50,
 		"udp":  17,
 		"tcp":  6,
 		"icmp": 1,

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -231,22 +231,22 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 }
 
 func TestAccAWSNetworkAcl_espProtocol(t *testing.T) {
-        var networkAcl ec2.NetworkAcl
+	var networkAcl ec2.NetworkAcl
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:      func() { testAccPreCheck(t) },
-                IDRefreshName: "aws_network_acl.testesp",
-                Providers:     testAccProviders,
-                CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
-                Steps: []resource.TestStep{
-                        resource.TestStep{
-                                Config: testAccAWSNetworkAclEsp,
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckAWSNetworkAclExists("aws_network_acl.testesp", &networkAcl),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_network_acl.testesp",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSNetworkAclEsp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclExists("aws_network_acl.testesp", &networkAcl),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -228,7 +228,25 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 			},
 		},
 	})
+}
 
+func TestAccAWSNetworkAcl_espProtocol(t *testing.T) {
+        var networkAcl ec2.NetworkAcl
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:      func() { testAccPreCheck(t) },
+                IDRefreshName: "aws_network_acl.testesp",
+                Providers:     testAccProviders,
+                CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccAWSNetworkAclEsp,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckAWSNetworkAclExists("aws_network_acl.testesp", &networkAcl),
+                                ),
+                        },
+                },
+        })
 }
 
 func testAccCheckAWSNetworkAclDestroy(s *terraform.State) error {
@@ -636,5 +654,28 @@ resource "aws_network_acl" "bar" {
 	tags {
 		Name = "acl-subnets-test"
 	}
+}
+`
+
+const testAccAWSNetworkAclEsp = `
+resource "aws_vpc" "testespvpc" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_network_acl" "testesp" {
+  vpc_id = "${aws_vpc.testespvpc.id}"
+
+  egress {
+    protocol   = "esp"
+    rule_no    = 5
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags {
+    Name = "test_esp"
+  }
 }
 `

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -955,7 +955,7 @@ func protocolForValue(v string) string {
 		return "-1"
 	}
 	// if it's a name like tcp, return that
-	if _, ok := protocolIntegers()[protocol]; ok {
+	if _, ok := sgProtocolIntegers()[protocol]; ok {
 		return protocol
 	}
 	// convert to int, look for that value
@@ -967,7 +967,7 @@ func protocolForValue(v string) string {
 		return protocol
 	}
 
-	for k, v := range protocolIntegers() {
+	for k, v := range sgProtocolIntegers() {
 		if p == v {
 			// guard against protocolIntegers sometime in the future not having lower
 			// case ids in the map
@@ -978,6 +978,23 @@ func protocolForValue(v string) string {
 	// fall through
 	log.Printf("[WARN] Unable to determine valid protocol: no matching protocols found")
 	return protocol
+}
+
+// a map of protocol names and their codes, defined at
+// https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml,
+// documented to be supported by AWS Security Groups
+// http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_IpPermission.html
+// Similar to protocolIntegers() used by Network ACLs, but explicitly only
+// supports "tcp", "udp", "icmp", and "all"
+func sgProtocolIntegers() map[string]int {
+	var protocolIntegers = make(map[string]int)
+	protocolIntegers = map[string]int{
+		"udp":  17,
+		"tcp":  6,
+		"icmp": 1,
+		"all":  -1,
+	}
+	return protocolIntegers
 }
 
 // The AWS Lambda service creates ENIs behind the scenes and keeps these around for a while


### PR DESCRIPTION
https://github.com/hashicorp/terraform/pull/8975 removed support for `ah` and `esp` string support for ingress/egress protocols in Security Groups. It seems it was too far reaching though, as while the SecurityGroup SDK/API does not support using strings for these protocols, the Network ACL API does.

This PR restores support for using the string version of those protocols with Network ACLs, while still removing support for them in Security Groups. 

Thanks to @jrnt30 for pointing this out, and @sarkis as well in #6915

A custom TravisCI run for all `TestAccAWSNet*` and `TestAccAWSSe*` tests:

- https://travis-ci.org/hashicorp/terraform/builds/163436738