### PR TITLE
terraform: configure provider aliases in the new apply graph

### DIFF
--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -286,6 +286,14 @@ aws_instance.foo:
   type = aws_instance
 `
 
+const testTerraformApplyProviderAliasConfigStr = `
+another_instance.bar:
+  ID = foo
+  provider = another.two
+another_instance.foo:
+  ID = foo
+`
+
 const testTerraformApplyEmptyModuleStr = `
 <no state>
 Outputs:

--- a/terraform/test-fixtures/apply-provider-alias-configure/main.tf
+++ b/terraform/test-fixtures/apply-provider-alias-configure/main.tf
@@ -1,0 +1,11 @@
+provider "another" {
+    foo = "bar"
+}
+
+provider "another" {
+    alias = "two"
+    foo = "bar"
+}
+
+resource "another_instance" "foo" {}
+resource "another_instance" "bar" { provider = "another.two" }

--- a/terraform/transform_attach_config_provider.go
+++ b/terraform/transform_attach_config_provider.go
@@ -47,8 +47,6 @@ func (t *AttachProviderConfigTransformer) attachProviders(g *Graph) error {
 			continue
 		}
 
-		// TODO: aliases?
-
 		// Determine what we're looking for
 		path := normalizeModulePath(apn.Path())
 		path = path[1:]
@@ -63,7 +61,14 @@ func (t *AttachProviderConfigTransformer) attachProviders(g *Graph) error {
 
 		// Go through the provider configs to find the matching config
 		for _, p := range tree.Config().ProviderConfigs {
-			if p.Name == name {
+			// Build the name, which is "name.alias" if an alias exists
+			current := p.Name
+			if p.Alias != "" {
+				current += "." + p.Alias
+			}
+
+			// If the configs match then attach!
+			if current == name {
 				log.Printf("[TRACE] Attaching provider config: %#v", p)
 				apn.AttachProvider(p)
 				break


### PR DESCRIPTION
Found via a shadow graph failure:

Provider aliases weren't being configured by the new apply graph.

This was caused by the transform that attaches configs to provider nodes
not being able to handle aliases and therefore not attaching a config.
Added a test to this and fixed it.