### PR TITLE
config: ignore_changes cannot have interpolations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -579,6 +579,20 @@ func (c *Config) Validate() error {
 						"together with a wildcard: %s", n, v))
 			}
 		}
+
+		// Verify ignore_changes has no interpolations
+		rc, err := NewRawConfig(map[string]interface{}{
+			"root": r.Lifecycle.IgnoreChanges,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"%s: lifecycle ignore_changes error: %s",
+				n, err))
+		} else if len(rc.Interpolations) > 0 {
+			errs = append(errs, fmt.Errorf(
+				"%s: lifecycle ignore_changes cannot contain interpolations",
+				n))
+		}
 	}
 
 	for source, vs := range vars {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -265,6 +265,13 @@ func TestConfigValidate_ignoreChangesBad(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_ignoreChangesInterpolate(t *testing.T) {
+	c := testConfig(t, "validate-ignore-changes-interpolate")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestConfigValidate_moduleNameBad(t *testing.T) {
 	c := testConfig(t, "validate-module-name-bad")
 	if err := c.Validate(); err == nil {

--- a/config/test-fixtures/validate-ignore-changes-interpolate/main.tf
+++ b/config/test-fixtures/validate-ignore-changes-interpolate/main.tf
@@ -1,0 +1,7 @@
+variable "foo" {}
+
+resource aws_instance "web" {
+  lifecycle {
+    ignore_changes = ["${var.foo}"]
+  }
+}


### PR DESCRIPTION
Fixes #9396

This is the limitation of all lifecycle attributes currently. Right now,
interpolations are allowed through and the user ends up thinking it
should work. We should give an error.

In the future it should be possible to support some minimal set of
interpolations (static variables, data sources even perhaps) but for now
let's validate that this doesn't work.