### PR TITLE
Refresh google_compute_instance machine_type on read

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -626,6 +626,10 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("can_ip_forward", instance.CanIpForward)
 
+	machineTypeResource := strings.Split(instance.MachineType, "/")
+	machineType := machineTypeResource[len(machineTypeResource)-1]
+	d.Set("machine_type", machineType)
+
 	// Set the service accounts
 	serviceAccounts := make([]map[string]interface{}, 0, 1)
 	for _, serviceAccount := range instance.ServiceAccounts {


### PR DESCRIPTION
I've changed a machine type manually in GCE and ran `terraform refresh` to update my local `tfstate` but `machine_type` was not updated. This MR `set()` `machine_type` in `resourceComputeInstanceRead`.
