### PR TITLE
provider/aws: Add support for `AutoMinorVersionUpgrade` to aws_elasticache_replication_group resource.

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -26,6 +26,8 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
 				),
 			},
 		},
@@ -48,6 +50,8 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "replication_group_description", "test description"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
 				),
 			},
 
@@ -59,6 +63,8 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "replication_group_description", "updated description"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "true"),
 				),
 			},
 		},
@@ -141,6 +147,8 @@ func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
 				),
 			},
 		},
@@ -353,6 +361,7 @@ resource "aws_elasticache_replication_group" "bar" {
     parameter_group_name = "default.redis3.2"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
+    auto_minor_version_upgrade = false
 }`, rName, rName, rName)
 }
 
@@ -431,6 +440,7 @@ resource "aws_elasticache_replication_group" "bar" {
     parameter_group_name = "default.redis3.2"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
+    auto_minor_version_upgrade = true
 }`, rName, rName, rName)
 }
 
@@ -513,6 +523,7 @@ resource "aws_elasticache_replication_group" "bar" {
     security_group_ids = ["${aws_security_group.bar.id}"]
     parameter_group_name = "default.redis3.2"
     availability_zones = ["us-west-2a"]
+    auto_minor_version_upgrade = false
 }
 
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))

--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
  If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource
 * `node_type` - (Required) The compute and memory capacity of the nodes in the node group.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. Defaults to `false`.
+* `auto_minor_version_upgrade` - (Optional) Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. Defaults to `true`.
 * `availability_zones` - (Optional) A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important.
 * `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group.
 * `parameter_group_name` - (Optional) The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.


### PR DESCRIPTION
This commit adds an ability to modify the `AutoMinorVersionUpgrade` property of the
Replication Group (which is enabled by default) accordingly.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>