### PR TITLE
Fix the misuse of the word 'comprised'

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -80,7 +80,7 @@ The general structure should be intuitive and straightforward.
 The `provider` block is used to configure the named provider, in
 our case "aws." A provider is responsible for creating and
 managing resources. Multiple provider blocks can exist if a
-Terraform configuration is comprised of multiple providers,
+Terraform configuration is composed of multiple providers,
 which is a common situation.
 
 The `resource` block defines a resource that exists within


### PR DESCRIPTION
The proper use of "comprise" is "Array1 comprises item1, item2, and item3" 
which is equivalent to saying "Array1 is composed of item1, item2, and item3." 
That is, "comprises" is equivalent to "is composed of." Therefore, to say 
"Array1 is comprised of item1, item2, and item3" is equivalent to saying 
"Array1 IS IS COMPOSED OF OF item1, item2, and item3" which makes no
sense and is like "The La Trattoria" from Mickey Blue Eyes! This change fixes
the misuse of the word.