### PR TITLE
provider/aws: Delete Loging Profile from IAM User on force_destroy

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -190,6 +190,16 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Error deleting access key %s: %s", k, err)
 			}
 		}
+
+		_, err = iamconn.DeleteLoginProfile(&iam.DeleteLoginProfileInput{
+			UserName: aws.String(d.Id()),
+		})
+		if err != nil {
+			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+				return nil
+			}
+			return fmt.Errorf("Error deleting Account Login Profile: %s", err)
+		}
 	}
 
 	request := &iam.DeleteUserInput{


### PR DESCRIPTION
When force_Destroy was specified on an iam_user, only Access Keys were
destroyed. Therefore, if a password was manually added via the AWS
console, it was causing an error as follows:

```
* aws_iam_user.user: Error deleting IAM User test-user-for-profile-delete: DeleteConflict: Cannot delete entity, must delete login profile first.
    status code: 409, request id: acd67e40-9aa8-11e6-8533-4db80bad7ea8
```

We now *try* to delete the LoginProfile and ignore a NoSuchEntity error
if it doesn't exist

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSUser_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/25 12:53:05 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSUser_
-timeout 120m
=== RUN   TestAccAWSUser_importBasic
--- PASS: TestAccAWSUser_importBasic (14.83s)
=== RUN   TestAccAWSUser_basic
--- PASS: TestAccAWSUser_basic (24.78s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws39.624s
```