### PR TITLE
providers/google: Add subnetwork_project field to enable cross-project networking

### DIFF
--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -407,6 +408,31 @@ func TestAccComputeInstance_subnet_custom(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeInstance_subnet_custom(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						"google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasSubnet(&instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_subnet_xpn(t *testing.T) {
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
+	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")
+	if xpn_host == "" {
+		t.Fatal("GOOGLE_XPN_HOST_PROJECT must be set for TestAccComputeInstance_subnet_xpn test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstance_subnet_xpn(instanceName, xpn_host),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						"google_compute_instance.foobar", &instance),
@@ -1037,6 +1063,40 @@ func testAccComputeInstance_subnet_custom(instance string) string {
 		}
 
 	}`, acctest.RandString(10), acctest.RandString(10), instance)
+}
+
+func testAccComputeInstance_subnet_xpn(instance string, xpn_host string) string {
+	return fmt.Sprintf(`
+	resource "google_compute_network" "inst-test-network" {
+		name = "inst-test-network-%s"
+		auto_create_subnetworks = false
+		project = "%s"
+	}
+
+	resource "google_compute_subnetwork" "inst-test-subnetwork" {
+		name = "inst-test-subnetwork-%s"
+		ip_cidr_range = "10.0.0.0/16"
+		region = "us-central1"
+		network = "${google_compute_network.inst-test-network.self_link}"
+		project = "%s"
+	}
+
+	resource "google_compute_instance" "foobar" {
+		name = "%s"
+		machine_type = "n1-standard-1"
+		zone = "us-central1-a"
+
+		disk {
+			image = "debian-8-jessie-v20160803"
+		}
+
+		network_interface {
+			subnetwork = "${google_compute_subnetwork.inst-test-subnetwork.name}"
+			subnetwork_project = "${google_compute_subnetwork.inst-test-subnetwork.project}"
+			access_config {	}
+		}
+
+	}`, acctest.RandString(10), xpn_host, acctest.RandString(10), xpn_host, instance)
 }
 
 func testAccComputeInstance_address_auto(instance string) string {

--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -1065,7 +1065,7 @@ func testAccComputeInstance_subnet_custom(instance string) string {
 	}`, acctest.RandString(10), acctest.RandString(10), instance)
 }
 
-func testAccComputeInstance_subnet_xpn(instance string, xpn_host string) string {
+func testAccComputeInstance_subnet_xpn(instance, xpn_host string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "inst-test-network" {
 		name = "inst-test-network-%s"

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -136,9 +136,12 @@ The `network_interface` block supports:
 * `network` - (Optional) The name or self_link of the network to attach this interface to.
     Either `network` or `subnetwork` must be provided.
 
-*  `subnetwork` - (Optional) the name of the subnetwork to attach this interface
+*  `subnetwork` - (Optional) The name of the subnetwork to attach this interface
     to. The subnetwork must exist in the same region this instance will be
     created in. Either `network` or `subnetwork` must be provided.
+
+*  `subnetwork_project` - (Optional) The project in which the subnetwork belongs.
+   If it is not provided, the provider project is used.
 
 * `address` - (Optional) The private IP address to assign to the instance. If
     empty, the address will be automatically assigned.


### PR DESCRIPTION
This change allows compute instances to be configured with a subnetwork that is part of a different project from the instance.

Projects using this new field must be set up for cross-project networking using the gcloud alpha API: https://cloud.google.com/sdk/gcloud/reference/alpha/compute/xpn/.

The new acceptance test requires an additional environment variable, GOOGLE_XPN_HOST_PROJECT, to be set to a project that is enabled as an XPN host. GOOGLE_PROJECT must be added as an associated XPN project to the XPN host project. The credentials used while running the test must have compute edit permissions on the xpn host project.

```
$ make testacc TEST=./builtin/providers/google GOOGLE_PROJECT=pod5-service-2 GOOGLE_REGION=us-central1 GOOGLE_XPN_HOST_PROJECT=pod5-xpn-host TESTARGS='-run=TestAccComputeInstance_subnet_xpn'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/27 10:38:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeInstance_subnet_xpn -timeout 120m
=== RUN   TestAccComputeInstance_subnet_xpn
--- PASS: TestAccComputeInstance_subnet_xpn (145.81s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/google 145.893s
```

cc @evandbrown 
