### PR TITLE
provider/aws: Update EFS resource to read performance mode and creation_token

### DIFF
--- a/builtin/providers/aws/resource_aws_efs_file_system_test.go
+++ b/builtin/providers/aws/resource_aws_efs_file_system_test.go
@@ -90,6 +90,10 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSEFSFileSystemConfig,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_efs_file_system.foo",
+						"performance_mode",
+						"generalPurpose"),
 					testAccCheckEfsFileSystem(
 						"aws_efs_file_system.foo",
 					),
@@ -278,13 +282,13 @@ func testAccCheckEfsFileSystemPerformanceMode(resourceID string, expectedMode st
 
 const testAccAWSEFSFileSystemConfig = `
 resource "aws_efs_file_system" "foo" {
-	reference_name = "radeksimko"
+	creation_token = "radeksimko"
 }
 `
 
 const testAccAWSEFSFileSystemConfigWithTags = `
 resource "aws_efs_file_system" "foo-with-tags" {
-	reference_name = "yada_yada"
+	creation_token = "yada_yada"
 	tags {
 		Name = "foo-efs"
 		Another = "tag"


### PR DESCRIPTION
Updates `aws_efs_file_system` to allow `creation_token` to be computed. This is needed to migrate users from the deprecated `reference_name` to `creation_token` without editing the state or completely recreating the file system. 

- removes the `reference_name` and `creation_token` conflict; they don't actually conflict (one overrides the other)
- adds `performance_mode` to the `READ` method and makes it computed 

This should fix #9231 allowing users to swap out `reference_name` for the `creation_token` once it's read, either with a refresh or via the API


------

There is a Travis CI custom run linked below in the checks