### PR TITLE
provider/azurerm: arm_virtual_machine diagnostics_profile was causing a panic on the Read func

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -1254,6 +1254,11 @@ resource "azurerm_virtual_machine" "test" {
 	admin_password = "Password1234!"
     }
 
+    boot_diagnostics {
+        enabled = true
+        storage_uri = "${azurerm_storage_account.test.primary_blob_endpoint}"
+    }
+
     os_profile_windows_config {
         winrm {
 	  protocol = "http"

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -207,7 +207,7 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 * `plan` - (Optional) A plan block as documented below.
 * `availability_set_id` - (Optional) The Id of the Availability Set in which to create the virtual machine
-* `diagnostics_profile` - (Optional) A Diagnostics Profile block as referenced below.
+* `boot_diagnostics` - (Optional) A boot diagnostics profile block as referenced below.
 * `vm_size` - (Required) Specifies the [size of the virtual machine](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-size-specs/).
 * `storage_image_reference` - (Optional) A Storage Image Reference block as documented below.
 * `storage_os_disk` - (Required) A Storage OS Disk block as referenced below.
@@ -228,10 +228,6 @@ For more information on the different example configurations, please check out t
 * `name` - (Required) Specifies the name of the image from the marketplace.
 * `publisher` - (Optional) Specifies the publisher of the image.
 * `product` - (Optional) Specifies the product of the image from the marketplace.
-
-`diagnostics_profile` supports the following:
-
-* `boot_diagnostics`: (Required) A Boot Diagnostics block as documented below.
 
 `boot_diagnostics` supports the following:
 


### PR DESCRIPTION
Fixes #8995

The Diagnostics profile was a badly laid out resource. All we needed to
set was whether it was enabled and the storage account to save the logs
to. The old schema parameter was deprecated and replaced with a much
simplier structure

```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMVirtualMachine_diagnosticsProfile'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/29 12:21:04 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMVirtualMachine_diagnosticsProfile -timeout 120m
=== RUN   TestAccAzureRMVirtualMachine_diagnosticsProfile
--- PASS: TestAccAzureRMVirtualMachine_diagnosticsProfile (1066.76s)
PASS
ok
github.com/hashicorp/terraform/builtin/providers/azurerm1066.776s
```