### PR TITLE
terraform: deposed should trigger PostApply hook

### DIFF
--- a/terraform/hook_mock.go
+++ b/terraform/hook_mock.go
@@ -20,6 +20,7 @@ type MockHook struct {
 	PostApplyError       error
 	PostApplyReturn      HookAction
 	PostApplyReturnError error
+	PostApplyFn          func(*InstanceInfo, *InstanceState, error) (HookAction, error)
 
 	PreDiffCalled bool
 	PreDiffInfo   *InstanceInfo
@@ -111,6 +112,11 @@ func (h *MockHook) PostApply(n *InstanceInfo, s *InstanceState, e error) (HookAc
 	h.PostApplyInfo = n
 	h.PostApplyState = s
 	h.PostApplyError = e
+
+	if h.PostApplyFn != nil {
+		return h.PostApplyFn(n, s, e)
+	}
+
 	return h.PostApplyReturn, h.PostApplyReturnError
 }
 

--- a/terraform/transform_deposed.go
+++ b/terraform/transform_deposed.go
@@ -145,6 +145,11 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 					State:        &state,
 					Index:        n.Index,
 				},
+				&EvalApplyPost{
+					Info:  info,
+					State: &state,
+					Error: &err,
+				},
 				&EvalReturnError{
 					Error: &err,
 				},


### PR DESCRIPTION
Fixes #6327

Deposed instances weren't calling PostApply which was causing the counts
for what happened during `apply` to be wrong. This was a simple fix to
ensure we call that hook.
