### PR TITLE
provider/aws: Make associate_public_ip_address computed

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -41,6 +41,7 @@ func resourceAwsInstance() *schema.Resource {
 			"associate_public_ip_address": &schema.Schema{
 				Type:     schema.TypeBool,
 				ForceNew: true,
+				Computed: true,
 				Optional: true,
 			},
 


### PR DESCRIPTION
https://github.com/hashicorp/terraform/pull/9453 introduced a READ on the `associate_public_ip_address` attribute of `aws_instance`. Because we're now setting it, we need to mark it as `Computed`. This mostly impacts us when importing resources