### PR TITLE
Service role is not updated on AWS for a CodeDeploy deployment group

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -271,6 +271,7 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 	input := codedeploy.UpdateDeploymentGroupInput{
 		ApplicationName:            aws.String(d.Get("app_name").(string)),
 		CurrentDeploymentGroupName: aws.String(d.Get("deployment_group_name").(string)),
+		ServiceRoleArn:             aws.String(d.Get("service_role_arn").(string)),
 	}
 
 	if d.HasChange("autoscaling_groups") {

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -37,6 +37,9 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "foo_"+rName),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestMatchResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/foo_role_.*")),
 
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
@@ -58,6 +61,9 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "bar_"+rName),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestMatchResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/bar_role_.*")),
 
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
@@ -558,7 +564,7 @@ resource "aws_codedeploy_app" "foo_app" {
 
 resource "aws_iam_role_policy" "foo_policy" {
 	name = "foo_policy_%s"
-	role = "${aws_iam_role.foo_role.id}"
+	role = "${aws_iam_role.bar_role.id}"
 	policy = <<EOF
 {
 	"Version": "2012-10-17",
@@ -584,8 +590,8 @@ resource "aws_iam_role_policy" "foo_policy" {
 EOF
 }
 
-resource "aws_iam_role" "foo_role" {
-	name = "foo_role_%s"
+resource "aws_iam_role" "bar_role" {
+	name = "bar_role_%s"
 	assume_role_policy = <<EOF
 {
 	"Version": "2012-10-17",
@@ -608,7 +614,7 @@ EOF
 resource "aws_codedeploy_deployment_group" "foo" {
 	app_name = "${aws_codedeploy_app.foo_app.name}"
 	deployment_group_name = "bar_%s"
-	service_role_arn = "${aws_iam_role.foo_role.arn}"
+	service_role_arn = "${aws_iam_role.bar_role.arn}"
 	ec2_tag_filter {
 		key = "filterkey"
 		type = "KEY_AND_VALUE"
@@ -748,7 +754,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create(rName strin
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_codedeploy_deployment_group" "foo_group" {
 	app_name = "${aws_codedeploy_app.foo_app.name}"
 	deployment_group_name = "foo-group-%s"
@@ -766,7 +772,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update(rName strin
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_codedeploy_deployment_group" "foo_group" {
 	app_name = "${aws_codedeploy_app.foo_app.name}"
 	deployment_group_name = "foo-group-%s"
@@ -784,7 +790,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple(rNa
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_sns_topic" "bar_topic" {
 	name = "bar-topic-%s"
 }
@@ -812,7 +818,7 @@ func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple(rNa
 	return fmt.Sprintf(`
 
 	%s
-	
+
 resource "aws_sns_topic" "bar_topic" {
 	name = "bar-topic-%s"
 }


### PR DESCRIPTION
Bug description:
I tried to change the service role for a CodeDeploy deployment group. The plan showed the change but it was never applied on AWS.

Affected resources:
 * aws_codedeploy_deployment_group

Affected version: Terraform v0.7.9-dev (24e5ea89521c8af3930c5a87a76c0bdef0037627)

I applied the fix in this PR and it works, but the tests  doesn't seem to check the real changes. Even if I remove my fix the updated acceptance tests still pass. Is it possible these tests only check for internal state changes and don't validate the AWS changes?

I ran the following acceptance tests:
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup_basic'
```

P.S.: sorry for the whitespace updates, if requested I remove them.