### PR TITLE
provider/aws: Allow `active` state while waiting for the VPC Peering Connection.

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -85,7 +85,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Waiting for VPC Peering Connection (%s) to become available.", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"pending"},
-		Target:  []string{"pending-acceptance"},
+		Target:  []string{"pending-acceptance", "active"},
 		Refresh: resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,
 	}

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -84,7 +84,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 	// Wait for the vpc peering connection to become available
 	log.Printf("[DEBUG] Waiting for VPC Peering Connection (%s) to become available.", d.Id())
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"pending"},
+		Pending: []string{"initiating-request", "provisioning", "pending"},
 		Target:  []string{"pending-acceptance", "active"},
 		Refresh: resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, d.Id()),
 		Timeout: 1 * time.Minute,


### PR DESCRIPTION
This commit adds `active` as one of the valid states in which the VPC Peering
Connection can be when it is being created. We also add other valid states e.g.
`initiating-request`, etc.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>