### PR TITLE
Bugfix in example

### DIFF
--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -36,7 +36,7 @@ resource "aws_route53_zone" "dev" {
 }
 
 resource "aws_route53_record" "dev-ns" {
-    zone_id = "${aws_route53_zone.main.zone_id}"
+    zone_id = "${aws_route53_zone.dev.zone_id}"
     name = "dev.example.com"
     type = "NS"
     ttl = "30"


### PR DESCRIPTION
Shouldn't the aws_route53_record in the example should use the "dev" zone_id?