### PR TITLE
aws_vpc_peering_connection ambiguous language

### DIFF
--- a/website/source/docs/providers/aws/r/vpc_peering.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_peering.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
    Defaults to the account ID the [AWS provider][1] is currently connected to.
 * `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC Peering Connection.
 * `vpc_id` - (Required) The ID of the requester VPC.
-* `auto_accept` - (Optional) Accept the peering (you need to be the owner of both VPCs).
+* `auto_accept` - (Optional) Accept the peering (both VPCs need to be in the same AWS account).
 * `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection]
 (http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options to be set for the VPC that accepts
 the peering connection (a maximum of one).
@@ -110,7 +110,9 @@ The following attributes are exported:
 
 ## Notes
 
-If you are not the owner of both VPCs, or do not enable the `auto_accept` attribute you will still
+AWS only supports VPC peering within the same AWS region.
+
+If both VPCs are not in the same AWS account do not enable the `auto_accept` attribute. You will still
 have to accept the VPC Peering Connection request manually using the AWS Management Console, AWS CLI,
 through SDKs, etc.
 


### PR DESCRIPTION
The documentation mentions ownership of both VPCs for aws_vpc_peering_connection auto_accept to work but if both VPC are in separate accounts it does not matter if both account are owned or not.

In #6843 its stated that aws_vpc_peering_connection only works if both VPC are in the same AWS account.

The documentation fails to mention that peeing of two VPCs in two different regions is not supported by AWS.