### PR TITLE
provider/aws: Setting static_routes_only on import of vpn_connection

### DIFF
--- a/builtin/providers/aws/import_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/import_aws_vpn_connection_test.go
@@ -14,11 +14,10 @@ func TestAccAWSVpnConnection_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsVpnConnectionConfig,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -57,78 +57,79 @@ func resourceAwsVpnConnection() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"vpn_gateway_id": &schema.Schema{
+			"vpn_gateway_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"customer_gateway_id": &schema.Schema{
+			"customer_gateway_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"static_routes_only": &schema.Schema{
+			"static_routes_only": {
 				Type:     schema.TypeBool,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
 			"tags": tagsSchema(),
 
 			// Begin read only attributes
-			"customer_gateway_configuration": &schema.Schema{
+			"customer_gateway_configuration": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
 			},
 
-			"tunnel1_address": &schema.Schema{
+			"tunnel1_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"tunnel1_preshared_key": &schema.Schema{
+			"tunnel1_preshared_key": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"tunnel2_address": &schema.Schema{
+			"tunnel2_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"tunnel2_preshared_key": &schema.Schema{
+			"tunnel2_preshared_key": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"routes": &schema.Schema{
+			"routes": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"destination_cidr_block": &schema.Schema{
+						"destination_cidr_block": {
 							Type:     schema.TypeString,
 							Computed: true,
 							Optional: true,
 						},
 
-						"source": &schema.Schema{
+						"source": {
 							Type:     schema.TypeString,
 							Computed: true,
 							Optional: true,
 						},
 
-						"state": &schema.Schema{
+						"state": {
 							Type:     schema.TypeString,
 							Computed: true,
 							Optional: true,
@@ -145,37 +146,37 @@ func resourceAwsVpnConnection() *schema.Resource {
 				},
 			},
 
-			"vgw_telemetry": &schema.Schema{
+			"vgw_telemetry": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"accepted_route_count": &schema.Schema{
+						"accepted_route_count": {
 							Type:     schema.TypeInt,
 							Computed: true,
 							Optional: true,
 						},
 
-						"last_status_change": &schema.Schema{
+						"last_status_change": {
 							Type:     schema.TypeString,
 							Computed: true,
 							Optional: true,
 						},
 
-						"outside_ip_address": &schema.Schema{
+						"outside_ip_address": {
 							Type:     schema.TypeString,
 							Computed: true,
 							Optional: true,
 						},
 
-						"status": &schema.Schema{
+						"status": {
 							Type:     schema.TypeString,
 							Computed: true,
 							Optional: true,
 						},
 
-						"status_message": &schema.Schema{
+						"status_message": {
 							Type:     schema.TypeString,
 							Computed: true,
 							Optional: true,
@@ -304,6 +305,9 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 		if err := d.Set("static_routes_only", vpnConnection.Options.StaticRoutesOnly); err != nil {
 			return err
 		}
+	} else {
+		//If there no Options on the connection then we do not support *static_routes*
+		d.Set("static_routes_only", false)
 	}
 
 	// Set read only attributes.

--- a/builtin/providers/aws/resource_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection_test.go
@@ -19,7 +19,7 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsVpnConnectionConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccAwsVpnConnection(
@@ -30,7 +30,7 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsVpnConnectionConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccAwsVpnConnection(
@@ -39,6 +39,29 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 						"aws_customer_gateway.customer_gateway",
 						"aws_vpn_connection.foo",
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSVpnConnection_withoutStaticRoutes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_vpn_connection.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccAwsVpnConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsVpnConnectionConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAwsVpnConnection(
+						"aws_vpc.vpc",
+						"aws_vpn_gateway.vpn_gateway",
+						"aws_customer_gateway.customer_gateway",
+						"aws_vpn_connection.foo",
+					),
+					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "static_routes_only", "false"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/vpn_connection.html.markdown
+++ b/website/source/docs/providers/aws/r/vpn_connection.html.markdown
@@ -41,7 +41,7 @@ resource "aws_vpn_connection" "main" {
 The following arguments are supported:
 
 * `customer_gateway_id` - (Required) The ID of the customer gateway.
-* `static_routes_only` - (Required) Whether the VPN connection uses static routes exclusively. Static routes must be used for devices that don't support BGP.
+* `static_routes_only` - (Optional, Default `false`) Whether the VPN connection uses static routes exclusively. Static routes must be used for devices that don't support BGP.
 * `tags` - (Optional) Tags to apply to the connection.
 * `type` - (Required) The type of VPN connection. The only type AWS supports at this time is "ipsec.1".
 * `vpn_gateway_id` - (Required) The ID of the virtual private gateway.


### PR DESCRIPTION
fixes #9110

An error was found where, static_routes_only was not set on a vpn
connection import. This commit introduces setting the static_routes_only
to false when no Options are found. This follows the AWS convention as follows:

```
- options (structure)

Indicates whether the VPN connection requires static routes. If you are creating a VPN connection for a device that does not support BGP, you must specify true .
Default: false

```

So we take it that `static_options_only` is false by default

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpnConnection_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/02 10:38:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnConnection_ -timeout 120m
=== RUN   TestAccAWSVpnConnection_importBasic
--- PASS: TestAccAWSVpnConnection_importBasic (178.29s)
=== RUN   TestAccAWSVpnConnection_basic
--- PASS: TestAccAWSVpnConnection_basic (336.81s)
=== RUN   TestAccAWSVpnConnection_withoutStaticRoutes
--- PASS: TestAccAWSVpnConnection_withoutStaticRoutes (195.45s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	710.572s
```