### PR TITLE
New AWS resource `ssm_activation`

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -319,6 +319,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_security_group":                           resourceAwsSecurityGroup(),
 			"aws_security_group_rule":                      resourceAwsSecurityGroupRule(),
 			"aws_simpledb_domain":                          resourceAwsSimpleDBDomain(),
+			"aws_ssm_activation":                           resourceAwsSsmActivation(),
 			"aws_ssm_association":                          resourceAwsSsmAssociation(),
 			"aws_ssm_document":                             resourceAwsSsmDocument(),
 			"aws_spot_datafeed_subscription":               resourceAwsSpotDataFeedSubscription(),

--- a/builtin/providers/aws/resource_aws_ssm_activation.go
+++ b/builtin/providers/aws/resource_aws_ssm_activation.go
@@ -1,0 +1,168 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSsmActivation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSsmActivationCreate,
+		Read:   resourceAwsSsmActivationRead,
+		Delete: resourceAwsSsmActivationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"expired": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expiration_date": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"iam_role": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"registration_limit": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"registration_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	log.Printf("[DEBUG] SSM activation create: %s", d.Id())
+
+	activationInput := &ssm.CreateActivationInput{
+		IamRole: aws.String(d.Get("name").(string)),
+	}
+
+	if _, ok := d.GetOk("name"); ok {
+		activationInput.DefaultInstanceName = aws.String(d.Get("name").(string))
+	}
+
+	if _, ok := d.GetOk("description"); ok {
+		activationInput.Description = aws.String(d.Get("description").(string))
+	}
+
+	if _, ok := d.GetOk("expiration_date"); ok {
+		activationInput.ExpirationDate = aws.Time(d.Get("expiration_date").(time.Time))
+	}
+
+	if _, ok := d.GetOk("iam_role"); ok {
+		activationInput.IamRole = aws.String(d.Get("iam_role").(string))
+	}
+
+	if _, ok := d.GetOk("registration_limit"); ok {
+		activationInput.RegistrationLimit = aws.Int64(int64(d.Get("registration_limit").(int)))
+	}
+
+	// Retry to allow iam_role to be created and policy attachment to take place
+	var resp *ssm.CreateActivationOutput
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		var err error
+
+		resp, err = ssmconn.CreateActivation(activationInput)
+
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+
+		return resource.NonRetryableError(err)
+	})
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error creating SSM activation: {{err}}", err)
+	}
+
+	if resp.ActivationId == nil {
+		return fmt.Errorf("[ERROR] ActivationId was nil")
+	}
+	d.SetId(*resp.ActivationId)
+
+	return resourceAwsSsmActivationRead(d, meta)
+}
+
+func resourceAwsSsmActivationRead(d *schema.ResourceData, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	log.Printf("[DEBUG] Reading SSM Activation: %s", d.Id())
+
+	params := &ssm.DescribeActivationsInput{
+		Filters: []*ssm.DescribeActivationsFilter{
+			{
+				FilterKey: aws.String("ActivationIds"),
+				FilterValues: []*string{
+					aws.String(d.Id()),
+				},
+			},
+		},
+		MaxResults: aws.Int64(1),
+	}
+
+	resp, err := ssmconn.DescribeActivations(params)
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error reading SSM activation: {{err}}", err)
+	}
+	if resp.ActivationList == nil || len(resp.ActivationList) == 0 {
+		return fmt.Errorf("[ERROR] ActivationList was nil or empty")
+	}
+
+	activation := resp.ActivationList[0] // Only 1 result as MaxResults is 1 above
+	d.Set("name", activation.DefaultInstanceName)
+	d.Set("description", activation.Description)
+	d.Set("expiration_date", activation.ExpirationDate)
+	d.Set("expired", activation.Expired)
+	d.Set("iam_role", activation.IamRole)
+	d.Set("registration_limit", activation.RegistrationLimit)
+	d.Set("registration_count", activation.RegistrationsCount)
+
+	return nil
+}
+
+func resourceAwsSsmActivationDelete(d *schema.ResourceData, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	log.Printf("[DEBUG] Deleting SSM Activation: %s", d.Id())
+
+	params := &ssm.DeleteActivationInput{
+		ActivationId: aws.String(d.Id()),
+	}
+
+	_, err := ssmconn.DeleteActivation(params)
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting SSM activation: {{err}}", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_ssm_activation_test.go
+++ b/builtin/providers/aws/resource_aws_ssm_activation_test.go
@@ -1,0 +1,131 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSSSMActivation_basic(t *testing.T) {
+	name := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMActivationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSSMActivationBasicConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSSMActivationExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SSM Activation ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ssmconn
+
+		_, err := conn.DescribeActivations(&ssm.DescribeActivationsInput{
+			Filters: []*ssm.DescribeActivationsFilter{
+				{
+					FilterKey: aws.String("ActivationIds"),
+					FilterValues: []*string{
+						aws.String(rs.Primary.ID),
+					},
+				},
+			},
+			MaxResults: aws.Int64(1),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Could not descripbe the activation - %s", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSSMActivationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ssmconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ssm_activation" {
+			continue
+		}
+
+		out, err := conn.DescribeActivations(&ssm.DescribeActivationsInput{
+			Filters: []*ssm.DescribeActivationsFilter{
+				{
+					FilterKey: aws.String("ActivationIds"),
+					FilterValues: []*string{
+						aws.String(rs.Primary.ID),
+					},
+				},
+			},
+			MaxResults: aws.Int64(1),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if len(out.ActivationList) > 0 {
+			return fmt.Errorf("Expected AWS SSM Activation to be gone, but was still found")
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("Default error in SSM Activation Test")
+}
+
+func testAccAWSSSMActivationBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test_role" {
+  name = "test_role-%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ssm.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test_attach" {
+  role = "${aws_iam_role.test_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_ssm_activation" "foo" {
+  name               = "test_ssm_activation-%s",
+  description        = "Test"
+  iam_role           = "${aws_iam_role.test_role.name}"
+  registration_limit = "5"
+  depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
+}
+`, rName, rName)
+}

--- a/website/source/docs/providers/aws/r/ssm_activation.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_activation.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ssm_activation"
+sidebar_current: "docs-aws-resource-ssm-activation"
+description: |-
+  Registers an on-premises server or virtual machine with Amazon EC2 so that it can be managed using Run Command.
+---
+
+# aws\_ssm\_activation
+
+Registers an on-premises server or virtual machine with Amazon EC2 so that it can be managed using Run Command.
+
+## Example Usage
+
+```
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+  assume_role_policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": {
+      "Effect": "Allow",
+      "Principal": {"Service": "ssm.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }
+  }
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test_attach" {
+  role = "${aws_iam_role.test_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_ssm_activation" "foo" {
+  name               = "test_ssm_activation",
+  description        = "Test"
+  iam_role           = "${aws_iam_role.test_role.id}"
+  registration_limit = "5"
+  depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The default name of the registerd managed instance.
+* `description` - (Optional) The description of the resource that you want to register.
+* `expiration_date` - (Optional) The date by which this activation request should expire. The default value is 24 hours.
+* `iam_role` - (Required) The IAM Role to attach to the managed instance.
+* `registration_limit` - (Optional) The maximum number of managed instances you want to register. The default value is 1 instance.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The default name of the registerd managed instance.
+* `description` - The description of the resource that was registered.
+* `expired` - If the current activation has expired.
+* `expiration_date` - The date by which this activation request should expire. The default value is 24 hours.
+* `iam_role` - The IAM Role attached to the managed instance.
+* `registration_limit` - The maximum number of managed instances you want to be registered. The default value is 1 instance.
+* `registration_count` - The number of managed instances that are currently registered using this activation.


### PR DESCRIPTION
Adding a new resource to support activation of managed instances for
on-premise virtual-machines.

Last of the resources to close off #4952