### PR TITLE
provider/aws: Add missing unit test and re-factor for clarity.

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -357,7 +357,8 @@ func validateHTTPMethod(v interface{}, k string) (ws []string, errors []error) {
 
 	if _, ok := validMethods[value]; !ok {
 		errors = append(errors, fmt.Errorf(
-			"%q must be one of 'GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE', or 'ANY'", k))
+			"%q contains an invalid method %q. Valid methods are either %q, %q, %q, %q, %q, %q, %q, or %q.",
+			k, value, "ANY", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"))
 	}
 	return
 }
@@ -482,9 +483,19 @@ func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
 
 func validateApiGatewayIntegrationType(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if value != "MOCK" && value != "AWS" && value != "HTTP" && value != "AWS_PROXY" && value != "HTTP_PROXY" {
+
+	validTypes := map[string]bool{
+		"AWS":        true,
+		"AWS_PROXY":  true,
+		"HTTP":       true,
+		"HTTP_PROXY": true,
+		"MOCK":       true,
+	}
+
+	if _, ok := validTypes[value]; !ok {
 		errors = append(errors, fmt.Errorf(
-			"%q must be one of 'AWS', 'MOCK', 'HTTP', 'AWS_PROXY', 'HTTP_PROXY'", k))
+			"%q contains an invalid integration type %q. Valid types are either %q, %q, %q, %q, or %q.",
+			k, value, "AWS", "AWS_PROXY", "HTTP", "HTTP_PROXY", "MOCK"))
 	}
 	return
 }

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -276,12 +276,48 @@ func TestValidateCIDRNetworkAddress(t *testing.T) {
 }
 
 func TestValidateHTTPMethod(t *testing.T) {
-	validCases := []string{"GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD", "PATCH", "ANY"}
-	for i, method := range validCases {
-		_, errs := validateHTTPMethod(method, "foo")
-		if len(errs) != 0 {
-			t.Fatalf("%d/%d: Expected no error, got errs: %#v",
-				i+1, len(validCases), errs)
+	type testCases struct {
+		Value    string
+		ErrCount int
+	}
+
+	invalidCases := []testCases{
+		{
+			Value:    "incorrect",
+			ErrCount: 1,
+		},
+		{
+			Value:    "delete",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range invalidCases {
+		_, errors := validateHTTPMethod(tc.Value, "http_method")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
+		}
+	}
+
+	validCases := []testCases{
+		{
+			Value:    "ANY",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DELETE",
+			ErrCount: 0,
+		},
+		{
+			Value:    "OPTIONS",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range validCases {
+		_, errors := validateHTTPMethod(tc.Value, "http_method")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
 		}
 	}
 }
@@ -603,6 +639,49 @@ func TestValidateJsonString(t *testing.T) {
 
 	for _, tc := range validCases {
 		_, errors := validateJsonString(tc.Value, "json")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
+		}
+	}
+}
+
+func TestValidateApiGatewayIntegrationType(t *testing.T) {
+	type testCases struct {
+		Value    string
+		ErrCount int
+	}
+
+	invalidCases := []testCases{
+		{
+			Value:    "incorrect",
+			ErrCount: 1,
+		},
+		{
+			Value:    "aws_proxy",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range invalidCases {
+		_, errors := validateApiGatewayIntegrationType(tc.Value, "types")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
+		}
+	}
+
+	validCases := []testCases{
+		{
+			Value:    "MOCK",
+			ErrCount: 0,
+		},
+		{
+			Value:    "AWS_PROXY",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range validCases {
+		_, errors := validateApiGatewayIntegrationType(tc.Value, "types")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
 		}


### PR DESCRIPTION
This commit adds a missing unit test for the API Gateway integration type
attribute validation helper, plus changes the way how value is inspected
to a simple lookup table. Additionally, changes the wording of the error
message, and adds invalid test cases to the HTTP method validation helper.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>