### PR TITLE
provider/azurerm: Load Balancer resources

### DIFF
--- a/builtin/providers/azurerm/loadbalancer.go
+++ b/builtin/providers/azurerm/loadbalancer.go
@@ -21,7 +21,7 @@ func resourceGroupAndLBNameFromId(loadBalancerId string) (string, string, error)
 	return resGroup, name, nil
 }
 
-func retrieveLoadbalancerById(loadBalancerId string, meta interface{}) (*network.LoadBalancer, bool, error) {
+func retrieveLoadBalancerById(loadBalancerId string, meta interface{}) (*network.LoadBalancer, bool, error) {
 	loadBalancerClient := meta.(*ArmClient).loadBalancerClient
 
 	resGroup, name, err := resourceGroupAndLBNameFromId(loadBalancerId)
@@ -135,7 +135,7 @@ func loadbalancerStateRefreshFunc(client *ArmClient, resourceGroupName string, l
 	}
 }
 
-func validateLoadbalancerPrivateIpAddressAllocation(v interface{}, k string) (ws []string, errors []error) {
+func validateLoadBalancerPrivateIpAddressAllocation(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
 	if value != "static" && value != "dynamic" {
 		errors = append(errors, fmt.Errorf("LoadBalancer Allocations can only be Static or Dynamic"))

--- a/builtin/providers/azurerm/loadbalancer.go
+++ b/builtin/providers/azurerm/loadbalancer.go
@@ -1,0 +1,148 @@
+package azurerm
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"net/http"
+	"strings"
+)
+
+func resourceGroupAndLBNameFromId(loadBalancerId string) (string, string, error) {
+	id, err := parseAzureResourceID(loadBalancerId)
+	if err != nil {
+		return "", "", err
+	}
+	name := id.Path["loadBalancers"]
+	resGroup := id.ResourceGroup
+
+	return resGroup, name, nil
+}
+
+func retrieveLoadbalancerById(loadBalancerId string, meta interface{}) (*network.LoadBalancer, bool, error) {
+	loadBalancerClient := meta.(*ArmClient).loadBalancerClient
+
+	resGroup, name, err := resourceGroupAndLBNameFromId(loadBalancerId)
+	if err != nil {
+		return nil, false, errwrap.Wrapf("TODO: error message {{err}}", err)
+	}
+
+	resp, err := loadBalancerClient.Get(resGroup, name, "")
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("Error making Read request on Azure Loadbalancer %s: %s", name, err)
+	}
+
+	return &resp, true, nil
+}
+
+func findLoadBalancerBackEndAddressPoolByName(lb *network.LoadBalancer, name string) (*network.BackendAddressPool, int, bool) {
+	if lb == nil || lb.Properties == nil || lb.Properties.BackendAddressPools == nil {
+		return nil, -1, false
+	}
+
+	for i, apc := range *lb.Properties.BackendAddressPools {
+		if apc.Name != nil && *apc.Name == name {
+			return &apc, i, true
+		}
+	}
+
+	return nil, -1, false
+}
+
+func findLoadBalancerFrontEndIpConfigurationByName(lb *network.LoadBalancer, name string) (*network.FrontendIPConfiguration, int, bool) {
+	if lb == nil || lb.Properties == nil || lb.Properties.FrontendIPConfigurations == nil {
+		return nil, -1, false
+	}
+
+	for i, feip := range *lb.Properties.FrontendIPConfigurations {
+		if feip.Name != nil && *feip.Name == name {
+			return &feip, i, true
+		}
+	}
+
+	return nil, -1, false
+}
+
+func findLoadBalancerRuleByName(lb *network.LoadBalancer, name string) (*network.LoadBalancingRule, int, bool) {
+	if lb == nil || lb.Properties == nil || lb.Properties.LoadBalancingRules == nil {
+		return nil, -1, false
+	}
+
+	for i, lbr := range *lb.Properties.LoadBalancingRules {
+		if lbr.Name != nil && *lbr.Name == name {
+			return &lbr, i, true
+		}
+	}
+
+	return nil, -1, false
+}
+
+func findLoadBalancerNatRuleByName(lb *network.LoadBalancer, name string) (*network.InboundNatRule, int, bool) {
+	if lb == nil || lb.Properties == nil || lb.Properties.InboundNatRules == nil {
+		return nil, -1, false
+	}
+
+	for i, nr := range *lb.Properties.InboundNatRules {
+		if nr.Name != nil && *nr.Name == name {
+			return &nr, i, true
+		}
+	}
+
+	return nil, -1, false
+}
+
+func findLoadBalancerNatPoolByName(lb *network.LoadBalancer, name string) (*network.InboundNatPool, int, bool) {
+	if lb == nil || lb.Properties == nil || lb.Properties.InboundNatPools == nil {
+		return nil, -1, false
+	}
+
+	for i, np := range *lb.Properties.InboundNatPools {
+		if np.Name != nil && *np.Name == name {
+			return &np, i, true
+		}
+	}
+
+	return nil, -1, false
+}
+
+func findLoadBalancerProbeByName(lb *network.LoadBalancer, name string) (*network.Probe, int, bool) {
+	if lb == nil || lb.Properties == nil || lb.Properties.Probes == nil {
+		return nil, -1, false
+	}
+
+	for i, p := range *lb.Properties.Probes {
+		if p.Name != nil && *p.Name == name {
+			return &p, i, true
+		}
+	}
+
+	return nil, -1, false
+}
+
+func loadbalancerStateRefreshFunc(client *ArmClient, resourceGroupName string, loadbalancer string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.loadBalancerClient.Get(resourceGroupName, loadbalancer, "")
+		if err != nil {
+			return nil, "", fmt.Errorf("Error issuing read request in loadbalancerStateRefreshFunc to Azure ARM for Loadbalancer '%s' (RG: '%s'): %s", loadbalancer, resourceGroupName, err)
+		}
+
+		return res, *res.Properties.ProvisioningState, nil
+	}
+}
+
+func validateLoadbalancerPrivateIpAddressAllocation(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	allocations := map[string]bool{
+		"static":  true,
+		"dynamic": true,
+	}
+
+	if !allocations[value] {
+		errors = append(errors, fmt.Errorf("Loadbalancer Allocations can only be Static or Dynamic"))
+	}
+	return
+}

--- a/builtin/providers/azurerm/loadbalancer.go
+++ b/builtin/providers/azurerm/loadbalancer.go
@@ -33,7 +33,7 @@ func retrieveLoadbalancerById(loadBalancerId string, meta interface{}) (*network
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, false, nil
 		}
-		return nil, false, fmt.Errorf("Error making Read request on Azure Loadbalancer %s: %s", name, err)
+		return nil, false, fmt.Errorf("Error making Read request on Azure LoadBalancer %s: %s", name, err)
 	}
 
 	return &resp, true, nil
