### PR TITLE
Fix typos in the bitbucket_repository example.

### DIFF
--- a/website/source/docs/providers/bitbucket/index.html.markdown
+++ b/website/source/docs/providers/bitbucket/index.html.markdown
@@ -22,9 +22,9 @@ provider "bitbucket" {
     password = "idoillusions" # you can also use app passwords
 }
 
-resource "bitbucket_repsitory" "illusions" {
+resource "bitbucket_repository" "illusions" {
     owner = "theleagueofmagicians"
-    name = "illussions"
+    name = "illusions"
     scm = "hg"
     is_private = true
 }


### PR DESCRIPTION
One of these is cosmetic, the other will stop people being able to copy and paste the example for testing.