### PR TITLE
DOCS: Update interpolation page to show list usage

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -25,10 +25,15 @@ will be rendered as a literal `${foo}`.
 
 **To reference user variables**, use the `var.` prefix followed by the
 variable name. For example, `${var.foo}` will interpolate the
-`foo` variable value. If the variable is a map, then you
-can reference static keys in the map with the syntax
-`var.MAP["KEY"]`. For example, `${var.amis["us-east-1"]` would
-get the value of the `us-east-1` key within the `amis` map variable.
+`foo` variable value.
+
+**To reference user map variables**, the syntax is `var.MAP["KEY"]`.  For
+example, `${var.amis["us-east-1"]}` would get the value of the `us-east-1`
+key within the `amis` map variable.
+
+**To reference user list variables**, the syntax is `["${var.LIST}"]`.  For
+example, `["${var.subnets}"]` would get the value of the `subnets` list, as a
+list.
 
 **To reference attributes of your own resource**, the syntax is
 `self.ATTRIBUTE`. For example `${self.private_ip_address}` will

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -23,7 +23,7 @@ will be rendered as a literal `${foo}`.
 
 ## Available Variables
 
-**To reference user variables**, use the `var.` prefix followed by the
+**To reference user string variables**, use the `var.` prefix followed by the
 variable name. For example, `${var.foo}` will interpolate the
 `foo` variable value.
 

--- a/website/source/docs/configuration/variables.html.md
+++ b/website/source/docs/configuration/variables.html.md
@@ -109,7 +109,7 @@ variable "users" {
 }
 ```
 
-The usage of maps, list, strings, etc. is documented fully in the
+The usage of maps, lists, strings, etc. is documented fully in the
 [interpolation syntax](/docs/configuration/interpolation.html)
 page.
 
@@ -194,7 +194,7 @@ $ TF_VAR_somemap='{foo = "bar", baz = "qux"}' terraform plan
 
 <a id="variable-files"></a>
 
-Variables can be collected in files and passed all at once using the 
+Variables can be collected in files and passed all at once using the
 `-var-file=foo.tfvars` flag. The format for variables in `.tfvars`
 files is [HCL](/docs/configuration/syntax.html#HCL), with top level key/value
 pairs:


### PR DESCRIPTION
Relevant to the current version of Terraform and website.

This page did not show how to actually use a list as a list.  The
variables page states that "The usage of maps, list, strings, etc. is
documented fully in the interpolation syntax page", but that wasn't the
case.

I've split them out to list them explicitly and provide examples of
each.

Closes #9037