### PR TITLE
provider/azurerm: fix resource ID parsing for subscriptions resources

### DIFF
--- a/builtin/providers/azurerm/resourceid.go
+++ b/builtin/providers/azurerm/resourceid.go
@@ -45,22 +45,29 @@ func parseAzureResourceID(id string) (*ResourceID, error) {
 		return nil, fmt.Errorf("The number of path segments is not divisible by 2 in %q", path)
 	}
 
+	var subscriptionID string
+
 	// Put the constituent key-value pairs into a map
 	componentMap := make(map[string]string, len(components)/2)
 	for current := 0; current < len(components); current += 2 {
 		key := components[current]
 		value := components[current+1]
 
-		componentMap[key] = value
+		// Catch the subscriptionID before it can be overwritten by another "subscriptions"
+		// value in the ID which is the case for the Service Bus subscription resource
+		if key == "subscriptions" && subscriptionID == "" {
+			subscriptionID = value
+		} else {
+			componentMap[key] = value
+		}
 	}
 
 	// Build up a ResourceID from the map
 	idObj := &ResourceID{}
 	idObj.Path = componentMap
 
-	if subscription, ok := componentMap["subscriptions"]; ok {
-		idObj.SubscriptionID = subscription
-		delete(componentMap, "subscriptions")
+	if subscriptionID != "" {
+		idObj.SubscriptionID = subscriptionID
 	} else {
 		return nil, fmt.Errorf("No subscription ID found in: %q", path)
 	}

--- a/builtin/providers/azurerm/resourceid_test.go
+++ b/builtin/providers/azurerm/resourceid_test.go
@@ -101,6 +101,20 @@ func TestParseAzureResourceID(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourceGroups/testGroup1/providers/Microsoft.ServiceBus/namespaces/testNamespace1/topics/testTopic1/subscriptions/testSubscription1",
+			&ResourceID{
+				SubscriptionID: "34ca515c-4629-458e-bf7c-738d77e0d0ea",
+				ResourceGroup:  "testGroup1",
+				Provider:       "Microsoft.ServiceBus",
+				Path: map[string]string{
+					"namespaces":    "testNamespace1",
+					"topics":        "testTopic1",
+					"subscriptions": "testSubscription1",
+				},
+			},
+			false,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
If a resource ID has more than one subscriptions key, as is the case for Service
Bus subscriptions the Azure SubscriptionID field was overwritten by the second
value.

TF_ACC= go test ./builtin/providers/azurerm -run TestParseAzureResourceID -timeout=30s -parallel=4
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	0.060s