### PR TITLE
Fix link pointing to GCE docs

### DIFF
--- a/website/source/docs/providers/google/r/compute_instance_group.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_group.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 The Google Compute Engine Instance Group API creates and manages pools
 of homogeneous Compute Engine virtual machine instances from a common instance
-template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/unmanaged-groups)
+template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)
 and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroups)
 
 ## Example Usage


### PR DESCRIPTION
This partially fixes #9522 . Not sure about the first link reported.