### PR TITLE
provider/aws: Fixed the SNS password-protected HTTPS endpoints autoconfirm

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -31,40 +31,40 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"protocol": &schema.Schema{
+			"protocol": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     false,
 				ValidateFunc: validateSNSSubscriptionProtocol,
 			},
-			"endpoint": &schema.Schema{
+			"endpoint": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"endpoint_auto_confirms": &schema.Schema{
+			"endpoint_auto_confirms": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-			"confirmation_timeout_in_minutes": &schema.Schema{
+			"confirmation_timeout_in_minutes": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  1,
 			},
-			"topic_arn": &schema.Schema{
+			"topic_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"delivery_policy": &schema.Schema{
+			"delivery_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"raw_message_delivery": &schema.Schema{
+			"raw_message_delivery": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -13,10 +13,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"regexp"
 )
 
 const awsSNSPendingConfirmationMessage = "pending confirmation"
 const awsSNSPendingConfirmationMessageWithoutSpaces = "pendingconfirmation"
+const awsSNSPasswordObfuscationPattern = "****"
 
 func resourceAwsSnsTopicSubscription() *schema.Resource {
 	return &schema.Resource{
@@ -244,13 +246,13 @@ func findSubscriptionByNonID(d *schema.ResourceData, snsconn *sns.SNS) (*sns.Sub
 	protocol := d.Get("protocol").(string)
 	endpoint := d.Get("endpoint").(string)
 	topic_arn := d.Get("topic_arn").(string)
+	obfuscatedEndpointPassword := obfuscateEndpointPassword(endpoint)
 
 	req := &sns.ListSubscriptionsByTopicInput{
 		TopicArn: aws.String(topic_arn),
 	}
 
 	for {
-
 		res, err := snsconn.ListSubscriptionsByTopic(req)
 
 		if err != nil {
@@ -258,8 +260,8 @@ func findSubscriptionByNonID(d *schema.ResourceData, snsconn *sns.SNS) (*sns.Sub
 		}
 
 		for _, subscription := range res.Subscriptions {
-			log.Printf("[DEBUG] check subscription with EndPoint %s, Protocol %s,  topicARN %s and SubscriptionARN %s", *subscription.Endpoint, *subscription.Protocol, *subscription.TopicArn, *subscription.SubscriptionArn)
-			if *subscription.Endpoint == endpoint && *subscription.Protocol == protocol && *subscription.TopicArn == topic_arn && !subscriptionHasPendingConfirmation(subscription.SubscriptionArn) {
+			log.Printf("[DEBUG] check subscription with EndPoint %s, Protocol %s, topicARN %s and SubscriptionARN %s", *subscription.Endpoint, *subscription.Protocol, *subscription.TopicArn, *subscription.SubscriptionArn)
+			if *subscription.Endpoint == obfuscatedEndpointPassword && *subscription.Protocol == protocol && *subscription.TopicArn == topic_arn && !subscriptionHasPendingConfirmation(subscription.SubscriptionArn) {
 				return subscription, nil
 			}
 		}
@@ -280,4 +282,10 @@ func subscriptionHasPendingConfirmation(arn *string) bool {
 	}
 
 	return true
+}
+
+// returns the endpoint with obfuscated password, if any
+func obfuscateEndpointPassword(endpoint string) string {
+	r := regexp.MustCompile("(://[^:]+):([^@]+)")
+	return r.ReplaceAllString(endpoint, fmt.Sprintf("$1:%s", awsSNSPasswordObfuscationPattern))
 }

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
@@ -20,7 +20,7 @@ func TestAccAWSSNSTopicSubscription_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSSNSTopicSubscriptionConfig(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
@@ -86,6 +86,22 @@ func testAccCheckAWSSNSTopicSubscriptionExists(n string) resource.TestCheckFunc 
 	}
 }
 
+func TestObfuscateEndpointPassword(t *testing.T) {
+	checks := map[string]string{
+		"https://example.com/myroute":                   "https://example.com/myroute",
+		"https://username@example.com/myroute":          "https://username@example.com/myroute",
+		"https://username:password@example.com/myroute": "https://username:****@example.com/myroute",
+	}
+
+	for endpoint, expected := range checks {
+		out := obfuscateEndpointPassword(endpoint)
+
+		if expected != out {
+			t.Fatalf("Expected %v, got %v", expected, out)
+		}
+	}
+}
+
 func testAccAWSSNSTopicSubscriptionConfig(i int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test_topic" {


### PR DESCRIPTION
Hi everyone,

Just suggesting a fix for the SNS autoconfirm for HTTPs endpoints having a Basic authentication. 
The suggested change makes the user-defined endpoint obfuscating the password. 

Related issue:
- https://github.com/hashicorp/terraform/issues/11108
