### PR TITLE
command/show: show state empty if it's empty with empty modules

### DIFF
--- a/command/format_state.go
+++ b/command/format_state.go
@@ -30,7 +30,7 @@ func FormatState(opts *FormatStateOpts) string {
 	}
 
 	s := opts.State
-	if len(s.Modules) == 0 {
+	if s.Empty() {
 		return "The state file is empty. No resources are represented."
 	}
 

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -256,10 +256,26 @@ func (s *State) Empty() bool {
 	if s == nil {
 		return true
 	}
+
 	s.Lock()
 	defer s.Unlock()
 
-	return len(s.Modules) == 0
+	// Prune so we we remove empty modules
+	s.prune()
+
+	// No modules? Empty
+	if len(s.Modules) == 0 {
+		return true
+	}
+
+	// Any non-empty modules? Not empty
+	for _, m := range s.Modules {
+		if !m.Empty() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // HasResources returns true if the state contains any resources.
@@ -914,6 +930,21 @@ type ModuleState struct {
 
 func (s *ModuleState) Lock()   { s.mu.Lock() }
 func (s *ModuleState) Unlock() { s.mu.Unlock() }
+
+// Empty returns true if this module state is empty and holds no values.
+func (m *ModuleState) Empty() bool {
+	if m == nil {
+		return true
+	}
+
+	// Prune so we're viewing a minimal case
+	m.prune()
+
+	m.Lock()
+	defer m.Unlock()
+
+	return len(m.Outputs) == 0 && len(m.Resources) == 0
+}
 
 // Equal tests whether one module state is equal to another.
 func (m *ModuleState) Equal(other *ModuleState) bool {

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -1224,7 +1224,7 @@ func TestStateEmpty(t *testing.T) {
 					&ModuleState{},
 				},
 			},
-			false,
+			true,
 		},
 	}
 
@@ -1282,7 +1282,7 @@ func TestStateHasResources(t *testing.T) {
 					},
 				},
 			},
-			true,
+			false,
 		},
 	}
 


### PR DESCRIPTION
Fixes #3576

This changes the state.Empty() logic to be a little more robust and
check if modules are empty rather than just checking if there are zero
in the state.

There were some tests in Terraform testing the opposite of this in some
cases and I think they're just wrong and changed them since it caused no
other Context tests to fail. If acc tests pass tonight I think its safe
to say that it doesn't make sense.
