### PR TITLE
provider/google: Add support for using source_disk to google_compute_image

### DIFF
--- a/builtin/providers/google/resource_compute_image_test.go
+++ b/builtin/providers/google/resource_compute_image_test.go
@@ -29,6 +29,25 @@ func TestAccComputeImage_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeImage_basedondisk(t *testing.T) {
+	var image compute.Image
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeImageDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeImage_basedondisk,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeImageExists(
+						"google_compute_image.foobar", &image),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeImageDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -83,3 +102,14 @@ resource "google_compute_image" "foobar" {
 	  source = "https://storage.googleapis.com/bosh-cpi-artifacts/bosh-stemcell-3262.4-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz"
 	}
 }`, acctest.RandString(10))
+
+var testAccComputeImage_basedondisk = fmt.Sprintf(`
+resource "google_compute_disk" "foobar" {
+	name = "disk-test-%s"
+	zone = "us-central1-a"
+	image = "debian-8-jessie-v20160803"
+}
+resource "google_compute_image" "foobar" {
+	name = "image-test-%s"
+	source_disk = "${google_compute_disk.foobar.self_link}"
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/website/source/docs/providers/google/r/compute_image.html.markdown
+++ b/website/source/docs/providers/google/r/compute_image.html.markdown
@@ -40,14 +40,18 @@ resource "google_compute_instance" "vm" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are supported: (Note that one of either source_disk or
+  raw_disk is required)
 
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `raw_disk` - (Required) The raw disk that will be used as the source of
-    the image. Changing this forces a new resource to be created.
-    Structure is documented below.
+* `source_disk` - The URL of a disk that will be used as the source of the
+    image. Changing this forces a new resource to be created.
+
+* `raw_disk` - The raw disk that will be used as the source of the image.
+    Changing this forces a new resource to be created. Structure is documented
+    below.
 
 The `raw_disk` block supports:
 


### PR DESCRIPTION
Fixes #9262.

Allows you to use an existing disk resource to then funnel back to an image resource.

```
$ make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccComputeImage...'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/26 01:09:22 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeImage... -timeout 120m
=== RUN   TestAccComputeImage_basic
--- PASS: TestAccComputeImage_basic (79.13s)
=== RUN   TestAccComputeImage_basedondisk
--- PASS: TestAccComputeImage_basedondisk (104.79s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/google 183.926s
```
