### PR TITLE
provider/scaleway: fix headline in docs

### DIFF
--- a/website/source/docs/providers/scaleway/r/ip.html.markdown
+++ b/website/source/docs/providers/scaleway/r/ip.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway IPs.
 ---
 
-# scaleway\ip
+# scaleway\_ip
 
 Provides IPs for ARM servers. This allows IPs to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#ips).

--- a/website/source/docs/providers/scaleway/r/security_group.html.markdown
+++ b/website/source/docs/providers/scaleway/r/security_group.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway security groups.
 ---
 
-# scaleway\security_group
+# scaleway\_security\_group
 
 Provides security groups. This allows security groups to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#security-groups).

--- a/website/source/docs/providers/scaleway/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/scaleway/r/security_group_rule.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway security group rules.
 ---
 
-# scaleway\security_group_rule
+# scaleway\_security\_group\_rule
 
 Provides security group rules. This allows security group rules to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#security-groups-manage-rules).

--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway servers.
 ---
 
-# scaleway\server
+# scaleway\_server
 
 Provides ARM servers. This allows servers to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#servers).

--- a/website/source/docs/providers/scaleway/r/volume.html.markdown
+++ b/website/source/docs/providers/scaleway/r/volume.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway Volumes.
 ---
 
-# scaleway\volume
+# scaleway\_volume
 
 Provides ARM volumes. This allows volumes to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#volumes).

--- a/website/source/docs/providers/scaleway/r/volume_attachment.html.markdown
+++ b/website/source/docs/providers/scaleway/r/volume_attachment.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway Volume attachments for servers.
 ---
 
-# scaleway\volume\_attachment
+# scaleway\_volume\_attachment
 
 This allows volumes to be attached to servers.
 


### PR DESCRIPTION
this PR adjusts the broken headlines for nearly all Scaleway resources