@@ -127,7 +127,7 @@ func loadbalancerStateRefreshFunc(client *ArmClient, resourceGroupName string, l
 	return func() (interface{}, string, error) {
 		res, err := client.loadBalancerClient.Get(resourceGroupName, loadbalancer, "")
 		if err != nil {
-			return nil, "", fmt.Errorf("Error issuing read request in loadbalancerStateRefreshFunc to Azure ARM for Loadbalancer '%s' (RG: '%s'): %s", loadbalancer, resourceGroupName, err)
+			return nil, "", fmt.Errorf("Error issuing read request in loadbalancerStateRefreshFunc to Azure ARM for LoadBalancer '%s' (RG: '%s'): %s", loadbalancer, resourceGroupName, err)
 		}
 
 		return res, *res.Properties.ProvisioningState, nil

--- a/builtin/providers/azurerm/loadbalancer.go
+++ b/builtin/providers/azurerm/loadbalancer.go
@@ -2,11 +2,12 @@ package azurerm
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
-	"net/http"
-	"strings"
 )
 
 func resourceGroupAndLBNameFromId(loadBalancerId string) (string, string, error) {
@@ -25,7 +26,7 @@ func retrieveLoadbalancerById(loadBalancerId string, meta interface{}) (*network
 
 	resGroup, name, err := resourceGroupAndLBNameFromId(loadBalancerId)
 	if err != nil {
-		return nil, false, errwrap.Wrapf("TODO: error message {{err}}", err)
+		return nil, false, errwrap.Wrapf("Error Getting LoadBalancer Name and Group: {{err}}", err)
 	}
 
 	resp, err := loadBalancerClient.Get(resGroup, name, "")
@@ -136,13 +137,8 @@ func loadbalancerStateRefreshFunc(client *ArmClient, resourceGroupName string, l
 
 func validateLoadbalancerPrivateIpAddressAllocation(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
-	allocations := map[string]bool{
-		"static":  true,
-		"dynamic": true,
-	}
-
-	if !allocations[value] {
-		errors = append(errors, fmt.Errorf("Loadbalancer Allocations can only be Static or Dynamic"))
+	if value != "static" && value != "dynamic" {
+		errors = append(errors, fmt.Errorf("LoadBalancer Allocations can only be Static or Dynamic"))
 	}
 	return
 }

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -46,9 +46,17 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			// These resources use the Azure ARM SDK
-			"azurerm_availability_set":          resourceArmAvailabilitySet(),
-			"azurerm_cdn_endpoint":              resourceArmCdnEndpoint(),
-			"azurerm_cdn_profile":               resourceArmCdnProfile(),
+			"azurerm_availability_set": resourceArmAvailabilitySet(),
+			"azurerm_cdn_endpoint":     resourceArmCdnEndpoint(),
+			"azurerm_cdn_profile":      resourceArmCdnProfile(),
+
+			"azurerm_lb":                      resourceArmLoadbalancer(),
+			"azurerm_lb_backend_address_pool": resourceArmLoadbalancerBackendAddressPool(),
+			"azurerm_lb_nat_rule":             resourceArmLoadbalancerNatRule(),
+			"azurerm_lb_nat_pool":             resourceArmLoadbalancerNatPool(),
+			"azurerm_lb_probe":                resourceArmLoadbalancerProbe(),
+			"azurerm_lb_rule":                 resourceArmLoadbalancerRule(),
+
 			"azurerm_local_network_gateway":     resourceArmLocalNetworkGateway(),
 			"azurerm_network_interface":         resourceArmNetworkInterface(),
 			"azurerm_network_security_group":    resourceArmNetworkSecurityGroup(),

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -50,12 +50,12 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_cdn_endpoint":     resourceArmCdnEndpoint(),
 			"azurerm_cdn_profile":      resourceArmCdnProfile(),
 
-			"azurerm_lb":                      resourceArmLoadbalancer(),
-			"azurerm_lb_backend_address_pool": resourceArmLoadbalancerBackendAddressPool(),
-			"azurerm_lb_nat_rule":             resourceArmLoadbalancerNatRule(),
-			"azurerm_lb_nat_pool":             resourceArmLoadbalancerNatPool(),
-			"azurerm_lb_probe":                resourceArmLoadbalancerProbe(),
-			"azurerm_lb_rule":                 resourceArmLoadbalancerRule(),
+			"azurerm_lb":                      resourceArmLoadBalancer(),
+			"azurerm_lb_backend_address_pool": resourceArmLoadBalancerBackendAddressPool(),
+			"azurerm_lb_nat_rule":             resourceArmLoadBalancerNatRule(),
+			"azurerm_lb_nat_pool":             resourceArmLoadBalancerNatPool(),
+			"azurerm_lb_probe":                resourceArmLoadBalancerProbe(),
+			"azurerm_lb_rule":                 resourceArmLoadBalancerRule(),
 
 			"azurerm_local_network_gateway":     resourceArmLocalNetworkGateway(),
 			"azurerm_network_interface":         resourceArmNetworkInterface(),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer.go
@@ -12,12 +12,12 @@ import (
 	"github.com/jen20/riviera/azure"
 )
 
-func resourceArmLoadbalancer() *schema.Resource {
+func resourceArmLoadBalancer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmLoadbalancerCreate,
-		Read:   resourceArmLoadbalancerRead,
-		Update: resourceArmLoadbalancerCreate,
-		Delete: resourceArmLoadbalancerDelete,
+		Create: resourceArmLoadBalancerCreate,
+		Read:   resourecArmLoadBalancerRead,
+		Update: resourceArmLoadBalancerCreate,
+		Delete: resourceArmLoadBalancerDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -72,7 +72,7 @@ func resourceArmLoadbalancer() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validateLoadbalancerPrivateIpAddressAllocation,
+							ValidateFunc: validateLoadBalancerPrivateIpAddressAllocation,
 						},
 
 						"load_balancer_rules": {
@@ -97,7 +97,7 @@ func resourceArmLoadbalancer() *schema.Resource {
 	}
 }
 
-func resourceArmLoadbalancerCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	loadBalancerClient := client.loadBalancerClient
 
@@ -112,7 +112,7 @@ func resourceArmLoadbalancerCreate(d *schema.ResourceData, meta interface{}) err
 	properties := network.LoadBalancerPropertiesFormat{}
 
 	if _, ok := d.GetOk("frontend_ip_configuration"); ok {
-		properties.FrontendIPConfigurations = expandAzureRmLoadbalancerFrontendIpConfigurations(d)
+		properties.FrontendIPConfigurations = expandAzureRmLoadBalancerFrontendIpConfigurations(d)
 	}
 
 	loadbalancer := network.LoadBalancer{
@@ -148,11 +148,11 @@ func resourceArmLoadbalancerCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", name, err)
 	}
 
-	return resourceArmLoadbalancerRead(d, meta)
+	return resourecArmLoadBalancerRead(d, meta)
 }
 
-func resourceArmLoadbalancerRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -171,7 +171,7 @@ func resourceArmLoadbalancerRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceArmLoadbalancerDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
 	loadBalancerClient := meta.(*ArmClient).loadBalancerClient
 
 	id, err := parseAzureResourceID(d.Id())
@@ -190,7 +190,7 @@ func resourceArmLoadbalancerDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func expandAzureRmLoadbalancerFrontendIpConfigurations(d *schema.ResourceData) *[]network.FrontendIPConfiguration {
+func expandAzureRmLoadBalancerFrontendIpConfigurations(d *schema.ResourceData) *[]network.FrontendIPConfiguration {
 	configs := d.Get("frontend_ip_configuration").([]interface{})
 	frontEndConfigs := make([]network.FrontendIPConfiguration, 0, len(configs))
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer.go
@@ -1,0 +1,295 @@
+package azurerm
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+)
+
+func resourceArmLoadbalancer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLoadbalancerCreate,
+		Read:   resourceArmLoadbalancerRead,
+		Update: resourceArmLoadbalancerCreate,
+		Delete: resourceArmLoadbalancerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"frontend_ip_configuration": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"private_ip_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"public_ip_address_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"private_ip_address_allocation": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateLoadbalancerPrivateIpAddressAllocation,
+						},
+
+						"load_balancer_rules": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+
+						"inbound_nat_rules": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+				Set: resourceArmLoadbalancerFrontEndIpConfigurationHash,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmLoadbalancerCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	loadBalancerClient := client.loadBalancerClient
+
+	log.Printf("[INFO] preparing arguments for Azure ARM Loadbalancer creation.")
+
+	name := d.Get("name").(string)
+	location := d.Get("location").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	tags := d.Get("tags").(map[string]interface{})
+	expandedTags := expandTags(tags)
+
+	properties := network.LoadBalancerPropertiesFormat{}
+
+	if _, ok := d.GetOk("frontend_ip_configuration"); ok {
+		frontEndConfigs, feIpcErr := expandAzureRmLoadbalancerFrontendIpConfigurations(d)
+		if feIpcErr != nil {
+			return fmt.Errorf("Error Building list of Loadbalancer Frontend IP Configurations: %s", feIpcErr)
+		}
+		properties.FrontendIPConfigurations = &frontEndConfigs
+	}
+
+	loadbalancer := network.LoadBalancer{
+		Name:       azure.String(name),
+		Location:   azure.String(location),
+		Tags:       expandedTags,
+		Properties: &properties,
+	}
+
+	_, err := loadBalancerClient.CreateOrUpdate(resGroup, name, loadbalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := loadBalancerClient.Get(resGroup, name, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", name, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", name)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  []string{"Succeeded"},
+		Refresh: loadbalancerStateRefreshFunc(client, resGroup, name),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", name, err)
+	}
+
+	return resourceArmLoadbalancerRead(d, meta)
+}
+
+func resourceArmLoadbalancerRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	if loadBalancer.Properties != nil && loadBalancer.Properties.FrontendIPConfigurations != nil {
+		d.Set("frontend_ip_configuration", flattenLoadBalancerFrontendIpConfiguration(loadBalancer.Properties.FrontendIPConfigurations))
+	}
+
+	flattenAndSetTags(d, loadBalancer.Tags)
+
+	return nil
+}
+
+func resourceArmLoadbalancerDelete(d *schema.ResourceData, meta interface{}) error {
+	loadBalancerClient := meta.(*ArmClient).loadBalancerClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["loadBalancers"]
+
+	_, err = loadBalancerClient.Delete(resGroup, name, make(chan struct{}))
+
+	return err
+}
+
+func resourceArmLoadbalancerFrontEndIpConfigurationHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+
+	if m["private_ip_address"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["private_ip_address"].(string)))
+	}
+	if m["public_ip_address_id"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["public_ip_address_id"].(string)))
+	}
+	if m["subnet_id"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+func expandAzureRmLoadbalancerFrontendIpConfigurations(d *schema.ResourceData) ([]network.FrontendIPConfiguration, error) {
+	configs := d.Get("frontend_ip_configuration").(*schema.Set).List()
+	frontEndConfigs := make([]network.FrontendIPConfiguration, 0, len(configs))
+
+	for _, configRaw := range configs {
+		data := configRaw.(map[string]interface{})
+
+		private_ip_allocation_method := data["private_ip_address_allocation"].(string)
+		properties := network.FrontendIPConfigurationPropertiesFormat{
+			PrivateIPAllocationMethod: network.IPAllocationMethod(private_ip_allocation_method),
+		}
+
+		if v := data["private_ip_address"].(string); v != "" {
+			properties.PrivateIPAddress = &v
+		}
+
+		if v := data["public_ip_address_id"].(string); v != "" {
+			properties.PublicIPAddress = &network.PublicIPAddress{
+				ID: &v,
+			}
+		}
+
+		if v := data["subnet_id"].(string); v != "" {
+			properties.Subnet = &network.Subnet{
+				ID: &v,
+			}
+		}
+
+		name := data["name"].(string)
+		frontEndConfig := network.FrontendIPConfiguration{
+			Name:       &name,
+			Properties: &properties,
+		}
+
+		frontEndConfigs = append(frontEndConfigs, frontEndConfig)
+	}
+
+	return frontEndConfigs, nil
+}
+
+func flattenLoadBalancerFrontendIpConfiguration(ipConfigs *[]network.FrontendIPConfiguration) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(*ipConfigs))
+	for _, config := range *ipConfigs {
+		ipConfig := make(map[string]interface{})
+		ipConfig["name"] = *config.Name
+		ipConfig["private_ip_address_allocation"] = config.Properties.PrivateIPAllocationMethod
+
+		if config.Properties.Subnet != nil {
+			ipConfig["subnet_id"] = *config.Properties.Subnet.ID
+		}
+
+		if config.Properties.PrivateIPAddress != nil {
+			ipConfig["private_ip_address"] = *config.Properties.PrivateIPAddress
+		}
+
+		if config.Properties.PublicIPAddress != nil {
+			ipConfig["public_ip_address_id"] = *config.Properties.PublicIPAddress.ID
+		}
+
+		if config.Properties.LoadBalancingRules != nil {
+			load_balancing_rules := make([]string, 0, len(*config.Properties.LoadBalancingRules))
+			for _, rule := range *config.Properties.LoadBalancingRules {
+				load_balancing_rules = append(load_balancing_rules, *rule.ID)
+			}
+
+			ipConfig["load_balancer_rules"] = load_balancing_rules
+
+		}
+
+		if config.Properties.InboundNatRules != nil {
+			inbound_nat_rules := make([]string, 0, len(*config.Properties.InboundNatRules))
+			for _, rule := range *config.Properties.InboundNatRules {
+				inbound_nat_rules = append(inbound_nat_rules, *rule.ID)
+			}
+
+			ipConfig["inbound_nat_rules"] = inbound_nat_rules
+
+		}
+
+		result = append(result, ipConfig)
+	}
+	return result
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -1,0 +1,207 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+)
+
+func resourceArmLoadbalancerBackendAddressPool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLoadbalancerBackendAddressPoolCreate,
+		Read:   resourceArmLoadbalancerBackendAddressPoolRead,
+		Delete: resourceArmLoadbalancerBackendAddressPoolDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"loadbalancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"backend_ip_configurations": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"load_balancing_rules": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	_, _, exists = findLoadBalancerBackEndAddressPoolByName(loadBalancer, d.Get("name").(string))
+	if exists {
+		return fmt.Errorf("A BackEnd Address Pool with name %q already exists.", d.Get("name").(string))
+	}
+
+	backendAddressPools := append(*loadBalancer.Properties.BackendAddressPools, expandAzureRmLoadbalancerBackendAddressPools(d))
+	loadBalancer.Properties.BackendAddressPools = &backendAddressPools
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  []string{"Succeeded"},
+		Refresh: loadbalancerStateRefreshFunc(client, resGroup, loadBalancerName),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+	}
+
+	return resourceArmLoadbalancerBackendAddressPoolRead(d, meta)
+}
+
+func resourceArmLoadbalancerBackendAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	configs := *loadBalancer.Properties.BackendAddressPools
+	for _, config := range configs {
+		if *config.Name == d.Get("name").(string) {
+			d.Set("name", config.Name)
+
+			if config.Properties.BackendIPConfigurations != nil {
+				backend_ip_configurations := make([]string, 0, len(*config.Properties.BackendIPConfigurations))
+				for _, backendConfig := range *config.Properties.BackendIPConfigurations {
+					backend_ip_configurations = append(backend_ip_configurations, *backendConfig.ID)
+				}
+
+				d.Set("backend_ip_configurations", backend_ip_configurations)
+			}
+
+			if config.Properties.LoadBalancingRules != nil {
+				load_balancing_rules := make([]string, 0, len(*config.Properties.LoadBalancingRules))
+				for _, rule := range *config.Properties.LoadBalancingRules {
+					load_balancing_rules = append(load_balancing_rules, *rule.ID)
+				}
+
+				d.Set("backend_ip_configurations", load_balancing_rules)
+			}
+
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceArmLoadbalancerBackendAddressPoolDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	_, index, exists := findLoadBalancerBackEndAddressPoolByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		return nil
+	}
+
+	oldBackEndPools := *loadBalancer.Properties.BackendAddressPools
+	newBackEndPools := append(oldBackEndPools[:index], oldBackEndPools[index+1:]...)
+	loadBalancer.Properties.BackendAddressPools = &newBackEndPools
+
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	return nil
+}
+
+func expandAzureRmLoadbalancerBackendAddressPools(d *schema.ResourceData) network.BackendAddressPool {
+	return network.BackendAddressPool{
+		Name: azure.String(d.Get("name").(string)),
+	}
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -12,11 +12,11 @@ import (
 	"github.com/jen20/riviera/azure"
 )
 
-func resourceArmLoadbalancerBackendAddressPool() *schema.Resource {
+func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmLoadbalancerBackendAddressPoolCreate,
-		Read:   resourceArmLoadbalancerBackendAddressPoolRead,
-		Delete: resourceArmLoadbalancerBackendAddressPoolDelete,
+		Create: resourceArmLoadBalancerBackendAddressPoolCreate,
+		Read:   resourceArmLoadBalancerBackendAddressPoolRead,
+		Delete: resourceArmLoadBalancerBackendAddressPoolDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -61,11 +61,11 @@ func resourceArmLoadbalancerBackendAddressPool() *schema.Resource {
 	}
 }
 
-func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -80,7 +80,7 @@ func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 		return fmt.Errorf("A BackEnd Address Pool with name %q already exists.", d.Get("name").(string))
 	}
 
