### PR TITLE
provider/aws: Import OpsWorks Custom Layers

### DIFF
--- a/builtin/providers/aws/import_aws_opsworks_custom_layer_test.go
+++ b/builtin/providers/aws/import_aws_opsworks_custom_layer_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSOpsWorksCustomLayerImportBasic(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resourceName := "aws_opsworks_custom_layer.tf-acc"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksCustomLayerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsOpsworksCustomLayerConfigVpcCreate(name),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/opsworks_layers.go
+++ b/builtin/providers/aws/opsworks_layers.go
@@ -251,6 +251,9 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 			client := meta.(*AWSClient).opsworksconn
 			return lt.Delete(d, client)
 		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: resourceSchema,
 	}

--- a/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
@@ -23,7 +23,7 @@ func TestAccAWSOpsworksCustomLayer(t *testing.T) {
 		CheckDestroy: testAccCheckAwsOpsworksCustomLayerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAwsOpsworksCustomLayerConfigCreate(stackName),
+				Config: testAccAwsOpsworksCustomLayerConfigNoVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_custom_layer.tf-acc", "name", stackName,
@@ -187,7 +187,7 @@ resource "aws_security_group" "tf-ops-acc-layer2" {
 }`, name, name)
 }
 
-func testAccAwsOpsworksCustomLayerConfigCreate(name string) string {
+func testAccAwsOpsworksCustomLayerConfigNoVpcCreate(name string) string {
 	return fmt.Sprintf(`
 provider "aws" {
 	region = "us-east-1"
@@ -222,6 +222,43 @@ resource "aws_opsworks_custom_layer" "tf-acc" {
 %s 
 
 `, name, testAccAwsOpsworksStackConfigNoVpcCreate(name), testAccAwsOpsworksCustomLayerSecurityGroups(name))
+}
+
+func testAccAwsOpsworksCustomLayerConfigVpcCreate(name string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-west-2"
+}
+
+resource "aws_opsworks_custom_layer" "tf-acc" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name = "%s"
+  short_name = "tf-ops-acc-custom-layer"
+  auto_assign_public_ips = false
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+  drain_elb_on_shutdown = true
+  instance_shutdown_timeout = 300
+  system_packages = [
+    "git",
+    "golang",
+  ]
+  ebs_volume {
+    type = "gp2"
+    number_of_disks = 2
+    mount_point = "/home"
+    size = 100
+    raid_level = 0
+  }
+}
+
+%s
+
+%s
+
+`, name, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAwsOpsworksCustomLayerSecurityGroups(name))
 }
 
 func testAccAwsOpsworksCustomLayerConfigUpdate(name string) string {

--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -338,6 +338,9 @@ func resourceAwsOpsworksStackCreate(d *schema.ResourceData, meta interface{}) er
 	if defaultAvailabilityZone, ok := d.GetOk("default_availability_zone"); ok {
 		req.DefaultAvailabilityZone = aws.String(defaultAvailabilityZone.(string))
 	}
+	if defaultRootDeviceType, ok := d.GetOk("default_root_device_type"); ok {
+		req.DefaultRootDeviceType = aws.String(defaultRootDeviceType.(string))
+	}
 
 	log.Printf("[DEBUG] Creating OpsWorks stack: %s", req)
 

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -68,6 +68,7 @@ To make a resource importable, please see the
 * aws_nat_gateway
 * aws_network_acl
 * aws_network_interface
+* aws_opsworks_custom_layer
 * aws_opsworks_stack
 * aws_placement_group
 * aws_rds_cluster

--- a/website/source/docs/providers/aws/r/opsworks_custom_layer.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_custom_layer.html.markdown
@@ -65,3 +65,12 @@ An `ebs_volume` block supports the following arguments:
 The following attributes are exported:
 
 * `id` - The id of the layer.
+
+
+## Import
+
+OpsWorks Custom Layers can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_opsworks_custom_layer.bar 00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
Add ability to import AWS OpsWorks Custom Layers.

Acceptance test passes:

```
vagrant@terraform:/opt/gopath/src/github.com/hashicorp/terraform$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsWorksCustomLayerImportBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/06 12:16:00 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsWorksCustomLayerImportBasic -timeout 120m
=== RUN   TestAccAWSOpsWorksCustomLayerImportBasic
--- PASS: TestAccAWSOpsWorksCustomLayerImportBasic (56.90s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	56.917s
```

Cheers