### PR TITLE
provider/openstack: Add 'value_specs' option to 'openstack_fw_firewall_v1' resource

### DIFF
--- a/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
+++ b/builtin/providers/openstack/resource_openstack_fw_firewall_v1.go
@@ -51,6 +51,11 @@ func resourceFWFirewallV1() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -65,12 +70,15 @@ func resourceFWFirewallV1Create(d *schema.ResourceData, meta interface{}) error 
 
 	adminStateUp := d.Get("admin_state_up").(bool)
 
-	firewallConfiguration := firewalls.CreateOpts{
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		PolicyID:     d.Get("policy_id").(string),
-		AdminStateUp: &adminStateUp,
-		TenantID:     d.Get("tenant_id").(string),
+	firewallConfiguration := FirewallCreateOpts{
+		firewalls.CreateOpts{
+			Name:         d.Get("name").(string),
+			Description:  d.Get("description").(string),
+			PolicyID:     d.Get("policy_id").(string),
+			AdminStateUp: &adminStateUp,
+			TenantID:     d.Get("tenant_id").(string),
+		},
+		MapValueSpecs(d),
 	}
 
 	log.Printf("[DEBUG] Create firewall: %#v", firewallConfiguration)

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -11,7 +12,19 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
 
-// FloatingIPCreateOpts represents the attributes used when creating a new port.
+// FirewallCreateOpts represents the attributes used when creating a new firewall.
+type FirewallCreateOpts struct {
+	firewalls.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToFirewallCreateMap casts a CreateOpts struct to a map.
+// It overrides firewalls.ToFirewallCreateMap to add the ValueSpecs field.
+func (opts FirewallCreateOpts) ToFirewallCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "firewall")
+}
+
+// FloatingIPCreateOpts represents the attributes used when creating a new floating ip.
 type FloatingIPCreateOpts struct {
 	floatingips.CreateOpts
 	ValueSpecs map[string]string `json:"value_specs,omitempty"`

--- a/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
+++ b/website/source/docs/providers/openstack/r/fw_firewall_v1.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
     to create a firewall for another tenant. Changing this creates a new
     firewall.
 
+* `value_specs` - (Optional) Map of additional options.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Refactor to use common 'types.go' and 'MapValueSpecs' function.
Website docs updated to reflect changes.

**Will require rebase after merging #9830, #9834 and #9835**