### PR TITLE
Automatic Rollback of CodeDeploy deployments and CloudWatch Alarms for a Deployment Group

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -237,6 +237,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 		triggerConfigs := buildTriggerConfigs(attr.(*schema.Set).List())
 		input.TriggerConfigurations = triggerConfigs
 	}
+
 	if attr, ok := d.GetOk("auto_rollback_configuration"); ok {
 		input.AutoRollbackConfiguration = buildAutoRollbackConfig(attr.([]interface{}))
 	}
@@ -316,6 +317,7 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 	if err := d.Set("trigger_configuration", triggerConfigsToMap(resp.DeploymentGroupInfo.TriggerConfigurations)); err != nil {
 		return err
 	}
+
 	if err := d.Set("auto_rollback_configuration", autoRollbackConfigToMap(resp.DeploymentGroupInfo.AutoRollbackConfiguration)); err != nil {
 		return err
 	}
@@ -364,6 +366,7 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 		triggerConfigs := buildTriggerConfigs(n.(*schema.Set).List())
 		input.TriggerConfigurations = triggerConfigs
 	}
+
 	if d.HasChange("auto_rollback_configuration") {
 		_, n := d.GetChange("auto_rollback_configuration")
 		input.AutoRollbackConfiguration = buildAutoRollbackConfig(n.([]interface{}))
@@ -491,6 +494,7 @@ func buildTriggerConfigs(configured []interface{}) []*codedeploy.TriggerConfig {
 // into a single codedeploy.AutoRollbackConfiguration
 func buildAutoRollbackConfig(configured []interface{}) *codedeploy.AutoRollbackConfiguration {
 	result := &codedeploy.AutoRollbackConfiguration{}
+
 	if len(configured) == 1 {
 		config := configured[0].(map[string]interface{})
 		result.Enabled = aws.Bool(config["enabled"].(bool))
@@ -499,6 +503,7 @@ func buildAutoRollbackConfig(configured []interface{}) *codedeploy.AutoRollbackC
 		result.Enabled = aws.Bool(false)
 		result.Events = make([]*string, 0)
 	}
+
 	return result
 }
 
@@ -527,6 +532,7 @@ func buildAlarmConfig(configured []interface{}) *codedeploy.AlarmConfiguration {
 		result.Enabled = aws.Bool(false)
 		result.IgnorePollAlarmFailure = aws.Bool(false)
 	}
+
 	return result
 }
 

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -510,13 +510,14 @@ func resourceAwsCodeDeployTriggerConfigHash(v interface{}) int {
 func validateTriggerEvent(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	triggerEvents := map[string]bool{
-		"DeploymentStart":   true,
-		"DeploymentStop":    true,
-		"DeploymentSuccess": true,
-		"DeploymentFailure": true,
-		"InstanceStart":     true,
-		"InstanceSuccess":   true,
-		"InstanceFailure":   true,
+		"DeploymentStart":    true,
+		"DeploymentStop":     true,
+		"DeploymentSuccess":  true,
+		"DeploymentFailure":  true,
+		"DeploymentRollback": true,
+		"InstanceStart":      true,
+		"InstanceSuccess":    true,
+		"InstanceFailure":    true,
 	}
 
 	if !triggerEvents[value] {

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -451,15 +451,14 @@ func buildTriggerConfigs(configured []interface{}) []*codedeploy.TriggerConfig {
 // into a single &codedeploy.AutoRollbackConfiguration
 func buildAutoRollbackConfig(configured []interface{}) *codedeploy.AutoRollbackConfiguration {
 	result := &codedeploy.AutoRollbackConfiguration{}
-
 	if len(configured) == 1 {
 		config := configured[0].(map[string]interface{})
 		result.Enabled = aws.Bool(config["enabled"].(bool))
 		result.Events = expandStringSet(config["events"].(*schema.Set))
 	} else {
 		result.Enabled = aws.Bool(false)
+		result.Events = make([]*string, 0)
 	}
-
 	return result
 }
 
@@ -518,7 +517,7 @@ func triggerConfigsToMap(list []*codedeploy.TriggerConfig) []map[string]interfac
 // into a []map[string]interface{} list containing a single item
 func autoRollbackConfigToMap(config *codedeploy.AutoRollbackConfiguration) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
-	if config != nil && *config.Enabled && len(config.Events) > 0 { // smelly...
+	if config != nil && (*config.Enabled == true || len(config.Events) > 0) {
 		item := make(map[string]interface{})
 		item["enabled"] = *config.Enabled
 		item["events"] = schema.NewSet(schema.HashString, flattenStringList(config.Events))

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -65,6 +65,7 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"alarms": &schema.Schema{
 							Type:     schema.TypeSet,
+							MaxItems: 10,
 							Optional: true,
 							Set:      schema.HashString,
 							Elem:     &schema.Schema{Type: schema.TypeString},

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -245,6 +245,10 @@ func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    "DeploymentRollback",
+			ErrCount: 0,
+		},
+		{
 			Value:    "InstanceStart",
 			ErrCount: 0,
 		},
@@ -748,7 +752,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create(rName strin
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_codedeploy_deployment_group" "foo_group" {
 	app_name = "${aws_codedeploy_app.foo_app.name}"
 	deployment_group_name = "foo-group-%s"
@@ -766,7 +770,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update(rName strin
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_codedeploy_deployment_group" "foo_group" {
 	app_name = "${aws_codedeploy_app.foo_app.name}"
 	deployment_group_name = "foo-group-%s"
@@ -784,7 +788,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple(rNa
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_sns_topic" "bar_topic" {
 	name = "bar-topic-%s"
 }
@@ -812,7 +816,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple(rNa
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_sns_topic" "bar_topic" {
 	name = "bar-topic-%s"
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -355,7 +355,41 @@ func estAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_toggle(t *test
 	})
 }
 
-func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_basic(t *testing.T) {
+func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
 	rName := acctest.RandString(5)
@@ -392,11 +426,92 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_basic(t *testing.T) 
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
-					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.1996459178", "bar"),
 					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// SKIP: This test does not pass but it really ought to pass...
+func skipTestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 		},
@@ -1194,6 +1309,35 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
     alarms = ["foo", "bar"]
     enabled = true
     ignore_poll_alarm_failure = true
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  alarm_configuration {
+    alarms = ["foo"]
+    enabled = false
   }
 }`, baseCodeDeployConfig(rName), rName)
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -46,6 +46,11 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.value", "filtervalue"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
 				),
 			},
 			resource.TestStep{
@@ -67,6 +72,11 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
 				),
 			},
 		},
@@ -217,6 +227,128 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 					}),
 					testAccCheckTriggerTargetArn(&group, "bar-trigger",
 						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:baz-topic-"+rName+"$")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_basic(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.104943466", "DEPLOYMENT_STOP_ON_ALARM"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_remove(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_none(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func estAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_toggle(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
 		},
@@ -842,4 +974,67 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 		trigger_target_arn = "${aws_sns_topic.baz_topic.arn}"
 	}
 }`, baseCodeDeployConfig(rName), rName, rName, rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  auto_rollback_configuration {
+    enabled = true
+    events = ["DEPLOYMENT_FAILURE"]
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  auto_rollback_configuration {
+    enabled = true
+    events = ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM"]
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_none(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  auto_rollback_configuration {
+    enabled = false
+    events = ["DEPLOYMENT_FAILURE"]
+  }
+}`, baseCodeDeployConfig(rName), rName)
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -353,8 +353,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 	})
 }
 
-// SKIP: This test does not pass when auto_rollback_configuration is TypeList, only TypeSet
-func skipTestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *testing.T) {
+func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
 	rName := acctest.RandString(5)
@@ -520,8 +519,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T)
 	})
 }
 
-// SKIP: This test does not pass when alarm_configuration is TypeList, only TypeSet
-func skipTestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T) {
+func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
 	rName := acctest.RandString(5)

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -48,9 +48,11 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.value", "filtervalue"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
 				),
 			},
 			resource.TestStep{
@@ -74,9 +76,11 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
 				),
 			},
 		},
@@ -244,7 +248,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(t *tes
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(rName),
+				Config: test_config_auto_rollback_configuration_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -252,7 +256,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(t *tes
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName),
+				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -280,7 +284,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(t *tes
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName),
+				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -294,7 +298,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(t *tes
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(rName),
+				Config: test_config_auto_rollback_configuration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -324,7 +328,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName),
+				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -338,7 +342,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(rName),
+				Config: test_config_auto_rollback_configuration_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -349,7 +353,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 	})
 }
 
-// SKIP: This test does not pass but it really ought to pass...
+// SKIP: This test does not pass when auto_rollback_configuration is TypeList, only TypeSet
 func skipTestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
@@ -361,7 +365,7 @@ func skipTestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName),
+				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -375,7 +379,7 @@ func skipTestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(rName),
+				Config: test_config_auto_rollback_configuration_disable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -403,7 +407,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T)
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(rName),
+				Config: test_config_alarm_configuration_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -411,7 +415,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T)
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName),
+				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -420,6 +424,10 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T)
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 		},
@@ -437,7 +445,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T)
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName),
+				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -453,7 +461,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T)
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(rName),
+				Config: test_config_alarm_configuration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -485,42 +493,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T)
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
-				),
-			},
-			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-// SKIP: This test does not pass but it really ought to pass...
-func skipTestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T) {
-	var group codedeploy.DeploymentGroupInfo
-
-	rName := acctest.RandString(5)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName),
+				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -536,7 +509,46 @@ func skipTestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testi
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(rName),
+				Config: test_config_alarm_configuration_delete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// SKIP: This test does not pass when alarm_configuration is TypeList, only TypeSet
+func skipTestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_alarm_configuration_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_alarm_configuration_disable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
@@ -692,50 +704,6 @@ func TestTriggerConfigsToMap(t *testing.T) {
 	}
 }
 
-func testAccCheckTriggerEvents(group *codedeploy.DeploymentGroupInfo, triggerName string, expectedEvents []string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-
-		for _, actual := range group.TriggerConfigurations {
-			if *actual.TriggerName == triggerName {
-
-				numberOfEvents := len(actual.TriggerEvents)
-				if numberOfEvents != len(expectedEvents) {
-					return fmt.Errorf("Trigger events do not match. Expected: %d. Got: %d.",
-						len(expectedEvents), numberOfEvents)
-				}
-
-				actualEvents := make([]string, 0, numberOfEvents)
-				for _, event := range actual.TriggerEvents {
-					actualEvents = append(actualEvents, *event)
-				}
-				sort.Strings(actualEvents)
-
-				if !reflect.DeepEqual(actualEvents, expectedEvents) {
-					return fmt.Errorf("Trigger events do not match.\nExpected: %v\nGot: %v\n",
-						expectedEvents, actualEvents)
-				}
-				break
-			}
-		}
-		return nil
-	}
-}
-
-func testAccCheckTriggerTargetArn(group *codedeploy.DeploymentGroupInfo, triggerName string, r *regexp.Regexp) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		for _, actual := range group.TriggerConfigurations {
-			if *actual.TriggerName == triggerName {
-				if !r.MatchString(*actual.TriggerTargetArn) {
-					return fmt.Errorf("Trigger target arn does not match regular expression.\nRegex: %v\nTriggerTargetArn: %v\n",
-						r, *actual.TriggerTargetArn)
-				}
-				break
-			}
-		}
-		return nil
-	}
-}
-
 func TestBuildAutoRollbackConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
@@ -871,6 +839,50 @@ func TestAlarmConfigToMap(t *testing.T) {
 	if fatal {
 		t.Fatalf("alarmConfigToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
+	}
+}
+
+func testAccCheckTriggerEvents(group *codedeploy.DeploymentGroupInfo, triggerName string, expectedEvents []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		for _, actual := range group.TriggerConfigurations {
+			if *actual.TriggerName == triggerName {
+
+				numberOfEvents := len(actual.TriggerEvents)
+				if numberOfEvents != len(expectedEvents) {
+					return fmt.Errorf("Trigger events do not match. Expected: %d. Got: %d.",
+						len(expectedEvents), numberOfEvents)
+				}
+
+				actualEvents := make([]string, 0, numberOfEvents)
+				for _, event := range actual.TriggerEvents {
+					actualEvents = append(actualEvents, *event)
+				}
+				sort.Strings(actualEvents)
+
+				if !reflect.DeepEqual(actualEvents, expectedEvents) {
+					return fmt.Errorf("Trigger events do not match.\nExpected: %v\nGot: %v\n",
+						expectedEvents, actualEvents)
+				}
+				break
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckTriggerTargetArn(group *codedeploy.DeploymentGroupInfo, triggerName string, r *regexp.Regexp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, actual := range group.TriggerConfigurations {
+			if *actual.TriggerName == triggerName {
+				if !r.MatchString(*actual.TriggerTargetArn) {
+					return fmt.Errorf("Trigger target arn does not match regular expression.\nRegex: %v\nTriggerTargetArn: %v\n",
+						r, *actual.TriggerTargetArn)
+				}
+				break
+			}
+		}
+		return nil
 	}
 }
 
@@ -1314,7 +1326,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName, rName, rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(rName string) string {
+func test_config_auto_rollback_configuration_create(rName string) string {
 	return fmt.Sprintf(`
 
   %s
@@ -1331,7 +1343,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(rName string) string {
+func test_config_auto_rollback_configuration_update(rName string) string {
 	return fmt.Sprintf(`
 
   %s
@@ -1348,7 +1360,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(rName string) string {
+func test_config_auto_rollback_configuration_delete(rName string) string {
 	return fmt.Sprintf(`
 
   %s
@@ -1360,7 +1372,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(rName string) string {
+func test_config_auto_rollback_configuration_disable(rName string) string {
 	return fmt.Sprintf(`
 
   %s
@@ -1377,7 +1389,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(rName string) string {
+func test_config_alarm_configuration_create(rName string) string {
 	return fmt.Sprintf(`
 
   %s
@@ -1394,7 +1406,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(rName string) string {
+func test_config_alarm_configuration_update(rName string) string {
 	return fmt.Sprintf(`
 
   %s
@@ -1412,7 +1424,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(rName string) string {
+func test_config_alarm_configuration_delete(rName string) string {
 	return fmt.Sprintf(`
 
   %s
@@ -1424,7 +1436,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 }`, baseCodeDeployConfig(rName), rName)
 }
 
-func testAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(rName string) string {
+func test_config_alarm_configuration_disable(rName string) string {
 	return fmt.Sprintf(`
 
   %s

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -82,6 +82,11 @@ resource "aws_codedeploy_deployment_group" "foo" {
         trigger_name = "foo-trigger"
         trigger_target_arn = "foo-topic-arn"
     }
+
+    auto_rollback_configuration {
+      enabled = true
+      events = ["DEPLOYMENT_FAILURE"]
+    }
 }
 ```
 
@@ -97,6 +102,7 @@ The following arguments are supported:
 * `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
 * `trigger_configuration` - (Optional) A Trigger Configuration block. Trigger Configurations are documented below.
+* `auto_rollback_configuration` - (Optional) Auto Rollback Configuration block, documented below.
 
 Both ec2_tag_filter and on_premises_tag_filter blocks support the following:
 
@@ -109,6 +115,11 @@ Add triggers to a Deployment Group to receive notifications about events related
  * `trigger_events` - (Required) The event type or types for which notifications are triggered. The following values are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.
  * `trigger_name` - (Required) The name of the notification trigger.
  * `trigger_target_arn` - (Required) The ARN of the SNS topic through which notifications are sent.
+
+You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. Only one rollback configuration block is allowed.
+
+ * `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
+ * `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -87,6 +87,11 @@ resource "aws_codedeploy_deployment_group" "foo" {
       enabled = true
       events = ["DEPLOYMENT_FAILURE"]
     }
+
+    alarm_configuration {
+      alarms = ["my-alarm-name"]
+      enabled = true
+    }
 }
 ```
 
@@ -102,7 +107,8 @@ The following arguments are supported:
 * `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
 * `trigger_configuration` - (Optional) A Trigger Configuration block. Trigger Configurations are documented below.
-* `auto_rollback_configuration` - (Optional) Auto Rollback Configuration block, documented below.
+* `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group, documented below.
+* `alarm_configuration` - (Optional) A list of alarms associated with the deployment group, documented below.
 
 Both ec2_tag_filter and on_premises_tag_filter blocks support the following:
 
@@ -120,6 +126,14 @@ You can configure a deployment group to automatically rollback when a deployment
 
  * `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
  * `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
+
+You can configure a deployment to stop when a CloudWatch alarm detects that a metric has fallen below or exceeded a defined threshold. Only one alarm configuration block is allowed.
+
+ * `alarms` - (Optional) A list of alarms configured for the deployment group. A maximum of 10 alarms can be added to a deployment group.
+ * `enabled` - (Optional) Indicates whether the alarm configuration is enabled. This option is useful when you want to temporarily deactivate alarm monitoring for a deployment group without having to add the same alarms again later.
+ * `ignore_poll_alarm_failure` - (Optional) Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch. The default value is `false`.
+    * `true`: The deployment will proceed even if alarm status information can't be retrieved.
+    * `false`: The deployment will stop if alarm status information can't be retrieved.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Added in [AWS SDK for Go v1.4.11](https://aws.amazon.com/releasenotes/3404190260331438)

This PR has a dependency on _AWS SDK for Go v1.4.11_

> AWS CodeDeploy also now supports automatically rolling back a deployment if certain conditions are met, such as a deployment failure or an activated alarm.
> 
> AWS CodeDeploy now integrates with Amazon CloudWatch alarms, making it possible to stop a deployment if there is a change in the state of a specified alarm for a number of consecutive periods, as specified in the alarm threshold. 

Although related, you could argue that these changes to `aws_codedeploy_deloyment_group` could be made separately. After all, you can configure automatic rollbacks without specifying a CloudWatch alarm. However, it might make sense to include them both in the same PR to avoid any delays (they were released together for a reason).

TODO:
- [x] Implement `auto_rollback_configuration`
- [x] Update docs for `auto_rollback_configuration`
- [x] Implement `alarm_configuration`
- [x] Update docs for `alarm_configuration`
- [x] Cleanup, refactoring, better test coverage?
- [x] Resolve issue of skipped tests (`TypeList` vs `TypeSet`)
