### PR TITLE
 #9419 - Feature request: Support for ElastiCache Redis cluster mode

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -233,6 +233,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_eip_association":                          resourceAwsEipAssociation(),
 			"aws_elasticache_cluster":                      resourceAwsElasticacheCluster(),
 			"aws_elasticache_parameter_group":              resourceAwsElasticacheParameterGroup(),
+			"aws_elasticache_redis_cluster":                resourceAwsElasticacheRedisCluster(),
 			"aws_elasticache_replication_group":            resourceAwsElasticacheReplicationGroup(),
 			"aws_elasticache_security_group":               resourceAwsElasticacheSecurityGroup(),
 			"aws_elasticache_subnet_group":                 resourceAwsElasticacheSubnetGroup(),

--- a/builtin/providers/aws/resource_aws_elasticache_redis_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_redis_cluster.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsElasticacheRedisCluster() *schema.Resource {
+
+	resourceSchema := resourceAwsElasticacheReplicationGroupCommon()
+
+	resourceSchema["automatic_failover_enabled"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	}
+
+	resourceSchema["number_cache_clusters"] = &schema.Schema{
+		Type:     schema.TypeInt,
+		Computed: true,
+		ForceNew: true,
+	}
+
+	resourceSchema["num_node_groups"] = &schema.Schema{
+		Type:     schema.TypeInt,
+		Required: true,
+		ForceNew: true,
+	}
+
+	resourceSchema["replicas_per_node_group"] = &schema.Schema{
+		Type:     schema.TypeInt,
+		Required: true,
+		ForceNew: true,
+	}
+
+	return &schema.Resource{
+		Create: resourceAwsElasticacheRedisClusterCreate,
+		Read:   resourceAwsElasticacheReplicationGroupRead,
+		Update: resourceAwsElasticacheReplicationGroupUpdate,
+		Delete: resourceAwsElasticacheReplicationGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: resourceSchema,
+	}
+}
+
+func resourceAwsElasticacheRedisClusterCreate(d *schema.ResourceData, meta interface{}) error {
+
+	params := resourceAwsElasticacheReplicationGroupCreateSetup(d, meta)
+
+	if v, ok := d.GetOk("num_node_groups"); ok {
+		params.NumNodeGroups = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("replicas_per_node_group"); ok {
+		params.ReplicasPerNodeGroup = aws.Int64(int64(v.(int)))
+	}
+
+	return resourceAwsElasticacheReplicationGroupCreateCommon(d, meta, params)
+}

--- a/builtin/providers/aws/resource_aws_elasticache_redis_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_redis_cluster_test.go
@@ -1,0 +1,101 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSElasticacheRedisCluster_vpc(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheRedisClusterVPCConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_redis_cluster.bar", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_redis_cluster.bar", "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_redis_cluster.bar", "replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_redis_cluster.bar", "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_redis_cluster.bar", "port", "6379"),
+				),
+			},
+		},
+	})
+}
+
+var testAccAWSElasticacheRedisClusterVPCConfig = fmt.Sprintf(`
+provider "aws" {
+    region = "us-west-2"
+}
+
+resource "aws_vpc" "foo" {
+    cidr_block = "192.168.0.0/16"
+    tags {
+        Name = "tf-test"
+    }
+}
+
+resource "aws_subnet" "foo" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "192.168.0.0/20"
+    availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-test-%03d"
+    }
+}
+
+resource "aws_subnet" "bar" {
+    vpc_id = "${aws_vpc.foo.id}"
+    cidr_block = "192.168.16.0/20"
+    availability_zone = "us-west-2b"
+    tags {
+        Name = "tf-test-%03d"
+    }
+}
+
+resource "aws_elasticache_subnet_group" "bar" {
+    name = "tf-test-cache-subnet-%03d"
+    description = "tf-test-cache-subnet-group-descr"
+    subnet_ids = [
+        "${aws_subnet.foo.id}",
+        "${aws_subnet.bar.id}"
+    ]
+}
+
+resource "aws_security_group" "bar" {
+    name = "tf-test-security-group-%03d"
+    description = "tf-test-security-group-descr"
+    vpc_id = "${aws_vpc.foo.id}"
+    ingress {
+        from_port = -1
+        to_port = -1
+        protocol = "icmp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_elasticache_redis_cluster" "bar" {
+    replication_group_id = "tf-%s"
+    replication_group_description = "test description"
+    node_type = "cache.t2.micro"
+    port = 6379
+    subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
+    security_group_ids = ["${aws_security_group.bar.id}"]
+    parameter_group_name = "default.redis3.2.cluster.on"
+	replicas_per_node_group = 1
+	num_node_groups = 2
+
+}
+`, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))

