### PR TITLE
Support recursive targeting on modules

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -4180,6 +4180,46 @@ module.child:
 	`)
 }
 
+func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
+	m := testModule(t, "apply-targeted-module-recursive")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		Targets: []string{"module.child"},
+	})
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	mod := state.ModuleByPath([]string{"root", "child", "subchild"})
+	if mod == nil {
+		t.Fatalf("no subchild module found in the state!\n\n%#v", state)
+	}
+	if len(mod.Resources) != 1 {
+		t.Fatalf("expected 1 resources, got: %#v", mod.Resources)
+	}
+
+	checkStateString(t, state, `
+<no state>
+module.child.subchild:
+  aws_instance.foo:
+    ID = foo
+    num = 2
+    type = aws_instance
+	`)
+}
+
 func TestContext2Apply_targetedModuleResource(t *testing.T) {
 	m := testModule(t, "apply-targeted-module-resource")
 	p := testProvider("aws")

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -144,7 +144,7 @@ func TestParseResourceAddress(t *testing.T) {
 			"module.a",
 			&ResourceAddress{
 				Path:         []string{"a"},
-				Type:         "",
+				Type:         "module",
 				Name:         "",
 				InstanceType: TypePrimary,
 				Index:        -1,
@@ -155,7 +155,7 @@ func TestParseResourceAddress(t *testing.T) {
 			"module.a.module.b",
 			&ResourceAddress{
 				Path:         []string{"a", "b"},
-				Type:         "",
+				Type:         "module",
 				Name:         "",
 				InstanceType: TypePrimary,
 				Index:        -1,

--- a/terraform/state_filter.go
+++ b/terraform/state_filter.go
@@ -71,7 +71,7 @@ func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
 
 			// Only add the module to the results if we haven't specified a type.
 			// We also ignore the root module.
-			if a.Type == "" && len(m.Path) > 1 {
+			if (a.Type == "" || a.Type == "module") && len(m.Path) > 1 {
 				results = append(results, &StateFilterResult{
 					Path:    m.Path[1:],
 					Address: (&ResourceAddress{Path: m.Path[1:]}).String(),
@@ -173,7 +173,7 @@ func (f *StateFilter) relevant(addr *ResourceAddress, raw interface{}) bool {
 
 		return true
 	case *ResourceState:
-		if addr.Type == "" {
+		if addr.Type == "" || addr.Type == "module" {
 			// If we have no resource type, then we're interested in all!
 			return true
 		}

--- a/terraform/test-fixtures/apply-targeted-module-recursive/child/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-recursive/child/main.tf
@@ -1,0 +1,3 @@
+module "subchild" {
+    source = "./subchild"
+}

--- a/terraform/test-fixtures/apply-targeted-module-recursive/child/subchild/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-recursive/child/subchild/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+    num = "2"
+}

--- a/terraform/test-fixtures/apply-targeted-module-recursive/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-recursive/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+    source = "./child"
+}

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -84,7 +84,9 @@ func (t *ResourceCountTransformer) nodeIsTargeted(node dag.Vertex) bool {
 
 	addr := addressable.ResourceAddress()
 	for _, targetAddr := range t.Targets {
-		if targetAddr.Equals(addr) {
+		if targetAddr.Type == "module" && targetAddr.ContainedInHierarchy(addr) {
+			return true
+		} else if targetAddr.Equals(addr) {
 			return true
 		}
 	}

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -109,7 +109,9 @@ func (t *TargetsTransformer) nodeIsTarget(
 	}
 	addr := r.ResourceAddress()
 	for _, targetAddr := range addrs {
-		if targetAddr.Equals(addr) {
+		if targetAddr.Type == "module" && targetAddr.ContainedInHierarchy(addr) {
+			return true
+		} else if targetAddr.Equals(addr) {
 			return true
 		}
 	}


### PR DESCRIPTION
The purpose of this PR is to fix https://github.com/hashicorp/terraform/issues/5190 and other related issues. A new resource type "module" is introduced and if the targeted resource is a module then instead of targeting only the resources, all resources in the resource hierarchy under the targeted module are targeted.
