### PR TITLE
DOCS: Added note about us-east-1 ACM certs.

### DIFF
--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -308,7 +308,8 @@ The arguments of `geo_restriction` are:
 
   * `acm_certificate_arn` - The ARN of the [AWS Certificate Manager][6]
     certificate that you wish to use with this distribution. Specify this,
-    `cloudfront_default_certificate`, or `iam_certificate_id`.
+    `cloudfront_default_certificate`, or `iam_certificate_id`.  The ACM
+    certificate must be in  US-EAST-1.
 
   * `cloudfront_default_certificate` - `true` if you want viewers to use HTTPS
     to request your objects and you're using the CloudFront domain name for your
@@ -356,7 +357,7 @@ The following attributes are exported:
 
   * `etag` - The current version of the distribution's information. For example:
     `E2QWRUHAPOMQZL`.
-  
+
   * `hosted_zone_id` - The CloudFront Route 53 zone ID that can be used to
      route an [Alias Resource Record Set][7] to. This attribute is simply an
      alias for the zone ID `Z2FDTNDATAQYW2`.
@@ -373,7 +374,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloudfront Distributions can be imported using the `id`, e.g. 
+Cloudfront Distributions can be imported using the `id`, e.g.
 
 ```
 $ terraform import aws_cloudfront_distribution.distribution E74FTE3EXAMPLE


### PR DESCRIPTION
Should note that ACM certs must be in US-EAST-1 in order to be used with CloudFront.  Relevant to current version.

#9170 