### PR TITLE
command/meta: always ask for unset variable input

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -221,10 +221,8 @@ func (m *Meta) InputMode() terraform.InputMode {
 
 	var mode terraform.InputMode
 	mode |= terraform.InputModeProvider
-	if len(m.variables) == 0 {
-		mode |= terraform.InputModeVar
-		mode |= terraform.InputModeVarUnset
-	}
+	mode |= terraform.InputModeVar
+	mode |= terraform.InputModeVarUnset
 
 	return mode
 }

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -175,7 +175,11 @@ func TestMetaInputMode_vars(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if m.InputMode()&terraform.InputModeVar != 0 {
+	if m.InputMode()&terraform.InputModeVar == 0 {
+		t.Fatalf("bad: %#v", m.InputMode())
+	}
+
+	if m.InputMode()&terraform.InputModeVarUnset == 0 {
 		t.Fatalf("bad: %#v", m.InputMode())
 	}
 }

--- a/command/test-fixtures/apply-input-partial/main.tf
+++ b/command/test-fixtures/apply-input-partial/main.tf
@@ -1,0 +1,5 @@
+variable "foo" {}
+variable "bar" {}
+
+output "foo" { value = "${var.foo}" }
+output "bar" { value = "${var.bar}" }

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -22,7 +22,8 @@ const (
 	// InputModeVar asks for all variables
 	InputModeVar InputMode = 1 << iota
 
-	// InputModeVarUnset asks for variables which are not set yet
+	// InputModeVarUnset asks for variables which are not set yet.
+	// InputModeVar must be set for this to have an effect.
 	InputModeVarUnset
 
 	// InputModeProvider asks for provider variables


### PR DESCRIPTION
Fixes #7975

This changes the InputMode for the CLI to always be:

    InputModeProvider | InputModeVar | InputModeVarUnset

Which means:

  * Ask for provider variables
  * Ask for user variables _that are not already set_

The change is the latter point. Before, we'd only ask for variables if
zero were given. This forces the user to either have no variables set
via the CLI, env vars, tfvars or ALL variables, but no in between. As
reported in #7975, this isn't expected behavior.

The new change makes is so that unset variables are always asked for.
Users can retain the previous behavior by setting `-input=false`. This
would ensure that variables set by external sources cover all cases.