### PR TITLE
provider/aws: removing toLower from flattenElastiCacheParameters

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -683,7 +683,7 @@ func flattenElastiCacheParameters(list []*elasticache.Parameter) []map[string]in
 		if i.ParameterValue != nil {
 			result = append(result, map[string]interface{}{
 				"name":  strings.ToLower(*i.ParameterName),
-				"value": strings.ToLower(*i.ParameterValue),
+				"value": *i.ParameterValue,
 			})
 		}
 	}


### PR DESCRIPTION
aws_elasticache_parameter_group parameters can be case sensitive
Namely notify-keyspace-events.
There are a few other instances in structure.go where parameter values are toLower'd.  I'm not certain this causes any issues.  I only found one other person making reference to this problem at the very bottom of issue 5854.
https://github.com/hashicorp/terraform/issues/5854