### PR TITLE
deps: Update github.com/jen20/awspolicyequivalence

### DIFF
--- a/vendor/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go
+++ b/vendor/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go
@@ -1,8 +1,9 @@
 package awspolicy
 
 import (
-	"reflect"
 	"encoding/json"
+	"reflect"
+	"strings"
 
 	"github.com/hashicorp/errwrap"
 )
@@ -104,7 +105,7 @@ func (statement *awsPolicyStatement) equals(other *awsPolicyStatement) bool {
 		return false
 	}
 
-	if statement.Effect != other.Effect {
+	if strings.ToLower(statement.Effect) != strings.ToLower(other.Effect) {
 		return false
 	}
 
@@ -164,7 +165,7 @@ func mapPrincipalsEqual(ours, theirs interface{}) bool {
 	}
 
 	theirPrincipalMap, ok := theirs.(map[string]interface{})
-	if ! ok {
+	if !ok {
 		return false
 	}
 
@@ -218,7 +219,6 @@ func stringPrincipalsEqual(ours, theirs interface{}) bool {
 	return false
 }
 
-
 type awsConditionsBlock map[string]map[string]interface{}
 
 func (conditions awsConditionsBlock) Equals(other awsConditionsBlock) bool {
@@ -256,7 +256,7 @@ func (conditions awsConditionsBlock) Equals(other awsConditionsBlock) bool {
 
 		for innerKey, oursInner := range ours {
 			theirsInner, ok := theirs[innerKey]
-			if ! ok {
+			if !ok {
 				return false
 			}
 
@@ -274,7 +274,7 @@ func (conditions awsConditionsBlock) Equals(other awsConditionsBlock) bool {
 
 		for innerKey, theirsInner := range theirs {
 			oursInner, ok := ours[innerKey]
-			if ! ok {
+			if !ok {
 				return false
 			}
 
@@ -286,7 +286,6 @@ func (conditions awsConditionsBlock) Equals(other awsConditionsBlock) bool {
 
 	return true
 }
-
 
 type awsStringSet []string
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1291,10 +1291,10 @@
 			"revision": "f233a8bac88d1f2dc282a98186f5a3363b806181"
 		},
 		{
-			"checksumSHA1": "cCSJGF1h+suYcgMq7wEm1carknw=",
+			"checksumSHA1": "zyyyjWKu9gGLFy00k8utV7pncvg=",
 			"path": "github.com/jen20/awspolicyequivalence",
-			"revision": "6b9230008577fc3dcd10c104ce8fb16ed679bf66",
-			"revisionTime": "2016-09-01T18:24:20Z"
+			"revision": "ebe5485f2c1822e7bee8b5008e14d9481a14a3a3",
+			"revisionTime": "2016-09-29T21:48:42Z"
 		},
 		{
 			"checksumSHA1": "oPpOfZn11Ef6DWOoETxSW9Venzs=",


### PR DESCRIPTION
This fixes a bug in the upstream library where different casing of `effect` values were not treated as equivalent.