### PR TITLE
adds import instructions for Bitbucket repos

### DIFF
--- a/website/source/docs/providers/bitbucket/r/repository.html.markdown
+++ b/website/source/docs/providers/bitbucket/r/repository.html.markdown
@@ -46,3 +46,11 @@ The following arguments are supported:
 
 The following arguments are computed. You can access both `clone_ssh` and
 `clone_https` for getting a clone URL.
+
+## Import
+
+Repositories can be imported using the `name`, e.g. 
+
+```
+$ terraform import bitbucket_repository.my-repo my-repo
+```


### PR DESCRIPTION
Hi there!

Started playing with the Bitbucket provider (great job @cwood!) and wanted to import a few dozen repositories. The documentation currently does not list it, but importing repositories is possible, using the following (for a repository identified as `my-repo`:

```
$ terraform import bitbucket_repository.my-repo my-repo
```

Hope this helps!