### PR TITLE
helper/schema: validate Read, Delete are set

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -317,6 +317,14 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap, writable bool) error
 
 		tsm = schemaMap(r.Schema)
 
+		// Destroy, and Read are required
+		if r.Read == nil {
+			return fmt.Errorf("Read must be implemented")
+		}
+		if r.Delete == nil {
+			return fmt.Errorf("Delete must be implemented")
+		}
+
 		// If we have an importer, we need to verify the importer.
 		if r.Importer != nil {
 			if err := r.Importer.InternalValidate(); err != nil {

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -480,13 +480,49 @@ func TestResourceInternalValidate(t *testing.T) {
 			false,
 			true,
 		},
+
+		// writable must have Read
+		{
+			&Resource{
+				Create: func(d *ResourceData, meta interface{}) error { return nil },
+				Update: func(d *ResourceData, meta interface{}) error { return nil },
+				Delete: func(d *ResourceData, meta interface{}) error { return nil },
+				Schema: map[string]*Schema{
+					"goo": &Schema{
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+			},
+			true,
+			true,
+		},
+
+		// writable must have Delete
+		{
+			&Resource{
+				Create: func(d *ResourceData, meta interface{}) error { return nil },
+				Read:   func(d *ResourceData, meta interface{}) error { return nil },
+				Update: func(d *ResourceData, meta interface{}) error { return nil },
+				Schema: map[string]*Schema{
+					"goo": &Schema{
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+			},
+			true,
+			true,
+		},
 	}
 
 	for i, tc := range cases {
-		err := tc.In.InternalValidate(schemaMap{}, tc.Writable)
-		if err != nil != tc.Err {
-			t.Fatalf("%d: bad: %s", i, err)
-		}
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			err := tc.In.InternalValidate(schemaMap{}, tc.Writable)
+			if err != nil != tc.Err {
+				t.Fatalf("%d: bad: %s", i, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #5916

This adds extra validation for helper/schema `InternalValidate` to verify that `Read` and `Delete` are non-nil. We don't check `Create` because its currently used as a heuristic to check for top level resources (a different issue).
