### PR TITLE
ResourceConfig.Equal, DeepCopy

### DIFF
--- a/config/interpolate_walk_test.go
+++ b/config/interpolate_walk_test.go
@@ -179,13 +179,15 @@ func TestInterpolationWalker_replace(t *testing.T) {
 			return tc.Value, nil
 		}
 
-		w := &interpolationWalker{F: fn, Replace: true}
-		if err := reflectwalk.Walk(tc.Input, w); err != nil {
-			t.Fatalf("err: %s", err)
-		}
+		t.Run(fmt.Sprintf("walk-%d", i), func(t *testing.T) {
+			w := &interpolationWalker{F: fn, Replace: true}
+			if err := reflectwalk.Walk(tc.Input, w); err != nil {
+				t.Fatalf("err: %s", err)
+			}
 
-		if !reflect.DeepEqual(tc.Input, tc.Output) {
-			t.Fatalf("%d: bad:\n\nexpected:%#v\ngot:%#v", i, tc.Output, tc.Input)
-		}
+			if !reflect.DeepEqual(tc.Input, tc.Output) {
+				t.Fatalf("%d: bad:\n\nexpected:%#v\ngot:%#v", i, tc.Output, tc.Input)
+			}
+		})
 	}
 }

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/config"
+	"github.com/mitchellh/copystructure"
 )
 
 // ResourceProvisionerConfig is used to pair a provisioner
