### PR TITLE
provider/docker: Upload files into container before first start

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -2,10 +2,14 @@ package docker
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
-
+	"io"
+	"os"
 	"regexp"
 
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -369,6 +373,54 @@ func resourceDockerContainer() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
+			"uploads": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"local_path": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+								path := v.(string)
+								if _, err := os.Stat(path); err != nil {
+									es = append(es, fmt.Errorf(
+										"%q must be valid path: %s", path, err))
+								}
+								return
+							},
+							StateFunc: func(v interface{}) string {
+								switch v.(type) {
+								case string:
+									reader, err := archive.Tar(v.(string), archive.Uncompressed)
+									if err != nil {
+										return "invalid"
+									}
+
+									hash := sha1.New()
+									if _, err := io.Copy(hash, reader); err != nil {
+										return "invalid"
+									}
+
+									return hex.EncodeToString(hash.Sum(nil)[:])
+								default:
+									return ""
+								}
+							},
+						},
+
+						"remote_path": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: resourceDockerUploadsHash,
+			},
 		},
 	}
 }
@@ -431,6 +483,21 @@ func resourceDockerVolumesHash(v interface{}) int {
 
 	if v, ok := m["read_only"]; ok {
 		buf.WriteString(fmt.Sprintf("%v-", v.(bool)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+func resourceDockerUploadsHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if v, ok := m["local_path"]; ok {
+		buf.WriteString(fmt.Sprintf("%v-", v.(string)))
+	}
+
+	if v, ok := m["remote_path"]; ok {
+		buf.WriteString(fmt.Sprintf("%v-", v.(string)))
 	}
 
 	return hashcode.String(buf.String())

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -2,14 +2,10 @@ package docker
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"os"
+
 	"regexp"
 
-	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -374,52 +370,27 @@ func resourceDockerContainer() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
-			"uploads": &schema.Schema{
+			"upload": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"local_path": &schema.Schema{
+						"content": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
+							// This is intentional. The container is mutated once, and never updated later.
+							// New configuration forces a new deployment, even with the same binaries.
 							ForceNew: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								path := v.(string)
-								if _, err := os.Stat(path); err != nil {
-									es = append(es, fmt.Errorf(
-										"%q must be valid path: %s", path, err))
-								}
-								return
-							},
-							StateFunc: func(v interface{}) string {
-								switch v.(type) {
-								case string:
-									reader, err := archive.Tar(v.(string), archive.Uncompressed)
-									if err != nil {
-										return "invalid"
-									}
-
-									hash := sha1.New()
-									if _, err := io.Copy(hash, reader); err != nil {
-										return "invalid"
-									}
-
-									return hex.EncodeToString(hash.Sum(nil)[:])
-								default:
-									return ""
-								}
-							},
 						},
-
-						"remote_path": &schema.Schema{
+						"file": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
 					},
 				},
-				Set: resourceDockerUploadsHash,
+				Set: resourceDockerUploadHash,
 			},
 		},
 	}
