### PR TITLE
Add scaleway server ipv6 address attribute

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -61,6 +61,10 @@ func resourceScalewayServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ipv6": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"state": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -140,6 +144,7 @@ func resourceScalewayServerRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("private_ip", server.PrivateIP)
 	d.Set("public_ip", server.PublicAddress.IP)
+	d.Set("ipv6", server.IPV6.Address)
 
 	d.Set("state", server.State)
 	d.Set("state_detail", server.StateDetail)


### PR DESCRIPTION
adds the `ipv6` attribute to the scaleway provisioner.

e.g.:

```
resource "scaleway_server" "demov6" {
  ...
  enable_ipv6 = true
  ...
  connection {
    host = "${self.ipv6}"
  }
}

```

allows to use ipv6 address of a scaleway server in e.g. ssh connections for remote provisioning of hosts without public ip.

needs `enable_ipv6` to be `true` to work.

no tests, yet
