### PR TITLE
`instance_profile` is a required parameter when creating an EMR instance group

### DIFF
--- a/website/source/docs/providers/aws/r/emr_cluster.html.md
+++ b/website/source/docs/providers/aws/r/emr_cluster.html.md
@@ -64,19 +64,19 @@ The following arguments are supported:
 * `release_label` - (Required) The release label for the Amazon EMR release
 * `master_instance_type` - (Required) The EC2 instance type of the master node
 * `core_instance_type` - (Optional) The EC2 instance type of the slave nodes
-* `core_instance_count` - (Optional) number of Amazon EC2 instances used to execute the job flow. Default `0`
+* `core_instance_count` - (Optional) Number of Amazon EC2 instances used to execute the job flow. Default `0`.
 * `log_uri` - (Optional) S3 bucket to write the log files of the job flow. If a value
 	is not provided, logs are not created
 * `applications` - (Optional) A list of applications for the cluster. Valid values are: `Hadoop`, `Hive`,
 	`Mahout`, `Pig`, and `Spark.` Case insensitive
-* `ec2_attributes` - (Optional) attributes for the EC2 instances running the job
+* `ec2_attributes` - (Optional) Attributes for the EC2 instances running the job
 flow. Defined below
-* `bootstrap_action` - (Optional) list of bootstrap actions that will be run before Hadoop is started on
+* `bootstrap_action` - (Optional) List of bootstrap actions that will be run before Hadoop is started on
 	the cluster nodes. Defined below
-* `configurations` - (Optional) list of configurations supplied for the EMR cluster you are creating
+* `configurations` - (Optional) List of configurations supplied for the EMR cluster you are creating
 * `service_role` - (Optional) IAM role that will be assumed by the Amazon EMR service to access AWS resources
 * `visible_to_all_users` - (Optional) Whether the job flow is visible to all IAM users of the AWS account associated with the job flow. Default `true`
-* `tags` - (Optional) list of tags to apply to the EMR Cluster
+* `tags` - (Optional) List of tags to apply to the EMR Cluster
 
 
 
@@ -88,24 +88,24 @@ Attributes for the Amazon EC2 instances running the job flow
 	node as the user called `hadoop`
 * `subnet_id` - (Optional) VPC subnet id where you want the job flow to launch.
 Cannot specify the `cc1.4xlarge` instance type for nodes of a job flow launched in a Amazon VPC
-* `additional_master_security_groups` - (Optional) list of additional Amazon EC2 security group IDs for the master node
-* `additional_slave_security_groups` - (Optional) list of additional Amazon EC2 security group IDs for the slave nodes
-* `emr_managed_master_security_group` - (Optional) identifier of the Amazon EC2 security group for the master node
-* `emr_managed_slave_security_group` - (Optional) identifier of the Amazon EC2 security group for the slave nodes
-* `instance_profile` - (Required) Instance Profile for EC2 instances of the cluster assume this role
+* `additional_master_security_groups` - (Optional) List of additional Amazon EC2 security group IDs for the master node
+* `additional_slave_security_groups` - (Optional) List of additional Amazon EC2 security group IDs for the slave nodes
+* `emr_managed_master_security_group` - (Optional) Identifier of the Amazon EC2 security group for the master node
+* `emr_managed_slave_security_group` - (Optional) Identifier of the Amazon EC2 security group for the slave nodes
+* `instance_profile` - (Required) Instance profile for EC2 instances of the cluster assume this role
 
 
 ## bootstrap\_action 
 
-* `name` - (Required) name of the bootstrap action
-* `path` - (Required) location of the script to run during a bootstrap action. Can be either a location in Amazon S3 or on a local file system
-* `args` - (Optional) list of command line arguments to pass to the bootstrap action script
+* `name` - (Required) Name of the bootstrap action
+* `path` - (Required) Location of the script to run during a bootstrap action. Can be either a location in Amazon S3 or on a local file system
+* `args` - (Optional) List of command line arguments to pass to the bootstrap action script
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The ID of the EMR Cluster
+* `id`
 * `name` 
 * `release_label` 
 * `master_instance_type`

--- a/website/source/docs/providers/aws/r/emr_cluster.html.md
+++ b/website/source/docs/providers/aws/r/emr_cluster.html.md
@@ -92,7 +92,7 @@ Cannot specify the `cc1.4xlarge` instance type for nodes of a job flow launched 
 * `additional_slave_security_groups` - (Optional) list of additional Amazon EC2 security group IDs for the slave nodes
 * `emr_managed_master_security_group` - (Optional) identifier of the Amazon EC2 security group for the master node
 * `emr_managed_slave_security_group` - (Optional) identifier of the Amazon EC2 security group for the slave nodes
-* `instance_profile` - (Optional) Instance Profile for EC2 instances of the cluster assume this role
+* `instance_profile` - (Required) Instance Profile for EC2 instances of the cluster assume this role
 
 
 ## bootstrap\_action 


### PR DESCRIPTION
When creating an EC2 instance group to process data in an EMR cluster,
specifying `instance_profile` as an attribute inside `ec2_attributes` is
mandatory, it would appear.

Not setting it results in an error from Terraform complaining that it isn't
set, and the AWS SDK for Go appears - at least in my interpretation - not to
default it anywhere:
https://github.com/aws/aws-sdk-go/blob/master/service/emr/api.go

This PR also includes some basic style and grammatical fixes.