### PR TITLE
config: formatlist accepts an empty list

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -994,6 +994,18 @@ func TestInterpolateFuncFormatList(t *testing.T) {
 				[]interface{}{"demo-rest-elb.id"},
 				false,
 			},
+			// Works with empty lists [GH-7607]
+			{
+				`${formatlist("%s", var.emptylist)}`,
+				[]interface{}{},
+				false,
+			},
+		},
+		Vars: map[string]ast.Variable{
+			"var.emptylist": {
+				Type:  ast.TypeList,
+				Value: []ast.Variable{},
+			},
 		},
 	})
 }
@@ -1928,7 +1940,6 @@ func testFunction(t *testing.T, config testFunctionConfig) {
 		}
 
 		result, err := hil.Eval(ast, langEvalConfig(config.Vars))
-		t.Logf("err: %v", err)
 		if err != nil != tc.Error {
 			t.Fatalf("Case #%d:\ninput: %#v\nerr: %v", i, tc.Input, err)
 		}


### PR DESCRIPTION
Fixes #7607

An empty list is a valid value for formatlist which means to just return
an empty list as a result. The logic was somewhat convoluted here so I
cleaned that up a bit too. The function overall can definitely be
cleaned up a lot more but I left it mostly as-is to fix the bug.