### PR TITLE
provider/aws: Fix. Return correct AMI image when `most_recent` is set to `true`.

### DIFF
--- a/builtin/providers/aws/data_source_aws_ami.go
+++ b/builtin/providers/aws/data_source_aws_ami.go
@@ -270,11 +270,12 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Your query returned more than one result. Please try a more " +
 				"specific search criteria, or set `most_recent` attribute to true.")
 		}
+	} else {
+		// Query returned single result.
+		image = filteredImages[0]
 	}
 
-	image = filteredImages[0]
 	log.Printf("[DEBUG] aws_ami - Single AMI found: %s", *image.ImageId)
-
 	return amiDescriptionAttributes(d, image)
 }
 


### PR DESCRIPTION
This commit resolves a regression introduced in #9033 that caused an
unfiltered image to be returned despite a search criteria being set
accordingly.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>