### PR TITLE
Provider/aws/fix acceptance test log bucket

### DIFF
--- a/builtin/providers/aws/import_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/import_aws_cloudfront_distribution_test.go
@@ -1,12 +1,17 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSCloudFrontDistribution_importBasic(t *testing.T) {
+	ri := acctest.RandInt()
+	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3Config, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
+
 	resourceName := "aws_cloudfront_distribution.s3_distribution"
 
 	resource.Test(t, resource.TestCase{
@@ -15,7 +20,7 @@ func TestAccAWSCloudFrontDistribution_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCloudFrontDistributionS3Config,
+				Config: testConfig,
 			},
 			resource.TestStep{
 				ResourceName:      resourceName,

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -20,13 +20,15 @@ import (
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
+	ri := acctest.RandInt()
+	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3Config, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCloudFrontDistributionS3Config,
+				Config: testConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
 						"aws_cloudfront_distribution.s3_distribution",
@@ -265,7 +267,7 @@ resource "aws_s3_bucket" "s3_bucket_logs" {
 }
 `)
 
-var testAccAWSCloudFrontDistributionS3Config = fmt.Sprintf(`
+var testAccAWSCloudFrontDistributionS3Config = `
 variable rand_id {
 	default = %d
 }
@@ -316,7 +318,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
+`
 
 var testAccAWSCloudFrontDistributionS3ConfigWithTags = `
 variable rand_id {

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -530,7 +530,7 @@ resource "aws_cloudfront_distribution" "multi_origin_distribution" {
 		max_ttl = 100
 		viewer_protocol_policy = "allow-all"
 	}
-	cache_behaviors = [{
+	cache_behavior {
 		allowed_methods = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
 		cached_methods = [ "GET", "HEAD" ]
 		target_origin_id = "myS3Origin"
@@ -545,8 +545,8 @@ resource "aws_cloudfront_distribution" "multi_origin_distribution" {
 		max_ttl = 50
 		viewer_protocol_policy = "allow-all"
 		path_pattern = "images1/*.jpg"
-	},
-	{
+	}
+	cache_behavior {
 		allowed_methods = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
 		cached_methods = [ "GET", "HEAD" ]
 		target_origin_id = "myCustomOrigin"
@@ -561,7 +561,8 @@ resource "aws_cloudfront_distribution" "multi_origin_distribution" {
 		max_ttl = 50
 		viewer_protocol_policy = "allow-all"
 		path_pattern = "images2/*.jpg"
-	}]
+	}
+
 	price_class = "PriceClass_All"
 	custom_error_response {
 		error_code = 404


### PR DESCRIPTION
* Factored out the s3 buckets used in the various test configs
* Made sure to define the logs bucket as part of the config.  Since it wasn't defined, it was giving me errors for not being found
* Also fixed up the bucket naming.  I don't think the bucket should be named <name>.s3.amazonaws.com. I think that adding the domain there is a convention for accessing the bucket, but the name should just be <name>. So for example, the name might be mylogs.73178316, and then in the logging config bucket you list mylogs.73178316.s3.amazonaws.com 