### PR TITLE
terraform: NewComputed doesn't quit Same logic

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -615,7 +615,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 			// that value is allowed since it may mean the value ended up
 			// being the same.
 			if diffOld.NewComputed {
-				continue
+				ok = true
 			}
 
 			// No exact match, but maybe this is a set containing computed

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -608,6 +608,34 @@ func TestInstanceDiffSame(t *testing.T) {
 			"",
 		},
 
+		// NewComputed on set, removed
+		{
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo.#": &ResourceAttrDiff{
+						Old:         "",
+						New:         "",
+						NewComputed: true,
+					},
+				},
+			},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo.1": &ResourceAttrDiff{
+						Old:        "foo",
+						New:        "",
+						NewRemoved: true,
+					},
+					"foo.2": &ResourceAttrDiff{
+						Old: "",
+						New: "bar",
+					},
+				},
+			},
+			true,
+			"",
+		},
+
 		{
 			&InstanceDiff{
 				Attributes: map[string]*ResourceAttrDiff{


### PR DESCRIPTION
For #9618, we added the ability to ignore old diffs that were computed
and removed (because the ultimate value ended up being the same). This
ended up breaking computed list/set logic.

The correct behavior, as is evident by how the other "skip" logics work,
is to set `ok = true` so that the remainder of the logic can run which
handles stuff such as computed lists and sets.