### PR TITLE
provider/azurerm: Fix VHD deletion when VM and Storage account are in separate resource groups

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -64,6 +64,7 @@ type ArmClient struct {
 	providers           resources.ProvidersClient
 	resourceGroupClient resources.GroupsClient
 	tagsClient          resources.TagsClient
+	resourceFindClient  resources.Client
 
 	jobsClient            scheduler.JobsClient
 	jobsCollectionsClient scheduler.JobCollectionsClient
@@ -313,6 +314,12 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	tc.Authorizer = spt
 	tc.Sender = autorest.CreateSender(withRequestLogging())
 	client.tagsClient = tc
+
+	rf := resources.NewClient(c.SubscriptionID)
+	setUserAgent(&rf.Client)
+	rf.Authorizer = spt
+	rf.Sender = autorest.CreateSender(withRequestLogging())
+	client.resourceFindClient = rf
 
 	jc := scheduler.NewJobsClient(c.SubscriptionID)
 	setUserAgent(&jc.Client)

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -1298,6 +1298,8 @@ func findStorageAccountResourceGroup(meta interface{}, storageAccountName string
 		return "", fmt.Errorf("Wrong number of results making resource request for query %s:  %s", filter, len(results))
 	}
 
+	// Storage Account ID is in the form
+	//   /subscriptions/[SUBSCRIPTION_ID]/resourceGroups/[RESOURCE_GROUP]/providers/Microsoft.Storage/storageAccounts/[STORAGE_ACCOUNT]
 	idSplit := strings.Split(strings.TrimPrefix(*results[0].ID, "/"), "/")
 	storageAccountResourceGroupName := idSplit[3]
 	return storageAccountResourceGroupName, nil

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -1287,8 +1287,8 @@ func findStorageAccountResourceGroup(meta interface{}, storageAccountName string
 	filter := fmt.Sprintf("name eq '%s' and resourceType eq 'Microsoft.Storage/storageAccounts'", storageAccountName)
 	expand := ""
 	var pager *int32
-	rf, err := client.List(filter, expand, pager)
 
+	rf, err := client.List(filter, expand, pager)
 	if err != nil {
 		return "", fmt.Errorf("Error making resource request for query %s: %s", filter, err)
 	}
@@ -1298,9 +1298,10 @@ func findStorageAccountResourceGroup(meta interface{}, storageAccountName string
 		return "", fmt.Errorf("Wrong number of results making resource request for query %s:  %s", filter, len(results))
 	}
 
-	// Storage Account ID is in the form
-	//   /subscriptions/[SUBSCRIPTION_ID]/resourceGroups/[RESOURCE_GROUP]/providers/Microsoft.Storage/storageAccounts/[STORAGE_ACCOUNT]
-	idSplit := strings.Split(strings.TrimPrefix(*results[0].ID, "/"), "/")
-	storageAccountResourceGroupName := idSplit[3]
-	return storageAccountResourceGroupName, nil
+	id, err := parseAzureResourceID(*results[0].ID)
+	if err != nil {
+		return "", err
+	}
+
+	return id.ResourceGroup, nil
 }

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -691,7 +691,7 @@ func resourceArmVirtualMachineDeleteVhd(uri, resGroup string, meta interface{}) 
 	}
 
 	if !saExists {
-		log.Printf("[INFO] Storage Account %q doesn't exist so the VHD blob won't exist", storageAccountName)
+		log.Printf("[INFO] Storage Account %q in resource group %q doesn't exist so the VHD blob won't exist", storageAccountName, resGroup)
 		return nil
 	}
 

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -248,8 +248,8 @@ func TestAccAzureRMVirtualMachine_deleteVHDOptOut(t *testing.T) {
 func TestAccAzureRMVirtualMachine_deleteVHDOptIn(t *testing.T) {
 	var vm compute.VirtualMachine
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisks, ri, ri, ri, ri, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineDeleteVM, ri, ri, ri, ri, ri)
+	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisksBefore, ri, ri, ri, ri, ri, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisksAfter, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -633,9 +633,14 @@ resource "azurerm_virtual_machine" "test" {
 }
 `
 
-var testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisks = `
+var testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisksBefore = `
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_resource_group" "test-sa" {
+    name = "acctestRG-sa-%d"
     location = "West US"
 }
 
@@ -667,7 +672,7 @@ resource "azurerm_network_interface" "test" {
 
 resource "azurerm_storage_account" "test" {
     name = "accsa%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+    resource_group_name = "${azurerm_resource_group.test-sa.name}"
     location = "westus"
     account_type = "Standard_LRS"
 
@@ -678,7 +683,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
     name = "vhds"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+    resource_group_name = "${azurerm_resource_group.test-sa.name}"
     storage_account_name = "${azurerm_storage_account.test.name}"
     container_access_type = "private"
 }
@@ -730,6 +735,62 @@ resource "azurerm_virtual_machine" "test" {
     	environment = "Production"
     	cost-center = "Ops"
     }
+}
+`
+
+var testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisksAfter = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_resource_group" "test-sa" {
+    name = "acctestRG-sa-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accsa%d"
+    resource_group_name = "${azurerm_resource_group.test-sa.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test-sa.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
 }
 `
 


### PR DESCRIPTION
`delete_os_disk_on_termination` and `delete_data_disk_on_termination` don't always remove the VHD disk blob when deleting a Virtual Machine.
This is because it assumes the storage account resource group is the same as the virtual machine's resource group. 

Unfortunately I can't find any information on the virtual machine that stores the storage account resource group and so I've had to go back the API. The only method I've found is to list the resources here https://godoc.org/github.com/Azure/azure-sdk-for-go/arm/resources/resources#Client.List

Other suggestions are welcome.