### PR TITLE
bump softlayer-go dependency to v0.7.0

### DIFF
--- a/vendor/github.com/cloudfoundry/bosh-utils/LICENSE
+++ b/vendor/github.com/cloudfoundry/bosh-utils/LICENSE
@@ -1,0 +1,176 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/vendor/github.com/cloudfoundry/bosh-utils/NOTICE
+++ b/vendor/github.com/cloudfoundry/bosh-utils/NOTICE
@@ -1,0 +1,15 @@
+bosh-utils
+
+Copyright (c) 2015 Pivotal Software, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/cloudfoundry/bosh-utils/logger/async.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/logger/async.go
@@ -1,0 +1,136 @@
+package logger
+
+import (
+	"errors"
+	"io"
+	"log"
+	"os"
+	"time"
+)
+
+type asyncWriter struct {
+	w       io.Writer
+	queue   chan []byte
+	flushCh chan chan<- struct{}
+}
+
+func newAsyncWriter(w io.Writer) *asyncWriter {
+	aw := &asyncWriter{
+		w:       w,
+		queue:   make(chan []byte, 512),
+		flushCh: make(chan chan<- struct{}),
+	}
+	go aw.doWork()
+	return aw
+}
+
+func (w *asyncWriter) Flush() error {
+	ch := make(chan struct{})
+	w.flushCh <- ch
+	<-ch
+	return nil
+}
+
+func (w *asyncWriter) Write(p []byte) (int, error) {
+	b := make([]byte, len(p))
+	copy(b, p)
+	w.queue <- b
+	return len(p), nil
+}
+
+func (w *asyncWriter) doFlush() {
+	n := len(w.queue)
+	for i := 0; i < n; i++ {
+		select {
+		case p := <-w.queue:
+			w.w.Write(p)
+		default:
+		}
+	}
+}
+
+func (w *asyncWriter) doWork() {
+	for {
+		select {
+		case c := <-w.flushCh:
+			w.doFlush()
+			close(c)
+		case p := <-w.queue:
+			w.w.Write(p)
+		}
+	}
+}
+
+type asyncLogger struct {
+	out *asyncWriter
+	err *asyncWriter
+	log *logger
+}
+
+func (l *asyncLogger) Flush() error {
+	l.out.Flush()
+	l.err.Flush()
+	return nil
+}
+
+func (l *asyncLogger) FlushTimeout(d time.Duration) error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- l.Flush()
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(d):
+		return errors.New("logger: flush timed out after " + d.String())
+	}
+}
+
+func NewAsyncWriterLogger(level LogLevel, out, err io.Writer) Logger {
+	wout := newAsyncWriter(out)
+	werr := newAsyncWriter(err)
+	return &asyncLogger{
+		out: wout,
+		err: werr,
+		log: &logger{
+			level: level,
+			out:   log.New(wout, "", log.LstdFlags),
+			err:   log.New(werr, "", log.LstdFlags),
+		},
+	}
+}
+
+func (l *asyncLogger) Debug(tag, msg string, args ...interface{}) {
+	l.log.Debug(tag, msg, args...)
+}
+
+func (l *asyncLogger) DebugWithDetails(tag, msg string, args ...interface{}) {
+	l.log.DebugWithDetails(tag, msg, args...)
+}
+
+func (l *asyncLogger) Info(tag, msg string, args ...interface{}) {
+	l.log.Info(tag, msg, args...)
+}
+
+func (l *asyncLogger) Warn(tag, msg string, args ...interface{}) {
+	l.log.Warn(tag, msg, args...)
+}
+
+func (l *asyncLogger) Error(tag, msg string, args ...interface{}) {
+	l.log.Error(tag, msg, args...)
+}
+
+func (l *asyncLogger) ErrorWithDetails(tag, msg string, args ...interface{}) {
+	l.log.ErrorWithDetails(tag, msg, args...)
+}
+
+func (l *asyncLogger) HandlePanic(tag string) {
+	if l.log.recoverPanic(tag) {
+		l.FlushTimeout(time.Second * 30)
+		os.Exit(2)
+	}
+}
+
+func (l *asyncLogger) ToggleForcedDebug() {
+	l.log.ToggleForcedDebug()
+}

--- a/vendor/github.com/cloudfoundry/bosh-utils/logger/logger.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/logger/logger.go
@@ -1,0 +1,181 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+)
+
+type LogLevel int
+
+const (
+	LevelDebug LogLevel = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+	LevelNone LogLevel = 99
+)
+
+var levels = map[string]LogLevel{
+	"DEBUG": LevelDebug,
+	"INFO":  LevelInfo,
+	"WARN":  LevelWarn,
+	"ERROR": LevelError,
+	"NONE":  LevelNone,
+}
+var levelKeys = []string{"DEBUG", "INFO", "WARN", "ERROR", "NONE"}
+
+func Levelify(levelString string) (LogLevel, error) {
+	upperLevelString := strings.ToUpper(levelString)
+	level, ok := levels[upperLevelString]
+	if !ok {
+		expected := strings.Join(levelKeys, ", ")
+		return level, fmt.Errorf("Unknown LogLevel string '%s', expected one of [%s]", levelString, expected)
+	}
+	return level, nil
+}
+
+type Logger interface {
+	Debug(tag, msg string, args ...interface{})
+	DebugWithDetails(tag, msg string, args ...interface{})
+	Info(tag, msg string, args ...interface{})
+	Warn(tag, msg string, args ...interface{})
+	Error(tag, msg string, args ...interface{})
+	ErrorWithDetails(tag, msg string, args ...interface{})
+	HandlePanic(tag string)
+	ToggleForcedDebug()
+	Flush() error
+	FlushTimeout(time.Duration) error
+}
+
+type logger struct {
+	level       LogLevel
+	out         *log.Logger
+	err         *log.Logger
+	forcedDebug bool
+	outMu       sync.Mutex
+	errMu       sync.Mutex
+}
+
+func New(level LogLevel, out, err *log.Logger) Logger {
+	return &logger{
+		level: level,
+		out:   out,
+		err:   err,
+	}
+}
+
+func NewLogger(level LogLevel) Logger {
+	return NewWriterLogger(level, os.Stdout, os.Stderr)
+}
+
+func NewWriterLogger(level LogLevel, out, err io.Writer) Logger {
+	return New(
+		level,
+		log.New(out, "", log.LstdFlags),
+		log.New(err, "", log.LstdFlags),
+	)
+}
+
+func (l *logger) Flush() error                       { return nil }
+func (l *logger) FlushTimeout(_ time.Duration) error { return nil }
+
+func (l *logger) Debug(tag, msg string, args ...interface{}) {
+	if l.level > LevelDebug && !l.forcedDebug {
+		return
+	}
+
+	msg = "DEBUG - " + msg
+	l.outPrintf(tag, msg, args...)
+}
+
+// DebugWithDetails will automatically change the format of the message
+// to insert a block of text after the log
+func (l *logger) DebugWithDetails(tag, msg string, args ...interface{}) {
+	msg = msg + "\n********************\n%s\n********************"
+	l.Debug(tag, msg, args...)
+}
+
+func (l *logger) Info(tag, msg string, args ...interface{}) {
+	if l.level > LevelInfo && !l.forcedDebug {
+		return
+	}
+
+	msg = "INFO - " + msg
+	l.outPrintf(tag, msg, args...)
+}
+
+func (l *logger) Warn(tag, msg string, args ...interface{}) {
+	if l.level > LevelWarn && !l.forcedDebug {
+		return
+	}
+
+	msg = "WARN - " + msg
+	l.errPrintf(tag, msg, args...)
+}
+
+func (l *logger) Error(tag, msg string, args ...interface{}) {
+	if l.level > LevelError && !l.forcedDebug {
+		return
+	}
+
+	msg = "ERROR - " + msg
+	l.errPrintf(tag, msg, args...)
+}
+
+// ErrorWithDetails will automatically change the format of the message
+// to insert a block of text after the log
+func (l *logger) ErrorWithDetails(tag, msg string, args ...interface{}) {
+	msg = msg + "\n********************\n%s\n********************"
+	l.Error(tag, msg, args...)
+}
+
+func (l *logger) recoverPanic(tag string) (didPanic bool) {
+	if e := recover(); e != nil {
+		var msg string
+		switch obj := e.(type) {
+		case string:
+			msg = obj
+		case fmt.Stringer:
+			msg = obj.String()
+		case error:
+			msg = obj.Error()
+		default:
+			msg = fmt.Sprintf("%#v", obj)
+		}
+		l.ErrorWithDetails(tag, "Panic: %s", msg, debug.Stack())
+		return true
+	}
+	return false
+}
+
+func (l *logger) HandlePanic(tag string) {
+	if l.recoverPanic(tag) {
+		os.Exit(2)
+	}
+}
+
+func (l *logger) ToggleForcedDebug() {
+	l.forcedDebug = !l.forcedDebug
+}
+
+func (l *logger) errPrintf(tag, msg string, args ...interface{}) {
+	s := fmt.Sprintf(msg, args...)
+	l.errMu.Lock()
+	l.err.SetPrefix("[" + tag + "] ")
+	l.err.Output(2, s)
+	l.errMu.Unlock()
+}
+
+func (l *logger) outPrintf(tag, msg string, args ...interface{}) {
+	s := fmt.Sprintf(msg, args...)
+	l.outMu.Lock()
+	l.out.SetPrefix("[" + tag + "] ")
+	l.out.Output(2, s)
+	l.outMu.Unlock()
+}

