### PR TITLE
provider/aws: Policy attachment resources accept multiple policy ARNs

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group_policy_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_policy_attachment_test.go
@@ -114,7 +114,7 @@ EOF
 
 resource "aws_iam_group_policy_attachment" "test-attach" {
     group = "${aws_iam_group.group.name}"
-    policy_arn = "${aws_iam_policy.policy.arn}"
+    policy_arns = ["${aws_iam_policy.policy.arn}"]
 }
 `
 
@@ -182,11 +182,7 @@ EOF
 
 resource "aws_iam_group_policy_attachment" "test-attach" {
     group = "${aws_iam_group.group.name}"
-    policy_arn = "${aws_iam_policy.policy2.arn}"
-}
-
-resource "aws_iam_group_policy_attachment" "test-attach2" {
-    group = "${aws_iam_group.group.name}"
-    policy_arn = "${aws_iam_policy.policy3.arn}"
+    policy_arns = ["${aws_iam_policy.policy2.arn}",
+                   "${aws_iam_policy.policy3.arn}"]
 }
 `

--- a/builtin/providers/aws/resource_aws_iam_role_policy_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_policy_attachment_test.go
@@ -129,7 +129,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "test-attach" {
     role = "${aws_iam_role.role.name}"
-    policy_arn = "${aws_iam_policy.policy.arn}"
+    policy_arns = ["${aws_iam_policy.policy.arn}"]
 }
 `
 
@@ -212,11 +212,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "test-attach" {
     role = "${aws_iam_role.role.name}"
-    policy_arn = "${aws_iam_policy.policy2.arn}"
-}
-
-resource "aws_iam_role_policy_attachment" "test-attach2" {
-    role = "${aws_iam_role.role.name}"
-    policy_arn = "${aws_iam_policy.policy3.arn}"
+    policy_arns = ["${aws_iam_policy.policy2.arn}",
+                    ${aws_iam_policy.policy3.arn}"]
 }
 `

--- a/builtin/providers/aws/resource_aws_iam_user_policy_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_policy_attachment_test.go
@@ -114,7 +114,7 @@ EOF
 
 resource "aws_iam_user_policy_attachment" "test-attach" {
     user = "${aws_iam_user.user.name}"
-    policy_arn = "${aws_iam_policy.policy.arn}"
+    policy_arns = ["${aws_iam_policy.policy.arn}"]
 }
 `
 
@@ -182,11 +182,7 @@ EOF
 
 resource "aws_iam_user_policy_attachment" "test-attach" {
     user = "${aws_iam_user.user.name}"
-    policy_arn = "${aws_iam_policy.policy2.arn}"
-}
-
-resource "aws_iam_user_policy_attachment" "test-attach2" {
-    user = "${aws_iam_user.user.name}"
-    policy_arn = "${aws_iam_policy.policy3.arn}"
+    policy_arns = ["${aws_iam_policy.policy2.arn}",
+                   "${aws_iam_policy.policy3.arn}"]
 }
 `

--- a/website/source/docs/providers/aws/r/iam_group_policy_attachment.markdown
+++ b/website/source/docs/providers/aws/r/iam_group_policy_attachment.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_iam_group_policy_attachment"
 sidebar_current: "docs-aws-resource-iam-group-policy-attachment"
 description: |-
-  Attaches a Managed IAM Policy to an IAM group
+  Attaches Managed IAM Policies to an IAM group
 ---
 
 # aws\_iam\_group\_policy\_attachment
 
-Attaches a Managed IAM Policy to an IAM group
+Attaches Managed IAM Policies to an IAM group
 
 ```
 resource "aws_iam_group" "group" {
@@ -23,7 +23,7 @@ resource "aws_iam_policy" "policy" {
 
 resource "aws_iam_group_policy_attachment" "test-attach" {
     group = "${aws_iam_group.group.name}"
-    policy_arn = "${aws_iam_policy.policy.arn}"
+    policy_arns = ["${aws_iam_policy.policy.arn}"]
 }
 ```
 
@@ -32,4 +32,4 @@ resource "aws_iam_group_policy_attachment" "test-attach" {
 The following arguments are supported:
 
 * `group`		(Required) - The group the policy should be applied to
-* `policy_arn`	(Required) - The ARN of the policy you want to apply
+* `policy_arns`	(Required) - A list of ARNs of the policies you want to apply

--- a/website/source/docs/providers/aws/r/iam_role_policy_attachment.markdown
+++ b/website/source/docs/providers/aws/r/iam_role_policy_attachment.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_iam_role_policy_attachment"
 sidebar_current: "docs-aws-resource-iam-role-policy-attachment"
 description: |-
-  Attaches a Managed IAM Policy to an IAM role
+  Attaches Managed IAM Policies to an IAM role
 ---
 
 # aws\_iam\_role\_policy\_attachment
 
-Attaches a Managed IAM Policy to an IAM role
+Attaches Managed IAM Policies to an IAM role
 
 ```
 resource "aws_iam_role" "role" {
@@ -23,7 +23,7 @@ resource "aws_iam_policy" "policy" {
 
 resource "aws_iam_role_policy_attachment" "test-attach" {
     role = "${aws_iam_role.role.name}"
-    policy_arn = "${aws_iam_policy.policy.arn}"
+    policy_arns = ["${aws_iam_policy.policy.arn}"]
 }
 ```
 
@@ -32,4 +32,4 @@ resource "aws_iam_role_policy_attachment" "test-attach" {
 The following arguments are supported:
 
 * `role`		(Required) - The role the policy should be applied to
-* `policy_arn`	(Required) - The ARN of the policy you want to apply
+* `policy_arns`	(Required) - A list of ARNs of the policies you want to apply

--- a/website/source/docs/providers/aws/r/iam_user_policy_attachment.markdown
+++ b/website/source/docs/providers/aws/r/iam_user_policy_attachment.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_iam_user_policy_attachment"
 sidebar_current: "docs-aws-resource-iam-user-policy-attachment"
 description: |-
-  Attaches a Managed IAM Policy to an IAM user
+  Attaches Managed IAM Policies to an IAM user
 ---
 
 # aws\_iam\_user\_policy\_attachment
 
-Attaches a Managed IAM Policy to an IAM user
+Attaches Managed IAM Policies to an IAM user
 
 ```
 resource "aws_iam_user" "user" {
@@ -23,7 +23,7 @@ resource "aws_iam_policy" "policy" {
 
 resource "aws_iam_user_policy_attachment" "test-attach" {
     user = "${aws_iam_user.user.name}"
-    policy_arn = "${aws_iam_policy.policy.arn}"
+    policy_arns = ["${aws_iam_policy.policy.arn}"]
 }
 ```
 
@@ -32,4 +32,4 @@ resource "aws_iam_user_policy_attachment" "test-attach" {
 The following arguments are supported:
 
 * `user`		(Required) - The user the policy should be applied to
-* `policy_arn`	(Required) - The ARN of the policy you want to apply
+* `policy_arns`	(Required) - A list of ARNs of the policies you want to apply


### PR DESCRIPTION
This alters the following resources:
- aws_iam_user_policy_attachment
- aws_iam_group_policy_attachment
- aws_iam_role_policy_attachment

to accept a list of policy ARNs (rather than a single policy) to be attached to an IAM user, group, or role.

Although this change is not backwards compatible for this resource, it simplifies configuration in cases where iam_policy_attachment is too restrictive and can't be used. It is also a more accurate reflection of what is happening in IAM when we want to reason about the policies associated with a specific user, group, or role rather than vice versa; see https://github.com/hashicorp/terraform/issues/5483#issuecomment-210290005.
