### PR TITLE
command/apply: apply from plan respects -backup and -state-out

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -98,6 +98,20 @@ func testModule(t *testing.T, name string) *module.Tree {
 	return mod
 }
 
+// testPlan returns a non-nil noop plan.
+func testPlan(t *testing.T) *terraform.Plan {
+	state := terraform.NewState()
+	state.RootModule().Outputs["foo"] = &terraform.OutputState{
+		Type:  "string",
+		Value: "foo",
+	}
+
+	return &terraform.Plan{
+		Module: testModule(t, "apply"),
+		State:  state,
+	}
+}
+
 func testPlanFile(t *testing.T, plan *terraform.Plan) string {
 	path := testTempFile(t)
 


### PR DESCRIPTION
Fixes #5409

I didn't expect this to be such a rabbit hole!

Based on git history, it appears that for "historical reasons"(tm),
setting up the various `state.State` structures for a plan were
_completely different logic_ than a normal `terraform apply`. This meant
that it was skipping things like disabling backups with `-backup="-"`.

This PR unifies loading from a plan to the normal state setup mechanism.
A few tests that were failing prior to this PR were added, no existing
tests were changed.
