### PR TITLE
provider/azurerm: expose default keys for servicebus_namespace

### DIFF
--- a/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
@@ -10,6 +10,10 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+// Default Authorization Rule/Policy created by Azure, used to populate the
+// default connection strings and keys
+var serviceBusNamespaceDefaultAuthorizationRule = "RootManageSharedAccessKey"
+
 func resourceArmServiceBusNamespace() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmServiceBusNamespaceCreate,
@@ -53,6 +57,26 @@ func resourceArmServiceBusNamespace() *schema.Resource {
 				ForceNew:     true,
 				Default:      1,
 				ValidateFunc: validateServiceBusNamespaceCapacity,
+			},
+
+			"default_primary_connection_string": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_secondary_connection_string": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_primary_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_secondary_key": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"tags": tagsSchema(),
@@ -123,6 +147,17 @@ func resourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", resp.Name)
 	d.Set("sku", strings.ToLower(string(resp.Sku.Name)))
 	d.Set("capacity", resp.Sku.Capacity)
+
+	keys, err := namespaceClient.ListKeys(resGroup, name, serviceBusNamespaceDefaultAuthorizationRule)
+	if err != nil {
+		log.Printf("[ERROR] Unable to List default keys for Namespace %s: %s", name, err)
+	} else {
+		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
+		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
+		d.Set("default_primary_key", keys.PrimaryKey)
+		d.Set("default_secondary_key", keys.SecondaryKey)
+	}
+
 	flattenAndSetTags(d, resp.Tags)
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_namespace_test.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -88,6 +89,33 @@ func TestAccAzureRMServiceBusNamespace_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceBusNamespaceExists("azurerm_servicebus_namespace.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMServiceBusNamespace_readDefaultKeys(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusNamespaceExists("azurerm_servicebus_namespace.test"),
+					resource.TestMatchResourceAttr(
+						"azurerm_servicebus_namespace.test", "default_primary_connection_string", regexp.MustCompile("Endpoint=.+")),
+					resource.TestMatchResourceAttr(
+						"azurerm_servicebus_namespace.test", "default_secondary_connection_string", regexp.MustCompile("Endpoint=.+")),
+					resource.TestMatchResourceAttr(
+						"azurerm_servicebus_namespace.test", "default_primary_key", regexp.MustCompile(".+")),
+					resource.TestMatchResourceAttr(
+						"azurerm_servicebus_namespace.test", "default_secondary_key", regexp.MustCompile(".+")),
 				),
 			},
 		},

--- a/website/source/docs/providers/azurerm/r/servicebus_namespace.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_namespace.html.markdown
@@ -53,3 +53,16 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ServiceBus Namespace ID.
+
+The following attributes are exported only if there is an authorization rule named
+`RootManageSharedAccessKey` which is created automatically by Azure.
+
+* `default_primary_connection_string` - The primary connection string for the authorization
+    rule `RootManageSharedAccessKey`.
+
+* `default_secondary_connection_string` - The secondary connection string for the
+    authorization rule `RootManageSharedAccessKey`.
+
+* `default_primary_key` - The primary access key for the authorization rule `RootManageSharedAccessKey`.
+
+* `default_secondary_key` - The secondary access key for the authorization rule `RootManageSharedAccessKey`.


### PR DESCRIPTION
A default authorization rule is created by Azure which, if present is exported by
the resource.

TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMServiceBusNamespace -timeout 120m
=== RUN   TestAccAzureRMServiceBusNamespaceCapacity_validation
--- PASS: TestAccAzureRMServiceBusNamespaceCapacity_validation (0.00s)
=== RUN   TestAccAzureRMServiceBusNamespaceSku_validation
--- PASS: TestAccAzureRMServiceBusNamespaceSku_validation (0.00s)
=== RUN   TestAccAzureRMServiceBusNamespace_basic
--- PASS: TestAccAzureRMServiceBusNamespace_basic (352.03s)
=== RUN   TestAccAzureRMServiceBusNamespace_readDefaultKeys
--- PASS: TestAccAzureRMServiceBusNamespace_readDefaultKeys (349.17s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	701.278s