### PR TITLE
provider/aws: Add support for reference_name to aws_route53_health_check

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -109,6 +109,11 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 			"insufficient_data_health_status": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"reference_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"tags": tagsSchema(),
@@ -253,8 +258,13 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 		}
 	}
 
+	callerRef := resource.UniqueId()
+	if v, ok := d.GetOk("reference_name"); ok {
+		callerRef = fmt.Sprintf("%s-%s", v.(string), callerRef)
+	}
+
 	input := &route53.CreateHealthCheckInput{
-		CallerReference:   aws.String(time.Now().Format(time.RFC3339Nano)),
+		CallerReference:   aws.String(callerRef),
 		HealthCheckConfig: healthConfig,
 	}
 

--- a/website/source/docs/providers/aws/r/route53_health_check.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_health_check.html.markdown
@@ -63,6 +63,8 @@ resource "aws_route53_health_check" "foo" {
 
 The following arguments are supported:
 
+* `reference_name` - (Optional) This is a reference name used in Caller Reference
+    (helpful for identifying single health_check set amongst others)
 * `fqdn` - (Optional) The fully qualified domain name of the endpoint to be checked.
 * `ip_address` - (Optional) The IP address of the endpoint to be checked.
 * `port` - (Optional) The port of the endpoint to be checked.


### PR DESCRIPTION
Fixes #8679

    The CallerReference attribute we passed to AWS in route53_health_checks was
    `time.Now().Format(time.RFC3339Nano)`

    When creating multiple resources with the Count meta-parameter, this was
    causing issues as follows:

    ```
    * aws_route53_health_check.healthstate.0: HealthCheckAlreadyExists: A
    different health check has already been created with the specified caller
    reference.
    ```
    We have now exposed a new attribute called `reference_name` that can be set
    to pass multiple resources to the request

    ``` make testacc TEST=./builtin/providers/aws
    TESTARGS='-run=TestAccAWSRoute53HealthCheck_'
    130 ↵ ✹
    ==> Cecking that code complies with gofmt requirements... go generate $(go
    list ./... | grep -v /terraform/vendor/) 2016/10/31 10:41:07 Generated
    command/internal_plugin_list.go TF_ACC=1 go test ./builtin/providers/aws -v
    -run=TestAccAWSRoute53HealthCheck_ -timeout 120m
    === RUN   TestAccAWSRoute53HealthCheck_importBasic
    --- PASS: TestAccAWSRoute53HealthCheck_importBasic (17.08s)
    === RUN   TestAccAWSRoute53HealthCheck_basic
    --- PASS: TestAccAWSRoute53HealthCheck_basic (28.17s)
    === RUN   TestAccAWSRoute53HealthCheck_withSearchString
    --- PASS: TestAccAWSRoute53HealthCheck_withSearchString (28.07s)
    === RUN   TestAccAWSRoute53HealthCheck_withChildHealthChecks
    --- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (20.71s)
    === RUN   TestAccAWSRoute53HealthCheck_IpConfig
    --- PASS: TestAccAWSRoute53HealthCheck_IpConfig (16.09s)
    === RUN   TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck
    --- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (22.42s) PASS
    ok  	github.com/hashicorp/terraform/builtin/providers/aws	132.568s
    ```