### PR TITLE
add policy file documentation (PR#3329)

### DIFF
--- a/website/source/docs/provisioners/chef.html.markdown
+++ b/website/source/docs/provisioners/chef.html.markdown
@@ -77,6 +77,12 @@ The following arguments are supported:
   subdirectory called `logfiles` created in your current directory. The filename will be
   the `node_name` of the new node.
 
+* `use_policyfile (boolean)` - (Optional) Use Chef Policyfiles.
+
+* `policy_group (string)` - (Optional) Chef  policy group.
+
+* `policy_name (string)` - (Optional) Chef policy name.
+
 * `http_proxy (string)` - (Optional) The proxy server for Chef Client HTTP connections.
 
 * `https_proxy (string)` - (Optional) The proxy server for Chef Client HTTPS connections.


### PR DESCRIPTION
#3329 did the work to add Chef policy files (https://docs.chef.io/policyfile.html).

However, I noticed that there was no associated documentation.  This PR is opened to add basic documentation .
