### PR TITLE
fix reading of environment attribute in resource_aws_opsworks_application

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_application.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application.go
@@ -400,12 +400,7 @@ func resourceAwsOpsworksSetApplicationEnvironmentVariable(d *schema.ResourceData
 			data["value"] = *config.Value
 		}
 		if config.Secure != nil {
-
-			if bool(*config.Secure) {
-				data["secure"] = &opsworksTrueString
-			} else {
-				data["secure"] = &opsworksFalseString
-			}
+			data["secure"] = *config.Secure
 		}
 		log.Printf("[DEBUG] v: %s", data)
 	}


### PR DESCRIPTION
Reading the `environment` attribute for a `resource_aws_opsworks_application` currently does not update the state correctly.

Due to a wrong value passed to the `Set` method it will return an error:

```
environment.0.secure: '' expected type 'bool', got unconvertible type '*string'
```

Sadly there is no error handling implemented which caused the method to just ignore it and continue.
