### PR TITLE
provider/azurerm: fix sql_database resource reading tags

### DIFF
--- a/builtin/providers/azurerm/resource_arm_sql_database.go
+++ b/builtin/providers/azurerm/resource_arm_sql_database.go
@@ -222,6 +222,8 @@ func resourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("creation_date", resp.CreationDate)
 	d.Set("default_secondary_location", resp.DefaultSecondaryLocation)
 
+	flattenAndSetTags(d, resp.Tags)
+
 	return nil
 }
 


### PR DESCRIPTION
tags were not being set in the read function

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMSqlDatabase_basic -timeout 120m
=== RUN   TestAccAzureRMSqlDatabase_basic
--- PASS: TestAccAzureRMSqlDatabase_basic (190.60s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	190.719s
```