### PR TITLE
provider/azurerm: fix loadbanacer_rule tests failing validation

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -61,7 +61,7 @@ func TestResourceAzureRMLoadBalancerRuleNameLabel_validation(t *testing.T) {
 func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
-	lbRuleName := fmt.Sprintf("LbRule-%d", ri)
+	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,7 +82,7 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 func TestAccAzureRMLoadBalancerRule_removal(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
-	lbRuleName := fmt.Sprintf("LbRule-%d", ri)
+	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMLoadBalancerRule -timeout 120m
=== RUN   TestAccAzureRMLoadBalancerRule_basic
--- PASS: TestAccAzureRMLoadBalancerRule_basic (149.43s)
=== RUN   TestAccAzureRMLoadBalancerRule_removal
--- PASS: TestAccAzureRMLoadBalancerRule_removal (165.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	314.894s
```