### PR TITLE
helper/schema: computed bool fields should not crash

### DIFF
--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -223,6 +223,9 @@ func stringToPrimitive(
 			returnVal = false
 			break
 		}
+		if computed {
+			break
+		}
 
 		v, err := strconv.ParseBool(value)
 		if err != nil {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2455,6 +2455,42 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			Err: false,
 		},
+
+		// GH-7715
+		"computed value for boolean field": {
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeBool,
+					ForceNew: true,
+					Computed: true,
+					Optional: true,
+				},
+			},
+
+			State: &terraform.InstanceState{},
+
+			Config: map[string]interface{}{
+				"foo": "${var.foo}",
+			},
+
+			ConfigVariables: map[string]ast.Variable{
+				"var.foo": interfaceToVariableSwallowError(
+					config.UnknownVariableValue),
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old:         "",
+						New:         "false",
+						NewComputed: true,
+						RequiresNew: true,
+					},
+				},
+			},
+
+			Err: false,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
Fixes #7715

If a bool field was computed and the raw value was not convertable to a
boolean, helper/schema would crash. The correct behavior is to try not
to read the raw value when the value is computed and to simply mark that
it is computed. This does that (and matches the behavior of the other
primitives).