### PR TITLE
provider/aws: 	Exposed aws_api_gateway_deployment.created_date attribute

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_deployment.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_deployment.go
@@ -20,34 +20,39 @@ func resourceAwsApiGatewayDeployment() *schema.Resource {
 		Delete: resourceAwsApiGatewayDeploymentDelete,
 
 		Schema: map[string]*schema.Schema{
-			"rest_api_id": &schema.Schema{
+			"rest_api_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"stage_name": &schema.Schema{
+			"stage_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"stage_description": &schema.Schema{
+			"stage_description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"variables": &schema.Schema{
+			"variables": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
 				Elem:     schema.TypeString,
+			},
+
+			"created_date": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -78,7 +83,7 @@ func resourceAwsApiGatewayDeploymentCreate(d *schema.ResourceData, meta interfac
 	d.SetId(*deployment.Id)
 	log.Printf("[DEBUG] API Gateway Deployment ID: %s", d.Id())
 
-	return nil
+	return resourceAwsApiGatewayDeploymentRead(d, meta)
 }
 
 func resourceAwsApiGatewayDeploymentRead(d *schema.ResourceData, meta interface{}) error {
@@ -97,8 +102,11 @@ func resourceAwsApiGatewayDeploymentRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 	log.Printf("[DEBUG] Received API Gateway Deployment: %s", out)
-	d.SetId(*out.Id)
 	d.Set("description", out.Description)
+
+	if err := d.Set("created_date", out.CreatedDate.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting created_date: %s", err)
+	}
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_api_gateway_deployment_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_deployment_test.go
@@ -19,7 +19,7 @@ func TestAccAWSAPIGatewayDeployment_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayDeploymentConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
@@ -29,6 +29,8 @@ func TestAccAWSAPIGatewayDeployment_basic(t *testing.T) {
 						"aws_api_gateway_deployment.test", "description", "This is a test"),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_deployment.test", "variables.a", "2"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_deployment.test", "created_date"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
@@ -68,3 +68,4 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the deployment
+* `created_date` - The creation date of the deployment


### PR DESCRIPTION
### Description

This allows to get the API GW deployment created_date when using the `aws_api_gateway_deployment` resource.
### Relevant Terraform version

Checked against: Terraform v0.7.8-dev (7cb2e69457b03c38332c4edfc849022c505852c5+CHANGES)
