### PR TITLE
terraform: GraphWalkerPanicwrap to catch panics, shadow graph uses it

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -736,11 +736,14 @@ func (c *Context) walk(
 
 	// If we have a shadow graph, wait for that to complete.
 	if shadowCloser != nil {
-		// Build the graph walker for the shadow.
-		shadowWalker := &ContextGraphWalker{
+		// Build the graph walker for the shadow. We also wrap this in
+		// a panicwrap so that panics are captured. For the shadow graph,
+		// we just want panics to be normal errors rather than to crash
+		// Terraform.
+		shadowWalker := GraphWalkerPanicwrap(&ContextGraphWalker{
 			Context:   shadowCtx,
 			Operation: operation,
-		}
+		})
 
 		// Kick off the shadow walk. This will block on any operations
 		// on the real walk so it is fine to start first.

--- a/terraform/graph_test.go
+++ b/terraform/graph_test.go
@@ -69,6 +69,29 @@ func TestGraphReplace_DependableWithNonDependable(t *testing.T) {
 	}
 }
 
+func TestGraphWalk_panicWrap(t *testing.T) {
+	var g Graph
+
+	// Add our crasher
+	v := &testGraphSubPath{
+		PathFn: func() []string {
+			panic("yo")
+		},
+	}
+	g.Add(v)
+
+	err := g.Walk(GraphWalkerPanicwrap(new(NullGraphWalker)))
+	if err == nil {
+		t.Fatal("should error")
+	}
+}
+
+type testGraphSubPath struct {
+	PathFn func() []string
+}
+
+func (v *testGraphSubPath) Path() []string { return v.PathFn() }
+
 type testGraphDependable struct {
 	VertexName      string
 	DependentOnMock []string

--- a/terraform/graph_walk.go
+++ b/terraform/graph_walk.go
@@ -15,12 +15,42 @@ type GraphWalker interface {
 	ExitEvalTree(dag.Vertex, interface{}, error) error
 }
 
+// GrpahWalkerPanicwrapper can be optionally implemented to catch panics
+// that occur while walking the graph. This is not generally recommended
+// since panics should crash Terraform and result in a bug report. However,
+// this is particularly useful for situations like the shadow graph where
+// you don't ever want to cause a panic.
+type GraphWalkerPanicwrapper interface {
+	GraphWalker
+
+	// Panic is called when a panic occurs. This will halt the panic from
+	// propogating so if the walker wants it to crash still it should panic
+	// again. This is called from within a defer so runtime/debug.Stack can
+	// be used to get the stack trace of the panic.
+	Panic(dag.Vertex, interface{})
+}
+
+// GraphWalkerPanicwrap wraps an existing Graphwalker to wrap and swallow
+// the panics. This doesn't lose the panics since the panics are still
+// returned as errors as part of a graph walk.
+func GraphWalkerPanicwrap(w GraphWalker) GraphWalkerPanicwrapper {
+	return &graphWalkerPanicwrapper{
+		GraphWalker: w,
+	}
+}
+
+type graphWalkerPanicwrapper struct {
+	GraphWalker
+}
+
+func (graphWalkerPanicwrapper) Panic(dag.Vertex, interface{}) {}
+
 // NullGraphWalker is a GraphWalker implementation that does nothing.
 // This can be embedded within other GraphWalker implementations for easily
 // implementing all the required functions.
 type NullGraphWalker struct{}
 
-func (NullGraphWalker) EnterPath([]string) EvalContext                  { return nil }
+func (NullGraphWalker) EnterPath([]string) EvalContext                  { return new(MockEvalContext) }
 func (NullGraphWalker) ExitPath([]string)                               {}
 func (NullGraphWalker) EnterVertex(dag.Vertex)                          {}
 func (NullGraphWalker) ExitVertex(dag.Vertex, error)                    {}


### PR DESCRIPTION
Related to #9840 

This PR:

  * Adds the ability for GraphWalkers to declare they want to catch panics (by implementing `GraphWalkerPanicwrapper`)

  * Modifies the graph walk to turn panics into errors if the above interface is implemented. This makes it so that panics are never able to be completely thrown away. They either crash Terraform or turn into errors that will bubble up.

  * Modifies shadow graph execution to always capture panics.

This adds some additional robustness around shadow graph execution so that panics during graph walking do not cause Terraform to crash. If this was in place for #9840 then the panic would've shown up as a normal shadow error versus crashing. This would've been okay since the original (non-shadow) graph finished successfully. 

This doesn't cover 100% of the scenarios where a shadow graph can crash, but it covers a very large section and one of two most likely areas it would crash (evaluation). The other area would be graph construction itself. This PR doesn't affect the latter positively or negatively.