### PR TITLE
terraform: disallow simple variables ("foo")

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -284,12 +284,14 @@ func (i *Interpolater) valueSimpleVar(
 	n string,
 	v *config.SimpleVariable,
 	result map[string]ast.Variable) error {
-	// SimpleVars are never handled by Terraform's interpolator
-	result[n] = ast.Variable{
-		Value: config.UnknownVariableValue,
-		Type:  ast.TypeString,
-	}
-	return nil
+	// This error message includes some information for people who
+	// relied on this for their template_file data sources. We should
+	// remove this at some point but there isn't any rush.
+	return fmt.Errorf(
+		"invalid variable syntax: %q. If this is part of inline `template` parameter\n" +
+			"then you must escape the interpolation with two dollar signs. For\n" +
+			"example: ${a} becomes $${a}." +
+			n)
 }
 
 func (i *Interpolater) valueUserVar(

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/hashicorp/terraform/config"
 )
 
+func TestInterpolater_simpleVar(t *testing.T) {
+	i := &Interpolater{}
+	scope := &InterpolationScope{}
+	testInterpolateErr(t, i, scope, "simple")
+}
+
 func TestInterpolater_countIndex(t *testing.T) {
 	i := &Interpolater{}
 


### PR DESCRIPTION
Fixes #5338 (and I'm sure many others)

There is no use case for "simple" variables in Terraform at all so
anytime one is found it should be an error.

There is a _huge_ backwards incompatibility here that was not supposed
to be by design but I'm sure a lot of people are relying on: in the
`template_file` datasource, this bug allowed you to not escape your
interpolations and have the work. For example:

```
data "template_file" "foo" {
  template = "${a}"
  vars { a = 12 }
}
```

The above would work, but it shouldn't. The template should have to be
`"$${a}"` (to escape the interpolation).

Because of this BC, I recommend holding this until Terraform 0.8.0 and
documenting it carefully. As part of this PR, I've added some special
error message notes.
