### PR TITLE
[WIP] provider/aws: Add new aws_vpc_endpoint_route_table_association resource.

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -339,6 +339,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_peering_connection":                   resourceAwsVpcPeeringConnection(),
 			"aws_vpc":                                      resourceAwsVpc(),
 			"aws_vpc_endpoint":                             resourceAwsVpcEndpoint(),
+			"aws_vpc_endpoint_route_table_association":     resourceAwsVpcEndpointRouteTableAssociation(),
 			"aws_vpn_connection":                           resourceAwsVpnConnection(),
 			"aws_vpn_connection_route":                     resourceAwsVpnConnectionRoute(),
 			"aws_vpn_gateway":                              resourceAwsVpnGateway(),

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
@@ -1,0 +1,56 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsVpcEndpointRouteTableAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsVPCEndpointRouteTableAssociationCreate,
+		Read:   resourceAwsVPCEndpointRouteTableAssociationRead,
+		Update: resourceAwsVPCEndpointRouteTableAssociationUpdate,
+		Delete: resourceAwsVPCEndpointRouteTableAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"vpc_endpoint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"route_table_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceAwsVPCEndpointRouteTableAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsVPCEndpointRouteTableAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsVPCEndpointRouteTableAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsVPCEndpointRouteTableAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -1,0 +1,16 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVpcEndpointRouteTableAssociation_basic(t *testing.T) {
+}
+
+func TestAccAWSVpcEndpointRouteTableAssociation_addRouteTables(t *testing.T) {
+}
+
+func TestAccAWSVpcEndpointRouteTableAssociation_removeRouteTables(t *testing.T) {
+}


### PR DESCRIPTION
This commit adds a new resource which allows to a list of route tables to be
either added and/or removed from an existing VPC Endpoint. This resource would
also be complimentary to the existing `aws_vpc_endpoint` resource where the
route tables might not be specified (not a requirement for a VPC Endpoint to
be created successfully) during creation, especially where the workflow is
such where the route tables are not immediately known.

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
