### PR TITLE
provider/aws: Modifying the parameter_group_name of aws_elasticache_replication_group caused a panic

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -275,7 +275,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 	}
 
 	if d.HasChange("parameter_group_name") {
-		params.CacheParameterGroupName = aws.String(d.Get("cache_parameter_group_name").(string))
+		params.CacheParameterGroupName = aws.String(d.Get("parameter_group_name").(string))
 		requestUpdate = true
 	}
 


### PR DESCRIPTION
Fixes #9097

The update for `parameter_group_name` was trying to find the incorrect
value to set `cache_parameter_group_name` - this is what was causing the
panic

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_updateParameterGroup'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/28 11:17:30 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSElasticacheReplicationGroup_updateParameterGroup -timeout
120m
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup
(903.90s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws903.931s
```