### PR TITLE
provider/aws: Hash the admin password of AWS directory services in statefile

### DIFF
--- a/builtin/providers/aws/resource_aws_directory_service_directory_migrate.go
+++ b/builtin/providers/aws/resource_aws_directory_service_directory_migrate.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsDirectoryServiceDirectoryMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Directory Service Directory State v0; migrating to v1")
+		return migrateDirectoryServiceStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateDirectoryServiceStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration %#v", is.Attributes)
+
+	// Replace password with password hash
+	is.Attributes["password"] = directoryServicePasswordHashSha256(is.Attributes["password"])
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/aws/resource_aws_directory_service_directory_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_directory_service_directory_migrate_test.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceAwsDirectoryServicesDirectoryMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			ID:           "d-abc123",
+			Attributes: map[string]string{
+				"password": "hunter2",
+			},
+			Expected: "f52fbd32b2b3b86ff88ef6c490628285f482af15ddcb29541f94bcf526a3f6c7",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsDirectoryServiceDirectoryMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.Attributes["password"] != tc.Expected {
+			t.Fatalf("Bad password hash migration: %s\n\n expected %s", is.Attributes["password"], tc.Expected)
+		}
+	}
+}


### PR DESCRIPTION
Implement a `StateFunc` against the `password` attribute of `aws_directory_service_directory` to generate a SHA-256 hash of the password instead of storing the password in the statefile in the clear.

Additionally, set `Sensitive: true` for the `password` attribute.

Increment the `SchemaVersion` of `aws_directory_service_directory` to 1, and implement schema migration functions and associated tests.