### PR TITLE
terraform: prevent_destroy works for decreasing count

### DIFF
--- a/terraform/eval_check_prevent_destroy.go
+++ b/terraform/eval_check_prevent_destroy.go
@@ -10,8 +10,9 @@ import (
 // error if a resource has PreventDestroy configured and the diff
 // would destroy the resource.
 type EvalCheckPreventDestroy struct {
-	Resource *config.Resource
-	Diff     **InstanceDiff
+	Resource   *config.Resource
+	ResourceId string
+	Diff       **InstanceDiff
 }
 
 func (n *EvalCheckPreventDestroy) Eval(ctx EvalContext) (interface{}, error) {
@@ -23,7 +24,12 @@ func (n *EvalCheckPreventDestroy) Eval(ctx EvalContext) (interface{}, error) {
 	preventDestroy := n.Resource.Lifecycle.PreventDestroy
 
 	if diff.GetDestroy() && preventDestroy {
-		return nil, fmt.Errorf(preventDestroyErrStr, n.Resource.Id())
+		resourceId := n.ResourceId
+		if resourceId == "" {
+			resourceId = n.Resource.Id()
+		}
+
+		return nil, fmt.Errorf(preventDestroyErrStr, resourceId)
 	}
 
 	return nil, nil

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -168,8 +168,9 @@ func (n *GraphNodeConfigResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 		// expand orphans, which have all the same semantics in a destroy
 		// as a primary or tainted resource.
 		steps = append(steps, &OrphanTransformer{
-			State: state,
-			View:  n.Resource.Id(),
+			Resource: n.Resource,
+			State:    state,
+			View:     n.Resource.Id(),
 		})
 
 		steps = append(steps, &DeposedTransformer{

--- a/terraform/test-fixtures/plan-prevent-destroy-count-bad/main.tf
+++ b/terraform/test-fixtures/plan-prevent-destroy-count-bad/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "foo" {
+  count = "1"
+  current = "${count.index}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/test-fixtures/plan-prevent-destroy-count-good/main.tf
+++ b/terraform/test-fixtures/plan-prevent-destroy-count-good/main.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "foo" {
+  count = "1"
+  current = "${count.index}"
+}

--- a/terraform/transform_orphan.go
+++ b/terraform/transform_orphan.go
@@ -17,6 +17,11 @@ type GraphNodeStateRepresentative interface {
 // OrphanTransformer is a GraphTransformer that adds orphans to the
 // graph. This transformer adds both resource and module orphans.
 type OrphanTransformer struct {
+	// Resource is resource configuration. This is only non-nil when
+	// expanding a resource that is in the configuration. It can't be
+	// dependend on.
+	Resource *config.Resource
+
 	// State is the global state. We require the global state to
 	// properly find module orphans at our path.
 	State *State
@@ -80,6 +85,7 @@ func (t *OrphanTransformer) Transform(g *Graph) error {
 			resourceVertexes[i] = g.Add(&graphNodeOrphanResource{
 				Path:        g.Path,
 				ResourceKey: rsk,
+				Resource:    t.Resource,
 				Provider:    rs.Provider,
 				dependentOn: rs.Dependencies,
 			})
@@ -159,6 +165,7 @@ func (n *graphNodeOrphanModule) Expand(b GraphBuilder) (GraphNodeSubgraph, error
 type graphNodeOrphanResource struct {
 	Path        []string
 	ResourceKey *ResourceStateKey
+	Resource    *config.Resource
 	Provider    string
 
 	dependentOn []string
@@ -282,6 +289,11 @@ func (n *graphNodeOrphanResource) managedResourceEvalNodes(info *InstanceInfo) [
 					Info:   info,
 					State:  &state,
 					Output: &diff,
+				},
+				&EvalCheckPreventDestroy{
+					Resource:   n.Resource,
+					ResourceId: n.ResourceKey.String(),
+					Diff:       &diff,
 				},
 				&EvalWriteDiff{
 					Name: n.ResourceKey.String(),


### PR DESCRIPTION
Fixes #5826

The `prevent_destroy` lifecycle configuration was not being checked when
the count was decreased for a resource with a count. It was only
checking when attributes changed on pre-existing resources.

This fixes that. Now, when changing a count from 2 to 1, for example, Terraform
will not allow this to happen if the `prevent_destroy` option was set.
