### PR TITLE
Fixed comma-separated github issues in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ BUG FIXES:
 FEATURES:
 
  * **New Data Source:** `scaleway_bootsscript`. ([#9386](https://github.com/hashicorp/terraform/issues/9386))
- * **New Data Source:** `scaleway_image`. [GH9386]
+ * **New Data Source:** `scaleway_image`. [GH-9386]
 
 IMPROVEMENTS:
 

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,6 +24,6 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-$SED 's/\[GH-([0-9]+)\]/\(\[#\1\]\(https:\/\/github.com\/hashicorp\/terraform\/issues\/\1\)\)/g' CHANGELOG.md
+$SED 's/GH-([0-9]+)/\[#\1\]\(https:\/\/github.com\/hashicorp\/terraform\/issues\/\1\)/g' -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 
 rm CHANGELOG.md.bak


### PR DESCRIPTION
This is small follow-up for https://github.com/hashicorp/terraform/pull/9651

It will handle comma-separated links like these:
`[GH-2052, GH-2053, GH-2372, GH-2380, GH-2394, GH-2515, GH-2530, GH-2562]`

/cc @catsby 