### PR TITLE
provider/aws: Refresh aws_autoscaling_schedule from state on 404

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_schedule.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_schedule.go
@@ -113,9 +113,15 @@ func resourceAwsAutoscalingScheduleCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceAwsAutoscalingScheduleRead(d *schema.ResourceData, meta interface{}) error {
-	sa, err := resourceAwsASGScheduledActionRetrieve(d, meta)
+	sa, err, exists := resourceAwsASGScheduledActionRetrieve(d, meta)
 	if err != nil {
 		return err
+	}
+
+	if !exists {
+		log.Printf("Error retrieving Autoscaling Scheduled Actions. Removing from state")
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("autoscaling_group_name", sa.AutoScalingGroupName)
@@ -153,7 +159,7 @@ func resourceAwsAutoscalingScheduleDelete(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceAwsASGScheduledActionRetrieve(d *schema.ResourceData, meta interface{}) (*autoscaling.ScheduledUpdateGroupAction, error) {
+func resourceAwsASGScheduledActionRetrieve(d *schema.ResourceData, meta interface{}) (*autoscaling.ScheduledUpdateGroupAction, error, bool) {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
 
 	params := &autoscaling.DescribeScheduledActionsInput{
@@ -164,13 +170,13 @@ func resourceAwsASGScheduledActionRetrieve(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Describing Autoscaling Scheduled Action: %+v", params)
 	actions, err := autoscalingconn.DescribeScheduledActions(params)
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving Autoscaling Scheduled Actions: %s", err)
+		return nil, fmt.Errorf("Error retrieving Autoscaling Scheduled Actions: %s", err), false
 	}
 
 	if len(actions.ScheduledUpdateGroupActions) != 1 ||
 		*actions.ScheduledUpdateGroupActions[0].ScheduledActionName != d.Id() {
-		return nil, fmt.Errorf("Unable to find Autoscaling Scheduled Action: %#v", actions.ScheduledUpdateGroupActions)
+		return nil, nil, false
 	}
 
-	return actions.ScheduledUpdateGroupActions[0], nil
+	return actions.ScheduledUpdateGroupActions[0], nil, true
 }


### PR DESCRIPTION
Fixes #9654

Before the fix, I created an ASG with a schedule on it. Went to the AWS
console and deleted the schedule. A terraform plan looked as follows:

```
% terraform plan
    See https://www.terraform.io/docs/internals/internal-plugins.html
    Refreshing Terraform state in-memory prior to plan...
    The refreshed state will be used to calculate this plan, but
    will not be persisted to local or remote state storage.

    aws_launch_configuration.foobar: Refreshing state... (ID:
    terraform-test-foobar5)
    aws_autoscaling_group.foobar: Refreshing state... (ID:
    terraform-test-foobar5)
    aws_autoscaling_schedule.foobar: Refreshing state... (ID: foobar)
    Error refreshing state: 1 error(s) occurred:

    * aws_autoscaling_schedule.foobar: Unable to find Autoscaling
    * Scheduled Action: []*autoscaling.ScheduledUpdateGroupAction(nil)
```

After the fix:

```
terraform plan                                                                                                                           1 ↵
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

aws_launch_configuration.foobar: Refreshing state... (ID: terraform-test-foobar5)
aws_autoscaling_group.foobar: Refreshing state... (ID: terraform-test-foobar5)
aws_autoscaling_schedule.foobar: Refreshing state... (ID: foobar)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ aws_autoscaling_schedule.foobar
    arn:                    "<computed>"
    autoscaling_group_name: "terraform-test-foobar5"
    desired_capacity:       "0"
    end_time:               "2018-01-16T13:00:00Z"
    max_size:               "0"
    min_size:               "0"
    recurrence:             "<computed>"
    scheduled_action_name:  "foobar"
    start_time:             "2018-01-16T07:00:00Z"

Plan: 1 to add, 0 to change, 0 to destroy.
```

Tests run as expected:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAutoscalingSchedule_'                                               2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/27 17:45:19 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAutoscalingSchedule_ -timeout 120m
=== RUN   TestAccAWSAutoscalingSchedule_basic
--- PASS: TestAccAWSAutoscalingSchedule_basic (140.94s)
=== RUN   TestAccAWSAutoscalingSchedule_disappears
--- PASS: TestAccAWSAutoscalingSchedule_disappears (179.17s)
=== RUN   TestAccAWSAutoscalingSchedule_recurrence
--- PASS: TestAccAWSAutoscalingSchedule_recurrence (186.72s)
=== RUN   TestAccAWSAutoscalingSchedule_zeroValues
--- PASS: TestAccAWSAutoscalingSchedule_zeroValues (167.73s)
PASS
ok	github.com/hashicorp/terraform/builtin/providers/aws	674.530s
```