### PR TITLE
provider/aws: data source for AWS Hosted Zone

### DIFF
--- a/builtin/providers/aws/data_source_aws_route53_zone.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone.go
@@ -1,0 +1,82 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsRoute53Zone() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRoute53ZoneRead,
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+	name, nameExists := d.GetOk("name")
+	id, idExists := d.GetOk("zone_id")
+	if nameExists && idExists {
+		return fmt.Errorf("zone_id and name arguments can't be used together")
+	}
+
+	if nameExists {
+		req := &route53.ListHostedZonesByNameInput{}
+		req.DNSName = aws.String(name.(string))
+		req.MaxItems = aws.String("1")
+		resp, err := conn.ListHostedZonesByName(req)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.HostedZones) == 0 || *resp.HostedZones[0].Name != name {
+			return fmt.Errorf("no matching Route53Zone found")
+		}
+
+		hostedZone := resp.HostedZones[0]
+		id := cleanZoneID(*hostedZone.Id)
+		d.SetId(id)
+		d.Set("zone_id", id)
+		d.Set("name", hostedZone.Name)
+		d.Set("comment", hostedZone.Config.Comment)
+
+	} else if idExists {
+		req := &route53.GetHostedZoneInput{}
+		req.Id = aws.String(id.(string))
+
+		resp, err := conn.GetHostedZone(req)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil {
+			return fmt.Errorf("no matching Route53Zone found")
+		}
+		hostedZone := resp.HostedZone
+		id := cleanZoneID(*resp.HostedZone.Id)
+		d.SetId(id)
+		d.Set("zone_id", id)
+		d.Set("name", hostedZone.Name)
+		d.Set("comment", hostedZone.Config.Comment)
+	} else {
+		return fmt.Errorf("name or zone_id have to be setted")
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_route53_zone.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone.go
@@ -117,6 +117,7 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 
 	return nil
 }
+
 // used to manage trailing .
 func HostedZoneName(name string) string {
 	n := len(name)

--- a/builtin/providers/aws/data_source_aws_route53_zone_test.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone_test.go
@@ -18,6 +18,8 @@ func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRoute53ZoneCheck("data.aws_route53_zone.by_zone_id"),
 					testAccDataSourceAwsRoute53ZoneCheck("data.aws_route53_zone.by_name"),
+					testAccDataSourceAwsRoute53ZoneCheckPrivate("data.aws_route53_zone.by_vpc"),
+					testAccDataSourceAwsRoute53ZoneCheckPrivate("data.aws_route53_zone.by_tag"),
 				),
 			},
 		},
@@ -55,11 +57,68 @@ func testAccDataSourceAwsRoute53ZoneCheck(name string) resource.TestCheckFunc {
 	}
 }
 
+func testAccDataSourceAwsRoute53ZoneCheckPrivate(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		hostedZone, ok := s.RootModule().Resources["aws_route53_zone.test_private"]
+		if !ok {
+			return fmt.Errorf("can't find aws_hosted_zone.test in state")
+		}
+
+		attr := rs.Primary.Attributes
+		if attr["id"] != hostedZone.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				attr["id"],
+				hostedZone.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["name"] != "test.acc." {
+			return fmt.Errorf(
+				"Route53 Zone name is %s; want test.acc.",
+				attr["name"],
+			)
+		}
+
+		return nil
+	}
+}
+
 const testAccDataSourceAwsRoute53ZoneConfig = `
 
 provider "aws" {
   region = "us-east-2"
 }
+
+resource "aws_vpc" "test" {
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "aws_route53_zone" "test_private" {
+  name = "test.acc."
+  vpc_id = "${aws_vpc.test.id}"
+  tags {
+    Environment = "dev"
+  }
+}
+data "aws_route53_zone" "by_vpc" {
+ name = "${aws_route53_zone.test_private.name}"
+ vpc_id = "${aws_vpc.test.id}"
+}
+
+data "aws_route53_zone" "by_tag" {
+ name = "${aws_route53_zone.test_private.name}"
+ private_zone = true
+ tags {
+ 	Environment = "dev"
+ }
+}
+
 resource "aws_route53_zone" "test" {
   name = "terraformtestacchz.com."
 }

--- a/builtin/providers/aws/data_source_aws_route53_zone_test.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone_test.go
@@ -71,5 +71,4 @@ data "aws_route53_zone" "by_name" {
   name = "${data.aws_route53_zone.by_zone_id.name}"
 }
 
-
 `