-	backendAddressPools := append(*loadBalancer.Properties.BackendAddressPools, expandAzureRmLoadbalancerBackendAddressPools(d))
+	backendAddressPools := append(*loadBalancer.Properties.BackendAddressPools, expandAzureRmLoadBalancerBackendAddressPools(d))
 	loadBalancer.Properties.BackendAddressPools = &backendAddressPools
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {
@@ -113,11 +113,11 @@ func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
-	return resourceArmLoadbalancerBackendAddressPoolRead(d, meta)
+	return resourceArmLoadBalancerBackendAddressPoolRead(d, meta)
 }
 
-func resourceArmLoadbalancerBackendAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+func resourceArmLoadBalancerBackendAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -157,11 +157,11 @@ func resourceArmLoadbalancerBackendAddressPoolRead(d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceArmLoadbalancerBackendAddressPoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerBackendAddressPoolDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -200,7 +200,7 @@ func resourceArmLoadbalancerBackendAddressPoolDelete(d *schema.ResourceData, met
 	return nil
 }
 
-func expandAzureRmLoadbalancerBackendAddressPools(d *schema.ResourceData) network.BackendAddressPool {
+func expandAzureRmLoadBalancerBackendAddressPools(d *schema.ResourceData) network.BackendAddressPool {
 	return network.BackendAddressPool{
 		Name: azure.String(d.Get("name").(string)),
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -67,11 +67,11 @@ func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
 		return nil
 	}
 
@@ -84,20 +84,20 @@ func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 	loadBalancer.Properties.BackendAddressPools = &backendAddressPools
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {
-		return errwrap.Wrapf("TODO: {{err}}", err)
+		return errwrap.Wrapf("Error Getting LoadBalancer Name and Group: {{err}}", err)
 	}
 
 	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Creating/Updating LoadBalancer {{err}}", err)
 	}
 
 	read, err := lbClient.Get(resGroup, loadBalancerName, "")
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer {{err}}", err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -110,7 +110,7 @@ func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
 	return resourceArmLoadbalancerBackendAddressPoolRead(d, meta)
@@ -119,11 +119,11 @@ func resourceArmLoadbalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 func resourceArmLoadbalancerBackendAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
 		return nil
 	}
 
@@ -163,7 +163,7 @@ func resourceArmLoadbalancerBackendAddressPoolDelete(d *schema.ResourceData, met
 
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
@@ -181,20 +181,20 @@ func resourceArmLoadbalancerBackendAddressPoolDelete(d *schema.ResourceData, met
 
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {
-		return errwrap.Wrapf("TODO: {{err}}", err)
+		return errwrap.Wrapf("Error Getting LoadBalancer Name and Group: {{err}}", err)
 	}
 
 	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Creating/Updating LoadBalancer {{err}}", err)
 	}
 
 	read, err := lbClient.Get(resGroup, loadBalancerName, "")
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer {{err}}", err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAzureRMLoadbalancerBackEndAddressPool_basic(t *testing.T) {
+func TestAccAzureRMLoadBalancerBackEndAddressPool_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
@@ -18,20 +18,20 @@ func TestAccAzureRMLoadbalancerBackEndAddressPool_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerBackEndAddressPool_basic(ri, addressPoolName),
+				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerBackEndAddressPoolExists(addressPoolName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerBackEndAddressPoolExists(addressPoolName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMLoadbalancerBackEndAddressPool_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerBackEndAddressPool_removal(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
@@ -39,20 +39,20 @@ func TestAccAzureRMLoadbalancerBackEndAddressPool_removal(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerBackEndAddressPool_removal(ri),
+				Config: testAccAzureRMLoadBalancerBackEndAddressPool_removal(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerBackEndAddressPoolNotExists(addressPoolName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerBackEndAddressPoolNotExists(addressPoolName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureRMLoadbalancerBackEndAddressPoolExists(addressPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerBackEndAddressPoolExists(addressPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerBackEndAddressPoolByName(lb, addressPoolName)
 		if !exists {
@@ -63,7 +63,7 @@ func testCheckAzureRMLoadbalancerBackEndAddressPoolExists(addressPoolName string
 	}
 }
 
-func testCheckAzureRMLoadbalancerBackEndAddressPoolNotExists(addressPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerBackEndAddressPoolNotExists(addressPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerBackEndAddressPoolByName(lb, addressPoolName)
 		if exists {
@@ -74,7 +74,7 @@ func testCheckAzureRMLoadbalancerBackEndAddressPoolNotExists(addressPoolName str
 	}
 }
 
-func testAccAzureRMLoadbalancerBackEndAddressPool_basic(rInt int, addressPoolName string) string {
+func testAccAzureRMLoadBalancerBackEndAddressPool_basic(rInt int, addressPoolName string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
@@ -109,7 +109,7 @@ resource "azurerm_lb_backend_address_pool" "test" {
 `, rInt, rInt, rInt, rInt, addressPoolName)
 }
 
-func testAccAzureRMLoadbalancerBackEndAddressPool_removal(rInt int) string {
+func testAccAzureRMLoadBalancerBackEndAddressPool_removal(rInt int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
@@ -1,0 +1,137 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMLoadbalancerBackEndAddressPool_basic(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerBackEndAddressPool_basic(ri, addressPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerBackEndAddressPoolExists(addressPoolName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadbalancerBackEndAddressPool_removal(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerBackEndAddressPool_removal(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerBackEndAddressPoolNotExists(addressPoolName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMLoadbalancerBackEndAddressPoolExists(addressPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerBackEndAddressPoolByName(lb, addressPoolName)
+		if !exists {
+			return fmt.Errorf("A BackEnd Address Pool with name %q cannot be found.", addressPoolName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLoadbalancerBackEndAddressPoolNotExists(addressPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerBackEndAddressPoolByName(lb, addressPoolName)
+		if exists {
+			return fmt.Errorf("A BackEnd Address Pool with name %q has been found.", addressPoolName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMLoadbalancerBackEndAddressPool_basic(rInt int, addressPoolName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+}
+
+`, rInt, rInt, rInt, rInt, addressPoolName)
+}
+
+func testAccAzureRMLoadbalancerBackEndAddressPool_removal(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+`, rInt, rInt, rInt, rInt)
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -12,12 +12,12 @@ import (
 	"github.com/jen20/riviera/azure"
 )
 
-func resourceArmLoadbalancerNatPool() *schema.Resource {
+func resourceArmLoadBalancerNatPool() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmLoadbalancerNatPoolCreate,
-		Read:   resourceArmLoadbalancerNatPoolRead,
-		Update: resourceArmLoadbalancerNatPoolCreate,
-		Delete: resourceArmLoadbalancerNatPoolDelete,
+		Create: resourceArmLoadBalancerNatPoolCreate,
+		Read:   resourceArmLoadBalancerNatPoolRead,
+		Update: resourceArmLoadBalancerNatPoolCreate,
+		Delete: resourceArmLoadBalancerNatPoolDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -78,11 +78,11 @@ func resourceArmLoadbalancerNatPool() *schema.Resource {
 	}
 }
 
-func resourceArmLoadbalancerNatPoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerNatPoolCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -97,7 +97,7 @@ func resourceArmLoadbalancerNatPoolCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("A NAT Pool with name %q already exists.", d.Get("name").(string))
 	}
 
-	newNatPool, err := expandAzureRmLoadbalancerNatPool(d, loadBalancer)
+	newNatPool, err := expandAzureRmLoadBalancerNatPool(d, loadBalancer)
 	if err != nil {
 		return errwrap.Wrapf("Error Expanding NAT Pool {{err}}", err)
 	}
@@ -135,11 +135,11 @@ func resourceArmLoadbalancerNatPoolCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
-	return resourceArmLoadbalancerNatPoolRead(d, meta)
+	return resourceArmLoadBalancerNatPoolRead(d, meta)
 }
 
-func resourceArmLoadbalancerNatPoolRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+func resourceArmLoadBalancerNatPoolRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -170,11 +170,11 @@ func resourceArmLoadbalancerNatPoolRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceArmLoadbalancerNatPoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerNatPoolDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -213,7 +213,7 @@ func resourceArmLoadbalancerNatPoolDelete(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func expandAzureRmLoadbalancerNatPool(d *schema.ResourceData, lb *network.LoadBalancer) (*network.InboundNatPool, error) {
+func expandAzureRmLoadBalancerNatPool(d *schema.ResourceData, lb *network.LoadBalancer) (*network.InboundNatPool, error) {
 
 	properties := network.InboundNatPoolPropertiesFormat{
 		Protocol:               network.TransportProtocol(d.Get("protocol").(string)),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -1,0 +1,244 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+)
+
+func resourceArmLoadbalancerNatPool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLoadbalancerNatPoolCreate,
+		Read:   resourceArmLoadbalancerNatPoolRead,
+		Update: resourceArmLoadbalancerNatPoolCreate,
+		Delete: resourceArmLoadbalancerNatPoolDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"loadbalancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"frontend_port_start": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"frontend_port_end": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"backend_port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"frontend_ip_configuration_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"frontend_ip_configuration_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmLoadbalancerNatPoolCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	_, _, exists = findLoadBalancerNatPoolByName(loadBalancer, d.Get("name").(string))
+	if exists {
+		return fmt.Errorf("A Nat Pool with name %q already exists.", d.Get("name").(string))
+	}
+
+	newNatPool, err := expandAzureRmLoadbalancerNatPool(d, loadBalancer)
+	if err != nil {
+		return err
+	}
+
+	natPools := append(*loadBalancer.Properties.InboundNatPools, *newNatPool)
+	loadBalancer.Properties.InboundNatPools = &natPools
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  []string{"Succeeded"},
+		Refresh: loadbalancerStateRefreshFunc(client, resGroup, loadBalancerName),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+	}
+
+	return resourceArmLoadbalancerNatPoolRead(d, meta)
+}
+
+func resourceArmLoadbalancerNatPoolRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	configs := *loadBalancer.Properties.InboundNatPools
+	for _, config := range configs {
+		if *config.Name == d.Get("name").(string) {
+			d.Set("name", config.Name)
+
+			d.Set("protocol", config.Properties.Protocol)
+			d.Set("frontend_port_start", config.Properties.FrontendPortRangeStart)
+			d.Set("frontend_port_end", config.Properties.FrontendPortRangeEnd)
+			d.Set("backend_port", config.Properties.BackendPort)
+
+			if config.Properties.FrontendIPConfiguration != nil {
+				d.Set("frontend_ip_configuration_id", config.Properties.FrontendIPConfiguration.ID)
+			}
+
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceArmLoadbalancerNatPoolDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	_, index, exists := findLoadBalancerNatPoolByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		return nil
+	}
+
+	oldNatPools := *loadBalancer.Properties.InboundNatPools
+	newNatPools := append(oldNatPools[:index], oldNatPools[index+1:]...)
+	loadBalancer.Properties.InboundNatPools = &newNatPools
+
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	return nil
+}
+
+func expandAzureRmLoadbalancerNatPool(d *schema.ResourceData, lb *network.LoadBalancer) (*network.InboundNatPool, error) {
+
+	properties := network.InboundNatPoolPropertiesFormat{
+		Protocol:               network.TransportProtocol(d.Get("protocol").(string)),
+		FrontendPortRangeStart: azure.Int32(int32(d.Get("frontend_port_start").(int))),
+		FrontendPortRangeEnd:   azure.Int32(int32(d.Get("frontend_port_end").(int))),
+		BackendPort:            azure.Int32(int32(d.Get("backend_port").(int))),
+	}
+
+	if v := d.Get("frontend_ip_configuration_name").(string); v != "" {
+		rule, _, exists := findLoadBalancerFrontEndIpConfigurationByName(lb, v)
+		if !exists {
+			return nil, fmt.Errorf("[ERROR] Cannot find FrontEnd IP Configuration with the name %s", v)
+		}
+
+		feip := network.SubResource{
+			ID: rule.ID,
+		}
+
+		properties.FrontendIPConfiguration = &feip
+	}
+
+	natPool := network.InboundNatPool{
+		Name:       azure.String(d.Get("name").(string)),
+		Properties: &properties,
+	}
+
+	return &natPool, nil
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -1,0 +1,149 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMLoadbalancerNatPool_basic(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natPoolName := fmt.Sprintf("NatPool-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerNatPool_basic(ri, natPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerNatPoolExists(natPoolName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadbalancerNatPool_removal(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natPoolName := fmt.Sprintf("NatPool-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerNatPool_basic(ri, natPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerNatPoolExists(natPoolName, &lb),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadbalancerNatPool_removal(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerNatPoolNotExists(natPoolName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMLoadbalancerNatPoolExists(natPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerNatPoolByName(lb, natPoolName)
+		if !exists {
+			return fmt.Errorf("A Nat Rule with name %q cannot be found.", natPoolName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLoadbalancerNatPoolNotExists(natPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerNatPoolByName(lb, natPoolName)
+		if exists {
+			return fmt.Errorf("A Nat Rule with name %q has been found.", natPoolName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMLoadbalancerNatPool_basic(rInt int, natPoolName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_pool" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port_start = 80
+  frontend_port_end = 81
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, natPoolName, rInt)
+}
+
+func testAccAzureRMLoadbalancerNatPool_removal(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+`, rInt, rInt, rInt, rInt)
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAzureRMLoadbalancerNatPool_basic(t *testing.T) {
+func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	natPoolName := fmt.Sprintf("NatPool-%d", ri)
@@ -18,20 +18,20 @@ func TestAccAzureRMLoadbalancerNatPool_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerNatPool_basic(ri, natPoolName),
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerNatPoolExists(natPoolName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMLoadbalancerNatPool_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerNatPool_removal(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	natPoolName := fmt.Sprintf("NatPool-%d", ri)
@@ -39,27 +39,27 @@ func TestAccAzureRMLoadbalancerNatPool_removal(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerNatPool_basic(ri, natPoolName),
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerNatPoolExists(natPoolName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadbalancerNatPool_removal(ri),
+				Config: testAccAzureRMLoadBalancerNatPool_removal(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerNatPoolNotExists(natPoolName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatPoolNotExists(natPoolName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureRMLoadbalancerNatPoolExists(natPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerNatPoolExists(natPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatPoolByName(lb, natPoolName)
 		if !exists {
@@ -70,7 +70,7 @@ func testCheckAzureRMLoadbalancerNatPoolExists(natPoolName string, lb *network.L
 	}
 }
 
-func testCheckAzureRMLoadbalancerNatPoolNotExists(natPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerNatPoolNotExists(natPoolName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatPoolByName(lb, natPoolName)
 		if exists {
@@ -81,7 +81,7 @@ func testCheckAzureRMLoadbalancerNatPoolNotExists(natPoolName string, lb *networ
 	}
 }
 
-func testAccAzureRMLoadbalancerNatPool_basic(rInt int, natPoolName string) string {
+func testAccAzureRMLoadBalancerNatPool_basic(rInt int, natPoolName string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
@@ -121,7 +121,7 @@ resource "azurerm_lb_nat_pool" "test" {
 `, rInt, rInt, rInt, rInt, natPoolName, rInt)
 }
 
-func testAccAzureRMLoadbalancerNatPool_removal(rInt int) string {
+func testAccAzureRMLoadBalancerNatPool_removal(rInt int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -63,7 +63,7 @@ func testCheckAzureRMLoadbalancerNatPoolExists(natPoolName string, lb *network.L
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatPoolByName(lb, natPoolName)
 		if !exists {
-			return fmt.Errorf("A Nat Rule with name %q cannot be found.", natPoolName)
+			return fmt.Errorf("A NAT Pool with name %q cannot be found.", natPoolName)
 		}
 
 		return nil
@@ -74,7 +74,7 @@ func testCheckAzureRMLoadbalancerNatPoolNotExists(natPoolName string, lb *networ
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatPoolByName(lb, natPoolName)
 		if exists {
-			return fmt.Errorf("A Nat Rule with name %q has been found.", natPoolName)
+			return fmt.Errorf("A NAT Pool with name %q has been found.", natPoolName)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -12,12 +12,12 @@ import (
 	"github.com/jen20/riviera/azure"
 )
 
-func resourceArmLoadbalancerNatRule() *schema.Resource {
+func resourceArmLoadBalancerNatRule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmLoadbalancerNatRuleCreate,
-		Read:   resourceArmLoadbalancerNatRuleRead,
-		Update: resourceArmLoadbalancerNatRuleCreate,
-		Delete: resourceArmLoadbalancerNatRuleDelete,
+		Create: resourceArmLoadBalancerNatRuleCreate,
+		Read:   resourceArmLoadBalancerNatRuleRead,
+		Update: resourceArmLoadBalancerNatRuleCreate,
+		Delete: resourceArmLoadBalancerNatRuleDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -78,11 +78,11 @@ func resourceArmLoadbalancerNatRule() *schema.Resource {
 	}
 }
 
-func resourceArmLoadbalancerNatRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerNatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -97,7 +97,7 @@ func resourceArmLoadbalancerNatRuleCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("A NAT Rule with name %q already exists.", d.Get("name").(string))
 	}
 
-	newNatRule, err := expandAzureRmLoadbalancerNatRule(d, loadBalancer)
+	newNatRule, err := expandAzureRmLoadBalancerNatRule(d, loadBalancer)
 	if err != nil {
 		return errwrap.Wrapf("Error Expanding NAT Rule {{err}}", err)
 	}
@@ -135,11 +135,11 @@ func resourceArmLoadbalancerNatRuleCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
-	return resourceArmLoadbalancerNatRuleRead(d, meta)
+	return resourceArmLoadBalancerNatRuleRead(d, meta)
 }
 
-func resourceArmLoadbalancerNatRuleRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+func resourceArmLoadBalancerNatRuleRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -173,11 +173,11 @@ func resourceArmLoadbalancerNatRuleRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceArmLoadbalancerNatRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerNatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -216,7 +216,7 @@ func resourceArmLoadbalancerNatRuleDelete(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func expandAzureRmLoadbalancerNatRule(d *schema.ResourceData, lb *network.LoadBalancer) (*network.InboundNatRule, error) {
+func expandAzureRmLoadBalancerNatRule(d *schema.ResourceData, lb *network.LoadBalancer) (*network.InboundNatRule, error) {
 
 	properties := network.InboundNatRulePropertiesFormat{
 		Protocol:     network.TransportProtocol(d.Get("protocol").(string)),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -1,0 +1,246 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+)
+
+func resourceArmLoadbalancerNatRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLoadbalancerNatRuleCreate,
+		Read:   resourceArmLoadbalancerNatRuleRead,
+		Update: resourceArmLoadbalancerNatRuleCreate,
+		Delete: resourceArmLoadbalancerNatRuleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"loadbalancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"frontend_port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"backend_port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"frontend_ip_configuration_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"frontend_ip_configuration_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"backend_ip_configuration_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmLoadbalancerNatRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	_, _, exists = findLoadBalancerNatRuleByName(loadBalancer, d.Get("name").(string))
+	if exists {
+		return fmt.Errorf("A Nat Rule with name %q already exists.", d.Get("name").(string))
+	}
+
+	newNatRule, err := expandAzureRmLoadbalancerNatRule(d, loadBalancer)
+	if err != nil {
+		return err
+	}
+
+	natRules := append(*loadBalancer.Properties.InboundNatRules, *newNatRule)
+	loadBalancer.Properties.InboundNatRules = &natRules
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  []string{"Succeeded"},
+		Refresh: loadbalancerStateRefreshFunc(client, resGroup, loadBalancerName),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+	}
+
+	return resourceArmLoadbalancerNatRuleRead(d, meta)
+}
+
+func resourceArmLoadbalancerNatRuleRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	configs := *loadBalancer.Properties.InboundNatRules
+	for _, config := range configs {
+		if *config.Name == d.Get("name").(string) {
+			d.Set("name", config.Name)
+
+			d.Set("protocol", config.Properties.Protocol)
+			d.Set("frontend_port", config.Properties.FrontendPort)
+			d.Set("backend_port", config.Properties.BackendPort)
+
+			if config.Properties.FrontendIPConfiguration != nil {
+				d.Set("frontend_ip_configuration_id", config.Properties.FrontendIPConfiguration.ID)
+			}
+
+			if config.Properties.BackendIPConfiguration != nil {
+				d.Set("backend_ip_configuration_id", config.Properties.BackendIPConfiguration.ID)
+			}
+
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceArmLoadbalancerNatRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	_, index, exists := findLoadBalancerNatRuleByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		return nil
+	}
+
+	oldNatRules := *loadBalancer.Properties.InboundNatRules
+	newNatRules := append(oldNatRules[:index], oldNatRules[index+1:]...)
+	loadBalancer.Properties.InboundNatRules = &newNatRules
+
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	return nil
+}
+
+func expandAzureRmLoadbalancerNatRule(d *schema.ResourceData, lb *network.LoadBalancer) (*network.InboundNatRule, error) {
+
+	properties := network.InboundNatRulePropertiesFormat{
+		Protocol:     network.TransportProtocol(d.Get("protocol").(string)),
+		FrontendPort: azure.Int32(int32(d.Get("frontend_port").(int))),
+		BackendPort:  azure.Int32(int32(d.Get("backend_port").(int))),
+	}
+
+	if v := d.Get("frontend_ip_configuration_name").(string); v != "" {
+		rule, _, exists := findLoadBalancerFrontEndIpConfigurationByName(lb, v)
+		if !exists {
+			return nil, fmt.Errorf("[ERROR] Cannot find FrontEnd IP Configuration with the name %s", v)
+		}
+
+		feip := network.SubResource{
+			ID: rule.ID,
+		}
+
+		properties.FrontendIPConfiguration = &feip
+	}
+
+	natRule := network.InboundNatRule{
+		Name:       azure.String(d.Get("name").(string)),
+		Properties: &properties,
+	}
+
+	return &natRule, nil
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -84,42 +84,42 @@ func resourceArmLoadbalancerNatRuleCreate(d *schema.ResourceData, meta interface
 
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
 		return nil
 	}
 
 	_, _, exists = findLoadBalancerNatRuleByName(loadBalancer, d.Get("name").(string))
 	if exists {
-		return fmt.Errorf("A Nat Rule with name %q already exists.", d.Get("name").(string))
+		return fmt.Errorf("A NAT Rule with name %q already exists.", d.Get("name").(string))
 	}
 
 	newNatRule, err := expandAzureRmLoadbalancerNatRule(d, loadBalancer)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Expanding NAT Rule {{err}}", err)
 	}
 
 	natRules := append(*loadBalancer.Properties.InboundNatRules, *newNatRule)
 	loadBalancer.Properties.InboundNatRules = &natRules
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {
-		return errwrap.Wrapf("TODO: {{err}}", err)
+		return errwrap.Wrapf("Error Getting LoadBalancer Name and Group: {{err}}", err)
 	}
 
 	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Creating / Updating LoadBalancer {{err}}", err)
 	}
 
 	read, err := lbClient.Get(resGroup, loadBalancerName, "")
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer {{err}}", err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -132,7 +132,7 @@ func resourceArmLoadbalancerNatRuleCreate(d *schema.ResourceData, meta interface
 		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
 	return resourceArmLoadbalancerNatRuleRead(d, meta)
@@ -141,11 +141,11 @@ func resourceArmLoadbalancerNatRuleCreate(d *schema.ResourceData, meta interface
 func resourceArmLoadbalancerNatRuleRead(d *schema.ResourceData, meta interface{}) error {
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
 		return nil
 	}
 
@@ -179,7 +179,7 @@ func resourceArmLoadbalancerNatRuleDelete(d *schema.ResourceData, meta interface
 
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
@@ -197,20 +197,20 @@ func resourceArmLoadbalancerNatRuleDelete(d *schema.ResourceData, meta interface
 
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {
-		return errwrap.Wrapf("TODO: {{err}}", err)
+		return errwrap.Wrapf("Error Getting LoadBalancer Name and Group: {{err}}", err)
 	}
 
 	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Creating/Updating LoadBalancer {{err}}", err)
 	}
 
 	read, err := lbClient.Get(resGroup, loadBalancerName, "")
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer {{err}}", err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -1,0 +1,148 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMLoadbalancerNatRule_basic(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natRuleName := fmt.Sprintf("NatRule-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerNatRule_basic(ri, natRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerNatRuleExists(natRuleName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadbalancerNatRule_removal(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natRuleName := fmt.Sprintf("NatRule-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerNatRule_basic(ri, natRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerNatRuleExists(natRuleName, &lb),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadbalancerNatRule_removal(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerNatRuleNotExists(natRuleName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMLoadbalancerNatRuleExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerNatRuleByName(lb, natRuleName)
+		if !exists {
+			return fmt.Errorf("A Nat Rule with name %q cannot be found.", natRuleName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLoadbalancerNatRuleNotExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerNatRuleByName(lb, natRuleName)
+		if exists {
+			return fmt.Errorf("A Nat Rule with name %q has been found.", natRuleName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMLoadbalancerNatRule_basic(rInt int, natRuleName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, natRuleName, rInt)
+}
+
+func testAccAzureRMLoadbalancerNatRule_removal(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+`, rInt, rInt, rInt, rInt)
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAzureRMLoadbalancerNatRule_basic(t *testing.T) {
+func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	natRuleName := fmt.Sprintf("NatRule-%d", ri)
@@ -18,20 +18,20 @@ func TestAccAzureRMLoadbalancerNatRule_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerNatRule_basic(ri, natRuleName),
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerNatRuleExists(natRuleName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMLoadbalancerNatRule_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerNatRule_removal(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	natRuleName := fmt.Sprintf("NatRule-%d", ri)
@@ -39,27 +39,27 @@ func TestAccAzureRMLoadbalancerNatRule_removal(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerNatRule_basic(ri, natRuleName),
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerNatRuleExists(natRuleName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadbalancerNatRule_removal(ri),
+				Config: testAccAzureRMLoadBalancerNatRule_removal(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerNatRuleNotExists(natRuleName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatRuleNotExists(natRuleName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureRMLoadbalancerNatRuleExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerNatRuleExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatRuleByName(lb, natRuleName)
 		if !exists {
@@ -70,7 +70,7 @@ func testCheckAzureRMLoadbalancerNatRuleExists(natRuleName string, lb *network.L
 	}
 }
 
-func testCheckAzureRMLoadbalancerNatRuleNotExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerNatRuleNotExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatRuleByName(lb, natRuleName)
 		if exists {
@@ -81,7 +81,7 @@ func testCheckAzureRMLoadbalancerNatRuleNotExists(natRuleName string, lb *networ
 	}
 }
 
-func testAccAzureRMLoadbalancerNatRule_basic(rInt int, natRuleName string) string {
+func testAccAzureRMLoadBalancerNatRule_basic(rInt int, natRuleName string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
@@ -120,7 +120,7 @@ resource "azurerm_lb_nat_rule" "test" {
 `, rInt, rInt, rInt, rInt, natRuleName, rInt)
 }
 
-func testAccAzureRMLoadbalancerNatRule_removal(rInt int) string {
+func testAccAzureRMLoadBalancerNatRule_removal(rInt int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -63,7 +63,7 @@ func testCheckAzureRMLoadbalancerNatRuleExists(natRuleName string, lb *network.L
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatRuleByName(lb, natRuleName)
 		if !exists {
-			return fmt.Errorf("A Nat Rule with name %q cannot be found.", natRuleName)
+			return fmt.Errorf("A NAT Rule with name %q cannot be found.", natRuleName)
 		}
 
 		return nil
@@ -74,7 +74,7 @@ func testCheckAzureRMLoadbalancerNatRuleNotExists(natRuleName string, lb *networ
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerNatRuleByName(lb, natRuleName)
 		if exists {
-			return fmt.Errorf("A Nat Rule with name %q has been found.", natRuleName)
+			return fmt.Errorf("A NAT Rule with name %q has been found.", natRuleName)
 		}
 
 		return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -90,11 +90,11 @@ func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}
 
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
 		return nil
 	}
 
@@ -105,27 +105,27 @@ func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}
 
 	newProbe, err := expandAzureRmLoadbalancerProbe(d, loadBalancer)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Expanding Probe {{err}}", err)
 	}
 
 	probes := append(*loadBalancer.Properties.Probes, *newProbe)
 	loadBalancer.Properties.Probes = &probes
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {
-		return errwrap.Wrapf("TODO: {{err}}", err)
+		return errwrap.Wrapf("Error Getting LoadBalancer Name and Group: {{err}}", err)
 	}
 
 	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Creating/Updating LoadBalancer {{err}}", err)
 	}
 
 	read, err := lbClient.Get(resGroup, loadBalancerName, "")
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer {{err}}", err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -138,7 +138,7 @@ func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}
 		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
 	return resourceArmLoadbalancerProbeRead(d, meta)
@@ -147,11 +147,11 @@ func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}
 func resourceArmLoadbalancerProbeRead(d *schema.ResourceData, meta interface{}) error {
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
 		return nil
 	}
 
@@ -179,7 +179,7 @@ func resourceArmLoadbalancerProbeDelete(d *schema.ResourceData, meta interface{}
 
 	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
@@ -197,20 +197,20 @@ func resourceArmLoadbalancerProbeDelete(d *schema.ResourceData, meta interface{}
 
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {
-		return errwrap.Wrapf("TODO: {{err}}", err)
+		return errwrap.Wrapf("Error Getting LoadBalancer Name and Group: {{err}}", err)
 	}
 
 	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Creating/Updating LoadBalancer {{err}}", err)
 	}
 
 	read, err := lbClient.Get(resGroup, loadBalancerName, "")
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error Getting LoadBalancer {{err}}", err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -1,0 +1,241 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+)
+
+func resourceArmLoadbalancerProbe() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLoadbalancerProbeCreate,
+		Read:   resourceArmLoadbalancerProbeRead,
+		Update: resourceArmLoadbalancerProbeCreate,
+		Delete: resourceArmLoadbalancerProbeDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"loadbalancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+
+			"port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"request_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"interval_in_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  15,
+			},
+
+			"number_of_probes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  2,
+			},
+
+			"load_balance_rules": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	_, _, exists = findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
+	if exists {
+		return fmt.Errorf("A Probe with name %q already exists.", d.Get("name").(string))
+	}
+
+	newProbe, err := expandAzureRmLoadbalancerProbe(d, loadBalancer)
+	if err != nil {
+		return err
+	}
+
+	probes := append(*loadBalancer.Properties.Probes, *newProbe)
+	loadBalancer.Properties.Probes = &probes
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  []string{"Succeeded"},
+		Refresh: loadbalancerStateRefreshFunc(client, resGroup, loadBalancerName),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+	}
+
+	return resourceArmLoadbalancerProbeRead(d, meta)
+}
+
+func resourceArmLoadbalancerProbeRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	configs := *loadBalancer.Properties.Probes
+	for _, config := range configs {
+		if *config.Name == d.Get("name").(string) {
+			d.Set("name", config.Name)
+
+			d.Set("protocol", config.Properties.Protocol)
+			d.Set("interval_in_seconds", config.Properties.IntervalInSeconds)
+			d.Set("number_of_probes", config.Properties.NumberOfProbes)
+			d.Set("port", config.Properties.Port)
+			d.Set("request_path", config.Properties.RequestPath)
+
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceArmLoadbalancerProbeDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	_, index, exists := findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		return nil
+	}
+
+	oldProbes := *loadBalancer.Properties.Probes
+	newProbes := append(oldProbes[:index], oldProbes[index+1:]...)
+	loadBalancer.Properties.Probes = &newProbes
+
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	return nil
+}
+
+func expandAzureRmLoadbalancerProbe(d *schema.ResourceData, lb *network.LoadBalancer) (*network.Probe, error) {
+
+	properties := network.ProbePropertiesFormat{
+		NumberOfProbes:    azure.Int32(int32(d.Get("number_of_probes").(int))),
+		IntervalInSeconds: azure.Int32(int32(d.Get("interval_in_seconds").(int))),
+		Port:              azure.Int32(int32(d.Get("port").(int))),
+	}
+
+	if v, ok := d.GetOk("protocol"); ok {
+		properties.Protocol = network.ProbeProtocol(v.(string))
+	}
+
+	if v, ok := d.GetOk("request_path"); ok {
+		properties.RequestPath = azure.String(v.(string))
+	}
+
+	probe := network.Probe{
+		Name:       azure.String(d.Get("name").(string)),
+		Properties: &properties,
+	}
+
+	return &probe, nil
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -12,12 +12,12 @@ import (
 	"github.com/jen20/riviera/azure"
 )
 
-func resourceArmLoadbalancerProbe() *schema.Resource {
+func resourceArmLoadBalancerProbe() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmLoadbalancerProbeCreate,
-		Read:   resourceArmLoadbalancerProbeRead,
-		Update: resourceArmLoadbalancerProbeCreate,
-		Delete: resourceArmLoadbalancerProbeDelete,
+		Create: resourceArmLoadBalancerProbeCreate,
+		Read:   resourceArmLoadBalancerProbeRead,
+		Update: resourceArmLoadBalancerProbeCreate,
+		Delete: resourceArmLoadBalancerProbeDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -84,11 +84,11 @@ func resourceArmLoadbalancerProbe() *schema.Resource {
 	}
 }
 
-func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -103,7 +103,7 @@ func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("A Probe with name %q already exists.", d.Get("name").(string))
 	}
 
-	newProbe, err := expandAzureRmLoadbalancerProbe(d, loadBalancer)
+	newProbe, err := expandAzureRmLoadBalancerProbe(d, loadBalancer)
 	if err != nil {
 		return errwrap.Wrapf("Error Expanding Probe {{err}}", err)
 	}
@@ -141,11 +141,11 @@ func resourceArmLoadbalancerProbeCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
-	return resourceArmLoadbalancerProbeRead(d, meta)
+	return resourceArmLoadBalancerProbeRead(d, meta)
 }
 
-func resourceArmLoadbalancerProbeRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+func resourceArmLoadBalancerProbeRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -173,11 +173,11 @@ func resourceArmLoadbalancerProbeRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceArmLoadbalancerProbeDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerProbeDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -216,7 +216,7 @@ func resourceArmLoadbalancerProbeDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func expandAzureRmLoadbalancerProbe(d *schema.ResourceData, lb *network.LoadBalancer) (*network.Probe, error) {
+func expandAzureRmLoadBalancerProbe(d *schema.ResourceData, lb *network.LoadBalancer) (*network.Probe, error) {
 
 	properties := network.ProbePropertiesFormat{
 		NumberOfProbes:    azure.Int32(int32(d.Get("number_of_probes").(int))),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -1,0 +1,144 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMLoadbalancerProbe_basic(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	probeName := fmt.Sprintf("probe-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerProbe_basic(ri, probeName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerProbeExists(probeName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadbalancerProbe_removal(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	probeName := fmt.Sprintf("probe-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerProbe_basic(ri, probeName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerProbeExists(probeName, &lb),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadbalancerProbe_removal(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerProbeNotExists(probeName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMLoadbalancerProbeExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerProbeByName(lb, natRuleName)
+		if !exists {
+			return fmt.Errorf("A Probe with name %q cannot be found.", natRuleName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLoadbalancerProbeNotExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerProbeByName(lb, natRuleName)
+		if exists {
+			return fmt.Errorf("A Probe with name %q has been found.", natRuleName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMLoadbalancerProbe_basic(rInt int, probeName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_probe" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  port = 22
+}
+`, rInt, rInt, rInt, rInt, probeName)
+}
+
+func testAccAzureRMLoadbalancerProbe_removal(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+`, rInt, rInt, rInt, rInt)
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAzureRMLoadbalancerProbe_basic(t *testing.T) {
+func TestAccAzureRMLoadBalancerProbe_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	probeName := fmt.Sprintf("probe-%d", ri)
@@ -18,20 +18,20 @@ func TestAccAzureRMLoadbalancerProbe_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerProbe_basic(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerProbeExists(probeName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMLoadbalancerProbe_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerProbe_removal(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	probeName := fmt.Sprintf("probe-%d", ri)
@@ -39,27 +39,27 @@ func TestAccAzureRMLoadbalancerProbe_removal(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerProbe_basic(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerProbeExists(probeName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadbalancerProbe_removal(ri),
+				Config: testAccAzureRMLoadBalancerProbe_removal(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerProbeNotExists(probeName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerProbeNotExists(probeName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureRMLoadbalancerProbeExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerProbeExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerProbeByName(lb, natRuleName)
 		if !exists {
@@ -70,7 +70,7 @@ func testCheckAzureRMLoadbalancerProbeExists(natRuleName string, lb *network.Loa
 	}
 }
 
-func testCheckAzureRMLoadbalancerProbeNotExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerProbeNotExists(natRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerProbeByName(lb, natRuleName)
 		if exists {
@@ -81,7 +81,7 @@ func testCheckAzureRMLoadbalancerProbeNotExists(natRuleName string, lb *network.
 	}
 }
 
-func testAccAzureRMLoadbalancerProbe_basic(rInt int, probeName string) string {
+func testAccAzureRMLoadBalancerProbe_basic(rInt int, probeName string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
@@ -116,7 +116,7 @@ resource "azurerm_lb_probe" "test" {
 `, rInt, rInt, rInt, rInt, probeName)
 }
 
-func testAccAzureRMLoadbalancerProbe_removal(rInt int) string {
+func testAccAzureRMLoadBalancerProbe_removal(rInt int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -1,0 +1,309 @@
+package azurerm
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jen20/riviera/azure"
+	"log"
+	"time"
+)
+
+func resourceArmLoadbalancerRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLoadbalancerRuleCreate,
+		Read:   resourceArmLoadbalancerRuleRead,
+		Update: resourceArmLoadbalancerRuleCreate,
+		Delete: resourceArmLoadbalancerRuleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: azureRMNormalizeLocation,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"loadbalancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"frontend_ip_configuration_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"frontend_ip_configuration_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"backend_address_pool_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"frontend_port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"backend_port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"probe_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"enable_floating_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"idle_timeout_in_minutes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"load_distribution": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmLoadbalancerRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	_, _, exists = findLoadBalancerRuleByName(loadBalancer, d.Get("name").(string))
+	if exists {
+		return fmt.Errorf("A Nat Rule with name %q already exists.", d.Get("name").(string))
+	}
+
+	newLbRule, err := expandAzureRmLoadbalancerRule(d, loadBalancer)
+	if err != nil {
+		return err
+	}
+
+	lbRules := append(*loadBalancer.Properties.LoadBalancingRules, *newLbRule)
+	loadBalancer.Properties.LoadBalancingRules = &lbRules
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Accepted", "Updating"},
+		Target:  []string{"Succeeded"},
+		Refresh: loadbalancerStateRefreshFunc(client, resGroup, loadBalancerName),
+		Timeout: 10 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Loadbalancer (%s) to become available: %s", loadBalancerName, err)
+	}
+
+	return resourceArmLoadbalancerRuleRead(d, meta)
+}
+
+func resourceArmLoadbalancerRuleRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Loadbalancer %q not found. Refreshing from state", d.Get("name").(string))
+		return nil
+	}
+
+	configs := *loadBalancer.Properties.LoadBalancingRules
+	for _, config := range configs {
+		if *config.Name == d.Get("name").(string) {
+			d.Set("name", config.Name)
+
+			d.Set("protocol", config.Properties.Protocol)
+			d.Set("frontend_port", config.Properties.FrontendPort)
+			d.Set("backend_port", config.Properties.BackendPort)
+
+			if config.Properties.EnableFloatingIP != nil {
+				d.Set("enable_floating_ip", config.Properties.EnableFloatingIP)
+			}
+
+			if config.Properties.IdleTimeoutInMinutes != nil {
+				d.Set("idle_timeout_in_minutes", config.Properties.IdleTimeoutInMinutes)
+			}
+
+			if config.Properties.FrontendIPConfiguration != nil {
+				d.Set("frontend_ip_configuration_id", config.Properties.FrontendIPConfiguration.ID)
+			}
+
+			if config.Properties.BackendAddressPool != nil {
+				d.Set("backend_address_pool_id", config.Properties.BackendAddressPool.ID)
+			}
+
+			if config.Properties.Probe != nil {
+				d.Set("probe_id", config.Properties.Probe.ID)
+			}
+
+			if config.Properties.LoadDistribution != "" {
+				d.Set("load_distribution", config.Properties.LoadDistribution)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceArmLoadbalancerRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	lbClient := client.loadBalancerClient
+
+	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	_, index, exists := findLoadBalancerRuleByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		return nil
+	}
+
+	oldLbRules := *loadBalancer.Properties.LoadBalancingRules
+	newLbRules := append(oldLbRules[:index], oldLbRules[index+1:]...)
+	loadBalancer.Properties.LoadBalancingRules = &newLbRules
+
+	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
+	if err != nil {
+		return errwrap.Wrapf("TODO: {{err}}", err)
+	}
+
+	_, err = lbClient.CreateOrUpdate(resGroup, loadBalancerName, *loadBalancer, make(chan struct{}))
+	if err != nil {
+		return err
+	}
+
+	read, err := lbClient.Get(resGroup, loadBalancerName, "")
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Loadbalancer %s (resource group %s) ID", loadBalancerName, resGroup)
+	}
+
+	return nil
+}
+
+func expandAzureRmLoadbalancerRule(d *schema.ResourceData, lb *network.LoadBalancer) (*network.LoadBalancingRule, error) {
+
+	properties := network.LoadBalancingRulePropertiesFormat{
+		Protocol:         network.TransportProtocol(d.Get("protocol").(string)),
+		FrontendPort:     azure.Int32(int32(d.Get("frontend_port").(int))),
+		BackendPort:      azure.Int32(int32(d.Get("backend_port").(int))),
+		EnableFloatingIP: azure.Bool(d.Get("enable_floating_ip").(bool)),
+	}
+
+	if v, ok := d.GetOk("idle_timeout_in_minutes"); ok {
+		properties.IdleTimeoutInMinutes = azure.Int32(int32(v.(int)))
+	}
+
+	if v := d.Get("load_distribution").(string); v != "" {
+		properties.LoadDistribution = network.LoadDistribution(v)
+	}
+
+	if v := d.Get("frontend_ip_configuration_name").(string); v != "" {
+		rule, _, exists := findLoadBalancerFrontEndIpConfigurationByName(lb, v)
+		if !exists {
+			return nil, fmt.Errorf("[ERROR] Cannot find FrontEnd IP Configuration with the name %s", v)
+		}
+
+		feip := network.SubResource{
+			ID: rule.ID,
+		}
+
+		properties.FrontendIPConfiguration = &feip
+	}
+
+	if v := d.Get("backend_address_pool_id").(string); v != "" {
+		beAP := network.SubResource{
+			ID: &v,
+		}
+
+		properties.BackendAddressPool = &beAP
+	}
+
+	if v := d.Get("probe_id").(string); v != "" {
+		pid := network.SubResource{
+			ID: &v,
+		}
+
+		properties.Probe = &pid
+	}
+
+	lbRule := network.LoadBalancingRule{
+		Name:       azure.String(d.Get("name").(string)),
+		Properties: &properties,
+	}
+
+	return &lbRule, nil
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -13,12 +13,12 @@ import (
 	"github.com/jen20/riviera/azure"
 )
 
-func resourceArmLoadbalancerRule() *schema.Resource {
+func resourceArmLoadBalancerRule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmLoadbalancerRuleCreate,
-		Read:   resourceArmLoadbalancerRuleRead,
-		Update: resourceArmLoadbalancerRuleCreate,
-		Delete: resourceArmLoadbalancerRuleDelete,
+		Create: resourceArmLoadBalancerRuleCreate,
+		Read:   resourceArmLoadBalancerRuleRead,
+		Update: resourceArmLoadBalancerRuleCreate,
+		Delete: resourceArmLoadBalancerRuleDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -105,11 +105,11 @@ func resourceArmLoadbalancerRule() *schema.Resource {
 	}
 }
 
-func resourceArmLoadbalancerRuleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -124,7 +124,7 @@ func resourceArmLoadbalancerRuleCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("A LoadBalancer Rule with name %q already exists.", d.Get("name").(string))
 	}
 
-	newLbRule, err := expandAzureRmLoadbalancerRule(d, loadBalancer)
+	newLbRule, err := expandAzureRmLoadBalancerRule(d, loadBalancer)
 	if err != nil {
 		return errwrap.Wrapf("Error Exanding LoadBalancer Rule {{err}}", err)
 	}
@@ -162,11 +162,11 @@ func resourceArmLoadbalancerRuleCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", loadBalancerName, err)
 	}
 
-	return resourceArmLoadbalancerRuleRead(d, meta)
+	return resourceArmLoadBalancerRuleRead(d, meta)
 }
 
-func resourceArmLoadbalancerRuleRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Id(), meta)
+func resourceArmLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) error {
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -214,11 +214,11 @@ func resourceArmLoadbalancerRuleRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceArmLoadbalancerRuleDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadbalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -257,7 +257,7 @@ func resourceArmLoadbalancerRuleDelete(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func expandAzureRmLoadbalancerRule(d *schema.ResourceData, lb *network.LoadBalancer) (*network.LoadBalancingRule, error) {
+func expandAzureRmLoadBalancerRule(d *schema.ResourceData, lb *network.LoadBalancer) (*network.LoadBalancingRule, error) {
 
 	properties := network.LoadBalancingRulePropertiesFormat{
 		Protocol:         network.TransportProtocol(d.Get("protocol").(string)),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -1,0 +1,148 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMLoadbalancerRule_basic(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	lbRuleName := fmt.Sprintf("LbRule-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerRule_basic(ri, lbRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerRuleExists(lbRuleName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadbalancerRule_removal(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	lbRuleName := fmt.Sprintf("LbRule-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancerRule_basic(ri, lbRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerRuleExists(lbRuleName, &lb),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadbalancerRule_removal(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadbalancerRuleNotExists(lbRuleName, &lb),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMLoadbalancerRuleExists(lbRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerRuleByName(lb, lbRuleName)
+		if !exists {
+			return fmt.Errorf("A LoadBalancer Rule with name %q cannot be found.", lbRuleName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLoadbalancerRuleNotExists(lbRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, _, exists := findLoadBalancerRuleByName(lb, lbRuleName)
+		if exists {
+			return fmt.Errorf("A LoadBalancer Rule with name %q has been found.", lbRuleName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMLoadbalancerRule_basic(rInt int, lbRuleName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, lbRuleName, rInt)
+}
+
+func testAccAzureRMLoadbalancerRule_removal(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+`, rInt, rInt, rInt, rInt)
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -10,6 +10,54 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceAzureRMLoadBalancerRuleNameLabel_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "-word",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing-",
+			ErrCount: 1,
+		},
+		{
+			Value:    "test123test",
+			ErrCount: 1,
+		},
+		{
+			Value:    acctest.RandStringFromCharSet(81, "abcdedfed"),
+			ErrCount: 1,
+		},
+		{
+			Value:    "test.rule",
+			ErrCount: 0,
+		},
+		{
+			Value:    "test_rule",
+			ErrCount: 0,
+		},
+		{
+			Value:    "test-rule",
+			ErrCount: 0,
+		},
+		{
+			Value:    "TestRule",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateArmLoadBalancerRuleName(tc.Value, "azurerm_lb_rule")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Azure RM LoadBalancer Rule Name Label to trigger a validation error")
+		}
+	}
+}
+
 func TestAccAzureRMLoadbalancerRule_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -58,7 +58,7 @@ func TestResourceAzureRMLoadBalancerRuleNameLabel_validation(t *testing.T) {
 	}
 }
 
-func TestAccAzureRMLoadbalancerRule_basic(t *testing.T) {
+func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	lbRuleName := fmt.Sprintf("LbRule-%d", ri)
@@ -66,20 +66,20 @@ func TestAccAzureRMLoadbalancerRule_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerRule_basic(ri, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerRuleExists(lbRuleName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMLoadbalancerRule_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerRule_removal(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	lbRuleName := fmt.Sprintf("LbRule-%d", ri)
@@ -87,27 +87,27 @@ func TestAccAzureRMLoadbalancerRule_removal(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancerRule_basic(ri, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerRuleExists(lbRuleName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadbalancerRule_removal(ri),
+				Config: testAccAzureRMLoadBalancerRule_removal(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
-					testCheckAzureRMLoadbalancerRuleNotExists(lbRuleName, &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerRuleNotExists(lbRuleName, &lb),
 				),
 			},
 		},
 	})
 }
 
-func testCheckAzureRMLoadbalancerRuleExists(lbRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerRuleExists(lbRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerRuleByName(lb, lbRuleName)
 		if !exists {
@@ -118,7 +118,7 @@ func testCheckAzureRMLoadbalancerRuleExists(lbRuleName string, lb *network.LoadB
 	}
 }
 
-func testCheckAzureRMLoadbalancerRuleNotExists(lbRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerRuleNotExists(lbRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerRuleByName(lb, lbRuleName)
 		if exists {
@@ -129,7 +129,7 @@ func testCheckAzureRMLoadbalancerRuleNotExists(lbRuleName string, lb *network.Lo
 	}
 }
 
-func testAccAzureRMLoadbalancerRule_basic(rInt int, lbRuleName string) string {
+func testAccAzureRMLoadBalancerRule_basic(rInt int, lbRuleName string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
@@ -168,7 +168,7 @@ resource "azurerm_lb_rule" "test" {
 `, rInt, rInt, rInt, rInt, lbRuleName, rInt)
 }
 
-func testAccAzureRMLoadbalancerRule_removal(rInt int) string {
+func testAccAzureRMLoadBalancerRule_removal(rInt int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceAzureRMLoadbalancerPrivateIpAddressAllocation_validation(t *testing.T) {
+func TestResourceAzureRMLoadBalancerPrivateIpAddressAllocation_validation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -39,54 +39,54 @@ func TestResourceAzureRMLoadbalancerPrivateIpAddressAllocation_validation(t *tes
 	}
 
 	for _, tc := range cases {
-		_, errors := validateLoadbalancerPrivateIpAddressAllocation(tc.Value, "azurerm_lb")
+		_, errors := validateLoadBalancerPrivateIpAddressAllocation(tc.Value, "azurerm_lb")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Loadbalancer private_ip_address_allocation to trigger a validation error")
+			t.Fatalf("Expected the Azure RM LoadBalancer private_ip_address_allocation to trigger a validation error")
 		}
 	}
 }
 
-func TestAccAzureRMLoadbalancer_basic(t *testing.T) {
+func TestAccAzureRMLoadBalancer_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancer_basic(ri),
+				Config: testAccAzureRMLoadBalancer_basic(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMLoadbalancer_frontEndConfig(t *testing.T) {
+func TestAccAzureRMLoadBalancer_frontEndConfig(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancer_frontEndConfig(ri),
+				Config: testAccAzureRMLoadBalancer_frontEndConfig(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					resource.TestCheckResourceAttr(
 						"azurerm_lb.test", "frontend_ip_configuration.#", "2"),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadbalancer_frontEndConfigRemoval(ri),
+				Config: testAccAzureRMLoadBalancer_frontEndConfigRemoval(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					resource.TestCheckResourceAttr(
 						"azurerm_lb.test", "frontend_ip_configuration.#", "1"),
 				),
@@ -95,19 +95,19 @@ func TestAccAzureRMLoadbalancer_frontEndConfig(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMLoadbalancer_tags(t *testing.T) {
+func TestAccAzureRMLoadBalancer_tags(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadbalancer_basic(ri),
+				Config: testAccAzureRMLoadBalancer_basic(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					resource.TestCheckResourceAttr(
 						"azurerm_lb.test", "tags.%", "2"),
 					resource.TestCheckResourceAttr(
@@ -117,9 +117,9 @@ func TestAccAzureRMLoadbalancer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMLoadbalancer_updatedTags(ri),
+				Config: testAccAzureRMLoadBalancer_updatedTags(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					resource.TestCheckResourceAttr(
 						"azurerm_lb.test", "tags.%", "1"),
 					resource.TestCheckResourceAttr(
@@ -130,7 +130,7 @@ func TestAccAzureRMLoadbalancer_tags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMLoadbalancerExists(name string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerExists(name string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -148,7 +148,7 @@ func testCheckAzureRMLoadbalancerExists(name string, lb *network.LoadBalancer) r
 		resp, err := conn.Get(resourceGroup, loadbalancerName, "")
 		if err != nil {
 			if resp.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("Bad: Loadbalancer %q (resource group: %q) does not exist", loadbalancerName, resourceGroup)
+				return fmt.Errorf("Bad: LoadBalancer %q (resource group: %q) does not exist", loadbalancerName, resourceGroup)
 			}
 
 			return fmt.Errorf("Bad: Get on loadBalancerClient: %s", err)
@@ -160,7 +160,7 @@ func testCheckAzureRMLoadbalancerExists(name string, lb *network.LoadBalancer) r
 	}
 }
 
-func testCheckAzureRMLoadbalancerDestroy(s *terraform.State) error {
+func testCheckAzureRMLoadBalancerDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
 
 	for _, rs := range s.RootModule().Resources {
@@ -178,14 +178,14 @@ func testCheckAzureRMLoadbalancerDestroy(s *terraform.State) error {
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("Loadbalancer still exists:\n%#v", resp.Properties)
+			return fmt.Errorf("LoadBalancer still exists:\n%#v", resp.Properties)
 		}
 	}
 
 	return nil
 }
 
-func testAccAzureRMLoadbalancer_basic(rInt int) string {
+func testAccAzureRMLoadBalancer_basic(rInt int) string {
 	return fmt.Sprintf(`
 
 resource "azurerm_resource_group" "test" {
@@ -206,7 +206,7 @@ resource "azurerm_lb" "test" {
 }`, rInt, rInt)
 }
 
-func testAccAzureRMLoadbalancer_updatedTags(rInt int) string {
+func testAccAzureRMLoadBalancer_updatedTags(rInt int) string {
 	return fmt.Sprintf(`
 
 resource "azurerm_resource_group" "test" {
@@ -226,7 +226,7 @@ resource "azurerm_lb" "test" {
 }`, rInt, rInt)
 }
 
-func testAccAzureRMLoadbalancer_frontEndConfig(rInt int) string {
+func testAccAzureRMLoadBalancer_frontEndConfig(rInt int) string {
 	return fmt.Sprintf(`
 
 resource "azurerm_resource_group" "test" {
@@ -265,7 +265,7 @@ resource "azurerm_lb" "test" {
 }`, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMLoadbalancer_frontEndConfigRemoval(rInt int) string {
+func testAccAzureRMLoadBalancer_frontEndConfigRemoval(rInt int) string {
 	return fmt.Sprintf(`
 
 resource "azurerm_resource_group" "test" {

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_test.go
@@ -1,0 +1,293 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceAzureRMLoadbalancerPrivateIpAddressAllocation_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "Random",
+			ErrCount: 1,
+		},
+		{
+			Value:    "Static",
+			ErrCount: 0,
+		},
+		{
+			Value:    "Dynamic",
+			ErrCount: 0,
+		},
+		{
+			Value:    "STATIC",
+			ErrCount: 0,
+		},
+		{
+			Value:    "static",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateLoadbalancerPrivateIpAddressAllocation(tc.Value, "azurerm_lb")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Azure RM Loadbalancer private_ip_address_allocation to trigger a validation error")
+		}
+	}
+}
+
+func TestAccAzureRMLoadbalancer_basic(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancer_basic(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadbalancer_frontEndConfig(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancer_frontEndConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb.test", "frontend_ip_configuration.#", "2"),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadbalancer_frontEndConfigRemoval(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb.test", "frontend_ip_configuration.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadbalancer_tags(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadbalancer_basic(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb.test", "tags.%", "2"),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb.test", "tags.Environment", "production"),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb.test", "tags.Purpose", "AcceptanceTests"),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadbalancer_updatedTags(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadbalancerExists("azurerm_lb.test", &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb.test", "tags.Purpose", "AcceptanceTests"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMLoadbalancerExists(name string, lb *network.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		loadbalancerName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for loadbalancer: %s", loadbalancerName)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
+
+		resp, err := conn.Get(resourceGroup, loadbalancerName, "")
+		if err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("Bad: Loadbalancer %q (resource group: %q) does not exist", loadbalancerName, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on loadBalancerClient: %s", err)
+		}
+
+		*lb = resp
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLoadbalancerDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_lb" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(resourceGroup, name, "")
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Loadbalancer still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureRMLoadbalancer_basic(rInt int) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    tags {
+    	Environment = "production"
+    	Purpose = "AcceptanceTests"
+    }
+
+}`, rInt, rInt)
+}
+
+func testAccAzureRMLoadbalancer_updatedTags(rInt int) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    tags {
+    	Purpose = "AcceptanceTests"
+    }
+
+}`, rInt, rInt)
+}
+
+func testAccAzureRMLoadbalancer_frontEndConfig(rInt int) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_public_ip" "test1" {
+    name = "another-test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+
+    frontend_ip_configuration {
+      name = "two-%d"
+      public_ip_address_id = "${azurerm_public_ip.test1.id}"
+    }
+}`, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMLoadbalancer_frontEndConfigRemoval(rInt int) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}`, rInt, rInt, rInt, rInt)
+}

--- a/builtin/providers/azurerm/tags.go
+++ b/builtin/providers/azurerm/tags.go
@@ -11,6 +11,7 @@ func tagsSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeMap,
 		Optional:     true,
+		Computed:     true,
 		ValidateFunc: validateAzureRMTags,
 	}
 }

--- a/website/source/docs/providers/azurerm/r/loadbalancer.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_lb"
+sidebar_current: "docs-azurerm-resource-loadbalancer"
+description: |-
+  Create a LoadBalancer Resource.
+---
+
+# azurerm\_lb
+
+Create a LoadBalancer Resource.
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "LoadBalancerRG"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "PublicIPForLB"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "TestLoadBalancer"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "PublicIPAddress"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the LoadBalancer.
+* `resource_group_name` - (Required) The name of the resource group in which to create the LoadBalancer.
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+* `frontend_ip_configuration` - (Optional) A frontend ip configuration block as documented below.
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
+
+`frontend_ip_configuration` supports the following:
+
+* `name` - (Required) Specifies the name of the frontend ip configuration.
+* `subnet_id` - (Optional) Reference to subnet associated with the IP Configuration.
+* `private_ip_address` - (Optional) Private IP Address to assign to the Load Balancer. The last one and first four IPs in any range are reserved and cannot be manually assigned.
+* `public_ip_address_id` - (Optional) Reference to Public IP address to be associated with the Load Balancer.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The LoadBalancer ID.
+

--- a/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_lb_backend_address_pool"
+sidebar_current: "docs-azurerm-resource-loadbalancer-backend-address-pool"
+description: |-
+  Create a LoadBalancer Backend Address Pool.
+---
+
+# azurerm\_lb\_backend\_address\_pool
+
+Create a LoadBalancer Backend Address Pool.
+
+~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "LoadBalancerRG"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "PublicIPForLB"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "TestLoadBalancer"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "PublicIPAddress"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "BackEndAddressPool"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Backend Address Pool.
+* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+* `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the Backend Address Pool. 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the LoadBalancer to which the resource is attached.

--- a/website/source/docs/providers/azurerm/r/loadbalancer_nat_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_nat_pool.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_lb_nat_pool"
+sidebar_current: "docs-azurerm-resource-loadbalancer-nat-pool"
+description: |-
+  Create a LoadBalancer NAT Pool.
+---
+
+# azurerm\_lb\_nat\_pool
+
+Create a LoadBalancer NAT pool.
+
+~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "LoadBalancerRG"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "PublicIPForLB"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "TestLoadBalancer"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "PublicIPAddress"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_pool" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "SampleApplication Pool"
+  protocol = "Tcp"
+  frontend_port_start = 80
+  frontend_port_end = 81
+  backend_port = 8080
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the NAT pool.
+* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+* `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT pool.
+* `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration exposing this rule.
+* `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp` or `Tcp`. 
+* `frontend_port_start` - (Required) The first port number in the range of external ports that will be used to provide Inbound Nat to NICs associated with this Load Balancer. Possible values range between 1 and 65534, inclusive.
+* `frontend_port_end` - (Required) The last port number in the range of external ports that will be used to provide Inbound Nat to NICs associated with this Load Balancer. Possible values range between 1 and 65534, inclusive.
+* `backend_port` - (Required) The port used for the internal endpoint. Possible values range between 1 and 65535, inclusive.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the LoadBalancer to which the resource is attached.

--- a/website/source/docs/providers/azurerm/r/loadbalancer_nat_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_nat_rule.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_lb_nat_rule"
+sidebar_current: "docs-azurerm-resource-loadbalancer-nat-rule"
+description: |-
+  Create a LoadBalancer NAT Rule.
+---
+
+# azurerm\_lb\_nat\_rule
+
+Create a LoadBalancer NAT Rule.
+
+~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "LoadBalancerRG"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "PublicIPForLB"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "TestLoadBalancer"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "PublicIPAddress"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "RDP Access"
+  protocol = "Tcp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the NAT Rule.
+* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+* `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule.
+* `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration exposing this rule.
+* `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp` or `Tcp`. 
+* `frontend_port` - (Required) The port for the external endpoint. Port numbers for each Rule must be unique within the Load Balancer. Possible values range between 1 and 65534, inclusive.
+* `backend_port` - (Required) The port used for internal connections on the endpoint. Possible values range between 1 and 65535, inclusive.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the LoadBalancer to which the resource is attached.

--- a/website/source/docs/providers/azurerm/r/loadbalancer_probe.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_probe.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_lb_probe"
+sidebar_current: "docs-azurerm-resource-loadbalancer-probe"
+description: |-
+  Create a LoadBalancer Probe Resource.
+---
+
+# azurerm\_lb\_probe
+
+Create a LoadBalancer Probe Resource.
+
+~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "LoadBalancerRG"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "PublicIPForLB"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "TestLoadBalancer"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "PublicIPAddress"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_probe" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "SSH Running Probe"
+  port = 22
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Probe.
+* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+* `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule.
+* `protocol` - (Optional) Specifies the protocol of the end point. Possible values are `Http` or `Tcp`. If Tcp is specified, a received ACK is required for the probe to be successful. If Http is specified, a 200 OK response from the specified URI is required for the probe to be successful.
+* `port` - (Required) Port on which the Probe queries the backend endpoint. Possible values range from 1 to 65535, inclusive.
+* `request_path` - (Optional) The URI used for requesting health status from the backend endpoint. Required if protocol is set to Http. Otherwise, it is not allowed.
+* `interval_in_seconds` - (Optional) The interval, in seconds between probes to the backend endpoint for health status. The default value is 15, the minimum value is 5.
+* `number_of_probes` - (Optional) The number of failed probe attempts after which the backend endpoint is removed from rotation. The default value is 2. NumberOfProbes multiplied by intervalInSeconds value must be greater or equal to 10.Endpoints are returned to rotation when at least one probe is successful.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the LoadBalancer to which the resource is attached.
+

--- a/website/source/docs/providers/azurerm/r/loadbalancer_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_rule.html.markdown
@@ -1,0 +1,75 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_lb_rule"
+sidebar_current: "docs-azurerm-resource-loadbalancer-rule"
+description: |-
+  Create a LoadBalancer Rule.
+---
+
+# azurerm\_lb\_rule
+
+Create a LoadBalancer Rule.
+
+~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+
+## Example Usage
+
+```
+resource "azurerm_resource_group" "test" {
+    name = "LoadBalancerRG"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "PublicIPForLB"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "TestLoadBalancer"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "PublicIPAddress"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "LBRule"
+  protocol = "Tcp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "PublicIPAddress"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the LB Rule.
+* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+* `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the Rule.
+* `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration to which the rule is associated.
+* `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp` or `Tcp`. 
+* `frontend_port` - (Required) The port for the external endpoint. Port numbers for each Rule must be unique within the Load Balancer. Possible values range between 1 and 65534, inclusive.
+* `backend_port` - (Required) The port used for internal connections on the endpoint. Possible values range between 1 and 65535, inclusive.
+* `backend_address_pool_id` - (Optional) A reference to a Backend Address Pool over which this Load Balancing Rule operates.
+* `probe_id` - (Optional) A reference to a Probe used by this Load Balancing Rule.
+* `enable_floating_ip` - (Optional) Floating IP is pertinent to failover scenarios: a “floating” IP is reassigned to a secondary server in case the primary server fails. Floating IP is required for SQL AlwaysOn.
+* `idle_timeout_in_minutes` - (Optional) Specifies the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to Tcp.
+* `load_distribution` - (Optional) Specifies the load balancing distribution type to be used by the Load Balancer. Possible values are: Default – The load balancer is configured to use a 5 tuple hash to map traffic to available servers. SourceIP – The load balancer is configured to use a 2 tuple hash to map traffic to available servers. SourceIPProtocol – The load balancer is configured to use a 3 tuple hash to map traffic to available servers.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the LoadBalancer to which the resource is attached.

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -75,7 +75,7 @@
             </li>
 
             <li<%= sidebar_current(/^docs-azurerm-resource-loadbalancer/) %>>
-              <a href="#">LoadBalancer Resources</a>
+              <a href="#">Load Balancer Resources</a>
               <ul class="nav nav-visible">
 
                   <li<%= sidebar_current("docs-azurerm-resource-loadbalancer") %>>

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -74,6 +74,37 @@
                 </ul>
             </li>
 
+            <li<%= sidebar_current(/^docs-azurerm-resource-loadbalancer/) %>>
+              <a href="#">LoadBalancer Resources</a>
+              <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer") %>>
+                    <a href="/docs/providers/azurerm/r/loadbalancer.html">azurerm_lb</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-backend-address-pool") %>>
+                    <a href="/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html">azurerm_lb_backend_address_pool</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-rule") %>>
+                    <a href="/docs/providers/azurerm/r/loadbalancer_rule.html">azurerm_lb_rule</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-nat-rule") %>>
+                    <a href="/docs/providers/azurerm/r/loadbalancer_nat_rule.html">azurerm_lb_nat_rule</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-nat-pool") %>>
+                    <a href="/docs/providers/azurerm/r/loadbalancer_nat_pool.html">azurerm_lb_nat_pool</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-probe") %>>
+                    <a href="/docs/providers/azurerm/r/loadbalancer_probe.html">azurerm_lb_probe</a>
+                  </li>
+
+              </ul>
+            </li>
+
             <li<%= sidebar_current(/^docs-azurerm-resource-network/) %>>
               <a href="#">Network Resources</a>
               <ul class="nav nav-visible">


### PR DESCRIPTION
* [x] `azurerm_lb`
* [x] `azurerm_lb_backend_address_pool`
* [x] `azurerm_lb_rule`
* [x] `azurerm_lb_nat_rule` 
* [x] `azurerm_lb_probe`
* [x] `azurerm_lb_nat_pool`

Current test status:

```
% make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMLoadbalancer'                           ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/05 12:52:28 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMLoadbalancer -timeout 120m
=== RUN   TestAccAzureRMLoadbalancerBackEndAddressPool_basic
--- PASS: TestAccAzureRMLoadbalancerBackEndAddressPool_basic (207.26s)
=== RUN   TestAccAzureRMLoadbalancerBackEndAddressPool_removal
--- PASS: TestAccAzureRMLoadbalancerBackEndAddressPool_removal (165.89s)
=== RUN   TestAccAzureRMLoadbalancerNatRule_basic
--- PASS: TestAccAzureRMLoadbalancerNatRule_basic (179.30s)
=== RUN   TestAccAzureRMLoadbalancerNatRule_removal
--- PASS: TestAccAzureRMLoadbalancerNatRule_removal (180.73s)
=== RUN   TestAccAzureRMLoadbalancerRule_basic
--- PASS: TestAccAzureRMLoadbalancerRule_basic (170.40s)
=== RUN   TestAccAzureRMLoadbalancerRule_removal
--- PASS: TestAccAzureRMLoadbalancerRule_removal (204.23s)
=== RUN   TestAccAzureRMLoadbalancer_basic
--- PASS: TestAccAzureRMLoadbalancer_basic (136.03s)
=== RUN   TestAccAzureRMLoadbalancer_frontEndConfig
--- PASS: TestAccAzureRMLoadbalancer_frontEndConfig (214.47s)
=== RUN   TestAccAzureRMLoadbalancer_tags
--- PASS: TestAccAzureRMLoadbalancer_tags (215.52s)
=== RUN   TestAccAzureRMLoadbalancerProbe_basic
--- PASS: TestAccAzureRMLoadbalancerProbe_basic (183.36s)
=== RUN   TestAccAzureRMLoadbalancerProbe_removal
--- PASS: TestAccAzureRMLoadbalancerProbe_removal (185.86s)
=== RUN   TestAccAzureRMLoadbalancerNatPool_basic
--- PASS: TestAccAzureRMLoadbalancerNatPool_basic (161.47s)
=== RUN   TestAccAzureRMLoadbalancerNatPool_removal
--- PASS: TestAccAzureRMLoadbalancerNatPool_removal (167.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	1673.852s

```