### PR TITLE
provider/scaleway: fix scaleway_volume_attachment with count > 1

### DIFF
--- a/builtin/providers/scaleway/helpers.go
+++ b/builtin/providers/scaleway/helpers.go
@@ -32,7 +32,7 @@ func deleteRunningServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) 
 		return err
 	}
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	return resource.Retry(20*time.Minute, func() *resource.RetryError {
 		_, err := scaleway.GetServer(server.Identifier)
 
 		if err == nil {
@@ -68,7 +68,7 @@ func deleteStoppedServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) 
 // the helpers.go file pulls in quite a lot dependencies, and they're just convenience wrappers anyway
 
 func waitForServerState(scaleway *api.ScalewayAPI, serverID, targetState string) error {
-	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+	return resource.Retry(20*time.Minute, func() *resource.RetryError {
 		s, err := scaleway.GetServer(serverID)
 
 		if err != nil {

--- a/builtin/providers/scaleway/helpers.go
+++ b/builtin/providers/scaleway/helpers.go
@@ -69,7 +69,7 @@ func deleteStoppedServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) 
 // NOTE copied from github.com/scaleway/scaleway-cli/pkg/api/helpers.go
 // the helpers.go file pulls in quite a lot dependencies, and they're just convenience wrappers anyway
 
-func waitForServerState(scaleway *api.ScalewayAPI, serverID string, targetState string) error {
+func waitForServerState(scaleway *api.ScalewayAPI, serverID, targetState string) error {
 	return resource.Retry(10*time.Minute, func() *resource.RetryError {
 		s, err := scaleway.GetServer(serverID)
 

--- a/builtin/providers/scaleway/helpers.go
+++ b/builtin/providers/scaleway/helpers.go
@@ -2,8 +2,6 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/builtin/providers/scaleway/provider.go
+++ b/builtin/providers/scaleway/provider.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -46,6 +47,8 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: providerConfigure,
 	}
 }
+
+var scalewayMutexKV = mutexkv.NewMutexKV()
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{

--- a/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
@@ -3,7 +3,6 @@ package scaleway
 import (
 	"fmt"
 	"log"
-	"sync"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/scaleway/scaleway-cli/pkg/api"
@@ -29,16 +28,14 @@ func resourceScalewayVolumeAttachment() *schema.Resource {
 	}
 }
 
-var mu = sync.Mutex{}
-
 func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
 	var startServerAgain = false
 
 	// guard against server shutdown/ startup race conditiond
-	mu.Lock()
-	defer mu.Unlock()
+	scalewayMutexKV.Lock(d.Get("server").(string))
+	defer scalewayMutexKV.Unlock(d.Get("server").(string))
 
 	server, err := scaleway.GetServer(d.Get("server").(string))
 	if err != nil {
@@ -147,8 +144,8 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 	var startServerAgain = false
 
 	// guard against server shutdown/ startup race conditiond
-	mu.Lock()
-	defer mu.Unlock()
+	scalewayMutexKV.Lock(d.Get("server").(string))
+	defer scalewayMutexKV.Unlock(d.Get("server").(string))
 
 	server, err := scaleway.GetServer(d.Get("server").(string))
 	if err != nil {


### PR DESCRIPTION
since scaleway requires servers to be powered off to attach volumes to we need
to make sure that we don't power down a server twice, or power up a server while
it's supposed to be modified. classic race condition.

sadly terraform doesn't seem to sport serialization primitives for use cases like
this, but putting the code in question behind a `sync.Mutex` does the trick, too.

this PR also migrates `waitForServerState` over to terraform's internal retry primitive.

fixes #9417

```
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScaleway -timeout 120m
=== RUN   TestAccScalewayDataSourceBootscript_Basic
--- PASS: TestAccScalewayDataSourceBootscript_Basic (1.46s)
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (1.16s)
=== RUN   TestAccScalewayDataSourceImage_Basic
--- PASS: TestAccScalewayDataSourceImage_Basic (7.22s)
=== RUN   TestAccScalewayDataSourceImage_Filtered
--- PASS: TestAccScalewayDataSourceImage_Filtered (7.17s)
=== RUN   TestAccScalewayIP_importBasic
--- PASS: TestAccScalewayIP_importBasic (1.95s)
=== RUN   TestAccScalewaySecurityGroup_importBasic
--- PASS: TestAccScalewaySecurityGroup_importBasic (2.35s)
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (138.48s)
=== RUN   TestAccScalewayVolume_importBasic
--- PASS: TestAccScalewayVolume_importBasic (3.49s)
=== RUN   TestAccScalewayIP_Basic
--- PASS: TestAccScalewayIP_Basic (10.79s)
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (6.57s)
=== RUN   TestAccScalewaySecurityGroup_Basic
--- PASS: TestAccScalewaySecurityGroup_Basic (2.52s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (129.39s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (166.02s)
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (373.03s)
=== RUN   TestAccScalewayVolume_Basic
--- PASS: TestAccScalewayVolume_Basic (3.27s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/scaleway	854.886s
```