### PR TITLE
provider/aws: Add new "ANY" as valid HTTP method to API Gateway validator.

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -343,9 +343,21 @@ func validateCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []
 
 func validateHTTPMethod(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if value != "GET" && value != "HEAD" && value != "OPTIONS" && value != "PUT" && value != "POST" && value != "PATCH" && value != "DELETE" {
+
+	validMethods := map[string]bool{
+		"ANY":     true,
+		"DELETE":  true,
+		"GET":     true,
+		"HEAD":    true,
+		"OPTIONS": true,
+		"PATCH":   true,
+		"POST":    true,
+		"PUT":     true,
+	}
+
+	if _, ok := validMethods[value]; !ok {
 		errors = append(errors, fmt.Errorf(
-			"%q must be one of 'GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE'", k))
+			"%q must be one of 'GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE', or 'ANY'", k))
 	}
 	return
 }

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -276,7 +276,7 @@ func TestValidateCIDRNetworkAddress(t *testing.T) {
 }
 
 func TestValidateHTTPMethod(t *testing.T) {
-	validCases := []string{"GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD", "PATCH"}
+	validCases := []string{"GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD", "PATCH", "ANY"}
 	for i, method := range validCases {
 		_, errs := validateHTTPMethod(method, "foo")
 		if len(errs) != 0 {

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
+* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
 * `type` - (Required) The integration input's type (HTTP, MOCK, AWS, AWS_PROXY, HTTP_PROXY)
 * `uri` - (Optional) The input's URI (HTTP, AWS). **Required** if `type` is `HTTP` or `AWS`.
   For HTTP integrations, the URI must be a fully formed, encoded HTTP(S) URL according to the RFC-3986 specification . For AWS integrations, the URI should be of the form `arn:aws:apigateway:{region}:{subdomain.service|service}:{path|action}/{service_api}`. `region`, `subdomain` and `service` are used to determine the right endpoint.

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
+* `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
 * `status_code` - (Required) The HTTP status code
 * `selection_pattern` - (Optional) Specifies the regular expression pattern used to choose
   an integration response based on the response from the backend.

--- a/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
+* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
 * `authorization` - (Required) The type of authorization used for the method (`NONE`, `CUSTOM`)
 * `authorizer_id` - (Optional) The authorizer id to be used when the authorization is `CUSTOM`
 * `api_key_required` - (Optional) Specify if the method requires an API key

--- a/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_method_response.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
-* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
+* `http_method` - (Required) The HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
 * `status_code` - (Required) The HTTP status code
 * `response_models` - (Optional) A map of the API models used for the response's content type
 * `response_parameters` - (Optional) A map of response parameters that can be sent to the caller.


### PR DESCRIPTION
This commit adds a new HTTP method to a list of valid HTTP methods which
is now accepted by API Gateway.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>