### PR TITLE
provider/azurerm: write load_balanacer attributes to network_interface_card hash

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -328,6 +328,12 @@ func resourceArmNetworkInterfaceIpConfigurationHash(v interface{}) int {
 	if m["public_ip_address_id"] != nil {
 		buf.WriteString(fmt.Sprintf("%s-", m["public_ip_address_id"].(string)))
 	}
+	if m["load_balancer_backend_address_pools_ids"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["load_balancer_backend_address_pools_ids"].(*schema.Set).GoString()))
+	}
+	if m["load_balancer_inbound_nat_rules_ids"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["load_balancer_inbound_nat_rules_ids"].(*schema.Set).GoString()))
+	}
 
 	return hashcode.String(buf.String())
 }


### PR DESCRIPTION
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMNetworkInterface -timeout 120m
=== RUN   TestAccAzureRMNetworkInterface_basic
--- PASS: TestAccAzureRMNetworkInterface_basic (197.24s)
=== RUN   TestAccAzureRMNetworkInterface_enableIPForwarding
--- PASS: TestAccAzureRMNetworkInterface_enableIPForwarding (188.65s)
=== RUN   TestAccAzureRMNetworkInterface_withTags
--- PASS: TestAccAzureRMNetworkInterface_withTags (226.13s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	612.088s
```