### PR TITLE
provider/random: Add b64_std to random_id

### DIFF
--- a/builtin/providers/random/provider.go
+++ b/builtin/providers/random/provider.go
@@ -16,16 +16,3 @@ func Provider() terraform.ResourceProvider {
 		},
 	}
 }
-
-// stubRead is a do-nothing Read implementation used for our resources,
-// which don't actually need to do anything on read.
-func stubRead(d *schema.ResourceData, meta interface{}) error {
-	return nil
-}
-
-// stubDelete is a do-nothing Dete implementation used for our resources,
-// which don't actually need to do anything unusual on delete.
-func stubDelete(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("")
-	return nil
-}

--- a/builtin/providers/random/resource_id.go
+++ b/builtin/providers/random/resource_id.go
@@ -4,42 +4,54 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
+	"errors"
 	"math/big"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceId() *schema.Resource {
 	return &schema.Resource{
 		Create: CreateID,
-		Read:   stubRead,
-		Delete: stubDelete,
+		Read:   schema.Noop,
+		Delete: schema.RemoveFromState,
 
 		Schema: map[string]*schema.Schema{
-			"keepers": &schema.Schema{
+			"keepers": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"byte_length": &schema.Schema{
+			"byte_length": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"b64": &schema.Schema{
+			"b64": {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use b64_url for old behavior, or b64_std for standard base64 encoding",
+			},
+
+			"b64_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"hex": &schema.Schema{
+			"b64_std": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"dec": &schema.Schema{
+			"hex": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"dec": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -47,28 +59,33 @@ func resourceId() *schema.Resource {
 	}
 }
 
-func CreateID(d *schema.ResourceData, meta interface{}) error {
+func CreateID(d *schema.ResourceData, _ interface{}) error {
 
 	byteLength := d.Get("byte_length").(int)
 	bytes := make([]byte, byteLength)
 
 	n, err := rand.Reader.Read(bytes)
 	if n != byteLength {
-		return fmt.Errorf("generated insufficient random bytes")
+		return errors.New("generated insufficient random bytes")
 	}
 	if err != nil {
-		return fmt.Errorf("error generating random bytes: %s", err)
+		return errwrap.Wrapf("error generating random bytes: {{err}}", err)
 	}
 
 	b64Str := base64.RawURLEncoding.EncodeToString(bytes)
+	b64StdStr := base64.StdEncoding.EncodeToString(bytes)
 	hexStr := hex.EncodeToString(bytes)
 
-	int := big.Int{}
-	int.SetBytes(bytes)
-	decStr := int.String()
+	bigInt := big.Int{}
+	bigInt.SetBytes(bytes)
+	decStr := bigInt.String()
 
 	d.SetId(b64Str)
+
 	d.Set("b64", b64Str)
+	d.Set("b64_url", b64Str)
+	d.Set("b64_std", b64StdStr)
+
 	d.Set("hex", hexStr)
 	d.Set("dec", decStr)
 

--- a/builtin/providers/random/resource_shuffle.go
+++ b/builtin/providers/random/resource_shuffle.go
@@ -7,23 +7,23 @@ import (
 func resourceShuffle() *schema.Resource {
 	return &schema.Resource{
 		Create: CreateShuffle,
-		Read:   stubRead,
-		Delete: stubDelete,
+		Read:   schema.Noop,
+		Delete: schema.RemoveFromState,
 
 		Schema: map[string]*schema.Schema{
-			"keepers": &schema.Schema{
+			"keepers": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"seed": &schema.Schema{
+			"seed": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"input": &schema.Schema{
+			"input": {
 				Type:     schema.TypeList,
 				Required: true,
 				ForceNew: true,
@@ -32,7 +32,7 @@ func resourceShuffle() *schema.Resource {
 				},
 			},
 
-			"result": &schema.Schema{
+			"result": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
@@ -40,7 +40,7 @@ func resourceShuffle() *schema.Resource {
 				},
 			},
 
-			"result_count": &schema.Schema{
+			"result_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
@@ -49,7 +49,7 @@ func resourceShuffle() *schema.Resource {
 	}
 }
 
-func CreateShuffle(d *schema.ResourceData, meta interface{}) error {
+func CreateShuffle(d *schema.ResourceData, _ interface{}) error {
 	input := d.Get("input").([]interface{})
 	seed := d.Get("seed").(string)
 


### PR DESCRIPTION
This commit makes three related changes to the `random_id` resource:

1. Deprecate the `b64` attribute.
1. Introduce a new `b64_url` attribut which functions in the same manner as the original `b64` attribute.
3. Introduce a new `b64_std` attribute which uses standard base64 encoding for the value rather than URL encoding.

Resource identifiers continue to use URL encoded base 64.

The reason for adding standard encoding of the base 64 value is to allow the use of generated values as a Serf Encryption Key for separating Consul clusters - these rely on standard encoding and do not permit some characters which are allowed by URL encoding. `b64_url` is introduced in order that there is consistency in specifying the desired encoding during interpolation.

We also clean up the code for the random provider and move to using the more recent schema-provided Noop functions in preference to custom functions in the provider.

cc @sean-, @stack72