### PR TITLE
Allow underscores in IAM user and group names

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -132,9 +132,9 @@ func resourceAwsIamGroupDelete(d *schema.ResourceData, meta interface{}) error {
 
 func validateAwsIamGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z=,.@-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, hyphens, commas, periods, @ symbols and equals signs allowed in %q: %q",
+			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols and equals signs allowed in %q: %q",
 			k, value))
 	}
 	return

--- a/builtin/providers/aws/resource_aws_iam_group_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_test.go
@@ -14,6 +14,7 @@ import (
 func TestValidateIamGroupName(t *testing.T) {
 	validNames := []string{
 		"test-group",
+		"test_group",
 		"testgroup123",
 		"TestGroup",
 		"Test-Group",
@@ -34,7 +35,6 @@ func TestValidateIamGroupName(t *testing.T) {
 		" ",
 		":",
 		";",
-		"testgroup_123",
 		"test name",
 		"/slash-at-the-beginning",
 		"slash-at-the-end/",

--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -217,9 +217,9 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 
 func validateAwsIamUserName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z=,.@-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, hyphens, commas, periods, @ symbols and equals signs allowed in %q: %q",
+			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols and equals signs allowed in %q: %q",
 			k, value))
 	}
 	return

--- a/builtin/providers/aws/resource_aws_iam_user_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_test.go
@@ -15,6 +15,7 @@ import (
 func TestValidateIamUserName(t *testing.T) {
 	validNames := []string{
 		"test-user",
+		"test_user",
 		"testuser123",
 		"TestUser",
 		"Test-User",
@@ -35,7 +36,6 @@ func TestValidateIamUserName(t *testing.T) {
 		" ",
 		":",
 		";",
-		"testuser_123",
 		"test name",
 		"/slash-at-the-beginning",
 		"slash-at-the-end/",

--- a/website/source/docs/providers/aws/r/iam_group.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group.html.markdown
@@ -23,7 +23,7 @@ resource "aws_iam_group" "developers" {
 
 The following arguments are supported:
 
-* `name` - (Required) The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`.
+* `name` - (Required) The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. Group names are not distinguished by case. For example, you cannot create groups named both "ADMINS" and "admins".
 * `path` - (Optional, default "/") Path in which to create the group.
 
 ## Attributes Reference

--- a/website/source/docs/providers/aws/r/iam_group.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group.html.markdown
@@ -23,7 +23,7 @@ resource "aws_iam_group" "developers" {
 
 The following arguments are supported:
 
-* `name` - (Required) The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-.`. 
+* `name` - (Required) The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`.
 * `path` - (Optional, default "/") Path in which to create the group.
 
 ## Attributes Reference
@@ -37,10 +37,10 @@ The following attributes are exported:
 * `unique_id` - The [unique ID][1] assigned by AWS.
 
   [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html#GUIDs
-  
+
 ## Import
 
-IAM Groups can be imported using the `name`, e.g. 
+IAM Groups can be imported using the `name`, e.g.
 
 ```
 $ terraform import aws_iam_group.developers developers

--- a/website/source/docs/providers/aws/r/iam_user.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user.html.markdown
@@ -46,7 +46,7 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Required) The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`.
+* `name` - (Required) The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both "TESTUSER" and "testuser".
 * `path` - (Optional, default "/") Path in which to create the user.
 * `force_destroy` - (Optional, default false) When destroying this user, destroy
   even if it has non-Terraform-managed IAM access keys. Without `force_destroy`

--- a/website/source/docs/providers/aws/r/iam_user.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user.html.markdown
@@ -46,7 +46,7 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Required) The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-.`.
+* `name` - (Required) The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`.
 * `path` - (Optional, default "/") Path in which to create the user.
 * `force_destroy` - (Optional, default false) When destroying this user, destroy
   even if it has non-Terraform-managed IAM access keys. Without `force_destroy`
@@ -64,7 +64,7 @@ The following attributes are exported:
 
 ## Import
 
-IAM Users can be imported using the `name`, e.g. 
+IAM Users can be imported using the `name`, e.g.
 
 ```
 $ terraform import aws_iam_user.lb loadbalancer


### PR DESCRIPTION
This PR solves https://github.com/hashicorp/terraform/issues/9679

My editor also cleaned up a few whitespaces in the docs. If you prefer them removed, please ping me and I update the PR.