### PR TITLE
provider/scaleway: update sdk for ams1 region

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_volume.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume.go
@@ -88,7 +88,9 @@ func resourceScalewayVolumeRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.Set("name", volume.Name)
-	d.Set("size_in_gb", volume.Size/gb)
+	if size, ok := volume.Size.(uint64); ok {
+		d.Set("size_in_gb", size/gb)
+	}
 	d.Set("type", volume.VolumeType)
 	d.Set("server", "")
 	if volume.Server != nil {

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/api/cache.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/api/cache.go
@@ -29,7 +29,6 @@ const (
 	CacheTitle
 	// CacheMarketPlaceUUID is used to determine the UUID of local images
 	CacheMarketPlaceUUID
-
 	// CacheMaxfield is used to determine the size of array
 	CacheMaxfield
 )
@@ -87,13 +86,14 @@ type ScalewayResolverResult struct {
 	Arch       string
 	Needle     string
 	RankMatch  int
+	Region     string
 }
 
 // ScalewayResolverResults is a list of `ScalewayResolverResult`
 type ScalewayResolverResults []ScalewayResolverResult
 
 // NewScalewayResolverResult returns a new ScalewayResolverResult
-func NewScalewayResolverResult(Identifier, Name, Arch string, Type int) (ScalewayResolverResult, error) {
+func NewScalewayResolverResult(Identifier, Name, Arch, Region string, Type int) (ScalewayResolverResult, error) {
 	if err := anonuuid.IsUUID(Identifier); err != nil {
 		return ScalewayResolverResult{}, err
 	}
@@ -102,6 +102,7 @@ func NewScalewayResolverResult(Identifier, Name, Arch string, Type int) (Scalewa
 		Type:       Type,
 		Name:       Name,
 		Arch:       Arch,
+		Region:     Region,
 	}, nil
 }
 
@@ -268,7 +269,7 @@ func (c *ScalewayCache) LookUpImages(needle string, acceptUUID bool) (ScalewayRe
 
 	if acceptUUID && anonuuid.IsUUID(needle) == nil {
 		if fields, ok := c.Images[needle]; ok {
-			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], IdentifierImage)
+			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierImage)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -282,7 +283,7 @@ func (c *ScalewayCache) LookUpImages(needle string, acceptUUID bool) (ScalewayRe
 	nameRegex := regexp.MustCompile(`(?i)` + regexp.MustCompile(`[_-]`).ReplaceAllString(needle, ".*"))
 	for identifier, fields := range c.Images {
 		if fields[CacheTitle] == needle {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierImage)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierImage)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -290,14 +291,14 @@ func (c *ScalewayCache) LookUpImages(needle string, acceptUUID bool) (ScalewayRe
 			exactMatches = append(exactMatches, entry)
 		}
 		if strings.HasPrefix(identifier, needle) || nameRegex.MatchString(fields[CacheTitle]) {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierImage)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierImage)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
 			entry.ComputeRankMatch(needle)
 			res = append(res, entry)
 		} else if strings.HasPrefix(fields[CacheMarketPlaceUUID], needle) || nameRegex.MatchString(fields[CacheMarketPlaceUUID]) {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierImage)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierImage)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -323,7 +324,7 @@ func (c *ScalewayCache) LookUpSnapshots(needle string, acceptUUID bool) (Scalewa
 
 	if acceptUUID && anonuuid.IsUUID(needle) == nil {
 		if fields, ok := c.Snapshots[needle]; ok {
-			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], IdentifierSnapshot)
+			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierSnapshot)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -336,7 +337,7 @@ func (c *ScalewayCache) LookUpSnapshots(needle string, acceptUUID bool) (Scalewa
 	nameRegex := regexp.MustCompile(`(?i)` + regexp.MustCompile(`[_-]`).ReplaceAllString(needle, ".*"))
 	for identifier, fields := range c.Snapshots {
 		if fields[CacheTitle] == needle {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierSnapshot)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierSnapshot)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -344,7 +345,7 @@ func (c *ScalewayCache) LookUpSnapshots(needle string, acceptUUID bool) (Scalewa
 			exactMatches = append(exactMatches, entry)
 		}
 		if strings.HasPrefix(identifier, needle) || nameRegex.MatchString(fields[CacheTitle]) {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierSnapshot)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierSnapshot)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -370,7 +371,7 @@ func (c *ScalewayCache) LookUpVolumes(needle string, acceptUUID bool) (ScalewayR
 
 	if acceptUUID && anonuuid.IsUUID(needle) == nil {
 		if fields, ok := c.Volumes[needle]; ok {
-			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], IdentifierVolume)
+			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierVolume)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -382,7 +383,7 @@ func (c *ScalewayCache) LookUpVolumes(needle string, acceptUUID bool) (ScalewayR
 	nameRegex := regexp.MustCompile(`(?i)` + regexp.MustCompile(`[_-]`).ReplaceAllString(needle, ".*"))
 	for identifier, fields := range c.Volumes {
 		if fields[CacheTitle] == needle {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierVolume)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierVolume)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -390,7 +391,7 @@ func (c *ScalewayCache) LookUpVolumes(needle string, acceptUUID bool) (ScalewayR
 			exactMatches = append(exactMatches, entry)
 		}
 		if strings.HasPrefix(identifier, needle) || nameRegex.MatchString(fields[CacheTitle]) {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierVolume)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierVolume)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -416,7 +417,7 @@ func (c *ScalewayCache) LookUpBootscripts(needle string, acceptUUID bool) (Scale
 
 	if acceptUUID && anonuuid.IsUUID(needle) == nil {
 		if fields, ok := c.Bootscripts[needle]; ok {
-			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], IdentifierBootscript)
+			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierBootscript)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -428,7 +429,7 @@ func (c *ScalewayCache) LookUpBootscripts(needle string, acceptUUID bool) (Scale
 	nameRegex := regexp.MustCompile(`(?i)` + regexp.MustCompile(`[_-]`).ReplaceAllString(needle, ".*"))
 	for identifier, fields := range c.Bootscripts {
 		if fields[CacheTitle] == needle {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierBootscript)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierBootscript)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -436,7 +437,7 @@ func (c *ScalewayCache) LookUpBootscripts(needle string, acceptUUID bool) (Scale
 			exactMatches = append(exactMatches, entry)
 		}
 		if strings.HasPrefix(identifier, needle) || nameRegex.MatchString(fields[CacheTitle]) {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierBootscript)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierBootscript)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -462,7 +463,7 @@ func (c *ScalewayCache) LookUpServers(needle string, acceptUUID bool) (ScalewayR
 
 	if acceptUUID && anonuuid.IsUUID(needle) == nil {
 		if fields, ok := c.Servers[needle]; ok {
-			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], IdentifierServer)
+			entry, err := NewScalewayResolverResult(needle, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierServer)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -474,7 +475,7 @@ func (c *ScalewayCache) LookUpServers(needle string, acceptUUID bool) (ScalewayR
 	nameRegex := regexp.MustCompile(`(?i)` + regexp.MustCompile(`[_-]`).ReplaceAllString(needle, ".*"))
 	for identifier, fields := range c.Servers {
 		if fields[CacheTitle] == needle {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierServer)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierServer)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -482,7 +483,7 @@ func (c *ScalewayCache) LookUpServers(needle string, acceptUUID bool) (ScalewayR
 			exactMatches = append(exactMatches, entry)
 		}
 		if strings.HasPrefix(identifier, needle) || nameRegex.MatchString(fields[CacheTitle]) {
-			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], IdentifierServer)
+			entry, err := NewScalewayResolverResult(identifier, fields[CacheTitle], fields[CacheArch], fields[CacheRegion], IdentifierServer)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -551,7 +552,7 @@ func (c *ScalewayCache) LookUpIdentifiers(needle string) (ScalewayResolverResult
 			return ScalewayResolverResults{}, err
 		}
 		for _, result := range servers {
-			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, IdentifierServer)
+			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, result.Region, IdentifierServer)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -566,7 +567,7 @@ func (c *ScalewayCache) LookUpIdentifiers(needle string) (ScalewayResolverResult
 			return ScalewayResolverResults{}, err
 		}
 		for _, result := range images {
-			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, IdentifierImage)
+			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, result.Region, IdentifierImage)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -581,7 +582,7 @@ func (c *ScalewayCache) LookUpIdentifiers(needle string) (ScalewayResolverResult
 			return ScalewayResolverResults{}, err
 		}
 		for _, result := range snapshots {
-			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, IdentifierSnapshot)
+			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, result.Region, IdentifierSnapshot)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -596,7 +597,7 @@ func (c *ScalewayCache) LookUpIdentifiers(needle string) (ScalewayResolverResult
 			return ScalewayResolverResults{}, err
 		}
 		for _, result := range volumes {
-			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, IdentifierVolume)
+			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, result.Region, IdentifierVolume)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}
@@ -611,7 +612,7 @@ func (c *ScalewayCache) LookUpIdentifiers(needle string) (ScalewayResolverResult
 			return ScalewayResolverResults{}, err
 		}
 		for _, result := range bootscripts {
-			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, IdentifierBootscript)
+			entry, err := NewScalewayResolverResult(result.Identifier, result.Name, result.Arch, result.Region, IdentifierBootscript)
 			if err != nil {
 				return ScalewayResolverResults{}, err
 			}

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/scwversion/version.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/scwversion/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 var (
 	// VERSION represents the semver version of the package
-	VERSION = "v1.9.0+dev"
+	VERSION = "v1.11+dev"
 
 	// GITCOMMIT represents the git commit hash of the package, it is configured at build time
 	GITCOMMIT string


### PR DESCRIPTION
this PR updates the Scaleway SDK for the new announced [Amsterdam 1](https://blog.online.net/2016/10/27/scaleway-global-expansion-starts-in-amsterdam/) region.

Previously the Scaleway provider would error when using `ams1` as region, because the SDK did not recognize the region yet.