### PR TITLE
provider/aws: Expose ARN suffix on ALB Target Group

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group_test.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_test.go
@@ -13,6 +13,37 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestALBTargetGroupCloudwatchSuffixFromARN(t *testing.T) {
+	cases := []struct {
+		name   string
+		arn    *string
+		suffix string
+	}{
+		{
+			name:   "valid suffix",
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup/my-targets/73e2d6bc24d8a067`),
+			suffix: `my-targets/73e2d6bc24d8a067`,
+		},
+		{
+			name:   "no suffix",
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup`),
+			suffix: ``,
+		},
+		{
+			name:   "nil ARN",
+			arn:    nil,
+			suffix: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		actual := albTargetGroupSuffixFromARN(tc.arn)
+		if actual != tc.suffix {
+			t.Fatalf("bad suffix: %q\nExpected: %s\n     Got: %s", tc.name, tc.suffix, actual)
+		}
+	}
+}
+
 func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 	var conf elbv2.TargetGroup
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))

--- a/website/source/docs/providers/aws/r/alb_target_group.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_target_group.html.markdown
@@ -62,6 +62,7 @@ The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The ARN of the Target Group (matches `arn`)
 * `arn` - The ARN of the Target Group (matches `id`)
+* `arn_suffix` - The ARN suffix for use with CloudWatch Metrics.
 
 ## Import
 


### PR DESCRIPTION
Fixes #9593 

When creating a CloudWatch Metric for an Application Load Balancer Target Group  it is
neccessary to use the suffix of the ARN as the reference to the load
balancer TG . This commit exposes that as an attribute on the `aws_alb_target_group`
resource to prevent the need to use regular expression substitution to
make the reference.