### PR TITLE
Update aws_lambda_permission doc for CloudWatch Events

### DIFF
--- a/website/source/docs/providers/aws/r/lambda_permission.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_permission.html.markdown
@@ -118,6 +118,7 @@ EOF
  	The permission will then apply to the specific qualified ARN.
  	e.g. `arn:aws:lambda:aws-region:acct-id:function:function-name:2`
  * `source_account` - (Optional) The AWS account ID (without a hyphen) of the source owner.
- * `source_arn` - (Optional) When granting Amazon S3 permission to invoke your function,
- 	you should specify this field with the bucket Amazon Resource Name (ARN) as its value.
- 	This ensures that only events generated from the specified bucket can invoke the function.
+ * `source_arn` - (Optional) When granting Amazon S3 or CloudWatch Events permission to
+  invoke your function, you should specify this field with the Amazon Resource Name (ARN)
+  for the S3 Bucket or CloudWatch Events Rule as its value.  This ensures that only events
+  generated from the specified bucket or rule can invoke the function.


### PR DESCRIPTION
Based on support case with AWS, CloudWatch Events invoking Lambda should also specify the `source_arn`

Example, the resulting policy needs to be like:
```
{
    "Condition": {
        "ArnLike": {
            "AWS:SourceArn": "arn:aws:events:us-east-1:0123456789:rule/my-cloudwatch-events-rule"
        }
    },
    "Action": "lambda:InvokeFunction",
    "Resource": "arn:aws:lambda:us-east-1:0123456789:function:my-lambda-function",
    "Effect": "Allow",
    "Principal": {
        "Service": "events.amazonaws.com"
    },
    "Sid": "AllowMyCloudWatchEventRuleToCallMyLambda"
}
```