### PR TITLE
Edits to remote-config documentation

### DIFF
--- a/website/source/docs/commands/remote-config.html.markdown
+++ b/website/source/docs/commands/remote-config.html.markdown
@@ -10,38 +10,21 @@ description: |-
 
 # Command: remote config
 
-The `terraform remote config` command is used to configure use of remote
-state storage. By default, Terraform persists its state only to a local
-disk. When remote state storage is enabled, Terraform will automatically
-fetch the latest state from the remote server when necessary and if any
-updates are made, the newest state is persisted back to the remote server.
-In this mode, users do not need to durably store the state using version
-control or shared storage.
+The `terraform remote config` command is used to configure the use of remote state storage. By default, Terraform persists its state to a local disk. When remote state storage is enabled, Terraform will automatically fetch the latest state from the remote server when required. If updates are made, the newest state is persisted back to the remote server. In this mode, users do not need to store the state using version control or shared storage.
 
 ## Usage
 
 Usage: `terraform remote config [options]`
 
-The `remote config` command can be used to enable remote storage, change
-configuration or disable the use of remote storage. Terraform supports multiple types
-of storage backends, specified by using the `-backend` flag. By default,
-Atlas is assumed to be the storage backend. Each backend expects different,
-configuration arguments documented below.
+The `remote config` command can be used to enable remote storage, change configuration or disable the use of remote storage. Terraform supports multiple types of storage backends, specified by using the `-backend` flag. By default, Atlas is assumed to be the storage backend. Each backend expects different configuration arguments documented below.
 
-When remote storage is enabled, an existing local state file can be migrated.
-By default, `remote config` will look for the "terraform.tfstate" file, but that
-can be specified by the `-state` flag. If no state file exists, a blank
-state will be configured.
+When remote storage is enabled, the existing local state file will be migrated. By default, `remote config` will look for the `terraform.tfstate` file, but that can be specified by the `-state` flag. If no state file exists, a blank state will be configured.
 
-When enabling remote storage, use the `-backend-config` flag to set
-the required configuration variables as documented below. See the example
-below this section for more details.
+When remote storage is disabled, the existing remote state is migrated back to a local file. The location of the new local state file defaults to the path specified in the `-state` flag.
 
-When remote storage is disabled, the existing remote state is migrated
-to a local file. This defaults to the `-state` path during restore.
+When enabling remote storage, we use the `-backend-config` flag to set any required configuration variables. 
 
-Supported storage backends and supported features of those
-are documented in the [Remote State](/docs/state/remote/index.html) section.
+Supported storage backends and supported features of each backend are documented in the [Remote State](/docs/state/remote/index.html) section.
 
 The command-line flags are all optional. The list of available flags are:
 
@@ -49,7 +32,7 @@ The command-line flags are all optional. The list of available flags are:
   supported backends.
 
 * `-backend-config="k=v"` - Specify a configuration variable for a backend.
-  This is how you set the required variables for the backend.
+  This is how you set any required variables for the backend.
 
 * `-backup=path` - Path to backup the existing state file before
   modifying. Defaults to the "-state" path with ".backup" extension.
@@ -62,18 +45,16 @@ The command-line flags are all optional. The list of available flags are:
   or after enabling. This defaults to true to ensure the latest state
   is available under both conditions.
 
-* `-state=path` - Path to read state. Defaults to "terraform.tfstate"
+* `-state=path` - Path to read state. Defaults to `terraform.tfstate`
   unless remote state is enabled.
 
 ## Example: Consul
 
-The example below will push your remote state to Consul. Note that for
-this example, it would go to the public Consul demo. In practice, you
-should use your own private Consul server:
+This example below will push your remote state to a Consul server. 
 
 ```
 $ terraform remote config \
     -backend=consul \
-    -backend-config="address=demo.consul.io:80" \
+    -backend-config="address=consul.example.com:80" \
     -backend-config="path=tf"
 ```


### PR DESCRIPTION
Minor grammar and style edits.

Also updated Consul example to not use `demo.consul.io` - seems like a bad idea to hard-code something folks might cut-n-paste to a host that's public. Principle of least risk, etc.