### PR TITLE
provider/aws: Remove VPC Endpoint from state if it's not found

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_endpoint.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint.go
@@ -106,6 +106,8 @@ func resourceAwsVPCEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		if ec2err.Code() == "InvalidVpcEndpointId.NotFound" {
+			log.Printf("[WARN] VPC Endpoint (%s) not found, removing from state", d.Id())
+			d.SetId("")
 			return nil
 		}
 


### PR DESCRIPTION
If a VPC Endpoint is removed outside of Terraform, we need to remove it from state when it's not found in the `READ` method