### PR TITLE
Allow import of aws_security_groups with more than one source_security_group_id rule

### DIFF
--- a/builtin/providers/aws/import_aws_security_group.go
+++ b/builtin/providers/aws/import_aws_security_group.go
@@ -25,7 +25,6 @@ func resourceAwsSecurityGroupImportState(
 		return nil, fmt.Errorf("security group not found")
 	}
 	sg := sgRaw.(*ec2.SecurityGroup)
-	sgId := d.Id()
 
 	// Start building our results
 	results := make([]*schema.ResourceData, 1,
@@ -33,60 +32,101 @@ func resourceAwsSecurityGroupImportState(
 	results[0] = d
 
 	// Construct the rules
-	ruleResource := resourceAwsSecurityGroupRule()
 	permMap := map[string][]*ec2.IpPermission{
 		"ingress": sg.IpPermissions,
 		"egress":  sg.IpPermissionsEgress,
 	}
 	for ruleType, perms := range permMap {
 		for _, perm := range perms {
-			// Construct the rule. We do this by populating the absolute
-			// minimum necessary for Refresh on the rule to work. This
-			// happens to be a lot of fields since they're almost all needed
-			// for de-dupping.
-			id := ipPermissionIDHash(sgId, ruleType, perm)
-			d := ruleResource.Data(nil)
-			d.SetId(id)
-			d.SetType("aws_security_group_rule")
-			d.Set("security_group_id", sgId)
-			d.Set("type", ruleType)
-
-			// 'self' is false by default. Below, we range over the group ids and set true
-			// if the parent sg id is found
-			d.Set("self", false)
-
-			if len(perm.UserIdGroupPairs) > 0 {
-				s := perm.UserIdGroupPairs[0]
-
-				// Check for Pair that is the same as the Security Group, to denote self.
-				// Otherwise, mark the group id in source_security_group_id
-				isVPC := sg.VpcId != nil && *sg.VpcId != ""
-				if isVPC {
-					if *s.GroupId == *sg.GroupId {
-						d.Set("self", true)
-						// prune the self reference from the UserIdGroupPairs, so we don't
-						// have duplicate sg ids (both self and in source_security_group_id)
-						perm.UserIdGroupPairs = append(perm.UserIdGroupPairs[:0], perm.UserIdGroupPairs[0+1:]...)
-					}
-				} else {
-					if *s.GroupName == *sg.GroupName {
-						d.Set("self", true)
-						// prune the self reference from the UserIdGroupPairs, so we don't
-						// have duplicate sg ids (both self and in source_security_group_id)
-						perm.UserIdGroupPairs = append(perm.UserIdGroupPairs[:0], perm.UserIdGroupPairs[0+1:]...)
-					}
-				}
+			ds, err := resourceAwsSecurityGroupImportStatePerm(sg, ruleType, perm)
+			if err != nil {
+				return nil, err
 			}
-
-			// XXX If the rule contained more than one source security group, this
-			// will choose one of them. We actually need to create one rule for each
-			// source security group.
-			if err := setFromIPPerm(d, sg, perm); err != nil {
-				return nil, errwrap.Wrapf("Error importing AWS Security Group: {{err}}", err)
-			}
-			results = append(results, d)
+			results = append(results, ds...)
 		}
 	}
 
 	return results, nil
+}
+
+func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) ([]*schema.ResourceData, error) {
+	var result []*schema.ResourceData
+
+	if len(perm.UserIdGroupPairs) == 0 {
+		r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, perm)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	} else {
+		// If the rule contained more than one source security group, this
+		// will iterate over them and create one rule for each
+		// source security group.
+		for _, pair := range perm.UserIdGroupPairs {
+			p := &ec2.IpPermission{
+				FromPort:      perm.FromPort,
+				IpProtocol:    perm.IpProtocol,
+				IpRanges:      perm.IpRanges,
+				PrefixListIds: perm.PrefixListIds,
+				ToPort:        perm.ToPort,
+
+				UserIdGroupPairs: []*ec2.UserIdGroupPair{pair},
+			}
+
+			r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, r)
+		}
+	}
+	return result, nil
+}
+
+func resourceAwsSecurityGroupImportStatePermPair(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) (*schema.ResourceData, error) {
+	// Construct the rule. We do this by populating the absolute
+	// minimum necessary for Refresh on the rule to work. This
+	// happens to be a lot of fields since they're almost all needed
+	// for de-dupping.
+	sgId := sg.GroupId
+	id := ipPermissionIDHash(*sgId, ruleType, perm)
+	ruleResource := resourceAwsSecurityGroupRule()
+	d := ruleResource.Data(nil)
+	d.SetId(id)
+	d.SetType("aws_security_group_rule")
+	d.Set("security_group_id", sgId)
+	d.Set("type", ruleType)
+
+	// 'self' is false by default. Below, we range over the group ids and set true
+	// if the parent sg id is found
+	d.Set("self", false)
+
+	if len(perm.UserIdGroupPairs) > 0 {
+		s := perm.UserIdGroupPairs[0]
+
+		// Check for Pair that is the same as the Security Group, to denote self.
+		// Otherwise, mark the group id in source_security_group_id
+		isVPC := sg.VpcId != nil && *sg.VpcId != ""
+		if isVPC {
+			if *s.GroupId == *sg.GroupId {
+				d.Set("self", true)
+				// prune the self reference from the UserIdGroupPairs, so we don't
+				// have duplicate sg ids (both self and in source_security_group_id)
+				perm.UserIdGroupPairs = append(perm.UserIdGroupPairs[:0], perm.UserIdGroupPairs[0+1:]...)
+			}
+		} else {
+			if *s.GroupName == *sg.GroupName {
+				d.Set("self", true)
+				// prune the self reference from the UserIdGroupPairs, so we don't
+				// have duplicate sg ids (both self and in source_security_group_id)
+				perm.UserIdGroupPairs = append(perm.UserIdGroupPairs[:0], perm.UserIdGroupPairs[0+1:]...)
+			}
+		}
+	}
+
+	if err := setFromIPPerm(d, sg, perm); err != nil {
+		return nil, errwrap.Wrapf("Error importing AWS Security Group: {{err}}", err)
+	}
+
+	return d, nil
 }

