### PR TITLE
provider/azurerm: Ensure availability set location is lowercase

### DIFF
--- a/builtin/providers/azurerm/resource_arm_availability_set.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -129,7 +130,7 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("platform_update_domain_count", availSet.PlatformUpdateDomainCount)
 	d.Set("platform_fault_domain_count", availSet.PlatformFaultDomainCount)
 	d.Set("name", resp.Name)
-	d.Set("location", resp.Location)
+	d.Set("location", strings.ToLower(*resp.Location))
 
 	flattenAndSetTags(d, resp.Tags)
 

--- a/builtin/providers/azurerm/resource_arm_availability_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set_test.go
@@ -28,6 +28,8 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 						"azurerm_availability_set.test", "platform_update_domain_count", "5"),
 					resource.TestCheckResourceAttr(
 						"azurerm_availability_set.test", "platform_fault_domain_count", "3"),
+					resource.TestCheckResourceAttr(
+						"azurerm_availability_set.test", "location", "canadacentral"),
 				),
 			},
 		},
@@ -153,11 +155,11 @@ func testCheckAzureRMAvailabilitySetDestroy(s *terraform.State) error {
 var testAccAzureRMVAvailabilitySet_basic = `
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
-    location = "West US"
+    location = "Canada Central"
 }
 resource "azurerm_availability_set" "test" {
     name = "acctestavset-%d"
-    location = "West US"
+    location = "Canada Central"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 `


### PR DESCRIPTION
For some regions it is returned from the API in camel case.

Before:

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMAvailabilitySet_basic -timeout 120m
=== RUN   TestAccAzureRMAvailabilitySet_basic
--- FAIL: TestAccAzureRMAvailabilitySet_basic (64.70s)
        testing.go:265: Step 0 error: Check failed: Check 4/4 error: azurerm_availability_set.test: Attribute 'location' expected "canadacentral", got "CanadaCentral"
FAIL
exit status 1
FAIL    github.com/hashicorp/terraform/builtin/providers/azurerm    64.715s
```

After:

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMAvailabilitySet_basic -timeout 120m
=== RUN   TestAccAzureRMAvailabilitySet_basic
--- PASS: TestAccAzureRMAvailabilitySet_basic (65.01s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm    65.022s
```

Closes #8183
