### PR TITLE
command: show shadow errors to the user

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -460,6 +460,42 @@ func (m *Meta) addModuleDepthFlag(flags *flag.FlagSet, moduleDepth *int) {
 	}
 }
 
+// outputShadowError outputs the error from ctx.ShadowError. If the
+// error is nil then nothing happens. If output is false then it isn't
+// outputted to the user (you can define logic to guard against outputting).
+func (m *Meta) outputShadowError(err error, output bool) bool {
+	// Do nothing if no error
+	if err == nil {
+		return false
+	}
+
+	// If not outputting, do nothing
+	if !output {
+		return false
+	}
+
+	// Output!
+	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
+		"[reset][bold][yellow]\nExperimental feature failure! Please report a bug.\n\n"+
+			"This is not an error. Your Terraform operation completed successfully.\n"+
+			"Your real infrastructure is unaffected by this message.\n\n"+
+			"[reset][yellow]While running, Terraform sometimes tests experimental features in the\n"+
+			"background. These features cannot affect real state and never touch\n"+
+			"real infrastructure. If the features work properly, you see nothing.\n"+
+			"If the features fail, this message appears.\n\n"+
+			"The following failures happened while running experimental features.\n"+
+			"Please report a Terraform bug so that future Terraform versions that\n"+
+			"enable these features can be improved!\n\n"+
+			"You can report an issue at: https://github.com/hashicorp/terraform/issues\n\n"+
+			"%s\n\n"+
+			"This is not an error. Your terraform operation completed successfully\n"+
+			"and your real infrastructure is unaffected by this message.",
+		err,
+	)))
+
+	return true
+}
+
 // contextOpts are the options used to load a context from a command.
 type contextOpts struct {
 	// Path to the directory where the root module is.

--- a/command/plan.go
+++ b/command/plan.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -57,6 +58,9 @@ func (c *PlanCommand) Run(args []string) int {
 	countHook := new(CountHook)
 	c.Meta.extraHooks = []terraform.Hook{countHook}
 
+	// This is going to keep track of shadow errors
+	var shadowErr error
+
 	ctx, _, err := c.Context(contextOpts{
 		Destroy:     destroy,
 		Path:        path,
@@ -71,6 +75,12 @@ func (c *PlanCommand) Run(args []string) int {
 	if err := ctx.Input(c.InputMode()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
 		return 1
+	}
+
+	// Record any shadow errors for later
+	if err := ctx.ShadowError(); err != nil {
+		shadowErr = multierror.Append(shadowErr, multierror.Prefix(
+			err, "input operation:"))
 	}
 
 	if !validateContext(ctx, c.Ui) {
@@ -137,6 +147,15 @@ func (c *PlanCommand) Run(args []string) int {
 		countHook.ToAdd+countHook.ToRemoveAndAdd,
 		countHook.ToChange,
 		countHook.ToRemove+countHook.ToRemoveAndAdd)))
+
+	// Record any shadow errors for later
+	if err := ctx.ShadowError(); err != nil {
+		shadowErr = multierror.Append(shadowErr, multierror.Prefix(
+			err, "plan operation:"))
+	}
+
+	// If we have an error in the shadow graph, let the user know.
+	c.outputShadowError(shadowErr, true)
 
 	if detailed {
 		return 2

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -79,6 +80,9 @@ func (c *RefreshCommand) Run(args []string) int {
 		}
 	}
 
+	// This is going to keep track of shadow errors
+	var shadowErr error
+
 	// Build the context based on the arguments given
 	ctx, _, err := c.Context(contextOpts{
 		Path:        configPath,
@@ -93,6 +97,12 @@ func (c *RefreshCommand) Run(args []string) int {
 	if err := ctx.Input(c.InputMode()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error configuring: %s", err))
 		return 1
+	}
+
+	// Record any shadow errors for later
+	if err := ctx.ShadowError(); err != nil {
+		shadowErr = multierror.Append(shadowErr, multierror.Prefix(
+			err, "input operation:"))
 	}
 
 	if !validateContext(ctx, c.Ui) {
@@ -114,6 +124,15 @@ func (c *RefreshCommand) Run(args []string) int {
 	if outputs := outputsAsString(newState, terraform.RootModulePath, ctx.Module().Config().Outputs, true); outputs != "" {
 		c.Ui.Output(c.Colorize().Color(outputs))
 	}
+
+	// Record any shadow errors for later
+	if err := ctx.ShadowError(); err != nil {
+		shadowErr = multierror.Append(shadowErr, multierror.Prefix(
+			err, "refresh operation:"))
+	}
+
+	// If we have an error in the shadow graph, let the user know.
+	c.outputShadowError(shadowErr, true)
 
 	return 0
 }


### PR DESCRIPTION
This builds on #9334 and now exposes shadow errors to the end user. They look like this:

![2016-11-03 at 2 47 pm](https://cloud.githubusercontent.com/assets/1299/19986543/68d051f8-a1d4-11e6-8b23-f257d0ecd986.png)

**A primary goal:** Don't block what would've otherwise been a successful operation on the fact that experimental features failed, and don't confuse the normal UX with experimental failures.

To that end, there are a few important points:

  * The shadow error message is verbose because it is meant to be sufficiently rare that we don't expect the user to know what happened. We assure the user quite a lot in it that everything is okay.

  * Shadow errors only happen if the TF operation succeeds. The user will never be overloaded with a failure and a shadow error.

  * Shadow errors show up currently in `refresh`, `plan`, `apply`, and `destroy`. 

  * Shadow errors can crop up at multiple points since `apply` for example can potentially run a Refresh, Plan, _and_ Apply operation. Shadow errors are collected and stored until the end and only shown if everything succeeds. This improves UX by not interrupted user flow with experimental feature errors when it would've otherwise succeeded.