### PR TITLE
provider/google: Ensure we don't assert on nil

### DIFF
--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -21,38 +21,38 @@ func resourceComputeTargetPool() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"backup_pool": &schema.Schema{
+			"backup_pool": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"failover_ratio": &schema.Schema{
+			"failover_ratio": {
 				Type:     schema.TypeFloat,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"health_checks": &schema.Schema{
+			"health_checks": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"instances": &schema.Schema{
+			"instances": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
@@ -60,26 +60,26 @@ func resourceComputeTargetPool() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"project": &schema.Schema{
+			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
 
-			"region": &schema.Schema{
+			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
 
-			"self_link": &schema.Schema{
+			"self_link": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"session_affinity": &schema.Schema{
+			"session_affinity": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -91,7 +91,7 @@ func resourceComputeTargetPool() *schema.Resource {
 func convertStringArr(ifaceArr []interface{}) []string {
 	arr := make([]string, len(ifaceArr))
 	for i, v := range ifaceArr {
-		arr[i] = v.(string)
+		arr[i], _ = v.(string)
 	}
 	return arr
 }


### PR DESCRIPTION
This commit tests whether an interface is nil before type asserting it to string - this should fix the panic reported in #8609 and #9359.

We also clean up the schema definition to the newer style without redundant type declarations.

Fixes #8609, fixes #9359.