### PR TITLE
provider/aws: Modify AWS User-Agent to new format

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -201,6 +201,10 @@ func (c *Config) Client() (interface{}, error) {
 	if err != nil {
 		return nil, errwrap.Wrapf("Error creating AWS session: {{err}}", err)
 	}
+
+	// Removes the SDK Version handler, so we only have the provider User-Agent
+	// Ex: "User-Agent: APN/1.0 HashiCorp/1.0 Terraform/0.7.9-dev"
+	sess.Handlers.Build.Remove(request.NamedHandler{Name: "core.SDKVersionUserAgentHandler"})
 	sess.Handlers.Build.PushFrontNamed(addTerraformVersionToUserAgent)
 
 	if extraDebug := os.Getenv("TERRAFORM_AWS_AUTHFAILURE_DEBUG"); extraDebug != "" {
@@ -358,7 +362,7 @@ func (c *Config) ValidateAccountId(accountId string) error {
 var addTerraformVersionToUserAgent = request.NamedHandler{
 	Name: "terraform.TerraformVersionUserAgentHandler",
 	Fn: request.MakeAddToUserAgentHandler(
-		"terraform", terraform.VersionString()),
+		"APN/1.0 HashiCorp/1.0 Terraform", terraform.VersionString()),
 }
 
 var debugAuthFailure = request.NamedHandler{


### PR DESCRIPTION
Modifies the `UserAgent` to match a newly recommended format for tracking Terraform usage in AWS. We do this by changing the string format and removing the SDK version information

Current format:

```
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: ec2.us-west-2.amazonaws.com
User-Agent: terraform/0.7.9-dev aws-sdk-go/1.4.17 (go1.7.3; darwin; amd64)
```

New format:

```
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: ec2.us-west-2.amazonaws.com
User-Agent: APN/1.0 HashiCorp/1.0 Terraform/0.7.9-dev
```

With this we should be able to get better information on Terraform usage.

I feel we'll need to note this in the CHANGELOG as a backwards incompatible change however, in the event that someone somewhere is relying on it (see #5020 , #5621 , cc @radeksimko and @phinze  as participants there)

It wasn't clear to me that the SDK version needed to be removed to match this new format, so I did for now. We can re-add it if needed 

------
Update: above I show `Terraform/0.7.9-dev`; this will only apply to custom complied versions of Terraform, say from a branch or `master`. Release versions do not have the `-dev`