### PR TITLE
provider/aws: Suceed deleting bucket policy on err

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_policy.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_policy.go
@@ -100,6 +100,9 @@ func resourceAwsS3BucketPolicyDelete(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoSuchBucket" {
+			return nil
+		}
 		return fmt.Errorf("Error deleting S3 policy: %s", err)
 	}
 


### PR DESCRIPTION
If there is no bucket, a bucket policy can be counted as successfully deleted.