### PR TITLE
provider/aws: Support S3 bucket object upload with AES256 server-side encryption

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
@@ -267,6 +267,24 @@ func TestAccAWSS3BucketObject_kms(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketObject_sse_aes256(t *testing.T) {
+	rInt := acctest.RandInt()
+	var obj s3.GetObjectOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				PreConfig: func() {},
+				Config:    testAccAWSS3BucketObjectConfig_withEncrypt(rInt),
+				Check:     testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3BucketObject_acl(t *testing.T) {
 	rInt := acctest.RandInt()
 	var obj s3.GetObjectOutput
@@ -557,6 +575,21 @@ resource "aws_s3_bucket_object" "object" {
 	key = "test-key"
 	content = "stuff"
 	kms_key_id = "${aws_kms_key.kms_key_1.arn}"
+}
+`, randInt)
+}
+
+func testAccAWSS3BucketObjectConfig_withEncrypt(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket_4" {
+	bucket = "tf-object-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "object" {
+	bucket = "${aws_s3_bucket.object_bucket_4.bucket}"
+	key = "test-key"
+	content = "stuff"
+	encrypt = true
 }
 `, randInt)
 }

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -44,6 +44,22 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 }
 ```
 
+### Encrypting with AES256
+
+```
+resource "aws_s3_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_object" "examplebucket_object" {
+  key        = "someobject"
+  bucket     = "${aws_s3_bucket.examplebucket.bucket}"
+  source     = "index.html"
+  encrypt    = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -63,9 +79,11 @@ for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", or "`STANDAR
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`.
 This attribute is not compatible with `kms_key_id`
 * `kms_key_id` - (Optional) Specifies the AWS KMS Key ID to use for object encryption.
+Implicitly enables `encrypt`.
 This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
-use the exported `arn` attribute:  
+use the exported `arn` attribute:
       `kms_key_id = "${aws_kms_key.foo.arn}"`
+* `encrypt` - (Optional) Specifies whether or not the object is encrypted. If the value is `true` and no `kms_key_id` is specified then AES256 is used.
 
 Either `source` or `content` must be provided to specify the bucket content.
 These two arguments are mutually-exclusive.


### PR DESCRIPTION
- Add optional aws_s3_bucket_object boolean `encrypt` attribute to allow AES256 server-side encryption modeled after the [S3 Remote State Backend](https://www.terraform.io/docs/state/remote/s3.html)
- If `encrypt = true` and no AWS KMS Key ID is specified then a server-side encryption value of **AES256** is used
- Setting a value for `kms_key_id` implicitly sets `encrypt = true`
- Update documentation
- Add new acceptance test:

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3BucketObject_sse_aes256' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/19 17:48:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3BucketObject_sse_aes256 -timeout 120m
=== RUN   TestAccAWSS3BucketObject_sse_aes256
--- PASS: TestAccAWSS3BucketObject_sse_aes256 (21.35s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    21.362s
```
- Verify no regression:

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3BucketObject_kms' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/19 17:47:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3BucketObject_kms -timeout 120m
=== RUN   TestAccAWSS3BucketObject_kms
--- PASS: TestAccAWSS3BucketObject_kms (42.98s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    42.991s
```
