### PR TITLE
AWS data source docs missing `data.`

### DIFF
--- a/website/source/docs/providers/aws/d/subnet.html.markdown
+++ b/website/source/docs/providers/aws/d/subnet.html.markdown
@@ -28,10 +28,10 @@ data "aws_subnet" "selected" {
 }
 
 resource "aws_security_group" "subnet" {
-  vpc_id = "${aws_subnet.selected.vpc_id}"
+  vpc_id = "${data.aws_subnet.selected.vpc_id}"
 
   ingress {
-    cidr_blocks = ["${aws_subnet.selected.cidr_block}"]
+    cidr_blocks = ["${data.aws_subnet.selected.cidr_block}"]
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"

--- a/website/source/docs/providers/aws/d/vpc.html.markdown
+++ b/website/source/docs/providers/aws/d/vpc.html.markdown
@@ -28,9 +28,9 @@ data "aws_vpc" "selected" {
 }
 
 resource "aws_subnet" "example" {
-  vpc_id            = "${aws_vpc.selected.id}"
+  vpc_id            = "${data.aws_vpc.selected.id}"
   availability_zone = "us-west-2a"
-  cidr_block        = "${cidrsubnet(aws_vpc.selected.cidr_block, 4, 1)}"
+  cidr_block        = "${cidrsubnet(data.aws_vpc.selected.cidr_block, 4, 1)}"
 }
 ```
 


### PR DESCRIPTION
Several variables were missing the `data.` prefix in the new subnet and
VPC data source documentation.