--- a/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/attempt_retry_strategy.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/attempt_retry_strategy.go
@@ -1,0 +1,52 @@
+package retrystrategy
+
+import (
+	"time"
+
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+)
+
+type attemptRetryStrategy struct {
+	maxAttempts int
+	delay       time.Duration
+	retryable   Retryable
+	logger      boshlog.Logger
+	logTag      string
+}
+
+func NewAttemptRetryStrategy(
+	maxAttempts int,
+	delay time.Duration,
+	retryable Retryable,
+	logger boshlog.Logger,
+) RetryStrategy {
+	return &attemptRetryStrategy{
+		maxAttempts: maxAttempts,
+		delay:       delay,
+		retryable:   retryable,
+		logger:      logger,
+		logTag:      "attemptRetryStrategy",
+	}
+}
+
+func (s *attemptRetryStrategy) Try() error {
+	var err error
+	var isRetryable bool
+
+	for i := 0; i < s.maxAttempts; i++ {
+		s.logger.Debug(s.logTag, "Making attempt #%d", i)
+
+		isRetryable, err = s.retryable.Attempt()
+		if err == nil {
+			return nil
+		}
+
+		if !isRetryable {
+			return err
+		}
+
+		time.Sleep(s.delay)
+	}
+
+	return err
+}

--- a/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/retry_strategy.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/retry_strategy.go
@@ -1,0 +1,23 @@
+package retrystrategy
+
+type RetryStrategy interface {
+	Try() error
+}
+
+type Retryable interface {
+	Attempt() (bool, error)
+}
+
+type retryable struct {
+	attemptFunc func() (bool, error)
+}
+
+func (r *retryable) Attempt() (bool, error) {
+	return r.attemptFunc()
+}
+
+func NewRetryable(attemptFunc func() (bool, error)) Retryable {
+	return &retryable{
+		attemptFunc: attemptFunc,
+	}
+}

--- a/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/timeout_retry_strategy.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/timeout_retry_strategy.go
@@ -1,0 +1,67 @@
+package retrystrategy
+
+import (
+	"time"
+
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+)
+
+type Clock interface {
+	Sleep(time.Duration)
+	Now() time.Time
+}
+
+type timeoutRetryStrategy struct {
+	timeout     time.Duration
+	delay       time.Duration
+	retryable   Retryable
+	timeService Clock
+	logger      boshlog.Logger
+	logTag      string
+}
+
+func NewTimeoutRetryStrategy(
+	timeout time.Duration,
+	delay time.Duration,
+	retryable Retryable,
+	timeService Clock,
+	logger boshlog.Logger,
+) RetryStrategy {
+	return &timeoutRetryStrategy{
+		timeout:     timeout,
+		delay:       delay,
+		retryable:   retryable,
+		timeService: timeService,
+		logger:      logger,
+		logTag:      "timeoutRetryStrategy",
+	}
+}
+
+func (s *timeoutRetryStrategy) Try() error {
+	var err error
+	var isRetryable bool
+
+	now := s.timeService.Now()
+	deadlineMinusDelay := now.Add(s.timeout).Add(-1 * s.delay)
+
+	for i := 0; true; i++ {
+		s.logger.Debug(s.logTag, "Making attempt #%d", i)
+		isRetryable, err = s.retryable.Attempt()
+		if err == nil {
+			return nil
+		}
+
+		if !isRetryable {
+			return err
+		}
+
+		now = s.timeService.Now()
+		if now.After(deadlineMinusDelay) {
+			return err
+		}
+
+		s.timeService.Sleep(s.delay)
+	}
+
+	return err
+}

--- a/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/unlimited_retry_strategy.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/retrystrategy/unlimited_retry_strategy.go
@@ -1,0 +1,44 @@
+package retrystrategy
+
+import (
+	"time"
+
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+)
+
+type unlimitedRetryStrategy struct {
+	maxAttempts int
+	delay       time.Duration
+	retryable   Retryable
+	logger      boshlog.Logger
+	logTag      string
+}
+
+func NewUnlimitedRetryStrategy(
+	delay time.Duration,
+	retryable Retryable,
+	logger boshlog.Logger,
+) RetryStrategy {
+	return &unlimitedRetryStrategy{
+		delay:     delay,
+		retryable: retryable,
+		logger:    logger,
+		logTag:    "unlimitedRetryStrategy",
+	}
+}
+
+func (s *unlimitedRetryStrategy) Try() error {
+	var err error
+	var isRetryable bool
+	for i := 0; ; i++ {
+		s.logger.Debug(s.logTag, "Making attempt #%d", i)
+		isRetryable, err = s.retryable.Attempt()
+		if err == nil {
+			return nil
+		}
+		if !isRetryable {
+			return err
+		}
+		time.Sleep(s.delay)
+	}
+}

--- a/vendor/github.com/maximilien/softlayer-go/client/softlayer_client.go
+++ b/vendor/github.com/maximilien/softlayer-go/client/softlayer_client.go
@@ -3,15 +3,17 @@ package client
 import (
 	"errors"
 	"fmt"
+	"os"
 
-	services "github.com/maximilien/softlayer-go/services"
-	softlayer "github.com/maximilien/softlayer-go/softlayer"
+	"github.com/maximilien/softlayer-go/services"
+	"github.com/maximilien/softlayer-go/softlayer"
 )
 
 const (
-	SOFTLAYER_API_URL  = "api.softlayer.com/rest/v3"
 	TEMPLATE_ROOT_PATH = "templates"
 )
