### PR TITLE
provider/scaleway: improve first setup experience

### DIFF
--- a/builtin/providers/scaleway/provider.go
+++ b/builtin/providers/scaleway/provider.go
@@ -1,9 +1,47 @@
 package scaleway
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func scwrcConfig() (map[string]string, error) {
+	f, err := os.Open(fmt.Sprintf("%s/.scwrc", os.Getenv("HOME")))
+	if err != nil {
+		return nil, err
+	}
+
+	defer f.Close()
+	bs, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var conf = make(map[string]string)
+	if err := json.Unmarshal(bs, &conf); err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
+
+func envWithScwrcFallbackFunc(envKey, fileKey string, dv interface{}) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		if v := os.Getenv(envKey); v != "" {
+			return v, nil
+		}
+
+		if conf, err := scwrcConfig(); err == nil {
+			return conf[fileKey], nil
+		}
+
+		return dv, nil
+	}
+}
 
 // Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {
@@ -12,13 +50,13 @@ func Provider() terraform.ResourceProvider {
 			"access_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SCALEWAY_ACCESS_KEY", nil),
+				DefaultFunc: envWithScwrcFallbackFunc("SCALEWAY_ACCESS_KEY", "token", nil),
 				Description: "The API key for Scaleway API operations.",
 			},
 			"organization": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SCALEWAY_ORGANIZATION", nil),
+				DefaultFunc: envWithScwrcFallbackFunc("SCALEWAY_ORGANIZATION", "organization", nil),
 				Description: "The Organization ID for Scaleway API operations.",
 			},
 		},

--- a/builtin/providers/scaleway/provider_test.go
+++ b/builtin/providers/scaleway/provider_test.go
@@ -36,3 +36,34 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("SCALEWAY_ACCESS_KEY must be set for acceptance tests")
 	}
 }
+
+func TestEnvWithScwrcFallbackFunc_FromEnv(t *testing.T) {
+	os.Setenv("SCALEWAY_TEST", "foo")
+	v, err := envWithScwrcFallbackFunc("SCALEWAY_TEST", "test", "dv")()
+	if err != nil {
+		t.Fatalf("Failed to lookup value from environment")
+	}
+	if v != "foo" {
+		t.Fatalf("Failed to lookup correct value from environment")
+	}
+}
+
+func TestEnvWithScwrcFallbackFunc_FromFile(t *testing.T) {
+	os.Setenv("HOME", "/tmp")
+	f, err := os.OpenFile("/tmp/.scwrc", os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString(`{"test": "bar"}`)
+	f.Close()
+	defer func() {
+		os.Remove("/tmp/.scwrc")
+	}()
+	v, err := envWithScwrcFallbackFunc("SCALEWAY_TEST", "test", "dv")()
+	if err != nil {
+		t.Fatalf("Failed to lookup value from file")
+	}
+	if v != "bar" {
+		t.Fatalf("Failed to lookup correct value from file. Expected %q got %q", "bar", v)
+	}
+}

--- a/website/source/docs/providers/scaleway/index.html.markdown
+++ b/website/source/docs/providers/scaleway/index.html.markdown
@@ -88,3 +88,6 @@ provider "scaleway" {}
 
 - **SCALEWAY_ORGANIZATION**: Your Scaleway organization
 - **SCALEWAY_ACCESS_KEY**: Your API Access key
+
+If you're already using the [scaleway CLI tool](https://github.com/scaleway/scaleway-cli#scw-login), terraform will also try to lookup
+the information from `$HOME/.scwrc`.


### PR DESCRIPTION
Assuming you're using the scaleway CLI already, we can improve the dev XP for scaleway & terraform a little by not forcing people to export their credentials to the environment, or hard code them for that matter.

the [scaleway CLI](https://github.com/scaleway/scaleway-cli#scw-login) stores all credentials in
`$HOME/.scwrc`. This file is JSON encoded and holds the necessary information
at `token` and `organization`.

Note that the scaleway CLI does not support multi-account setups, which is why
this is a viable way to get these information, besides the environment of course.