### PR TITLE
Documentation Update: Changing virtualization type in documentation for aws_instance

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -24,11 +24,11 @@ data "aws_ami" "ubuntu" {
   most_recent = true
   filter {
     name = "name"
-    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
   }
   filter {
     name = "virtualization-type"
-    values = ["paravirtual"]
+    values = ["hvm"]
   }
   owners = ["099720109477"] # Canonical
 }

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -15,9 +15,9 @@ and deleted. Instances also support [provisioning](/docs/provisioners/index.html
 
 ```
 # Create a new instance of the latest Ubuntu 14.04 on an
-# t1.micro node with an AWS Tag naming it "HelloWorld"
+# t2.micro node with an AWS Tag naming it "HelloWorld"
 provider "aws" {
-    region = "us-east-1"
+    region = "us-west-2"
 }
 
 data "aws_ami" "ubuntu" {
@@ -35,7 +35,7 @@ data "aws_ami" "ubuntu" {
 
 resource "aws_instance" "web" {
     ami = "${data.aws_ami.ubuntu.id}"
-    instance_type = "t1.micro"
+    instance_type = "t2.micro"
     tags {
         Name = "HelloWorld"
     }

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -17,11 +17,11 @@ data "aws_ami" "ubuntu" {
   most_recent = true
   filter {
     name = "name"
-    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
   }
   filter {
     name = "virtualization-type"
-    values = ["paravirtual"]
+    values = ["hvm"]
   }
   owners = ["099720109477"] # Canonical
 }
@@ -48,11 +48,11 @@ data "aws_ami" "ubuntu" {
   most_recent = true
   filter {
     name = "name"
-    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
   }
   filter {
     name = "virtualization-type"
-    values = ["paravirtual"]
+    values = ["hvm"]
   }
   owners = ["099720109477"] # Canonical
 }
@@ -95,11 +95,11 @@ data "aws_ami" "ubuntu" {
   most_recent = true
   filter {
     name = "name"
-    values = ["ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
   }
   filter {
     name = "virtualization-type"
-    values = ["paravirtual"]
+    values = ["hvm"]
   }
   owners = ["099720109477"] # Canonical
 }

--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -29,7 +29,7 @@ data "aws_ami" "ubuntu" {
 resource "aws_launch_configuration" "as_conf" {
     name = "web_config"
     image_id = "${data.aws_ami.ubuntu.id}"
-    instance_type = "t1.micro"
+    instance_type = "t2.micro"
 }
 ```
 
@@ -60,7 +60,7 @@ data "aws_ami" "ubuntu" {
 resource "aws_launch_configuration" "as_conf" {
     name_prefix = "terraform-lc-example-"
     image_id = "${data.aws_ami.ubuntu.id}"
-    instance_type = "t1.micro"
+    instance_type = "t2.micro"
 
     lifecycle {
       create_before_destroy = true
@@ -106,7 +106,7 @@ data "aws_ami" "ubuntu" {
 
 resource "aws_launch_configuration" "as_conf" {
     image_id = "${data.aws_ami.ubuntu.id}"
-    instance_type = "t1.micro"
+    instance_type = "m4.large"
     spot_price = "0.001"
     lifecycle {
       create_before_destroy = true


### PR DESCRIPTION

In current Terraform documentation for resource aws_instance and aws_launch_configuration, virtualization type is still "paravirtual" although AWS documentation suggests "hvm":

"For the best performance, we recommend that you use current generation instance types and HVM AMIs when you launch your instances."

Source: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html

Therefore, I though it would make sense to update Terraform documentation for aws_instance and aws_launch_configuration and have virtualization type "hvm" instead of "paravirtual".

What do you think?
