### PR TITLE
provider/docker: Fixes for docker_container host object and documentation

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -229,13 +229,13 @@ func resourceDockerContainer() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"ip": &schema.Schema{
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ForceNew: true,
 						},
 
 						"host": &schema.Schema{
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ForceNew: true,
 						},
 					},

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
   kept running. If false, then as long as the container exists, Terraform
   assumes it is successful.
 * `ports` - (Optional, block) See [Ports](#ports) below for details.
-* `host_entry` - (Optional, block) See [Extra Hosts](#extra_hosts) below for
+* `host` - (Optional, block) See [Extra Hosts](#extra_hosts) below for
   details.
 * `privileged` - (Optional, bool) Run container in privileged mode.
 * `publish_all_ports` - (Optional, bool) Publish all ports of the container.
@@ -97,12 +97,12 @@ the following:
 <a id="extra_hosts"></a>
 ### Extra Hosts
 
-`host_entry` is a block within the configuration that can be repeated to specify
-the extra host mappings for the container. Each `host_entry` block supports
+`host` is a block within the configuration that can be repeated to specify
+the extra host mappings for the container. Each `host` block supports
 the following:
 
-* `host` - (Required, int) Hostname to add.
-* `ip` - (Required, int) IP address this hostname should resolve to..
+* `host` - (Required, string) Hostname to add.
+* `ip` - (Required, string) IP address this hostname should resolve to..
 
 This is equivalent to using the `--add-host` option when using the `run`
 command of the Docker CLI.

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -102,7 +102,7 @@ the extra host mappings for the container. Each `host` block supports
 the following:
 
 * `host` - (Required, string) Hostname to add.
-* `ip` - (Required, string) IP address this hostname should resolve to..
+* `ip` - (Required, string) IP address this hostname should resolve to.
 
 This is equivalent to using the `--add-host` option when using the `run`
 command of the Docker CLI.


### PR DESCRIPTION
Fixes for docker_container host object

Feedback from ticket #9350 updated codebase so it reflects the requirements from docker in regards to `host` which is `Required` and not `optional`.

* renamed `hosts_entry` to `host`
* added correct type information to *Extra Hosts* section.
* updated docker_container.host schema change `optional` to `required`

It now accurately reflects the docker requirements and the terraform documentation.

Test results

> Bear in mind the failure it is because my laptop doesnt support memory swap. So this test will always fail.

Changing the Schema from `optional` to `required` made no difference to the tests.

make testacc TEST=./builtin/providers/docker/
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/14 15:04:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/docker/ -v  -timeout 120m
=== RUN   TestAccDockerRegistryImage_basic
--- PASS: TestAccDockerRegistryImage_basic (4.57s)
=== RUN   TestAccDockerRegistryImage_private
--- PASS: TestAccDockerRegistryImage_private (6.22s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDockerContainer_basic
--- PASS: TestAccDockerContainer_basic (7.16s)
=== RUN   TestAccDockerContainer_volume
--- PASS: TestAccDockerContainer_volume (7.37s)
=== RUN   TestAccDockerContainer_customized
--- FAIL: TestAccDockerContainer_customized (18.99s)
	testing.go:265: Step 0 error: Check failed: Check 2/2 error: Container has wrong memory swap setting: -1
	Please check that you machine supports memory swap (you can do that by running 'docker info' command).
=== RUN   TestAccDockerImage_basic
--- PASS: TestAccDockerImage_basic (2.58s)
=== RUN   TestAccDockerImage_private
--- PASS: TestAccDockerImage_private (2.70s)
=== RUN   TestAccDockerImage_destroy
--- PASS: TestAccDockerImage_destroy (30.00s)
=== RUN   TestAccDockerImage_data
--- PASS: TestAccDockerImage_data (5.93s)
=== RUN   TestAccDockerNetwork_basic
--- PASS: TestAccDockerNetwork_basic (0.24s)
=== RUN   TestAccDockerVolume_basic
--- PASS: TestAccDockerVolume_basic (0.05s)
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/docker	85.816s
Makefile:47: recipe for target 'testacc' failed
make: *** [testacc] Error 1

Refs: 9350