### PR TITLE
provider/azurerm: allow storage_account resource with name "$root"

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_container.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container.go
@@ -53,7 +53,7 @@ func resourceArmStorageContainer() *schema.Resource {
 //Following the naming convention as laid out in the docs
 func validateArmStorageContainerName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^\$root$|^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only lowercase alphanumeric characters and hyphens allowed in %q: %q",
 			k, value))

--- a/builtin/providers/azurerm/resource_arm_storage_container_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container_test.go
@@ -58,6 +58,29 @@ func TestAccAzureRMStorageContainer_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageContainer_root(t *testing.T) {
+	var c storage.Container
+
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := fmt.Sprintf(testAccAzureRMStorageContainer_root, ri, rs)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageContainerExists("azurerm_storage_container.test", &c),
+					resource.TestCheckResourceAttr("azurerm_storage_container.test", "name", "$root"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMStorageContainerExists(name string, c *storage.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -191,6 +214,7 @@ func TestValidateArmStorageContainerName(t *testing.T) {
 	validNames := []string{
 		"valid-name",
 		"valid02-name",
+		"$root",
 	}
 	for _, v := range validNames {
 		_, errors := validateArmStorageContainerName(v, "name")
@@ -205,6 +229,7 @@ func TestValidateArmStorageContainerName(t *testing.T) {
 		"invalid_name",
 		"invalid!",
 		"ww",
+		"$notroot",
 		strings.Repeat("w", 65),
 	}
 	for _, v := range invalidNames {
@@ -234,6 +259,31 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
     name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+`
+
+var testAccAzureRMStorageContainer_root = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "westus"
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "acctestacc%s"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "$root"
     resource_group_name = "${azurerm_resource_group.test.name}"
     storage_account_name = "${azurerm_storage_account.test.name}"
     container_access_type = "private"


### PR DESCRIPTION
Fixes #8763

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMStorageContainer -timeout 120m
=== RUN   TestAccAzureRMStorageContainer_basic
--- PASS: TestAccAzureRMStorageContainer_basic (131.40s)
=== RUN   TestAccAzureRMStorageContainer_disappears
--- PASS: TestAccAzureRMStorageContainer_disappears (126.20s)
=== RUN   TestAccAzureRMStorageContainer_root
--- PASS: TestAccAzureRMStorageContainer_root (125.98s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	383.661s
```