### PR TITLE
provider/google Support MySQL 5.7 instances

### DIFF
--- a/builtin/providers/google/sqladmin_operation.go
+++ b/builtin/providers/google/sqladmin_operation.go
@@ -64,7 +64,7 @@ func sqladminOperationWait(config *Config, op *sqladmin.Operation, activity stri
 	}
 
 	state := w.Conf()
-	state.Timeout = 5 * time.Minute
+	state.Timeout = 10 * time.Minute
 	state.MinTimeout = 2 * time.Second
 	opRaw, err := state.WaitForState()
 	if err != nil {

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -38,7 +38,10 @@ The following arguments are supported:
 - - -
 
 * `database_version` - (Optional, Default: `MYSQL_5_6`) The MySQL version to
-    use. Can be either `MYSQL_5_5` or `MYSQL_5_6`.
+    use. Can be either `MYSQL_5_6` or `MYSQL_5_7` for second-generation
+    instances, or `MYSQL_5_5` or `MYSQL_5_6` for first-generation instances.
+    See Google's [Second Generation Capabilities](https://cloud.google.com/sql/docs/1st-2nd-gen-differences)
+    for more information.
 
 * `name` - (Optional, Computed) The name of the instance. If the name is left
     blank, Terraform will randomly generate one when the instance is first


### PR DESCRIPTION
Google Cloud SQL has support for MySQL 5.7, but the option is not documented in the `google_sql_database_instance` resource, and the resource times out when attempting to create. These commits document creating 5.7 and allow it to succeed.