### PR TITLE
config: validate that outputs have a name

### DIFF
--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -324,7 +324,8 @@ func loadModulesHcl(list *ast.ObjectList) ([]*Module, error) {
 func loadOutputsHcl(list *ast.ObjectList) ([]*Output, error) {
 	list = list.Children()
 	if len(list.Items) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf(
+			"'output' must be followed by exactly one string: a name")
 	}
 
 	// Go through each object and turn it into an actual result.

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -565,6 +565,18 @@ func TestLoadFile_provisioners(t *testing.T) {
 	}
 }
 
+func TestLoadFile_unnamedOutput(t *testing.T) {
+	_, err := LoadFile(filepath.Join(fixtureDir, "output-unnamed.tf"))
+	if err == nil {
+		t.Fatalf("bad: expected error")
+	}
+
+	errorStr := err.Error()
+	if !strings.Contains(errorStr, "'output' must be followed") {
+		t.Fatalf("bad: expected error has wrong text: %s", errorStr)
+	}
+}
+
 func TestLoadFile_connections(t *testing.T) {
 	c, err := LoadFile(filepath.Join(fixtureDir, "connection.tf"))
 	if err != nil {

--- a/config/test-fixtures/output-unnamed.tf
+++ b/config/test-fixtures/output-unnamed.tf
@@ -1,0 +1,3 @@
+output {
+  value = "foo"
+}


### PR DESCRIPTION
Fixes #9774 

This adds validation so that an output has a name. 