### PR TITLE
Allow new aws api gateway http_method and integration type [WIP]

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -45,9 +45,9 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if value != "MOCK" && value != "AWS" && value != "HTTP" {
+					if value != "MOCK" && value != "AWS" && value != "HTTP" && value != "AWS_PROXY" {
 						errors = append(errors, fmt.Errorf(
-							"%q must be one of 'AWS', 'MOCK', 'HTTP'", k))
+							"%q must be one of 'AWS', 'MOCK', 'HTTP', 'AWS_PROXY'", k))
 					}
 					return
 				},

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -343,9 +343,9 @@ func validateCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []
 
 func validateHTTPMethod(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if value != "GET" && value != "HEAD" && value != "OPTIONS" && value != "PUT" && value != "POST" && value != "PATCH" && value != "DELETE" {
+	if value != "GET" && value != "HEAD" && value != "OPTIONS" && value != "PUT" && value != "POST" && value != "PATCH" && value != "DELETE" && value != "ANY" {
 		errors = append(errors, fmt.Errorf(
-			"%q must be one of 'GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE'", k))
+			"%q must be one of 'GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE', 'ANY'", k))
 	}
 	return
 }

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -45,8 +45,8 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
-* `type` - (Required) The integration input's type (HTTP, MOCK, AWS)
+* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
+* `type` - (Required) The integration input's type (`HTTP`, `MOCK`, `AWS`, `AWS_PROXY`)
 * `uri` - (Optional) The input's URI (HTTP, AWS). **Required** if `type` is `HTTP` or `AWS`.
   For HTTP integrations, the URI must be a fully formed, encoded HTTP(S) URL according to the RFC-3986 specification . For AWS integrations, the URI should be of the form `arn:aws:apigateway:{region}:{subdomain.service|service}:{path|action}/{service_api}`. `region`, `subdomain` and `service` are used to determine the right endpoint.
   e.g. `arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:012345678901:function:my-func/invocations`

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
+* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
 * `status_code` - (Required) The HTTP status code
 * `selection_pattern` - (Optional) Specifies the regular expression pattern used to choose
   an integration response based on the response from the backend.

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
+* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
 * `authorization` - (Required) The type of authorization used for the method (`NONE`, `CUSTOM`)
 * `authorizer_id` - (Optional) The authorizer id to be used when the authorization is `CUSTOM`
 * `api_key_required` - (Optional) Specify if the method requires an API key

--- a/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
+* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
 * `status_code` - (Required) The HTTP status code
 * `response_models` - (Optional) A map of the API models used for the response's content type
 * `response_parameters` - (Optional) A map of response parameters that can be sent to the caller.


### PR DESCRIPTION
AWS API Gateway has been updated to permit an "ANY" http_method.  And integration type of AWS_PROXY (helpfully reported in aws web interface as LAMBDA_PROXY).

Pointing me toward existing PRs, like this one, that I could use as guidance would be appreciated.  Or next steps that are needed?

When using ANY http_method with AWS_PROXY integration type, the integration response resource is not created correctly.  Not sure why yet, so I have marked this [WIP].