### PR TITLE
AWS: Skip DetachVolume if volume is not attached

### DIFF
--- a/builtin/providers/aws/resource_aws_volume_attachment.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment.go
@@ -153,6 +153,20 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 	vID := d.Get("volume_id").(string)
 	iID := d.Get("instance_id").(string)
 
+	desc_opts := &ec2.DescribeVolumesInput{
+		VolumeIds: []*string{aws.String(vID)},
+	}
+
+	attr, desc_err := conn.DescribeVolumes(desc_opts)
+	if desc_err != nil {
+		return fmt.Errorf("Error reading EC2 volume %s: %s", vID, desc_err)
+	}
+
+	if *attr.Volumes[0].State == "available" {
+		d.SetId("")
+		return nil
+	}
+
 	opts := &ec2.DetachVolumeInput{
 		Device:     aws.String(d.Get("device_name").(string)),
 		InstanceId: aws.String(iID),

--- a/builtin/providers/aws/resource_aws_volume_attachment.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment.go
@@ -162,7 +162,7 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error reading EC2 volume %s: %s", vID, desc_err)
 	}
 
-	if *attr.Volumes[0].State == "available" {
+	if len(attr.Volumes) == 0 || *attr.Volumes[0].State == "available" {
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
I manually terminated an instance thus putting the EBS volume in an "available" state. When running `terraform apply` I got this error...
```
* aws_volume_attachment.jira_data_volume: Failed to detach Volume (vol-8237ff0d) from Instance (i-8d44ef87): IncorrectState: Volume 'vol-1537ff1d'is in the 'available' state.
    status code: 400, request id: e0fc1368-c2c5-4a9d-83c9-e958c8ee3ca2
```

This change appears to have fixed the problem. I ran `terraform apply` and the aws_volume_attachment resource was deleted as expected.