### PR TITLE
Filter nil Deposed values during State init

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1403,9 +1403,18 @@ func (s *ResourceState) init() {
 		s.Deposed = make([]*InstanceState, 0)
 	}
 
-	for _, dep := range s.Deposed {
-		dep.init()
+	// clean out any possible nil values read in from the state file
+	end := len(s.Deposed) - 1
+	for i := 0; i <= end; i++ {
+		if s.Deposed[i] == nil {
+			s.Deposed[i], s.Deposed[end] = s.Deposed[end], s.Deposed[i]
+			end--
+			i--
+		} else {
+			s.Deposed[i].init()
+		}
 	}
+	s.Deposed = s.Deposed[:end+1]
 }
 
 func (s *ResourceState) deepcopy() *ResourceState {

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -254,30 +254,64 @@ func TestStateModuleOrphans_deepNestedNilConfig(t *testing.T) {
 
 func TestStateDeepCopy(t *testing.T) {
 	cases := []struct {
-		One, Two *State
-		F        func(*State) interface{}
+		State *State
 	}{
 		// Version
 		{
 			&State{Version: 5},
-			&State{Version: 5},
-			func(s *State) interface{} { return s.Version },
 		},
-
 		// TFVersion
 		{
 			&State{TFVersion: "5"},
-			&State{TFVersion: "5"},
-			func(s *State) interface{} { return s.TFVersion },
+		},
+		// Modules
+		{
+			&State{
+				Version: 6,
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: rootModulePath,
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Primary: &InstanceState{
+									Meta: map[string]string{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// Deposed
+		{
+			&State{
+				Version: 6,
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: rootModulePath,
+						Resources: map[string]*ResourceState{
+							"test_instance.foo": &ResourceState{
+								Primary: &InstanceState{
+									Meta: map[string]string{},
+								},
+								Deposed: []*InstanceState{
+									{ID: "test"},
+									nil,
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("copy-%d", i), func(t *testing.T) {
-			actual := tc.F(tc.One.DeepCopy())
-			expected := tc.F(tc.Two)
+			actual := tc.State.DeepCopy()
+			expected := tc.State
 			if !reflect.DeepEqual(actual, expected) {
-				t.Fatalf("Bad: %d\n\n%s\n\n%s", i, actual, expected)
+				t.Fatalf("Expected: %#v\nRecevied: %#v\n", expected, actual)
 			}
 		})
 	}

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -283,6 +283,8 @@ func TestStateDeepCopy(t *testing.T) {
 			},
 		},
 		// Deposed
+		// The nil values shouldn't be there if the State was properly init'ed,
+		// but the Copy should still work anyway.
 		{
 			&State{
 				Version: 6,

--- a/vendor/github.com/mitchellh/copystructure/copystructure.go
+++ b/vendor/github.com/mitchellh/copystructure/copystructure.go
@@ -177,8 +177,8 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 	case reflectwalk.SliceElem:
 		// Pop off the value and the index and set it on the slice
 		v := w.valPop()
+		i := w.valPop().Interface().(int)
 		if v.IsValid() {
-			i := w.valPop().Interface().(int)
 			s := w.cs[len(w.cs)-1]
 			se := s.Index(i)
 			if se.CanSet() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1474,10 +1474,10 @@
 			"revision": "8631ce90f28644f54aeedcb3e389a85174e067d1"
 		},
 		{
-			"checksumSHA1": "BsIMq23KDyxdhQC7g2dDz/9oHbA=",
+			"checksumSHA1": "guxbLo8KHHBeM0rzou4OTzzpDNs=",
 			"path": "github.com/mitchellh/copystructure",
-			"revision": "c4815f984fb5c5486f6db1c9a5660e7605fd4c20",
-			"revisionTime": "2016-10-03T18:23:19Z"
+			"revision": "5af94aef99f597e6a9e1f6ac6be6ce0f3c96b49d",
+			"revisionTime": "2016-10-13T19:53:42Z"
 		},
 		{
 			"path": "github.com/mitchellh/go-homedir",


### PR DESCRIPTION
The Deposed slice wasn't being normalized and nil values could be read
in from a state file. Filter out the nils during init. There is
still a bug in copystructure, but that will be addressed separately.

Fixes #9337 