### PR TITLE
helper/shadow: keyedValue.WaitForChange must unlock

### DIFF
--- a/helper/shadow/keyed_value.go
+++ b/helper/shadow/keyed_value.go
@@ -58,6 +58,7 @@ func (w *KeyedValue) WaitForChange(k string) interface{} {
 
 	// If we're closed, we're closed
 	if w.closed {
+		w.lock.Unlock()
 		return ErrClosed
 	}
 

--- a/helper/shadow/keyed_value_test.go
+++ b/helper/shadow/keyed_value_test.go
@@ -312,3 +312,25 @@ func TestKeyedValueWaitForChange_closed(t *testing.T) {
 		t.Fatalf("bad: %#v", val)
 	}
 }
+
+func TestKeyedValueWaitForChange_closedFirst(t *testing.T) {
+	var v KeyedValue
+
+	// Close
+	v.Close()
+
+	// Verify
+	val := v.WaitForChange("foo")
+	if val != ErrClosed {
+		t.Fatalf("bad: %#v", val)
+	}
+
+	// Set a value
+	v.SetValue("foo", 42)
+
+	// Try again
+	val = v.WaitForChange("foo")
+	if val != ErrClosed {
+		t.Fatalf("bad: %#v", val)
+	}
+}


### PR DESCRIPTION
Fixes #9501 

I'm going to fast track this merge since it blocks acceptance tests.

There was a way for the shadow keyed value to block. This fixes that. 