### PR TITLE
Added AWS Resource WAF SizeConstraintSet

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -355,9 +355,10 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpn_gateway":                              resourceAwsVpnGateway(),
 			"aws_vpn_gateway_attachment":                   resourceAwsVpnGatewayAttachment(),
 			"aws_waf_byte_match_set":                       resourceAwsWafByteMatchSet(),
-			"aws_waf_web_acl":                              resourceAwsWafWebAcl(),
-			"aws_waf_rule":                                 resourceAwsWafRule(),
 			"aws_waf_ipset":                                resourceAwsWafIPSet(),
+			"aws_waf_rule":                                 resourceAwsWafRule(),
+			"aws_waf_size_constraint_set":                  resourceAwsWafSizeConstraintSet(),
+			"aws_waf_web_acl":                              resourceAwsWafWebAcl(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/aws/resource_aws_waf_size_constraint_set.go
+++ b/builtin/providers/aws/resource_aws_waf_size_constraint_set.go
@@ -1,0 +1,191 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsWafSizeConstraintSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafSizeConstraintSetCreate,
+		Read:   resourceAwsWafSizeConstraintSetRead,
+		Update: resourceAwsWafSizeConstraintSetUpdate,
+		Delete: resourceAwsWafSizeConstraintSetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"size_constraints": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_to_match": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"data": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"comparison_operator": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"size": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"text_transformation": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsWafSizeConstraintSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+
+	log.Printf("[INFO] Creating SizeConstraintSet: %s", d.Get("name").(string))
+
+	// ChangeToken
+	var ct *waf.GetChangeTokenInput
+
+	res, err := conn.GetChangeToken(ct)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
+	}
+
+	params := &waf.CreateSizeConstraintSetInput{
+		ChangeToken: res.ChangeToken,
+		Name:        aws.String(d.Get("name").(string)),
+	}
+
+	resp, err := conn.CreateSizeConstraintSet(params)
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error creating SizeConstraintSet: {{err}}", err)
+	}
+
+	d.SetId(*resp.SizeConstraintSet.SizeConstraintSetId)
+
+	return resourceAwsWafSizeConstraintSetUpdate(d, meta)
+}
+
+func resourceAwsWafSizeConstraintSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+	log.Printf("[INFO] Reading SizeConstraintSet: %s", d.Get("name").(string))
+	params := &waf.GetSizeConstraintSetInput{
+		SizeConstraintSetId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetSizeConstraintSet(params)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
+			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.SizeConstraintSet.Name)
+
+	return nil
+}
+
+func resourceAwsWafSizeConstraintSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating SizeConstraintSet: %s", d.Get("name").(string))
+	err := updateSizeConstraintSetResource(d, meta, waf.ChangeActionInsert)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+	}
+	return resourceAwsWafSizeConstraintSetRead(d, meta)
+}
+
+func resourceAwsWafSizeConstraintSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+
+	log.Printf("[INFO] Deleting SizeConstraintSet: %s", d.Get("name").(string))
+	err := updateSizeConstraintSetResource(d, meta, waf.ChangeActionDelete)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting SizeConstraintSet: {{err}}", err)
+	}
+
+	var ct *waf.GetChangeTokenInput
+
+	resp, err := conn.GetChangeToken(ct)
+
+	req := &waf.DeleteSizeConstraintSetInput{
+		ChangeToken:         resp.ChangeToken,
+		SizeConstraintSetId: aws.String(d.Id()),
+	}
+
+	_, err = conn.DeleteSizeConstraintSet(req)
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting SizeConstraintSet: {{err}}", err)
+	}
+
+	return nil
+}
+
+func updateSizeConstraintSetResource(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
+	conn := meta.(*AWSClient).wafconn
+
+	var ct *waf.GetChangeTokenInput
+
+	resp, err := conn.GetChangeToken(ct)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
+	}
+
+	req := &waf.UpdateSizeConstraintSetInput{
+		ChangeToken:         resp.ChangeToken,
+		SizeConstraintSetId: aws.String(d.Id()),
+	}
+
+	sizeConstraints := d.Get("size_constraints").(*schema.Set)
+	for _, sizeConstraint := range sizeConstraints.List() {
+		sc := sizeConstraint.(map[string]interface{})
+		sizeConstraintUpdate := &waf.SizeConstraintSetUpdate{
+			Action: aws.String(ChangeAction),
+			SizeConstraint: &waf.SizeConstraint{
+				FieldToMatch:       expandFieldToMatch(sc["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				ComparisonOperator: aws.String(sc["comparison_operator"].(string)),
+				Size:               aws.Int64(int64(sc["size"].(int))),
+				TextTransformation: aws.String(sc["text_transformation"].(string)),
+			},
+		}
+		req.Updates = append(req.Updates, sizeConstraintUpdate)
+	}
+
+	_, err = conn.UpdateSizeConstraintSet(req)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/builtin/providers/aws/resource_aws_waf_size_constraint_set_test.go
@@ -1,0 +1,232 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAWSWafSizeConstraintSet_basic(t *testing.T) {
+	var v waf.SizeConstraintSet
+	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafSizeConstraintSetConfig(sizeConstraintSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafSizeConstraintSetExists("aws_waf_size_constraint_set.size_constraint_set", &v),
+					resource.TestCheckResourceAttr(
+						"aws_waf_size_constraint_set.size_constraint_set", "name", sizeConstraintSet),
+					resource.TestCheckResourceAttr(
+						"aws_waf_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafSizeConstraintSet_changeNameForceNew(t *testing.T) {
+	var before, after waf.SizeConstraintSet
+	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+	sizeConstraintSetNewName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafSizeConstraintSetConfig(sizeConstraintSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafSizeConstraintSetExists("aws_waf_size_constraint_set.size_constraint_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_waf_size_constraint_set.size_constraint_set", "name", sizeConstraintSet),
+					resource.TestCheckResourceAttr(
+						"aws_waf_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSWafSizeConstraintSetConfigChangeName(sizeConstraintSetNewName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafSizeConstraintSetExists("aws_waf_size_constraint_set.size_constraint_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_waf_size_constraint_set.size_constraint_set", "name", sizeConstraintSetNewName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafSizeConstraintSet_disappears(t *testing.T) {
+	var v waf.SizeConstraintSet
+	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafSizeConstraintSetConfig(sizeConstraintSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafSizeConstraintSetExists("aws_waf_size_constraint_set.size_constraint_set", &v),
+					testAccCheckAWSWafSizeConstraintSetDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafSizeConstraintSetDisappears(v *waf.SizeConstraintSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+
+		var ct *waf.GetChangeTokenInput
+
+		resp, err := conn.GetChangeToken(ct)
+		if err != nil {
+			return fmt.Errorf("Error getting change token: %s", err)
+		}
+
+		req := &waf.UpdateSizeConstraintSetInput{
+			ChangeToken:         resp.ChangeToken,
+			SizeConstraintSetId: v.SizeConstraintSetId,
+		}
+
+		for _, sizeConstraint := range v.SizeConstraints {
+			sizeConstraintUpdate := &waf.SizeConstraintSetUpdate{
+				Action: aws.String("DELETE"),
+				SizeConstraint: &waf.SizeConstraint{
+					FieldToMatch:       sizeConstraint.FieldToMatch,
+					ComparisonOperator: sizeConstraint.ComparisonOperator,
+					Size:               sizeConstraint.Size,
+					TextTransformation: sizeConstraint.TextTransformation,
+				},
+			}
+			req.Updates = append(req.Updates, sizeConstraintUpdate)
+		}
+		_, err = conn.UpdateSizeConstraintSet(req)
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+		}
+
+		resp, err = conn.GetChangeToken(ct)
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
+		}
+
+		opts := &waf.DeleteSizeConstraintSetInput{
+			ChangeToken:         resp.ChangeToken,
+			SizeConstraintSetId: v.SizeConstraintSetId,
+		}
+		if _, err := conn.DeleteSizeConstraintSet(opts); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSWafSizeConstraintSetExists(n string, v *waf.SizeConstraintSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF SizeConstraintSet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+		resp, err := conn.GetSizeConstraintSet(&waf.GetSizeConstraintSetInput{
+			SizeConstraintSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.SizeConstraintSet.SizeConstraintSetId == rs.Primary.ID {
+			*v = *resp.SizeConstraintSet
+			return nil
+		}
+
+		return fmt.Errorf("WAF SizeConstraintSet (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSWafSizeConstraintSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_waf_byte_match_set" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+		resp, err := conn.GetSizeConstraintSet(
+			&waf.GetSizeConstraintSetInput{
+				SizeConstraintSetId: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if *resp.SizeConstraintSet.SizeConstraintSetId == rs.Primary.ID {
+				return fmt.Errorf("WAF SizeConstraintSet %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the SizeConstraintSet is already destroyed
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "WAFNonexistentItemException" {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSWafSizeConstraintSetConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_size_constraint_set" "size_constraint_set" {
+  name = "%s"
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = "EQ"
+    size = "4096"
+    field_to_match {
+      type = "BODY"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafSizeConstraintSetConfigChangeName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_size_constraint_set" "size_constraint_set" {
+  name = "%s"
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = "EQ"
+    size = "4096"
+    field_to_match {
+      type = "BODY"
+    }
+  }
+}`, name)
+}

--- a/website/source/docs/providers/aws/r/waf_size_constraint_set.html.markdown
+++ b/website/source/docs/providers/aws/r/waf_size_constraint_set.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "aws"
+page_title: "AWS: waf_size_constraint_set"
+sidebar_current: "docs-aws-resource-waf-size-constraint-set"
+description: |-
+  Provides a AWS WAF SizeConstraintSet resource.
+---
+
+## Example Usage
+
+```
+resource "aws_waf_size_constraint_set" "size_constraint_set" {
+  name = "tfsize_constraints"
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = "EQ"
+    size = "4096"
+    field_to_match {
+      type = "BODY"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or description of the SizeConstraintSet.
+* `size_constraints` - (Required) The size constraint and the part of the web request to check.
+
+## Remarks
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF ByteMatchSet.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -805,7 +805,11 @@
                   </li>
                   
                   <li<%= sidebar_current("docs-aws-resource-waf-bytematchset") %>>
-                    <a href="/docs/providers/aws/r/waf_waf_byte_match_set.html">aws_waf_byte_match_set</a>
+                    <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
+                  </li>
+                  
+                  <li<%= sidebar_current("docs-aws-resource-waf-size-constraint-set") %>>
+                    <a href="/docs/providers/aws/r/waf_size_constraint_set.html">aws_waf_size_constraint_set</a>
                   </li>
 
                   <li<%= sidebar_current("docs-aws-resource-waf-rule") %>>


### PR DESCRIPTION
```
➜  terraform git:(master) ✗ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSWafSizeConstraintSet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/28 20:42:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSWafSizeConstraintSet_ -timeout 120m
=== RUN   TestAccAWSWafSizeConstraintSet_basic
--- PASS: TestAccAWSWafSizeConstraintSet_basic (115.53s)
=== RUN   TestAccAWSWafSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafSizeConstraintSet_changeNameForceNew (119.62s)
=== RUN   TestAccAWSWafSizeConstraintSet_disappears
--- PASS: TestAccAWSWafSizeConstraintSet_disappears (64.22s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	304.653s
```

/cc @stack72 

If SizeConstraintSet is nill that means there is an error that is handled already :)