### PR TITLE
add missing reference to `iops` property in `aws_ami` data source documentation

### DIFF
--- a/website/source/docs/providers/aws/d/ami.html.markdown
+++ b/website/source/docs/providers/aws/d/ami.html.markdown
@@ -73,7 +73,7 @@ interpolation.
     will be deleted on termination.
   * `block_device_mappings.#.ebs.encrypted` - `true` if the EBS volume
     is encrypted.
-  * `block_device_mappings.#.ebs.encrypted` - `0` if the EBS volume
+  * `block_device_mappings.#.ebs.iops` - `0` if the EBS volume is
     not a provisioned IOPS image, otherwise the supported IOPS count.
   * `block_device_mappings.#.ebs.snapshot_id` - The ID of the snapshot.
   * `block_device_mappings.#.ebs.volume_size` - The size of the volume, in GiB.


### PR DESCRIPTION
In the documentation the reference data within the `aws_ami` datasource was referring to `*.ebs.encrypted` twice, when one instance should have been `*.ebs.iops`. The descriptions for each of these keys is correct.

AFAIK - this affects version 0.7