### PR TITLE
provider/consul: Fixes for consul_service resource

### DIFF
--- a/builtin/providers/consul/resource_consul_service_test.go
+++ b/builtin/providers/consul/resource_consul_service_test.go
@@ -21,6 +21,7 @@ func TestAccConsulService_basic(t *testing.T) {
 					testAccCheckConsulServiceExists(),
 					testAccCheckConsulServiceValue("consul_service.app", "address", "www.google.com"),
 					testAccCheckConsulServiceValue("consul_service.app", "id", "google"),
+					testAccCheckConsulServiceValue("consul_service.app", "service_id", "google"),
 					testAccCheckConsulServiceValue("consul_service.app", "name", "google"),
 					testAccCheckConsulServiceValue("consul_service.app", "port", "80"),
 					testAccCheckConsulServiceValue("consul_service.app", "tags.#", "2"),
@@ -83,6 +84,7 @@ func testAccCheckConsulServiceValue(n, attr, val string) resource.TestCheckFunc 
 const testAccConsulServiceConfig = `
 resource "consul_service" "app" {
 	address = "www.google.com"
+	service_id = "google"
 	name = "google"
 	port = 80
 	tags = ["tag0", "tag1"]

--- a/website/source/docs/providers/consul/r/service.html.markdown
+++ b/website/source/docs/providers/consul/r/service.html.markdown
@@ -25,14 +25,16 @@ resource "consul_service" "google" {
 
 The following arguments are supported:
 
-* `address` - (Optional) The address of the service. Defaults to the
+* `service_id` - (Optional, string) The id of the service, defaults to the value of `name` if not supplied.
+
+* `address` - (Optional, string) The address of the service. Defaults to the
   address of the agent.
 
-* `name` - (Required) The name of the service.
+* `name` - (Required, string) The name of the service.
 
-* `port` - (Optional) The port of the service.
+* `port` - (Optional, int) The port of the service.
 
-* `tags` - (Optional) A list of values that are opaque to Consul,
+* `tags` - (Optional, set of strings) A list of values that are opaque to Consul,
   but can be used to distinguish between services or nodes.
   
 
@@ -40,8 +42,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `service_id` - The id of the service, defaults to the value of `name`.
 * `address` - The address of the service.
-* `id` - The id of the service, defaults to the value of `name`.
 * `name` - The name of the service.
 * `port` - The port of the service.
 * `tags` - The tags of the service.


### PR DESCRIPTION
Added `service_id` in place of `id` for resource.
modified created, read, update to use `service_id`
modified tests to include `service_id`.
modified documentation for consul_service to include new value.

Tests results

CONSUL_HTTP_ADDR=localhost:8500 make testacc TEST=./builtin/providers/consul/

==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/14 14:43:05 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/consul/ -v  -timeout 120m
=== RUN   TestAccDataConsulKeys_basic
--- PASS: TestAccDataConsulKeys_basic (0.05s)
=== RUN   TestAccConsulAgentService_basic
--- PASS: TestAccConsulAgentService_basic (0.05s)
=== RUN   TestAccConsulCatalogEntry_basic
--- PASS: TestAccConsulCatalogEntry_basic (0.06s)
=== RUN   TestAccConsulKeyPrefix_basic
--- PASS: TestAccConsulKeyPrefix_basic (0.19s)
=== RUN   TestConsulKeysMigrateState
--- PASS: TestConsulKeysMigrateState (0.00s)
=== RUN   TestConsulKeysMigrateState_empty
--- PASS: TestConsulKeysMigrateState_empty (0.00s)
=== RUN   TestAccConsulKeys_basic
--- PASS: TestAccConsulKeys_basic (0.13s)
=== RUN   TestAccConsulNode_basic
--- PASS: TestAccConsulNode_basic (0.05s)
=== RUN   TestAccConsulPreparedQuery_basic
--- PASS: TestAccConsulPreparedQuery_basic (0.12s)
=== RUN   TestAccConsulService_basic
--- PASS: TestAccConsulService_basic (0.05s)
=== RUN   TestResourceProvider
--- PASS: TestResourceProvider (0.00s)
=== RUN   TestResourceProvider_impl
--- PASS: TestResourceProvider_impl (0.00s)
=== RUN   TestResourceProvider_Configure
--- PASS: TestResourceProvider_Configure (0.00s)
=== RUN   TestResourceProvider_ConfigureTLS
--- PASS: TestResourceProvider_ConfigureTLS (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/consul	0.708s

Refs: #9351