### PR TITLE
Azure RM loadbalancer rules have correct naming restrictions

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -324,9 +324,9 @@ func expandAzureRmLoadBalancerRule(d *schema.ResourceData, lb *network.LoadBalan
 
 func validateArmLoadBalancerRuleName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z._-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[a-zA-Z_0-9.-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only word characters and hyphens allowed in %q: %q",
+			"only word characters, numbers, underscores, periods, and hyphens allowed in %q: %q",
 			k, value))
 	}
 
@@ -339,14 +339,14 @@ func validateArmLoadBalancerRuleName(v interface{}, k string) (ws []string, erro
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be an empty string: %q", k, value))
 	}
-	if !regexp.MustCompile(`[a-zA-Z]$`).MatchString(value) {
+	if !regexp.MustCompile(`[a-zA-Z0-9_]$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must end with a word character: %q", k, value))
+			"%q must end with a word character, number, or underscore: %q", k, value))
 	}
 
-	if !regexp.MustCompile(`^[a-zA-Z]`).MatchString(value) {
+	if !regexp.MustCompile(`^[a-zA-Z0-9]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must start with a word character: %q", k, value))
+			"%q must start with a word character or number: %q", k, value))
 	}
 
 	return

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -25,7 +25,7 @@ func TestResourceAzureRMLoadBalancerRuleNameLabel_validation(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    "test123test",
+			Value:    "test#test",
 			ErrCount: 1,
 		},
 		{
@@ -42,6 +42,14 @@ func TestResourceAzureRMLoadBalancerRuleNameLabel_validation(t *testing.T) {
 		},
 		{
 			Value:    "test-rule",
+			ErrCount: 0,
+		},
+		{
+			Value:    "TestRule",
+			ErrCount: 0,
+		},
+		{
+			Value:    "Test123Rule",
 			ErrCount: 0,
 		},
 		{


### PR DESCRIPTION
The current rule name validator does not match Azure's actual requirements. This PR fixes the validator to use the following requirements:

- The name cannot be empty
- The name cannot be more than 80 characters
- The name must begin with a letter or number
- The name must end with a letter, number, or underscore
- The name must only contain letters, numbers, underscores, periods, or hyphens