### PR TITLE
Allow resizing DigitalOcean Droplets without increasing disk size.

### DIFF
--- a/website/source/docs/providers/do/r/droplet.html.markdown
+++ b/website/source/docs/providers/do/r/droplet.html.markdown
@@ -32,9 +32,6 @@ The following arguments are supported:
 * `name` - (Required) The Droplet name
 * `region` - (Required) The region to start in
 * `size` - (Required) The instance size to start
-
--> **Note:** When resizing a Droplet, only a bigger Droplet size can be chosen.
-
 * `backups` - (Optional) Boolean controlling if backups are made. Defaults to
    false.
 * `ipv6` - (Optional) Boolean controlling if IPv6 is enabled. Defaults to false.
@@ -44,6 +41,10 @@ The following arguments are supported:
    the format `[12345, 123456]`. To retrieve this info, use a tool such
    as `curl` with the [DigitalOcean API](https://developers.digitalocean.com/#keys),
    to retrieve them.
+* `resize_disk` - (Optional) Boolean controlling whether to increase the disk
+   size when resizing a Droplet. It defaults to `true`. When set to `false`,
+   only the Droplet's RAM and CPU will be resized. **Increasing a Droplet's disk
+   size is a permanent change**. Increasing only RAM and CPU is reversible.
 * `tags` - (Optional) A list of the tags to label this droplet. A tag resource
    must exist before it can be associated with a droplet.
 * `user_data` (Optional) - A string of the desired User Data for the Droplet.
@@ -67,6 +68,8 @@ The following attributes are exported:
 * `locked` - Is the Droplet locked
 * `private_networking` - Is private networking enabled
 * `size` - The instance size
+* `disk` - The size of the instance's disk in GB
+* `vcpus` - The number of the instance's virtual CPUs
 * `status` - The status of the droplet
 * `tags` - The tags associated with the droplet
 * `volume_ids` - A list of the attached block storage volumes


### PR DESCRIPTION
This adds a new Boolean argument for the DigitalOcean Droplet resource, `resize_disk` It defaults to `true` to match the current behavior. When set to `false`, resizing a Droplet will only resize the RAM and CPU making it a reversible operation.

https://developers.digitalocean.com/documentation/v2/#resize-a-droplet

It also exposes the `disk` and `vcpus` attributes.

It resolves #9402.