### PR TITLE
provider/aws: Exposed aws_api_gw_domain_name.certificate_upload_date attribute

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -52,6 +52,11 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 				Computed: true,
 			},
 
+			"certificate_upload_date": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"cloudfront_zone_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,

--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name_test.go
@@ -41,6 +41,9 @@ func TestAccAWSAPIGatewayDomainName_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_domain_name.test", "domain_name", name,
 					),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_domain_name.test", "certificate_upload_date",
+					),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
@@ -69,6 +69,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The internal id assigned to this domain name by API Gateway.
+* `certificate_upload_date` - The upload date associated with the domain certificate.
 * `cloudfront_domain_name` - The hostname created by Cloudfront to represent
   the distribution that implements this domain name mapping.
 * `cloudfront_zone_id` - For convenience, the hosted zone id (`Z2FDTNDATAQYW2`)


### PR DESCRIPTION
### Description
This allows to get the API key certificate_upload_date when using the `aws_api_gateway_domain_name` resource.

### Relevant Terraform version
Checked against: Terraform v0.7.8-dev (7cb2e69457b03c38332c4edfc849022c505852c5+CHANGES)