### PR TITLE
provider/scaleway: add support for importing resources

### DIFF
--- a/builtin/providers/scaleway/import_scaleway_ip_test.go
+++ b/builtin/providers/scaleway/import_scaleway_ip_test.go
@@ -1,0 +1,28 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewayIP_importBasic(t *testing.T) {
+	resourceName := "scaleway_ip.base"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayIPConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/scaleway/import_scaleway_security_group_test.go
+++ b/builtin/providers/scaleway/import_scaleway_security_group_test.go
@@ -1,0 +1,28 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewaySecurityGroup_importBasic(t *testing.T) {
+	resourceName := "scaleway_security_group.base"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewaySecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewaySecurityGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/scaleway/import_scaleway_server_test.go
+++ b/builtin/providers/scaleway/import_scaleway_server_test.go
@@ -1,0 +1,28 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewayServer_importBasic(t *testing.T) {
+	resourceName := "scaleway_server.base"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayServerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayServerConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/scaleway/import_scaleway_volume_test.go
+++ b/builtin/providers/scaleway/import_scaleway_volume_test.go
@@ -1,0 +1,28 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewayVolume_importBasic(t *testing.T) {
+	resourceName := "scaleway_volume.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayVolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayVolumeConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/scaleway/resource_scaleway_ip.go
+++ b/builtin/providers/scaleway/resource_scaleway_ip.go
@@ -13,6 +13,10 @@ func resourceScalewayIP() *schema.Resource {
 		Read:   resourceScalewayIPRead,
 		Update: resourceScalewayIPUpdate,
 		Delete: resourceScalewayIPDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"server": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/scaleway/resource_scaleway_security_group.go
+++ b/builtin/providers/scaleway/resource_scaleway_security_group.go
@@ -14,6 +14,10 @@ func resourceScalewaySecurityGroup() *schema.Resource {
 		Read:   resourceScalewaySecurityGroupRead,
 		Update: resourceScalewaySecurityGroupUpdate,
 		Delete: resourceScalewaySecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/scaleway/resource_scaleway_server.go
+++ b/builtin/providers/scaleway/resource_scaleway_server.go
@@ -14,6 +14,10 @@ func resourceScalewayServer() *schema.Resource {
 		Read:   resourceScalewayServerRead,
 		Update: resourceScalewayServerUpdate,
 		Delete: resourceScalewayServerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -138,6 +142,10 @@ func resourceScalewayServerRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	d.Set("name", server.Name)
+	d.Set("image", server.Image.Identifier)
+	d.Set("type", server.CommercialType)
+	d.Set("enable_ipv6", server.EnableIPV6)
 	d.Set("private_ip", server.PrivateIP)
 	d.Set("public_ip", server.PublicAddress.IP)
 

--- a/builtin/providers/scaleway/resource_scaleway_volume.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume.go
@@ -16,6 +16,10 @@ func resourceScalewayVolume() *schema.Resource {
 		Read:   resourceScalewayVolumeRead,
 		Update: resourceScalewayVolumeUpdate,
 		Delete: resourceScalewayVolumeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/website/source/docs/providers/scaleway/r/ip.html.markdown
+++ b/website/source/docs/providers/scaleway/r/ip.html.markdown
@@ -32,3 +32,11 @@ The following attributes are exported:
 
 * `id` - id of the new resource
 * `ip` - IP of the new resource
+
+## Import
+
+Instances can be imported using the `id`, e.g.
+
+```
+$ terraform import scaleway_ip.jump_host 5faef9cd-ea9b-4a63-9171-9e26bec03dbc
+```

--- a/website/source/docs/providers/scaleway/r/security_group.html.markdown
+++ b/website/source/docs/providers/scaleway/r/security_group.html.markdown
@@ -34,3 +34,11 @@ Field `name`, `description` are editable.
 The following attributes are exported:
 
 * `id` - id of the new resource
+
+## Import
+
+Instances can be imported using the `id`, e.g.
+
+```
+$ terraform import scaleway_security_group.test 5faef9cd-ea9b-4a63-9171-9e26bec03dbc
+```

--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -43,3 +43,11 @@ The following attributes are exported:
 * `id` - id of the new resource
 * `private_ip` - private ip of the new resource
 * `public_ip` - public ip of the new resource
+
+## Import
+
+Instances can be imported using the `id`, e.g.
+
+```
+$ terraform import scaleway_server.web 5faef9cd-ea9b-4a63-9171-9e26bec03dbc
+```

--- a/website/source/docs/providers/scaleway/r/volume.html.markdown
+++ b/website/source/docs/providers/scaleway/r/volume.html.markdown
@@ -42,3 +42,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - id of the new resource
+
+## Import
+
+Instances can be imported using the `id`, e.g.
+
+```
+$ terraform import scaleway_volume.test 5faef9cd-ea9b-4a63-9171-9e26bec03dbc
+```


### PR DESCRIPTION
this PR adds support for importing `scaleway_server`, `scaleway_volume`, `scaleway_ip` and `scaleway_security_group`.

I've added importer tests as well, and updated the docs to indicate how to use the importers.