### PR TITLE
provider/aws: Add some tests for the Import for aws_eip

### DIFF
--- a/builtin/providers/aws/resource_aws_eip.go
+++ b/builtin/providers/aws/resource_aws_eip.go
@@ -29,6 +29,7 @@ func resourceAwsEip() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"instance": &schema.Schema{
@@ -168,7 +169,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	// On import (domain never set, which it must've been if we created),
 	// set the 'vpc' attribute depending on if we're in a VPC.
-	if _, ok := d.GetOk("domain"); !ok {
+	if address.Domain != nil {
 		d.Set("vpc", *address.Domain == "vpc")
 	}
 


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEIP_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/23 09:28:32 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEIP_ -timeout
120m
=== RUN   TestAccAWSEIP_importEc2Classic
--- PASS: TestAccAWSEIP_importEc2Classic (116.16s)
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (61.89s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (18.86s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (185.95s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (63.20s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (65.64s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (201.34s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    713.072s
```