### PR TITLE
provider/openstack: Add 'value_specs' option to 'openstack_networking…

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_floatingip_v2.go
@@ -57,6 +57,11 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -75,12 +80,16 @@ func resourceNetworkFloatingIPV2Create(d *schema.ResourceData, meta interface{})
 	if len(poolID) == 0 {
 		return fmt.Errorf("No network found with name: %s", d.Get("pool").(string))
 	}
-	createOpts := floatingips.CreateOpts{
-		FloatingNetworkID: poolID,
-		PortID:            d.Get("port_id").(string),
-		TenantID:          d.Get("tenant_id").(string),
-		FixedIP:           d.Get("fixed_ip").(string),
+	createOpts := FloatingIPCreateOpts{
+		floatingips.CreateOpts{
+			FloatingNetworkID: poolID,
+			PortID:            d.Get("port_id").(string),
+			TenantID:          d.Get("tenant_id").(string),
+			FixedIP:           d.Get("fixed_ip").(string),
+		},
+		MapValueSpecs(d),
 	}
+
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	floatingIP, err := floatingips.Create(networkingClient, createOpts).Extract()
 	if err != nil {

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -1,10 +1,23 @@
 package openstack
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
+
+// FloatingIPCreateOpts represents the attributes used when creating a new port.
+type FloatingIPCreateOpts struct {
+	floatingips.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToFloatingIPCreateMap casts a CreateOpts struct to a map.
+// It overrides floatingips.ToFloatingIPCreateMap to add the ValueSpecs field.
+func (opts FloatingIPCreateOpts) ToFloatingIPCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "floatingip")
+}
 
 // NetworkCreateOpts represents the attributes used when creating a new network.
 type NetworkCreateOpts struct {

--- a/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_floatingip_v2.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 * `fixed_ip` - Fixed IP of the port to associate with this floating IP. Required if
 the port has multiple fixed IPs.
 
+* `value_specs` - (Optional) Map of additional options.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
…_floatingip_v2' resource,

refactor into common `types.go` and use new `MapValueSpecs` function.
Added supporting documentation.