### PR TITLE
provider/aws: Add tagging support to aws_redshift_subnet_group

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group.go
@@ -24,25 +24,27 @@ func resourceAwsRedshiftSubnetGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				ForceNew:     true,
 				Required:     true,
 				ValidateFunc: validateRedshiftSubnetGroupName,
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "Managed by Terraform",
 			},
 
-			"subnet_ids": &schema.Schema{
+			"subnet_ids": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -55,11 +57,13 @@ func resourceAwsRedshiftSubnetGroupCreate(d *schema.ResourceData, meta interface
 	for i, subnetId := range subnetIdsSet.List() {
 		subnetIds[i] = aws.String(subnetId.(string))
 	}
+	tags := tagsFromMapRedshift(d.Get("tags").(map[string]interface{}))
 
 	createOpts := redshift.CreateClusterSubnetGroupInput{
 		ClusterSubnetGroupName: aws.String(d.Get("name").(string)),
 		Description:            aws.String(d.Get("description").(string)),
 		SubnetIds:              subnetIds,
+		Tags:                   tags,
 	}
 
 	log.Printf("[DEBUG] Create Redshift Subnet Group: %#v", createOpts)
@@ -97,12 +101,25 @@ func resourceAwsRedshiftSubnetGroupRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", d.Id())
 	d.Set("description", describeResp.ClusterSubnetGroups[0].Description)
 	d.Set("subnet_ids", subnetIdsToSlice(describeResp.ClusterSubnetGroups[0].Subnets))
+	if err := d.Set("tags", tagsToMapRedshift(describeResp.ClusterSubnetGroups[0].Tags)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting Redshift Subnet Group Tags: %#v", err)
+	}
 
 	return nil
 }
 
 func resourceAwsRedshiftSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
+
+	arn, tagErr := buildRedshiftSubnetGroupARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	if tagErr != nil {
+		return fmt.Errorf("Error building ARN for Redshift Subnet Group, not updating Tags for Subnet Group %s", d.Id())
+	} else {
+		if tagErr := setTagsRedshift(conn, d, arn); tagErr != nil {
+			return tagErr
+		}
+	}
+
 	if d.HasChange("subnet_ids") || d.HasChange("description") {
 		_, n := d.GetChange("subnet_ids")
 		if n == nil {
@@ -188,4 +205,16 @@ func validateRedshiftSubnetGroupName(v interface{}, k string) (ws []string, erro
 			"%q is not allowed as %q", "Default", k))
 	}
 	return
+}
+
+func buildRedshiftSubnetGroupARN(identifier, partition, accountid, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct Subnet Group ARN because of missing AWS partition")
+	}
+	if accountid == "" {
+		return "", fmt.Errorf("Unable to construct Subnet Group ARN because of missing AWS Account ID")
+	}
+	arn := fmt.Sprintf("arn:%s:redshift:%s:%s:subnetgroup:%s", partition, region, accountid, identifier)
+	return arn, nil
+
 }

--- a/website/source/docs/providers/aws/r/redshift_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_subnet_group.html.markdown
@@ -38,6 +38,9 @@ resource "aws_subnet" "bar" {
 resource "aws_redshift_subnet_group" "foo" {
 	name = "foo"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+	tags {
+	    environment = "Production"
+	}
 }
 ```
 
@@ -47,7 +50,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Redshift Subnet group.
 * `description` - (Optional) The description of the Redshift Subnet group. Defaults to "Managed by Terraform".
-* `subnet_ids` - (Optional) An array of VPC subnet IDs..
+* `subnet_ids` - (Optional) An array of VPC subnet IDs.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #9492

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftSubnetGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/21 17:16:02 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftSubnetGroup_ -timeout 120m
=== RUN   TestAccAWSRedshiftSubnetGroup_importBasic
--- PASS: TestAccAWSRedshiftSubnetGroup_importBasic (86.54s)
=== RUN   TestAccAWSRedshiftSubnetGroup_basic
--- PASS: TestAccAWSRedshiftSubnetGroup_basic (85.50s)
=== RUN   TestAccAWSRedshiftSubnetGroup_updateSubnetIds
--- PASS: TestAccAWSRedshiftSubnetGroup_updateSubnetIds (140.01s)
=== RUN   TestAccAWSRedshiftSubnetGroup_tags
--- PASS: TestAccAWSRedshiftSubnetGroup_tags (136.02s)
PASS
ok	github.com/hashicorp/terraform/builtin/providers/aws	448.075
```