### PR TITLE
Align output command -help and documentation

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -247,7 +247,9 @@ func (c *OutputCommand) Help() string {
 Usage: terraform output [options] [NAME]
 
   Reads an output variable from a Terraform state file and prints
-  the value.  If NAME is not specified, all outputs are printed.
+  the value. With no additional arguments, output will display all
+  the outputs for the root module.  If NAME is not specified, all
+  outputs are printed.
 
 Options:
 


### PR DESCRIPTION
`terraform output -help` is missing one paragraph from the web documentation: "_With no additional arguments, output will display all the outputs for the root module._"

That means it says only "_If NAME is not specified, all outputs are printed._", which made me think it would give _all_ outputs, for all modules, which it does not, instead giving me an error message about no outputs being defined (my root module does not have any outputs).