### PR TITLE
provider/aws - Add update support for `search_string` in aws_cloudwatch_metric_alarm

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -151,6 +151,10 @@ func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{
 		updateHealthCheck.HealthThreshold = aws.Int64(int64(d.Get("child_health_threshold").(int)))
 	}
 
+	if d.HasChange("search_string") {
+		updateHealthCheck.SearchString = aws.String(d.Get("search_string").(string))
+	}
+
 	if d.HasChange("cloudwatch_alarm_name") || d.HasChange("cloudwatch_alarm_region") {
 		cloudwatchAlarm := &route53.AlarmIdentifier{
 			Name:   aws.String(d.Get("cloudwatch_alarm_name").(string)),


### PR DESCRIPTION
When updating a `search_string` using the `"aws_route53_health_check"` resource it doesn't actually update the search_string. 

This PR aims to solve that issue, also added a separate test case for this. 

Done by: @comebackoneyear & @heimweh