### PR TITLE
Add Google Compute Image docs to sidebar.

### DIFF
--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -53,6 +53,10 @@
 			<a href="/docs/providers/google/r/compute_https_health_check.html">google_compute_https_health_check</a>
 			</li>
 
+			<li<%= sidebar_current("docs-google-compute-image") %>>
+			<a href="/docs/providers/google/r/compute_image.html">google_compute_image</a>
+			</li>
+
 			<li<%= sidebar_current("docs-google-compute-instance") %>>
 			<a href="/docs/providers/google/r/compute_instance.html">google_compute_instance</a>
 			</li>


### PR DESCRIPTION
Docs were originally added in #7960, but weren't added to the sidebar.

This perhaps should be pulled into stable-website too, as the docs and resource are already live since 0.7.1