### PR TITLE
helper/schema: removed optional items force new

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -285,6 +285,11 @@ func (s *Schema) finalizeDiff(
 		d.New = normalizeBoolString(d.New)
 	}
 
+	if s.ForceNew {
+		// Force new, set it to true in the diff
+		d.RequiresNew = true
+	}
+
 	if d.NewRemoved {
 		return d
 	}
@@ -300,11 +305,6 @@ func (s *Schema) finalizeDiff(
 			// Computed attribute without a new value set
 			d.NewComputed = true
 		}
-	}
-
-	if s.ForceNew {
-		// Force new, set it to true in the diff
-		d.RequiresNew = true
 	}
 
 	if s.Sensitive {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2019,9 +2019,10 @@ func TestSchemaMap_Diff(t *testing.T) {
 						RequiresNew: true,
 					},
 					"instances.3": &terraform.ResourceAttrDiff{
-						Old:        "foo",
-						New:        "",
-						NewRemoved: true,
+						Old:         "foo",
+						New:         "",
+						NewRemoved:  true,
+						RequiresNew: true,
 					},
 				},
 			},
@@ -2331,9 +2332,10 @@ func TestSchemaMap_Diff(t *testing.T) {
 						New: "2",
 					},
 					"instances.2": &terraform.ResourceAttrDiff{
-						Old:        "22",
-						New:        "",
-						NewRemoved: true,
+						Old:         "22",
+						New:         "",
+						NewRemoved:  true,
+						RequiresNew: true,
 					},
 					"instances.3": &terraform.ResourceAttrDiff{
 						Old:         "333",
@@ -2416,6 +2418,37 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Diff: &terraform.InstanceDiff{
 				Attributes:     map[string]*terraform.ResourceAttrDiff{},
 				DestroyTainted: true,
+			},
+
+			Err: false,
+		},
+
+		"removed optional items should trigger ForceNew": {
+			Schema: map[string]*Schema{
+				"description": &Schema{
+					Type:     TypeString,
+					ForceNew: true,
+					Optional: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"description": "foo",
+				},
+			},
+
+			Config: map[string]interface{}{},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"description": &terraform.ResourceAttrDiff{
+						Old:         "foo",
+						New:         "",
+						RequiresNew: true,
+						NewRemoved:  true,
+					},
+				},
 			},
 
 			Err: false,


### PR DESCRIPTION
Fixes #5138

If an item is optional and is removed completely from the configuration,
it should still trigger a destroy/create if the field itself was marked
as "ForceNew".

See the example in #5138.
