### PR TITLE
provider/scaleway server volume property

### DIFF
--- a/builtin/providers/scaleway/helpers.go
+++ b/builtin/providers/scaleway/helpers.go
@@ -18,6 +18,22 @@ func String(val string) *string {
 	return &val
 }
 
+func validateVolumeType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value != "l_ssd" {
+		errors = append(errors, fmt.Errorf("%q must be l_ssd", k))
+	}
+	return
+}
+
+func validateVolumeSize(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(int)
+	if value < 1 || value > 150 {
+		errors = append(errors, fmt.Errorf("%q be more than 1 and less than 150", k))
+	}
+	return
+}
+
 // deleteRunningServer terminates the server and waits until it is removed.
 func deleteRunningServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) error {
 	err := scaleway.PostServerAction(server.Identifier, "terminate")

--- a/builtin/providers/scaleway/resource_scaleway_server_test.go
+++ b/builtin/providers/scaleway/resource_scaleway_server_test.go
@@ -31,6 +31,39 @@ func TestAccScalewayServer_Basic(t *testing.T) {
 	})
 }
 
+func TestAccScalewayServer_Volumes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayServerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayServerVolumeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayServerExists("scaleway_server.base"),
+					testAccCheckScalewayServerAttributes("scaleway_server.base"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "type", "C1"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "volume.#", "2"),
+					resource.TestCheckResourceAttrSet(
+						"scaleway_server.base", "volume.0.volume_id"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "volume.0.type", "l_ssd"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "volume.0.size_in_gb", "20"),
+					resource.TestCheckResourceAttrSet(
+						"scaleway_server.base", "volume.1.volume_id"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "volume.1.type", "l_ssd"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "volume.1.size_in_gb", "30"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccScalewayServer_SecurityGroup(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -159,6 +192,25 @@ resource "scaleway_server" "base" {
   image = "%s"
   type = "C1"
   tags = [ "terraform-test" ]
+}`, armImageIdentifier)
+
+var testAccCheckScalewayServerVolumeConfig = fmt.Sprintf(`
+resource "scaleway_server" "base" {
+  name = "test"
+  # ubuntu 14.04
+  image = "%s"
+  type = "C1"
+  tags = [ "terraform-test" ]
+
+  volume {
+    size_in_gb = 20
+    type = "l_ssd"
+  }
+
+  volume {
+    size_in_gb = 30
+    type = "l_ssd"
+  }
 }`, armImageIdentifier)
 
 var testAccCheckScalewayServerConfig_SecurityGroup = fmt.Sprintf(`

--- a/builtin/providers/scaleway/resource_scaleway_volume.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume.go
@@ -26,26 +26,14 @@ func resourceScalewayVolume() *schema.Resource {
 				Required: true,
 			},
 			"size_in_gb": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-					if value < 1 || value > 150 {
-						errors = append(errors, fmt.Errorf("%q be more than 1 and less than 150", k))
-					}
-					return
-				},
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validateVolumeSize,
 			},
 			"type": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if value != "l_ssd" {
-						errors = append(errors, fmt.Errorf("%q must be l_ssd", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateVolumeType,
 			},
 			"server": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/scaleway/resource_scaleway_volume.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume.go
@@ -76,8 +76,8 @@ func resourceScalewayVolumeRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.Set("name", volume.Name)
-	if size, ok := volume.Size.(uint64); ok {
-		d.Set("size_in_gb", size/gb)
+	if size, ok := volume.Size.(float64); ok {
+		d.Set("size_in_gb", uint64(size)/gb)
 	}
 	d.Set("type", volume.VolumeType)
 	d.Set("server", "")

--- a/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
@@ -69,7 +69,7 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 
 	// the API request requires most volume attributes to be unset to succeed
 	for k, v := range volumes {
-		v.Size = 0
+		v.Size = nil
 		v.CreationDate = ""
 		v.Organization = ""
 		v.ModificationDate = ""
@@ -174,7 +174,7 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 
 	// the API request requires most volume attributes to be unset to succeed
 	for k, v := range volumes {
-		v.Size = 0
+		v.Size = nil
 		v.CreationDate = ""
 		v.Organization = ""
 		v.ModificationDate = ""

--- a/builtin/providers/scaleway/resource_scaleway_volume_test.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_test.go
@@ -60,7 +60,7 @@ func testAccCheckScalewayVolumeAttributes(n string) resource.TestCheckFunc {
 		if volume.Name != "test" {
 			return fmt.Errorf("volume has wrong name: %q", volume.Name)
 		}
-		if volume.Size != 2000000000 {
+		if volume.Size != 2e+09 {
 			return fmt.Errorf("volume has wrong size: %d", volume.Size)
 		}
 		if volume.VolumeType != "l_ssd" {

--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -17,7 +17,12 @@ For additional details please refer to [API documentation](https://developer.sca
 resource "scaleway_server" "test" {
   name = "test"
   image = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
-  type = "C1"
+  type = "VC1M"
+
+  volume {
+    size_in_gb = 20
+    type = "l_ssd"
+  }
 }
 ```
 
@@ -35,6 +40,16 @@ The following arguments are supported:
 * `security_group` - (Optional) assign security group to server
 
 Field `name`, `type`, `tags`, `dynamic_ip_required`, `security_group` are editable.
+
+## Volume
+
+You can attach additional volumes to your instance, which will share the lifetime
+of your `scaleway_server` resource.
+
+The `volume` mapping supports the following:
+
+* `type` - (Required) The type of volume. Can be `"l_ssd"`
+* `size_in_gb` - (Required) The size of the volume in gigabytes.
 
 ## Attributes Reference
 


### PR DESCRIPTION
as discussed in #9254 and #9499, some Scaleway server instance types require volumes to be specified at creation time, in order to be used.

The Scaleway CLI chooses to [hide this from the user](https://github.com/scaleway/scaleway-cli/blob/master/pkg/api/helpers.go#L340), but I think it's worthwile to make this choice explicit.

this PR adds a new property to `scaleway_server`, to make this work:

```
resource "scaleway_server" "test" {
  name = "test"
  image = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
  type = "VC1M"

  volume {
    size_in_gb = 50
    type = "l_ssd"
  }
}
```

I've updated the docs and added test cases which pass:

```
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScalewayServer_Volumes -timeout 120m
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (98.30s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/scaleway	98.317s
kepler22b@terraform [scaleway/server-private-volumes*] # tig
```

this PR might need rebasing once #9687 is merged.