### PR TITLE
provider/openstack: Don't default 'shared' value, instead only set if…

### DIFF
--- a/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
@@ -44,7 +44,6 @@ func resourceFWPolicyV1() *schema.Resource {
 			"shared": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -79,15 +78,18 @@ func resourceFWPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	audited := d.Get("audited").(bool)
-	shared := d.Get("shared").(bool)
 
 	opts := policies.CreateOpts{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Audited:     &audited,
-		Shared:      &shared,
 		TenantID:    d.Get("tenant_id").(string),
 		Rules:       rules,
+	}
+
+	if r, ok := d.GetOk("shared"); ok {
+		shared := r.(bool)
+		opts.Shared = &shared
 	}
 
 	log.Printf("[DEBUG] Create firewall policy: %#v", opts)

--- a/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
@@ -64,9 +64,10 @@ The following arguments are supported:
     firewall policy.
 
 * `shared` - (Optional) Sharing status of the firewall policy (must be "true"
-    or "false" if provided - defaults to "false"). If this is "true" the policy
-    is visible to, and can be used in, firewalls in other tenants. Changing this
-    updates the `shared` status of an existing firewall policy.
+    or "false" if provided). If this is "true" the policy is visible to, and
+    can be used in, firewalls in other tenants. Changing this updates the
+    `shared` status of an existing firewall policy. Only administrative users
+    can specify if the policy should be shared.
 
 ## Attributes Reference
 


### PR DESCRIPTION
… specified. 
Fixes #9829