### PR TITLE
Aws elasticache cluster import

### DIFF
--- a/builtin/providers/aws/import_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/import_aws_elasticache_cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -11,6 +12,8 @@ func TestAccAWSElasticacheCluster_importBasic(t *testing.T) {
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	name := acctest.RandString(10)
 
 	resourceName := "aws_elasticache_cluster.bar"
 
@@ -20,7 +23,7 @@ func TestAccAWSElasticacheCluster_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSElasticacheClusterConfig,
+				Config: testAccAWSElasticacheClusterConfigBasic(name),
 			},
 
 			resource.TestStep{

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -364,9 +364,11 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 		}
 
 		d.Set("subnet_group_name", c.CacheSubnetGroupName)
-		d.Set("security_group_names", c.CacheSecurityGroups)
-		d.Set("security_group_ids", c.SecurityGroups)
-		d.Set("parameter_group_name", c.CacheParameterGroup)
+		d.Set("security_group_names", flattenElastiCacheSecurityGroupNames(c.CacheSecurityGroups))
+		d.Set("security_group_ids", flattenElastiCacheSecurityGroupIds(c.SecurityGroups))
+		if c.CacheParameterGroup != nil {
+			d.Set("parameter_group_name", c.CacheParameterGroup.CacheParameterGroupName)
+		}
 		d.Set("maintenance_window", c.PreferredMaintenanceWindow)
 		d.Set("snapshot_window", c.SnapshotWindow)
 		d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)

--- a/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster_test.go
@@ -219,6 +219,23 @@ func testAccCheckAWSElasticacheClusterExists(n string, v *elasticache.CacheClust
 	}
 }
 
+func testAccAWSElasticacheClusterConfigBasic(clusterId string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_elasticache_cluster" "bar" {
+    cluster_id = "tf-%s"
+    engine = "memcached"
+    node_type = "cache.m1.small"
+    num_cache_nodes = 1
+    port = 11211
+    parameter_group_name = "default.memcached1.4"
+}
+`, clusterId)
+}
+
 var testAccAWSElasticacheClusterConfig = fmt.Sprintf(`
 provider "aws" {
 	region = "us-east-1"

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -758,6 +758,26 @@ func flattenAttachment(a *ec2.NetworkInterfaceAttachment) map[string]interface{}
 	return att
 }
 
+func flattenElastiCacheSecurityGroupNames(securityGroups []*elasticache.CacheSecurityGroupMembership) []string {
+	result := make([]string, 0, len(securityGroups))
+	for _, sg := range securityGroups {
+		if sg.CacheSecurityGroupName != nil {
+			result = append(result, *sg.CacheSecurityGroupName)
+		}
+	}
+	return result
+}
+
+func flattenElastiCacheSecurityGroupIds(securityGroups []*elasticache.SecurityGroupMembership) []string {
+	result := make([]string, 0, len(securityGroups))
+	for _, sg := range securityGroups {
+		if sg.SecurityGroupId != nil {
+			result = append(result, *sg.SecurityGroupId)
+		}
+	}
+	return result
+}
+
 // Flattens step adjustments into a list of map[string]interface.
 func flattenStepAdjustments(adjustments []*autoscaling.StepAdjustment) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(adjustments))

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `load_balancers` (Optional) A list of load balancer names to add to the autoscaling
    group names.
 * `vpc_zone_identifier` (Optional) A list of subnet IDs to launch resources in.
-* `target_group_arns` (Optional) A list of `aws_target_group` ARNs, for use with
+* `target_group_arns` (Optional) A list of `aws_alb_target_group` ARNs, for use with
 Application Load Balancing
 * `termination_policies` (Optional) A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default`.
 * `tag` (Optional) A list of tag blocks. Tags documented below.


### PR DESCRIPTION
Superceeds #8325

Initial tests were failing as follows:

```
=== RUN   TestAccAWSElasticacheCluster_importBasic
--- FAIL: TestAccAWSElasticacheCluster_importBasic (362.66s)
        testing.go:265: Step 1 error: ImportStateVerify attributes not
        equivalent. Difference is shown below. Top is actual, bottom is
        expected.

        (map[string]string) {

        }

(map[string]string) (len=2) {
             (string) (len=20) "parameter_group_name": (string) (len=20)
             "default.memcached1.4",
                             (string) (len=22) "security_group_names.#":
                             (string) (len=1) "0"

}

FAIL
exit status 1
```

The import of ElastiCache clusters helped to point out 3 things:

1. Currently, we were trying to set the parameter_group_name as follows:

```
d.Set("parameter_group_name", c.CacheParameterGroup)
```

Unfortunately, c.CacheParameterGroup is a struct not a string. This was
causing the test import failure. So this had to be replaced as follows:

```
if c.CacheParameterGroup != nil {
      d.Set("parameter_group_name", c.CacheParameterGroup.CacheParameterGroupName)
}
```

2. We were trying to set the security_group_names as follows:

```
d.Set("security_group_names", c.CacheSecurityGroups)
```

The CacheSecurityGroups was actually a []* so had to be changed to work
as follows:

```
if len(c.CacheSecurityGroups) > 0 {
            d.Set("security_group_names",
            flattenElastiCacheSecurityGroupNames(c.CacheSecurityGroups))

}
```

3. We were trying to set the security_group_ids as follows:

```
d.Set("security_group_ids", c.SecurityGroups)
```

This is another []* and needs to be changed as follows:

```
if len(c.SecurityGroups) > 0 {
            d.Set("security_group_ids",
            flattenElastiCacheSecurityGroupIds(c.SecurityGroups))

}
```

This then allows the import test to pass as expected:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheCluster_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/23 10:59:01 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSElasticacheCluster_importBasic -timeout 120m
=== RUN   TestAccAWSElasticacheCluster_importBasic
--- PASS: TestAccAWSElasticacheCluster_importBasic (351.96s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    351.981s
```

As a final test, I ran the basic ElastiCache cluster creation to make
sure all passed as expected:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheCluster_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/23 11:05:51 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSElasticacheCluster_basic -timeout 120m
=== RUN   TestAccAWSElasticacheCluster_basic
--- PASS: TestAccAWSElasticacheCluster_basic (809.25s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    809.267s
```