### PR TITLE
terraform: validate graph on resource expansation to catch cycles

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -841,6 +841,27 @@ func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_provisionerCycle(t *testing.T) {
+	m := testModule(t, "plan-provisioner-cycle")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	pr := testProvisioner()
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		Provisioners: map[string]ResourceProvisionerFactory{
+			"local-exec": testProvisionerFuncFixed(pr),
+		},
+	})
+
+	_, err := ctx.Plan()
+	if err == nil {
+		t.Fatalf("should error")
+	}
+}
+
 func TestContext2Plan_computed(t *testing.T) {
 	m := testModule(t, "plan-computed")
 	p := testProvider("aws")

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -188,7 +188,7 @@ func (n *GraphNodeConfigResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 	steps = append(steps, &RootTransformer{})
 
 	// Build the graph
-	b := &BasicGraphBuilder{Steps: steps}
+	b := &BasicGraphBuilder{Steps: steps, Validate: true}
 	return b.Build(ctx.Path())
 }
 

--- a/terraform/test-fixtures/plan-provisioner-cycle/main.tf
+++ b/terraform/test-fixtures/plan-provisioner-cycle/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+    count = 3
+
+    provisioner "local-exec" {
+        command = "echo ${aws_instance.foo.0.id} ${aws_instance.foo.1.id} ${aws_instance.foo.2.id}"
+    }
+}


### PR DESCRIPTION
Fixes #5342

The dynamically expanded subgraph wasn't being validated so cycles
weren't being caught here and Terraform would just hang. This fixes
that.

Note that it may make sense to validate higher level when the graph is
expanded but there are certain cases we actually expect the graph to
potentially be invalid, so this seems safer for now.

In the future I think we'll move provisioners out to their own graph nodes
so that behavior like this is actually possible.
