### PR TITLE
provider/aws: limiting aws_redshift_subnet_group name to alphanumeric and hyphens

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group.go
@@ -174,9 +174,9 @@ func subnetIdsToSlice(subnetIds []*redshift.Subnet) []string {
 
 func validateRedshiftSubnetGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9a-z-_]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only lowercase alphanumeric characters, hyphens, underscores, and periods allowed in %q", k))
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
 	}
 	if len(value) > 255 {
 		errors = append(errors, fmt.Errorf(

--- a/builtin/providers/aws/resource_aws_redshift_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group_test.go
@@ -80,6 +80,14 @@ func TestResourceAWSRedshiftSubnetGroupNameValidation(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
+			Value:    "testing_123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing.123",
+			ErrCount: 1,
+		},
+		{
 			Value:    randomString(256),
 			ErrCount: 1,
 		},


### PR DESCRIPTION
Redshift subnet groups are limited to lower case alphanumeric values and hyphens only.  Underscores and periods are not allowed.  https://github.com/aws/aws-sdk-go/blob/master/service/redshift/api.go#L6816

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestResourceAWSRedshiftSubnetGroupNameValidation'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/21 11:26:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestResourceAWSRedshiftSubnetGroupNameValidation -timeout 120m
=== RUN   TestResourceAWSRedshiftSubnetGroupNameValidation
--- PASS: TestResourceAWSRedshiftSubnetGroupNameValidation (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.023s
```