### PR TITLE
provider/aws: aws_ami: handle deletion of AMIs

### DIFF
--- a/builtin/providers/aws/resource_aws_ami.go
+++ b/builtin/providers/aws/resource_aws_ami.go
@@ -121,6 +121,12 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 
 	res, err := client.DescribeImages(req)
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAMIID.NotFound" {
+			log.Printf("[DEBUG] %s no longer exists, so we'll drop it from the state", id)
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Previously this resource (and, by extension, the `aws_ami_copy` and `aws_ami_from_instance` resources that share much of its implementation) was handling correctly the case where an AMI had been recently deregistered, and was thus still returned from the API, but not correctly dealing with the situation where the AMI has been removed altogether.

Now we additionally handle the `NotFound` error returned by the API when we request a non-existent AMI, and remove the AMI from the state in the same way we do for deregistered AMIs.

(I'm sorry to say that I've been sitting on this one for a while and just `-target`ing around the issues this was causing in my environment. :disappointed:)
