### PR TITLE
Fix S3 ARN generation to be GovCloud compatible.

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -795,7 +795,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.Set("arn", fmt.Sprint("arn:aws:s3:::", d.Id()))
+	d.Set("arn", fmt.Sprintf("arn:%s:s3:::%s", meta.(*AWSClient).partition, d.Id()))
 
 	return nil
 }


### PR DESCRIPTION
Hello, recently ran into a bug attempting to build out an AWS environment within the GovCloud region. As you may see below it would always generate a specific S3 ARN that is not compatible with GovCloud. This did not become apparent until I tried passing the ARN to the aws_s3_bucket_policy in which it would always fail -- as it should.

This is what the output of the module looked like previously. 

```
  bucket = arn:aws:s3:::couchbase-backup
```

Did some digging around and this seems like this might be a fix. It worked within my govcloud region.

```
  bucket = arn:aws-us-gov:s3:::couchbase-backup
```

Please let me know if I need to make changes as I'm a complete neophyte in GO.
