### PR TITLE
Fix precedence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ testacc: fmtcheck generate
 		echo "  make testacc TEST=./builtin/providers/aws"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -parallel=9
 
 # testrace runs the race checker
 testrace: fmtcheck generate

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -217,12 +217,12 @@ func defaultCacheBehaviorHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
 	}
 	if d, ok := m["allowed_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
+		for _, e := range sortInterfaceSlice(d.(*schema.Set).List()) {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
 	if d, ok := m["cached_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
+		for _, e := range sortInterfaceSlice(d.(*schema.Set).List()) {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
@@ -269,10 +269,10 @@ func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 		cb.SmoothStreaming = aws.Bool(v.(bool))
 	}
 	if v, ok := m["allowed_methods"]; ok {
-		cb.AllowedMethods = expandAllowedMethods(v.([]interface{}))
+		cb.AllowedMethods = expandAllowedMethods(v.(*schema.Set))
 	}
 	if v, ok := m["cached_methods"]; ok {
-		cb.AllowedMethods.CachedMethods = expandCachedMethods(v.([]interface{}))
+		cb.AllowedMethods.CachedMethods = expandCachedMethods(v.(*schema.Set))
 	}
 	if v, ok := m["path_pattern"]; ok {
 		cb.PathPattern = aws.String(v.(string))
@@ -461,32 +461,32 @@ func flattenCookieNames(cn *cloudfront.CookieNames) []interface{} {
 	return []interface{}{}
 }
 
-func expandAllowedMethods(s []interface{}) *cloudfront.AllowedMethods {
+func expandAllowedMethods(s *schema.Set) *cloudfront.AllowedMethods {
 	return &cloudfront.AllowedMethods{
-		Quantity: aws.Int64(int64(len(s))),
-		Items:    expandStringList(s),
+		Quantity: aws.Int64(int64(s.Len())),
+		Items:    expandStringList(s.List()),
 	}
 }
 
-func flattenAllowedMethods(am *cloudfront.AllowedMethods) []interface{} {
+func flattenAllowedMethods(am *cloudfront.AllowedMethods) *schema.Set {
 	if am.Items != nil {
-		return flattenStringList(am.Items)
+		return schema.NewSet(schema.HashString, flattenStringList(am.Items))
 	}
-	return []interface{}{}
+	return nil
 }
 
-func expandCachedMethods(s []interface{}) *cloudfront.CachedMethods {
+func expandCachedMethods(s *schema.Set) *cloudfront.CachedMethods {
 	return &cloudfront.CachedMethods{
-		Quantity: aws.Int64(int64(len(s))),
-		Items:    expandStringList(s),
+		Quantity: aws.Int64(int64(s.Len())),
+		Items:    expandStringList(s.List()),
 	}
 }
 
-func flattenCachedMethods(cm *cloudfront.CachedMethods) []interface{} {
+func flattenCachedMethods(cm *cloudfront.CachedMethods) *schema.Set {
 	if cm.Items != nil {
-		return flattenStringList(cm.Items)
+		return schema.NewSet(schema.HashString, flattenStringList(cm.Items))
 	}
-	return []interface{}{}
+	return nil
 }
 
 func expandOrigins(s *schema.Set) *cloudfront.Origins {

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -42,7 +42,7 @@ func (p StringPtrSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // Used by the aws_cloudfront_distribution Create and Update functions.
 func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionConfig {
 	distributionConfig := &cloudfront.DistributionConfig{
-		CacheBehaviors:       expandCacheBehaviors(d.Get("cache_behavior").(*schema.Set)),
+		CacheBehaviors:       expandCacheBehaviors(d.Get("cache_behavior").([]interface{})),
 		CustomErrorResponses: expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
 		DefaultCacheBehavior: expandDefaultCacheBehavior(d.Get("default_cache_behavior").(*schema.Set).List()[0].(map[string]interface{})),
 		Enabled:              aws.Bool(d.Get("enabled").(bool)),
@@ -229,10 +229,10 @@ func defaultCacheBehaviorHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func expandCacheBehaviors(s *schema.Set) *cloudfront.CacheBehaviors {
+func expandCacheBehaviors(lst []interface{}) *cloudfront.CacheBehaviors {
 	var qty int64
 	var items []*cloudfront.CacheBehavior
-	for _, v := range s.List() {
+	for _, v := range lst {
 		items = append(items, expandCacheBehavior(v.(map[string]interface{})))
 		qty++
 	}
@@ -242,12 +242,12 @@ func expandCacheBehaviors(s *schema.Set) *cloudfront.CacheBehaviors {
 	}
 }
 
-func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) *schema.Set {
-	s := []interface{}{}
+func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) []interface{} {
+	lst := []interface{}{}
 	for _, v := range cbs.Items {
-		s = append(s, flattenCacheBehavior(v))
+		lst = append(lst, flattenCacheBehavior(v))
 	}
-	return schema.NewSet(cacheBehaviorHash, s)
+	return lst
 }
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
@@ -311,46 +311,6 @@ func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 		m["path_pattern"] = *cb.PathPattern
 	}
 	return m
-}
-
-// Assemble the hash for the aws_cloudfront_distribution cache_behavior
-// TypeSet attribute.
-func cacheBehaviorHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%t-", m["compress"].(bool)))
-	buf.WriteString(fmt.Sprintf("%s-", m["viewer_protocol_policy"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["target_origin_id"].(string)))
-	buf.WriteString(fmt.Sprintf("%d-", forwardedValuesHash(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{}))))
-	buf.WriteString(fmt.Sprintf("%d-", m["min_ttl"].(int)))
-	if d, ok := m["trusted_signers"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["max_ttl"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
-	}
-	if d, ok := m["smooth_streaming"]; ok {
-		buf.WriteString(fmt.Sprintf("%t-", d.(bool)))
-	}
-	if d, ok := m["default_ttl"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
-	}
-	if d, ok := m["allowed_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["cached_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["path_pattern"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", d))
-	}
-	return hashcode.String(buf.String())
 }
 
 func expandTrustedSigners(s []interface{}) *cloudfront.TrustedSigners {

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -36,8 +36,8 @@ func cacheBehaviorConf2() map[string]interface{} {
 	return cb
 }
 
-func cacheBehaviorsConf() *schema.Set {
-	return schema.NewSet(cacheBehaviorHash, []interface{}{cacheBehaviorConf1(), cacheBehaviorConf2()})
+func cacheBehaviorsConf() []interface{} {
+	return []interface{}{cacheBehaviorConf1(), cacheBehaviorConf2()}
 }
 
 func trustedSignersConf() []interface{} {
@@ -382,10 +382,10 @@ func TestCloudFrontStructure_flattenCacheBehaviors(t *testing.T) {
 	in := cacheBehaviorsConf()
 	cbs := expandCacheBehaviors(in)
 	out := flattenCacheBehaviors(cbs)
-	diff := in.Difference(out)
-
-	if len(diff.List()) > 0 {
-		t.Fatalf("Expected out to be %v, got %v, diff: %v", in, out, diff)
+	for i := range in {
+		if reflect.DeepEqual(in[i], out[i]) {
+			t.Fatalf("Expected out to be %v, got %v", in, out)
+		}
 	}
 }
 

--- a/builtin/providers/aws/import_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/import_aws_cloudfront_distribution_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccAWSCloudFrontDistribution_importBasic(t *testing.T) {
+	t.Parallel()
 	ri := acctest.RandInt()
 	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3Config, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -39,12 +39,12 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"cached_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -169,12 +169,12 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"cached_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -22,6 +22,9 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 			State: resourceAwsCloudFrontDistributionImport,
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsCloudFrontDistributionMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -34,9 +34,8 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Set:      aliasesHash,
 			},
 			"cache_behavior": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
-				Set:      cacheBehaviorHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": {

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -35,7 +36,13 @@ func migrateCloudFrontDistributionStateV0toV1(is *terraform.InstanceState) (*ter
 	var newAttributes = make(map[string]string, 0)
 
 	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
-	for k, v := range is.Attributes {
+	var keys []string
+	for k, _ := range is.Attributes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := is.Attributes[k]
 
 		// change cache_behavior.1784951082 to cache_behavior.0
 		newKey := migrateCacheBehaviorKeyFromSetToList(&hashToIdx, k)

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate.go
@@ -1,0 +1,81 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var cacheBehaviorExp = regexp.MustCompile(`^cache_behavior\.([0-9]+)\.`)
+var cacheBehaviorFormat = "cache_behavior.%d."
+var httpMethodExp = regexp.MustCompile(`\.(?P<allowedOrCached>allowed|cached)_methods\.[0-9]+`)
+var httpMethodFormat = `.${allowedOrCached}_methods.%d`
+
+func resourceAwsCloudFrontDistributionMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS CloudFront Distribution State v0; migrating to v1")
+		return migrateCloudFrontDistributionStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateCloudFrontDistributionStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty CloudFront Distribution State; nothing to migrate.")
+		return is, nil
+	}
+
+	var hashToIdx = make(map[string]int, 0)
+	var newAttributes = make(map[string]string, 0)
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+	for k, v := range is.Attributes {
+
+		// change cache_behavior.1784951082 to cache_behavior.0
+		newKey := migrateCacheBehaviorKeyFromSetToList(&hashToIdx, k)
+
+		// change allowed_methods.0 to allowed_methods.1040875975
+		newKey = migrateHttpMethodsKeysFromListToSet(newKey, v)
+
+		log.Printf("[DEBUG] Deleting %s", k)
+		delete(is.Attributes, k)
+		log.Printf("[DEBUG] Adding %s", newKey)
+		newAttributes[newKey] = v
+	}
+	is.Attributes = newAttributes
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}
+
+func migrateCacheBehaviorKeyFromSetToList(hashToIdx *map[string]int, k string) string {
+	subMatchGroups := cacheBehaviorExp.FindStringSubmatch(k)
+	if subMatchGroups != nil {
+		var newIndex int
+		hash := subMatchGroups[1]
+		if idx, ok := (*hashToIdx)[hash]; ok {
+			newIndex = idx
+		} else {
+			newIndex = len(*hashToIdx)
+			(*hashToIdx)[hash] = newIndex
+		}
+		return cacheBehaviorExp.ReplaceAllLiteralString(k, fmt.Sprintf(cacheBehaviorFormat, newIndex))
+	}
+	return k
+}
+
+func migrateHttpMethodsKeysFromListToSet(k string, v string) string {
+	computeHash := schema.HashSchema(&schema.Schema{Type: schema.TypeString})
+	subMatchGroups := httpMethodExp.FindStringSubmatch(k)
+	if subMatchGroups != nil {
+		hash := computeHash(v)
+		return httpMethodExp.ReplaceAllString(k, fmt.Sprintf(httpMethodFormat, hash))
+	}
+	return k
+}

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate_test.go
@@ -182,13 +182,13 @@ func TestAWSCloudFrontDistributionMigrateState(t *testing.T) {
 func stateDiff(expected map[string]string, actual map[string]string) map[string]string {
 	var diff = make(map[string]string, 0)
 	for k, v := range expected {
-		if value, ok := actual[k]; !ok && value != v {
+		if value, ok := actual[k]; !ok || value != v {
 			newKey := fmt.Sprintf("%s_EXPECTED", k)
 			diff[newKey] = v
 		}
 	}
 	for k, v := range actual {
-		if value, ok := expected[k]; !ok && value != v {
+		if value, ok := expected[k]; !ok || value != v {
 			newKey := fmt.Sprintf("%s_ACTUAL", k)
 			diff[newKey] = v
 		}

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_migrate_test.go
@@ -1,0 +1,197 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSCloudFrontDistributionMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0_1_single_cache_behavior": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"cache_behavior.#":                                                                             "1",
+				"cache_behavior.1346915471.allowed_methods.#":                                                  "2",
+				"cache_behavior.1346915471.allowed_methods.0":                                                  "GET",
+				"cache_behavior.1346915471.allowed_methods.1":                                                  "HEAD",
+				"cache_behavior.1346915471.cached_methods.#":                                                   "2",
+				"cache_behavior.1346915471.cached_methods.0":                                                   "GET",
+				"cache_behavior.1346915471.cached_methods.1":                                                   "HEAD",
+				"cache_behavior.1346915471.compress":                                                           "false",
+				"cache_behavior.1346915471.default_ttl":                                                        "3600",
+				"cache_behavior.1346915471.forwarded_values.#":                                                 "1",
+				"cache_behavior.1346915471.forwarded_values.2759845635.cookies.#":                              "1",
+				"cache_behavior.1346915471.forwarded_values.2759845635.cookies.2625240281.forward":             "none",
+				"cache_behavior.1346915471.forwarded_values.2759845635.cookies.2625240281.whitelisted_names.#": "0",
+				"cache_behavior.1346915471.forwarded_values.2759845635.headers.#":                              "0",
+				"cache_behavior.1346915471.forwarded_values.2759845635.query_string":                           "false",
+				"cache_behavior.1346915471.max_ttl":                                                            "86400",
+				"cache_behavior.1346915471.min_ttl":                                                            "100",
+				"cache_behavior.1346915471.path_pattern":                                                       "/first/*",
+				"cache_behavior.1346915471.smooth_streaming":                                                   "",
+				"cache_behavior.1346915471.target_origin_id":                                                   "myS3Origin",
+				"cache_behavior.1346915471.trusted_signers.#":                                                  "0",
+				"cache_behavior.1346915471.viewer_protocol_policy":                                             "allow-all",
+			},
+			Expected: map[string]string{
+				"cache_behavior.#":                                                                    "1",
+				"cache_behavior.0.allowed_methods.#":                                                  "2",
+				"cache_behavior.0.allowed_methods.1040875975":                                         "GET",
+				"cache_behavior.0.allowed_methods.1445840968":                                         "HEAD",
+				"cache_behavior.0.cached_methods.#":                                                   "2",
+				"cache_behavior.0.cached_methods.1040875975":                                          "GET",
+				"cache_behavior.0.cached_methods.1445840968":                                          "HEAD",
+				"cache_behavior.0.compress":                                                           "false",
+				"cache_behavior.0.default_ttl":                                                        "3600",
+				"cache_behavior.0.forwarded_values.#":                                                 "1",
+				"cache_behavior.0.forwarded_values.2759845635.cookies.#":                              "1",
+				"cache_behavior.0.forwarded_values.2759845635.cookies.2625240281.forward":             "none",
+				"cache_behavior.0.forwarded_values.2759845635.cookies.2625240281.whitelisted_names.#": "0",
+				"cache_behavior.0.forwarded_values.2759845635.headers.#":                              "0",
+				"cache_behavior.0.forwarded_values.2759845635.query_string":                           "false",
+				"cache_behavior.0.max_ttl":                                                            "86400",
+				"cache_behavior.0.min_ttl":                                                            "100",
+				"cache_behavior.0.path_pattern":                                                       "/first/*",
+				"cache_behavior.0.smooth_streaming":                                                   "",
+				"cache_behavior.0.target_origin_id":                                                   "myS3Origin",
+				"cache_behavior.0.trusted_signers.#":                                                  "0",
+				"cache_behavior.0.viewer_protocol_policy":                                             "allow-all",
+			},
+		},
+		"v0_1_multiple_cache_behaviors": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"cache_behavior.#":                                                                             "2",
+				"cache_behavior.1346915471.allowed_methods.#":                                                  "2",
+				"cache_behavior.1346915471.allowed_methods.0":                                                  "GET",
+				"cache_behavior.1346915471.allowed_methods.1":                                                  "HEAD",
+				"cache_behavior.1346915471.cached_methods.#":                                                   "2",
+				"cache_behavior.1346915471.cached_methods.0":                                                   "GET",
+				"cache_behavior.1346915471.cached_methods.1":                                                   "HEAD",
+				"cache_behavior.1346915471.compress":                                                           "false",
+				"cache_behavior.1346915471.default_ttl":                                                        "3600",
+				"cache_behavior.1346915471.forwarded_values.#":                                                 "1",
+				"cache_behavior.1346915471.forwarded_values.2759845635.cookies.#":                              "1",
+				"cache_behavior.1346915471.forwarded_values.2759845635.cookies.2625240281.forward":             "none",
+				"cache_behavior.1346915471.forwarded_values.2759845635.cookies.2625240281.whitelisted_names.#": "0",
+				"cache_behavior.1346915471.forwarded_values.2759845635.headers.#":                              "0",
+				"cache_behavior.1346915471.forwarded_values.2759845635.query_string":                           "false",
+				"cache_behavior.1346915471.max_ttl":                                                            "86400",
+				"cache_behavior.1346915471.min_ttl":                                                            "100",
+				"cache_behavior.1346915471.path_pattern":                                                       "/first/*",
+				"cache_behavior.1346915471.smooth_streaming":                                                   "",
+				"cache_behavior.1346915471.target_origin_id":                                                   "myS3Origin",
+				"cache_behavior.1346915471.trusted_signers.#":                                                  "0",
+				"cache_behavior.1346915471.viewer_protocol_policy":                                             "allow-all",
+				"cache_behavior.2342080937.allowed_methods.#":                                                  "2",
+				"cache_behavior.2342080937.allowed_methods.0":                                                  "GET",
+				"cache_behavior.2342080937.allowed_methods.1":                                                  "HEAD",
+				"cache_behavior.2342080937.cached_methods.#":                                                   "2",
+				"cache_behavior.2342080937.cached_methods.0":                                                   "GET",
+				"cache_behavior.2342080937.cached_methods.1":                                                   "HEAD",
+				"cache_behavior.2342080937.compress":                                                           "false",
+				"cache_behavior.2342080937.default_ttl":                                                        "3600",
+				"cache_behavior.2342080937.forwarded_values.#":                                                 "1",
+				"cache_behavior.2342080937.forwarded_values.2759845635.cookies.#":                              "1",
+				"cache_behavior.2342080937.forwarded_values.2759845635.cookies.2625240281.forward":             "none",
+				"cache_behavior.2342080937.forwarded_values.2759845635.cookies.2625240281.whitelisted_names.#": "0",
+				"cache_behavior.2342080937.forwarded_values.2759845635.headers.#":                              "0",
+				"cache_behavior.2342080937.forwarded_values.2759845635.query_string":                           "false",
+				"cache_behavior.2342080937.max_ttl":                                                            "86400",
+				"cache_behavior.2342080937.min_ttl":                                                            "200",
+				"cache_behavior.2342080937.path_pattern":                                                       "/second/*",
+				"cache_behavior.2342080937.smooth_streaming":                                                   "",
+				"cache_behavior.2342080937.target_origin_id":                                                   "myS3Origin",
+				"cache_behavior.2342080937.trusted_signers.#":                                                  "0",
+				"cache_behavior.2342080937.viewer_protocol_policy":                                             "allow-all",
+			},
+			Expected: map[string]string{
+				"cache_behavior.#":                                                                    "2",
+				"cache_behavior.0.allowed_methods.#":                                                  "2",
+				"cache_behavior.0.allowed_methods.1040875975":                                         "GET",
+				"cache_behavior.0.allowed_methods.1445840968":                                         "HEAD",
+				"cache_behavior.0.cached_methods.#":                                                   "2",
+				"cache_behavior.0.cached_methods.1040875975":                                          "GET",
+				"cache_behavior.0.cached_methods.1445840968":                                          "HEAD",
+				"cache_behavior.0.compress":                                                           "false",
+				"cache_behavior.0.default_ttl":                                                        "3600",
+				"cache_behavior.0.forwarded_values.#":                                                 "1",
+				"cache_behavior.0.forwarded_values.2759845635.cookies.#":                              "1",
+				"cache_behavior.0.forwarded_values.2759845635.cookies.2625240281.forward":             "none",
+				"cache_behavior.0.forwarded_values.2759845635.cookies.2625240281.whitelisted_names.#": "0",
+				"cache_behavior.0.forwarded_values.2759845635.headers.#":                              "0",
+				"cache_behavior.0.forwarded_values.2759845635.query_string":                           "false",
+				"cache_behavior.0.max_ttl":                                                            "86400",
+				"cache_behavior.0.min_ttl":                                                            "100",
+				"cache_behavior.0.path_pattern":                                                       "/first/*",
+				"cache_behavior.0.smooth_streaming":                                                   "",
+				"cache_behavior.0.target_origin_id":                                                   "myS3Origin",
+				"cache_behavior.0.trusted_signers.#":                                                  "0",
+				"cache_behavior.0.viewer_protocol_policy":                                             "allow-all",
+				"cache_behavior.1.allowed_methods.#":                                                  "2",
+				"cache_behavior.1.allowed_methods.1040875975":                                         "GET",
+				"cache_behavior.1.allowed_methods.1445840968":                                         "HEAD",
+				"cache_behavior.1.cached_methods.#":                                                   "2",
+				"cache_behavior.1.cached_methods.1040875975":                                          "GET",
+				"cache_behavior.1.cached_methods.1445840968":                                          "HEAD",
+				"cache_behavior.1.compress":                                                           "false",
+				"cache_behavior.1.default_ttl":                                                        "3600",
+				"cache_behavior.1.forwarded_values.#":                                                 "1",
+				"cache_behavior.1.forwarded_values.2759845635.cookies.#":                              "1",
+				"cache_behavior.1.forwarded_values.2759845635.cookies.2625240281.forward":             "none",
+				"cache_behavior.1.forwarded_values.2759845635.cookies.2625240281.whitelisted_names.#": "0",
+				"cache_behavior.1.forwarded_values.2759845635.headers.#":                              "0",
+				"cache_behavior.1.forwarded_values.2759845635.query_string":                           "false",
+				"cache_behavior.1.max_ttl":                                                            "86400",
+				"cache_behavior.1.min_ttl":                                                            "200",
+				"cache_behavior.1.path_pattern":                                                       "/second/*",
+				"cache_behavior.1.smooth_streaming":                                                   "",
+				"cache_behavior.1.target_origin_id":                                                   "myS3Origin",
+				"cache_behavior.1.trusted_signers.#":                                                  "0",
+				"cache_behavior.1.viewer_protocol_policy":                                             "allow-all",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "E1L3MHGHRZSNX",
+			Attributes: tc.Attributes,
+		}
+		migratedState, err := resourceAwsCloudFrontDistributionMigrateState(
+			tc.StateVersion, is, tc.Meta)
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+		if !reflect.DeepEqual(tc.Expected, migratedState.Attributes) {
+			t.Logf("[DEBUG] Diff between expected and actual: %#v", stateDiff(tc.Expected, migratedState.Attributes))
+			t.Fatalf("Expected CF distribution attributes to match after migration\nGiven: %#v\nExpected: %#v",
+				migratedState.Attributes, tc.Expected)
+		}
+	}
+}
+
+func stateDiff(expected map[string]string, actual map[string]string) map[string]string {
+	var diff = make(map[string]string, 0)
+	for k, v := range expected {
+		if value, ok := actual[k]; !ok && value != v {
+			newKey := fmt.Sprintf("%s_EXPECTED", k)
+			diff[newKey] = v
+		}
+	}
+	for k, v := range actual {
+		if value, ok := expected[k]; !ok && value != v {
+			newKey := fmt.Sprintf("%s_ACTUAL", k)
+			diff[newKey] = v
+		}
+	}
+	return diff
+}

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -20,6 +20,7 @@ import (
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
+	t.Parallel()
 	ri := acctest.RandInt()
 	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3Config, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 	resource.Test(t, resource.TestCase{
@@ -45,6 +46,7 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 }
 
 func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
+	t.Parallel()
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTags, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 	postConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTagsUpdated, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
@@ -90,6 +92,7 @@ func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
+	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -113,6 +116,7 @@ func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
+	t.Parallel()
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAWSCloudFrontDistributionMultiOriginConfig, ri, originBucket, logBucket, cacheBehavior0, cacheBehavior1, testAccAWSCloudFrontDistributionRetainConfig())
 
@@ -139,6 +143,7 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_cacheBehaviorPrecedence(t *testing.T) {
+	t.Parallel()
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionMultiOriginConfig, ri, originBucket, logBucket, cacheBehavior0, cacheBehavior1, testAccAWSCloudFrontDistributionRetainConfig())
 	postConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionMultiOriginConfig, ri, originBucket, logBucket, cacheBehavior1, cacheBehavior0, testAccAWSCloudFrontDistributionRetainConfig())
@@ -182,6 +187,7 @@ func TestAccAWSCloudFrontDistribution_cacheBehaviorPrecedence(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
+	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -206,6 +212,7 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
+	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -224,6 +231,7 @@ func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
 }
 
 func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) {
+	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -242,6 +250,7 @@ func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) 
 }
 
 func TestResourceAWSCloudFrontDistribution_validateHTTP(t *testing.T) {
+	t.Parallel()
 	var value string
 	var errors []error
 

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -66,6 +66,49 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     max_ttl                = 86400
   }
 
+  # cache behavior with precedence 0
+  cache_behavior {
+    path_pattern = "/content/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myS3Origin"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+
+  # cache behavior with precedence 1
+  cache_behavior {
+    path_pattern = "/resources/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myS3Origin"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
   price_class = "PriceClass_200"
 
   restrictions {
@@ -92,7 +135,8 @@ of several sub-resources - these resources are laid out below.
     this distribution.
 
   * `cache_behavior` (Optional) - A [cache behavior](#cache-behavior-arguments)
-    resource for this distribution (multiples allowed).
+    resource for this distribution (multiples allowed). List from top to bottom
+    in order of precedence. The topmost cache behavior will have precedence 0.
 
   * `comment` (Optional) - Any comments you want to include about the
     distribution.


### PR DESCRIPTION
@stack72 Here is a more complete fix for cache behavior precedence, based heavily on what @radeksimko did. Tests pass (I think, though running one more time just to be sure).

Addresses: #7253 
Relates to: #7395 #9167

Precedence is vitally important for most real world uses of cloudfront. For example, if you want to run wordpress through cloudfront, you typically need certain rules for `/<blog-name>/wp-admin*` that come before `/blog-name*`. Otherwise, the wordpress admin tool will not work.

For us, Terraform is pretty much unusable for cloudfront without precedence.

Therefore, would really like to get this merged in! Thanks!
