### PR TITLE
command: FlagTypedKV parses bool as string

### DIFF
--- a/command/flag_kv.go
+++ b/command/flag_kv.go
@@ -166,11 +166,19 @@ func parseVarFlagAsHCL(input string) (string, interface{}, error) {
 	if _, err := strconv.ParseFloat(trimmed, 64); err == nil {
 		return probablyName, value, nil
 	}
+
 	// HCL will also parse hex as a number
 	if strings.HasPrefix(trimmed, "0x") {
 		if _, err := strconv.ParseInt(trimmed[2:], 16, 64); err == nil {
 			return probablyName, value, nil
 		}
+	}
+
+	// If the value is a boolean value, also convert it to a simple string
+	// since Terraform core doesn't accept primitives as anything other
+	// than string for now.
+	if _, err := strconv.ParseBool(trimmed); err == nil {
+		return probablyName, value, nil
 	}
 
 	parsed, err := hcl.Parse(input)

--- a/command/flag_kv_test.go
+++ b/command/flag_kv_test.go
@@ -99,6 +99,12 @@ func TestFlagTypedKV(t *testing.T) {
 		},
 
 		{
+			"key=false",
+			map[string]interface{}{"key": "false"},
+			false,
+		},
+
+		{
 			"map.key=foo",
 			map[string]interface{}{"map.key": "foo"},
 			false,


### PR DESCRIPTION
When passing a bool type to a variable such as `-var foo=true`, the CLI
would parse this as a `bool` type which Terraform core cannot handle.
It would then error with an invalid type error.

This changes the handling to convert the bool to its literally string
value given on the command-line.

From chat:

![2016-10-26 at 9 36 pm](https://cloud.githubusercontent.com/assets/1299/19751221/b5d23396-9bc5-11e6-92ea-c3971fb12d97.png)
