### PR TITLE
provider/aws: Add the enable_sni attribute for Route53 health checks.

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -115,6 +115,11 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"enable_sni": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 
 			"tags": tagsSchema(),
 		},
@@ -173,6 +178,10 @@ func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{
 		updateHealthCheck.InsufficientDataHealthStatus = aws.String(d.Get("insufficient_data_health_status").(string))
 	}
 
+	if d.HasChange("enable_sni") {
+		updateHealthCheck.EnableSNI = aws.Bool(d.Get("enable_sni").(bool))
+	}
+
 	_, err := conn.UpdateHealthCheck(updateHealthCheck)
 	if err != nil {
 		return err
@@ -228,6 +237,10 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("invert_healthcheck"); ok {
 		healthConfig.Inverted = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("enable_sni"); ok {
+		healthConfig.EnableSNI = aws.Bool(v.(bool))
 	}
 
 	if *healthConfig.Type == route53.HealthCheckTypeCalculated {
@@ -314,6 +327,7 @@ func resourceAwsRoute53HealthCheckRead(d *schema.ResourceData, meta interface{})
 	d.Set("child_healthchecks", updated.ChildHealthChecks)
 	d.Set("child_health_threshold", updated.HealthThreshold)
 	d.Set("insufficient_data_health_status", updated.InsufficientDataHealthStatus)
+	d.Set("enable_sni", updated.EnableSNI)
 
 	if updated.AlarmIdentifier != nil {
 		d.Set("cloudwatch_alarm_name", updated.AlarmIdentifier.Name)

--- a/website/source/docs/providers/aws/r/route53_health_check.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_health_check.html.markdown
@@ -75,6 +75,7 @@ The following arguments are supported:
 * `search_string` - (Optional) String searched in the first 5120 bytes of the response body for check to be considered healthy.
 * `measure_latency` - (Optional) A Boolean value that indicates whether you want Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint and to display CloudWatch latency graphs in the Route 53 console.
 * `invert_healthcheck` - (Optional) A boolean value that indicates whether the status of health check should be inverted. For example, if a health check is healthy but Inverted is True , then Route 53 considers the health check to be unhealthy.
+* `enable_sni` - (Optional) A boolean value that indicates whether Route53 should send the `fqdn` to the endpoint when performing the health check. This defaults to AWS' defaults: when the `type` is "HTTPS" `enable_sni` defaults to `true`, when `type` is anything else `enable_sni` defaults to `false`.
 * `child_healthchecks` - (Optional) For a specified parent health check, a list of HealthCheckId values for the associated child health checks.
 * `child_health_threshold` - (Optional) The minimum number of child health checks that must be healthy for Route 53 to consider the parent health check to be healthy. Valid values are integers between 0 and 256, inclusive
 * `cloudwatch_alarm_name` - (Optional) The name of the CloudWatch alarm.


### PR DESCRIPTION
In #8502 it was requested that we add support for the EnableSNI
parameter of Route53's health checks; this enables customers to
manually specify whether or not the health check will use SNI when
communicating with the endpoint.

The reporter originally requested we default to `false`. While
implementing the issue, I discovered that when creating health
checks with a Type set to HTTP, Amazon's default value for EnableSNI
is `false`. However, when creating health checks with a Type set to
HTTPS, Amazon's default value is `true`. So rather than setting a
default value, I made the attribute computed.