--- a/builtin/providers/aws/data_source_aws_route53_zone_test.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone_test.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsRoute53ZoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRoute53ZoneCheck("data.aws_route53_zone.by_zone_id"),
+					testAccDataSourceAwsRoute53ZoneCheck("data.aws_route53_zone.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRoute53ZoneCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		hostedZone, ok := s.RootModule().Resources["aws_route53_zone.test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_hosted_zone.test in state")
+		}
+		attr := rs.Primary.Attributes
+
+		if attr["id"] != hostedZone.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				attr["id"],
+				hostedZone.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["name"] != "terraformtestacchz.com." {
+			return fmt.Errorf(
+				"Route53 Zone name is %s; want terraformtestacchz.com.",
+				attr["name"],
+			)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsRoute53ZoneConfig = `
+provider "aws" {
+  region = "us-east-2"
+}
+resource "aws_route53_zone" "test" {
+  name = "terraformtestacchz.com."
+}
+data "aws_route53_zone" "by_zone_id" {
+  zone_id = "${aws_route53_zone.test.zone_id}"
+}
+
+data "aws_route53_zone" "by_name" {
+  name = "${data.aws_route53_zone.by_zone_id.name}"
+}
+
+
+`

--- a/builtin/providers/aws/data_source_aws_route53_zone_test.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone_test.go
@@ -36,7 +36,6 @@ func testAccDataSourceAwsRoute53ZoneCheck(name string) resource.TestCheckFunc {
 			return fmt.Errorf("can't find aws_hosted_zone.test in state")
 		}
 		attr := rs.Primary.Attributes
-
 		if attr["id"] != hostedZone.Primary.Attributes["id"] {
 			return fmt.Errorf(
 				"id is %s; want %s",
@@ -57,6 +56,7 @@ func testAccDataSourceAwsRoute53ZoneCheck(name string) resource.TestCheckFunc {
 }
 
 const testAccDataSourceAwsRoute53ZoneConfig = `
+
 provider "aws" {
   region = "us-east-2"
 }

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -151,6 +151,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudformation_stack":     dataSourceAwsCloudFormationStack(),
 			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),
 			"aws_elb_service_account":      dataSourceAwsElbServiceAccount(),
+			"aws_route53_zone":             dataSourceAwsRoute53Zone(),
 			"aws_iam_policy_document":      dataSourceAwsIamPolicyDocument(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
 			"aws_prefix_list":              dataSourceAwsPrefixList(),

--- a/website/source/docs/providers/aws/d/hosted_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/hosted_zone.html.markdown
@@ -43,7 +43,8 @@ Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `p
 * `name` - (Optional) The Hosted Zone name of the desired Hosted Zone.
 * `private_zone` - (Optional) Used with `name` field to get a private Hosted Zone.
 * `vpc_id` - (Optional) Used with `name` field to get a private Hosted Zone associated with the vpc_id (in this case, private_zone is not mandatory).
-
+* `tags` - (Optional) Used with `name` field. A mapping of tags, each pair of which must exactly match
+a pair on the desired security group.
 ## Attributes Reference
 
 All of the argument attributes are also exported as

--- a/website/source/docs/providers/aws/d/hosted_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/hosted_zone.html.markdown
@@ -21,6 +21,7 @@ The following example shows how to get a Hosted Zone from it's name and from thi
 ```
 data "aws_route53_zone" "selected" {
   name = "test.com."
+  private_zone = true
 }
 
 resource "aws_route53_record" "www" {
@@ -36,11 +37,12 @@ resource "aws_route53_record" "www" {
 
 The arguments of this data source act as filters for querying the available
 Hosted Zone. You have to use `zone_id` or `name`, not both of them. The given filter must match exactly one
-Hosted Zone.
+Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `private_zone` field to `true`
 
 * `zone_id` - (Optional) The Hosted Zone id of the desired Hosted Zone.
 
 * `name` - (Optional) The Hosted Zone name of the desired Hosted Zone.
+* `private_zone` - (Optional) Used with `name` field to get a private Hosted Zone.
 
 ## Attributes Reference
 
@@ -51,4 +53,6 @@ the selected Hosted Zone.
 
 The following attribute is additionally exported:
 
+* `caller_reference` - Caller Reference of the Hosted Zone.
 * `comment` - The comment field of the Hosted Zone.
+* `resource_record_set_count` - the number of Record Set in the Hosted Zone

--- a/website/source/docs/providers/aws/d/hosted_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/hosted_zone.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "aws"
+page_title: "AWS: aws_hosted_zone"
+sidebar_current: "docs-aws-datasource-hosted-zone"
+description: |-
+    Provides details about a specific Hosted Zone
+---
+
+# aws\_vpc
+
+`aws_hosted_zone` provides details about a specific Hosted Zone.
+
+This resource can be useful when a module accepts a Hosted Zone name as
+an input variable and needs to, for example, add a Record Set in Route 53
+
+## Example Usage
+
+The following example shows how to get a Hosted Zone from it's name and from this data how to create a Record Set.
+
+
+```
+data "aws_route53_zone" "selected" {
+  name = "test.com."
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = "${data.aws_route53_zone.selected.zone_id}"
+  name = "www.${data.aws_route53_zone.selected.name}"
+  type = "A"
+  ttl = "300"
+  records = ["10.0.0.1"]
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available
+Hosted Zone. You have to use `zone_id` or `name`, not both of them. The given filter must match exactly one
+Hosted Zone.
+
+* `zone_id` - (Optional) The Hosted Zone id of the desired Hosted Zone.
+
+* `name` - (Optional) The Hosted Zone name of the desired Hosted Zone.
+
+## Attributes Reference
+
+All of the argument attributes are also exported as
+result attributes. This data source will complete the data by populating
+any fields that are not included in the configuration with the data for
+the selected Hosted Zone.
+
+The following attribute is additionally exported:
+
+* `comment` - The comment field of the Hosted Zone.

--- a/website/source/docs/providers/aws/d/hosted_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/hosted_zone.html.markdown
@@ -42,6 +42,7 @@ Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `p
 
 * `name` - (Optional) The Hosted Zone name of the desired Hosted Zone.
 * `private_zone` - (Optional) Used with `name` field to get a private Hosted Zone.
+* `vpc_id` - (Optional) Used with `name` field to get a private Hosted Zone associated with the vpc_id (in this case, private_zone is not mandatory).
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/d/hosted_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/hosted_zone.html.markdown
@@ -6,12 +6,11 @@ description: |-
     Provides details about a specific Hosted Zone
 ---
 
-# aws\_vpc
+# aws\_hosted\_zone
 
 `aws_hosted_zone` provides details about a specific Hosted Zone.
 
-This resource can be useful when a module accepts a Hosted Zone name as
-an input variable and needs to, for example, add a Record Set in Route 53
+This data source allows to find a Hosted Zone ID given Hosted Zone name and certain search criteria. 
 
 ## Example Usage
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -35,6 +35,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-elb-service-account") %>>
                             <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-hosted-zone") %>>
+                          <a href="/docs/providers/aws/d/hosted_zone.html">aws_hosted_zone</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-iam-policy-document") %>>
                             <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
                         </li>


### PR DESCRIPTION
To add Hosted Zone data source for AWS provider.
```
data "aws_route53_zone" "selected" {
  name = "test.com."
}
```
For example we can do that with this data source 

```
resource "aws_route53_record" "www" {
  zone_id = "${data.aws_route53_zone.selected.zone_id}"
  name = "www.${data.aws_route53_zone.selected.name}"
  type = "A"
  ttl = "300"
  records = ["10.0.0.1"]
}
```

**The acceptance test** 
```
TF_ACC=true go test -v github.com/hashicorp/terraform/builtin/providers/aws -run ^TestAccDataSourceAwsRoute53Zone$
=== RUN   TestAccDataSourceAwsRoute53Zone
--- PASS: TestAccDataSourceAwsRoute53Zone (48.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	48.932s
```