### PR TITLE
provider/aws: Added aws_api_gateway_rest_api created_date attribute

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_rest_api.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_rest_api.go
@@ -20,17 +20,22 @@ func resourceAwsApiGatewayRestApi() *schema.Resource {
 		Delete: resourceAwsApiGatewayRestApiDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"root_resource_id": &schema.Schema{
+			"root_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"created_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -56,7 +61,11 @@ func resourceAwsApiGatewayRestApiCreate(d *schema.ResourceData, meta interface{}
 
 	d.SetId(*gateway.Id)
 
-	return resourceAwsApiGatewayRestApiRefreshResources(d, meta)
+	if err = resourceAwsApiGatewayRestApiRefreshResources(d, meta); err != nil {
+		return err
+	}
+
+	return resourceAwsApiGatewayRestApiRead(d, meta)
 }
 
 func resourceAwsApiGatewayRestApiRefreshResources(d *schema.ResourceData, meta interface{}) error {
@@ -94,9 +103,12 @@ func resourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	d.SetId(*api.Id)
 	d.Set("name", api.Name)
 	d.Set("description", api.Description)
+
+	if err := d.Set("created_date", api.CreatedDate.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting created_date: %s", err)
+	}
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_rest_api_test.go
@@ -18,7 +18,7 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayRestAPIDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayRestAPIConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
@@ -27,10 +27,12 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 						"aws_api_gateway_rest_api.test", "name", "bar"),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_rest_api.test", "description", ""),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_rest_api.test", "created_date"),
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayRestAPIUpdateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
@@ -40,6 +42,8 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 						"aws_api_gateway_rest_api.test", "name", "test"),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_rest_api.test", "description", "test"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_rest_api.test", "created_date"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/api_gateway_rest_api.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_rest_api.html.markdown
@@ -32,3 +32,4 @@ The following attributes are exported:
 
 * `id` - The ID of the REST API
 * `root_resource_id` - The resource ID of the REST API's root
+* `created_date` - The creation date of the REST API


### PR DESCRIPTION
### Description

This allows to get the API key value when using the `aws_api_gateway_rest_api` resource.
### Relevant Terraform version

Checked against: Terraform v0.7.8-dev (7cb2e69457b03c38332c4edfc849022c505852c5+CHANGES)
