### PR TITLE
provider/aws: Refresh AWS EIP association from state when not found

### DIFF
--- a/builtin/providers/aws/resource_aws_eip_association.go
+++ b/builtin/providers/aws/resource_aws_eip_association.go
@@ -119,7 +119,9 @@ func resourceAwsEipAssociationRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if response.Addresses == nil || len(response.Addresses) == 0 {
-		return fmt.Errorf("Unable to find EIP Association: %s", d.Id())
+		log.Printf("[INFO] EIP Association ID Not Found. Refreshing from state")
+		d.SetId("")
+		return nil
 	}
 
 	return readAwsEipAssociation(d, response.Addresses[0])

--- a/builtin/providers/aws/resource_aws_eip_association_test.go
+++ b/builtin/providers/aws/resource_aws_eip_association_test.go
@@ -39,6 +39,42 @@ func TestAccAWSEIPAssociation_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSEIPAssociation_disappears(t *testing.T) {
+	var a ec2.Address
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEIPAssociationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEIPAssociationConfigDisappears,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(
+						"aws_eip.bar", &a),
+					testAccCheckAWSEIPAssociationExists(
+						"aws_eip_association.by_allocation_id", &a),
+					testAccCheckEIPAssociationDisappears(&a),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEIPAssociationDisappears(address *ec2.Address) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		opts := &ec2.DisassociateAddressInput{
+			AssociationId: address.AssociationId,
+		}
+		if _, err := conn.DisassociateAddress(opts); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
 func testAccCheckAWSEIPAssociationExists(name string, res *ec2.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -150,3 +186,29 @@ resource "aws_network_interface" "baz" {
 	}
 }
 `
+
+const testAccAWSEIPAssociationConfigDisappears = `
+resource "aws_vpc" "main" {
+	cidr_block = "192.168.0.0/24"
+}
+resource "aws_subnet" "sub" {
+	vpc_id = "${aws_vpc.main.id}"
+	cidr_block = "192.168.0.0/25"
+	availability_zone = "us-west-2a"
+}
+resource "aws_internet_gateway" "igw" {
+	vpc_id = "${aws_vpc.main.id}"
+}
+resource "aws_instance" "foo" {
+	ami = "ami-21f78e11"
+	availability_zone = "us-west-2a"
+	instance_type = "t1.micro"
+	subnet_id = "${aws_subnet.sub.id}"
+}
+resource "aws_eip" "bar" {
+	vpc = true
+}
+resource "aws_eip_association" "by_allocation_id" {
+	allocation_id = "${aws_eip.bar.id}"
+	instance_id = "${aws_instance.foo.id}"
+}`


### PR DESCRIPTION
Fixes #6758

We used to throw an error when this was the case - we should refresh
from state so the association can be recreated

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEIPAssociation_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/26 16:42:37 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSEIPAssociation_ -timeout 120m
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (272.92s)
=== RUN   TestAccAWSEIPAssociation_disappears
--- PASS: TestAccAWSEIPAssociation_disappears (119.62s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws392.559s
```