### PR TITLE
provider/aws: Decouple and randomize OpsWorks test configs

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_permission_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_permission_test.go
@@ -1,18 +1,22 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSOpsworksPermission(t *testing.T) {
+	rName := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	roleName := fmt.Sprintf("tf-ops-user-profile-%d", acctest.RandInt())
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAwsOpsworksPermissionCreate,
+				Config: testAccAwsOpsworksPermissionCreate(rName, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "true",
@@ -29,7 +33,8 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 	})
 }
 
-var testAccAwsOpsworksPermissionCreate = testAccAwsOpsworksUserProfileCreate + `
+func testAccAwsOpsworksPermissionCreate(rn, roleName string) string {
+	return fmt.Sprintf(`
 resource "aws_opsworks_permission" "tf-acc-perm" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
 
@@ -38,4 +43,17 @@ resource "aws_opsworks_permission" "tf-acc-perm" {
   user_arn = "${aws_opsworks_user_profile.user.user_arn}"
   level = "iam_only"
 }
-`
+
+resource "aws_opsworks_user_profile" "user" {
+  user_arn = "${aws_iam_user.user.arn}"
+  ssh_username = "${aws_iam_user.user.name}"
+}
+
+resource "aws_iam_user" "user" {
+	name = "%s"
+	path = "/"
+}
+	
+%s
+`, rn, testAccAwsOpsworksStackConfigNoVpcCreate(rn))
+}

--- a/builtin/providers/aws/resource_aws_opsworks_user_profile_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_user_profile_test.go
@@ -1,24 +1,28 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSOpsworksUserProfile(t *testing.T) {
+	rName := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	roleName := fmt.Sprintf("tf-ops-user-profile-%d", acctest.RandInt())
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAwsOpsworksUserProfileCreate,
+				Config: testAccAwsOpsworksUserProfileCreate(rName, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_user_profile.user", "ssh_public_key", "",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_opsworks_user_profile.user", "ssh_username", "test-user",
+						"aws_opsworks_user_profile.user", "ssh_username", rName,
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_user_profile.user", "allow_self_management", "false",
@@ -29,16 +33,18 @@ func TestAccAWSOpsworksUserProfile(t *testing.T) {
 	})
 }
 
-var testAccAwsOpsworksUserProfileCreate = testAccAWSOpsUserConfig + testAccAwsOpsworksStackConfigNoVpcCreate("tf-ops-acc-user-profile") + `
+func testAccAwsOpsworksUserProfileCreate(rn, roleName string) string {
+	return fmt.Sprintf(`
 resource "aws_opsworks_user_profile" "user" {
   user_arn = "${aws_iam_user.user.arn}"
   ssh_username = "${aws_iam_user.user.name}"
 }
-`
 
-var testAccAWSOpsUserConfig = `
 resource "aws_iam_user" "user" {
-	name = "test-user"
+	name = "%s"
 	path = "/"
 }
-`
+
+%s
+	`, rn, testAccAwsOpsworksStackConfigNoVpcCreate(roleName))
+}


### PR DESCRIPTION
Decouple the shared config structure of `TestAccAWSOpsworksPermission` and `TestAccAWSOpsworksUserProfile` so that they can run in parallel and pass. 
