### PR TITLE
provider/azurerm: lower servicebus_topic max size to Azure limit, fix test

### DIFF
--- a/builtin/providers/azurerm/resource_arm_servicebus_topic.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic.go
@@ -235,8 +235,8 @@ func resourceArmServiceBusTopicDelete(d *schema.ResourceData, meta interface{}) 
 
 func validateArmServiceBusTopicMaxSize(i interface{}, k string) (s []string, es []error) {
 	v := i.(int)
-	if v%1024 != 0 || v < 0 || v > 10240 {
-		es = append(es, fmt.Errorf("%q must be a multiple of 1024 up to and including 10240", k))
+	if v%1024 != 0 || v < 0 || v > 5120 {
+		es = append(es, fmt.Errorf("%q must be a multiple of 1024 up to and including 5120", k))
 	}
 
 	return

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
@@ -81,7 +81,7 @@ func TestAccAzureRMServiceBusTopic_enablePartitioning(t *testing.T) {
 						"azurerm_servicebus_topic.test", "enable_partitioning", "true"),
 					// Ensure size is read back in it's original value and not the x16 value returned by Azure
 					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "max_size_in_megabytes", "10240"),
+						"azurerm_servicebus_topic.test", "max_size_in_megabytes", "5120"),
 				),
 			},
 		},
@@ -236,7 +236,7 @@ resource "azurerm_servicebus_topic" "test" {
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
-	max_size_in_megabytes = 10240
+	max_size_in_megabytes = 5120
 }
 `
 

--- a/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
@@ -86,8 +86,8 @@ The following arguments are supported:
 
 * `max_size_in_megabytes` - (Optional) Integer value which controls the size of
     memory allocated for the topic. Supported values are multiples of 1024 up to
-    10240, if `enable_partitioning` is enabled then 16 partitions will be created
-    per GB, making the maximum possible topic size 163840 (10240 * 16).
+    5120, if `enable_partitioning` is enabled then 16 partitions will be created
+    per GB, making the maximum possible topic size 81920 (5120 * 16).
 
 * `requires_duplicate_detection` - (Optional) Boolean flag which controls whether
     the Topic requires duplicate detection. Defaults to false. Changing this forces


### PR DESCRIPTION
This test was previously passing but the limit appears to have been reduced
since.

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMServiceBusTopic_enableParti -timeout 120m
=== RUN   TestAccAzureRMServiceBusTopic_enablePartitioning
--- PASS: TestAccAzureRMServiceBusTopic_enablePartitioning (377.14s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	377.235s
```