### PR TITLE
provider/aws: Remove references to documentation localised in French.

### DIFF
--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -102,12 +102,12 @@ database, and to use this value as the source database. This correlates to the
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Defaults to true.
 * `allow_major_version_upgrade` - (Optional) Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.
 * `monitoring_role_arn` - (Optional) The ARN for the IAM role that permits RDS to send
-enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html)
+enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html)
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `monitoring_interval` - (Optional) The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key.
 * `character_set_name` - (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed.
-[Oracle Character Sets Supported in Amazon RDS](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
+[Oracle Character Sets Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
@@ -142,7 +142,7 @@ On Oracle instances the following is exported additionally:
 * `character_set_name` - The character set used on Oracle instances.
 
 [1]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html
-[2]: https://docs.aws.amazon.com/fr_fr/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html
+[2]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html
 
 ## Import
 

--- a/website/source/docs/providers/aws/r/eip.html.markdown
+++ b/website/source/docs/providers/aws/r/eip.html.markdown
@@ -122,4 +122,4 @@ EIPs in EC2 Classic can be imported using their Public IP, e.g.
 $ terraform import aws_eip.bar 52.0.0.0
 ```
 
-[1]: https://docs.aws.amazon.com/fr_fr/AWSEC2/latest/APIReference/API_AssociateAddress.html
+[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateAddress.html

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_configuration_template.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_configuration_template.html.markdown
@@ -50,7 +50,7 @@ The `setting` field supports the following format:
 * `namespace` - unique namespace identifying the option's associated AWS resource
 * `name` - name of the configuration option
 * `value` - value for the configuration option
-* `resource` - (Optional) resource name for [scheduled action](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-autoscalingscheduledaction)
+* `resource` - (Optional) resource name for [scheduled action](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-autoscalingscheduledaction)
 
 ## Attributes Reference
 
@@ -63,6 +63,6 @@ The following attributes are exported:
 * `option_settings`
 * `solution_stack_name`
 
-[1]: http://docs.aws.amazon.com/fr_fr/elasticbeanstalk/latest/dg/concepts.platforms.html
+[1]: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html
 
 

--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -66,7 +66,7 @@ changing these tags after initial application
 
 ## Option Settings
 
-Some options can be stack-specific, check [AWS Docs](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html)
+Some options can be stack-specific, check [AWS Docs](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html)
 for supported options and examples.
 
 The `setting` and `all_settings` mappings support the following format:
@@ -74,7 +74,7 @@ The `setting` and `all_settings` mappings support the following format:
 * `namespace` - unique namespace identifying the option's associated AWS resource
 * `name` - name of the configuration option
 * `value` - value for the configuration option
-* `resource` - (Optional) resource name for [scheduled action](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-autoscalingscheduledaction)
+* `resource` - (Optional) resource name for [scheduled action](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-autoscalingscheduledaction)
 
 ### Example With Options
 
@@ -124,7 +124,7 @@ The following attributes are exported:
 
 
 
-[1]: http://docs.aws.amazon.com/fr_fr/elasticbeanstalk/latest/dg/concepts.platforms.html
+[1]: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html
 
 
 ## Import

--- a/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_cluster.html.markdown
@@ -121,7 +121,7 @@ The following attributes are exported:
 * `cluster_address` - (Memcached only) The DNS name of the cache cluster without the port appended.
 
 [1]: https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html
-[2]: https://docs.aws.amazon.com/fr_fr/AmazonElastiCache/latest/UserGuide/Clusters.Modify.html
+[2]: https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Modify.html
 
 
 ## Import

--- a/website/source/docs/providers/aws/r/emr_cluster.html.md
+++ b/website/source/docs/providers/aws/r/emr_cluster.html.md
@@ -52,7 +52,7 @@ The `aws_emr_cluster` resource typically requires two IAM roles, one for the EMR
 to use as a service, and another to place on your Cluster Instances to interact
 with AWS from those instances. The suggested role policy template for the EMR service is `AmazonElasticMapReduceRole`,
 and `AmazonElasticMapReduceforEC2Role` for the EC2 profile. See the [Getting
-Started](http://docs.aws.amazon.com/fr_fr/ElasticMapReduce/latest/ManagementGuide/emr-gs-launch-sample-cluster.html) 
+Started](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-gs-launch-sample-cluster.html) 
 guide for more information on these IAM roles. There is also a fully-bootable
 example Terraform configuration at the bottom of this page. 
 

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -110,7 +110,7 @@ load-balanced across replicas
 
 [2]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html
 [3]: /docs/providers/aws/r/rds_cluster_instance.html
-[4]: http://docs.aws.amazon.com/fr_fr/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html
+[4]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html
 
 ## Import
 

--- a/website/source/docs/providers/aws/r/vpc.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc.html.markdown
@@ -64,7 +64,7 @@ The following attributes are exported:
 * `default_route_table_id` - The ID of the route table created by default on VPC creation
 
 
-[1]: http://docs.aws.amazon.com/fr_fr/AWSEC2/latest/UserGuide/vpc-classiclink.html
+[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html
 
 ## Import
 


### PR DESCRIPTION
This commit points the links to the documentation back to the English language version.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>