--- a/builtin/providers/aws/import_aws_security_group_test.go
+++ b/builtin/providers/aws/import_aws_security_group_test.go
@@ -54,3 +54,22 @@ func TestAccAWSSecurityGroup_importSelf(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAWSSecurityGroup_importSourceSecurityGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSecurityGroupConfig_importSourceSecurityGroup,
+			},
+
+			resource.TestStep{
+				ResourceName:      "aws_security_group.test_group_1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -1813,6 +1813,51 @@ resource "aws_security_group_rule" "allow_all-1" {
 }
 `
 
+const testAccAWSSecurityGroupConfig_importSourceSecurityGroup = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "tf_sg_import_test"
+  }
+}
+
+resource "aws_security_group" "test_group_1" {
+  name        = "test group 1"
+  vpc_id      = "${aws_vpc.foo.id}"
+}
+
+resource "aws_security_group" "test_group_2" {
+  name        = "test group 2"
+  vpc_id      = "${aws_vpc.foo.id}"
+}
+
+resource "aws_security_group" "test_group_3" {
+  name        = "test group 3"
+  vpc_id      = "${aws_vpc.foo.id}"
+}
+
+resource "aws_security_group_rule" "allow_test_group_2" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "tcp"
+
+  source_security_group_id = "${aws_security_group.test_group_1.id}"
+  security_group_id = "${aws_security_group.test_group_2.id}"
+}
+
+resource "aws_security_group_rule" "allow_test_group_3" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "tcp"
+
+  source_security_group_id = "${aws_security_group.test_group_1.id}"
+  security_group_id = "${aws_security_group.test_group_3.id}"
+}
+`
+
 const testAccAWSSecurityGroupConfigPrefixListEgress = `
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
     cidr_block = "10.0.0.0/16"


### PR DESCRIPTION
Fixes #9459 

Example:

```
$ aws ec2 describe-security-groups --group-id sg-83bcaaf9
{
    "SecurityGroups": [
        {
            "IpPermissionsEgress": [
                {
                    "IpProtocol": "-1", 
                    "IpRanges": [
                        {
                            "CidrIp": "0.0.0.0/0"
                        }
                    ], 
                    "UserIdGroupPairs": [], 
                    "PrefixListIds": []
                }
            ], 
            "Description": "Kubernetes security group applied to master nodes", 
            "Tags": [
                {
                    "Value": "kubernetes_tom", 
                    "Key": "KubernetesCluster"
                }
            ], 
            "IpPermissions": [
                {
                    "IpProtocol": "-1", 
                    "IpRanges": [], 
                    "UserIdGroupPairs": [
                        {
                            "UserId": "376248598259", 
                            "GroupId": "sg-80bcaafa"
                        }, 
                        {
                            "UserId": "376248598259", 
                            "GroupId": "sg-83bcaaf9"
                        }
                    ], 
                    "PrefixListIds": []
                }, 
                {
                    "PrefixListIds": [], 
                    "FromPort": 22, 
                    "IpRanges": [
                        {
                            "CidrIp": "0.0.0.0/0"
                        }
                    ], 
                    "ToPort": 22, 
                    "IpProtocol": "tcp", 
                    "UserIdGroupPairs": []
                }, 
                {
                    "PrefixListIds": [], 
                    "FromPort": 443, 
                    "IpRanges": [
                        {
                            "CidrIp": "0.0.0.0/0"
                        }
                    ], 
                    "ToPort": 443, 
                    "IpProtocol": "tcp", 
                    "UserIdGroupPairs": []
                }
            ], 
            "GroupName": "kubernetes-master-kubernetes_tom", 
            "VpcId": "vpc-dc0e0cbb", 
            "OwnerId": "376248598259", 
            "GroupId": "sg-83bcaaf9"
        }
    ]
}