+
+var sl_endpoint_servers = [4]string{"api.softlayer.com", "api.service.softlayer.com", "66.228.119.120", "10.0.80.88"}
 
 type SoftLayerClient struct {
 	HttpClient softlayer.HttpClient
@@ -21,7 +23,7 @@ type SoftLayerClient struct {
 
 func NewSoftLayerClient(username, apiKey string) *SoftLayerClient {
 	slc := &SoftLayerClient{
-		HttpClient: NewHttpsClient(username, apiKey, SOFTLAYER_API_URL, TEMPLATE_ROOT_PATH),
+		HttpClient: NewHttpsClient(username, apiKey, GetSLApiEndpoint(), TEMPLATE_ROOT_PATH),
 
 		softLayerServices: map[string]softlayer.Service{},
 	}
@@ -170,6 +172,24 @@ func (slc *SoftLayerClient) GetSoftLayer_Dns_Domain_ResourceRecord_Service() (so
 	}
 
 	return slService.(softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service), nil
+}
+
+func GetSLApiEndpoint() string {
+	sl_api_endpoint := os.Getenv("SL_API_ENDPOINT")
+	var included bool = false
+
+	for _, server := range sl_endpoint_servers {
+		if server == sl_api_endpoint {
+			included = true
+			break
+		}
+	}
+	if !included {
+		sl_api_endpoint = "api.softlayer.com"
+	}
+	softlayer_api_url := fmt.Sprintf("%s/rest/v3", sl_api_endpoint)
+
+	return softlayer_api_url
 }
 
 //Private methods

--- a/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_container_product_order.go
+++ b/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_container_product_order.go
@@ -29,14 +29,15 @@ type SoftLayer_Container_Product_Order struct {
 
 //http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi
 type SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi struct {
-	ComplexType   string                                  `json:"complexType"`
-	Location      string                                  `json:"location,omitempty"`
-	PackageId     int                                     `json:"packageId"`
-	Prices        []SoftLayer_Product_Item_Price          `json:"prices,omitempty"`
-	VirtualGuests []VirtualGuest                          `json:"virtualGuests,omitempty"`
-	Properties    []Property                              `json:"properties,omitempty"`
-	Quantity      int                                     `json:"quantity,omitempty"`
-	OsFormatType  SoftLayer_Network_Storage_Iscsi_OS_Type `json:"osFormatType,omitempty"`
+	ComplexType      string                                  `json:"complexType"`
+	Location         string                                  `json:"location,omitempty"`
+	PackageId        int                                     `json:"packageId"`
+	Prices           []SoftLayer_Product_Item_Price          `json:"prices,omitempty"`
+	VirtualGuests    []VirtualGuest                          `json:"virtualGuests,omitempty"`
+	Properties       []Property                              `json:"properties,omitempty"`
+	Quantity         int                                     `json:"quantity,omitempty"`
+	OsFormatType     SoftLayer_Network_Storage_Iscsi_OS_Type `json:"osFormatType,omitempty"`
+	UseHourlyPricing bool                                    `json:"useHourlyPricing,omitempty"`
 }
 
 //http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade

--- a/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_hardware.go
+++ b/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_hardware.go
@@ -8,6 +8,10 @@ type SoftLayer_Hardware_Template_Parameters struct {
 	Parameters []SoftLayer_Hardware_Template `json:"parameters"`
 }
 
+type SoftLayer_Hardware_Parameters struct {
+	Parameters []SoftLayer_Hardware `json:"parameters"`
+}
+
 type SoftLayer_Hardware_Template struct {
 	Hostname                     string `json:"hostname"`
 	Domain                       string `json:"domain"`
@@ -20,14 +24,27 @@ type SoftLayer_Hardware_Template struct {
 }
 
 type SoftLayer_Hardware struct {
-	BareMetalInstanceFlag int        `json:"bareMetalInstanceFlag"`
-	Domain                string     `json:"domain"`
-	Hostname              string     `json:"hostname"`
-	Id                    int        `json:"id"`
-	HardwareStatusId      int        `json:"hardwareStatusId"`
-	ProvisionDate         *time.Time `json:"provisionDate"`
-	GlobalIdentifier      string     `json:"globalIdentifier"`
-	PrimaryIpAddress      string     `json:"primaryIpAddress"`
+	BareMetalInstanceFlag    int        `json:"bareMetalInstanceFlag"`
+	Domain                   string     `json:"domain"`
+	Hostname                 string     `json:"hostname"`
+	Id                       int        `json:"id"`
+	HardwareStatusId         int        `json:"hardwareStatusId"`
+	ProvisionDate            *time.Time `json:"provisionDate"`
+	GlobalIdentifier         string     `json:"globalIdentifier"`
+	PrimaryIpAddress         string     `json:"primaryIpAddress"`
+	PrimaryBackendIpAddress  string     `json:"primaryBackendIpAddress"`
+	FullyQualifiedDomainName string     `json:"fullyQualifiedDomainName,omitempty"`
 
 	OperatingSystem *SoftLayer_Operating_System `json:"operatingSystem"`
+
+	Location   *SoftLayer_Location `json:"location"`
+	Datacenter *SoftLayer_Location `json:"datacenter"`
+}
+
+type SoftLayer_Hardware_String_Parameters struct {
+	Parameters []string `json:"parameters"`
+}
+
+type SoftLayer_Hardware_NetworkStorage_Parameters struct {
+	Parameters SoftLayer_Network_Storage `json:"parameters"`
 }

--- a/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_product_item_price.go
+++ b/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_product_item_price.go
@@ -1,10 +1,13 @@
 package data_types
 
+import "strconv"
+
 type SoftLayer_Product_Item_Price struct {
-	Id              int        `json:"id"`
-	LocationGroupId int        `json:"locationGroupId"`
-	Categories      []Category `json:"categories,omitempty"`
-	Item            *Item      `json:"item,omitempty"`
+	Id              int         `json:"id"`
+	LocationGroupId int         `json:"locationGroupId"`
+	Categories      []Category  `json:"categories,omitempty"`
+	Item            *Item       `json:"item,omitempty"`
+	Attributes      *Attributes `json:"attributes,omitempty"`
 }
 
 type Item struct {
@@ -16,4 +19,31 @@ type Item struct {
 type Category struct {
 	Id           int    `json:"id"`
 	CategoryCode string `json:"categoryCode"`
+}
+
+type Attributes struct {
+	Value string `json:"value"`
+}
+
+type SoftLayer_Product_Item_Price_Sorted_Data []SoftLayer_Product_Item_Price
+
+func (sorted_data SoftLayer_Product_Item_Price_Sorted_Data) Len() int {
+	return len(sorted_data)
+}
+
+func (sorted_data SoftLayer_Product_Item_Price_Sorted_Data) Swap(i, j int) {
+	sorted_data[i], sorted_data[j] = sorted_data[j], sorted_data[i]
+}
+
+func (sorted_data SoftLayer_Product_Item_Price_Sorted_Data) Less(i, j int) bool {
+	value1, err := strconv.Atoi(sorted_data[i].Item.Capacity)
+	if err != nil {
+		return false
+	}
+	value2, err := strconv.Atoi(sorted_data[j].Item.Capacity)
+	if err != nil {
+		return false
+	}
+
+	return value1 < value2
 }

--- a/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_virtual_guest_block_device_template_group.go
+++ b/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_virtual_guest_block_device_template_group.go
@@ -8,11 +8,11 @@ type SoftLayer_Virtual_Guest_Block_Device_Template_Group struct {
 	Id               int        `json:"id"`
 	Name             string     `json:"name"`
 	Note             string     `json:"note"`
-	ParentId         *int       `json:"parentId"`
+	ParentId         int        `json:"parentId"`
 	PublicFlag       int        `json:"publicFlag"`
 	StatusId         int        `json:"statusId"`
 	Summary          string     `json:"summary"`
-	TransactionId    *int       `json:"transactionId"`
+	TransactionId    int        `json:"transactionId"`
 	UserRecordId     int        `json:"userRecordId"`
 	GlobalIdentifier string     `json:"globalIdentifier"`
 }

--- a/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_virtual_guest_network_component.go
+++ b/vendor/github.com/maximilien/softlayer-go/data_types/softlayer_virtual_guest_network_component.go
@@ -1,0 +1,19 @@
+package data_types
+
+import "time"
+
+type SoftLayer_Virtual_Guest_Network_Component struct {
+	CreateDate       *time.Time `json:"createDate,omitempty"`
+	GuestId          int        `json:"guestId,omitempty"`
+	Id               int        `json:"id,omitempty"`
+	MacAddress       string     `json:"macAddress,omitempty"`
+	MaxSpeed         int        `json:"maxSpeed,omitempty"`
+	ModifyDate       *time.Time `json:"modifyDate,omitempty"`
+	Name             string     `json:"name,omitempty"`
+	NetworkId        int        `json:"networkId,omitempty"`
+	Port             int        `json:"port,omitempty"`
+	PrimaryIpAddress string     `json:"primaryIpAddress,omitempty"`
+	Speed            int        `json:"speed,omitempty"`
+	Status           string     `json:"status,omitempty"`
+	Uuid             string     `json:"uuid,omitempty"`
+}

--- a/vendor/github.com/maximilien/softlayer-go/services/softLayer_account.go
+++ b/vendor/github.com/maximilien/softlayer-go/services/softLayer_account.go
@@ -397,7 +397,7 @@ func (slas *softLayer_Account_Service) GetHardware() ([]datatypes.SoftLayer_Hard
 	return hardwares, nil
 }
 
-func (slas *softLayer_Account_Service) GetDnsDomains() ([]datatypes.SoftLayer_Dns_Domain, error) {
+func (slas *softLayer_Account_Service) GetDomains() ([]datatypes.SoftLayer_Dns_Domain, error) {
 	path := fmt.Sprintf("%s/%s", slas.GetName(), "getDomains.json")
 	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
 	if err != nil {

--- a/vendor/github.com/maximilien/softlayer-go/services/softLayer_virtual_guest_block_device_template_group.go
+++ b/vendor/github.com/maximilien/softlayer-go/services/softLayer_virtual_guest_block_device_template_group.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	common "github.com/maximilien/softlayer-go/common"
 	datatypes "github.com/maximilien/softlayer-go/data_types"
@@ -400,17 +401,12 @@ func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) Set
 }
 
 func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) CreatePublicArchiveTransaction(id int, groupName string, summary string, note string, locations []datatypes.SoftLayer_Location) (int, error) {
-	locationIdsArray := []int{}
-	for _, location := range locations {
-		locationIdsArray = append(locationIdsArray, location.Id)
-	}
-
 	groupName = url.QueryEscape(groupName)
 	summary = url.QueryEscape(summary)
 	note = url.QueryEscape(note)
 
 	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameters2{
-		Parameters: []interface{}{groupName, summary, note, locationIdsArray},
+		Parameters: []interface{}{groupName, summary, note, locations},
 	}
 
 	requestBody, err := json.Marshal(parameters)
@@ -434,4 +430,15 @@ func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) Cre
 	}
 
 	return transactionId, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetGlobalIdentifier(id int) (string, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getGlobalIdentifier.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getGlobalIdentifier, HTTP error code: '%d'", errorCode)
+		return "", errors.New(errorMessage)
+	}
+
+	return string(strings.TrimSpace(string(response))), err
 }

--- a/vendor/github.com/maximilien/softlayer-go/services/softlayer_dns_domain.go
+++ b/vendor/github.com/maximilien/softlayer-go/services/softlayer_dns_domain.go
@@ -111,3 +111,27 @@ func (sldds *softLayer_Dns_Domain_Service) DeleteObject(dnsId int) (bool, error)
 
 	return true, err
 }
+
+func (sldds *softLayer_Dns_Domain_Service) GetByDomainName(name string) ([]datatypes.SoftLayer_Dns_Domain, error) {
+	path := fmt.Sprintf("%s/%s/%s", sldds.GetName(), "getByDomainName", name)
+	responseBytes, errorCode, err := sldds.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain#getByDomainName, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Dns_Domain{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain#getByDomainName, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Dns_Domain{}, errors.New(errorMessage)
+	}
+
+	domains := []datatypes.SoftLayer_Dns_Domain{}
+	err = json.Unmarshal(responseBytes, &domains)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	return domains, nil
+}

--- a/vendor/github.com/maximilien/softlayer-go/services/softlayer_hardware.go
+++ b/vendor/github.com/maximilien/softlayer-go/services/softlayer_hardware.go
@@ -25,6 +25,33 @@ func (slhs *softLayer_Hardware_Service) GetName() string {
 	return "SoftLayer_Hardware"
 }
 
+func (slhs *softLayer_Hardware_Service) AllowAccessToNetworkStorage(id int, storage datatypes.SoftLayer_Network_Storage) (bool, error) {
+	parameters := datatypes.SoftLayer_Hardware_NetworkStorage_Parameters{
+		Parameters: storage,
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/allowAccessToNetworkStorage.json", slhs.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#allowAccessToNetworkStorage, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to allowAccessToNetworkStorage with id '%d', got '%s' as response from the API.", id, res))
+	}
+
+	return true, nil
+}
+
 func (slhs *softLayer_Hardware_Service) CreateObject(template datatypes.SoftLayer_Hardware_Template) (datatypes.SoftLayer_Hardware, error) {
 	parameters := datatypes.SoftLayer_Hardware_Template_Parameters{
 		Parameters: []datatypes.SoftLayer_Hardware_Template{
@@ -52,16 +79,25 @@ func (slhs *softLayer_Hardware_Service) CreateObject(template datatypes.SoftLaye
 		return datatypes.SoftLayer_Hardware{}, err
 	}
 
-	bare_metal_server := datatypes.SoftLayer_Hardware{}
-	err = json.Unmarshal(response, &bare_metal_server)
+	hardware := datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(response, &hardware)
 	if err != nil {
 		return datatypes.SoftLayer_Hardware{}, err
 	}
 
-	return bare_metal_server, nil
+	return hardware, nil
 }
 
-func (slhs *softLayer_Hardware_Service) GetObject(id string) (datatypes.SoftLayer_Hardware, error) {
+func (slhs *softLayer_Hardware_Service) FindByIpAddress(ipAddress string) (datatypes.SoftLayer_Hardware, error) {
+
+	ipAddressParameters := datatypes.SoftLayer_Hardware_String_Parameters{
+		Parameters: []string{ipAddress},
+	}
+
+	requestBody, err := json.Marshal(ipAddressParameters)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
 
 	objectMask := []string{
 		"bareMetalInstanceFlag",
@@ -74,9 +110,50 @@ func (slhs *softLayer_Hardware_Service) GetObject(id string) (datatypes.SoftLaye
 		"primaryIpAddress",
 		"operatingSystem.passwords.password",
 		"operatingSystem.passwords.username",
+		"datacenter.name",
+		"datacenter.longName",
+		"datacenter.id",
 	}
 
-	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%s.json", slhs.GetName(), id), objectMask, "GET", new(bytes.Buffer))
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/findByIpAddress.json", slhs.GetName()), objectMask, "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#findByIpAddress, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Hardware{}, errors.New(errorMessage)
+	}
+
+	hardware := datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(response, &hardware)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	return hardware, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetObject(id int) (datatypes.SoftLayer_Hardware, error) {
+
+	objectMask := []string{
+		"bareMetalInstanceFlag",
+		"domain",
+		"hostname",
+		"id",
+		"hardwareStatusId",
+		"provisionDate",
+		"globalIdentifier",
+		"primaryIpAddress",
+		"primaryBackendIpAddress",
+		"operatingSystem.passwords.password",
+		"operatingSystem.passwords.username",
+		"datacenter.name",
+		"datacenter.longName",
+		"datacenter.id",
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slhs.GetName(), id), objectMask, "GET", new(bytes.Buffer))
 	if err != nil {
 		return datatypes.SoftLayer_Hardware{}, err
 	}
@@ -91,11 +168,278 @@ func (slhs *softLayer_Hardware_Service) GetObject(id string) (datatypes.SoftLaye
 		return datatypes.SoftLayer_Hardware{}, err
 	}
 
-	bare_metal_server := datatypes.SoftLayer_Hardware{}
-	err = json.Unmarshal(response, &bare_metal_server)
+	hardware := datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(response, &hardware)
 	if err != nil {
 		return datatypes.SoftLayer_Hardware{}, err
 	}
 
-	return bare_metal_server, nil
+	return hardware, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetAttachedNetworkStorages(id int, nasType string) ([]datatypes.SoftLayer_Network_Storage, error) {
+
+	nasTypeParameters := datatypes.SoftLayer_Hardware_String_Parameters{
+		Parameters: []string{nasType},
+	}
+
+	requestBody, err := json.Marshal(nasTypeParameters)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	objectMask := []string{
+		"accountId",
+		"capacityGb",
+		"createDate",
+		"guestId",
+		"hardwareId",
+		"hostId",
+		"id",
+		"fullyQualifiedDomainName",
+		"nasType",
+		"notes",
+		"Password",
+		"serviceProviderId",
+		"upgradableFlag",
+		"username",
+		"billingItem.id",
+		"billingItem.orderItem.order.id",
+		"lunId",
+		"serviceResourceBackendIpAddress",
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getAttachedNetworkStorages.json", slhs.GetName(), id), objectMask, "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getAttachedNetworkStorages, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	err = slhs.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	storageList := []datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(response, &storageList)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return storageList, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetAllowedHost(id int) (datatypes.SoftLayer_Network_Storage_Allowed_Host, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getAllowedHost.json", slhs.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getAllowedHost, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, errors.New(errorMessage)
+	}
+
+	allowedHost := datatypes.SoftLayer_Network_Storage_Allowed_Host{}
+	err = json.Unmarshal(response, &allowedHost)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, err
+	}
+
+	return allowedHost, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetDatacenter(id int) (datatypes.SoftLayer_Location, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getDatacenter.json", slhs.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Location{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getDatacenter, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Location{}, errors.New(errorMessage)
+	}
+
+	datacenter := datatypes.SoftLayer_Location{}
+	err = json.Unmarshal(response, &datacenter)
+	if err != nil {
+		return datatypes.SoftLayer_Location{}, err
+	}
+
+	return datacenter, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetPrimaryIpAddress(id int) (string, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getPrimaryIpAddress.json", slhs.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return "", err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getPrimaryIpAddress, HTTP error code: '%d'", errorCode)
+		return "", errors.New(errorMessage)
+	}
+
+	return string(response[:]), nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetPrimaryBackendIpAddress(id int) (string, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getPrimaryBackendIpAddress.json", slhs.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return "", err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getPrimaryBackendIpAddress, HTTP error code: '%d'", errorCode)
+		return "", errors.New(errorMessage)
+	}
+
+	return string(response[:]), nil
+}
+
+func (slhs *softLayer_Hardware_Service) PowerOff(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOff.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#powerOff, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power off hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) PowerOffSoft(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOffSoft.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power off soft hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#powerOffSoft, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) PowerOn(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOn.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power on hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#powerOn, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) RebootDefault(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootDefault.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to default reboot hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#rebootDefault, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) RebootSoft(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootSoft.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to soft reboot hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#rebootSoft, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) RebootHard(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootHard.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to hard reboot hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#rebootHard, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) SetTags(instanceId int, tags []string) (bool, error) {
+	var tagStringBuffer bytes.Buffer
+	for i, tag := range tags {
+		tagStringBuffer.WriteString(tag)
+		if i != len(tags)-1 {
+			tagStringBuffer.WriteString(", ")
+		}
+	}
+
+	setTagsParameters := datatypes.SoftLayer_Hardware_String_Parameters{
+		Parameters: []string{tagStringBuffer.String()},
+	}
+
+	requestBody, err := json.Marshal(setTagsParameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/setTags.json", slhs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#setTags, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to setTags for hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	return true, nil
 }

--- a/vendor/github.com/maximilien/softlayer-go/services/softlayer_network_storage.go
+++ b/vendor/github.com/maximilien/softlayer-go/services/softlayer_network_storage.go
@@ -5,19 +5,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
-	common "github.com/maximilien/softlayer-go/common"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	boshretry "github.com/cloudfoundry/bosh-utils/retrystrategy"
+	"github.com/maximilien/softlayer-go/common"
 	datatypes "github.com/maximilien/softlayer-go/data_types"
-	softlayer "github.com/maximilien/softlayer-go/softlayer"
+	"github.com/maximilien/softlayer-go/softlayer"
+	"github.com/pivotal-golang/clock"
+	"os"
 )
 
 const (
 	NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID = 222
-	BLOCK_ITEM_PRICE_ID                    = 40678 // file or block item price id
 	CREATE_ISCSI_VOLUME_MAX_RETRY_TIME     = 60
-	CREATE_ISCSI_VOLUME_CHECK_INTERVAL     = 5 // seconds
+	CREATE_ISCSI_VOLUME_CHECK_INTERVAL     = 10 // seconds
 )
 
 type softLayer_Network_Storage_Service struct {
@@ -34,7 +38,7 @@ func (slns *softLayer_Network_Storage_Service) GetName() string {
 	return "SoftLayer_Network_Storage"
 }
 
-func (slns *softLayer_Network_Storage_Service) CreateIscsiVolume(size int, location string) (datatypes.SoftLayer_Network_Storage, error) {
+func (slns *softLayer_Network_Storage_Service) CreateNetworkStorage(size int, capacity int, location string, useHourlyPricing bool) (datatypes.SoftLayer_Network_Storage, error) {
 	if size < 0 {
 		return datatypes.SoftLayer_Network_Storage{}, errors.New("Cannot create negative sized volumes")
 	}
@@ -44,7 +48,22 @@ func (slns *softLayer_Network_Storage_Service) CreateIscsiVolume(size int, locat
 		return datatypes.SoftLayer_Network_Storage{}, err
 	}
 
-	iopsItemPriceId := slns.getPerformanceStorageItemPriceIdByIops(size)
+	var iopsItemPriceId int
+
+	if capacity == 0 {
+		iopsItemPriceId, err = slns.selectMediumIopsItemPriceIdOnSize(size)
+		if err != nil {
+			return datatypes.SoftLayer_Network_Storage{}, err
+		}
+
+	} else {
+		iopsItemPriceId, err = slns.getItemPriceIdBySizeAndIops(size, capacity)
+		if err != nil {
+			return datatypes.SoftLayer_Network_Storage{}, err
+		}
+	}
+
+	blockStorageItemPriceId, err := slns.getBlockStorageItemPriceId()
 
 	order := datatypes.SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi{
 		Location:    location,
@@ -61,11 +80,12 @@ func (slns *softLayer_Network_Storage_Service) CreateIscsiVolume(size int, locat
 				Id: iopsItemPriceId,
 			},
 			datatypes.SoftLayer_Product_Item_Price{
-				Id: BLOCK_ITEM_PRICE_ID,
+				Id: blockStorageItemPriceId,
 			},
 		},
-		PackageId: NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID,
-		Quantity:  1,
+		PackageId:        NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID,
+		Quantity:         1,
+		UseHourlyPricing: useHourlyPricing,
 	}
 
 	productOrderService, err := slns.client.GetSoftLayer_Product_Order_Service()
@@ -79,16 +99,29 @@ func (slns *softLayer_Network_Storage_Service) CreateIscsiVolume(size int, locat
 	}
 
 	var iscsiStorage datatypes.SoftLayer_Network_Storage
+	SL_CREATE_ISCSI_VOLUME_TIMEOUT, err := strconv.Atoi(os.Getenv("SL_CREATE_ISCSI_VOLUME_TIMEOUT"))
+	if err != nil || SL_CREATE_ISCSI_VOLUME_TIMEOUT == 0 {
+		SL_CREATE_ISCSI_VOLUME_TIMEOUT = 600
+	}
+	SL_CREATE_ISCSI_VOLUME_POLLING_INTERVAL, err := strconv.Atoi(os.Getenv("SL_CREATE_ISCSI_VOLUME_POLLING_INTERVAL"))
+	if err != nil || SL_CREATE_ISCSI_VOLUME_POLLING_INTERVAL == 0 {
+		SL_CREATE_ISCSI_VOLUME_POLLING_INTERVAL = 10
+	}
 
-	for i := 0; i < CREATE_ISCSI_VOLUME_MAX_RETRY_TIME; i++ {
-		iscsiStorage, err = slns.findIscsiVolumeId(receipt.OrderId)
-		if err == nil {
-			break
-		} else if i == CREATE_ISCSI_VOLUME_MAX_RETRY_TIME-1 {
-			return datatypes.SoftLayer_Network_Storage{}, err
-		}
+	execStmtRetryable := boshretry.NewRetryable(
+		func() (bool, error) {
+			iscsiStorage, err = slns.findIscsiVolumeId(receipt.OrderId)
+			if err != nil {
+				return true, errors.New(fmt.Sprintf("Failed to find iSCSI volume with id `%d` due to `%s`, retrying...", receipt.OrderId, err.Error()))
+			}
 
-		time.Sleep(CREATE_ISCSI_VOLUME_CHECK_INTERVAL * time.Second)
+			return false, nil
+		})
+	timeService := clock.NewClock()
+	timeoutRetryStrategy := boshretry.NewTimeoutRetryStrategy(time.Duration(SL_CREATE_ISCSI_VOLUME_TIMEOUT)*time.Second, time.Duration(SL_CREATE_ISCSI_VOLUME_POLLING_INTERVAL)*time.Second, execStmtRetryable, timeService, boshlog.NewLogger(boshlog.LevelInfo))
+	err = timeoutRetryStrategy.Try()
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, errors.New(fmt.Sprintf("Failed to find iSCSI volume with id `%d` after retry within `%d` seconds", receipt.OrderId, SL_CREATE_ISCSI_VOLUME_TIMEOUT))
 	}
 
 	return iscsiStorage, nil
@@ -113,7 +146,7 @@ func (slvgs *softLayer_Network_Storage_Service) DeleteObject(volumeId int) (bool
 	return true, err
 }
 
-func (slns *softLayer_Network_Storage_Service) DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error {
+func (slns *softLayer_Network_Storage_Service) DeleteNetworkStorage(volumeId int, immediateCancellationFlag bool) error {
 
 	billingItem, err := slns.GetBillingItem(volumeId)
 	if err != nil {
@@ -141,7 +174,7 @@ func (slns *softLayer_Network_Storage_Service) DeleteIscsiVolume(volumeId int, i
 	return errors.New(errorMessage)
 }
 
-func (slns *softLayer_Network_Storage_Service) GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error) {
+func (slns *softLayer_Network_Storage_Service) GetNetworkStorage(volumeId int) (datatypes.SoftLayer_Network_Storage, error) {
 	objectMask := []string{
 		"accountId",
 		"capacityGb",
@@ -229,7 +262,33 @@ func (slns *softLayer_Network_Storage_Service) HasAllowedVirtualGuest(volumeId i
 	return false, nil
 }
 
-func (slns *softLayer_Network_Storage_Service) AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error) {
+func (slns *softLayer_Network_Storage_Service) HasAllowedHardware(volumeId int, vmId int) (bool, error) {
+	filter := string(`{"allowedVirtualGuests":{"id":{"operation":"` + strconv.Itoa(vmId) + `"}}}`)
+	response, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequestWithObjectFilterAndObjectMask(fmt.Sprintf("%s/%d/getAllowedHardware.json", slns.GetName(), volumeId), []string{"id"}, fmt.Sprintf(string(filter)), "GET", new(bytes.Buffer))
+
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("Cannot check authentication for volume %d in vm %d", volumeId, vmId))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#hasAllowedHardware, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	hardware := []datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(response, &hardware)
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("Failed to unmarshal response of checking authentication for volume %d in vm %d", volumeId, vmId))
+	}
+
+	if len(hardware) > 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) AttachNetworkStorageToVirtualGuest(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error) {
 	parameters := datatypes.SoftLayer_Virtual_Guest_Parameters{
 		Parameters: []datatypes.SoftLayer_Virtual_Guest{
 			virtualGuest,
@@ -247,7 +306,7 @@ func (slns *softLayer_Network_Storage_Service) AttachIscsiVolume(virtualGuest da
 	}
 
 	if common.IsHttpErrorCode(errorCode) {
-		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#attachIscsiVolume, HTTP error code: '%d'", errorCode)
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#attachNetworkStorageToVirtualGuest, HTTP error code: '%d'", errorCode)
 		return false, errors.New(errorMessage)
 	}
 
@@ -259,7 +318,37 @@ func (slns *softLayer_Network_Storage_Service) AttachIscsiVolume(virtualGuest da
 	return allowable, nil
 }
 
-func (slns *softLayer_Network_Storage_Service) DetachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error {
+func (slns *softLayer_Network_Storage_Service) AttachNetworkStorageToHardware(hardware datatypes.SoftLayer_Hardware, volumeId int) (bool, error) {
+	parameters := datatypes.SoftLayer_Hardware_Parameters{
+		Parameters: []datatypes.SoftLayer_Hardware{
+			hardware,
+		},
+	}
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	resp, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/allowAccessFromHardware.json", slns.GetName(), volumeId), "PUT", bytes.NewBuffer(requestBody))
+
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#attachNetworkStorageToHardware, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	allowable, err := strconv.ParseBool(string(resp[:]))
+	if err != nil {
+		return false, nil
+	}
+
+	return allowable, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) DetachNetworkStorageFromVirtualGuest(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error {
 	parameters := datatypes.SoftLayer_Virtual_Guest_Parameters{
 		Parameters: []datatypes.SoftLayer_Virtual_Guest{
 			virtualGuest,
@@ -276,7 +365,31 @@ func (slns *softLayer_Network_Storage_Service) DetachIscsiVolume(virtualGuest da
 	}
 
 	if common.IsHttpErrorCode(errorCode) {
-		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getAccountStatus, HTTP error code: '%d'", errorCode)
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#detachNetworkStorageToVirtualGuest, HTTP error code: '%d'", errorCode)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+func (slns *softLayer_Network_Storage_Service) DetachNetworkStorageFromHardware(hardware datatypes.SoftLayer_Hardware, volumeId int) error {
+	parameters := datatypes.SoftLayer_Hardware_Parameters{
+		Parameters: []datatypes.SoftLayer_Hardware{
+			hardware,
+		},
+	}
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return err
+	}
+
+	_, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/removeAccessFromHardware.json", slns.GetName(), volumeId), "PUT", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#detachNetworkStorageToHardware, HTTP error code: '%d'", errorCode)
 		return errors.New(errorMessage)
 	}
 
@@ -305,13 +418,36 @@ func (slns *softLayer_Network_Storage_Service) findIscsiVolumeId(orderId int) (d
 	return datatypes.SoftLayer_Network_Storage{}, errors.New(fmt.Sprintf("Cannot find an performance storage (iSCSI volume) with order id %d", orderId))
 }
 
+func (slns *softLayer_Network_Storage_Service) getBlockStorageItemPriceId() (int, error) {
+	productPackageService, err := slns.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return 0, err
+	}
+
+	filters := string(`{"items":{"categories":{"categoryCode":{"operation":"performance_storage_iscsi"}}}}`)
+	itemPrices, err := productPackageService.GetItems(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, filters)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(itemPrices) > 0 {
+		if len(itemPrices[0].Prices) > 0 {
+			return itemPrices[0].Prices[0].Id, nil
+		}
+	}
+
+	return 0, errors.New(fmt.Sprint("No proper block performance storage item price id"))
+}
+
 func (slns *softLayer_Network_Storage_Service) getIscsiVolumeItemIdBasedOnSize(size int) (int, error) {
 	productPackageService, err := slns.client.GetSoftLayer_Product_Package_Service()
 	if err != nil {
 		return 0, err
 	}
 
-	itemPrices, err := productPackageService.GetItemPricesBySize(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, size)
+	keyName := strconv.Itoa(size) + "_GB_PERFORMANCE_STORAGE_SPACE"
+	filters := string(`{"itemPrices":{"item":{"keyName":{"operation":"` + keyName + `"}}}}`)
+	itemPrices, err := productPackageService.GetItemPrices(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, filters)
 	if err != nil {
 		return 0, err
 	}
@@ -322,6 +458,7 @@ func (slns *softLayer_Network_Storage_Service) getIscsiVolumeItemIdBasedOnSize(s
 		for _, itemPrice := range itemPrices {
 			if itemPrice.LocationGroupId == 0 {
 				currentItemId = itemPrice.Id
+				break
 			}
 		}
 	}
@@ -329,19 +466,126 @@ func (slns *softLayer_Network_Storage_Service) getIscsiVolumeItemIdBasedOnSize(s
 	if currentItemId == 0 {
 		return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
 	}
-
 	return currentItemId, nil
 }
 
-func (slns *softLayer_Network_Storage_Service) getPerformanceStorageItemPriceIdByIops(size int) int {
-	switch size {
-	case 20:
-		return 40838 // 500 IOPS
-	case 40:
-		return 40988 // 1000 IOPS
-	case 80:
-		return 41288 // 2000 IOPS
-	default:
-		return 41788 // 3000 IOPS
+func (slns *softLayer_Network_Storage_Service) getItemPriceIdBySizeAndIops(size int, capacity int) (int, error) {
+	productPackageService, err := slns.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return 0, err
 	}
+
+	filters := fmt.Sprintf(`{"itemPrices":{"item":{"capacity":{"operation":%d}},"attributes":{"value":{"operation":%d}},"categories":{"categoryCode":{"operation":"performance_storage_iops"}}}}`, capacity, size)
+	itemPrices, err := productPackageService.GetItemPrices(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, filters)
+	if err != nil {
+		return 0, err
+	}
+
+	var currentItemId int
+
+	if len(itemPrices) > 0 {
+		for _, itemPrice := range itemPrices {
+			if itemPrice.LocationGroupId == 0 {
+				currentItemId = itemPrice.Id
+				break
+			}
+		}
+	}
+
+	if currentItemId == 0 {
+		return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+	}
+	return currentItemId, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) selectMaximunIopsItemPriceIdOnSize(size int) (int, error) {
+	productPackageService, err := slns.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return 0, err
+	}
+
+	filters := fmt.Sprintf(`{"itemPrices":{"attributes":{"value":{"operation":%d}},"categories":{"categoryCode":{"operation":"performance_storage_iops"}}}}`, size)
+	itemPrices, err := productPackageService.GetItemPrices(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, filters)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(itemPrices) > 0 {
+		candidates := filter(itemPrices, func(itemPrice datatypes.SoftLayer_Product_Item_Price) bool {
+			return itemPrice.LocationGroupId == 0
+		})
+		if len(candidates) > 0 {
+			sort.Sort(datatypes.SoftLayer_Product_Item_Price_Sorted_Data(candidates))
+			return candidates[len(candidates)-1].Id, nil
+		} else {
+			return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+		}
+	}
+
+	return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+}
+
+func (slns *softLayer_Network_Storage_Service) selectMediumIopsItemPriceIdOnSize(size int) (int, error) {
+	productPackageService, err := slns.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return 0, err
+	}
+
+	filters := fmt.Sprintf(`{"itemPrices":{"attributes":{"value":{"operation":%d}},"categories":{"categoryCode":{"operation":"performance_storage_iops"}}}}`, size)
+	itemPrices, err := productPackageService.GetItemPrices(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, filters)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(itemPrices) > 0 {
+		candidates := filter(itemPrices, func(itemPrice datatypes.SoftLayer_Product_Item_Price) bool {
+			return itemPrice.LocationGroupId == 0
+		})
+		if len(candidates) > 0 {
+			sort.Sort(datatypes.SoftLayer_Product_Item_Price_Sorted_Data(candidates))
+			return candidates[len(candidates)/2].Id, nil
+		} else {
+			return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+		}
+	}
+
+	return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+}
+
+func (slns *softLayer_Network_Storage_Service) selectMinimumIopsItemPriceIdOnSize(size int) (int, error) {
+	productPackageService, err := slns.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return 0, err
+	}
+
+	filters := fmt.Sprintf(`{"itemPrices":{"attributes":{"value":{"operation":%d}},"categories":{"categoryCode":{"operation":"performance_storage_iops"}}}}`, size)
+	itemPrices, err := productPackageService.GetItemPrices(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, filters)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(itemPrices) > 0 {
+		candidates := filter(itemPrices, func(itemPrice datatypes.SoftLayer_Product_Item_Price) bool {
+			return itemPrice.LocationGroupId == 0
+		})
+		if len(candidates) > 0 {
+			sort.Sort(datatypes.SoftLayer_Product_Item_Price_Sorted_Data(candidates))
+			return candidates[0].Id, nil
+		} else {
+			return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+		}
+	}
+
+	return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+}
+
+func filter(vs []datatypes.SoftLayer_Product_Item_Price, f func(datatypes.SoftLayer_Product_Item_Price) bool) []datatypes.SoftLayer_Product_Item_Price {
+	vsf := make([]datatypes.SoftLayer_Product_Item_Price, 0)
+	for _, v := range vs {
+		if f(v) {
+			vsf = append(vsf, v)
+		}
+	}
+
+	return vsf
 }

--- a/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_account_service.go
+++ b/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_account_service.go
@@ -20,4 +20,5 @@ type SoftLayer_Account_Service interface {
 	GetBlockDeviceTemplateGroupsWithFilter(filters string) ([]datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error)
 	GetDatacentersWithSubnetAllocations() ([]datatypes.SoftLayer_Location, error)
 	GetHardware() ([]datatypes.SoftLayer_Hardware, error)
+	GetDomains() ([]datatypes.SoftLayer_Dns_Domain, error)
 }

--- a/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_dns_domain_service.go
+++ b/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_dns_domain_service.go
@@ -12,4 +12,5 @@ type SoftLayer_Dns_Domain_Service interface {
 	CreateObject(template datatypes.SoftLayer_Dns_Domain_Template) (datatypes.SoftLayer_Dns_Domain, error)
 	DeleteObject(dnsId int) (bool, error)
 	GetObject(dnsId int) (datatypes.SoftLayer_Dns_Domain, error)
+	GetByDomainName(name string) ([]datatypes.SoftLayer_Dns_Domain, error)
 }

--- a/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_hardware_service.go
+++ b/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_hardware_service.go
@@ -7,6 +7,26 @@ import (
 type SoftLayer_Hardware_Service interface {
 	Service
 
+	AllowAccessToNetworkStorage(id int, storage datatypes.SoftLayer_Network_Storage) (bool, error)
+
 	CreateObject(template datatypes.SoftLayer_Hardware_Template) (datatypes.SoftLayer_Hardware, error)
-	GetObject(id string) (datatypes.SoftLayer_Hardware, error)
+
+	FindByIpAddress(ipAddress string) (datatypes.SoftLayer_Hardware, error)
+
+	GetObject(id int) (datatypes.SoftLayer_Hardware, error)
+	GetAllowedHost(id int) (datatypes.SoftLayer_Network_Storage_Allowed_Host, error)
+	GetAttachedNetworkStorages(id int, nasType string) ([]datatypes.SoftLayer_Network_Storage, error)
+	GetDatacenter(id int) (datatypes.SoftLayer_Location, error)
+	GetPrimaryIpAddress(id int) (string, error)
+	GetPrimaryBackendIpAddress(id int) (string, error)
+
+	PowerOff(instanceId int) (bool, error)
+	PowerOffSoft(instanceId int) (bool, error)
+	PowerOn(instanceId int) (bool, error)
+
+	RebootDefault(instanceId int) (bool, error)
+	RebootSoft(instanceId int) (bool, error)
+	RebootHard(instanceId int) (bool, error)
+
+	SetTags(instanceId int, tags []string) (bool, error)
 }

--- a/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_network_storage_service.go
+++ b/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_network_storage_service.go
@@ -9,11 +9,14 @@ type SoftLayer_Network_Storage_Service interface {
 
 	DeleteObject(volumeId int) (bool, error)
 
-	CreateIscsiVolume(size int, location string) (datatypes.SoftLayer_Network_Storage, error)
-	DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error
-	GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error)
+	CreateNetworkStorage(size int, capacity int, location string, userHourlyPricing bool) (datatypes.SoftLayer_Network_Storage, error)
+	DeleteNetworkStorage(volumeId int, immediateCancellationFlag bool) error
+	GetNetworkStorage(volumeId int) (datatypes.SoftLayer_Network_Storage, error)
 	GetBillingItem(volumeId int) (datatypes.SoftLayer_Billing_Item, error)
 	HasAllowedVirtualGuest(volumeId int, vmId int) (bool, error)
-	AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error)
-	DetachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error
+	HasAllowedHardware(volumeId int, vmId int) (bool, error)
+	AttachNetworkStorageToVirtualGuest(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error)
+	DetachNetworkStorageFromVirtualGuest(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error
+	AttachNetworkStorageToHardware(hardware datatypes.SoftLayer_Hardware, volumeId int) (bool, error)
+	DetachNetworkStorageFromHardware(hardware datatypes.SoftLayer_Hardware, volumeId int) error
 }

--- a/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_product_package_service.go
+++ b/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_product_package_service.go
@@ -7,9 +7,8 @@ import (
 type SoftLayer_Product_Package_Service interface {
 	Service
 
-	GetItemPrices(packageId int) ([]datatypes.SoftLayer_Product_Item_Price, error)
-	GetItemPricesBySize(packageId int, size int) ([]datatypes.SoftLayer_Product_Item_Price, error)
-	GetItems(packageId int) ([]datatypes.SoftLayer_Product_Item, error)
+	GetItemPrices(packageId int, filters string) ([]datatypes.SoftLayer_Product_Item_Price, error)
+	GetItems(packageId int, filters string) ([]datatypes.SoftLayer_Product_Item, error)
 	GetItemsByType(packageType string) ([]datatypes.SoftLayer_Product_Item, error)
 
 	GetPackagesByType(packageType string) ([]datatypes.Softlayer_Product_Package, error)

--- a/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_virtual_guest_block_device_template_group.go
+++ b/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_virtual_guest_block_device_template_group.go
@@ -28,6 +28,8 @@ type SoftLayer_Virtual_Guest_Block_Device_Template_Group_Service interface {
 
 	GetTransaction(id int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
 
+	GetGlobalIdentifier(id int) (string, error)
+
 	PermitSharingAccess(id int, accountId int) (bool, error)
 
 	RemoveLocations(id int, locations []datatypes.SoftLayer_Location) (bool, error)

--- a/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_virtual_guest_service.go
+++ b/vendor/github.com/maximilien/softlayer-go/softlayer/softlayer_virtual_guest_service.go
@@ -36,16 +36,22 @@ type SoftLayer_Virtual_Guest_Service interface {
 	GetLastTransaction(instanceId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
 	GetActiveTransactions(instanceId int) ([]datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
 	GetAllowedHost(instanceId int) (datatypes.SoftLayer_Network_Storage_Allowed_Host, error)
+	GetLocalDiskFlag(instanceId int) (bool, error)
+	GetNetworkComponents(instanceId int) ([]datatypes.SoftLayer_Virtual_Guest_Network_Component, error)
 	GetNetworkVlans(instanceId int) ([]datatypes.SoftLayer_Network_Vlan, error)
 	GetObject(instanceId int) (datatypes.SoftLayer_Virtual_Guest, error)
 	GetObjectByPrimaryIpAddress(ipAddress string) (datatypes.SoftLayer_Virtual_Guest, error)
 	GetObjectByPrimaryBackendIpAddress(ipAddress string) (datatypes.SoftLayer_Virtual_Guest, error)
 	GetPrimaryIpAddress(instanceId int) (string, error)
+	GetPrimaryBackendIpAddress(instanceId int) (string, error)
+	GetPrimaryBackendNetworkComponent(instanceId int) (datatypes.SoftLayer_Virtual_Guest_Network_Component, error)
+	GetPrimaryNetworkComponent(instanceId int) (datatypes.SoftLayer_Virtual_Guest_Network_Component, error)
 	GetPowerState(instanceId int) (datatypes.SoftLayer_Virtual_Guest_Power_State, error)
 	GetSshKeys(instanceId int) ([]datatypes.SoftLayer_Security_Ssh_Key, error)
 	GetTagReferences(instanceId int) ([]datatypes.SoftLayer_Tag_Reference, error)
 	GetUpgradeItemPrices(instanceId int) ([]datatypes.SoftLayer_Product_Item_Price, error)
 	GetUserData(instanceId int) ([]datatypes.SoftLayer_Virtual_Guest_Attribute, error)
+	GetAvailableUpgradeItemPrices(upgradeOptions *UpgradeOptions) ([]datatypes.SoftLayer_Product_Item_Price, error)
 
 	PowerCycle(instanceId int) (bool, error)
 	PowerOff(instanceId int) (bool, error)
@@ -63,5 +69,4 @@ type SoftLayer_Virtual_Guest_Service interface {
 	ReloadOperatingSystem(instanceId int, template datatypes.Image_Template_Config) error
 
 	UpgradeObject(instanceId int, upgradeOptions *UpgradeOptions) (bool, error)
-	GetAvailableUpgradeItemPrices(upgradeOptions *UpgradeOptions) ([]datatypes.SoftLayer_Product_Item_Price, error)
 }

--- a/vendor/github.com/pivotal-golang/clock/LICENSE
+++ b/vendor/github.com/pivotal-golang/clock/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/pivotal-golang/clock/NOTICE
+++ b/vendor/github.com/pivotal-golang/clock/NOTICE
@@ -1,0 +1,15 @@
+clock
+
+Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/pivotal-golang/clock/README.md
+++ b/vendor/github.com/pivotal-golang/clock/README.md
@@ -1,0 +1,5 @@
+# clock
+
+**Note**: This repository should be imported as `code.cloudfoundry.org/clock`.
+
+Provides a `Clock` interface, useful for injecting time dependencies in tests.

--- a/vendor/github.com/pivotal-golang/clock/clock.go
+++ b/vendor/github.com/pivotal-golang/clock/clock.go
@@ -1,0 +1,42 @@
+package clock
+
+import "time"
+
+type Clock interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+	Since(t time.Time) time.Duration
+
+	NewTimer(d time.Duration) Timer
+	NewTicker(d time.Duration) Ticker
+}
+
+type realClock struct{}
+
+func NewClock() Clock {
+	return &realClock{}
+}
+
+func (clock *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (clock *realClock) Since(t time.Time) time.Duration {
+	return time.Now().Sub(t)
+}
+
+func (clock *realClock) Sleep(d time.Duration) {
+	<-clock.NewTimer(d).C()
+}
+
+func (clock *realClock) NewTimer(d time.Duration) Timer {
+	return &realTimer{
+		t: time.NewTimer(d),
+	}
+}
+
+func (clock *realClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{
+		t: time.NewTicker(d),
+	}
+}

--- a/vendor/github.com/pivotal-golang/clock/ticker.go
+++ b/vendor/github.com/pivotal-golang/clock/ticker.go
@@ -1,0 +1,20 @@
+package clock
+
+import "time"
+
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+type realTicker struct {
+	t *time.Ticker
+}
+
+func (t *realTicker) C() <-chan time.Time {
+	return t.t.C
+}
+
+func (t *realTicker) Stop() {
+	t.t.Stop()
+}

--- a/vendor/github.com/pivotal-golang/clock/timer.go
+++ b/vendor/github.com/pivotal-golang/clock/timer.go
@@ -1,0 +1,25 @@
+package clock
+
+import "time"
+
+type Timer interface {
+	C() <-chan time.Time
+	Reset(d time.Duration) bool
+	Stop() bool
+}
+
+type realTimer struct {
+	t *time.Timer
+}
+
+func (t *realTimer) C() <-chan time.Time {
+	return t.t.C
+}
+
+func (t *realTimer) Reset(d time.Duration) bool {
+	return t.t.Reset(d)
+}
+
+func (t *realTimer) Stop() bool {
+	return t.t.Stop()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -817,6 +817,18 @@
 			"revisionTime": "2016-06-01T21:42:51Z"
 		},
 		{
+			"checksumSHA1": "TbzNl200lJFg2rpZ4V6rG8Dxvdc=",
+			"path": "github.com/cloudfoundry/bosh-utils/logger",
+			"revision": "96cb2971e599f7fab2698f37e4dee9178a0d2390",
+			"revisionTime": "2016-10-25T15:52:44Z"
+		},
+		{
+			"checksumSHA1": "dNDmmKT7dGb6SHqKKbwQgalVrFA=",
+			"path": "github.com/cloudfoundry/bosh-utils/retrystrategy",
+			"revision": "96cb2971e599f7fab2698f37e4dee9178a0d2390",
+			"revisionTime": "2016-10-25T15:52:44Z"
+		},
+		{
 			"comment": "v2.3.0-alpha.0-652-ge552791",
 			"path": "github.com/coreos/etcd/client",
 			"revision": "e5527914aa42cae3063f52892e1ca4518da0e4ae"
@@ -1639,29 +1651,34 @@
 			"revision": "56b76bdf51f7708750eac80fa38b952bb9f32639"
 		},
 		{
-			"comment": "v0.6.0",
+			"checksumSHA1": "E611q4DGLEibKTtgMltyFAeHyqU=",
+			"comment": "v0.7.0",
 			"path": "github.com/maximilien/softlayer-go/client",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
+			"revision": "1d4217550aef2c9207aeae5a93c7ce5c3c91ef21"
 		},
 		{
-			"comment": "v0.6.0",
+			"checksumSHA1": "nPaYMMjIl21a30j9R2lURjb8Nts=",
+			"comment": "v0.7.0",
 			"path": "github.com/maximilien/softlayer-go/common",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
+			"revision": "1d4217550aef2c9207aeae5a93c7ce5c3c91ef21"
 		},
 		{
-			"comment": "v0.6.0",
+			"checksumSHA1": "QX0ziTd3v7aZ6fsWYQ7CbOl24BM=",
+			"comment": "v0.7.0",
 			"path": "github.com/maximilien/softlayer-go/data_types",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
+			"revision": "1d4217550aef2c9207aeae5a93c7ce5c3c91ef21"
 		},
 		{
-			"comment": "v0.6.0",
+			"checksumSHA1": "THDBrQO5vqBZ0MwBmJXXqwaNXjg=",
+			"comment": "v0.7.0",
 			"path": "github.com/maximilien/softlayer-go/services",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
+			"revision": "1d4217550aef2c9207aeae5a93c7ce5c3c91ef21"
 		},
 		{
-			"comment": "v0.6.0",
+			"checksumSHA1": "1zyBZBF+cSPCrO06RVYCiu/AnIA=",
+			"comment": "v0.7.0",
 			"path": "github.com/maximilien/softlayer-go/softlayer",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
+			"revision": "1d4217550aef2c9207aeae5a93c7ce5c3c91ef21"
 		},
 		{
 			"checksumSHA1": "GSum+utW01N3KeMdvAPnsW0TemM=",
@@ -1752,6 +1769,12 @@
 		{
 			"path": "github.com/pearkes/mailgun",
 			"revision": "b88605989c4141d22a6d874f78800399e5bb7ac2"
+		},
+		{
+			"checksumSHA1": "6c5Q7PkY6NB46Na/wZhMBbjbz+U=",
+			"path": "github.com/pivotal-golang/clock",
+			"revision": "e0835a7d46f9ea781e764f0dc9325110e32a97dd",
+			"revisionTime": "2016-07-26T17:46:41Z"
 		},
 		{
 			"comment": "v0.3.0",


### PR DESCRIPTION
A [new version of softlayer-go](https://github.com/maximilien/softlayer-go/releases/tag/v0.7.0) was just released. This release fixes hashicorp/terraform#9241 and should generate better errors for debugging hashicorp/terraform#9083 and hashicorp/terraform#8734. This includes the patch applied in hashicorp/terraform#9264 and can be merged in place of that PR.

This PR was generated by running

```
govendor fetch github.com/maximilien/softlayer-go/client@1d4217550aef2c9207aeae5a93c7ce5c3c91ef21
govendor fetch github.com/maximilien/softlayer-go/common@1d4217550aef2c9207aeae5a93c7ce5c3c91ef21
govendor fetch github.com/maximilien/softlayer-go/data_types@1d4217550aef2c9207aeae5a93c7ce5c3c91ef21
govendor fetch github.com/maximilien/softlayer-go/services@1d4217550aef2c9207aeae5a93c7ce5c3c91ef21
govendor fetch github.com/maximilien/softlayer-go/softlayer@1d4217550aef2c9207aeae5a93c7ce5c3c91ef21
```

and manually fixing the comments in `vender.json` (`s/0.6.0/0.7.0/`). Note the new version of softlayer-go adds a few additional dependencies:

```
github.com/cloudfoundry/bosh-utils/logger
github.com/cloudfoundry/bosh-utils/retrystrategy
github.com/pivotal-golang/clock
```

I'm a first-time contributor to terraform -- if anything needs to be changed about this PR, please let me know!
