### PR TITLE
Make dnsimple_records importable

### DIFF
--- a/builtin/providers/dnsimple/import_dnsimple_record_test.go
+++ b/builtin/providers/dnsimple/import_dnsimple_record_test.go
@@ -1,0 +1,41 @@
+package dnsimple
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDnsimpleRecord_import(t *testing.T) {
+	resourceName := "dnsimple_record.foobar"
+	domain := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_import, domain),
+			},
+			resource.TestStep{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s_", domain),
+			},
+		},
+	})
+}
+
+const testAccCheckDNSimpleRecordConfig_import = `
+resource "dnsimple_record" "foobar" {
+	domain = "%s"
+
+	name = "terraform"
+	value = "192.168.0.10"
+	type = "A"
+	ttl = 3600
+}`

--- a/builtin/providers/dnsimple/resource_dnsimple_record.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record.go
@@ -16,6 +16,9 @@ func resourceDNSimpleRecord() *schema.Resource {
 		Read:   resourceDNSimpleRecordRead,
 		Update: resourceDNSimpleRecordUpdate,
 		Delete: resourceDNSimpleRecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDNSimpleRecordImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"domain": {
@@ -183,4 +186,20 @@ func resourceDNSimpleRecordDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	return nil
+}
+
+func resourceDNSimpleRecordImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "_")
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Error Importing dnsimple_record. Please make sure the record ID is in the form DOMAIN_RECORDID (i.e. example.com_1234")
+	}
+
+	d.SetId(parts[1])
+	d.Set("domain", parts[0])
+
+	if err := resourceDNSimpleRecordRead(d, meta); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/source/docs/providers/dnsimple/r/record.html.markdown
+++ b/website/source/docs/providers/dnsimple/r/record.html.markdown
@@ -58,3 +58,13 @@ The following attributes are exported:
 * `priority` - The priority of the record
 * `domain_id` - The domain ID of the record
 * `hostname` - The FQDN of the record
+
+## Import
+
+DNSimple resources can be imported using their domain name and numeric ID, e.g.
+
+```
+$ terraform import dnsimple_record.resource_name example.com_1234
+```
+
+The numeric ID can be found in the URL when editing a record on the dnsimple web dashboard.


### PR DESCRIPTION
This makes the `dnsimple_record` resource importable.

Unfortunately, the DNSimple v2 API requires a domain name and record ID to fetch a record, so the import command accepts both pieces of data as an underscore delimited string like so:

```
terraform import dnsimple_record.test example.com_1234
terraform import module.foo.dnsimple_record.test example.com_1234
```
The underscore delimited approach is very similar to the one used to import an  [aws_route53_record resource](https://www.terraform.io/docs/providers/aws/r/route53_record.html).

The numeric resource ID is visible in the URL when editing a record on the dnsimple dashboard (ie. the `1234` in https://dnsimple.com/a/xxx/domains/example.com/records/1234/edit