### PR TITLE
provider/azurerm: Support AzureRM Sql Database DataWarehouse

### DIFF
--- a/builtin/providers/azurerm/resource_arm_sql_database.go
+++ b/builtin/providers/azurerm/resource_arm_sql_database.go
@@ -17,103 +17,103 @@ func resourceArmSqlDatabase() *schema.Resource {
 		Delete: resourceArmSqlDatabaseDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"location": &schema.Schema{
+			"location": {
 				Type:      schema.TypeString,
 				Required:  true,
 				ForceNew:  true,
 				StateFunc: azureRMNormalizeLocation,
 			},
 
-			"resource_group_name": &schema.Schema{
+			"resource_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"server_name": &schema.Schema{
+			"server_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"create_mode": &schema.Schema{
+			"create_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "Default",
 			},
 
-			"source_database_id": &schema.Schema{
+			"source_database_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"restore_point_in_time": &schema.Schema{
+			"restore_point_in_time": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"edition": &schema.Schema{
+			"edition": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validateArmSqlDatabaseEdition,
 			},
 
-			"collation": &schema.Schema{
+			"collation": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"max_size_bytes": &schema.Schema{
+			"max_size_bytes": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"requested_service_objective_id": &schema.Schema{
+			"requested_service_objective_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"requested_service_objective_name": &schema.Schema{
+			"requested_service_objective_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"source_database_deletion_date": &schema.Schema{
+			"source_database_deletion_date": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"elastic_pool_name": &schema.Schema{
+			"elastic_pool_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"encryption": &schema.Schema{
+			"encryption": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"creation_date": &schema.Schema{
+			"creation_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"default_secondary_location": &schema.Schema{
+			"default_secondary_location": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -245,13 +245,13 @@ func resourceArmSqlDatabaseDelete(d *schema.ResourceData, meta interface{}) erro
 
 func validateArmSqlDatabaseEdition(v interface{}, k string) (ws []string, errors []error) {
 	editions := map[string]bool{
-		"Basic":    true,
-		"Standard": true,
-		"Premium":  true,
+		"Basic":         true,
+		"Standard":      true,
+		"Premium":       true,
+		"DataWarehouse": true,
 	}
-
 	if !editions[v.(string)] {
-		errors = append(errors, fmt.Errorf("SQL Database Edition can only be Basic, Standard or Premium"))
+		errors = append(errors, fmt.Errorf("SQL Database Edition can only be Basic, Standard, Premium or DataWarehouse"))
 	}
 	return
 }

--- a/builtin/providers/azurerm/resource_arm_sql_database_test.go
+++ b/builtin/providers/azurerm/resource_arm_sql_database_test.go
@@ -31,6 +31,10 @@ func TestResourceAzureRMSqlDatabaseEdition_validation(t *testing.T) {
 			Value:    "Premium",
 			ErrCount: 0,
 		},
+		{
+			Value:    "DataWarehouse",
+			ErrCount: 0,
+		},
 	}
 
 	for _, tc := range cases {
@@ -51,7 +55,7 @@ func TestAccAzureRMSqlDatabase_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlDatabaseExists("azurerm_sql_database.test"),
@@ -71,7 +75,7 @@ func TestAccAzureRMSqlDatabase_withTags(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlDatabaseExists("azurerm_sql_database.test"),
@@ -79,13 +83,31 @@ func TestAccAzureRMSqlDatabase_withTags(t *testing.T) {
 						"azurerm_sql_database.test", "tags.%", "2"),
 				),
 			},
-
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlDatabaseExists("azurerm_sql_database.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_sql_database.test", "tags.%", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMSqlDatabase_datawarehouse(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSqlDatabase_datawarehouse, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlDatabaseExists("azurerm_sql_database.test"),
 				),
 			},
 		},
@@ -225,5 +247,30 @@ resource "azurerm_sql_database" "test" {
     tags {
     	environment = "production"
     }
+}
+`
+
+var testAccAzureRMSqlDatabase_datawarehouse = `
+resource "azurerm_resource_group" "test" {
+    name = "acctest_rg_%d"
+    location = "West US"
+}
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_sql_database" "test" {
+    name = "acctestdb%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    server_name = "${azurerm_sql_server.test.name}"
+    location = "West US"
+    edition = "DataWarehouse"
+    collation = "SQL_Latin1_General_CP1_CI_AS"
+    requested_service_objective_name = "DW400"
 }
 `

--- a/website/source/docs/providers/azurerm/r/sql_database.html.markdown
+++ b/website/source/docs/providers/azurerm/r/sql_database.html.markdown
@@ -21,7 +21,7 @@ resource "azurerm_sql_database" "test" {
     name = "MySQLDatabase"
     resource_group_name = "${azurerm_resource_group.test.name}"
     location = "West US"
-    
+
 
     tags {
     	environment = "production"
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the database.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the database.  This must be the same as Database Server resource group currently. 
+* `resource_group_name` - (Required) The name of the resource group in which to create the database.  This must be the same as Database Server resource group currently.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `restore_point_in_time` - (Optional) The point in time for the restore. Only applies if `create_mode` is `PointInTimeRestore` e.g. 2013-11-08T22:00:40Z
 
-* `edition` - (Optional) The edition of the database to be created. Applies only if `create_mode` is `Default`. Valid values are: `Basic`, `Standard`, `Premium`.  Please see [Azure SQL Database Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
+* `edition` - (Optional) The edition of the database to be created. Applies only if `create_mode` is `Default`. Valid values are: `Basic`, `Standard`, `Premium`, or `DataWarehouse`. Please see [Azure SQL Database Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
 
 * `collation` - (Optional) The name of the collation. Applies only if `create_mode` is `Default`.  Azure default is `SQL_LATIN1_GENERAL_CP1_CI_AS`
 
@@ -54,14 +54,14 @@ The following arguments are supported:
 
 * `requested_service_objective_id` - (Optional) Use `requested_service_objective_id` or `requested_service_objective_name` to set the performance level for the database.
  Valid values are: `S0`, `S1`, `S2`, `S3`, `P1`, `P2`, `P4`, `P6`, `P11` and `ElasticPool`.  Please see [Azure SQL Database Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
- 
+
 * `requested_service_objective_name` - (Optional) Use `requested_service_objective_name` or `requested_service_objective_id` to set the performance level for the database.  Please see [Azure SQL Database Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
 
 * `source_database_deletion_date` - (Optional) The deletion date time of the source database. Only applies to deleted databases where `create_mode` is `PointInTimeRestore`.
 
 * `elastic_pool_name` - (Optional) The name of the elastic database pool.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #9194

Removes the validation for the types and adds an acceptance test to make
sure we get a successful Sql Database created

```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMSqlDatabase_datawarehouse'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/03 21:57:16 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMSqlDatabase_datawarehouse -timeout 120m
=== RUN   TestAccAzureRMSqlDatabase_datawarehouse
--- PASS: TestAccAzureRMSqlDatabase_datawarehouse (307.95s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm307.963s
```