### PR TITLE
provider/openstack: Add value_specs option to `openstack_networking_port_v2`

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -115,6 +115,11 @@ func resourceNetworkingPortV2() *schema.Resource {
 					},
 				},
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -126,17 +131,20 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	createOpts := ports.CreateOpts{
-		Name:                d.Get("name").(string),
-		AdminStateUp:        resourcePortAdminStateUpV2(d),
-		NetworkID:           d.Get("network_id").(string),
-		MACAddress:          d.Get("mac_address").(string),
-		TenantID:            d.Get("tenant_id").(string),
-		DeviceOwner:         d.Get("device_owner").(string),
-		SecurityGroups:      resourcePortSecurityGroupsV2(d),
-		DeviceID:            d.Get("device_id").(string),
-		FixedIPs:            resourcePortFixedIpsV2(d),
-		AllowedAddressPairs: resourceAllowedAddressPairsV2(d),
+	createOpts := PortCreateOpts{
+		ports.CreateOpts{
+			Name:                d.Get("name").(string),
+			AdminStateUp:        resourcePortAdminStateUpV2(d),
+			NetworkID:           d.Get("network_id").(string),
+			MACAddress:          d.Get("mac_address").(string),
+			TenantID:            d.Get("tenant_id").(string),
+			DeviceOwner:         d.Get("device_owner").(string),
+			SecurityGroups:      resourcePortSecurityGroupsV2(d),
+			DeviceID:            d.Get("device_id").(string),
+			FixedIPs:            resourcePortFixedIpsV2(d),
+			AllowedAddressPairs: resourceAllowedAddressPairsV2(d),
+		},
+		MapValueSpecs(d),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
 
@@ -16,6 +17,18 @@ type NetworkCreateOpts struct {
 // It overrides networks.ToNetworkCreateMap to add the ValueSpecs field.
 func (opts NetworkCreateOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
 	return BuildRequest(opts, "network")
+}
+
+// PortCreateOpts represents the attributes used when creating a new port.
+type PortCreateOpts struct {
+	ports.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToPortCreateMap casts a CreateOpts struct to a map.
+// It overrides ports.ToPortCreateMap to add the ValueSpecs field.
+func (opts PortCreateOpts) ToPortCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "port")
 }
 
 // RouterCreateOpts represents the attributes used when creating a new router.

--- a/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
@@ -67,6 +67,8 @@ The following arguments are supported:
     addresses that can be active on this port. The structure is described
     below.
 
+* `value_specs` - (Optional) Map of additional options.
+
 The `fixed_ip` block supports:
 
 * `subnet_id` - (Required) Subnet in which to allocate IP address for


### PR DESCRIPTION
Also refactored to use common `types.go` and `MapValueSpecs` function.
Add supporting documentation