### PR TITLE
provider/aws: Import aws_db_event_subscription

### DIFF
--- a/builtin/providers/aws/import_aws_db_event_subscription_test.go
+++ b/builtin/providers/aws/import_aws_db_event_subscription_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDBEventSubscription_importBasic(t *testing.T) {
+	resourceName := "aws_db_event_subscription.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBEventSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBEventSubscriptionConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_db_event_subscription.go
+++ b/builtin/providers/aws/resource_aws_db_event_subscription.go
@@ -18,6 +18,9 @@ func resourceAwsDbEventSubscription() *schema.Resource {
 		Read:   resourceAwsDbEventSubscriptionRead,
 		Update: resourceAwsDbEventSubscriptionUpdate,
 		Delete: resourceAwsDbEventSubscriptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:         schema.TypeString,

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -35,6 +35,7 @@ To make a resource importable, please see the
 * aws_cloudwatch_log_group
 * aws_cloudwatch_metric_alarm
 * aws_customer_gateway
+* aws_db_event_subscription
 * aws_db_instance
 * aws_db_option_group
 * aws_db_parameter_group

--- a/website/source/docs/providers/aws/r/db_event_subscription.html.markdown
+++ b/website/source/docs/providers/aws/r/db_event_subscription.html.markdown
@@ -32,3 +32,12 @@ The following arguments are supported:
 * `event_categories` - (Optional) A list of event categories for a SourceType that you want to subscribe to.
 * `enabled` - (Optional) A boolean flag to enable/disable the subscription. Defaults to true.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+
+## Import
+
+DB Event Subscriptions can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_db_event_subscription.default rds-event-sub
+```


### PR DESCRIPTION
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBEventSubscription_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/04 14:19:32 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBEventSubscription_importBasic -timeout 120m
=== RUN   TestAccAWSDBEventSubscription_importBasic
--- PASS: TestAccAWSDBEventSubscription_importBasic (471.58s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	471.587s
```