### PR TITLE
provider/google: Add support for default-internet-gateway alias for google_compute_route

### DIFF
--- a/builtin/providers/google/resource_compute_route.go
+++ b/builtin/providers/google/resource_compute_route.go
@@ -118,7 +118,11 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 		nextHopIp = v.(string)
 	}
 	if v, ok := d.GetOk("next_hop_gateway"); ok {
-		nextHopGateway = v.(string)
+		if v == "default-internet-gateway" {
+			nextHopGateway = fmt.Sprintf("projects/%s/global/gateways/default-internet-gateway", project)
+		} else {
+			nextHopGateway = v.(string)
+		}
 	}
 	if v, ok := d.GetOk("next_hop_vpn_tunnel"); ok {
 		nextHopVpnTunnel = v.(string)

--- a/builtin/providers/google/resource_compute_route_test.go
+++ b/builtin/providers/google/resource_compute_route_test.go
@@ -29,6 +29,25 @@ func TestAccComputeRoute_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeRoute_defaultInternetGateway(t *testing.T) {
+	var route compute.Route
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouteDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeRoute_defaultInternetGateway,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouteExists(
+						"google_compute_route.foobar", &route),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRouteDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -87,5 +106,19 @@ resource "google_compute_route" "foobar" {
 	dest_range = "15.0.0.0/24"
 	network = "${google_compute_network.foobar.name}"
 	next_hop_ip = "10.0.1.5"
+	priority = 100
+}`, acctest.RandString(10), acctest.RandString(10))
+
+var testAccComputeRoute_defaultInternetGateway = fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+	name = "route-test-%s"
+	ipv4_range = "10.0.0.0/16"
+}
+
+resource "google_compute_route" "foobar" {
+	name = "route-test-%s"
+	dest_range = "0.0.0.0/0"
+	network = "${google_compute_network.foobar.name}"
+	next_hop_gateway = "default-internet-gateway"
 	priority = 100
 }`, acctest.RandString(10), acctest.RandString(10))

--- a/website/source/docs/providers/google/r/compute_route.html.markdown
+++ b/website/source/docs/providers/google/r/compute_route.html.markdown
@@ -43,8 +43,9 @@ The following arguments are supported:
 
 - - -
 
-* `next_hop_gateway` - (Optional) The name of the internet gateway to route
-    to if this route is matched.
+* `next_hop_gateway` - (Optional) The URL of the internet gateway to route
+    to if this route is matched. The alias "default-internet-gateway" can also
+    be used.
 
 * `next_hop_instance` - (Optional) The name of the VM instance to route to
     if this route is matched.


### PR DESCRIPTION
Adds support for using an alias of "default-internet-gateway" to specify the projects default internet gateway. At this time, the internet gateway is the only possible option for this field, so an alias for it seems like a quality of life improvement to me.
API reference: https://cloud.google.com/compute/docs/reference/latest/routes
