### PR TITLE
provider/openstack: Add 'value_specs' option to 'openstack_fw_rule_v1' resource

### DIFF
--- a/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_rule_v1.go
@@ -74,6 +74,11 @@ func resourceFWRuleV1() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -90,18 +95,21 @@ func resourceFWRuleV1Create(d *schema.ResourceData, meta interface{}) error {
 	ipVersion := resourceFWRuleV1DetermineIPVersion(d.Get("ip_version").(int))
 	protocol := resourceFWRuleV1DetermineProtocol(d.Get("protocol").(string))
 
-	ruleConfiguration := rules.CreateOpts{
-		Name:                 d.Get("name").(string),
-		Description:          d.Get("description").(string),
-		Protocol:             protocol,
-		Action:               d.Get("action").(string),
-		IPVersion:            ipVersion,
-		SourceIPAddress:      d.Get("source_ip_address").(string),
-		DestinationIPAddress: d.Get("destination_ip_address").(string),
-		SourcePort:           d.Get("source_port").(string),
-		DestinationPort:      d.Get("destination_port").(string),
-		Enabled:              &enabled,
-		TenantID:             d.Get("tenant_id").(string),
+	ruleConfiguration := RuleCreateOpts{
+		rules.CreateOpts{
+			Name:                 d.Get("name").(string),
+			Description:          d.Get("description").(string),
+			Protocol:             protocol,
+			Action:               d.Get("action").(string),
+			IPVersion:            ipVersion,
+			SourceIPAddress:      d.Get("source_ip_address").(string),
+			DestinationIPAddress: d.Get("destination_ip_address").(string),
+			SourcePort:           d.Get("source_port").(string),
+			DestinationPort:      d.Get("destination_port").(string),
+			Enabled:              &enabled,
+			TenantID:             d.Get("tenant_id").(string),
+		},
+		MapValueSpecs(d),
 	}
 
 	log.Printf("[DEBUG] Create firewall rule: %#v", ruleConfiguration)

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -67,6 +68,27 @@ type RouterCreateOpts struct {
 // It overrides routers.ToRouterCreateMap to add the ValueSpecs field.
 func (opts RouterCreateOpts) ToRouterCreateMap() (map[string]interface{}, error) {
 	return BuildRequest(opts, "router")
+}
+
+// RuleCreateOpts represents the attributes used when creating a new firewall rule.
+type RuleCreateOpts struct {
+	rules.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToRuleCreateMap casts a CreateOpts struct to a map.
+// It overrides rules.ToRuleCreateMap to add the ValueSpecs field.
+func (opts RuleCreateOpts) ToRuleCreateMap() (map[string]interface{}, error) {
+	b, err := BuildRequest(opts, "firewall_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	if m := b["firewall_rule"].(map[string]interface{}); m["protocol"] == "any" {
+		m["protocol"] = nil
+	}
+
+	return b, nil
 }
 
 // SubnetCreateOpts represents the attributes used when creating a new subnet.

--- a/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_rule_v1.html.markdown
@@ -73,6 +73,8 @@ The following arguments are supported:
     wants to create a firewall rule for another tenant. Changing this creates a
     new firewall rule.
 
+* `value_specs` - (Optional) Map of additional options.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Refactor to use common 'types.go' and 'MapValueSpecs' function.
Website docs updated.