### PR TITLE
provider/azurerm: lock mutex in load_balancer resources

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -65,7 +65,11 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -172,7 +176,11 @@ func resourceArmLoadBalancerBackendAddressPoolDelete(d *schema.ResourceData, met
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -82,7 +82,11 @@ func resourceArmLoadBalancerNatPoolCreate(d *schema.ResourceData, meta interface
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -185,7 +189,11 @@ func resourceArmLoadBalancerNatPoolDelete(d *schema.ResourceData, meta interface
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -82,7 +82,11 @@ func resourceArmLoadBalancerNatRuleCreate(d *schema.ResourceData, meta interface
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -188,7 +192,11 @@ func resourceArmLoadBalancerNatRuleDelete(d *schema.ResourceData, meta interface
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -88,7 +88,11 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -188,7 +192,11 @@ func resourceArmLoadBalancerProbeDelete(d *schema.ResourceData, meta interface{}
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -109,7 +109,11 @@ func resourceArmLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{})
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
@@ -229,7 +233,11 @@ func resourceArmLoadBalancerRuleDelete(d *schema.ResourceData, meta interface{})
 	client := meta.(*ArmClient)
 	lbClient := client.loadBalancerClient
 
-	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
+	loadBalancerID := d.Get("loadbalancer_id").(string)
+	armMutexKV.Lock(loadBalancerID)
+	defer armMutexKV.Unlock(loadBalancerID)
+
+	loadBalancer, exists, err := retrieveLoadBalancerById(loadBalancerID, meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -115,6 +115,32 @@ func TestAccAzureRMLoadBalancerRule_removal(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform/issues/9424
+func TestAccAzureRMLoadBalancerRule_inconsistentReads(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	backendPoolName := fmt.Sprintf("LbPool-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	probeName := fmt.Sprintf("LbProbe-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerRule_inconsistentRead(ri, backendPoolName, probeName, lbRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerBackEndAddressPoolExists(backendPoolName, &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMLoadBalancerRuleExists(lbRuleName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, _, exists := findLoadBalancerRuleByName(lb, lbRuleName)
@@ -201,4 +227,59 @@ resource "azurerm_lb" "test" {
     }
 }
 `, rInt, rInt, rInt, rInt)
+}
+
+// https://github.com/hashicorp/terraform/issues/9424
+func testAccAzureRMLoadBalancerRule_inconsistentRead(rInt int, backendPoolName, probeName, lbRuleName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_backend_address_pool" "teset" {
+  name                = "%s"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+}
+
+resource "azurerm_lb_probe" "test" {
+  name                = "%s"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  protocol            = "Tcp"
+  port                = 443
+}
+
+resource "azurerm_lb_rule" "test" {
+  name = "%s"
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  protocol = "Tcp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+`, rInt, rInt, rInt, rInt, backendPoolName, probeName, lbRuleName, rInt)
 }


### PR DESCRIPTION
This fixes races between sub resources causing inconsistent writes of the load
balancer resource

Fixes #9424

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMLoadBalancer -timeout 120m
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_basic
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_basic (150.95s)
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_removal
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_removal (146.25s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_basic
--- PASS: TestAccAzureRMLoadBalancerNatPool_basic (157.43s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_removal
--- PASS: TestAccAzureRMLoadBalancerNatPool_removal (169.46s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_basic
--- PASS: TestAccAzureRMLoadBalancerNatRule_basic (149.04s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_removal
--- PASS: TestAccAzureRMLoadBalancerNatRule_removal (170.35s)
=== RUN   TestAccAzureRMLoadBalancerProbe_basic
--- PASS: TestAccAzureRMLoadBalancerProbe_basic (146.88s)
=== RUN   TestAccAzureRMLoadBalancerProbe_removal
--- PASS: TestAccAzureRMLoadBalancerProbe_removal (166.25s)
=== RUN   TestAccAzureRMLoadBalancerRule_basic
--- PASS: TestAccAzureRMLoadBalancerRule_basic (146.36s)
=== RUN   TestAccAzureRMLoadBalancerRule_removal
--- PASS: TestAccAzureRMLoadBalancerRule_removal (164.24s)
=== RUN   TestAccAzureRMLoadBalancerRule_inconsistentReads
--- PASS: TestAccAzureRMLoadBalancerRule_inconsistentReads (153.19s)
=== RUN   TestAccAzureRMLoadBalancer_basic
--- PASS: TestAccAzureRMLoadBalancer_basic (102.59s)
=== RUN   TestAccAzureRMLoadBalancer_frontEndConfig
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfig (187.92s)
=== RUN   TestAccAzureRMLoadBalancer_tags
--- PASS: TestAccAzureRMLoadBalancer_tags (119.93s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	2130.930s
```