### PR TITLE
provider/aws Skip importing routes for VPC endpoints

### DIFF
--- a/builtin/providers/aws/import_aws_route_table.go
+++ b/builtin/providers/aws/import_aws_route_table.go
@@ -40,6 +40,12 @@ func resourceAwsRouteTableImportState(
 				continue
 			}
 
+			if route.DestinationPrefixListId != nil {
+				// Skipping because VPC endpoint routes are handled separately
+				// See aws_vpc_endpoint
+				continue
+			}
+
 			// Minimal data for route
 			d := subResource.Data(nil)
 			d.SetType("aws_route")


### PR DESCRIPTION
* Same logic as in `resourceAwsRouteTableRead`
* Fixes #8225 