### PR TITLE
Update Travis to Go 1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.7
+- 1.7.1
 install:
 # This script is used by the Travis build to install a cookie for
 # go.googlesource.com so rate limits are higher when using `go get` to fetch


### PR DESCRIPTION
This updates Travis to use Go 1.7.1 (similar to the Vagrantfile that was updated earlier today).