### PR TITLE
provider/aws: Fix hashing of EBS volumes in spot fleet requests to prevent panics

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -805,7 +805,7 @@ func launchSpecToMap(
 }
 
 func ebsBlockDevicesToSet(bdm []*ec2.BlockDeviceMapping, rootDevName *string) *schema.Set {
-	set := &schema.Set{F: hashEphemeralBlockDevice}
+	set := &schema.Set{F: hashEbsBlockDevice}
 
 	for _, val := range bdm {
 		if val.Ebs != nil {
@@ -1009,7 +1009,11 @@ func hashLaunchSpecification(v interface{}) int {
 func hashEbsBlockDevice(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["snapshot_id"].(string)))
+	if name, ok := m["device_name"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", name.(string)))
+	}
+	if id, ok := m["snapshot_id"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", id.(string)))
+	}
 	return hashcode.String(buf.String())
 }


### PR DESCRIPTION
Spot fleet requests were mistakenly trying to hash EBS volumes using ephemeral volume attributes. This led to crashes and weird EOF errors, as seen in #8822 when the value ended up being nil when it wasn't expected to be.

To fix this, I switched to using the `hashEbsBlockDevice` function used in the Schema, but that also assumed that optional attributes would be present. To fix the crashes it had, I checked for existence of those attributes before trying to use them.

The majority of the PR is an acceptance test that exposed the issue, which now passes.

Fixes #8822