### PR TITLE
Use new Datadog GraphDefinitionRequest struct

### DIFF
--- a/builtin/providers/datadog/resource_datadog_timeboard.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard.go
@@ -119,12 +119,9 @@ func buildTemplateVariables(terraformTemplateVariables *[]interface{}) *[]datado
 func appendRequests(datadogGraph *datadog.Graph, terraformRequests *[]interface{}) {
 	for _, t_ := range *terraformRequests {
 		t := t_.(map[string]interface{})
-		d := struct {
-			Query              string `json:"q"`
-			Stacked            bool   `json:"stacked"`
-			Aggregator         string
-			ConditionalFormats []datadog.DashboardConditionalFormat `json:"conditional_formats,omitempty"`
-		}{Query: t["q"].(string)}
+		d := datadog.GraphDefinitionRequest{
+			Query: t["q"].(string),
+		}
 		if stacked, ok := t["stacked"]; ok {
 			d.Stacked = stacked.(bool)
 		}


### PR DESCRIPTION
We want to add features to the dashboard datadog terraform provider, that relies on the [go-datadog-api](https://github.com/zorkian/go-datadog-api). But at the moment any change would break the terraform code.
[This new struct](https://github.com/alphagov/paas-terraform/blob/datadog_dashboard/builtin/providers/datadog/resource_datadog_timeboard.go#L122-L124) avoids requiring to repeat the struct definition in this code [here](https://github.com/hashicorp/terraform/blob/b79aea491bd8d3c2e83236b6f265938469114530/builtin/providers/datadog/resource_datadog_timeboard.go#L122-L127). It avoids duplication and makes it more flexible so more options can be added to the struct without breaking the code here.

This PR must be merged alongside [this PR on go-datadog-api](https://github.com/zorkian/go-datadog-api/pull/58).
