### PR TITLE
terraform: new apply resource node supports data sources

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -508,6 +508,38 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_dataBasic(t *testing.T) {
+	m := testModule(t, "apply-data-basic")
+	p := testProvider("null")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	p.ReadDataApplyReturn = &InstanceState{ID: "yo"}
+
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"null": testProviderFuncFixed(p),
+		},
+	})
+
+	if p, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	} else {
+		t.Logf(p.String())
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(testTerraformApplyDataBasicStr)
+	if actual != expected {
+		t.Fatalf("bad: \n%s", actual)
+	}
+}
+
 func TestContext2Apply_destroyData(t *testing.T) {
 	m := testModule(t, "apply-destroy-data-resource")
 	p := testProvider("null")

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -25,13 +25,13 @@ func TestMain(m *testing.M) {
 	// Experimental features
 	xNewApply := flag.Bool("Xnew-apply", false, "Experiment: new apply graph")
 
+	// Normal features
+	shadow := flag.Bool("shadow", true, "Enable shadow graph")
+
 	flag.Parse()
 
 	// Setup experimental features
 	X_newApply = *xNewApply
-	if X_newApply {
-		println("Xnew-apply enabled")
-	}
 
 	if testing.Verbose() {
 		// if we're verbose, use the logging requested by TF_LOG
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 	contextTestDeepCopyOnPlan = true
 
 	// Shadow the new graphs
-	contextTestShadow = true
+	contextTestShadow = *shadow
 
 	os.Exit(m.Run())
 }
@@ -255,6 +255,11 @@ aws_instance.foo:
   ID = foo
   num = 2
   type = aws_instance
+`
+
+const testTerraformApplyDataBasicStr = `
+data.null_data_source.testing:
+  ID = yo
 `
 
 const testTerraformApplyRefCountStr = `

--- a/terraform/test-fixtures/apply-data-basic/main.tf
+++ b/terraform/test-fixtures/apply-data-basic/main.tf
@@ -1,0 +1,1 @@
+data "null_data_source" "testing" {}


### PR DESCRIPTION
    This enables the new apply graph's resource node to apply data sources.
    Data sources appear to only be tested for "refresh" which is likely
    where they're set but they've also been implemented (not my code, not
    trying to edit code) within the "apply" operation as well.

    This adds an apply test to ensure data sources work, and then modifies
    the new apply node to support data sources.