### PR TITLE
core: Fixed variables not being in scope for destroy -target on modules

### DIFF
--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -86,6 +86,15 @@ func (t *TargetsTransformer) selectTargetedNodes(
 			var err error
 			if t.Destroy {
 				deps, err = g.Descendents(v)
+
+				// Select any variables that we depend on in case we need them later for
+				// interpolating in the count
+				ancestors, _ := g.Ancestors(v)
+				for _, a := range ancestors.List() {
+					if _, ok := a.(*GraphNodeConfigVariableFlat); ok {
+						deps.Add(a)
+					}
+				}
 			} else {
 				deps, err = g.Ancestors(v)
 			}


### PR DESCRIPTION
Addresses the bug in #8146. The call to `selectTargetedNodes()` was only returning the resource and not the variable that it depended on to interpolate its count, so the variable got removed from the graph and wasn't in scope for later interpolations, causing the `unknown variable accessed` error.


@phinze