### PR TITLE
[WIP] provider/azurerm: enable ForceNew for storage_account enable_blob_encryption

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_account.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account.go
@@ -81,9 +81,12 @@ func resourceArmStorageAccount() *schema.Resource {
 				}, true),
 			},
 
+			// ForceNew enabled as changing this value no longer works, appears to be an
+			// Azure bug, support case pending.
 			"enable_blob_encryption": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"primary_location": {

--- a/website/source/docs/providers/azurerm/r/storage_account.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_account.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `enable_bool_encryption` - (Optional) Boolean flag which controls if Encryption
     Services are enabled for Blob storage, see [here](https://azure.microsoft.com/en-us/documentation/articles/storage-service-encryption/)
-    for more information. 
+    for more information. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
While this value could be updated previously, this is not possible currently,
enabled ForceNew until Azure support issue is resolved.
