### PR TITLE
provider/aws: Make encryption in Aurora instances computed-only

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -85,16 +85,12 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 
 			"kms_key_id": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			"storage_encrypted": &schema.Schema{
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
+				Computed: true,
 			},
 
 			"monitoring_role_arn": &schema.Schema{
@@ -233,6 +229,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set("instance_class", db.DBInstanceClass)
 	d.Set("identifier", db.DBInstanceIdentifier)
 	d.Set("storage_encrypted", db.StorageEncrypted)
+	d.Set("kms_key_id", db.KmsKeyId)
 	d.Set("promotion_tier", db.PromotionTier)
 
 	if db.MonitoringInterval != nil {

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -281,8 +281,6 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   cluster_identifier      = "${aws_rds_cluster.default.id}"
   instance_class          = "db.r3.large"
   db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
-  storage_encrypted = true
-  kms_key_id = "${aws_kms_key.foo.arn}"
 }
 
 resource "aws_db_parameter_group" "bar" {


### PR DESCRIPTION
This is fixing two bugs:

1. The KMS Key ID was never read back from the API
2. It is only possible to set encryption (and hence KMS key ID too) on the cluster level, it is impossible to have a mixture of encrypted & unencrypted instances in the same cluster, as described [in the documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html#Overview.Encryption.Limitations). Even though these fields have been marked as `Optional`, they were not actually used anywhere in any API calls when specified by the user.

## Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSClusterInstance'
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSClusterInstance -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_importBasic
--- PASS: TestAccAWSRDSClusterInstance_importBasic (803.05s)
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (959.59s)
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (844.50s)
=== RUN   TestAccAWSRDSClusterInstance_disappears
2016/09/26 18:22:50 Request body type has been overwritten. May cause race conditions
--- PASS: TestAccAWSRDSClusterInstance_disappears (979.28s)
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (997.34s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	4583.792s
```