### PR TITLE
provider/google docs: Config should reflect description

### DIFF
--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -112,13 +112,14 @@ resource "google_container_cluster" "primary" {
 * `horizontal_pod_autoscaling` - (Optional) The status of the Horizontal Pod Autoscaling addon. It is enabled by default; set `disabled = true` to disable.
 
 This example `addons_config` disables both addons:
+
 ```
 addons_config {
   http_load_balancing { 
-    disabled = false
+    disabled = true
   }
   horizontal_pod_autoscaling {
-    disabled = false
+    disabled = true
   }
 }
 ```


### PR DESCRIPTION
Example addons_config was supposed to show how to disable addons (http_load_balancing and horizontal_pod_autoscaling), but it was enabling them instead.