### PR TITLE
provider/aws: aws_redshift_subnet_group allows description to be modified

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_subnet_group.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group.go
@@ -103,7 +103,7 @@ func resourceAwsRedshiftSubnetGroupRead(d *schema.ResourceData, meta interface{}
 
 func resourceAwsRedshiftSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
-	if d.HasChange("subnet_ids") {
+	if d.HasChange("subnet_ids") || d.HasChange("description") {
 		_, n := d.GetChange("subnet_ids")
 		if n == nil {
 			n = new(schema.Set)
@@ -117,6 +117,7 @@ func resourceAwsRedshiftSubnetGroupUpdate(d *schema.ResourceData, meta interface
 
 		_, err := conn.ModifyClusterSubnetGroup(&redshift.ModifyClusterSubnetGroupInput{
 			ClusterSubnetGroupName: aws.String(d.Id()),
+			Description:            aws.String(d.Get("description").(string)),
 			SubnetIds:              sIds,
 		})
 

--- a/builtin/providers/aws/resource_aws_redshift_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_subnet_group_test.go
@@ -33,6 +33,35 @@ func TestAccAWSRedshiftSubnetGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRedshiftSubnetGroup_updateDescription(t *testing.T) {
+	var v redshift.ClusterSubnetGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRedshiftSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRedshiftSubnetGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_subnet_group.foo", "description", "foo description"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccRedshiftSubnetGroup_updateDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_subnet_group.foo", "description", "foo description updated"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRedshiftSubnetGroup_updateSubnetIds(t *testing.T) {
 	var v redshift.ClusterSubnetGroup
 
@@ -177,6 +206,37 @@ resource "aws_subnet" "bar" {
 
 resource "aws_redshift_subnet_group" "foo" {
 	name = "foo"
+	description = "foo description"
+	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+}
+`
+
+const testAccRedshiftSubnetGroup_updateDescription = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "foo" {
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-1"
+	}
+}
+
+resource "aws_subnet" "bar" {
+	cidr_block = "10.1.2.0/24"
+	availability_zone = "us-west-2b"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-dbsubnet-test-2"
+	}
+}
+
+resource "aws_redshift_subnet_group" "foo" {
+	name = "foo"
+	description = "foo description updated"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 }
 `


### PR DESCRIPTION
Updating the description of aws_redshift_subnet_group would show in a plan, and update tfstate, but never update the value on AWS.
```
/tmp/tfissue $ cat rs_sg.tf
provider "aws" {
    region = "us-west-2"
}

resource "aws_redshift_subnet_group" "test" {
    name = "redshift-test"
    description = "My description"
    subnet_ids  = [ "REDACTED" ]
}

/tmp/tfissue $ ./terraform apply
aws_redshift_subnet_group.test: Creating...
  description:           "" => "My description"
  name:                  "" => "redshift-test"
  subnet_ids.#:          "" => "1"
  subnet_ids.3988262476: "" => "REDACTED"
aws_redshift_subnet_group.test: Creation complete

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

/tmp/tfissue $ aws redshift describe-cluster-subnet-groups
{
    "ClusterSubnetGroups": [
        {
provider "aws" {
            "Description": "My description",
            "ClusterSubnetGroupName": "redshift-test"
        }
    ]
}

/tmp/tfissue $ vi rs_sg.tf
...changing description in file...

/tmp/tfissue $ ./terraform plan
aws_redshift_subnet_group.test: Refreshing state... (ID: redshift-test)

~ aws_redshift_subnet_group.test
    description: "My description" => "Totally different"

Plan: 0 to add, 1 to change, 0 to destroy.

/tmp/tfissue $ ./terraform apply
aws_redshift_subnet_group.test: Refreshing state... (ID: redshift-test)
aws_redshift_subnet_group.test: Modifying...
  description: "My description" => "Totally different"
aws_redshift_subnet_group.test: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

/tmp/tfissue $ aws redshift describe-cluster-subnet-groups
{
    "ClusterSubnetGroups": [
        {
            "Description": "My description",
            "ClusterSubnetGroupName": "redshift-test"
        }
    ]
}
```

Acceptance tests
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftSubnetGroup_updateDescription'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/21 12:12:09 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftSubnetGroup_updateDescription -timeout 120m
=== RUN   TestAccAWSRedshiftSubnetGroup_updateDescription
--- PASS: TestAccAWSRedshiftSubnetGroup_updateDescription (50.29s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	50.330s
```