### PR TITLE
provider/aws: Redshift Cluster: Fix for master_username & password

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -328,6 +328,14 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		d.SetId(*resp.Cluster.ClusterIdentifier)
 
 	} else {
+		if _, ok := d.GetOk("master_password"); !ok {
+			return fmt.Errorf(`provider.aws: aws_redshift_cluster: %s: "master_password": required field is not set`, d.Get("cluster_identifier").(string))
+		}
+
+		if _, ok := d.GetOk("master_username"); !ok {
+			return fmt.Errorf(`provider.aws: aws_redshift_cluster: %s: "master_username": required field is not set`, d.Get("cluster_identifier").(string))
+		}
+
 		createOpts := &redshift.CreateClusterInput{
 			ClusterIdentifier:                aws.String(d.Get("cluster_identifier").(string)),
 			Port:                             aws.Int64(int64(d.Get("port").(int))),

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -34,10 +34,11 @@ string.
  If you do not provide a name, Amazon Redshift will create a default database called `dev`.
 * `node_type` - (Required) The node type to be provisioned for the cluster.
 * `cluster_type` - (Optional) The cluster type to use. Either `single-node` or `multi-node`. 
-* `master_password` - (Required) Password for the master DB user. Note that this may
-    show up in logs, and it will be stored in the state file. Password must contain at least 8 chars and 
+* `master_password` - (Required unless a `snapshot_identifier` is provided) Password for the master DB user. 
+    Note that this may show up in logs, and it will be stored in the state file. Password must contain at least 8 chars and 
     contain at least one uppercase letter, one lowercase letter, and one number.
-* `master_username` - (Required) Username for the master DB user
+* `master_username` - (Required unless a `snapshot_identifier` is provided) Username for the master DB user. 
+
 * `cluster_security_groups` - (Optional) A list of security groups to be associated with this cluster.
 * `vpc_security_group_ids` - (Optional) A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster.
 * `cluster_subnet_group_name` - (Optional) The name of a cluster subnet group to be associated with this cluster. If this parameter is not provided the resulting cluster will be deployed outside virtual private cloud (VPC).


### PR DESCRIPTION
This forces the `master_username` & `master_password` to be defined when not in a restore mode. 
If `snapshot_identifier` is not set by the user, those are required. Currently, AWS returns errors about those being not set. 