### PR TITLE
updates digitalocean example main.tf to correct syntax for private_key & file function

### DIFF
--- a/examples/digitalocean/main.tf
+++ b/examples/digitalocean/main.tf
@@ -24,7 +24,7 @@ resource "digitalocean_droplet" "mywebserver" {
 
     connection {
       type     = "ssh"
-      key_file = "file(${HOME}/.ssh/id_rsa)"
+      private_key = "${file("~/.ssh/id_rsa")}"
       user     = "root"
       timeout  = "2m"
     }


### PR DESCRIPTION
This updates the following misinformation in the [digitalocean example](https://github.com/hashicorp/terraform/blob/master/examples/digitalocean/main.tf#L27):
- changes deprecated `key_file` to `private_key`
- changes ` ${HOME}` to `~` (all other examples use the `~` and `${HOME}` doesn't seem to interpolate the way this example expects
- adds `"`s to the inner string of the `file` function

These were gotchas I had to work through on my own through reading other documentation (the google-two-tier example), but have found that this updated syntax works..