### PR TITLE
Parse AWS partition from ARN.

### DIFF
--- a/builtin/providers/aws/auth_helpers_test.go
+++ b/builtin/providers/aws/auth_helpers_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-func TestAWSGetAccountId_shouldBeValid_fromEC2Role(t *testing.T) {
+func TestAWSGetAccountInfo_shouldBeValid_fromEC2Role(t *testing.T) {
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 	// capture the test server's close method, to call after the test returns
@@ -32,9 +32,14 @@ func TestAWSGetAccountId_shouldBeValid_fromEC2Role(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	id, err := GetAccountId(iamConn, stsConn, ec2rolecreds.ProviderName)
+	part, id, err := GetAccountInfo(iamConn, stsConn, ec2rolecreds.ProviderName)
 	if err != nil {
 		t.Fatalf("Getting account ID from EC2 metadata API failed: %s", err)
+	}
+
+	expectedPart := "aws"
+	if part != expectedPart {
+		t.Fatalf("Expected partition: %s, given: %s", expectedPart, part)
 	}
 
 	expectedAccountId := "123456789013"
@@ -43,7 +48,7 @@ func TestAWSGetAccountId_shouldBeValid_fromEC2Role(t *testing.T) {
 	}
 }
 
-func TestAWSGetAccountId_shouldBeValid_EC2RoleHasPriority(t *testing.T) {
+func TestAWSGetAccountInfo_shouldBeValid_EC2RoleHasPriority(t *testing.T) {
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 	// capture the test server's close method, to call after the test returns
@@ -59,9 +64,14 @@ func TestAWSGetAccountId_shouldBeValid_EC2RoleHasPriority(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	id, err := GetAccountId(iamConn, stsConn, ec2rolecreds.ProviderName)
+	part, id, err := GetAccountInfo(iamConn, stsConn, ec2rolecreds.ProviderName)
 	if err != nil {
 		t.Fatalf("Getting account ID from EC2 metadata API failed: %s", err)
+	}
+
+	expectedPart := "aws"
+	if part != expectedPart {
+		t.Fatalf("Expected partition: %s, given: %s", expectedPart, part)
 	}
 
 	expectedAccountId := "123456789013"
@@ -70,7 +80,7 @@ func TestAWSGetAccountId_shouldBeValid_EC2RoleHasPriority(t *testing.T) {
 	}
 }
 
-func TestAWSGetAccountId_shouldBeValid_fromIamUser(t *testing.T) {
+func TestAWSGetAccountInfo_shouldBeValid_fromIamUser(t *testing.T) {
 	iamEndpoints := []*iamEndpoint{
 		{
 			Request:  &iamRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
@@ -81,9 +91,14 @@ func TestAWSGetAccountId_shouldBeValid_fromIamUser(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	id, err := GetAccountId(iamConn, stsConn, "")
+	part, id, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via GetUser failed: %s", err)
+	}
+
+	expectedPart := "aws"
+	if part != expectedPart {
+		t.Fatalf("Expected partition: %s, given: %s", expectedPart, part)
 	}
 
 	expectedAccountId := "123456789012"
@@ -92,7 +107,7 @@ func TestAWSGetAccountId_shouldBeValid_fromIamUser(t *testing.T) {
 	}
 }
 
-func TestAWSGetAccountId_shouldBeValid_fromGetCallerIdentity(t *testing.T) {
+func TestAWSGetAccountInfo_shouldBeValid_fromGetCallerIdentity(t *testing.T) {
 	iamEndpoints := []*iamEndpoint{
 		{
 			Request:  &iamRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
@@ -106,9 +121,14 @@ func TestAWSGetAccountId_shouldBeValid_fromGetCallerIdentity(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	id, err := GetAccountId(iamConn, stsConn, "")
+	part, id, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via GetUser failed: %s", err)
+	}
+
+	expectedPart := "aws"
+	if part != expectedPart {
+		t.Fatalf("Expected partition: %s, given: %s", expectedPart, part)
 	}
 
 	expectedAccountId := "123456789012"
@@ -117,7 +137,7 @@ func TestAWSGetAccountId_shouldBeValid_fromGetCallerIdentity(t *testing.T) {
 	}
 }
 
-func TestAWSGetAccountId_shouldBeValid_fromIamListRoles(t *testing.T) {
+func TestAWSGetAccountInfo_shouldBeValid_fromIamListRoles(t *testing.T) {
 	iamEndpoints := []*iamEndpoint{
 		{
 			Request:  &iamRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
@@ -135,9 +155,14 @@ func TestAWSGetAccountId_shouldBeValid_fromIamListRoles(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	id, err := GetAccountId(iamConn, stsConn, "")
+	part, id, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via ListRoles failed: %s", err)
+	}
+
+	expectedPart := "aws"
+	if part != expectedPart {
+		t.Fatalf("Expected partition: %s, given: %s", expectedPart, part)
 	}
 
 	expectedAccountId := "123456789012"
@@ -146,7 +171,7 @@ func TestAWSGetAccountId_shouldBeValid_fromIamListRoles(t *testing.T) {
 	}
 }
 
-func TestAWSGetAccountId_shouldBeValid_federatedRole(t *testing.T) {
+func TestAWSGetAccountInfo_shouldBeValid_federatedRole(t *testing.T) {
 	iamEndpoints := []*iamEndpoint{
 		{
 			Request:  &iamRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
@@ -160,9 +185,14 @@ func TestAWSGetAccountId_shouldBeValid_federatedRole(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	id, err := GetAccountId(iamConn, stsConn, "")
+	part, id, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via ListRoles failed: %s", err)
+	}
+
+	expectedPart := "aws"
+	if part != expectedPart {
+		t.Fatalf("Expected partition: %s, given: %s", expectedPart, part)
 	}
 
 	expectedAccountId := "123456789012"
@@ -171,7 +201,7 @@ func TestAWSGetAccountId_shouldBeValid_federatedRole(t *testing.T) {
 	}
 }
 
-func TestAWSGetAccountId_shouldError_unauthorizedFromIam(t *testing.T) {
+func TestAWSGetAccountInfo_shouldError_unauthorizedFromIam(t *testing.T) {
 	iamEndpoints := []*iamEndpoint{
 		{
 			Request:  &iamRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
@@ -185,9 +215,13 @@ func TestAWSGetAccountId_shouldError_unauthorizedFromIam(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	id, err := GetAccountId(iamConn, stsConn, "")
+	part, id, err := GetAccountInfo(iamConn, stsConn, "")
 	if err == nil {
 		t.Fatal("Expected error when getting account ID")
+	}
+
+	if part != "" {
+		t.Fatalf("Expected no partition, given: %s", part)
 	}
 
 	if id != "" {
@@ -195,19 +229,23 @@ func TestAWSGetAccountId_shouldError_unauthorizedFromIam(t *testing.T) {
 	}
 }
 
-func TestAWSParseAccountIdFromArn(t *testing.T) {
+func TestAWSParseAccountInfoFromArn(t *testing.T) {
 	validArn := "arn:aws:iam::101636750127:instance-profile/aws-elasticbeanstalk-ec2-role"
+	expectedPart := "aws"
 	expectedId := "101636750127"
-	id, err := parseAccountIdFromArn(validArn)
+	part, id, err := parseAccountInfoFromArn(validArn)
 	if err != nil {
 		t.Fatalf("Expected no error when parsing valid ARN: %s", err)
+	}
+	if part != expectedPart {
+		t.Fatalf("Parsed part doesn't match with expected (%q != %q)", part, expectedPart)
 	}
 	if id != expectedId {
 		t.Fatalf("Parsed id doesn't match with expected (%q != %q)", id, expectedId)
 	}
 
 	invalidArn := "blablah"
-	id, err = parseAccountIdFromArn(invalidArn)
+	part, id, err = parseAccountInfoFromArn(invalidArn)
 	if err == nil {
 		t.Fatalf("Expected error when parsing invalid ARN (%q)", invalidArn)
 	}

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -118,6 +118,7 @@ type AWSClient struct {
 	stsconn               *sts.STS
 	redshiftconn          *redshift.Redshift
 	r53conn               *route53.Route53
+	partition             string
 	accountid             string
 	region                string
 	rdsconn               *rds.RDS
@@ -226,8 +227,9 @@ func (c *Config) Client() (interface{}, error) {
 	}
 
 	if !c.SkipRequestingAccountId {
-		accountId, err := GetAccountId(client.iamconn, client.stsconn, cp.ProviderName)
+		partition, accountId, err := GetAccountInfo(client.iamconn, client.stsconn, cp.ProviderName)
 		if err == nil {
+			client.partition = partition
 			client.accountid = accountId
 		}
 	}

--- a/builtin/providers/aws/resource_aws_db_event_subscription.go
+++ b/builtin/providers/aws/resource_aws_db_event_subscription.go
@@ -155,20 +155,23 @@ func resourceAwsDbEventSubscriptionRead(d *schema.ResourceData, meta interface{}
 	// list tags for resource
 	// set tags
 	conn := meta.(*AWSClient).rdsconn
-	arn := buildRDSEventSubscriptionARN(d.Get("customer_aws_id").(string), d.Id(), meta.(*AWSClient).region)
-	resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
-		ResourceName: aws.String(arn),
-	})
+	if arn, err := buildRDSEventSubscriptionARN(d.Get("customer_aws_id").(string), d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).region); err != nil {
+		log.Printf("[DEBUG] Error building ARN for RDS Event Subscription, not setting Tags for Event Subscription %s", *sub.CustSubscriptionId)
+	} else {
+		resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
+			ResourceName: aws.String(arn),
+		})
 
-	if err != nil {
-		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
-	}
+		if err != nil {
+			log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+		}
 
-	var dt []*rds.Tag
-	if len(resp.TagList) > 0 {
-		dt = resp.TagList
+		var dt []*rds.Tag
+		if len(resp.TagList) > 0 {
+			dt = resp.TagList
+		}
+		d.Set("tags", tagsToMapRDS(dt))
 	}
-	d.Set("tags", tagsToMapRDS(dt))
 
 	return nil
 }
@@ -261,11 +264,12 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		d.SetPartial("source_type")
 	}
 
-	arn := buildRDSEventSubscriptionARN(d.Get("customer_aws_id").(string), d.Id(), meta.(*AWSClient).region)
-	if err := setTagsRDS(rdsconn, d, arn); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
+	if arn, err := buildRDSEventSubscriptionARN(d.Get("customer_aws_id").(string), d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).region); err == nil {
+		if err := setTagsRDS(rdsconn, d, arn); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
 	}
 
 	if d.HasChange("source_ids") {
@@ -372,7 +376,10 @@ func resourceAwsDbEventSubscriptionRefreshFunc(
 	}
 }
 
-func buildRDSEventSubscriptionARN(customerAwsId, subscriptionId, region string) string {
-	arn := fmt.Sprintf("arn:aws:rds:%s:%s:es:%s", region, customerAwsId, subscriptionId)
-	return arn
+func buildRDSEventSubscriptionARN(customerAwsId, subscriptionId, partition, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS partition")
+	}
+	arn := fmt.Sprintf("arn:%s:rds:%s:%s:es:%s", partition, region, customerAwsId, subscriptionId)
+	return arn, nil
 }

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -693,7 +693,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	// list tags for resource
 	// set tags
 	conn := meta.(*AWSClient).rdsconn
-	arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
 	if err != nil {
 		name := "<empty>"
 		if v.DBName != nil && *v.DBName != "" {
@@ -976,7 +976,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
+	if arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
 		if err := setTagsRDS(conn, d, arn); err != nil {
 			return err
 		} else {
@@ -1052,11 +1052,10 @@ func resourceAwsDbInstanceStateRefreshFunc(
 	}
 }
 
-func buildRDSARN(identifier, accountid, region string) (string, error) {
+func buildRDSARN(identifier, partition, accountid, region string) (string, error) {
 	if accountid == "" {
 		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS Account ID")
 	}
-	arn := fmt.Sprintf("arn:aws:rds:%s:%s:db:%s", region, accountid, identifier)
+	arn := fmt.Sprintf("arn:%s:rds:%s:%s:db:%s", partition, region, accountid, identifier)
 	return arn, nil
-
 }

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -1053,6 +1053,9 @@ func resourceAwsDbInstanceStateRefreshFunc(
 }
 
 func buildRDSARN(identifier, partition, accountid, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS partition")
+	}
 	if accountid == "" {
 		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS Account ID")
 	}

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -350,7 +350,7 @@ func testAccCheckAWSDBInstanceSnapshot(s *terraform.State) error {
 			}
 		} else { // snapshot was found,
 			// verify we have the tags copied to the snapshot
-			instanceARN, err := buildRDSARN(snapshot_identifier, testAccProvider.Meta().(*AWSClient).accountid, testAccProvider.Meta().(*AWSClient).region)
+			instanceARN, err := buildRDSARN(snapshot_identifier, testAccProvider.Meta().(*AWSClient).partition, testAccProvider.Meta().(*AWSClient).accountid, testAccProvider.Meta().(*AWSClient).region)
 			// tags have a different ARN, just swapping :db: for :snapshot:
 			tagsARN := strings.Replace(instanceARN, ":db:", ":snapshot:", 1)
 			if err != nil {

--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -141,7 +141,7 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
 
 	paramGroup := describeResp.DBParameterGroups[0]
-	arn, err := buildRDSPGARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	arn, err := buildRDSPGARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
 	if err != nil {
 		name := "<empty>"
 		if paramGroup.DBParameterGroupName != nil && *paramGroup.DBParameterGroupName != "" {
@@ -217,7 +217,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if arn, err := buildRDSPGARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
+	if arn, err := buildRDSPGARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
 		if err := setTagsRDS(rdsconn, d, arn); err != nil {
 			return err
 		} else {
@@ -278,11 +278,14 @@ func resourceAwsDbParameterHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func buildRDSPGARN(identifier, accountid, region string) (string, error) {
+func buildRDSPGARN(identifier, partition, accountid, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS partition")
+	}
 	if accountid == "" {
 		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS Account ID")
 	}
-	arn := fmt.Sprintf("arn:aws:rds:%s:%s:pg:%s", region, accountid, identifier)
+	arn := fmt.Sprintf("arn:%s:rds:%s:%s:pg:%s", partition, region, accountid, identifier)
 	return arn, nil
 
 }

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -626,6 +626,9 @@ func resourceAwsRDSClusterStateRefreshFunc(
 }
 
 func buildRDSClusterARN(identifier, partition, accountid, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct RDS Cluster ARN because of missing AWS partition")
+	}
 	if accountid == "" {
 		return "", fmt.Errorf("Unable to construct RDS Cluster ARN because of missing AWS Account ID")
 	}

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -467,7 +467,7 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Fetch and save tags
-	arn, err := buildRDSClusterARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	arn, err := buildRDSClusterARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
 	if err != nil {
 		log.Printf("[DEBUG] Error building ARN for RDS Cluster (%s), not setting Tags", *dbc.DBClusterIdentifier)
 	} else {
@@ -536,7 +536,7 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if arn, err := buildRDSClusterARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
+	if arn, err := buildRDSClusterARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
 		if err := setTagsRDS(conn, d, arn); err != nil {
 			return err
 		} else {
@@ -625,12 +625,12 @@ func resourceAwsRDSClusterStateRefreshFunc(
 	}
 }
 
-func buildRDSClusterARN(identifier, accountid, region string) (string, error) {
+func buildRDSClusterARN(identifier, partition, accountid, region string) (string, error) {
 	if accountid == "" {
 		return "", fmt.Errorf("Unable to construct RDS Cluster ARN because of missing AWS Account ID")
 	}
 
-	arn := fmt.Sprintf("arn:aws:rds:%s:%s:cluster:%s", region, accountid, identifier)
+	arn := fmt.Sprintf("arn:%s:rds:%s:%s:cluster:%s", partition, region, accountid, identifier)
 	return arn, nil
 
 }

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance.go
@@ -245,7 +245,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	}
 
 	// Fetch and save tags
-	arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
 	if err != nil {
 		log.Printf("[DEBUG] Error building ARN for RDS Cluster Instance (%s), not setting Tags", *db.DBInstanceIdentifier)
 	} else {
@@ -322,7 +322,7 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 
 	}
 
-	if arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
+	if arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
 		if err := setTagsRDS(conn, d, arn); err != nil {
 			return err
 		}

--- a/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
@@ -146,7 +146,7 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 	d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
 
 	paramGroup := describeResp.DBClusterParameterGroups[0]
-	arn, err := buildRDSCPGARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	arn, err := buildRDSCPGARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
 	if err != nil {
 		name := "<empty>"
 		if paramGroup.DBClusterParameterGroupName != nil && *paramGroup.DBClusterParameterGroupName != "" {
@@ -211,7 +211,7 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 		d.SetPartial("parameter")
 	}
 
-	if arn, err := buildRDSCPGARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
+	if arn, err := buildRDSCPGARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {
 		if err := setTagsRDS(rdsconn, d, arn); err != nil {
 			return err
 		} else {
@@ -262,11 +262,14 @@ func resourceAwsRDSClusterParameterGroupDeleteRefreshFunc(
 	}
 }
 
-func buildRDSCPGARN(identifier, accountid, region string) (string, error) {
+func buildRDSCPGARN(identifier, partition, accountid, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct RDS Cluster ARN because of missing AWS partition")
+	}
 	if accountid == "" {
 		return "", fmt.Errorf("Unable to construct RDS Cluster ARN because of missing AWS Account ID")
 	}
-	arn := fmt.Sprintf("arn:aws:rds:%s:%s:cluster-pg:%s", region, accountid, identifier)
+	arn := fmt.Sprintf("arn:%s:rds:%s:%s:cluster-pg:%s", partition, region, accountid, identifier)
 	return arn, nil
 
 }

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -526,7 +526,7 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).redshiftconn
 	d.Partial(true)
 
-	arn, tagErr := buildRedshiftARN(d.Id(), meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	arn, tagErr := buildRedshiftARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
 	if tagErr != nil {
 		return fmt.Errorf("Error building ARN for Redshift Cluster, not updating Tags for cluster %s", d.Id())
 	} else {
@@ -894,11 +894,14 @@ func validateRedshiftClusterMasterPassword(v interface{}, k string) (ws []string
 	return
 }
 
-func buildRedshiftARN(identifier, accountid, region string) (string, error) {
+func buildRedshiftARN(identifier, partition, accountid, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct cluster ARN because of missing AWS partition")
+	}
 	if accountid == "" {
 		return "", fmt.Errorf("Unable to construct cluster ARN because of missing AWS Account ID")
 	}
-	arn := fmt.Sprintf("arn:aws:redshift:%s:%s:cluster:%s", region, accountid, identifier)
+	arn := fmt.Sprintf("arn:%s:redshift:%s:%s:cluster:%s", partition, region, accountid, identifier)
 	return arn, nil
 
 }


### PR DESCRIPTION
Helper functions used to construct arn strings in several aws resources assume the "aws" partition: "arn:aws:%s...". This results in incorrect arn strings when using a different aws partition, like aws-us-gov or aws-cn. This patch parses the current partition while getting the current account id and passes the partition to the various arn helper functions.

[Resolves #5307]