@@ -90,6 +91,25 @@ type ResourceConfig struct {
 func NewResourceConfig(c *config.RawConfig) *ResourceConfig {
 	result := &ResourceConfig{raw: c}
 	result.interpolateForce()
+	return result
+}
+
+// DeepCopy performs a deep copy of the configuration. This makes it safe
+// to modify any of the structures that are part of the resource config without
+// affecting the original configuration.
+func (c *ResourceConfig) DeepCopy() *ResourceConfig {
+	// Copy, this will copy all the exported attributes
+	copy, err := copystructure.Config{Lock: true}.Copy(c)
+	if err != nil {
+		panic(err)
+	}
+
+	// Force the type
+	result := copy.(*ResourceConfig)
+
+	// For the raw configuration, we can just use its own copy method
+	result.raw = c.raw.Copy()
+
 	return result
 }
 

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -113,6 +113,26 @@ func (c *ResourceConfig) DeepCopy() *ResourceConfig {
 	return result
 }
 
+// Equal checks the equality of two resource configs.
+func (c *ResourceConfig) Equal(c2 *ResourceConfig) bool {
+	// Two resource configs if their exported properties are equal.
+	// We don't compare "raw" because it is never used again after
+	// initialization and for all intents and purposes they are equal
+	// if the exported properties are equal.
+	check := [][2]interface{}{
+		{c.ComputedKeys, c2.ComputedKeys},
+		{c.Raw, c2.Raw},
+		{c.Config, c2.Config},
+	}
+	for _, pair := range check {
+		if !reflect.DeepEqual(pair[0], pair[1]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // CheckSet checks that the given list of configuration keys is
 // properly set. If not, errors are returned for each unset key.
 //

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -212,6 +213,19 @@ func TestResourceConfigGet(t *testing.T) {
 		if !reflect.DeepEqual(v, tc.Value) {
 			t.Fatalf("%d bad: %#v", i, v)
 		}
+
+		// If we have vars, we don't test copying
+		if len(tc.Vars) > 0 {
+			continue
+		}
+
+		// Test copying
+		t.Run(fmt.Sprintf("copy-%d", i), func(t *testing.T) {
+			copy := rc.DeepCopy()
+			if !reflect.DeepEqual(copy, rc) {
+				t.Fatalf("bad:\n\n%#v\n\n%#v", copy, rc)
+			}
+		})
 	}
 }
 

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -209,21 +209,31 @@ func TestResourceConfigGet(t *testing.T) {
 		rc := NewResourceConfig(rawC)
 		rc.interpolateForce()
 
-		v, _ := rc.Get(tc.Key)
-		if !reflect.DeepEqual(v, tc.Value) {
-			t.Fatalf("%d bad: %#v", i, v)
-		}
+		// Test getting a key
+		t.Run(fmt.Sprintf("get-%d", i), func(t *testing.T) {
+			v, _ := rc.Get(tc.Key)
+			if !reflect.DeepEqual(v, tc.Value) {
+				t.Fatalf("%d bad: %#v", i, v)
+			}
+		})
 
 		// If we have vars, we don't test copying
 		if len(tc.Vars) > 0 {
 			continue
 		}
 
-		// Test copying
-		t.Run(fmt.Sprintf("copy-%d", i), func(t *testing.T) {
+		// Test copying and equality
+		t.Run(fmt.Sprintf("copy-and-equal-%d", i), func(t *testing.T) {
 			copy := rc.DeepCopy()
 			if !reflect.DeepEqual(copy, rc) {
 				t.Fatalf("bad:\n\n%#v\n\n%#v", copy, rc)
+			}
+
+			if !copy.Equal(rc) {
+				t.Fatalf("copy != rc:\n\n%#v\n\n%#v", copy, rc)
+			}
+			if !rc.Equal(copy) {
+				t.Fatalf("rc != copy:\n\n%#v\n\n%#v", copy, rc)
 			}
 		})
 	}

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -272,11 +273,13 @@ func TestStateDeepCopy(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		actual := tc.F(tc.One.DeepCopy())
-		expected := tc.F(tc.Two)
-		if !reflect.DeepEqual(actual, expected) {
-			t.Fatalf("Bad: %d\n\n%s\n\n%s", i, actual, expected)
-		}
+		t.Run(fmt.Sprintf("copy-%d", i), func(t *testing.T) {
+			actual := tc.F(tc.One.DeepCopy())
+			expected := tc.F(tc.Two)
+			if !reflect.DeepEqual(actual, expected) {
+				t.Fatalf("Bad: %d\n\n%s\n\n%s", i, actual, expected)
+			}
+		})
 	}
 }
 

--- a/vendor/github.com/mitchellh/copystructure/copystructure.go
+++ b/vendor/github.com/mitchellh/copystructure/copystructure.go
@@ -295,10 +295,22 @@ func (w *walker) StructField(f reflect.StructField, v reflect.Value) error {
 		return nil
 	}
 
+	// If PkgPath is non-empty, this is a private (unexported) field.
+	// We do not set this unexported since the Go runtime doesn't allow us.
+	if f.PkgPath != "" {
+		w.ignore()
+		return nil
+	}
+
 	// Push the field onto the stack, we'll handle it when we exit
 	// the struct field in Exit...
 	w.valPush(reflect.ValueOf(f))
 	return nil
+}
+
+// ignore causes the walker to ignore any more values until we exit this on
+func (w *walker) ignore() {
+	w.ignoreDepth = w.depth
 }
 
 func (w *walker) ignoring() bool {

--- a/vendor/github.com/mitchellh/reflectwalk/reflectwalk.go
+++ b/vendor/github.com/mitchellh/reflectwalk/reflectwalk.go
@@ -4,9 +4,7 @@
 // those elements.
 package reflectwalk
 
-import (
-	"reflect"
-)
+import "reflect"
 
 // PrimitiveWalker implementations are able to handle primitive values
 // within complex structures. Primitive values are numbers, strings,
@@ -145,6 +143,12 @@ func walkMap(v reflect.Value, w interface{}) error {
 	for _, k := range v.MapKeys() {
 		kv := v.MapIndex(k)
 
+		// if the map value type is an interface, we need to extract the Elem
+		// for the next call to walk
+		if kv.Kind() == reflect.Interface {
+			kv = kv.Elem()
+		}
+
 		if mw, ok := w.(MapWalker); ok {
 			if err := mw.MapElem(v, k, kv); err != nil {
 				return err
@@ -203,6 +207,12 @@ func walkSlice(v reflect.Value, w interface{}) (err error) {
 
 	for i := 0; i < v.Len(); i++ {
 		elem := v.Index(i)
+
+		// if the value type is an interface, we need to extract the Elem
+		// for the next call to walk
+		if elem.Kind() == reflect.Interface {
+			elem = elem.Elem()
+		}
 
 		if sw, ok := w.(SliceWalker); ok {
 			if err := sw.SliceElem(i, elem); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1474,8 +1474,8 @@
 		{
 			"checksumSHA1": "EDAtec3XSbTjw6gWG+NNScows9M=",
 			"path": "github.com/mitchellh/copystructure",
-			"revision": "8f3c396a26dadccbd29ee24c76c89166249cc16f",
-			"revisionTime": "2016-09-27T21:34:29Z"
+			"revision": "49a4444999946bce1882f9db0eb3ba0a44ed1fbb",
+			"revisionTime": "2016-09-28T02:49:35Z"
 		},
 		{
 			"path": "github.com/mitchellh/go-homedir",
@@ -1507,10 +1507,10 @@
 			"revision": "6e6954073784f7ee67b28f2d22749d6479151ed7"
 		},
 		{
-			"checksumSHA1": "5fFCVadmQVH6jqnB6Zd739s28QM=",
+			"checksumSHA1": "kXh6sdGViiRK0REpIWydJvpsyY0=",
 			"path": "github.com/mitchellh/reflectwalk",
-			"revision": "84fc159ad78a797bb094a1e0c364392d837e1cd8",
-			"revisionTime": "2016-09-28T02:14:22Z"
+			"revision": "0c9480f65513be815a88d6076a3d8d95d4274236",
+			"revisionTime": "2016-09-28T02:49:03Z"
 		},
 		{
 			"checksumSHA1": "/iig5lYSPCL3C8J7e4nTAevYNDE=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1472,10 +1472,10 @@
 			"revision": "8631ce90f28644f54aeedcb3e389a85174e067d1"
 		},
 		{
-			"checksumSHA1": "Vfkp+PcZ1wZ4+D6AsHTpKkdsQG0=",
+			"checksumSHA1": "EDAtec3XSbTjw6gWG+NNScows9M=",
 			"path": "github.com/mitchellh/copystructure",
-			"revision": "501dcbdc7c358c4d0bfa066018834bedca79fde3",
-			"revisionTime": "2016-09-16T19:51:24Z"
+			"revision": "8f3c396a26dadccbd29ee24c76c89166249cc16f",
+			"revisionTime": "2016-09-27T21:34:29Z"
 		},
 		{
 			"path": "github.com/mitchellh/go-homedir",
@@ -1507,8 +1507,10 @@
 			"revision": "6e6954073784f7ee67b28f2d22749d6479151ed7"
 		},
 		{
+			"checksumSHA1": "Qfbnn/PnYNR2ZHraUeHTxT4H7lM=",
 			"path": "github.com/mitchellh/reflectwalk",
-			"revision": "eecf4c70c626c7cfbb95c90195bc34d386c74ac6"
+			"revision": "2d53f44828cae4c770d745a3560e37d3356774a6",
+			"revisionTime": "2016-09-27T21:55:38Z"
 		},
 		{
 			"checksumSHA1": "/iig5lYSPCL3C8J7e4nTAevYNDE=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1507,10 +1507,10 @@
 			"revision": "6e6954073784f7ee67b28f2d22749d6479151ed7"
 		},
 		{
-			"checksumSHA1": "Qfbnn/PnYNR2ZHraUeHTxT4H7lM=",
+			"checksumSHA1": "5fFCVadmQVH6jqnB6Zd739s28QM=",
 			"path": "github.com/mitchellh/reflectwalk",
-			"revision": "2d53f44828cae4c770d745a3560e37d3356774a6",
-			"revisionTime": "2016-09-27T21:55:38Z"
+			"revision": "84fc159ad78a797bb094a1e0c364392d837e1cd8",
+			"revisionTime": "2016-09-28T02:14:22Z"
 		},
 		{
 			"checksumSHA1": "/iig5lYSPCL3C8J7e4nTAevYNDE=",


### PR DESCRIPTION
This PR:

  * Introduces `ResourceConfig.Equal`, `ResourceConfig.DeepCopy`
  * Updates copystructure and reflectwalk to fix panic cases when copying certain structures

This API is needed for the shadow graph I am working on which has to deep copy everything to ensure nothing "real" is modified, and to be able to compare (Equal) to verify that parameters are equivalent to provider APIs.

I'd normally do the vendor update separate but since it is so small, putting it in here.