### PR TITLE
(WIP) Update cloudfront behaviors to behave like lists and allow for ordering

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -42,7 +42,7 @@ func (p StringPtrSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // Used by the aws_cloudfront_distribution Create and Update functions.
 func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionConfig {
 	distributionConfig := &cloudfront.DistributionConfig{
-		CacheBehaviors:       expandCacheBehaviors(d.Get("cache_behaviors").([]interface{})),
+		CacheBehaviors:       expandCacheBehaviors(d.Get("cache_behavior").([]interface{})),
 		CustomErrorResponses: expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
 		DefaultCacheBehavior: expandDefaultCacheBehavior(d.Get("default_cache_behavior").(*schema.Set).List()[0].(map[string]interface{})),
 		Enabled:              aws.Bool(d.Get("enabled").(bool)),

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -247,7 +247,6 @@ func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) []interface{} {
 	for _, v := range cbs.Items {
 		s = append(s, flattenCacheBehavior(v))
 	}
-	//return schema.NewSet(cacheBehaviorHash, s)
 	return s
 }
 

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -138,7 +138,7 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 		}
 	}
 	if distributionConfig.CacheBehaviors != nil {
-		err = d.Set("cache_behaviors", flattenCacheBehaviors(distributionConfig.CacheBehaviors))
+		err = d.Set("cache_behavior", flattenCacheBehaviors(distributionConfig.CacheBehaviors))
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -36,8 +36,8 @@ func cacheBehaviorConf2() map[string]interface{} {
 	return cb
 }
 
-func cacheBehaviorsConf() *schema.Set {
-	return schema.NewSet(cacheBehaviorHash, []interface{}{cacheBehaviorConf1(), cacheBehaviorConf2()})
+func cacheBehaviorsConf() []interface{} {
+	return []interface{}{cacheBehaviorConf1(), cacheBehaviorConf2()}
 }
 
 func trustedSignersConf() []interface{} {
@@ -382,10 +382,11 @@ func TestCloudFrontStructure_flattenCacheBehaviors(t *testing.T) {
 	in := cacheBehaviorsConf()
 	cbs := expandCacheBehaviors(in)
 	out := flattenCacheBehaviors(cbs)
-	diff := in.Difference(out)
 
-	if len(diff.List()) > 0 {
-		t.Fatalf("Expected out to be %v, got %v, diff: %v", in, out, diff)
+	for i := range in {
+		if reflect.DeepEqual(in[i], out[i]) {
+			t.Fatalf("Expected out to be %v, got %v", in, out)
+		}
 	}
 }
 

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -32,10 +32,9 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      aliasesHash,
 			},
-			"cache_behavior": &schema.Schema{
-				Type:     schema.TypeSet,
+			"cache_behaviors": &schema.Schema{
+				Type:     schema.TypeList,
 				Optional: true,
-				Set:      cacheBehaviorHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -32,7 +32,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      aliasesHash,
 			},
-			"cache_behaviors": &schema.Schema{
+			"cache_behavior": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{


### PR DESCRIPTION
#7253
- Updated references to sets instead of lists
- Updated tests so they pass
- Successfully added ordered rules to cloudfront

However, some setbacks:
Still encountering a bug that maybe someone can help me with... I get an index out of bounds exception when I run `terraform apply` due to this line:

cloudfront_distribution_configuration_structure.go
`ForwardedValues:      expandForwardedValues(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{})),
`

There may also be a bug in field_reader.go addrToSchema. I'm not sure that code is robust against crazy combinations of nested sets and lists.

TODO:
1. Fix index out of bounds exception
2. Write new tests for this behavior
3. Update documentation about the new syntax for cache_behaviors
4. If necessary, concoct some migration plan from sets to lists... Then again, seemed to maybe work fine just making the changes to the tf file? Maybe to be safe, we can keep support for the set in a deprecated way.