$ ./bin/terraform import aws_security_group.test sg-83bcaaf9
provider.aws.region
  The region where AWS operations will take place. Examples
  are us-east-1, us-west-2, etc.

  Default: us-east-1
  Enter a value: 

aws_security_group.test: Importing from ID "sg-83bcaaf9"...
aws_security_group.test: Import complete!
  Imported aws_security_group (ID: sg-83bcaaf9)
  Imported aws_security_group_rule (ID: sgrule-1277326544)
  Imported aws_security_group_rule (ID: sgrule-385890077)
  Imported aws_security_group_rule (ID: sgrule-114861958)
  Imported aws_security_group_rule (ID: sgrule-253799570)
  Imported aws_security_group_rule (ID: sgrule-3072042539)
aws_security_group_rule.test-3: Refreshing state... (ID: sgrule-253799570)
aws_security_group_rule.test-4: Refreshing state... (ID: sgrule-3072042539)
aws_security_group_rule.test-2: Refreshing state... (ID: sgrule-114861958)
aws_security_group.test: Refreshing state... (ID: sg-83bcaaf9)
aws_security_group_rule.test-1: Refreshing state... (ID: sgrule-385890077)
aws_security_group_rule.test: Refreshing state... (ID: sgrule-1277326544)

Import success! The resources imported are shown above. These are
now in your Terraform state. Import does not currently generate
configuration, so you must do this next. If you do not create configuration
for the above resources, then the next `terraform plan` will mark
them for destruction.

