### PR TITLE
Search configured project image families

### DIFF
--- a/builtin/providers/google/image.go
+++ b/builtin/providers/google/image.go
@@ -21,8 +21,14 @@ func resolveImage(c *Config, name string) (string, error) {
 
 			// Must infer the project name:
 
-			// First, try the configured project.
+			// First, try the configured project for a specific image:
 			image, err := c.clientCompute.Images.Get(c.Project, name).Do()
+			if err == nil {
+				return image.SelfLink, nil
+			}
+
+			// If it doesn't exist, try to see if it works as an image family:
+			image, err = c.clientCompute.Images.GetFromFamily(c.Project, name).Do()
 			if err == nil {
 				return image.SelfLink, nil
 			}

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -112,9 +112,11 @@ the type is "local-ssd", in which case scratch must be true).
     `google_compute_disk`) to attach.
 
 * `image` - The image from which to initialize this
-    disk. Either the full URL, a contraction of the form "project/name", an
+    disk. Either the full URL, a contraction of the form "project/name", the
+    name of a Google-supported
     [image family](https://cloud.google.com/compute/docs/images#image_families),
-    or just a name (in which case the current project is used).
+    or simple the name of an image or image family (in which case the current
+    project is used).
 
 * `auto_delete` - (Optional) Whether or not the disk should be auto-deleted.
     This defaults to true. Leave true for local SSDs.


### PR DESCRIPTION
Fixes #9229.

This adds a check to search image families in the configured project prior to trying to search for an alternative project.
