### PR TITLE
Remove deprecated key_file and bastion_key_file

### DIFF
--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -32,7 +32,7 @@ const (
 )
 
 // connectionInfo is decoded from the ConnInfo of the resource. These are the
-// only keys we look at. If a KeyFile is given, that is used instead
+// only keys we look at. If a PrivateKey is given, that is used instead
 // of a password.
 type connectionInfo struct {
 	User       string
@@ -50,10 +50,6 @@ type connectionInfo struct {
 	BastionPrivateKey string `mapstructure:"bastion_private_key"`
 	BastionHost       string `mapstructure:"bastion_host"`
 	BastionPort       int    `mapstructure:"bastion_port"`
-
-	// Deprecated
-	KeyFile        string `mapstructure:"key_file"`
-	BastionKeyFile string `mapstructure:"bastion_key_file"`
 }
 
 // parseConnectionInfo is used to convert the ConnInfo of the InstanceState into
@@ -99,15 +95,6 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		connInfo.TimeoutVal = safeDuration(connInfo.Timeout, DefaultTimeout)
 	} else {
 		connInfo.TimeoutVal = DefaultTimeout
-	}
-
-	// Load deprecated fields; we can handle either path or contents in
-	// underlying implementation.
-	if connInfo.PrivateKey == "" && connInfo.KeyFile != "" {
-		connInfo.PrivateKey = connInfo.KeyFile
-	}
-	if connInfo.BastionPrivateKey == "" && connInfo.BastionKeyFile != "" {
-		connInfo.BastionPrivateKey = connInfo.BastionKeyFile
 	}
 
 	// Default all bastion config attrs to their non-bastion counterparts

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -127,27 +127,3 @@ func TestProvisioner_connInfoHostname(t *testing.T) {
 		t.Fatalf("bad %v", conf)
 	}
 }
-
-func TestProvisioner_connInfoLegacy(t *testing.T) {
-	r := &terraform.InstanceState{
-		Ephemeral: terraform.EphemeralState{
-			ConnInfo: map[string]string{
-				"type":         "ssh",
-				"key_file":     "/my/key/file.pem",
-				"bastion_host": "127.0.1.1",
-			},
-		},
-	}
-
-	conf, err := parseConnectionInfo(r)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if conf.PrivateKey != "/my/key/file.pem" {
-		t.Fatalf("bad: %v", conf)
-	}
-	if conf.BastionPrivateKey != "/my/key/file.pem" {
-		t.Fatalf("bad: %v", conf)
-	}
-}

--- a/website/source/docs/provisioners/connection.html.markdown
+++ b/website/source/docs/provisioners/connection.html.markdown
@@ -108,18 +108,3 @@ The `ssh` connection also supports the following fields to facilitate connnectio
   host. These can be loaded from a file on disk using the [`file()`
   interpolation function](/docs/configuration/interpolation.html#file_path_).
   Defaults to the value of the `private_key` field.
-
-## Deprecations
-
-These fields are supported for backwards compatibility and may be removed in a
-future version:
-
-* `key_file` - A path to or the contents of an SSH key to use for the
-  connection. These can be loaded from a file on disk using the [`file()`
-  interpolation function](/docs/configuration/interpolation.html#file_path_).
-  This takes preference over the password, if provided.
-
-* `bastion_key_file` - The contents of an SSH key file to use for the bastion
-  host. These can be loaded from a file on disk using the [`file()`
-  interpolation function](/docs/configuration/interpolation.html#file_path_).
-  Defaults to the value of the `key_file` field.


### PR DESCRIPTION
These were deprecated in the 0.6.x series. Their functionality was broken
in a recent release which should have removed them as well.