### PR TITLE
DOCS: Add reference about AWS IAM policy requirements

### DIFF
--- a/website/source/docs/providers/aws/d/iam_policy_document.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_policy_document.html.markdown
@@ -88,7 +88,7 @@ each accept the following arguments:
   apply to. Used to apply a policy statement to all actions *except* those
   listed.
 * `resources` (Optional) - A list of resource ARNs that this statement applies
-  to.
+  to. This is required by AWS if used for an IAM policy.
 * `not_resources` (Optional) - A list of resource ARNs that this statement
   does *not* apply to. Used to apply a policy statement to all resources
   *except* those listed.
@@ -139,4 +139,3 @@ should be processed by AWS rather than by Terraform.
 The following attribute is exported:
 
 * `json` - The above arguments serialized as a standard JSON policy document.
-

--- a/website/source/docs/providers/aws/r/iam_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy.html.markdown
@@ -39,7 +39,9 @@ The following arguments are supported:
 * `description` - (Optional) Description of the IAM policy.
 * `path` - (Optional, default "/") Path in which to create the policy.
 * `policy` - (Required) The policy document. This is a JSON formatted string.
-  The heredoc syntax or `file` function is helpful here.
+  The heredoc syntax, `file` function, or the [`aws_iam_policy_document` data
+  source](/docs/providers/aws/d/iam_policy_document.html)
+  are all helpful here.
 * `name` (Required) - The name of the policy.
 
 ## Attributes Reference


### PR DESCRIPTION
Relevant to the current version of Terraform and website.

This adds a note in the `aws_iam_policy_document` documentation that
`resources` is required by AWS if used on an IAM policy.  Also added a
note on `aws_iam_policy` that `aws_iam_policy_document` is a good thing
to use when configuring.

Closes #9002