### PR TITLE
Don't parse a TestFlagTypedKV value as a number

### DIFF
--- a/command/flag_kv_test.go
+++ b/command/flag_kv_test.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"flag"
-	"github.com/davecgh/go-spew/spew"
 	"io/ioutil"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 func TestFlagStringKV_impl(t *testing.T) {
@@ -143,6 +144,29 @@ func TestFlagTypedKV(t *testing.T) {
 		{
 			"key=1234.dkr.ecr.us-east-1.amazonaws.com/proj:abcdef",
 			map[string]interface{}{"key": "1234.dkr.ecr.us-east-1.amazonaws.com/proj:abcdef"},
+			false,
+		},
+
+		// simple values that can parse as numbers should remain strings
+		{
+			"key=1",
+			map[string]interface{}{
+				"key": "1",
+			},
+			false,
+		},
+		{
+			"key=1.0",
+			map[string]interface{}{
+				"key": "1.0",
+			},
+			false,
+		},
+		{
+			"key=0x10",
+			map[string]interface{}{
+				"key": "0x10",
+			},
 			false,
 		},
 	}

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -559,7 +559,7 @@ func TestPush_tfvars(t *testing.T) {
 		"-var-file", path + "/terraform.tfvars",
 		"-vcs=false",
 		"-var",
-		"bar=1",
+		"bar=[1,2]",
 		path,
 	}
 	if code := c.Run(args); code != 0 {
@@ -586,7 +586,7 @@ func TestPush_tfvars(t *testing.T) {
 	// update bar to match cli value
 	for i, v := range tfvars {
 		if v.Key == "bar" {
-			tfvars[i].Value = "1"
+			tfvars[i].Value = "[1, 2]"
 			tfvars[i].IsHCL = true
 		}
 	}


### PR DESCRIPTION
Don't try to parse a varibale as HCL if the value can be parse as a
single number. HCL will always attempt to convert the value to a number,
even if we later find the configured variable's type to be a string.

Fixes #7962 