### PR TITLE
core: Ensure hasComputedSubKeys iterates over Sets and Lists properly

### DIFF
--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -265,12 +265,30 @@ func (r *ConfigFieldReader) hasComputedSubKeys(key string, schema *Schema) bool 
 	switch t := schema.Elem.(type) {
 	case *Resource:
 		for k, schema := range t.Schema {
-			if r.Config.IsComputed(prefix + k) {
+			addr := prefix + k
+			if r.Config.IsComputed(addr) {
 				return true
 			}
 
-			if r.hasComputedSubKeys(prefix+k, schema) {
-				return true
+			// We need to loop into sets and lists to ensure we pass the correct
+			// address to the raw config - otherwise for sets we get something like
+			// set.0.set.item instead of set.0.set.0.item, which renders an
+			// inaccurate result.
+			if schema.Type == TypeSet || schema.Type == TypeList {
+				raw, err := readListField(&nestedConfigFieldReader{r}, strings.Split(addr, "."), schema)
+				if err != nil {
+					panic(fmt.Errorf("readListField failed when field was supposed to be list-like: %v", err))
+				}
+				// Just range into the address space here, we don't need the value.
+				for i := range raw.Value.([]interface{}) {
+					if r.hasComputedSubKeys(addr+"."+strconv.Itoa(i), schema) {
+						return true
+					}
+				}
+			} else {
+				if r.hasComputedSubKeys(addr, schema) {
+					return true
+				}
 			}
 		}
 	}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3267,6 +3267,157 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 
 			Err: false,
 		},
+
+		"Complex structure with set of computed string should mark root set as computed": {
+			Schema: map[string]*Schema{
+				"outer": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"outer_str": &Schema{
+								Type:     TypeString,
+								Optional: true,
+							},
+							"inner": &Schema{
+								Type:     TypeSet,
+								Optional: true,
+								Elem: &Resource{
+									Schema: map[string]*Schema{
+										"inner_str": &Schema{
+											Type:     TypeString,
+											Optional: true,
+										},
+									},
+								},
+								Set: func(v interface{}) int {
+									return 2
+								},
+							},
+						},
+					},
+					Set: func(v interface{}) int {
+						return 1
+					},
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"outer": []map[string]interface{}{
+					map[string]interface{}{
+						"outer_str": "foo",
+						"inner": []map[string]interface{}{
+							map[string]interface{}{
+								"inner_str": "${var.bar}",
+							},
+						},
+					},
+				},
+			},
+
+			ConfigVariables: map[string]ast.Variable{
+				"var.bar": interfaceToVariableSwallowError(config.UnknownVariableValue),
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"outer.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"outer.~1.outer_str": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "foo",
+					},
+					"outer.~1.inner.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"outer.~1.inner.~2.inner_str": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "${var.bar}",
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		"Complex structure with complex list of computed string should mark root set as computed": {
+			Schema: map[string]*Schema{
+				"outer": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"outer_str": &Schema{
+								Type:     TypeString,
+								Optional: true,
+							},
+							"inner": &Schema{
+								Type:     TypeList,
+								Optional: true,
+								Elem: &Resource{
+									Schema: map[string]*Schema{
+										"inner_str": &Schema{
+											Type:     TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+						},
+					},
+					Set: func(v interface{}) int {
+						return 1
+					},
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"outer": []map[string]interface{}{
+					map[string]interface{}{
+						"outer_str": "foo",
+						"inner": []map[string]interface{}{
+							map[string]interface{}{
+								"inner_str": "${var.bar}",
+							},
+						},
+					},
+				},
+			},
+
+			ConfigVariables: map[string]ast.Variable{
+				"var.bar": interfaceToVariableSwallowError(config.UnknownVariableValue),
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"outer.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"outer.~1.outer_str": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "foo",
+					},
+					"outer.~1.inner.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"outer.~1.inner.0.inner_str": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "${var.bar}",
+					},
+				},
+			},
+
+			Err: false,
+		},
 	}
 
 	for tn, tc := range cases {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3321,7 +3321,7 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 				"var.bar": interfaceToVariableSwallowError(config.UnknownVariableValue),
 			},
 
-			Diff: &terraform.InstanceDiff{
+			ExpectedDiff: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
 					"outer.#": &terraform.ResourceAttrDiff{
 						Old: "0",
@@ -3336,8 +3336,9 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 						New: "1",
 					},
 					"outer.~1.inner.~2.inner_str": &terraform.ResourceAttrDiff{
-						Old: "",
-						New: "${var.bar}",
+						Old:         "",
+						New:         "${var.bar}",
+						NewComputed: true,
 					},
 				},
 			},
@@ -3395,7 +3396,7 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 				"var.bar": interfaceToVariableSwallowError(config.UnknownVariableValue),
 			},
 
-			Diff: &terraform.InstanceDiff{
+			ExpectedDiff: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
 					"outer.#": &terraform.ResourceAttrDiff{
 						Old: "0",
@@ -3410,8 +3411,9 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 						New: "1",
 					},
 					"outer.~1.inner.0.inner_str": &terraform.ResourceAttrDiff{
-						Old: "",
-						New: "${var.bar}",
+						Old:         "",
+						New:         "${var.bar}",
+						NewComputed: true,
 					},
 				},
 			},


### PR DESCRIPTION
WIP - Adding tests to this :)

> This fixes some edge-ish cases where a set in a config has a set or list
> in it that contains computed values, but non-set or list values in the
> parent do not.
> 
> This can cause "diffs didn't match during apply" errors in a scenario
> such as when a set's hash is calculated off of child items (including
> any sub-lists or sets, as it should be), and the hash changes between
> the plan and apply diffs due to the computed values present in the
> sub-list or set items. These will be marked as computed, but due to the
> fact that the function was not iterating over the list or set items
> properly (ie: not adding the item number to the address, so
> set.0.set.foo was being yielded instead of set.0.set.0.foo), these
> computed values were not being properly propagated to the parent set to
> be marked as computed.
> 
> Fixes hashicorp/terraform#6527.
> Fixes hashicorp/terraform#8271.
> 
> This possibly fixes other non-CloudFront related issues too.
