### PR TITLE
provisioner/chef: Add ability to skip chef registration

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -103,6 +103,7 @@ type Provisioner struct {
 	SecretKey             string   `mapstructure:"secret_key"`
 	ServerURL             string   `mapstructure:"server_url"`
 	SkipInstall           bool     `mapstructure:"skip_install"`
+	SkipRegister          bool     `mapstructure:"skip_register"`
 	SSLVerifyMode         string   `mapstructure:"ssl_verify_mode"`
 	UserName              string   `mapstructure:"user_name"`
 	UserKey               string   `mapstructure:"user_key"`
@@ -210,16 +211,18 @@ func (r *ResourceProvisioner) Apply(
 		return err
 	}
 
-	if p.FetchChefCertificates {
-		o.Output("Fetch Chef certificates...")
-		if err := p.fetchChefCertificates(o, comm); err != nil {
+	if !p.SkipRegister {
+		if p.FetchChefCertificates {
+			o.Output("Fetch Chef certificates...")
+			if err := p.fetchChefCertificates(o, comm); err != nil {
+				return err
+			}
+		}
+
+		o.Output("Generate the private key...")
+		if err := p.generateClientKey(o, comm); err != nil {
 			return err
 		}
-	}
-
-	o.Output("Generate the private key...")
-	if err := p.generateClientKey(o, comm); err != nil {
-		return err
 	}
 
 	if p.VaultJSON != "" {

--- a/website/source/docs/provisioners/chef.html.markdown
+++ b/website/source/docs/provisioners/chef.html.markdown
@@ -115,13 +115,17 @@ The following arguments are supported:
   machine. This assumes Chef Client is already installed when you run the `chef`
   provisioner.
 
+* `skip_register (boolean)` - (Optional) Skip the registration of Chef Client on the remote
+  machine. This assumes Chef Client is already registered when you run the `chef`
+  provisioner.
+
 * `ssl_verify_mode (string)` - (Optional) Use to set the verify mode for Chef Client HTTPS
   requests.
 
 * `user_name (string)` - (Required) The name of an existing Chef user to use for registering
   the new Chef Client and (optionally) configure Chef Vaults.
 
-* `user_key (string)` - (Required) The contents of the user key that will be used to 
+* `user_key (string)` - (Required) The contents of the user key that will be used to
   authenticate with the Chef Server. This can be loaded from a file on disk using the [`file()`
   interpolation function](/docs/configuration/interpolation.html#file_path_).
 


### PR DESCRIPTION
This change allows a user to skip the bootstrap stage for a machine.

A machine might self register on boot for use outside of terraform. In this case we don't want to recreate the client but just skip the registration as this is done already.