### PR TITLE
Document about ElastiCache Replication Group port

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `availability_zones` - (Optional) A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important.
 * `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group.
 * `parameter_group_name` - (Optional) The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.
+* `port` – (Required) The port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.
 * `subnet_group_name` - (Optional) The name of the cache subnet group to be used for the replication group.
 * `security_group_names` - (Optional) A list of cache security group names to associate with this replication group.
 * `security_group_ids` - (Optional) One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud 


### PR DESCRIPTION
## WHY

ElastiCache Replication Group `port` is _required_ argument, but there is no description about this argument in website.

[AWS: aws_elasticache_replication_group - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/elasticache_replication_group.html)

## WHAT

Add description of `port` argument in aws_elasticache_replication_group document website.