### PR TITLE
provider/aws: aws_db_option_group flattenOptions failing due to missing values

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -624,10 +624,14 @@ func flattenOptions(list []*rds.Option) []map[string]interface{} {
 			if i.OptionSettings != nil {
 				settings := make([]map[string]interface{}, 0, len(i.OptionSettings))
 				for _, j := range i.OptionSettings {
-					settings = append(settings, map[string]interface{}{
-						"name":  *j.Name,
-						"value": *j.Value,
-					})
+					setting := map[string]interface{}{
+						"name": *j.Name,
+					}
+					if j.Value != nil {
+						setting["value"] = *j.Value
+					}
+
+					settings = append(settings, setting)
 				}
 
 				r["option_settings"] = settings


### PR DESCRIPTION
Fixes #8332

Not all option_group parameters have values. For example, when you
enable the MariaDB option_group, some of the settings have empty values
(see screenshot)

This PR adds a safety net on reading those values back to the statefile

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBOptionGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/26 13:55:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDBOptionGroup_ -timeout 120m
=== RUN   TestAccAWSDBOptionGroup_importBasic
--- PASS: TestAccAWSDBOptionGroup_importBasic (20.12s)
=== RUN   TestAccAWSDBOptionGroup_basic
--- PASS: TestAccAWSDBOptionGroup_basic (18.45s)
=== RUN   TestAccAWSDBOptionGroup_basicDestroyWithInstance
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (597.90s)
=== RUN   TestAccAWSDBOptionGroup_OptionSettings
--- PASS: TestAccAWSDBOptionGroup_OptionSettings (33.27s)
=== RUN   TestAccAWSDBOptionGroup_sqlServerOptionsUpdate
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (33.39s)
=== RUN   TestAccAWSDBOptionGroup_multipleOptions
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (19.87s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    723.037s
```

<img width="1204" alt="screen shot 2016-09-26 at 13 56 19" src="https://cloud.githubusercontent.com/assets/227823/18835388/c57aec4c-83f2-11e6-9e0c-d2065df4c63b.png">
