### PR TITLE
provider/aws: fix aws_elasticache_replication_group for Redis in cluster mode

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -47,6 +47,11 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		Computed: true,
 	}
 
+	resourceSchema["configuration_endpoint_address"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+
 	resourceSchema["engine"].Required = false
 	resourceSchema["engine"].Optional = true
 	resourceSchema["engine"].Default = "redis"
@@ -236,10 +241,15 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 			d.Set("parameter_group_name", c.CacheParameterGroup.CacheParameterGroupName)
 		}
 		d.Set("maintenance_window", c.PreferredMaintenanceWindow)
-		d.Set("snapshot_window", c.SnapshotWindow)
-		d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
-		d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
-		d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
+		d.Set("snapshot_window", rgp.SnapshotWindow)
+		d.Set("snapshot_retention_limit", rgp.SnapshotRetentionLimit)
+		if rgp.ConfigurationEndpoint != nil {
+			d.Set("port", rgp.ConfigurationEndpoint.Port)
+			d.Set("configuration_endpoint_address", rgp.ConfigurationEndpoint.Address)
+		} else {
+			d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
+			d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
+		}
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -162,6 +162,39 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "automatic_failover_enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "snapshot_window", "02:00-03:00"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "7"),
+					resource.TestCheckResourceAttrSet(
+						"aws_elasticache_replication_group.bar", "primary_endpoint_address"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "automatic_failover_enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "snapshot_window", "02:00-03:00"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "7"),
+					resource.TestCheckResourceAttrSet(
+						"aws_elasticache_replication_group.bar", "configuration_endpoint_address"),
 				),
 			},
 		},
@@ -542,5 +575,72 @@ resource "aws_elasticache_replication_group" "bar" {
     parameter_group_name = "default.redis3.2"
     availability_zones = ["us-west-2a","us-west-2b"]
     automatic_failover_enabled = true
+    snapshot_window = "02:00-03:00"
+    snapshot_retention_limit = 7
+}
+`, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
+
+var testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig = fmt.Sprintf(`
+resource "aws_vpc" "foo" {
+    cidr_block = "192.168.0.0/16"
+    tags {
+            Name = "tf-test"
+    }
+}
+
+resource "aws_subnet" "foo" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "192.168.0.0/20"
+    availability_zone = "us-west-2a"
+    tags {
+            Name = "tf-test-%03d"
+    }
+}
+
+resource "aws_subnet" "bar" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "192.168.16.0/20"
+    availability_zone = "us-west-2b"
+    tags {
+            Name = "tf-test-%03d"
+    }
+}
+
+resource "aws_elasticache_subnet_group" "bar" {
+    name = "tf-test-cache-subnet-%03d"
+    description = "tf-test-cache-subnet-group-descr"
+    subnet_ids = [
+        "${aws_subnet.foo.id}",
+        "${aws_subnet.bar.id}"
+    ]
+}
+
+resource "aws_security_group" "bar" {
+    name = "tf-test-security-group-%03d"
+    description = "tf-test-security-group-descr"
+    vpc_id = "${aws_vpc.foo.id}"
+    ingress {
+        from_port = -1
+        to_port = -1
+        protocol = "icmp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_elasticache_replication_group" "bar" {
+    replication_group_id = "tf-%s"
+    replication_group_description = "test description"
+    node_type = "cache.t2.micro"
+    number_cache_clusters = "2"
+    port = 6379
+    subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
+    security_group_ids = ["${aws_security_group.bar.id}"]
+    parameter_group_name = "default.redis3.2.cluster.on"
+    availability_zones = ["us-west-2a","us-west-2b"]
+    automatic_failover_enabled = true
+    snapshot_window = "02:00-03:00"
+    snapshot_retention_limit = 7
+    engine_version = "3.2.4"
+    maintenance_window = "thu:03:00-thu:04:00"
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))

--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -67,8 +67,9 @@ Please note that setting a `snapshot_retention_limit` is not supported on cache.
 
 The following attributes are exported:
 
-* `id` - The ID of the ElastiCache Replication Group
-* `primary_endpoint_address` - The address of the endpoint for the primary node in the replication group
+* `id` - The ID of the ElastiCache Replication Group.
+* `primary_endpoint_address` - The address of the endpoint for the primary node in the replication group. If Redis, only present when cluster mode is disabled.
+* `configuration_endpoint_address` - (Redis only) The address of the replication group configuration endpoint when cluster mode is enabled.
 
 ## Import
 


### PR DESCRIPTION
This is a fix for issue https://github.com/hashicorp/terraform/issues/9596.

Changes:
 - Adds new output attribute `configuration_endpoint_address`. Only
   used in Redis when in cluster mode.
 - Read the `snapshot_window` and `snapshot_retention_limit` from
   the
   replication group description instead of the cache cluster
   description.
 - Adds acceptance test and modifies an existing acceptance test to
   make sure that everything is still good in non-cluster mode
 - Updates docs to describe new output attribute