### PR TITLE
provider/azurerm: fix cdn_profile ID parsing, add import capability

### DIFF
--- a/builtin/providers/azurerm/import_arm_cdn_profile_test.go
+++ b/builtin/providers/azurerm/import_arm_cdn_profile_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMCdnProfile_importWithTags(t *testing.T) {
+	resourceName := "azurerm_cdn_profile.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMCdnProfile_withTags, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_cdn_profile.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile.go
@@ -17,6 +17,9 @@ func resourceArmCdnProfile() *schema.Resource {
 		Read:   resourceArmCdnProfileRead,
 		Update: resourceArmCdnProfileUpdate,
 		Delete: resourceArmCdnProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -96,7 +99,7 @@ func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	resGroup := id.ResourceGroup
-	name := id.Path["Profiles"]
+	name := id.Path["profiles"]
 
 	resp, err := cdnProfilesClient.Get(name, resGroup)
 	if err != nil {
@@ -106,6 +109,10 @@ func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		return fmt.Errorf("Error making Read request on Azure CDN Profile %s: %s", name, err)
 	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
 	if resp.Sku != nil {
 		d.Set("sku", string(resp.Sku.Name))
@@ -147,7 +154,7 @@ func resourceArmCdnProfileDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 	resGroup := id.ResourceGroup
-	name := id.Path["Profiles"]
+	name := id.Path["profiles"]
 
 	_, err = cdnProfilesClient.DeleteIfExists(name, resGroup, make(chan struct{}))
 


### PR DESCRIPTION
cdn_profile resource was using `Profiles` instead of `profiles` to gather the
name in the read and delete methods, added importing capability with test to
confirm read now works as expected.

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMCdnProfile -timeout 120m
=== RUN   TestAccAzureRMCdnProfile_importWithTags
--- PASS: TestAccAzureRMCdnProfile_importWithTags (170.00s)
=== RUN   TestAccAzureRMCdnProfile_basic
--- PASS: TestAccAzureRMCdnProfile_basic (166.33s)
=== RUN   TestAccAzureRMCdnProfile_withTags
--- PASS: TestAccAzureRMCdnProfile_withTags (185.94s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	522.333s
```