### PR TITLE
provider/aws: Add retry logic to the aws_ecr_repository delete func

### DIFF
--- a/builtin/providers/aws/resource_aws_ecr_repository.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository.go
@@ -2,12 +2,14 @@ package aws
 
 import (
 	"log"
+	"time"
 
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -117,7 +119,34 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	log.Printf("[DEBUG] repository %q deleted.", d.Get("arn").(string))
+	log.Printf("[DEBUG] Waiting for ECR Repository %q to be deleted", d.Id())
+	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
+		_, err := conn.DescribeRepositories(&ecr.DescribeRepositoriesInput{
+			RepositoryNames: []*string{aws.String(d.Id())},
+		})
+
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if !ok {
+				return resource.NonRetryableError(err)
+			}
+
+			if awsErr.Code() == "RepositoryNotFoundException" {
+				return nil
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		return resource.RetryableError(
+			fmt.Errorf("%q: Timeout while waiting for the ECR Repository to be deleted", d.Id()))
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	log.Printf("[DEBUG] repository %q deleted.", d.Get("name").(string))
 
 	return nil
 }


### PR DESCRIPTION
Fixes #8597

There was sometimes an issue where Terraform was deleting the ECR
repository from the statefile before the reposity was actually deleted.

Added retry logic for Terraform to wait for the repository to be deleted
before proceeding with the statefile update

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcrRepository_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/26 12:46:57 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSEcrRepository_ -timeout 120m
=== RUN   TestAccAWSEcrRepository_importBasic
--- PASS: TestAccAWSEcrRepository_importBasic (17.86s)
=== RUN   TestAccAWSEcrRepository_basic
--- PASS: TestAccAWSEcrRepository_basic (16.40s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    34.288s
```