--- a/website/source/docs/providers/aws/r/elasticache_redis_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_redis_cluster.html.markdown
@@ -1,0 +1,73 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elasticache_replication_group_redis_cluster"
+sidebar_current: "docs-aws-resource-elasticache-replication-group-redis-cluster"
+description: |-
+  Provides an ElastiCache Replication Group Redis Cluster resource.
+---
+
+# aws\_elasticache\_replication\_group\_redis\_cluster
+
+Provides an ElastiCache Replication Group Native Redis Cluster resource.
+
+## Example Usage
+
+```
+resource "aws_elasticache_replication_group_redis_cluster" "bar" {
+  replication_group_id          = "tf-replication-group-1"
+  replication_group_description = "test description"
+  node_type                     = "cache.m1.small"
+  port                          = 6379
+  parameter_group_name          = "default.redis3.2.cluster.on"
+  replicas_per_node_group       = 1
+  num_node_groups               = 4
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `replication_group_id` – (Required) The replication group identifier. This parameter is stored as a lowercase string.
+* `replication_group_description` – (Required) A user-created description for the replication group.
+* `node_type` - (Required) The compute and memory capacity of the nodes in the node group.
+* `parameter_group_name` - (Optional) The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.
+* `subnet_group_name` - (Optional) The name of the cache subnet group to be used for the replication group.
+* `security_group_names` - (Optional) A list of cache security group names to associate with this replication group.
+* `security_group_ids` - (Optional) One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud 
+* `snapshot_arns` – (Optional) A single-element string list containing an
+Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3.
+Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
+* `snapshot_name` - (Optional) The name of a snapshot from which to restore data into the new node group. Changing the `snapshot_name` forces a new resource. 
+* `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance
+on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).
+The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`
+* `notification_topic_arn` – (Optional) An Amazon Resource Name (ARN) of an
+SNS topic to send ElastiCache notifications to. Example:
+`arn:aws:sns:us-east-1:012345678999:my_sns_topic`
+* `snapshot_window` - (Optional, Redis only) The daily time range (in UTC) during which ElastiCache will
+begin taking a daily snapshot of your cache cluster. Example: 05:00-09:00
+* `snapshot_retention_limit` - (Optional, Redis only) The number of days for which ElastiCache will
+retain automatic cache cluster snapshots before deleting them. For example, if you set
+SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days
+before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.
+Please note that setting a `snapshot_retention_limit` is not supported on cache.t1.micro or cache.t2.* cache nodes
+* `apply_immediately` - (Optional) Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is `false`. 
+* `tags` - (Optional) A mapping of tags to assign to the resource
+* `replicas_per_node_group` - (Optional) Specify the number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource.
+* `num_node_groups - (Optional) Specify the number of node groups for this Redis replication group. Changing this number will force a new resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the ElastiCache Replication Group
+* `endpoint_address` - The address of the endpoint for the primary node in the replication group
+
+## Import
+
+ElastiCache Replication Groups can be imported using the `replication_group_id`, e.g.
+
+```
+$ terraform import aws_elasticache_replication_group.my_replication_group replication-group-1
+```


### PR DESCRIPTION
 Added support for a new resource aws_elasticache_redis_cluster it will provision
 an ElastiCache Redis cluster with cluster mode enabled. See following for more information:

 https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Replication.Redis-RedisCluster.html

 It reuses much of aws_elasticache_replication_group resource with the following changes:

 Added support for two new attributes:

   - replicas_per_node_group - (required) the number of replica nodes in each node group
   - num_node_groups - (required) the number of node groups for this Redis replication group

 These attributes have different defaults or functionality:

   - automatic_failover_enabled defaults to true. AWS will fail if its set to false.
   - number_cache_clusters is now a computed field. Its value is:
     ```num_node_groups + num_node_groups * replicas_per_node_group```

Notes:

I added this as a new resource however I would prefer to have it provision a cluster based on a flag:

```cluster_mode_enabled = true``` 

Then replicas_per_node_group and num_node_groups would become required parameters but I did not see how to change the schema after the resource has been called. If you have any ideas on how to do this better please let me know.

@stack72 @catsby

Thank you,