### PR TITLE
terraform: new apply graph creates provisioners in modules

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2246,6 +2246,43 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_provisionerModule(t *testing.T) {
+	m := testModule(t, "apply-provisioner-module")
+	p := testProvider("aws")
+	pr := testProvisioner()
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		Provisioners: map[string]ResourceProvisionerFactory{
+			"shell": testProvisionerFuncFixed(pr),
+		},
+	})
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(state.String())
+	expected := strings.TrimSpace(testTerraformApplyProvisionerModuleStr)
+	if actual != expected {
+		t.Fatalf("bad: \n%s", actual)
+	}
+
+	// Verify apply was invoked
+	if !pr.ApplyCalled {
+		t.Fatalf("provisioner not invoked")
+	}
+}
+
 func TestContext2Apply_Provisioner_compute(t *testing.T) {
 	m := testModule(t, "apply-provisioner-compute")
 	p := testProvider("aws")

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -100,16 +100,16 @@ meta.count-boundary (count boundary fixup)
   module.child.aws_instance.create
   module.child.aws_instance.other
   module.child.provider.aws
+  module.child.provisioner.exec
   provider.aws
-  provisioner.exec
 module.child.aws_instance.create
   module.child.provider.aws
-  provisioner.exec
+  module.child.provisioner.exec
 module.child.aws_instance.other
   module.child.aws_instance.create
   module.child.provider.aws
 module.child.provider.aws
   provider.aws
+module.child.provisioner.exec
 provider.aws
-provisioner.exec
 `

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -522,6 +522,13 @@ aws_instance.foo:
   type = aws_instance
 `
 
+const testTerraformApplyProvisionerModuleStr = `
+<no state>
+module.child:
+  aws_instance.bar:
+    ID = foo
+`
+
 const testTerraformApplyProvisionerFailStr = `
 aws_instance.bar: (tainted)
   ID = foo

--- a/terraform/test-fixtures/apply-provisioner-module/child/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-module/child/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "bar" {
+    provisioner "shell" {
+        foo = "bar"
+    }
+}

--- a/terraform/test-fixtures/apply-provisioner-module/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-module/main.tf
@@ -1,0 +1,1 @@
+module "child" { source = "./child" }

--- a/terraform/test-fixtures/transform-provisioner-module/child/main.tf
+++ b/terraform/test-fixtures/transform-provisioner-module/child/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+    provisioner "shell" {}
+}

--- a/terraform/test-fixtures/transform-provisioner-module/main.tf
+++ b/terraform/test-fixtures/transform-provisioner-module/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+  provisioner "shell" {}
+}
+
+module "child" {
+  source = "./child"
+}


### PR DESCRIPTION
Fixes #9840

The new apply graph wasn't properly nesting provisioners. This resulted
in reading the provisioners being nil on apply in the shadow graph which
caused the crash in the above issue.

The actual cause of this is that the new graphs we're moving towards do
not have any "flattening" (they are flat to begin with): all modules are
in the root graph from the beginning of construction versus building a
number of different graphs and flattening them. The transform that adds
the provisioners wasn't modified to handle already-flat graphs and so
was only adding provisioners to the root module, not children.

The change modifies the `MissingProvisionerTransformer` (primarily) to
support already-flat graphs and add provisioners for all module levels.
Tests are there to cover this as well.

**NOTE:** This PR focuses on fixing that specific issue. I'm going to follow up
this PR with another PR that is more focused on being robust against
crashing (more nil checks, recover() for shadow graph, etc.). In the
interest of focus and keeping a PR reviewable this focuses only on the
issue itself.