### PR TITLE
provider/scaleway speedup server deletion

### DIFF
--- a/builtin/providers/scaleway/helpers.go
+++ b/builtin/providers/scaleway/helpers.go
@@ -1,9 +1,11 @@
 package scaleway
 
 import (
+	"fmt"
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/scaleway/scaleway-cli/pkg/api"
 )
 
@@ -15,6 +17,37 @@ func Bool(val bool) *bool {
 // String returns a pointer to of the string value passed in.
 func String(val string) *string {
 	return &val
+}
+
+// deleteRunningServer terminates the server and waits until it is removed.
+func deleteRunningServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) error {
+	err := scaleway.PostServerAction(server.Identifier, "terminate")
+
+	if err != nil {
+		if serr, ok := err.(api.ScalewayAPIError); ok {
+			if serr.StatusCode == 404 {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := scaleway.GetServer(server.Identifier)
+
+		if err == nil {
+			return resource.RetryableError(fmt.Errorf("Waiting for server %q to be deleted", server.Identifier))
+		}
+
+		if serr, ok := err.(api.ScalewayAPIError); ok {
+			if serr.StatusCode == 404 {
+				return nil
+			}
+		}
+
+		return resource.RetryableError(err)
+	})
 }
 
 // deleteStoppedServer needs to cleanup attached root volumes. this is not done


### PR DESCRIPTION
using `terminate` instead of `poweroff` leads to a faster shutdown

fixes #9430 

tests remain green. I've used the opportunity to start switching from indefinite waits to `resource.Retry` so things time out properly after a while. Previously this would not happen.

```
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScaleway -timeout 120m
=== RUN   TestAccScalewayDataSourceBootscript_Basic
--- PASS: TestAccScalewayDataSourceBootscript_Basic (1.43s)
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (1.30s)
=== RUN   TestAccScalewayDataSourceImage_Basic
--- PASS: TestAccScalewayDataSourceImage_Basic (7.55s)
=== RUN   TestAccScalewayDataSourceImage_Filtered
--- PASS: TestAccScalewayDataSourceImage_Filtered (6.82s)
=== RUN   TestAccScalewayIP_importBasic
--- PASS: TestAccScalewayIP_importBasic (1.96s)
=== RUN   TestAccScalewaySecurityGroup_importBasic
--- PASS: TestAccScalewaySecurityGroup_importBasic (2.52s)
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (99.63s)
=== RUN   TestAccScalewayVolume_importBasic
--- PASS: TestAccScalewayVolume_importBasic (4.32s)
=== RUN   TestAccScalewayIP_Basic
--- PASS: TestAccScalewayIP_Basic (8.95s)
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (5.50s)
=== RUN   TestAccScalewaySecurityGroup_Basic
--- PASS: TestAccScalewaySecurityGroup_Basic (3.23s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (87.76s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (184.57s)
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (333.76s)
=== RUN   TestAccScalewayVolume_Basic
--- PASS: TestAccScalewayVolume_Basic (4.61s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/scaleway	753.928s
```