### PR TITLE
travis: Update to Go 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.7.1
+- 1.7.3
 install:
 # This script is used by the Travis build to install a cookie for
 # go.googlesource.com so rate limits are higher when using `go get` to fetch


### PR DESCRIPTION
Update Travis builds to run with Go 1.7.3