### PR TITLE
provider/aws: Update aws_appautoscaling_target_test

### DIFF
--- a/builtin/providers/aws/resource_aws_appautoscaling_target_test.go
+++ b/builtin/providers/aws/resource_aws_appautoscaling_target_test.go
@@ -284,7 +284,7 @@ resource "aws_ecs_service" "service" {
 	name = "foobar"
 	cluster = "${aws_ecs_cluster.foo.id}"
 	task_definition = "${aws_ecs_task_definition.task.arn}"
-	desired_count = 1
+	desired_count = 2
 
 	deployment_maximum_percent = 200
 	deployment_minimum_healthy_percent = 50


### PR DESCRIPTION
The update of the test was causing a test failure - it was setting
desired_count to 1 when min_size was set to 2 - this was causing a
perpetual diff in the test

Turns this:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAppautoScalingTarget_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/31 10:19:06 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAppautoScalingTarget_basic -timeout 120m
=== RUN   TestAccAWSAppautoScalingTarget_basic
--- FAIL: TestAccAWSAppautoScalingTarget_basic (114.57s)
	testing.go:265: Step 1 error: After applying this step and refreshing, the plan was not empty:

		DIFF:

		UPDATE: aws_ecs_service.service
		  desired_count: "2" => "1"

		STATE:
```

into this:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAppautoScalingTarget_basic'                         2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/31 10:23:52 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAppautoScalingTarget_basic -timeout 120m
=== RUN   TestAccAWSAppautoScalingTarget_basic
--- PASS: TestAccAWSAppautoScalingTarget_basic (116.67s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	116.691s
```