### PR TITLE
provider/aws: Fix the validateFunc of aws_elasticache_replication_group

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -456,9 +456,9 @@ func validateAwsElastiCacheReplicationGroupEngine(v interface{}, k string) (ws [
 
 func validateAwsElastiCacheReplicationGroupId(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if (len(value) < 1) || (len(value) > 16) {
+	if (len(value) < 1) || (len(value) > 20) {
 		errors = append(errors, fmt.Errorf(
-			"%q must contain from 1 to 16 alphanumeric characters or hyphens", k))
+			"%q must contain from 1 to 20 alphanumeric characters or hyphens", k))
 	}
 	if !regexp.MustCompile(`^[0-9a-zA-Z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -235,7 +235,7 @@ func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(17),
+			Value:    randomString(21),
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
Fixes #9895

The replication_group_id should allow length to be max of 20 not 16

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestResourceAWSElastiCacheReplicationGroupIdValidation'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/07 16:17:52 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestResourceAWSElastiCacheReplicationGroupIdValidation -timeout
120m
=== RUN   TestResourceAWSElastiCacheReplicationGroupIdValidation
--- PASS: TestResourceAWSElastiCacheReplicationGroupIdValidation (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws0.032s
```