### PR TITLE
terraform: ResourceConfig.Equal should sort ComputedKeys

### DIFF
--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -143,6 +144,10 @@ func (c *ResourceConfig) Equal(c2 *ResourceConfig) bool {
 	if c == nil || c2 == nil {
 		return c == c2
 	}
+
+	// Sort the computed keys so they're deterministic
+	sort.Strings(c.ComputedKeys)
+	sort.Strings(c2.ComputedKeys)
 
 	// Two resource configs if their exported properties are equal.
 	// We don't compare "raw" because it is never used again after

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -268,6 +268,20 @@ func TestResourceConfigEqual_nil(t *testing.T) {
 	}
 }
 
+func TestResourceConfigEqual_computedKeyOrder(t *testing.T) {
+	c := map[string]interface{}{"foo": "${a.b.c}"}
+	rc := NewResourceConfig(config.TestRawConfig(t, c))
+	rc2 := NewResourceConfig(config.TestRawConfig(t, c))
+
+	// Set the computed keys manual
+	rc.ComputedKeys = []string{"foo", "bar"}
+	rc2.ComputedKeys = []string{"bar", "foo"}
+
+	if !rc.Equal(rc2) {
+		t.Fatal("should be equal")
+	}
+}
+
 func testResourceConfig(
 	t *testing.T, c map[string]interface{}) *ResourceConfig {
 	raw, err := config.NewRawConfig(c)

--- a/terraform/shadow_resource_provider.go
+++ b/terraform/shadow_resource_provider.go
@@ -140,6 +140,9 @@ func (p *shadowResourceProviderReal) ValidateResource(
 		Errors: errs,
 	})
 
+	// With it locked, call SetValue again so that it triggers WaitForChange
+	p.Shared.ValidateResource.SetValue(key, wrapper)
+
 	// Return the result
 	return warns, errs
 }


### PR DESCRIPTION
This was causing otherwise equal ResourceConfigs to report non-equal
which was incorrect, thus causing incorrect shadow graph errors.

Same, will fast track this since it was causing errors on master.