### PR TITLE
Fix race on Provisioner.RawConfig

### DIFF
--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -215,13 +215,13 @@ func (n *EvalApplyProvisioners) apply(ctx EvalContext) error {
 		provisioner := ctx.Provisioner(prov.Type)
 
 		// Interpolate the provisioner config
-		provConfig, err := ctx.Interpolate(prov.RawConfig, n.InterpResource)
+		provConfig, err := ctx.Interpolate(prov.RawConfig.Copy(), n.InterpResource)
 		if err != nil {
 			return err
 		}
 
 		// Interpolate the conn info, since it may contain variables
-		connInfo, err := ctx.Interpolate(prov.ConnInfo, n.InterpResource)
+		connInfo, err := ctx.Interpolate(prov.ConnInfo.Copy(), n.InterpResource)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A race when accessing Provisioner.RawConfig can cause unexpected output
for provisioners that interpolate variables. Use RawConfig.Copy which
needs to acquire the RawConfig mutex to get the values.

Fixes #8890