### PR TITLE
[WIP] aws_snapshot_create_volume_permission

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -343,6 +343,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_spot_fleet_request":                       resourceAwsSpotFleetRequest(),
 			"aws_sqs_queue":                                resourceAwsSqsQueue(),
 			"aws_sqs_queue_policy":                         resourceAwsSqsQueuePolicy(),
+			"aws_snapshot_create_volume_permission":        resourceAwsSnapshotCreateVolumePermission(),
 			"aws_sns_topic":                                resourceAwsSnsTopic(),
 			"aws_sns_topic_policy":                         resourceAwsSnsTopicPolicy(),
 			"aws_sns_topic_subscription":                   resourceAwsSnsTopicSubscription(),

--- a/builtin/providers/aws/resource_aws_snapshot_create_volume_permission.go
+++ b/builtin/providers/aws/resource_aws_snapshot_create_volume_permission.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSnapshotCreateVolumePermission() *schema.Resource {
+	return &schema.Resource{
+		Exists: resourceAwsSnapshotCreateVolumePermissionExists,
+		Create: resourceAwsSnapshotCreateVolumePermissionCreate,
+		Read:   resourceAwsSnapshotCreateVolumePermissionRead,
+		Delete: resourceAwsSnapshotCreateVolumePermissionDelete,
+
+		Schema: map[string]*schema.Schema{
+			"snapshot_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"account_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSnapshotCreateVolumePermissionExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*AWSClient).ec2conn
+
+	snapshot_id := d.Get("snapshot_id").(string)
+	account_id := d.Get("account_id").(string)
+	return hasCreateVolumePermission(conn, snapshot_id, account_id)
+}
+
+func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	snapshot_id := d.Get("snapshot_id").(string)
+	account_id := d.Get("account_id").(string)
+
+	_, err := conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
+		SnapshotId: aws.String(snapshot_id),
+		Attribute:  aws.String("createVolumePermission"),
+		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
+			Add: []*ec2.CreateVolumePermission{
+				&ec2.CreateVolumePermission{UserId: aws.String(account_id)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error creating snapshot volume permission: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s-%s", snapshot_id, account_id))
+	return nil
+}
+
+func resourceAwsSnapshotCreateVolumePermissionRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsSnapshotCreateVolumePermissionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	snapshot_id := d.Get("snapshot_id").(string)
+	account_id := d.Get("account_id").(string)
+
+	_, err := conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
+		SnapshotId: aws.String(snapshot_id),
+		Attribute:  aws.String("createVolumePermission"),
+		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
+			Remove: []*ec2.CreateVolumePermission{
+				&ec2.CreateVolumePermission{UserId: aws.String(account_id)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error removing snapshot volume permission: %s", err)
+	}
+
+	return nil
+}
+
+func hasCreateVolumePermission(conn *ec2.EC2, snapshot_id string, account_id string) (bool, error) {
+	attrs, err := conn.DescribeSnapshotAttribute(&ec2.DescribeSnapshotAttributeInput{
+		SnapshotId: aws.String(snapshot_id),
+		Attribute:  aws.String("createVolumePermission"),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, vp := range attrs.CreateVolumePermissions {
+		if *vp.UserId == account_id {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/builtin/providers/aws/resource_aws_snapshot_create_volume_permission_test.go
+++ b/builtin/providers/aws/resource_aws_snapshot_create_volume_permission_test.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSSnapshotCreateVolumePermission_Basic(t *testing.T) {
+	snapshot_id := ""
+	account_id := os.Getenv("AWS_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if os.Getenv("AWS_ACCOUNT_ID") == "" {
+				t.Fatal("AWS_ACCOUNT_ID must be set")
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Scaffold everything
+			resource.TestStep{
+				Config: testAccAWSSnapshotCreateVolumePermissionConfig(account_id, true),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceGetAttr("aws_ami_copy.test", "block_device_mappings.0.ebs.snapshot_id", &snapshot_id),
+					testAccAWSSnapshotCreateVolumePermissionExists(account_id, &snapshot_id),
+				),
+			},
+			// Drop just create volume permission to test destruction
+			resource.TestStep{
+				Config: testAccAWSSnapshotCreateVolumePermissionConfig(account_id, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSSnapshotCreateVolumePermissionDestroyed(account_id, &snapshot_id),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSSnapshotCreateVolumePermissionExists(account_id string, snapshot_id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		if has, err := hasCreateVolumePermission(conn, *snapshot_id, account_id); err != nil {
+			return err
+		} else if !has {
+			return fmt.Errorf("create volume permission does not exist for '%s' on '%s'", account_id, *snapshot_id)
+		}
+		return nil
+	}
+}
+
+func testAccAWSSnapshotCreateVolumePermissionDestroyed(account_id string, snapshot_id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		if has, err := hasCreateVolumePermission(conn, *snapshot_id, account_id); err != nil {
+			return err
+		} else if has {
+			return fmt.Errorf("create volume permission still exists for '%s' on '%s'", account_id, *snapshot_id)
+		}
+		return nil
+	}
+}
+
+func testAccAWSSnapshotCreateVolumePermissionConfig(account_id string, includeCreateVolumePermission bool) string {
+	base := `
+resource "aws_ami_copy" "test" {
+  name = "create-volume-permission-test"
+  description = "Create Volume Permission Test Copy"
+  source_ami_id = "ami-7172b611"
+  source_ami_region = "us-west-2"
+}
+`
+
+	if !includeCreateVolumePermission {
+		return base
+	}
+
+	return base + fmt.Sprintf(`
+resource "aws_snapshot_create_volume_permission" "self-test" {
+  snapshot_id   = "${lookup(lookup(element(aws_ami_copy.test.block_device_mappings, 0), "ebs"), "snapshot_id")}"
+  account_id = "%s"
+}
+`, account_id)
+}


### PR DESCRIPTION
Note: this is almost a direct copy of aws_ami_launch_permission since the API is almost identical for this functionality.

This adds the new resource aws_snapshot_create_volume_permission which manages the createVolumePermission attribute of snapshots.  This allows granting an AWS account permissions to create a volume from a particular snapshot.  This is often required to allow another account to copy a private AMI.

There's a few outstanding issues I could use some help with:
- ~~there's a bug which is causing the AWS API call to succeed, but no create volume permission modifications to occur~~ It turns out this is just really slow to update.  Resolved with a wait.
- the resource is almost useless due to #9693, though there may be a workaround to get this to a half usable state
- the tests are non-functional until the above workaround is found

Here's some example code for testing things out.  The snapshot_id has to be provided as an input after the copy completes.
```hcl
variable "region" {
  type = "string"
}

variable "share_account_id" {
  type = "string"
}

variable "snapshot_id" {
  type = "string"
}

provider "aws" {
  region = "${var.region}"
}

data "aws_ami" "test" {
  name_regex  = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-.*"
  owners      = ["099720109477"]
  most_recent = true
}

resource "aws_ami_copy" "test" {
  name = "create-volume-permission-test"
  description = "Create Volume Permission Test Copy"
  source_ami_id = "${data.aws_ami.test.id}"
  source_ami_region = "${var.region}"

  lifecycle {
    ignore_changes = ["source_ami_id"]
  }
}

# resource "aws_snapshot_create_volume_permission" "self-test" {
#   snapshot_id = "${var.snapshot_id}"
#   account_id = "${var.share_account_id}"
# }
```