### PR TITLE
Doc: GCE template - fix deprecation warnings for automatic_restart and on_host_maintenance parameters

### DIFF
--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -27,8 +27,11 @@ resource "google_compute_instance_template" "foobar" {
   instance_description = "description assigned to instances"
   machine_type         = "n1-standard-1"
   can_ip_forward       = false
-  automatic_restart    = true
-  on_host_maintenance  = "MIGRATE"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
 
   // Create a new boot disk from an image
   disk {


### PR DESCRIPTION
Use correct syntax in sample to remove the following deprecation warnings:

```
  * google_compute_instance_template.nat: "automatic_restart": [DEPRECATED] Please use `scheduling.automatic_restart` instead
  * google_compute_instance_template.nat: "on_host_maintenance": [DEPRECATED] Please use `scheduling.on_host_maintenance` instead
```