### PR TITLE
provider/azurerm: support importing of subnet resource

### DIFF
--- a/builtin/providers/azurerm/import_arm_subnet_test.go
+++ b/builtin/providers/azurerm/import_arm_subnet_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMSubnet_importBasic(t *testing.T) {
+	resourceName := "azurerm_subnet.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_subnet.go
+++ b/builtin/providers/azurerm/resource_arm_subnet.go
@@ -16,6 +16,9 @@ func resourceArmSubnet() *schema.Resource {
 		Read:   resourceArmSubnetRead,
 		Update: resourceArmSubnetCreate,
 		Delete: resourceArmSubnetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -140,7 +143,20 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error making Read request on Azure Subnet %s: %s", name, err)
 	}
 
-	if resp.Properties.IPConfigurations != nil && len(*resp.Properties.IPConfigurations) > 0 {
+	d.Set("name", name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("virtual_network_name", vnetName)
+	d.Set("address_prefix", resp.Properties.AddressPrefix)
+
+	if resp.Properties.NetworkSecurityGroup != nil {
+		d.Set("network_security_group_id", resp.Properties.NetworkSecurityGroup.ID)
+	}
+
+	if resp.Properties.RouteTable != nil {
+		d.Set("route_table_id", resp.Properties.RouteTable.ID)
+	}
+
+	if resp.Properties.IPConfigurations != nil {
 		ips := make([]string, 0, len(*resp.Properties.IPConfigurations))
 		for _, ip := range *resp.Properties.IPConfigurations {
 			ips = append(ips, *ip.ID)
@@ -149,6 +165,8 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("ip_configurations", ips); err != nil {
 			return err
 		}
+	} else {
+		d.Set("ip_configurations", []string{})
 	}
 
 	return nil

--- a/website/source/docs/providers/azurerm/r/subnet.html.markdown
+++ b/website/source/docs/providers/azurerm/r/subnet.html.markdown
@@ -59,3 +59,11 @@ The following attributes are exported:
 
 * `id` - The subnet ID.
 * `ip_configurations` - The collection of IP Configurations with IPs within this subnet.
+
+## Import
+
+Subnets can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_subnet.testSubnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1
+```


### PR DESCRIPTION
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMSubnet -timeout 120m
=== RUN   TestAccAzureRMSubnet_importBasic
--- PASS: TestAccAzureRMSubnet_importBasic (165.04s)
=== RUN   TestAccAzureRMSubnet_basic
--- PASS: TestAccAzureRMSubnet_basic (165.39s)
=== RUN   TestAccAzureRMSubnet_disappears
--- PASS: TestAccAzureRMSubnet_disappears (170.02s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	500.533s
```