### PR TITLE
provider/google: Add google resources to importability docs

### DIFF
--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -124,6 +124,16 @@ To make a resource importable, please see the
 
 * fastly_service_v1
 
+### Google
+
+* google_compute_autoscaler
+* google_compute_firewall
+* google_compute_forwarding_rule
+* google_compute_http_health_check
+* google_compute_instance_group_manager
+* google_compute_instance_template
+* google_compute_target_pool
+
 ### OpenStack
 
 * openstack_blockstorage_volume_v1


### PR DESCRIPTION
The google_compute_* objects that were previously had import scripts added, were not added to the website list of importable objects.