### PR TITLE
Added "arn" attribute to AWS Lambda alias

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_alias.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias.go
@@ -33,6 +33,10 @@ func resourceAwsLambdaAlias() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -84,6 +88,7 @@ func resourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("description", aliasConfiguration.Description)
 	d.Set("function_version", aliasConfiguration.FunctionVersion)
 	d.Set("name", aliasConfiguration.Name)
+	d.Set("arn", aliasConfiguration.AliasArn)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_lambda_alias_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -23,6 +24,7 @@ func TestAccAWSLambdaAlias_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaAliasExists("aws_lambda_alias.lambda_alias_test", &conf),
 					testAccCheckAwsLambdaAttributes(&conf),
+					resource.TestMatchResourceAttr("aws_lambda_alias.lambda_alias_test", "arn", regexp.MustCompile(`^arn:aws:lambda:[a-z]+-[a-z]+-[0-9]+:\d{12}:function:example_lambda_name_create:testalias$`)),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/lambda_alias.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_alias.html.markdown
@@ -31,5 +31,9 @@ resource "aws_lambda_alias" "test_alias" {
 * `function_name` - (Required) The function ARN of the Lambda function for which you want to create an alias.
 * `function_version` - (Required) Lambda function version for which you are creating the alias. Pattern: `(\$LATEST|[0-9]+)`.
 
+## Attributes Reference
+
+* `arn` - The Amazon Resource Name (ARN) identifying your Lambda function alias.
+
 [1]: http://docs.aws.amazon.com/lambda/latest/dg/welcome.html
 [2]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html


### PR DESCRIPTION
### What has changed?

Per title.

### Why it's needed?

Without the `arn` attribute, you have to combine `function_name` and `name` to specify `arn`, which is very troublesome.
For instance, 
```hcl
resource "aws_cloudwatch_event_target" "my_event_target" {
  rule = "my-event-rule"
  target_id = "tf-my-event-target"
  arn = "${aws_lambda_alias.my_alias.arn}:${aws_lambda_alias.my_alias.name}"
}
```
