### PR TITLE
terraform: remove pruning of module vars if they ref non-existing nodes

### DIFF
--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -105,11 +105,11 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// Add root variables
 		&RootVariableTransformer{Module: b.Module},
 
-		// Add module variables
-		&ModuleVariableTransformer{Module: b.Module},
-
 		// Add the outputs
 		&OutputTransformer{Module: b.Module},
+
+		// Add module variables
+		&ModuleVariableTransformer{Module: b.Module},
 
 		// Connect references so ordering is correct
 		&ReferenceTransformer{},

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -494,6 +494,18 @@ module.child:
     provider = aws.eu
 `
 
+const testTerraformApplyModuleVarRefExistingStr = `
+aws_instance.foo:
+  ID = foo
+  foo = bar
+
+module.child:
+  aws_instance.foo:
+    ID = foo
+    type = aws_instance
+    value = bar
+`
+
 const testTerraformApplyOutputOrphanStr = `
 <no state>
 Outputs:

--- a/terraform/test-fixtures/apply-ref-existing/child/main.tf
+++ b/terraform/test-fixtures/apply-ref-existing/child/main.tf
@@ -1,0 +1,5 @@
+variable "var" {}
+
+resource "aws_instance" "foo" {
+    value = "${var.var}"
+}

--- a/terraform/test-fixtures/apply-ref-existing/main.tf
+++ b/terraform/test-fixtures/apply-ref-existing/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" { foo = "bar" }
+
+module "child" {
+    source = "./child"
+
+    var = "${aws_instance.foo.foo}"
+}

--- a/terraform/transform_module_variable.go
+++ b/terraform/transform_module_variable.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
-	"github.com/hashicorp/terraform/dag"
 )
 
 // ModuleVariableTransformer is a GraphTransformer that adds all the variables
@@ -68,9 +67,6 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, m *module.
 		return nil
 	}
 
-	// Build the reference map so we can determine if we're referencing things.
-	refMap := NewReferenceMap(g.Vertices())
-
 	// Add all variables here
 	for _, v := range vars {
 		// Determine the value of the variable. If it isn't in the
@@ -98,20 +94,6 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, m *module.
 			Config:    v,
 			Value:     value,
 			Module:    t.Module,
-		}
-
-		// If the node references something, then we check to make sure
-		// that the thing it references is in the graph. If it isn't, then
-		// we don't add it because we may not be able to compute the output.
-		//
-		// If the node references nothing, we always include it since there
-		// is no other clear time to compute it.
-		matches, missing := refMap.References(node)
-		if len(missing) > 0 {
-			log.Printf(
-				"[INFO] Not including %q in graph, matches: %v, missing: %s",
-				dag.VertexName(node), matches, missing)
-			continue
 		}
 
 		// Add it!

--- a/terraform/transform_module_variable_test.go
+++ b/terraform/transform_module_variable_test.go
@@ -17,7 +17,7 @@ func TestModuleVariableTransformer(t *testing.T) {
 	}
 
 	{
-		tf := &ModuleVariableTransformer{Module: module}
+		tf := &ModuleVariableTransformer{Module: module, DisablePrune: true}
 		if err := tf.Transform(&g); err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -42,7 +42,7 @@ func TestModuleVariableTransformer_nested(t *testing.T) {
 	}
 
 	{
-		tf := &ModuleVariableTransformer{Module: module}
+		tf := &ModuleVariableTransformer{Module: module, DisablePrune: true}
 		if err := tf.Transform(&g); err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/terraform/transform_reference_test.go
+++ b/terraform/transform_reference_test.go
@@ -112,10 +112,55 @@ func TestReferenceMapReferences(t *testing.T) {
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 			rm := NewReferenceMap(tc.Nodes)
-			result, err := rm.References(tc.Check)
-			if err != nil {
-				t.Fatalf("err: %s", err)
+			result, _ := rm.References(tc.Check)
+
+			var resultStr []string
+			for _, v := range result {
+				resultStr = append(resultStr, dag.VertexName(v))
 			}
+
+			sort.Strings(resultStr)
+			sort.Strings(tc.Result)
+			if !reflect.DeepEqual(resultStr, tc.Result) {
+				t.Fatalf("bad: %#v", resultStr)
+			}
+		})
+	}
+}
+
+func TestReferenceMapReferencedBy(t *testing.T) {
+	cases := map[string]struct {
+		Nodes  []dag.Vertex
+		Check  dag.Vertex
+		Result []string
+	}{
+		"simple": {
+			Nodes: []dag.Vertex{
+				&graphNodeRefChildTest{
+					NameValue: "A",
+					Refs:      []string{"A"},
+				},
+				&graphNodeRefChildTest{
+					NameValue: "B",
+					Refs:      []string{"A"},
+				},
+				&graphNodeRefChildTest{
+					NameValue: "C",
+					Refs:      []string{"B"},
+				},
+			},
+			Check: &graphNodeRefParentTest{
+				NameValue: "foo",
+				Names:     []string{"A"},
+			},
+			Result: []string{"A", "B"},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			rm := NewReferenceMap(tc.Nodes)
+			result := rm.ReferencedBy(tc.Check)
 
 			var resultStr []string
 			for _, v := range result {


### PR DESCRIPTION
Fixes a shadow graph error found during usage.

This change only affects the new apply graph.

The new apply graph was only adding module variables that referenced
data that existed _in the graph_. This isn't a valid optimization since
the data it is referencing may be in the state with no diff, and
therefore available but not in the graph.

This just removes that optimization logic, which causes no failing
tests. It also adds a test that exposes the bug if we had the pruning
logic.