### PR TITLE
Fix Scaleway documentation typo/error

### DIFF
--- a/website/source/docs/providers/scaleway/r/volume.html.markdown
+++ b/website/source/docs/providers/scaleway/r/volume.html.markdown
@@ -14,7 +14,7 @@ For additional details please refer to [API documentation](https://developer.sca
 ## Example Usage
 
 ```
-resource "scaleway_volume" "test" {
+resource "scaleway_server" "test" {
   name = "test"
   image = "aecaed73-51a5-4439-a127-6d8229847145"
   type = "C2S"


### PR DESCRIPTION
This is definitely scaleway_server instead of scaleway_volume, wouldn't make any sense otherwise.