### PR TITLE
provider/aws: Deprecated aws_lambda_function nodejs runtime in favor of nodejs4.3

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -77,10 +77,10 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Required: true,
 			},
 			"runtime": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "nodejs",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRuntime,
 			},
 			"timeout": {
 				Type:     schema.TypeInt,
@@ -563,4 +563,15 @@ func validateVPCConfig(v interface{}) (map[string]interface{}, error) {
 	}
 
 	return config, nil
+}
+
+func validateRuntime(v interface{}, k string) (ws []string, errors []error) {
+	runtime := v.(string)
+
+	if runtime == lambda.RuntimeNodejs {
+		errors = append(errors, fmt.Errorf(
+			"%s has reached end of life since October 2016 and has been deprecated in favor of %s.",
+			runtime, lambda.RuntimeNodejs43))
+	}
+	return
 }

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -320,7 +320,7 @@ func TestAccAWSLambdaFunction_s3Update(t *testing.T) {
 			},
 			// Extra step because of missing ComputedWhen
 			// See https://github.com/hashicorp/terraform/pull/4846 & https://github.com/hashicorp/terraform/pull/5330
-			resource.TestStep{
+			{
 				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", "tf_acc_lambda_name_s3", &conf),

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -611,6 +611,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 `, rName)
 }
@@ -710,6 +711,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     publish = true
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 `, rName)
 }
@@ -721,6 +723,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 
     vpc_config = {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}"]
@@ -766,6 +769,7 @@ resource "aws_lambda_function" "lambda_function_s3test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 `, acctest.RandInt(), rName)
 }
@@ -795,6 +799,7 @@ resource "aws_lambda_function" "lambda_function_local" {
     function_name = "tf_acc_lambda_name_local"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 `
 
@@ -832,23 +837,24 @@ resource "aws_lambda_function" "lambda_function_local" {
     function_name = "tf_acc_lambda_name_local"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 `
 
 const testAccAWSLambdaFunctionConfig_s3_tpl = `
 resource "aws_s3_bucket" "artifacts" {
-	bucket = "%s"
-	acl = "private"
-	force_destroy = true
-	versioning {
-		enabled = true
-	}
+    bucket = "%s"
+    acl = "private"
+    force_destroy = true
+    versioning {
+        enabled = true
+    }
 }
 resource "aws_s3_bucket_object" "o" {
-	bucket = "${aws_s3_bucket.artifacts.bucket}"
-	key = "%s"
-	source = "%s"
-	etag = "${md5(file("%s"))}"
+    bucket = "${aws_s3_bucket.artifacts.bucket}"
+    key = "%s"
+    source = "%s"
+    etag = "${md5(file("%s"))}"
 }
 resource "aws_iam_role" "iam_for_lambda" {
     name = "iam_for_lambda"
@@ -869,12 +875,13 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 resource "aws_lambda_function" "lambda_function_s3" {
-	s3_bucket = "${aws_s3_bucket_object.o.bucket}"
-	s3_key = "${aws_s3_bucket_object.o.key}"
-	s3_object_version = "${aws_s3_bucket_object.o.version_id}"
+    s3_bucket = "${aws_s3_bucket_object.o.bucket}"
+    s3_key = "${aws_s3_bucket_object.o.key}"
+    s3_object_version = "${aws_s3_bucket_object.o.version_id}"
     function_name = "tf_acc_lambda_name_s3"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 `
 
@@ -885,15 +892,15 @@ func genAWSLambdaFunctionConfig_s3(bucket, key, path string) string {
 
 const testAccAWSLambdaFunctionConfig_s3_unversioned_tpl = `
 resource "aws_s3_bucket" "artifacts" {
-	bucket = "%s"
-	acl = "private"
-	force_destroy = true
+    bucket = "%s"
+    acl = "private"
+    force_destroy = true
 }
 resource "aws_s3_bucket_object" "o" {
-	bucket = "${aws_s3_bucket.artifacts.bucket}"
-	key = "%s"
-	source = "%s"
-	etag = "${md5(file("%s"))}"
+    bucket = "${aws_s3_bucket.artifacts.bucket}"
+    key = "%s"
+    source = "%s"
+    etag = "${md5(file("%s"))}"
 }
 resource "aws_iam_role" "iam_for_lambda" {
     name = "iam_for_lambda"
@@ -914,11 +921,12 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 resource "aws_lambda_function" "lambda_function_s3" {
-	s3_bucket = "${aws_s3_bucket_object.o.bucket}"
-	s3_key = "${aws_s3_bucket_object.o.key}"
+    s3_bucket = "${aws_s3_bucket_object.o.bucket}"
+    s3_key = "${aws_s3_bucket_object.o.key}"
     function_name = "tf_acc_lambda_name_s3_unversioned"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 `
 

--- a/website/source/docs/providers/aws/r/lambda_function.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_function.html.markdown
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "test_lambda" {
 * `role` - (Required) IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See [Lambda Permission Model][4] for more details.
 * `description` - (Optional) Description of what your Lambda Function does.
 * `memory_size` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
-* `runtime` - (Optional) Defaults to `nodejs`. See [Runtimes][6] for valid values.
+* `runtime` - (Required) See [Runtimes][6] for valid values.
 * `timeout` - (Optional) The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `vpc_config` - (Optional) Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]


### PR DESCRIPTION
This aims to fix #8348, which is about deprecating nodejs in favor of nodejs4.3 since it will reach end of life in a few hours. (Reference: http://docs.aws.amazon.com/fr_fr/lambda/latest/dg/nodejs-prog-model-using-old-runtime.html)

Excerpt:

> Given the upcoming end of life for this version, you will no longer be able to create new functions using this version on October 2016

As you could read in the related issue, this is a breaking change since the `runtime` attribute is now required.
This enforces that the runtime is set and to the appropriate version, which should not be nodejs anymore.

Also, this fixes some mixed whitespaces (tabs and spaces) in the related tests. Tell me if you want a separate PR :)

**Note**: At the time of this PR creation, the nodejs is not yet deprecated (will check in a few hours)
