### PR TITLE
Updated the documentation to reflect that subnets_ids is required

### DIFF
--- a/website/source/docs/providers/aws/r/redshift_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_subnet_group.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Redshift Subnet group.
 * `description` - (Optional) The description of the Redshift Subnet group. Defaults to "Managed by Terraform".
-* `subnet_ids` - (Optional) An array of VPC subnet IDs.
+* `subnet_ids` - (Required) An array of VPC subnet IDs.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
### Reasonning for this change
Redshift Subnet Group Group subnet_ids is a [required argument](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_redshift_subnet_group.go#L42), but it is showed as optional.