### PR TITLE
provider/aws: Fix TestAccAWSAPIGatewayDomainName_basic test

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -105,7 +105,9 @@ func resourceAwsApiGatewayDomainNameRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("certificate_name", domainName.CertificateName)
-	d.Set("certificate_upload_date", domainName.CertificateUploadDate)
+	if err := d.Set("certificate_upload_date", domainName.CertificateUploadDate.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting certificate_upload_date: %s", err)
+	}
 	d.Set("cloudfront_domain_name", domainName.DistributionDomainName)
 	d.Set("domain_name", domainName.DomainName)
 


### PR DESCRIPTION
The test `TestAccAWSAPIGatewayDomainName_basic` is failing because we're setting a `*time.Time` value to a `String` and it's failing to convert automatically. This PR formats the time to `RFC3339` (see [here for reference](https://golang.org/pkg/time/#pkg-constants))

Refs #9533 