### PR TITLE
provider/aws: Ignore NoSuchEntity error when IAM user does not have login profile

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -197,10 +197,9 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 			UserName: aws.String(d.Id()),
 		})
 		if err != nil {
-			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
-				return nil
+			if iamerr, ok := err.(awserr.Error); !ok || iamerr.Code() != "NoSuchEntity" {
+				return fmt.Errorf("Error deleting Account Login Profile: %s", err)
 			}
-			return fmt.Errorf("Error deleting Account Login Profile: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Fixes #9863 

When IAM user does not have login profile, we shoud simply ignore it.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSUser_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/05 23:34:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSUser_ -timeout 120m
=== RUN   TestAccAWSUser_importBasic
--- PASS: TestAccAWSUser_importBasic (24.16s)
=== RUN   TestAccAWSUser_basic
--- PASS: TestAccAWSUser_basic (41.82s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    66.001s

```