### PR TITLE
provider/aws: Support Import of AWS elasticache_replication_groups

### DIFF
--- a/builtin/providers/aws/import_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/import_aws_elasticache_replication_group_test.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSElasticacheReplicationGroup_importBasic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	name := acctest.RandString(10)
+
+	resourceName := "aws_elasticache_replication_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheReplicationGroupConfig(name),
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"}, //not in the API
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -57,6 +57,9 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		Read:   resourceAwsElasticacheReplicationGroupRead,
 		Update: resourceAwsElasticacheReplicationGroupUpdate,
 		Delete: resourceAwsElasticacheReplicationGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: resourceSchema,
 	}
@@ -192,7 +195,17 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		return nil
 	}
 
-	d.Set("automatic_failover_enabled", rgp.AutomaticFailover)
+	if rgp.AutomaticFailover != nil {
+		switch strings.ToLower(*rgp.AutomaticFailover) {
+		case "disabled", "disabling":
+			d.Set("automatic_failover_enabled", false)
+		case "enabled", "enabling":
+			d.Set("automatic_failover_enabled", true)
+		default:
+			log.Printf("Unknown AutomaticFailover state %s", *rgp.AutomaticFailover)
+		}
+	}
+
 	d.Set("replication_group_description", rgp.Description)
 	d.Set("number_cache_clusters", len(rgp.MemberClusters))
 	d.Set("replication_group_id", rgp.ReplicationGroupId)
@@ -217,15 +230,16 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		d.Set("engine", c.Engine)
 		d.Set("engine_version", c.EngineVersion)
 		d.Set("subnet_group_name", c.CacheSubnetGroupName)
-		d.Set("security_group_names", c.CacheSecurityGroups)
-		d.Set("security_group_ids", c.SecurityGroups)
-		d.Set("parameter_group_name", c.CacheParameterGroup)
+		d.Set("security_group_names", flattenElastiCacheSecurityGroupNames(c.CacheSecurityGroups))
+		d.Set("security_group_ids", flattenElastiCacheSecurityGroupIds(c.SecurityGroups))
+		if c.CacheParameterGroup != nil {
+			d.Set("parameter_group_name", c.CacheParameterGroup.CacheParameterGroupName)
+		}
 		d.Set("maintenance_window", c.PreferredMaintenanceWindow)
 		d.Set("snapshot_window", c.SnapshotWindow)
 		d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
-
+		d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
-
 	}
 
 	return nil

--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -69,3 +69,11 @@ The following attributes are exported:
 
 * `id` - The ID of the ElastiCache Replication Group
 * `primary_endpoint_address` - The address of the endpoint for the primary node in the replication group
+
+## Import
+
+ElastiCache Replication Groups can be imported using the `replication_group_id`, e.g.
+
+```
+$ terraform import aws_elasticache_replication_group.my_replication_group replication-group-1
+```


### PR DESCRIPTION
Fixes #9094

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/30 00:09:04 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSElasticacheReplicationGroup_importBasic -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_importBasic
--- PASS: TestAccAWSElasticacheReplicationGroup_importBasic (756.38s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws756.398s
```