### PR TITLE
Infer aws_instance.associate_public_ip_address from the presence of a network interface association.

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -498,6 +498,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			if *ni.Attachment.DeviceIndex == 0 {
 				d.Set("subnet_id", ni.SubnetId)
 				d.Set("network_interface_id", ni.NetworkInterfaceId)
+				d.Set("associate_public_ip_address", ni.Association != nil)
 			}
 		}
 	} else {


### PR DESCRIPTION
Fixes #8187

Tested:
```
$ ./bin/terraform import aws_instance.main i-c5c902f5
...

$ grep  associate_public_ip_address terraform.tfstate 
                            "associate_public_ip_address": "true",

$ ./bin/terraform import aws_instance.main i-4500ca75 
...

$ grep  associate_public_ip_address terraform.tfstate 
                            "associate_public_ip_address": "false",
```