### PR TITLE
command/import: allow configuration from files

### DIFF
--- a/command/import.go
+++ b/command/import.go
@@ -19,8 +19,8 @@ func (c *ImportCommand) Run(args []string) int {
 	args = c.Meta.process(args, true)
 
 	cmdFlags := c.Meta.flagSet("import")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }

--- a/command/import.go
+++ b/command/import.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -34,8 +35,16 @@ func (c *ImportCommand) Run(args []string) int {
 		return 1
 	}
 
+	pwd, err := os.Getwd()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error getting pwd: %s", err))
+		return 1
+	}
+
 	// Build the context based on the arguments given
 	ctx, _, err := c.Context(contextOpts{
+		Path:        pwd,
+		PathEmptyOk: true,
 		StatePath:   c.Meta.statePath,
 		Parallelism: c.Meta.parallelism,
 	})

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -102,6 +102,63 @@ func TestImport_providerConfig(t *testing.T) {
 	testStateOutput(t, statePath, testImportStr)
 }
 
+func TestImport_providerConfigDisable(t *testing.T) {
+	defer testChdir(t, testFixturePath("import-provider"))()
+
+	statePath := testTempFile(t)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ImportCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	p.ImportStateFn = nil
+	p.ImportStateReturn = []*terraform.InstanceState{
+		&terraform.InstanceState{
+			ID: "yay",
+			Ephemeral: terraform.EphemeralState{
+				Type: "test_instance",
+			},
+		},
+	}
+
+	configured := false
+	p.ConfigureFn = func(c *terraform.ResourceConfig) error {
+		configured = true
+
+		if v, ok := c.Get("foo"); ok {
+			return fmt.Errorf("bad value: %#v", v)
+		}
+
+		return nil
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-config", "",
+		"test_instance.foo",
+		"bar",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Verify that we were called
+	if !configured {
+		t.Fatal("Configure should be called")
+	}
+
+	if !p.ImportStateCalled {
+		t.Fatal("ImportState should be called")
+	}
+
+	testStateOutput(t, statePath, testImportStr)
+}
+
 /*
 func TestRefresh_badState(t *testing.T) {
 	p := testProvider()

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -36,6 +37,62 @@ func TestImport(t *testing.T) {
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	if !p.ImportStateCalled {
+		t.Fatal("ImportState should be called")
+	}
+
+	testStateOutput(t, statePath, testImportStr)
+}
+
+func TestImport_providerConfig(t *testing.T) {
+	defer testChdir(t, testFixturePath("import-provider"))()
+
+	statePath := testTempFile(t)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ImportCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	p.ImportStateFn = nil
+	p.ImportStateReturn = []*terraform.InstanceState{
+		&terraform.InstanceState{
+			ID: "yay",
+			Ephemeral: terraform.EphemeralState{
+				Type: "test_instance",
+			},
+		},
+	}
+
+	configured := false
+	p.ConfigureFn = func(c *terraform.ResourceConfig) error {
+		configured = true
+
+		if v, ok := c.Get("foo"); !ok || v.(string) != "bar" {
+			return fmt.Errorf("bad value: %#v", v)
+		}
+
+		return nil
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+		"bar",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Verify that we were called
+	if !configured {
+		t.Fatal("Configure should be called")
 	}
 
 	if !p.ImportStateCalled {

--- a/command/test-fixtures/import-provider/main.tf
+++ b/command/test-fixtures/import-provider/main.tf
@@ -1,0 +1,3 @@
+provider "test" {
+    foo = "bar"
+}

--- a/config/loader.go
+++ b/config/loader.go
@@ -12,6 +12,18 @@ import (
 	"github.com/hashicorp/hcl"
 )
 
+// ErrNoConfigsFound is the error returned by LoadDir if no
+// Terraform configuration files were found in the given directory.
+type ErrNoConfigsFound struct {
+	Dir string
+}
+
+func (e ErrNoConfigsFound) Error() string {
+	return fmt.Sprintf(
+		"No Terraform configuration files found in directory: %s",
+		e.Dir)
+}
+
 // LoadJSON loads a single Terraform configuration from a given JSON document.
 //
 // The document must be a complete Terraform configuration. This function will
@@ -69,9 +81,7 @@ func LoadDir(root string) (*Config, error) {
 		return nil, err
 	}
 	if len(files) == 0 {
-		return nil, fmt.Errorf(
-			"No Terraform configuration files found in directory: %s",
-			root)
+		return nil, &ErrNoConfigsFound{Dir: root}
 	}
 
 	// Determine the absolute path to the directory.

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+func TestErrNoConfigsFound_impl(t *testing.T) {
+	var _ error = new(ErrNoConfigsFound)
+}
+
 func TestIsEmptyDir(t *testing.T) {
 	val, err := IsEmptyDir(fixtureDir)
 	if err != nil {

--- a/terraform/context_import.go
+++ b/terraform/context_import.go
@@ -43,10 +43,17 @@ func (c *Context) Import(opts *ImportOpts) (*State, error) {
 	// Copy our own state
 	c.state = c.state.DeepCopy()
 
+	// If no module is given, default to the module configured with
+	// the Context.
+	module := opts.Module
+	if module == nil {
+		module = c.module
+	}
+
 	// Initialize our graph builder
 	builder := &ImportGraphBuilder{
 		ImportTargets: opts.Targets,
-		Module:        opts.Module,
+		Module:        module,
 		Providers:     c.components.ResourceProviders(),
 	}
 

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -264,6 +264,36 @@ func TestContextImport_providerVarConfig(t *testing.T) {
 	}
 }
 
+// Test that provider configs can't reference resources.
+func TestContextImport_providerNonVarConfig(t *testing.T) {
+	p := testProvider("aws")
+	ctx := testContext2(t, &ContextOpts{
+		Module: testModule(t, "import-provider-non-vars"),
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	p.ImportStateReturn = []*InstanceState{
+		&InstanceState{
+			ID:        "foo",
+			Ephemeral: EphemeralState{Type: "aws_instance"},
+		},
+	}
+
+	_, err := ctx.Import(&ImportOpts{
+		Targets: []*ImportTarget{
+			&ImportTarget{
+				Addr: "aws_instance.foo",
+				ID:   "bar",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("should error")
+	}
+}
+
 func TestContextImport_refresh(t *testing.T) {
 	p := testProvider("aws")
 	ctx := testContext2(t, &ContextOpts{

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -49,11 +49,11 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		&DisableProviderTransformerOld{},
 		&PruneProviderTransformer{},
 
-		// Single root
-		&RootTransformer{},
-
 		// Insert nodes to close opened plugin connections
 		&CloseProviderTransformer{},
+
+		// Single root
+		&RootTransformer{},
 
 		// Optimize
 		&TransitiveReductionTransformer{},

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -36,6 +36,14 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		mod = module.NewEmptyTree()
 	}
 
+	// Custom factory for creating providers.
+	providerFactory := func(name string, path []string) GraphNodeProvider {
+		return &NodeApplyableProvider{
+			NameValue: name,
+			PathValue: path,
+		}
+	}
+
 	steps := []GraphTransformer{
 		// Create all our resources from the configuration and state
 		&ConfigTransformerOld{Module: mod},
@@ -44,13 +52,11 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		&ImportStateTransformer{Targets: b.ImportTargets},
 
 		// Provider-related transformations
-		&MissingProviderTransformer{Providers: b.Providers},
+		&MissingProviderTransformer{Providers: b.Providers, Factory: providerFactory},
 		&ProviderTransformer{},
 		&DisableProviderTransformerOld{},
 		&PruneProviderTransformer{},
-
-		// Insert nodes to close opened plugin connections
-		&CloseProviderTransformer{},
+		&AttachProviderConfigTransformer{Module: mod},
 
 		// Single root
 		&RootTransformer{},

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -58,6 +58,9 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		&PruneProviderTransformer{},
 		&AttachProviderConfigTransformer{Module: mod},
 
+		// This validates that the providers only depend on variables
+		&ImportProviderValidateTransformer{},
+
 		// Single root
 		&RootTransformer{},
 

--- a/terraform/test-fixtures/import-provider-non-vars/main.tf
+++ b/terraform/test-fixtures/import-provider-non-vars/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+    foo = "${aws_instance.foo.bar}"
+}
+
+resource "aws_instance" "foo" {
+    bar = "value"
+}

--- a/terraform/test-fixtures/import-provider-vars/main.tf
+++ b/terraform/test-fixtures/import-provider-vars/main.tf
@@ -1,0 +1,5 @@
+variable "foo" {}
+
+provider "aws" {
+  foo = "${var.foo}"
+}

--- a/terraform/transform_import_provider.go
+++ b/terraform/transform_import_provider.go
@@ -1,0 +1,38 @@
+package terraform
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ImportProviderValidateTransformer is a GraphTransformer that goes through
+// the providers in the graph and validates that they only depend on variables.
+type ImportProviderValidateTransformer struct{}
+
+func (t *ImportProviderValidateTransformer) Transform(g *Graph) error {
+	for _, v := range g.Vertices() {
+		// We only care about providers
+		pv, ok := v.(GraphNodeProvider)
+		if !ok {
+			continue
+		}
+
+		// We only care about providers that reference things
+		rn, ok := pv.(GraphNodeReferencer)
+		if !ok {
+			continue
+		}
+
+		for _, ref := range rn.References() {
+			if !strings.HasPrefix(ref, "var.") {
+				return fmt.Errorf(
+					"Provider %q depends on non-var %q. Providers for import can currently\n"+
+						"only depend on variables or must be hardcoded. You can stop import\n"+
+						"from loading configurations by specifying `-config=\"\"`.",
+					pv.ProviderName(), ref)
+			}
+		}
+	}
+
+	return nil
+}

--- a/website/source/docs/commands/import.html.md
+++ b/website/source/docs/commands/import.html.md
@@ -35,6 +35,11 @@ The command-line flags are all optional. The list of available flags are:
   the `-state-out` path with the ".backup" extension. Set to "-" to disable
   backups.
 
+* `-config=path` - Path to directory of Terraform configuration files that
+  configure the provider for import. This defaults to your working directory.
+  If this directory contains no Terraform configuration files, the provider
+  must be configured via manual input or environmental variables.
+
 * `-input=true` - Whether to ask for input for provider configuration.
 
 * `-state=path` - The path to read and save state files (unless state-out is
@@ -46,12 +51,35 @@ The command-line flags are all optional. The list of available flags are:
 
 ## Provider Configuration
 
-To access the provider that the resource is being imported from, Terraform
-will ask you for access credentials. If you don't want to be asked for input,
-verify that all environment variables for your provider are set.
+Terraform will attempt to load configuration files that configure the
+provider being used for import. If no configuration files are present or
+no configuration for that specific provider is present, Terraform will
+prompt you for access credentials. You may also specify environmental variables
+to configure the provider.
 
-The import command cannot read provider configuration from a Terraform
-configuration file.
+The only limitation Terraform has when reading the configuration files
+is that the import provider configurations must not depend on non-variable
+inputs. For example, a provider configuration cannot depend on a data
+source.
+
+As a working example, if you're importing AWS resources and you have a
+configuration file with the contents below, then Terraform will configure
+the AWS provider with this file.
+
+```
+variable "access_key" {}
+variable "secret_key" {}
+
+provider "aws" {
+  access_key = "${var.access_key}"
+  secret_key = "${var.secret_key}"
+}
+```
+
+You can force Terraform to explicitly not load your configuration by
+specifying `-config=""` (empty string). This is useful in situations where
+you want to manually configure the provider because your configuration
+may not be valid.
 
 ## Example: AWS Instance
 

--- a/website/source/docs/import/usage.html.md
+++ b/website/source/docs/import/usage.html.md
@@ -22,9 +22,6 @@ $ terraform import aws_instance.bar i-abcd1234
 ...
 ```
 
-~> **Note:** In order to import resources, the provider should be configured with environment variables.
-We currently do not support passing credentials directly to the provider.
-
 The above command imports an AWS instance with the given ID to the
 address `aws_instance.bar`. You can also import resources into modules.
 See the [resource addressing](/docs/internals/resource-addressing.html)


### PR DESCRIPTION
Fixes #7774

This PR does the following, with details below:

  * `terraform import` will configure providers based on TF config files

  * `terraform import` has a new flag `-config` to specify the directory of the configurations. More importantly, this can be set to "" (empty string) to disable config loading.

  * Provider configurations for import must only reference variables. Any other references such as data sources are invalid and unsupported currently.

  * Updates the website to clarify this new functionality with examples.

This is done in the spirit of slowly improving and increasing the functionality of import. As usual, it is still somewhat restricted (such point 3 above) but this should cover a much larger set of use cases now.

Tagged for 0.8.