### PR TITLE
provider/azurerm Fix multiple loadbalancer resource IDs

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -100,7 +100,18 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
-	d.SetId(*read.ID)
+	var pool_id string
+	for _, element := range *(*read.Properties).BackendAddressPools {
+		if *element.Name == d.Get("name").(string) {
+			pool_id = *element.ID
+		}
+	}
+
+	if pool_id != "" {
+		d.SetId(pool_id)
+	} else {
+		return fmt.Errorf("Error can not find created loadbalacner backend address pool id %s", pool_id)
+	}
 
 	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
 	stateConf := &resource.StateChangeConf{
@@ -117,7 +128,7 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 }
 
 func resourceArmLoadBalancerBackendAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -101,9 +101,9 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 	}
 
 	var pool_id string
-	for _, element := range *(*read.Properties).BackendAddressPools {
-		if *element.Name == d.Get("name").(string) {
-			pool_id = *element.ID
+	for _, BackendAddressPool := range *(*read.Properties).BackendAddressPools {
+		if *BackendAddressPool.Name == d.Get("name").(string) {
+			pool_id = *BackendAddressPool.ID
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -15,6 +16,12 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
 
+	testAccPreCheck(t)
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	backendAddressPool_id := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/backendAddressPools/%s",
+		subscriptionID, ri, ri, addressPoolName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -25,6 +32,8 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerBackEndAddressPoolExists(addressPoolName, &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb_backend_address_pool.test", "id", backendAddressPool_id),
 				),
 			},
 		},

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
@@ -16,7 +16,6 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
 
-	testAccPreCheck(t)
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	backendAddressPool_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/backendAddressPools/%s",

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -123,9 +123,9 @@ func resourceArmLoadBalancerNatPoolCreate(d *schema.ResourceData, meta interface
 	}
 
 	var natPool_id string
-	for _, element := range *(*read.Properties).InboundNatPools {
-		if *element.Name == d.Get("name").(string) {
-			natPool_id = *element.ID
+	for _, InboundNatPool := range *(*read.Properties).InboundNatPools {
+		if *InboundNatPool.Name == d.Get("name").(string) {
+			natPool_id = *InboundNatPool.ID
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -122,7 +122,18 @@ func resourceArmLoadBalancerNatPoolCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
-	d.SetId(*read.ID)
+	var natPool_id string
+	for _, element := range *(*read.Properties).InboundNatPools {
+		if *element.Name == d.Get("name").(string) {
+			natPool_id = *element.ID
+		}
+	}
+
+	if natPool_id != "" {
+		d.SetId(natPool_id)
+	} else {
+		return fmt.Errorf("Error can not find created loadbalancer nat pool id %s", natPool_id)
+	}
 
 	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
 	stateConf := &resource.StateChangeConf{
@@ -139,7 +150,7 @@ func resourceArmLoadBalancerNatPoolCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmLoadBalancerNatPoolRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -15,6 +16,12 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	natPoolName := fmt.Sprintf("NatPool-%d", ri)
 
+	testAccPreCheck(t)
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	natPool_id := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/inboundNatPools/%s",
+		subscriptionID, ri, ri, natPoolName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -25,6 +32,8 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb_nat_pool.test", "id", natPool_id),
 				),
 			},
 		},

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -16,7 +16,6 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	natPoolName := fmt.Sprintf("NatPool-%d", ri)
 
-	testAccPreCheck(t)
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	natPool_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/inboundNatPools/%s",

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -122,7 +122,18 @@ func resourceArmLoadBalancerNatRuleCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
-	d.SetId(*read.ID)
+	var natRule_id string
+	for _, element := range *(*read.Properties).InboundNatRules {
+		if *element.Name == d.Get("name").(string) {
+			natRule_id = *element.ID
+		}
+	}
+
+	if natRule_id != "" {
+		d.SetId(natRule_id)
+	} else {
+		return fmt.Errorf("Error can not find created loadbalancer nat rule id %s", natRule_id)
+	}
 
 	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
 	stateConf := &resource.StateChangeConf{
@@ -139,7 +150,7 @@ func resourceArmLoadBalancerNatRuleCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmLoadBalancerNatRuleRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -123,9 +123,9 @@ func resourceArmLoadBalancerNatRuleCreate(d *schema.ResourceData, meta interface
 	}
 
 	var natRule_id string
-	for _, element := range *(*read.Properties).InboundNatRules {
-		if *element.Name == d.Get("name").(string) {
-			natRule_id = *element.ID
+	for _, InboundNatRule := range *(*read.Properties).InboundNatRules {
+		if *InboundNatRule.Name == d.Get("name").(string) {
+			natRule_id = *InboundNatRule.ID
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -15,6 +16,12 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	natRuleName := fmt.Sprintf("NatRule-%d", ri)
 
+	testAccPreCheck(t)
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	natRule_id := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/inboundNatRules/%s",
+		subscriptionID, ri, ri, natRuleName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -25,6 +32,8 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb_nat_rule.test", "id", natRule_id),
 				),
 			},
 		},

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -16,7 +16,6 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	natRuleName := fmt.Sprintf("NatRule-%d", ri)
 
-	testAccPreCheck(t)
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	natRule_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/inboundNatRules/%s",

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -156,7 +156,7 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmLoadBalancerProbeRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -128,7 +128,18 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
-	d.SetId(*read.ID)
+	var createdProbe_id string
+	for _, element := range *(*read.Properties).Probes {
+		if *element.Name == d.Get("name").(string) {
+			createdProbe_id = *element.ID
+		}
+	}
+
+	if createdProbe_id != "" {
+		d.SetId(createdProbe_id)
+	} else {
+		return fmt.Errorf("Error can not find created probe id %s", createdProbe_id)
+	}
 
 	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
 	stateConf := &resource.StateChangeConf{

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -129,9 +129,9 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	var createdProbe_id string
-	for _, element := range *(*read.Properties).Probes {
-		if *element.Name == d.Get("name").(string) {
-			createdProbe_id = *element.ID
+	for _, Probe := range *(*read.Properties).Probes {
+		if *Probe.Name == d.Get("name").(string) {
+			createdProbe_id = *Probe.ID
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -15,6 +16,12 @@ func TestAccAzureRMLoadBalancerProbe_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	probeName := fmt.Sprintf("probe-%d", ri)
 
+	testAccPreCheck(t)
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	probe_id := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/probes/%s",
+		subscriptionID, ri, ri, probeName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -25,6 +32,8 @@ func TestAccAzureRMLoadBalancerProbe_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb_probe.test", "id", probe_id),
 				),
 			},
 		},

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -16,7 +16,6 @@ func TestAccAzureRMLoadBalancerProbe_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	probeName := fmt.Sprintf("probe-%d", ri)
 
-	testAccPreCheck(t)
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	probe_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/probes/%s",

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -149,7 +149,18 @@ func resourceArmLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", loadBalancerName, resGroup)
 	}
 
-	d.SetId(*read.ID)
+	var rule_id string
+	for _, element := range *(*read.Properties).LoadBalancingRules {
+		if *element.Name == d.Get("name").(string) {
+			rule_id = *element.ID
+		}
+	}
+
+	if rule_id != "" {
+		d.SetId(rule_id)
+	} else {
+		return fmt.Errorf("Error can not find created loadbalancer rule id %s", rule_id)
+	}
 
 	log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", loadBalancerName)
 	stateConf := &resource.StateChangeConf{
@@ -166,7 +177,7 @@ func resourceArmLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) error {
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
+	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -150,9 +150,9 @@ func resourceArmLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	var rule_id string
-	for _, element := range *(*read.Properties).LoadBalancingRules {
-		if *element.Name == d.Get("name").(string) {
-			rule_id = *element.ID
+	for _, LoadBalancingRule := range *(*read.Properties).LoadBalancingRules {
+		if *LoadBalancingRule.Name == d.Get("name").(string) {
+			rule_id = *LoadBalancingRule.ID
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -63,6 +64,12 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
+	testAccPreCheck(t)
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	lbRule_id := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
+		subscriptionID, ri, ri, lbRuleName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -73,6 +80,8 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb_rule.test", "id", lbRule_id),
 				),
 			},
 		},

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -64,7 +64,6 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
-	testAccPreCheck(t)
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	lbRule_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",


### PR DESCRIPTION
Fixes GH-9311 and usage of ID property for azurerm loadbalancers including:

azurerm_lb_probe
azurerm_lb_backend_address_pool
azurerm_lb_rule
azurerm_lb_nat_rule
azurerm_lb_nat_pool
