### PR TITLE
Get rid of the list when parsing HCL maps for vars

### DIFF
--- a/command/flag_kv_test.go
+++ b/command/flag_kv_test.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"flag"
-	"github.com/davecgh/go-spew/spew"
 	"io/ioutil"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 func TestFlagStringKV_impl(t *testing.T) {
@@ -118,11 +119,9 @@ func TestFlagTypedKV(t *testing.T) {
 		{
 			`key={"hello" = "world", "foo" = "bar"}`,
 			map[string]interface{}{
-				"key": []map[string]interface{}{
-					map[string]interface{}{
-						"hello": "world",
-						"foo":   "bar",
-					},
+				"key": map[string]interface{}{
+					"hello": "world",
+					"foo":   "bar",
 				},
 			},
 			false,
@@ -169,6 +168,10 @@ func TestFlagKVFile(t *testing.T) {
 	inputLibucl := `
 foo = "bar"
 `
+	inputMap := `
+foo = {
+	k = "v"
+}`
 
 	inputJson := `{
 		"foo": "bar"}`
@@ -193,6 +196,16 @@ foo = "bar"
 		{
 			`map.key = "foo"`,
 			map[string]interface{}{"map.key": "foo"},
+			false,
+		},
+
+		{
+			inputMap,
+			map[string]interface{}{
+				"foo": map[string]interface{}{
+					"k": "v",
+				},
+			},
 			false,
 		},
 	}

--- a/terraform/eval_output.go
+++ b/terraform/eval_output.go
@@ -98,6 +98,19 @@ func (n *EvalWriteOutput) Eval(ctx EvalContext) (interface{}, error) {
 			Sensitive: n.Sensitive,
 			Value:     valueTyped,
 		}
+	case []map[string]interface{}:
+		// an HCL map is multi-valued, so if this was read out of a config the
+		// map may still be in a slice.
+		if len(valueTyped) == 1 {
+			mod.Outputs[n.Name] = &OutputState{
+				Type:      "map",
+				Sensitive: n.Sensitive,
+				Value:     valueTyped[0],
+			}
+			break
+		}
+		return nil, fmt.Errorf("output %s type (%T) with %d values not valid for type map",
+			n.Name, valueTyped, len(valueTyped))
 	default:
 		return nil, fmt.Errorf("output %s is not a valid type (%T)\n", n.Name, valueTyped)
 	}

--- a/terraform/eval_output_test.go
+++ b/terraform/eval_output_test.go
@@ -1,0 +1,56 @@
+package terraform
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestEvalWriteMapOutput(t *testing.T) {
+	ctx := new(MockEvalContext)
+	ctx.StateState = NewState()
+	ctx.StateLock = new(sync.RWMutex)
+
+	cases := []struct {
+		name string
+		cfg  *ResourceConfig
+		err  bool
+	}{
+		{
+			// Eval should recognize a single map in a slice, and collapse it
+			// into the map value
+			"single-map",
+			&ResourceConfig{
+				Config: map[string]interface{}{
+					"value": []map[string]interface{}{
+						map[string]interface{}{"a": "b"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			// we can't apply a multi-valued map to a variable, so this should error
+			"multi-map",
+			&ResourceConfig{
+				Config: map[string]interface{}{
+					"value": []map[string]interface{}{
+						map[string]interface{}{"a": "b"},
+						map[string]interface{}{"c": "d"},
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		evalNode := &EvalWriteOutput{Name: tc.name}
+		ctx.InterpolateConfigResult = tc.cfg
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := evalNode.Eval(ctx)
+			if err != nil && !tc.err {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When we parse a map from HCL, it's decoded into a list of maps because
HCL allows declaring a key multiple times to implicitly add it to a
list.  Since there's no terraform variable configuration that supports
this structure, we can always flatten a `[]map[string]interface{}` value
to a `map[string]interface{}` and remove any type errors trying to apply
that value.

Fixes #8057 
