### PR TITLE
provider/azurerm: add servicebus_topic resource

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -69,6 +69,7 @@ type ArmClient struct {
 	trafficManagerEndpointsClient trafficmanager.EndpointsClient
 
 	serviceBusNamespacesClient servicebus.NamespacesClient
+	serviceBusTopicsClient     servicebus.TopicsClient
 }
 
 func withRequestLogging() autorest.SendDecorator {
@@ -351,6 +352,12 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	sbnc.Authorizer = spt
 	sbnc.Sender = autorest.CreateSender(withRequestLogging())
 	client.serviceBusNamespacesClient = sbnc
+
+	sbtc := servicebus.NewTopicsClient(c.SubscriptionID)
+	setUserAgent(&sbtc.Client)
+	sbtc.Authorizer = spt
+	sbtc.Sender = autorest.CreateSender(withRequestLogging())
+	client.serviceBusTopicsClient = sbtc
 
 	return &client, nil
 }

--- a/builtin/providers/azurerm/import_arm_servicebus_topic_test.go
+++ b/builtin/providers/azurerm/import_arm_servicebus_topic_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMServiceBusTopic_importBasic(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -57,6 +57,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_route":                     resourceArmRoute(),
 			"azurerm_route_table":               resourceArmRouteTable(),
 			"azurerm_servicebus_namespace":      resourceArmServiceBusNamespace(),
+			"azurerm_servicebus_topic":          resourceArmServiceBusTopic(),
 			"azurerm_storage_account":           resourceArmStorageAccount(),
 			"azurerm_storage_blob":              resourceArmStorageBlob(),
 			"azurerm_storage_container":         resourceArmStorageContainer(),

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic.go
@@ -1,0 +1,223 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/arm/servicebus"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmServiceBusTopic() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmServiceBusTopicCreate,
+		Read:   resourceArmServiceBusTopicRead,
+		Update: resourceArmServiceBusTopicCreate,
+		Delete: resourceArmServiceBusTopicDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"namespace_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"auto_delete_on_idle": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"default_message_ttl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"duplicate_detection_history_time_window": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"enable_batched_operations": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"enable_express": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"enable_filtering_messages_before_publishing": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"enable_partitioning": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"max_size_in_megabytes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"requires_duplicate_detection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"support_ordering": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceArmServiceBusTopicCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).serviceBusTopicsClient
+	log.Printf("[INFO] preparing arguments for Azure ARM ServiceBus Topic creation.")
+
+	name := d.Get("name").(string)
+	namespaceName := d.Get("namespace_name").(string)
+	location := d.Get("location").(string)
+	resGroup := d.Get("resource_group_name").(string)
+
+	parameters := servicebus.TopicCreateOrUpdateParameters{
+		Name:       &name,
+		Location:   &location,
+		Properties: &servicebus.TopicProperties{},
+	}
+
+	if autoDeleteOnIdle := d.Get("auto_delete_on_idle").(string); autoDeleteOnIdle != "" {
+		parameters.Properties.AutoDeleteOnIdle = &autoDeleteOnIdle
+	}
+
+	if defaultTTL := d.Get("default_message_ttl").(string); defaultTTL != "" {
+		parameters.Properties.DefaultMessageTimeToLive = &defaultTTL
+	}
+
+	if duplicateWindow := d.Get("duplicate_detection_history_time_window").(string); duplicateWindow != "" {
+		parameters.Properties.DuplicateDetectionHistoryTimeWindow = &duplicateWindow
+	}
+
+	enableBatchedOps := d.Get("enable_batched_operations").(bool)
+	enableExpress := d.Get("enable_express").(bool)
+	enableFiltering := d.Get("enable_filtering_messages_before_publishing").(bool)
+	enablePartitioning := d.Get("enable_partitioning").(bool)
+	maxSize := int64(d.Get("max_size_in_megabytes").(int))
+	requiresDuplicateDetection := d.Get("requires_duplicate_detection").(bool)
+	supportOrdering := d.Get("support_ordering").(bool)
+
+	parameters.Properties.EnableBatchedOperations = &enableBatchedOps
+	parameters.Properties.EnableExpress = &enableExpress
+	parameters.Properties.FilteringMessagesBeforePublishing = &enableFiltering
+	parameters.Properties.EnablePartitioning = &enablePartitioning
+	parameters.Properties.MaxSizeInMegabytes = &maxSize
+	parameters.Properties.RequiresDuplicateDetection = &requiresDuplicateDetection
+	parameters.Properties.SupportOrdering = &supportOrdering
+
+	_, err := client.CreateOrUpdate(resGroup, namespaceName, name, parameters)
+	if err != nil {
+		return err
+	}
+
+	read, err := client.Get(resGroup, namespaceName, name)
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read ServiceBus Topic %s (resource group %s) ID", name, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmServiceBusTopicRead(d, meta)
+}
+
+func resourceArmServiceBusTopicRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).serviceBusTopicsClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	namespaceName := id.Path["namespaces"]
+	name := id.Path["topics"]
+
+	resp, err := client.Get(resGroup, namespaceName, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure ServiceBus Topic %s: %s", name, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("namespace_name", namespaceName)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+
+	props := resp.Properties
+	d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)
+	d.Set("default_message_ttl", props.DefaultMessageTimeToLive)
+
+	if props.DuplicateDetectionHistoryTimeWindow != nil && *props.DuplicateDetectionHistoryTimeWindow != "" {
+		d.Set("duplicate_detection_history_time_window", props.DuplicateDetectionHistoryTimeWindow)
+	}
+
+	d.Set("enable_batched_operations", props.EnableBatchedOperations)
+	d.Set("enable_express", props.EnableExpress)
+	d.Set("enable_filtering_messages_before_publishing", props.FilteringMessagesBeforePublishing)
+	d.Set("enable_partitioning", props.EnablePartitioning)
+	d.Set("max_size_in_megabytes", int(*props.MaxSizeInMegabytes))
+	d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
+	d.Set("support_ordering", props.SupportOrdering)
+
+	return nil
+}
+
+func resourceArmServiceBusTopicDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).serviceBusTopicsClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	namespaceName := id.Path["namespaces"]
+	name := id.Path["topics"]
+
+	_, err = client.Delete(resGroup, namespaceName, name)
+
+	return err
+}

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
@@ -1,0 +1,161 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_update, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+				),
+			},
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"azurerm_servicebus_topic.test", "enable_batched_operations", "true"),
+					resource.TestCheckResourceAttr(
+						"azurerm_servicebus_topic.test", "enable_express", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMServiceBusTopicDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ArmClient).serviceBusTopicsClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_servicebus_topic" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		namespaceName := rs.Primary.Attributes["namespace_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := client.Get(resourceGroup, namespaceName, name)
+		if err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				return nil
+			}
+			return err
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("ServiceBus Topic still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+func testCheckAzureRMServiceBusTopicExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		topicName := rs.Primary.Attributes["name"]
+		namespaceName := rs.Primary.Attributes["namespace_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for topic: %s", topicName)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).serviceBusTopicsClient
+
+		resp, err := client.Get(resourceGroup, namespaceName, topicName)
+		if err != nil {
+			return fmt.Errorf("Bad: Get on serviceBusTopicsClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Topic %q (resource group: %q) does not exist", namespaceName, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+var testAccAzureRMServiceBusTopic_basic = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+    name = "acctestservicebusnamespace-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+    name = "acctestservicebustopic-%d"
+    location = "West US"
+    namespace_name = "${azurerm_servicebus_namespace.test.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`
+
+var testAccAzureRMServiceBusTopic_update = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+    name = "acctestservicebusnamespace-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+    name = "acctestservicebustopic-%d"
+    location = "West US"
+    namespace_name = "${azurerm_servicebus_namespace.test.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    enable_batched_operations = true
+    enable_express = true
+}
+`

--- a/vendor/github.com/Azure/go-autorest/autorest/date/time.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/time.go
@@ -1,12 +1,16 @@
 package date
 
 import (
+	"strings"
 	"time"
 )
 
+// Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
 const (
-	rfc3339JSON = `"` + time.RFC3339Nano + `"`
-	rfc3339     = time.RFC3339Nano
+	azureUtcFormatJSON = `"2006-01-02T15:04:05.999999999"`
+	azureUtcFormat     = "2006-01-02T15:04:05.999999999"
+	rfc3339JSON        = `"` + time.RFC3339Nano + `"`
+	rfc3339            = time.RFC3339Nano
 )
 
 // Time defines a type similar to time.Time but assumes a layout of RFC3339 date-time (i.e.,
@@ -36,7 +40,12 @@ func (t Time) MarshalJSON() (json []byte, err error) {
 // UnmarshalJSON reconstitutes the Time from a JSON string conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalJSON(data []byte) (err error) {
-	t.Time, err = ParseTime(rfc3339JSON, string(data))
+	stringData := string(data)
+	timeFormat := azureUtcFormatJSON
+	if strings.IndexAny(stringData, "Zz") > -1 {
+		timeFormat = rfc3339JSON
+	}
+	t.Time, err = ParseTime(timeFormat, stringData)
 	return err
 }
 
@@ -49,7 +58,12 @@ func (t Time) MarshalText() (text []byte, err error) {
 // UnmarshalText reconstitutes a Time saved as a byte array conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalText(data []byte) (err error) {
-	t.Time, err = ParseTime(rfc3339, string(data))
+	stringData := string(data)
+	timeFormat := azureUtcFormat
+	if strings.IndexAny(stringData, "Zz") > -1 {
+		timeFormat = rfc3339
+	}
+	t.Time, err = ParseTime(timeFormat, stringData)
 	return err
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,8 +6,8 @@
 			"checksumSHA1": "5FXJC6+oMCYl8sij1fa3mkHJefs=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/cdn",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -15,8 +15,8 @@
 			"checksumSHA1": "L584obqdMyoxf+nJCYpvSd2ES7g=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/compute",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -24,8 +24,8 @@
 			"checksumSHA1": "WjYcsax85SzuHBfuQe/b7jYLrI4=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/network",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -33,8 +33,8 @@
 			"checksumSHA1": "IDsbbd9jDoH5aNqcvCp0mJAHWkw=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/resources/resources",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -42,16 +42,16 @@
 			"checksumSHA1": "FmCejoSUVUSP++xqGYMuD7xSov0=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/scheduler",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "cZIBlFsR4SYA5hKbta4jazmT2YQ=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/servicebus",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -59,16 +59,16 @@
 			"checksumSHA1": "IbhYdKi3/52yodSVkJiy640neJc=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/storage",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
 		{
 			"checksumSHA1": "/C4ILtBEhZ1iXcH0+ObtvVSqRig=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/trafficmanager",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -76,8 +76,8 @@
 			"checksumSHA1": "+YUbdDgrxVZAyjcps6X2gB8BT+I=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -85,8 +85,8 @@
 			"checksumSHA1": "TcQ6KXoBkvUhCYeggJ/bwcz+QaQ=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/affinitygroup",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -94,8 +94,8 @@
 			"checksumSHA1": "HfjyhRfmKBsVgWLTOfWVcxe8Z88=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/hostedservice",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -103,8 +103,8 @@
 			"checksumSHA1": "4otMhU6xZ41HfmiGZFYtV93GdcI=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/location",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -112,8 +112,8 @@
 			"checksumSHA1": "hxivwm3D13cqFGOlOS3q8HD7DN0=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/networksecuritygroup",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -121,8 +121,8 @@
 			"checksumSHA1": "XzrPv8SWFBYdh5oie+NGysqnLIM=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/osimage",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -130,8 +130,8 @@
 			"checksumSHA1": "hzwziaU5QlMlFcFPdbEmW18oV3Y=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/sql",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -139,8 +139,8 @@
 			"checksumSHA1": "YoAhDE0X6hSFuPpXbpfqcTC0Zvw=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/storageservice",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -148,8 +148,8 @@
 			"checksumSHA1": "6xEiZL4a9rr5YbnY0RdzuzhEF1Q=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualmachine",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -157,8 +157,8 @@
 			"checksumSHA1": "xcBM3zQtfcE3VHNBACJJGEesCBI=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualmachinedisk",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -166,8 +166,8 @@
 			"checksumSHA1": "0bfdkDZ2JFV7bol6GQFfC0g+lP4=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualmachineimage",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -175,8 +175,8 @@
 			"checksumSHA1": "IhjDqm84VDVSIoHyiGvUzuljG3s=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/virtualnetwork",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -184,8 +184,8 @@
 			"checksumSHA1": "+ykSkHo40/f6VK6/zXDqzF8Lh14=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/management/vmutils",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -193,8 +193,8 @@
 			"checksumSHA1": "T1DpzOaZGsKlUq16elkdwF6ddsU=",
 			"comment": "v2.1.1-beta-8-gca4d906",
 			"path": "github.com/Azure/azure-sdk-for-go/storage",
-			"revision": "63d3f3e3b12ffb726ba3f72fef1aa8c1c7cd1012",
-			"revisionTime": "2016-09-12T22:19:52Z",
+			"revision": "5dbdd3e002c0c232938bf953a5e7fa9a58ee749e",
+			"revisionTime": "2016-09-27T20:53:54Z",
 			"version": "v3.2.0-beta",
 			"versionExact": "v3.2.0-beta"
 		},
@@ -202,43 +202,35 @@
 			"checksumSHA1": "eVSHe6GIHj9/ziFrQLZ1SC7Nn6k=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest",
-			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
-			"revisionTime": "2016-08-11T21:24:34Z",
-			"version": "v7.1.0",
-			"versionExact": "v7.1.0"
+			"revision": "928711bfb9b6bc052ea85a8f4e1d8f4e1bf55f95",
+			"revisionTime": "2016-09-27T17:55:41Z"
 		},
 		{
 			"checksumSHA1": "z8FwqeLK0Pluo7FYC5k2MVBoils=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest/azure",
-			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
-			"revisionTime": "2016-08-11T21:24:34Z",
-			"version": "v7.1.0",
-			"versionExact": "v7.1.0"
+			"revision": "928711bfb9b6bc052ea85a8f4e1d8f4e1bf55f95",
+			"revisionTime": "2016-09-27T17:55:41Z"
 		},
 		{
-			"checksumSHA1": "q4bSpJ5t571H3ny1PwIgTn6g75E=",
+			"checksumSHA1": "euBLq6AtwLOQUJfDf1dyR+0nQfU=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest/date",
-			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
-			"revisionTime": "2016-08-11T21:24:34Z",
-			"version": "v7.1.0",
-			"versionExact": "v7.1.0"
+			"revision": "928711bfb9b6bc052ea85a8f4e1d8f4e1bf55f95",
+			"revisionTime": "2016-09-27T17:55:41Z"
 		},
 		{
 			"checksumSHA1": "Ev8qCsbFjDlMlX0N2tYAhYQFpUc=",
 			"comment": "v7.0.5",
 			"path": "github.com/Azure/go-autorest/autorest/to",
-			"revision": "f0b1c4ee355163629bf0d9d52b7bef1d238f3426",
-			"revisionTime": "2016-08-11T21:24:34Z",
-			"version": "v7.1.0",
-			"versionExact": "v7.1.0"
+			"revision": "928711bfb9b6bc052ea85a8f4e1d8f4e1bf55f95",
+			"revisionTime": "2016-09-27T17:55:41Z"
 		},
 		{
 			"checksumSHA1": "oBixceM+55gdk47iff8DSEIh3po=",
 			"path": "github.com/Azure/go-autorest/autorest/validation",
-			"revision": "3a30515cff8ca0504593132b55cd9e5aa2136f74",
-			"revisionTime": "2016-08-31T20:22:12Z"
+			"revision": "928711bfb9b6bc052ea85a8f4e1d8f4e1bf55f95",
+			"revisionTime": "2016-09-27T17:55:41Z"
 		},
 		{
 			"comment": "0.0.2-27-gedd0930",

--- a/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
@@ -1,0 +1,104 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_servicebus_topic"
+sidebar_current: "docs-azurerm-resource-servicebus-topic"
+description: |-
+  Create a ServiceBus Topic.
+---
+
+# azurerm\_servicebus\_topic
+
+Create a ServiceBus Topic.
+
+**Note** Topics can only be created in Namespaces with an SKU or `standard` or
+higher.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "resourceGroup1"
+    location = "West US"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+    name = "acceptanceTestServiceBusNamespace"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "standard"
+
+    tags {
+        environment = "Production"
+    }
+}
+
+resource "azurerm_servicebus_topic" "test" {
+    name = "testTopic"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    namespace_name = "${azurerm_servicebus_namespace.test.name}"
+
+    enable_partitioning = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the ServiceBus Topic resource. Changing this forces a
+    new resource to be created.
+
+* `namespace_name` - (Required) The name of the ServiceBus Namespace to create
+    this topic in. Changing this forces a new resource to be created.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+    Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the namespace. Changing this forces a new resource to be created.
+
+* `auto_delete_on_idle` - (Optional) The idle interval after which the
+    Topic is automatically deleted, minimum of 5 minutes. Provided in the [TimeSpan](#timespan-format)
+    format.
+
+* `default_message_ttl` - (Optional) The TTL of messages sent to this topic if no
+    TTL value is set on the message itself. Provided in the [TimeSpan](#timespan-format)
+    format.
+
+* `duplicate_detection_history_time_window` - (Optional) The duration during which
+    duplicates can be detected. Provided in the [TimeSpan](#timespan-format) format.
+
+* `enable_batched_operations` - (Optional) Boolean flag which controls if server-side
+    batched operations are enabled. Defaults to false.
+
+* `enable_express` - (Optional) Boolean flag which controls whether Express Entities
+    are enabled. An express topic holds a message in memory temporarily before writing
+    it to persistent storage. Defaults to false.
+
+* `enable_filtering_messages_before_publishing` - (Optional) Boolean flag which
+    controls whether messages should be filtered before publishing. Defaults to
+    false.
+
+* `enable_partitioning` - (Optional) Boolean flag which controls whether to enable
+    the topic to be partitioned across multiple message brokers. Defaults to false.
+
+* `max_size_in_megabytes` - (Optional) Integer value which controls the size of
+    memory allocated for the topic.
+
+* `requires_duplicate_detection` - (Optional) Boolean flag which controls whether
+    the Topic requires duplicate detection. Defaults to false.
+
+* `support_ordering` - (Optional) Boolean flag which controls whether the Topic
+    supports ordering. Defaults to false.
+
+### TimeSpan Format
+
+Some arguments for this resource are required in the TimeSpan format which is
+used to represent a lengh of time. The supported format is documented [here](https://msdn.microsoft.com/en-us/library/se73z7b9(v=vs.110).aspx#Anchor_2)
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ServiceBus Topic ID.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -144,6 +144,10 @@
                 <li<%= sidebar_current("docs-azurerm-resource-servicebus-namespace") %>>
                   <a href="/docs/providers/azurerm/r/servicebus_namespace.html">azurerm_servicebus_namespace</a>
                 </li>
+
+                <li<%= sidebar_current("docs-azurerm-resource-servicebus-topic") %>>
+                  <a href="/docs/providers/azurerm/r/servicebus_topic.html">azurerm_servicebus_topic</a>
+                </li>
               </ul>
             </li>
 


### PR DESCRIPTION
Includes a small bump of SDK version to pull in go-autorest time parsing fix.

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMServiceBusTopic -timeout 120m
=== RUN   TestAccAzureRMServiceBusTopic_importBasic
--- PASS: TestAccAzureRMServiceBusTopic_importBasic (328.72s)
=== RUN   TestAccAzureRMServiceBusTopic_basic
--- PASS: TestAccAzureRMServiceBusTopic_basic (331.04s)
=== RUN   TestAccAzureRMServiceBusTopic_update
--- PASS: TestAccAzureRMServiceBusTopic_update (348.69s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	1008.588s
```