### PR TITLE
Update doc: aws_iam_user with force_destroy deletes IAM User Login Profile

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -54,7 +54,7 @@ func resourceAwsIamUser() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Delete user even if it has non-Terraform-managed IAM access keys",
+				Description: "Delete user even if it has non-Terraform-managed IAM access keys and login profile",
 			},
 		},
 	}
@@ -167,7 +167,7 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// All access keys for the user must be removed
+	// All access keys and login profile for the user must be removed
 	if d.Get("force_destroy").(bool) {
 		var accessKeys []string
 		listAccessKeys := &iam.ListAccessKeysInput{

--- a/website/source/docs/providers/aws/r/iam_user.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user.html.markdown
@@ -49,8 +49,8 @@ The following arguments are supported:
 * `name` - (Required) The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both "TESTUSER" and "testuser".
 * `path` - (Optional, default "/") Path in which to create the user.
 * `force_destroy` - (Optional, default false) When destroying this user, destroy
-  even if it has non-Terraform-managed IAM access keys. Without `force_destroy`
-  a user with non-Terraform-managed access keys will fail to be destroyed.
+  even if it has non-Terraform-managed IAM access keys and login profile. Without `force_destroy`
+  a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The aws_iam_user with force_destroy option now deletes IAM User Login Profile.

refs: https://github.com/hashicorp/terraform/pull/9583

But this behavior is not documented.  So I updated the doc.