### PR TITLE
provider/azurerm: Guard against panic when importing arm_virtual_network

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -165,11 +165,13 @@ func resourceArmVirtualNetworkRead(d *schema.ResourceData, meta interface{}) err
 	}
 	d.Set("subnet", subnets)
 
-	dnses := []string{}
-	for _, dns := range *vnet.DhcpOptions.DNSServers {
-		dnses = append(dnses, dns)
+	if vnet.DhcpOptions != nil && vnet.DhcpOptions.DNSServers != nil {
+		dnses := []string{}
+		for _, dns := range *vnet.DhcpOptions.DNSServers {
+			dnses = append(dnses, dns)
+		}
+		d.Set("dns_servers", dnses)
 	}
-	d.Set("dns_servers", dnses)
 
 	flattenAndSetTags(d, resp.Tags)
 


### PR DESCRIPTION
Fixes #9410

When importing an azurerm_virtual_network that has no DNSServers,
terraform was throwing a panic as it was trying to dereference that list
of servers to set to state

This commit adds a simple check to make sure there are DNSServers before
dereferencing them

```
make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMVirtualNetwork_'                            2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/10/31 11:20:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm -v
-run=TestAccAzureRMVirtualNetwork_ -timeout 120m
=== RUN   TestAccAzureRMVirtualNetwork_importBasic
--- PASS: TestAccAzureRMVirtualNetwork_importBasic (150.63s)
=== RUN   TestAccAzureRMVirtualNetwork_basic
--- PASS: TestAccAzureRMVirtualNetwork_basic (122.90s)
=== RUN   TestAccAzureRMVirtualNetwork_disappears
--- PASS: TestAccAzureRMVirtualNetwork_disappears (113.07s)
=== RUN   TestAccAzureRMVirtualNetwork_withTags
--- PASS: TestAccAzureRMVirtualNetwork_withTags (139.56s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/azurerm526.168
```