### PR TITLE
provider/azurerm: fix servicebus_topic updating values

### DIFF
--- a/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
@@ -82,12 +82,16 @@ The following arguments are supported:
 
 * `enable_partitioning` - (Optional) Boolean flag which controls whether to enable
     the topic to be partitioned across multiple message brokers. Defaults to false.
+    Changing this forces a new resource to be created.
 
 * `max_size_in_megabytes` - (Optional) Integer value which controls the size of
-    memory allocated for the topic.
+    memory allocated for the topic. Supported values are multiples of 1024 up to
+    10240, if `enable_partitioning` is enabled then 16 partitions will be created
+    per GB, making the maximum possible topic size 163840 (10240 * 16).
 
 * `requires_duplicate_detection` - (Optional) Boolean flag which controls whether
-    the Topic requires duplicate detection. Defaults to false.
+    the Topic requires duplicate detection. Defaults to false. Changing this forces
+    a new resource to be created.
 
 * `support_ordering` - (Optional) Boolean flag which controls whether the Topic
     supports ordering. Defaults to false.


### PR DESCRIPTION
enable_partitioning set to ForceNew
requires_duplicate_detection set to ForceNew

max_size_in_megabytes would cause a loop if enable_partitioning was true as this
causes the value to be multiplied by 16 for it's effective value, this computed
value is then returned by the ARM API in the same field which caused Terraform
to always detect a change

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMServiceBusTopic -timeout 120m
=== RUN   TestAccAzureRMServiceBusTopic_importBasic
--- PASS: TestAccAzureRMServiceBusTopic_importBasic (345.08s)
=== RUN   TestAccAzureRMServiceBusTopic_basic
--- PASS: TestAccAzureRMServiceBusTopic_basic (342.23s)
=== RUN   TestAccAzureRMServiceBusTopic_update
--- PASS: TestAccAzureRMServiceBusTopic_update (359.56s)
=== RUN   TestAccAzureRMServiceBusTopic_enablePartitioning
--- PASS: TestAccAzureRMServiceBusTopic_enablePartitioning (362.80s)
=== RUN   TestAccAzureRMServiceBusTopic_enableDuplicateDetection
--- PASS: TestAccAzureRMServiceBusTopic_enableDuplicateDetection (364.97s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	1774.657s
```