### PR TITLE
Update the PowerShell example to set the PATH

### DIFF
--- a/website/source/intro/getting-started/install.html.markdown
+++ b/website/source/intro/getting-started/install.html.markdown
@@ -31,7 +31,7 @@ Example for Linux/Mac - Type the following into your terminal:
 >`PATH=/usr/local/terraform/bin:/home/your-user-name/terraform:$PATH`
 
 Example for Windows - Type the following into Powershell:
->`set PATH=%PATH%;C:\terraform`
+>`[Environment]::SetEnvironmentVariable("PATH", $env:PATH + ({;C:\terraform},{C:\terraform})[$env:PATH[-1] -eq ';'], "User")`
 
 
 ## Verifying the Installation


### PR DESCRIPTION
`set PATH=%PATH%;C:\terraform` is the old fashioned CMD ways to do which doesn't work in a PowerShell command line.
Moreover, the change made in the CMD console would not be permanent.

The solution proposed here uses .NET Framework’s System.Environment class in PowerShell to properly edit the path.
Source : https://technet.microsoft.com/en-us/library/ff730964.aspx