### PR TITLE
provider/scaleway: Change bootscript datasource acceptance test

### DIFF
--- a/builtin/providers/scaleway/data_source_scaleway_bootscript_test.go
+++ b/builtin/providers/scaleway/data_source_scaleway_bootscript_test.go
@@ -20,7 +20,7 @@ func TestAccScalewayDataSourceBootscript_Basic(t *testing.T) {
 					testAccCheckBootscriptID("data.scaleway_bootscript.debug"),
 					resource.TestCheckResourceAttr("data.scaleway_bootscript.debug", "architecture", "x86_64"),
 					resource.TestCheckResourceAttr("data.scaleway_bootscript.debug", "public", "true"),
-					resource.TestMatchResourceAttr("data.scaleway_bootscript.debug", "kernel", regexp.MustCompile("4.5.7")),
+					resource.TestMatchResourceAttr("data.scaleway_bootscript.debug", "kernel", regexp.MustCompile("4.8.3")),
 				),
 			},
 		},
@@ -60,7 +60,7 @@ func testAccCheckBootscriptID(n string) resource.TestCheckFunc {
 
 const testAccCheckScalewayBootscriptConfig = `
 data "scaleway_bootscript" "debug" {
-  name = "x86_64 4.5.7 debug #3"
+  name = "x86_64 4.8.3 debug #1"
 }
 `
 


### PR DESCRIPTION
The tests were referencing an old bootscript - this just bumps the value
to the latest. The list of bootscripts can be found at
http://devhub.scaleway.com/#/bootscripts