### PR TITLE
provider/azurerm: fix computed tags causing non-empty plan

### DIFF
--- a/builtin/providers/azurerm/tags.go
+++ b/builtin/providers/azurerm/tags.go
@@ -64,6 +64,7 @@ func expandTags(tagsMap map[string]interface{}) *map[string]*string {
 
 func flattenAndSetTags(d *schema.ResourceData, tagsMap *map[string]*string) {
 	if tagsMap == nil {
+		d.Set("tags", make(map[string]interface{}))
 		return
 	}
 


### PR DESCRIPTION
The tag schema was changed in #9199, setting the Computed flag, this was causing
the plan to not be empty for resources which support tags but none were set, as
no value would be set by flattenAndSetTags.

Setting an empty map instead fixes the issue, ran original failing test and an
update tags test to ensure nothing else was broken.

Depends on #9305.

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMCdnProfile -timeout 120m
=== RUN   TestAccAzureRMCdnProfile_importWithTags
--- PASS: TestAccAzureRMCdnProfile_importWithTags (171.64s)
=== RUN   TestAccAzureRMCdnProfile_basic
--- PASS: TestAccAzureRMCdnProfile_basic (162.70s)
=== RUN   TestAccAzureRMCdnProfile_withTags
--- PASS: TestAccAzureRMCdnProfile_withTags (203.12s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	537.538s
```