### PR TITLE
Allow empty route_table_ids list in aws_vpc_endpoint resources

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_endpoint.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint.go
@@ -59,9 +59,15 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 func resourceAwsVPCEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	input := &ec2.CreateVpcEndpointInput{
-		VpcId:         aws.String(d.Get("vpc_id").(string)),
-		RouteTableIds: expandStringList(d.Get("route_table_ids").(*schema.Set).List()),
-		ServiceName:   aws.String(d.Get("service_name").(string)),
+		VpcId:       aws.String(d.Get("vpc_id").(string)),
+		ServiceName: aws.String(d.Get("service_name").(string)),
+	}
+
+	if v, ok := d.GetOk("route_table_ids"); ok {
+		list := v.(*schema.Set).List()
+		if len(list) > 0 {
+			input.RouteTableIds = expandStringList(list)
+		}
 	}
 
 	if v, ok := d.GetOk("policy"); ok {

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
@@ -139,6 +139,26 @@ func testAccCheckVpcEndpointPrefixListAvailable(n string) resource.TestCheckFunc
 	}
 }
 
+func TestAccAWSVpcEndpointWithoutRouteTableOrPolicyConfig(t *testing.T) {
+	var endpoint ec2.VpcEndpoint
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_vpc_endpoint.second-private-s3",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVpcEndpointDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcEndpointWithoutRouteTableOrPolicyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointExists("aws_vpc_endpoint.second-private-s3", &endpoint),
+					testAccCheckVpcEndpointPrefixListAvailable("aws_vpc_endpoint.second-private-s3"),
+				),
+			},
+		},
+	})
+}
+
 const testAccVpcEndpointWithRouteTableAndPolicyConfig = `
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
@@ -225,5 +245,16 @@ resource "aws_route_table" "default" {
 resource "aws_route_table_association" "main" {
     subnet_id = "${aws_subnet.foo.id}"
     route_table_id = "${aws_route_table.default.id}"
+}
+`
+
+const testAccVpcEndpointWithoutRouteTableOrPolicyConfig = `
+resource "aws_vpc" "foo" {
+    cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc_endpoint" "second-private-s3" {
+    vpc_id = "${aws_vpc.foo.id}"
+    service_name = "com.amazonaws.us-west-2.s3"
 }
 `


### PR DESCRIPTION
Without this change, TF submits a request with empty RouteTableIDs and AWS responds `400 bad request`.
With this change, I can create a VPC Endpoint without a route table.

I am almost completely ignorant of Go, so let me know if there's a better to solve this.