### PR TITLE
Read back aws_launch_configuration's associate_public_ip_address field, to enable importing.

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -545,6 +545,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	d.Set("spot_price", lc.SpotPrice)
 	d.Set("enable_monitoring", lc.InstanceMonitoring.Enabled)
 	d.Set("security_groups", lc.SecurityGroups)
+	d.Set("associate_public_ip_address", lc.AssociatePublicIpAddress)
 
 	d.Set("vpc_classic_link_id", lc.ClassicLinkVPCId)
 	d.Set("vpc_classic_link_security_groups", lc.ClassicLinkVPCSecurityGroups)


### PR DESCRIPTION
I imported a aws_launch_configuration:

```
$ terraform  import -state=tfstate -var-file=tfvars module.infra.aws_launch_configuration.minions kubernetes_dev-minion-group-us-east-1a-c3.4xlarge
```

and wrote the respective config for it:

```
resource "aws_launch_configuration" "minions" {
    name = "${var.cluster_name}-minion-group-${var.availability_zone}-${var.minion_instance_type}"
    image_id = "${var.ami_id}"
    instance_type = "${var.minion_instance_type}"

    associate_public_ip_address = true

    ephemeral_block_device {
        virtual_name = "ephemeral0"
        device_name = "/dev/sdc"
    }

    ephemeral_block_device {
        virtual_name = "ephemeral1"
        device_name = "/dev/sdd"
    }

    ephemeral_block_device {
        virtual_name = "ephemeral2"
        device_name = "/dev/sde"
    }

    ephemeral_block_device {
        virtual_name = "ephemeral3"
        device_name = "/dev/sdf"
    }

    iam_instance_profile = "${aws_iam_instance_profile.minions.name}"

    key_name = "..."
}
```

But I would still see a diff when doing a `terraform plan`:

```
$ terraform plan -var-file=tfvars -state=tfstate -target=module.infra
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

module.infra.aws_iam_role.minion: Refreshing state... (ID: kubernetes-minion)
module.infra.aws_iam_role.master: Refreshing state... (ID: kubernetes-master)
module.infra.aws_vpc_dhcp_options.main: Refreshing state... (ID: dopt-6468c300)
module.infra.aws_vpc.main: Refreshing state... (ID: vpc-a2a12fc5)
module.infra.aws_iam_instance_profile.minions: Refreshing state... (ID: kubernetes-minion)
module.infra.aws_iam_role_policy.minion: Refreshing state... (ID: kubernetes-minion:kubernetes-minion)
module.infra.aws_iam_role_policy.master: Refreshing state... (ID: kubernetes-master:kubernetes-master)
module.infra.aws_launch_configuration.minions: Refreshing state... (ID: kubernetes_dev-minion-group-us-east-1a-c3.4xlarge)
module.infra.aws_subnet.main: Refreshing state... (ID: subnet-d11a34fb)
module.infra.aws_security_group.masters: Refreshing state... (ID: sg-ec734797)
module.infra.aws_internet_gateway.gw: Refreshing state... (ID: igw-3ad5f85e)
module.infra.aws_security_group.minions: Refreshing state... (ID: sg-de7347a5)
module.infra.aws_network_acl.main: Refreshing state... (ID: acl-f8ef9d9f)
module.infra.aws_security_group_rule.masters-allow-https: Refreshing state... (ID: sgrule-2373692995)
module.infra.aws_security_group_rule.masters-allow-ssh: Refreshing state... (ID: sgrule-1130086772)
module.infra.aws_security_group_rule.masters-disallow-ingress: Refreshing state... (ID: sgrule-2300295140)
module.infra.aws_security_group_rule.masters-disallow-egress: Refreshing state... (ID: sgrule-3689494767)
module.infra.aws_autoscaling_group.minions: Refreshing state... (ID: kubernetes_dev-minion-group-us-east-1a)
module.infra.aws_security_group_rule.minions-disallow-ingress: Refreshing state... (ID: sgrule-1658975523)
module.infra.aws_security_group_rule.minions-disallow-egress: Refreshing state... (ID: sgrule-2533620319)
module.infra.aws_security_group_rule.minions-allow-ssh: Refreshing state... (ID: sgrule-3841135837)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

-/+ module.infra.aws_launch_configuration.minions
    associate_public_ip_address:                    "" => "true" (forces new resource)
    ebs_block_device.#:                             "0" => "<computed>"
    ebs_optimized:                                  "false" => "<computed>"
    enable_monitoring:                              "true" => "true"
    ephemeral_block_device.#:                       "4" => "4"
    ephemeral_block_device.1458338698.device_name:  "/dev/sde" => "/dev/sde"
    ephemeral_block_device.1458338698.virtual_name: "ephemeral2" => "ephemeral2"
    ephemeral_block_device.2690118092.device_name:  "/dev/sdd" => "/dev/sdd"
    ephemeral_block_device.2690118092.virtual_name: "ephemeral1" => "ephemeral1"
    ephemeral_block_device.3292514005.device_name:  "/dev/sdc" => "/dev/sdc"
    ephemeral_block_device.3292514005.virtual_name: "ephemeral0" => "ephemeral0"
    ephemeral_block_device.4064093701.device_name:  "/dev/sdf" => "/dev/sdf"
    ephemeral_block_device.4064093701.virtual_name: "ephemeral3" => "ephemeral3"
    iam_instance_profile:                           "kubernetes-minion" => "kubernetes-minion"
    image_id:                                       "ami-08ee2f65" => "ami-08ee2f65"
    instance_type:                                  "c3.4xlarge" => "c3.4xlarge"
    key_name:                                       "..." => "..."
    name:                                           "kubernetes_dev-minion-group-us-east-1a-c3.4xlarge" => "kubernetes_dev-minion-group-us-east-1a-c3.4xlarge"
    root_block_device.#:                            "1" => "<computed>"


Plan: 1 to add, 1 to destroy.
```

This PR fixes that.