### PR TITLE
provider/azurerm: add enable_blob_encryption to storage_account resource

### DIFF
--- a/website/source/docs/providers/azurerm/r/storage_account.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_account.html.markdown
@@ -51,6 +51,10 @@ The following arguments are supported:
     documentation for more information on which types of accounts can be converted
     into other types.
 
+* `enable_bool_encryption` - (Optional) Boolean flag which controls if Encryption
+    Services are enabled for Blob storage, see [here](https://azure.microsoft.com/en-us/documentation/articles/storage-service-encryption/)
+    for more information. 
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Note that although the Azure API supports setting custom domain names for


### PR DESCRIPTION
This allows Storage Service Encryption to be enabled.

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMStorageAccount -timeout 120m
=== RUN   TestAccAzureRMStorageAccount_importBasic
--- PASS: TestAccAzureRMStorageAccount_importBasic (139.00s)
=== RUN   TestAccAzureRMStorageAccount_basic
--- PASS: TestAccAzureRMStorageAccount_basic (151.03s)
=== RUN   TestAccAzureRMStorageAccount_blobEncryption
--- PASS: TestAccAzureRMStorageAccount_blobEncryption (149.94s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	440.051s
```