### PR TITLE
provider/aws: Increase ECS service drain timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -349,7 +349,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 	wait := resource.StateChangeConf{
 		Pending:    []string{"DRAINING"},
 		Target:     []string{"INACTIVE"},
-		Timeout:    5 * time.Minute,
+		Timeout:    10 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			log.Printf("[DEBUG] Checking if ECS service %s is INACTIVE", d.Id())


### PR DESCRIPTION
ECS service may sometimes take more than 5 mins to be fully deleted (i.e. turn from `DRAINING` to `INACTIVE`).

```
aws_ecs_service.svc: Still destroying... (5m0s elapsed)
Error applying plan:

1 error(s) occurred:

* aws_ecs_service.svc: timeout while waiting for state to become 'INACTIVE' (last state: 'DRAINING', timeout: 5m0s)
```

Terraform `v0.7.6`

### After fix

```
aws_ecs_service.svc: Still destroying... (5m20s elapsed)
aws_ecs_service.svc: Still destroying... (5m30s elapsed)
aws_ecs_service.svc: Destruction complete
```