### PR TITLE
[WIP] Make the `port` attribute optional in the aws_alb_target_group_attachment resource.

### DIFF
--- a/website/source/docs/providers/aws/r/alb_target_group_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_target_group_attachment.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `target_group_arn` - (Required) The ARN of the target group with which to register targets
 * `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container.
-* `port` - (Required) The port on which targets receive traffic.
+* `port` - (Optional) The port on which targets receive traffic.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This commit makes the `port` attribute optional, allowing for the port number
for the target group to be used by default.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>