### PR TITLE
provider/azurerm: add account_kind and access_tier to storage_account

### DIFF
--- a/website/source/docs/providers/azurerm/r/storage_account.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_account.html.markdown
@@ -45,11 +45,19 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the
     resource exists. Changing this forces a new resource to be created.
 
+* `account_kind` - (Optional) Defines the Kind of account. Valid options are `Storage`
+    and `BlobStorage`. Changing this forces a new resource to be created. Defaults
+    to `Storage`. 
+
 * `account_type` - (Required) Defines the type of storage account to be
     created. Valid options are `Standard_LRS`, `Standard_ZRS`, `Standard_GRS`,
     `Standard_RAGRS`, `Premium_LRS`. Changing this is sometimes valid - see the Azure
     documentation for more information on which types of accounts can be converted
     into other types.
+
+* `access_tier` - (Required for `BlobStorage` accounts) Defines the access tier
+    for `BlobStorage` accounts. Valid options are `Hot` and `Cold`, defaults to
+    `Hot`.
 
 * `enable_bool_encryption` - (Optional) Boolean flag which controls if Encryption
     Services are enabled for Blob storage, see [here](https://azure.microsoft.com/en-us/documentation/articles/storage-service-encryption/)


### PR DESCRIPTION
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMStorageAccount -timeout 120m
=== RUN   TestAccAzureRMStorageAccount_importBasic
--- PASS: TestAccAzureRMStorageAccount_importBasic (140.06s)
=== RUN   TestAccAzureRMStorageAccount_basic
--- PASS: TestAccAzureRMStorageAccount_basic (155.43s)
=== RUN   TestAccAzureRMStorageAccount_disappears
--- PASS: TestAccAzureRMStorageAccount_disappears (134.99s)
=== RUN   TestAccAzureRMStorageAccount_blobEncryption
--- PASS: TestAccAzureRMStorageAccount_blobEncryption (161.59s)
=== RUN   TestAccAzureRMStorageAccount_blobStorageWithUpdate
--- PASS: TestAccAzureRMStorageAccount_blobStorageWithUpdate (131.49s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	723.694s
```