### PR TITLE
provider/openstack: Add 'value_specs' option to 'openstack_compute_keypa…

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_keypair_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_keypair_v2.go
@@ -34,6 +34,11 @@ func resourceComputeKeypairV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -45,9 +50,12 @@ func resourceComputeKeypairV2Create(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	createOpts := keypairs.CreateOpts{
-		Name:      d.Get("name").(string),
-		PublicKey: d.Get("public_key").(string),
+	createOpts := KeyPairCreateOpts{
+		keypairs.CreateOpts{
+			Name:      d.Get("name").(string),
+			PublicKey: d.Get("public_key").(string),
+		},
+		MapValueSpecs(d),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -18,6 +19,18 @@ type FloatingIPCreateOpts struct {
 // It overrides floatingips.ToFloatingIPCreateMap to add the ValueSpecs field.
 func (opts FloatingIPCreateOpts) ToFloatingIPCreateMap() (map[string]interface{}, error) {
 	return BuildRequest(opts, "floatingip")
+}
+
+// KeyPairCreateOpts represents the attributes used when creating a new keypair.
+type KeyPairCreateOpts struct {
+	keypairs.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToKeyPairCreateMap casts a CreateOpts struct to a map.
+// It overrides keypairs.ToKeyPairCreateMap to add the ValueSpecs field.
+func (opts KeyPairCreateOpts) ToKeyPairCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "keypair")
 }
 
 // NetworkCreateOpts represents the attributes used when creating a new network.

--- a/website/source/docs/providers/openstack/r/compute_keypair_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_keypair_v2.html.markdown
@@ -34,6 +34,8 @@ The following arguments are supported:
 * `public_key` - (Required) A pregenerated OpenSSH-formatted public key.
     Changing this creates a new keypair.
 
+* `value_specs` - (Optional) Map of additional options.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
…ir_v2' resource,

refactor to use common `types.go` and `MapValueSpecs`.
Added supporting documentation. 