### PR TITLE
provider/openstack: Add 'value_specs' option to 'openstack_fw_policy_v1' resource

### DIFF
--- a/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_policy_v1.go
@@ -56,6 +56,11 @@ func resourceFWPolicyV1() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -79,12 +84,15 @@ func resourceFWPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	audited := d.Get("audited").(bool)
 
-	opts := policies.CreateOpts{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Audited:     &audited,
-		TenantID:    d.Get("tenant_id").(string),
-		Rules:       rules,
+	opts := PolicyCreateOpts{
+		policies.CreateOpts{
+			Name:        d.Get("name").(string),
+			Description: d.Get("description").(string),
+			Audited:     &audited,
+			TenantID:    d.Get("tenant_id").(string),
+			Rules:       rules,
+		},
+		MapValueSpecs(d),
 	}
 
 	if r, ok := d.GetOk("shared"); ok {

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
@@ -44,6 +45,18 @@ type NetworkCreateOpts struct {
 // It overrides networks.ToNetworkCreateMap to add the ValueSpecs field.
 func (opts NetworkCreateOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
 	return BuildRequest(opts, "network")
+}
+
+// PolicyCreateOpts represents the attributes used when creating a new firewall policy.
+type PolicyCreateOpts struct {
+	policies.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToPolicyCreateMap casts a CreateOpts struct to a map.
+// It overrides policies.ToFirewallPolicyCreateMap to add the ValueSpecs field.
+func (opts PolicyCreateOpts) ToFirewallPolicyCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "firewall_policy")
 }
 
 // PortCreateOpts represents the attributes used when creating a new port.

--- a/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_policy_v1.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
     `shared` status of an existing firewall policy. Only administrative users
     can specify if the policy should be shared.
 
+* `value_specs` - (Optional) Map of additional options.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Refactor to use common 'types.go' and 'MapValueSpecs' function.
Website docs updated to reflect additions

**WIll require re-base after #9830 and #9834 are merged**