### PR TITLE
provider/azurerm: Add disk_size_gb param to VM storage_os_disk

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -524,6 +524,7 @@ resource "azurerm_virtual_machine" "test" {
         vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
         caching = "ReadWrite"
         create_option = "FromImage"
+        disk_size_gb = "45"
     }
 
     os_profile {

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -249,6 +249,7 @@ For more information on the different example configurations, please check out t
 * `caching` - (Optional) Specifies the caching requirements.
 * `image_uri` - (Optional) Specifies the image_uri in the form publisherName:offer:skus:version. `image_uri` can also specify the [VHD uri](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-deploy-templates/#create-a-custom-vm-image) of a custom VM image to clone. When cloning a custom disk image the `os_type` documented below becomes required.
 * `os_type` - (Optional) Specifies the operating system Type, valid values are windows, linux.
+* `disk_size_gb` - (Optional) Specifies the size of the data disk in gigabytes.
 
 `storage_data_disk` supports the following:
 


### PR DESCRIPTION
    TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMVirtualMachine_basicLinuxMachine -timeout 120m
    === RUN   TestAccAzureRMVirtualMachine_basicLinuxMachine
    --- PASS: TestAccAzureRMVirtualMachine_basicLinuxMachine (540.83s)
    PASS
    ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	540.841s

    TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMVirtualMachine_withDataDisk -timeout 120m
    === RUN   TestAccAzureRMVirtualMachine_withDataDisk
    --- PASS: TestAccAzureRMVirtualMachine_withDataDisk (431.19s)
    PASS
    ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	431.203s