$ cat terraform.tfstate 
{
    "version": 3,
    "terraform_version": "0.7.8",
    "serial": 0,
    "lineage": "a21423a4-13a2-4a99-8456-701f875f6a12",
    "modules": [
        {
            "path": [
                "root"
            ],
            "outputs": {},
            "resources": {
                "aws_security_group.test": {
                    "type": "aws_security_group",
                    "depends_on": [],
                    "primary": {
                        "id": "sg-83bcaaf9",
                        "attributes": {
                            "description": "Kubernetes security group applied to master nodes",
                            "egress.#": "1",
                            "egress.482069346.cidr_blocks.#": "1",
                            "egress.482069346.cidr_blocks.0": "0.0.0.0/0",
                            "egress.482069346.from_port": "0",
                            "egress.482069346.prefix_list_ids.#": "0",
                            "egress.482069346.protocol": "-1",
                            "egress.482069346.security_groups.#": "0",
                            "egress.482069346.self": "false",
                            "egress.482069346.to_port": "0",
                            "id": "sg-83bcaaf9",
                            "ingress.#": "3",
                            "ingress.2211002184.cidr_blocks.#": "0",
                            "ingress.2211002184.from_port": "0",
                            "ingress.2211002184.protocol": "-1",
                            "ingress.2211002184.security_groups.#": "1",
                            "ingress.2211002184.security_groups.3938065707": "sg-80bcaafa",
                            "ingress.2211002184.self": "true",
                            "ingress.2211002184.to_port": "0",
                            "ingress.2541437006.cidr_blocks.#": "1",
                            "ingress.2541437006.cidr_blocks.0": "0.0.0.0/0",
                            "ingress.2541437006.from_port": "22",
                            "ingress.2541437006.protocol": "tcp",
                            "ingress.2541437006.security_groups.#": "0",
                            "ingress.2541437006.self": "false",
                            "ingress.2541437006.to_port": "22",
                            "ingress.2617001939.cidr_blocks.#": "1",
                            "ingress.2617001939.cidr_blocks.0": "0.0.0.0/0",
                            "ingress.2617001939.from_port": "443",
                            "ingress.2617001939.protocol": "tcp",
                            "ingress.2617001939.security_groups.#": "0",
                            "ingress.2617001939.self": "false",
                            "ingress.2617001939.to_port": "443",
                            "name": "kubernetes-master-kubernetes_tom",
                            "owner_id": "376248598259",
                            "tags.%": "1",
                            "tags.KubernetesCluster": "kubernetes_tom",
                            "vpc_id": "vpc-dc0e0cbb"
                        },
                        "meta": {},
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "aws"
                },
                "aws_security_group_rule.test": {
                    "type": "aws_security_group_rule",
                    "depends_on": [],
                    "primary": {
                        "id": "sgrule-1277326544",
                        "attributes": {
                            "cidr_blocks.#": "0",
                            "from_port": "0",
                            "id": "sgrule-1277326544",
                            "prefix_list_ids.#": "0",
                            "protocol": "-1",
                            "security_group_id": "sg-83bcaaf9",
                            "self": "false",
                            "source_security_group_id": "sg-80bcaafa",
                            "to_port": "0",
                            "type": "ingress"
                        },
                        "meta": {
                            "schema_version": "2"
                        },
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "aws"
                },
                "aws_security_group_rule.test-1": {
                    "type": "aws_security_group_rule",
                    "depends_on": [],
                    "primary": {
                        "id": "sgrule-385890077",
                        "attributes": {
                            "cidr_blocks.#": "0",
                            "from_port": "0",
                            "id": "sgrule-385890077",
                            "prefix_list_ids.#": "0",
                            "protocol": "-1",
                            "security_group_id": "sg-83bcaaf9",
                            "self": "true",
                            "source_security_group_id": "sg-83bcaaf9",
                            "to_port": "0",
                            "type": "ingress"
                        },
                        "meta": {
                            "schema_version": "2"
                        },
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "aws"
                },
                "aws_security_group_rule.test-2": {
                    "type": "aws_security_group_rule",
                    "depends_on": [],
                    "primary": {
                        "id": "sgrule-114861958",
                        "attributes": {
                            "cidr_blocks.#": "1",
                            "cidr_blocks.0": "0.0.0.0/0",
                            "from_port": "22",
                            "id": "sgrule-114861958",
                            "prefix_list_ids.#": "0",
                            "protocol": "tcp",
                            "security_group_id": "sg-83bcaaf9",
                            "self": "false",
                            "to_port": "22",
                            "type": "ingress"
                        },
                        "meta": {
                            "schema_version": "2"
                        },
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "aws"
                },
                "aws_security_group_rule.test-3": {
                    "type": "aws_security_group_rule",
                    "depends_on": [],
                    "primary": {
                        "id": "sgrule-253799570",
                        "attributes": {
                            "cidr_blocks.#": "1",
                            "cidr_blocks.0": "0.0.0.0/0",
                            "from_port": "443",
                            "id": "sgrule-253799570",
                            "prefix_list_ids.#": "0",
                            "protocol": "tcp",
                            "security_group_id": "sg-83bcaaf9",
                            "self": "false",
                            "to_port": "443",
                            "type": "ingress"
                        },
                        "meta": {
                            "schema_version": "2"
                        },
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "aws"
                },
                "aws_security_group_rule.test-4": {
                    "type": "aws_security_group_rule",
                    "depends_on": [],
                    "primary": {
                        "id": "sgrule-3072042539",
                        "attributes": {
                            "cidr_blocks.#": "1",
                            "cidr_blocks.0": "0.0.0.0/0",
                            "from_port": "0",
                            "id": "sgrule-3072042539",
                            "prefix_list_ids.#": "0",
                            "protocol": "-1",
                            "security_group_id": "sg-83bcaaf9",
                            "self": "false",
                            "to_port": "0",
                            "type": "egress"
                        },
                        "meta": {
                            "schema_version": "2"
                        },
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "aws"
                }
            },
            "depends_on": []
        }
    ]
}

$ cat test.tf 
resource "aws_security_group" "test" {
    description = "Kubernetes security group applied to master nodes"
    name = "kubernetes-master-kubernetes_tom"
    tags {
        KubernetesCluster = "kubernetes_tom"
    }
    vpc_id = "vpc-dc0e0cbb"
}

resource "aws_security_group_rule" "test" {
    security_group_id = "${aws_security_group.test.id}"
    type = "ingress"

    from_port = 0
    to_port = 0
    protocol = "-1"
    source_security_group_id = "sg-80bcaafa"
}

resource "aws_security_group_rule" "test-1" {
    security_group_id = "${aws_security_group.test.id}"
    type = "ingress"

    from_port = 0
    to_port = 0
    protocol = "-1"
    self = "true"
}

resource "aws_security_group_rule" "test-2" {
    security_group_id = "${aws_security_group.test.id}"
    type = "ingress"

    from_port = 22
    to_port = 22
    protocol = "tcp"
    cidr_blocks = ["0.0.0.0/0"]
}

resource "aws_security_group_rule" "test-3" {
    security_group_id = "${aws_security_group.test.id}"
    type = "ingress"

    from_port = 443
    to_port = 443
    protocol = "tcp"
    cidr_blocks = ["0.0.0.0/0"]
}

resource "aws_security_group_rule" "test-4" {
    security_group_id = "${aws_security_group.test.id}"
    type = "egress"

    from_port = 0
    to_port = 0
    protocol = -1
    cidr_blocks = ["0.0.0.0/0"]
}

$ ./bin/terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

aws_security_group.test: Refreshing state... (ID: sg-83bcaaf9)
aws_security_group_rule.test: Refreshing state... (ID: sgrule-1277326544)
aws_security_group_rule.test-4: Refreshing state... (ID: sgrule-3072042539)
aws_security_group_rule.test-2: Refreshing state... (ID: sgrule-114861958)
aws_security_group_rule.test-1: Refreshing state... (ID: sgrule-385890077)
aws_security_group_rule.test-3: Refreshing state... (ID: sgrule-253799570)

No changes. Infrastructure is up-to-date. This means that Terraform
could not detect any differences between your configuration and
the real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```

See #9459 for previous (broken) walk through.
