### PR TITLE
provider/pagerduty Fix incorrect service timeout documentation

### DIFF
--- a/website/source/docs/providers/pagerduty/r/service.html.markdown
+++ b/website/source/docs/providers/pagerduty/r/service.html.markdown
@@ -49,8 +49,8 @@ The following arguments are supported:
   * `name` - (Required) The name of the service.
   * `description` - (Optional) A human-friendly description of the escalation policy.
     If not set, a placeholder of "Managed by Terraform" will be set.
-  * `auto_resolve_timeout` - (Optional) Time in seconds that an incident is automatically resolved if left open for that long. Value is "null" is the feature is disabled.
-  * `acknowledgement_timeout` - (Optional) Time in seconds that an incident changes to the Triggered State after being Acknowledged. Value is "null" is the feature is disabled.
+  * `auto_resolve_timeout` - (Optional) Time in seconds that an incident is automatically resolved if left open for that long.
+  * `acknowledgement_timeout` - (Optional) Time in seconds that an incident changes to the Triggered State after being Acknowledged.
   * `escalation_policy` - (Required) The escalation policy used by this service.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixing incorrect `timeout` documentation for `pagerduty_service`. 

This resolves: https://github.com/hashicorp/terraform/issues/9861