### PR TITLE
provider/aws: Fix cause error when re-apply specified together `etag` and `kms_key_id`

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -99,8 +99,9 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				// This will conflict with SSE-C and SSE-KMS encryption and multi-part upload
 				// if/when it's actually implemented. The Etag then won't match raw-file MD5.
 				// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
-				Optional: true,
-				Computed: true,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"kms_key_id"},
 			},
 
 			"version_id": &schema.Schema{
@@ -133,12 +134,6 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 		body = bytes.NewReader([]byte(content))
 	} else {
 		return fmt.Errorf("Must specify \"source\" or \"content\" field")
-	}
-
-	if _, ok := d.GetOk("kms_key_id"); ok {
-		if _, ok := d.GetOk("etag"); ok {
-			return fmt.Errorf("Unable to specify 'kms_key_id' and 'etag' together because 'etag' wouldn't equal the MD5 digest of the raw object data")
-		}
 	}
 
 	bucket := d.Get("bucket").(string)


### PR DESCRIPTION
Fix follow error.

```
aws_s3_bucket_object.hoge: Unable to specify 'kms_key_id' and 'etag' together because 'etag' wouldn't equal the MD5 digest of the raw object data
```

* Acceptance test

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3BucketObject_'                                                  
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/02 15:04:02 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_source (40.84s)
=== RUN   TestAccAWSS3BucketObject_content
--- PASS: TestAccAWSS3BucketObject_content (37.45s)
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (39.39s)
=== RUN   TestAccAWSS3BucketObject_updates
--- PASS: TestAccAWSS3BucketObject_updates (63.08s)
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (66.91s)
=== RUN   TestAccAWSS3BucketObject_kms
--- PASS: TestAccAWSS3BucketObject_kms (65.05s)
=== RUN   TestAccAWSS3BucketObject_acl
--- PASS: TestAccAWSS3BucketObject_acl (63.45s)
=== RUN   TestAccAWSS3BucketObject_storageClass
--- PASS: TestAccAWSS3BucketObject_storageClass (61.97s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    438.163s
```

### Reference

* #6698
