### PR TITLE
Link to Gitter chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Terraform
 =========
 
 - Website: http://www.terraform.io
-- IRC: `#terraform-tool` on Freenode
+- [![Gitter chat](https://badges.gitter.im/terraform-tool/Lobby.png)](https://gitter.im/terraform-tool/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
 ![Terraform](https://raw.githubusercontent.com/hashicorp/terraform/master/website/source/assets/images/readme.png)


### PR DESCRIPTION
IRC has been deprecated in favor of Gitter, this links directly to the Gitter chat room

Signed-off-by: Dave Walter <dwalter@pivotal.io>