### PR TITLE
provider/aws: Provide the option to skip_destroy on aws_volume_attachment

### DIFF
--- a/builtin/providers/aws/resource_aws_volume_attachment.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment.go
@@ -21,25 +21,30 @@ func resourceAwsVolumeAttachment() *schema.Resource {
 		Delete: resourceAwsVolumeAttachmentDelete,
 
 		Schema: map[string]*schema.Schema{
-			"device_name": &schema.Schema{
+			"device_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"instance_id": &schema.Schema{
+			"instance_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"volume_id": &schema.Schema{
+			"volume_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"force_detach": &schema.Schema{
+			"force_detach": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"skip_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
@@ -155,6 +160,12 @@ func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
+
+	if _, ok := d.GetOk("skip_destroy"); ok {
+		log.Printf("[INFO] Found skip_destroy to be true, removing attachment %q from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	vID := d.Get("volume_id").(string)
 	iID := d.Get("instance_id").(string)

--- a/website/source/docs/providers/aws/r/volume_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/volume_attachment.html.markdown
@@ -49,10 +49,11 @@ example, `/dev/sdh` or `xvdh`)
 volume to detach. Useful if previous attempts failed, but use this option only 
 as a last resort, as this can result in **data loss**. See 
 [Detaching an Amazon EBS Volume from an Instance][1] for more information.
-* `skip_destroy` - (Optional, Boolean) Set to `true` if you don't want to
-try and remove an EBS volume from a running disk. This is required in the
-case when you want to mount and unmount specific drives and let the instance
-take care of attachment / detaching.
+* `skip_destroy` - (Optional, Boolean) Set this to true if you do not wish 
+to detach the volume from the instance to which it is attached at destroy 
+time, and instead just remove the attachment from Terraform state. This is 
+useful when destroying an instance which has volumes created by some other 
+means attached.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/volume_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/volume_attachment.html.markdown
@@ -49,6 +49,10 @@ example, `/dev/sdh` or `xvdh`)
 volume to detach. Useful if previous attempts failed, but use this option only 
 as a last resort, as this can result in **data loss**. See 
 [Detaching an Amazon EBS Volume from an Instance][1] for more information.
+* `skip_destroy` - (Optional, Boolean) Set to `true` if you don't want to
+try and remove an EBS volume from a running disk. This is required in the
+case when you want to mount and unmount specific drives and let the instance
+take care of attachment / detaching.
 
 ## Attributes Reference
 


### PR DESCRIPTION
When you want to attach and detach pre-existing EBS volumes to an
instance, we would do that as follows:

```
resource "aws_instance" "web" {
	ami = "ami-21f78e11"
  availability_zone = "us-west-2a"
	instance_type = "t1.micro"
	tags {
		Name = "HelloWorld"
	}
}

data "aws_ebs_volume" "ebs_volume" {
  filter {
  	name = "size"
  	values = ["${aws_ebs_volume.example.size}"]
  }
  filter {
  	name = "availability-zone"
  	values = ["${aws_ebs_volume.example.availability_zone}"]
  }
  filter {
  	name = "tag:Name"
  	values = ["TestVolume"]
  }
}

resource "aws_volume_attachment" "ebs_att" {
  device_name = "/dev/sdh"
	volume_id = "${data.aws_ebs_volume.ebs_volume.id}"
	instance_id = "${aws_instance.web.id}"
	skip_destroy = true
}
```

The issue here is that when we run a terraform destroy command, the volume tries to get detached from a running instance and can go into a non-responsive state. We would have to force_destroy the volume at that point and risk losing any data on it.

This PR introduces the idea of `skip_destroy` on a volume attachment. tl;dr:

We want the volume to be detached from the instane when the instance itself has been destroyed. This way the normal shut procedures will happen and protect the disk for attachment to another instance

Volume Attachment Tests:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVolumeAttachment_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/02 00:47:27 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVolumeAttachment_ -timeout 120m
=== RUN   TestAccAWSVolumeAttachment_basic
--- PASS: TestAccAWSVolumeAttachment_basic (133.49s)
=== RUN   TestAccAWSVolumeAttachment_skipDestroy
--- PASS: TestAccAWSVolumeAttachment_skipDestroy (119.64s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	253.158s
```

EBS Volume Tests:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEBSVolume_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/02 01:00:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEBSVolume_ -timeout 120m
=== RUN   TestAccAWSEBSVolume_importBasic
--- PASS: TestAccAWSEBSVolume_importBasic (26.38s)
=== RUN   TestAccAWSEBSVolume_basic
--- PASS: TestAccAWSEBSVolume_basic (26.86s)
=== RUN   TestAccAWSEBSVolume_NoIops
--- PASS: TestAccAWSEBSVolume_NoIops (27.89s)
=== RUN   TestAccAWSEBSVolume_withTags
--- PASS: TestAccAWSEBSVolume_withTags (26.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	108.032s
```