### PR TITLE
provider/aws: Poll to confirm delete of resource_aws_customer_gateway

### DIFF
--- a/builtin/providers/aws/resource_aws_customer_gateway.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway.go
@@ -200,5 +200,40 @@ func resourceAwsCustomerGatewayDelete(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
+	gatewayFilter := &ec2.Filter{
+		Name:   aws.String("customer-gateway-id"),
+		Values: []*string{aws.String(d.Id())},
+	}
+
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err := conn.DescribeCustomerGateways(&ec2.DescribeCustomerGatewaysInput{
+			Filters: []*ec2.Filter{gatewayFilter},
+		})
+
+		if err != nil {
+			if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "InvalidCustomerGatewayID.NotFound" {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		if len(resp.CustomerGateways) != 1 {
+			return resource.RetryableError(fmt.Errorf("[ERROR] Error finding CustomerGateway for delete: %s", d.Id()))
+		}
+
+		switch *resp.CustomerGateways[0].State {
+		case "pending", "available", "deleting":
+			return resource.RetryableError(fmt.Errorf("[DEBUG] Gateway (%s) in state (%s), retrying", d.Id(), *resp.CustomerGateways[0].State))
+		case "deleted":
+			return nil
+		default:
+			return resource.RetryableError(fmt.Errorf("[DEBUG] Unrecognized state (%s) for Customer Gateway delete on (%s)", *resp.CustomerGateways[0].State, d.Id()))
+		}
+	})
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
poll for delete of customer gateway, should help `TestAccAWSVpnConnectionRoute_basic` pass regularly 