### PR TITLE
provider/google Change default MySQL instance version to 5.6

### DIFF
--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -154,7 +154,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 			"database_version": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "MYSQL_5_5",
+				Default:  "MYSQL_5_6",
 				ForceNew: true,
 			},
 

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 - - -
 
-* `database_version` - (Optional, Default: `MYSQL_5_5`) The MySQL version to
+* `database_version` - (Optional, Default: `MYSQL_5_6`) The MySQL version to
     use. Can be either `MYSQL_5_5` or `MYSQL_5_6`.
 
 * `name` - (Optional, Computed) The name of the instance. If the name is left


### PR DESCRIPTION
The Google Cloud SQL API defaults to 5.6, and 5.6 is the only version avaiable
to both first- and second-generation Cloud SQL instances.