### PR TITLE
provider/aws: aws_route53_record alias refresh manually updated record

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -374,15 +374,14 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if alias := record.AliasTarget; alias != nil {
-		if _, ok := d.GetOk("alias"); !ok {
-			d.Set("alias", []interface{}{
-				map[string]interface{}{
-					"zone_id": *alias.HostedZoneId,
-					"name":    *alias.DNSName,
-					"evaluate_target_health": *alias.EvaluateTargetHealth,
-				},
-			})
-		}
+		name := strings.TrimSuffix(*alias.DNSName, ".")
+		d.Set("alias", []interface{}{
+			map[string]interface{}{
+				"zone_id": *alias.HostedZoneId,
+				"name":    name,
+				"evaluate_target_health": *alias.EvaluateTargetHealth,
+			},
+		})
 	}
 
 	d.Set("ttl", record.TTL)


### PR DESCRIPTION
Fixes #9108

When an aws_route53_record alias is created with terraform and then
modified via cli or console, terraform wasn't picking up the changes. I
had the following config:

```
resource "aws_route53_record" "alias" {
  zone_id = "${aws_route53_zone.main.zone_id}"
  name = "www"
  type = "A"

  alias {
  	zone_id = "${aws_elb.main.zone_id}"
  	name = "${aws_elb.main.dns_name}"
  	evaluate_target_health = true
  }
}
```

I changed the evaluate_health_target on the AWS console and terraform plan showed me this:

```
% terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

aws_route53_zone.main: Refreshing state... (ID: Z32Z9B1UPAIP6X)
aws_elb.main: Refreshing state... (ID: foobar-terraform-elb-1111)
aws_route53_record.alias: Refreshing state... (ID: Z32Z9B1UPAIP6X_www_A)

No changes. Infrastructure is up-to-date. This means that Terraform
could not detect any differences between your configuration and
the real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```

When rebuilding the provider with the changes in the PR, a terraform plan then looks as follows:

```
% terraform plan
[WARN] /Users/stacko/Code/go/bin/terraform-provider-aws overrides an internal plugin for aws-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
[WARN] /Users/stacko/Code/go/bin/terraform-provider-azurerm overrides an internal plugin for azurerm-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

aws_route53_zone.main: Refreshing state... (ID: Z32Z9B1UPAIP6X)
aws_elb.main: Refreshing state... (ID: foobar-terraform-elb-1111)
aws_route53_record.alias: Refreshing state... (ID: Z32Z9B1UPAIP6X_www_A)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

~ aws_route53_record.alias
    alias.1050468691.evaluate_target_health: "" => "true"
    alias.1050468691.name:                   "" => "foobar-terraform-elb-1111-522021794.us-west-2.elb.amazonaws.com"
    alias.1050468691.zone_id:                "" => "Z1H1FL5HABSF5"
    alias.2906616344.evaluate_target_health: "false" => "false"
    alias.2906616344.name:                   "foobar-terraform-elb-1111-522021794.us-west-2.elb.amazonaws.com." => ""
    alias.2906616344.zone_id:                "Z1H1FL5HABSF5" => ""

Plan: 0 to add, 1 to change, 0 to destroy.
```

the apply then changed the target back to true