### PR TITLE
provider/openstack: LoadBalancer v2 VIP Port ID

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -57,6 +57,11 @@ func resourceLoadBalancerV2() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"vip_port_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"admin_state_up": &schema.Schema{
 				Type:     schema.TypeBool,
 				Default:  true,
@@ -145,6 +150,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("vip_subnet_id", lb.VipSubnetID)
 	d.Set("tenant_id", lb.TenantID)
 	d.Set("vip_address", lb.VipAddress)
+	d.Set("vip_port_id", lb.VipPortID)
 	d.Set("admin_state_up", lb.AdminStateUp)
 	d.Set("flavor", lb.Flavor)
 	d.Set("provider", lb.Provider)

--- a/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2_test.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
@@ -27,6 +28,7 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 				Config: TestAccLBV2LoadBalancerConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("openstack_lb_loadbalancer_v2.loadbalancer_1", "name", "tf_test_loadbalancer_v2_updated"),
+					resource.TestMatchResourceAttr("openstack_lb_loadbalancer_v2.loadbalancer_1", "vip_port_id", regexp.MustCompile("^[a-f0-9-]+")),
 				),
 			},
 		},

--- a/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
@@ -27,7 +27,7 @@ The following arguments are supported:
     `OS_REGION_NAME` environment variable is used. Changing this creates a new
     LB member.
 
-* `vip_subnet_id` - (Required) The network on which to allocate the 
+* `vip_subnet_id` - (Required) The network on which to allocate the
     Loadbalancer's address. A tenant can only create Loadbalancers on networks
     authorized by policy (e.g. networks that belong to them or networks that
     are shared).  Changing this creates a new loadbalancer.
@@ -40,13 +40,13 @@ The following arguments are supported:
 * `tenant_id` - (Optional) Required for admins. The UUID of the tenant who owns
     the Loadbalancer.  Only administrative users can specify a tenant UUID
     other than their own.  Changing this creates a new loadbalancer.
-    
+
 * `vip_address` - (Optional) The ip address of the load balancer.
     Changing this creates a new loadbalancer.
-    
+
 * `admin_state_up` - (Optional) The administrative state of the Loadbalancer.
     A valid value is true (UP) or false (DOWN).
-    
+
 * `flavor` - (Optional) The UUID of a flavor. Changing this creates a new
     loadbalancer.
 
@@ -66,3 +66,4 @@ The following attributes are exported:
 * `admin_state_up` - See Argument Reference above.
 * `flavor` - See Argument Reference above.
 * `provider` - See Argument Reference above.
+* `vip_port_id` - The Port ID of the Load Balancer IP.


### PR DESCRIPTION
This commit adds vip_port_id as an exported attribute to the
lb_loadbalancer_v2 resource.

Fixes #7542

/cc @dkalleg 
