### PR TITLE
Allow new aws api-gateway integration types

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -45,9 +45,9 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if value != "MOCK" && value != "AWS" && value != "HTTP" {
+					if value != "MOCK" && value != "AWS" && value != "HTTP" && value != "AWS_PROXY" && value != "HTTP_PROXY" {
 						errors = append(errors, fmt.Errorf(
-							"%q must be one of 'AWS', 'MOCK', 'HTTP'", k))
+							"%q must be one of 'AWS', 'MOCK', 'HTTP', 'AWS_PROXY', 'HTTP_PROXY'", k))
 					}
 					return
 				},

--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -41,16 +41,9 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 			},
 
 			"type": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if value != "MOCK" && value != "AWS" && value != "HTTP" && value != "AWS_PROXY" && value != "HTTP_PROXY" {
-						errors = append(errors, fmt.Errorf(
-							"%q must be one of 'AWS', 'MOCK', 'HTTP', 'AWS_PROXY', 'HTTP_PROXY'", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateApiGatewayIntegrationType,
 			},
 
 			"uri": &schema.Schema{

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -467,3 +467,12 @@ func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
 	}
 	return
 }
+
+func validateApiGatewayIntegrationType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value != "MOCK" && value != "AWS" && value != "HTTP" && value != "AWS_PROXY" && value != "HTTP_PROXY" {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of 'AWS', 'MOCK', 'HTTP', 'AWS_PROXY', 'HTTP_PROXY'", k))
+	}
+	return
+}

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `resource_id` - (Required) The API resource ID
 * `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`)
-* `type` - (Required) The integration input's type (HTTP, MOCK, AWS)
+* `type` - (Required) The integration input's type (HTTP, MOCK, AWS, AWS_PROXY, HTTP_PROXY)
 * `uri` - (Optional) The input's URI (HTTP, AWS). **Required** if `type` is `HTTP` or `AWS`.
   For HTTP integrations, the URI must be a fully formed, encoded HTTP(S) URL according to the RFC-3986 specification . For AWS integrations, the URI should be of the form `arn:aws:apigateway:{region}:{subdomain.service|service}:{path|action}/{service_api}`. `region`, `subdomain` and `service` are used to determine the right endpoint.
   e.g. `arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:012345678901:function:my-func/invocations`


### PR DESCRIPTION
The added types are 'AWS_PROXY' for integrating with lambdas and
'HTTP_PROXY' for integrating via http.

See http://docs.aws.amazon.com/apigateway/api-reference/resource/integration/