### PR TITLE
Added AWS Resource WAF XssMatchSet

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -359,6 +359,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_rule":                                 resourceAwsWafRule(),
 			"aws_waf_size_constraint_set":                  resourceAwsWafSizeConstraintSet(),
 			"aws_waf_web_acl":                              resourceAwsWafWebAcl(),
+			"aws_waf_xss_match_set":                        resourceAwsWafXssMatchSet(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/aws/resource_aws_waf_xss_match_set.go
+++ b/builtin/providers/aws/resource_aws_waf_xss_match_set.go
@@ -1,0 +1,181 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsWafXssMatchSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafXssMatchSetCreate,
+		Read:   resourceAwsWafXssMatchSetRead,
+		Update: resourceAwsWafXssMatchSetUpdate,
+		Delete: resourceAwsWafXssMatchSetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"xss_match_tuples": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_to_match": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"data": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"text_transformation": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsWafXssMatchSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+
+	log.Printf("[INFO] Creating XssMatchSet: %s", d.Get("name").(string))
+
+	// ChangeToken
+	var ct *waf.GetChangeTokenInput
+
+	res, err := conn.GetChangeToken(ct)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
+	}
+
+	params := &waf.CreateXssMatchSetInput{
+		ChangeToken: res.ChangeToken,
+		Name:        aws.String(d.Get("name").(string)),
+	}
+
+	resp, err := conn.CreateXssMatchSet(params)
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error creating XssMatchSet: {{err}}", err)
+	}
+
+	d.SetId(*resp.XssMatchSet.XssMatchSetId)
+
+	return resourceAwsWafXssMatchSetUpdate(d, meta)
+}
+
+func resourceAwsWafXssMatchSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+	log.Printf("[INFO] Reading XssMatchSet: %s", d.Get("name").(string))
+	params := &waf.GetXssMatchSetInput{
+		XssMatchSetId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetXssMatchSet(params)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
+			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.XssMatchSet.Name)
+
+	return nil
+}
+
+func resourceAwsWafXssMatchSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating XssMatchSet: %s", d.Get("name").(string))
+	err := updateXssMatchSetResource(d, meta, waf.ChangeActionInsert)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
+	}
+	return resourceAwsWafXssMatchSetRead(d, meta)
+}
+
+func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+
+	log.Printf("[INFO] Deleting XssMatchSet: %s", d.Get("name").(string))
+	err := updateXssMatchSetResource(d, meta, waf.ChangeActionDelete)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting XssMatchSet: {{err}}", err)
+	}
+
+	var ct *waf.GetChangeTokenInput
+
+	resp, err := conn.GetChangeToken(ct)
+
+	req := &waf.DeleteXssMatchSetInput{
+		ChangeToken:   resp.ChangeToken,
+		XssMatchSetId: aws.String(d.Id()),
+	}
+
+	_, err = conn.DeleteXssMatchSet(req)
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting XssMatchSet: {{err}}", err)
+	}
+
+	return nil
+}
+
+func updateXssMatchSetResource(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
+	conn := meta.(*AWSClient).wafconn
+
+	var ct *waf.GetChangeTokenInput
+
+	resp, err := conn.GetChangeToken(ct)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
+	}
+
+	req := &waf.UpdateXssMatchSetInput{
+		ChangeToken:   resp.ChangeToken,
+		XssMatchSetId: aws.String(d.Id()),
+	}
+
+	xssMatchTuples := d.Get("xss_match_tuples").(*schema.Set)
+	for _, xssMatchTuple := range xssMatchTuples.List() {
+		xmt := xssMatchTuple.(map[string]interface{})
+		xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
+			Action: aws.String(ChangeAction),
+			XssMatchTuple: &waf.XssMatchTuple{
+				FieldToMatch:       expandFieldToMatch(xmt["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				TextTransformation: aws.String(xmt["text_transformation"].(string)),
+			},
+		}
+		req.Updates = append(req.Updates, xssMatchTupleUpdate)
+	}
+
+	_, err = conn.UpdateXssMatchSet(req)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_waf_xss_match_set_test.go
+++ b/builtin/providers/aws/resource_aws_waf_xss_match_set_test.go
@@ -1,0 +1,240 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAWSWafXssMatchSet_basic(t *testing.T) {
+	var v waf.XssMatchSet
+	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafXssMatchSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafXssMatchSetConfig(xssMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafXssMatchSetExists("aws_waf_xss_match_set.xss_match_set", &v),
+					resource.TestCheckResourceAttr(
+						"aws_waf_xss_match_set.xss_match_set", "name", xssMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_waf_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafXssMatchSet_changeNameForceNew(t *testing.T) {
+	var before, after waf.XssMatchSet
+	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	xssMatchSetNewName := fmt.Sprintf("xssMatchSetNewName-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafXssMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafXssMatchSetConfig(xssMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafXssMatchSetExists("aws_waf_xss_match_set.xss_match_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_waf_xss_match_set.xss_match_set", "name", xssMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_waf_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSWafXssMatchSetConfigChangeName(xssMatchSetNewName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafXssMatchSetExists("aws_waf_xss_match_set.xss_match_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_waf_xss_match_set.xss_match_set", "name", xssMatchSetNewName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafXssMatchSet_disappears(t *testing.T) {
+	var v waf.XssMatchSet
+	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafXssMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafXssMatchSetConfig(xssMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafXssMatchSetExists("aws_waf_xss_match_set.xss_match_set", &v),
+					testAccCheckAWSWafXssMatchSetDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+
+		var ct *waf.GetChangeTokenInput
+
+		resp, err := conn.GetChangeToken(ct)
+		if err != nil {
+			return fmt.Errorf("Error getting change token: %s", err)
+		}
+
+		req := &waf.UpdateXssMatchSetInput{
+			ChangeToken:   resp.ChangeToken,
+			XssMatchSetId: v.XssMatchSetId,
+		}
+
+		for _, xssMatchTuple := range v.XssMatchTuples {
+			xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
+				Action: aws.String("DELETE"),
+				XssMatchTuple: &waf.XssMatchTuple{
+					FieldToMatch:       xssMatchTuple.FieldToMatch,
+					TextTransformation: xssMatchTuple.TextTransformation,
+				},
+			}
+			req.Updates = append(req.Updates, xssMatchTupleUpdate)
+		}
+		_, err = conn.UpdateXssMatchSet(req)
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
+		}
+
+		resp, err = conn.GetChangeToken(ct)
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
+		}
+
+		opts := &waf.DeleteXssMatchSetInput{
+			ChangeToken:   resp.ChangeToken,
+			XssMatchSetId: v.XssMatchSetId,
+		}
+		if _, err := conn.DeleteXssMatchSet(opts); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSWafXssMatchSetExists(n string, v *waf.XssMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF XssMatchSet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+		resp, err := conn.GetXssMatchSet(&waf.GetXssMatchSetInput{
+			XssMatchSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.XssMatchSet.XssMatchSetId == rs.Primary.ID {
+			*v = *resp.XssMatchSet
+			return nil
+		}
+
+		return fmt.Errorf("WAF XssMatchSet (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSWafXssMatchSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_waf_byte_match_set" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+		resp, err := conn.GetXssMatchSet(
+			&waf.GetXssMatchSetInput{
+				XssMatchSetId: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if *resp.XssMatchSet.XssMatchSetId == rs.Primary.ID {
+				return fmt.Errorf("WAF XssMatchSet %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the XssMatchSet is already destroyed
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "WAFNonexistentItemException" {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSWafXssMatchSetConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_xss_match_set" "xss_match_set" {
+  name = "%s"
+  xss_match_tuples {
+    text_transformation = "NONE"
+    field_to_match {
+      type = "URI"
+    }
+  }
+
+  xss_match_tuples {
+    text_transformation = "NONE"
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafXssMatchSetConfigChangeName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_xss_match_set" "xss_match_set" {
+  name = "%s"
+  xss_match_tuples {
+    text_transformation = "NONE"
+    field_to_match {
+      type = "URI"
+    }
+  }
+
+  xss_match_tuples {
+    text_transformation = "NONE"
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+}`, name)
+}

--- a/website/source/docs/providers/aws/r/waf_xss_match_set.html.markdown
+++ b/website/source/docs/providers/aws/r/waf_xss_match_set.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "aws"
+page_title: "AWS: waf_xss_match_set"
+sidebar_current: "docs-aws-resource-waf-xss-match-set"
+description: |-
+  Provides a AWS WAF XssMatchSet resource.
+---
+
+## Example Usage
+
+```
+resource "aws_waf_xss_match_set" "xss_match_set" {
+  name = "xss_match_set"
+  xss_match_tuples {
+    text_transformation = "NONE"
+    field_to_match {
+      type = "URI"
+    }
+  }
+
+  xss_match_tuples {
+    text_transformation = "NONE"
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or description of the SizeConstraintSet.
+* `xss_match_tuples` - The parts of web requests that you want to inspect for cross-site scripting attacks.
+
+## Remarks
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF XssMatchSet.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -819,6 +819,10 @@
                   <li<%= sidebar_current("docs-aws-resource-waf-ipset") %>>
                     <a href="/docs/providers/aws/r/aws_waf_ipset.html">aws_waf_ipset</a>
                   </li>
+                  
+                  <li<%= sidebar_current("docs-aws-resource-waf-xss-match-set") %>>
+                    <a href="/docs/providers/aws/r/waf_xss_match_set.html">aws_waf_xss_match_set</a>
+                  </li>
 
                 </ul>
               </li>


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSWafXssMatchSet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/29 09:06:29 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSWafXssMatchSet_ -timeout 120m
=== RUN   TestAccAWSWafXssMatchSet_basic
--- PASS: TestAccAWSWafXssMatchSet_basic (67.03s)
=== RUN   TestAccAWSWafXssMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafXssMatchSet_changeNameForceNew (102.42s)
=== RUN   TestAccAWSWafXssMatchSet_disappears
--- PASS: TestAccAWSWafXssMatchSet_disappears (55.53s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    230.726s
```

/cc @stack72 