@@ -488,15 +459,15 @@ func resourceDockerVolumesHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func resourceDockerUploadsHash(v interface{}) int {
+func resourceDockerUploadHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	if v, ok := m["local_path"]; ok {
+	if v, ok := m["content"]; ok {
 		buf.WriteString(fmt.Sprintf("%v-", v.(string)))
 	}
 
-	if v, ok := m["remote_path"]; ok {
+	if v, ok := m["file"]; ok {
 		buf.WriteString(fmt.Sprintf("%v-", v.(string)))
 	}
 

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	dc "github.com/fsouza/go-dockerclient"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -183,6 +184,19 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 			network := rawNetwork.(string)
 			if err := client.ConnectNetwork(network, connectionOpts); err != nil {
 				return fmt.Errorf("Unable to connect to network '%s': %s", network, err)
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("uploads"); ok {
+		for _, upload := range v.(*schema.Set).List() {
+			uploadOpts, err := uploadFile(upload.(map[string]interface{}))
+			if err != nil {
+				return err
+			}
+
+			if err := client.UploadToContainer(retContainer.ID, *uploadOpts); err != nil {
+				return fmt.Errorf("Unable to upload to container: %s", err)
 			}
 		}
 	}
@@ -411,4 +425,21 @@ func volumeSetToDockerVolumes(volumes *schema.Set) (map[string]struct{}, []strin
 	}
 
 	return retVolumeMap, retHostConfigBinds, retVolumeFromContainers, nil
+}
+
+func uploadFile(upload map[string]interface{}) (*dc.UploadToContainerOptions, error) {
+	localPath := upload["local_path"].(string)
+	remotePath := upload["remote_path"].(string)
+
+	stream, err := archive.Tar(localPath, archive.Uncompressed)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to send %s to container: %s", localPath, err)
+	}
+
+	uploadOpts := &dc.UploadToContainerOptions{
+		InputStream:          stream,
+		Path:                 remotePath,
+		NoOverwriteDirNonDir: false,
+	}
+	return uploadOpts, nil
 }

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 * `networks` - (Optional, set of strings) Id of the networks in which the
   container is.
 * `destroy_grace_seconds` - (Optional, int) If defined will attempt to stop the container before destroying. Container will be destroyed after `n` seconds or on successful stop.
-* `uploads` - (Optional) See [Uploads](#uploads) below for details.
+* `upload` - (Optional, block) See [File Upload](#upload) below for details.
 
 <a id="ports"></a>
 ### Ports
@@ -128,16 +128,15 @@ the following:
 
 One of `from_container`, `host_path` or `volume_name` must be set.
 
-<a id="uploads"></a>
-### Uploads
+<a id="upload"></a>
+### File Upload
 
-`uploads` is a block within the configuration that can be repeated to specify
-files and directories to upload to the container before starting it.
-Each `uploads` supports the following
+`upload` is a block within the configuration that can be repeated to specify
+files to upload to the container before starting it.
+Each `upload` supports the following
 
-* `local_path` - (Required, string) local path to a file or directory to upload.
-* `remote_path` - (Required, string) path to a file or directory in the
-  container.
+* `content` - (Required, string) A content of a file to upload.
+* `file` - (Required, string) path to a file in the container.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -80,6 +80,7 @@ The following arguments are supported:
 * `networks` - (Optional, set of strings) Id of the networks in which the
   container is.
 * `destroy_grace_seconds` - (Optional, int) If defined will attempt to stop the container before destroying. Container will be destroyed after `n` seconds or on successful stop.
+* `uploads` - (Optional) See [Uploads](#uploads) below for details.
 
 <a id="ports"></a>
 ### Ports
@@ -126,6 +127,17 @@ the following:
   Defaults to false.
 
 One of `from_container`, `host_path` or `volume_name` must be set.
+
+<a id="uploads"></a>
+### Uploads
+
+`uploads` is a block within the configuration that can be repeated to specify
+files and directories to upload to the container before starting it.
+Each `uploads` supports the following
+
+* `local_path` - (Required, string) local path to a file or directory to upload.
+* `remote_path` - (Required, string) path to a file or directory in the
+  container.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is another attempt to implement a feature started by @ColinHebert in #4921.
The main difference from the original PR - Terraform operates with file content instead of filenames, this allows rendering files from templates, and detect changes on resource update.
# Rationale
1. Storing secrets.  
   For example, private TLS-keys: they cannot be stored inside Docker image in a registry, so have to be copied into a specific container instance on start.  
   There is a practice to store such data in [environment variables](https://12factor.net/config), but this approach still has limitations. Sometimes using plain files if preferable.
2. Working with official images from Docker Hub.  
   Most of the tools require text configuration files, like `nginx.conf`, `elasticsearch.yml`, or `influxdb.conf`. Even if dynamic data (like hostnames) is moved into environment variables, we still need to customize these files, and overwrite defaults stored inside an official image. Current solutions are:
   - Build your own image on top of official one.  
     But this approach significantly complicates a workflow.
   - Put configs into a volume, and mount it into a container.  
     Better, but does not allow to control versions of the data.
# Solution

`docker_container` resource gets a new `upload` block.
Configuration files are copied into a created container before it's started.

```
resource "docker_image" "nginx" {
  name = "nginx:latest"
}

resource "docker_container" "nginx" {
  image = "${docker_image.nginx.latest}"

  upload {
    content = "${file("tls.conf")}"
    file = "/etc/nginx/conf.d/tls.conf"
  }
  upload {
    content = "${file("nginx.crt")}"
    file = "/etc/nginx/ssl/nginx.crt"
  }
  upload {
    content = "${file("nginx.key")}"
    file = "/etc/nginx/ssl/nginx.key"
  }
}
```

It works the same way as Docker client:

```
> docker create nginx
fa6015c4e044857
> docker cp tls.conf fa6015:/etc/nginx/conf.d/
> docker start fa6015
```

There was an idea of a provisioner for Docker containers, suggested in #6216 and #6827, but this is a different feature, and cannot be used for the use cases described here. 
- Provision is performed _after_ a container is started - at that moment it's too late to change configuration files.
- We need to detect changes in a content, and re-create containers.
