### PR TITLE
fix CreateBeforeDestroy with datasources

### DIFF
--- a/terraform/graph_builder_test.go
+++ b/terraform/graph_builder_test.go
@@ -173,6 +173,7 @@ func TestBuiltinGraphBuilder_cbdDepNonCbd(t *testing.T) {
 	}
 }
 
+// This now returns no errors due to a general fix while building the graph
 func TestBuiltinGraphBuilder_cbdDepNonCbd_errorsWhenVerbose(t *testing.T) {
 	b := &BuiltinGraphBuilder{
 		Root:     testModule(t, "graph-builder-cbd-non-cbd"),
@@ -181,8 +182,8 @@ func TestBuiltinGraphBuilder_cbdDepNonCbd_errorsWhenVerbose(t *testing.T) {
 	}
 
 	_, err := b.Build(RootModulePath)
-	if err == nil {
-		t.Fatalf("expected err, got none")
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
 }
 

--- a/terraform/test-fixtures/plan-cdb-depends-datasource/main.tf
+++ b/terraform/test-fixtures/plan-cdb-depends-datasource/main.tf
@@ -1,0 +1,11 @@
+resource "aws_instance" "foo" {
+  count = 2
+  num     = "2"
+  compute = "${element(data.aws_vpc.bar.*.id, count.index)}"
+  lifecycle { create_before_destroy = true }
+}
+
+data "aws_vpc" "bar" {
+  count = 2
+  foo = "${count.index}"
+}


### PR DESCRIPTION
The graph transformation we implement around create_before_destroy
need to re-order all resources that depend on the create_before_destroy
resource. Up until now, we've requires that users mark all of these
resources as create_before_destroy. Data soruces however don't have a
lifecycle block for create_before_destroy, and could not be marked this
way.

This PR checks each DestroyNode that doesn't implement CreateBeforeDestroy
for any ancestors that do implement CreateBeforeDestroy. If there are
any, we inherit the behavior and re-order the graph as such.