### PR TITLE
Correct 'VPN Endpoints' to 'VPC Endpoints'

### DIFF
--- a/website/source/docs/providers/aws/r/vpc_endpoint.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_endpoint.html.markdown
@@ -40,7 +40,7 @@ The following attributes are exported:
 
 ## Import
 
-VPN Endpoints can be imported using the `vpc endpoint id`, e.g. 
+VPC Endpoints can be imported using the `vpc endpoint id`, e.g. 
 
 ```
 $ terraform import aws_vpc_endpoint.endpoint1 vpce-3ecf2a57


### PR DESCRIPTION
Documentation correction:
`VPN Endpoints` -> `VPC Endpoints`