### PR TITLE
provider/aws: Added aws_api_gateway_api_key created_date & last_updated_date attributes

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_api_key.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_api_key.go
@@ -23,40 +23,50 @@ func resourceAwsApiGatewayApiKey() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "Managed by Terraform",
 			},
 
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
 
-			"stage_key": &schema.Schema{
+			"stage_key": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"rest_api_id": &schema.Schema{
+						"rest_api_id": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"stage_name": &schema.Schema{
+						"stage_name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 					},
 				},
+			},
+
+			"created_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"last_updated_date": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -101,6 +111,14 @@ func resourceAwsApiGatewayApiKeyRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("description", apiKey.Description)
 	d.Set("enabled", apiKey.Enabled)
 	d.Set("stage_key", flattenApiGatewayStageKeys(apiKey.StageKeys))
+
+	if err := d.Set("created_date", apiKey.CreatedDate.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting created_date: %s", err)
+	}
+
+	if err := d.Set("last_updated_date", apiKey.LastUpdatedDate.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting last_updated_date: %s", err)
+	}
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_api_gateway_api_key_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_api_key_test.go
@@ -20,7 +20,7 @@ func TestAccAWSAPIGatewayApiKey_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayApiKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayApiKeyConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayApiKeyExists("aws_api_gateway_api_key.test", &conf),
@@ -29,6 +29,10 @@ func TestAccAWSAPIGatewayApiKey_basic(t *testing.T) {
 						"aws_api_gateway_api_key.test", "name", "foo"),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_api_key.test", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_api_key.test", "created_date"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_api_key.test", "last_updated_date"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/api_gateway_api_key.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_api_key.html.markdown
@@ -51,6 +51,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the API key
+* `created_date` - The creation date of the API key
+* `last_updated_date` - The last update date of the API key
 
 
 ## Import


### PR DESCRIPTION
### Description

This allows to get the API key dates (creation/last_update) when using the `aws_api_gateway_api_key` resource.
### Relevant Terraform version

Checked against: Terraform v0.7.8-dev (7cb2e69457b03c38332c4edfc849022c505852c5+CHANGES)
