### PR TITLE
AWS S3 bucket life_cycle rule IDs must be unique.

### DIFF
--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -121,8 +121,9 @@ resource "aws_s3_bucket" "bucket" {
 			days = 90
 		}
 	}
+
 	lifecycle_rule {
-		id = "log"
+		id = "tmp"
 		prefix = "tmp/"
 		enabled = true
 


### PR DESCRIPTION
Noticed while browsing the docs.

CC @stack72 or @catsby for review.