### PR TITLE
Add base_archive argument to archive_file resource

### DIFF
--- a/builtin/providers/archive/archiver.go
+++ b/builtin/providers/archive/archiver.go
@@ -7,6 +7,7 @@ import (
 
 type Archiver interface {
 	ArchiveContent(content []byte, infilename string) error
+	CopyArchive(archivename string) error
 	ArchiveFile(infilename string) error
 	ArchiveDir(indirname string) error
 }

--- a/builtin/providers/archive/data_source_archive_file.go
+++ b/builtin/providers/archive/data_source_archive_file.go
@@ -47,6 +47,11 @@ func dataSourceFile() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"source_content", "source_content_filename", "source_file"},
 			},
+			"base_archive": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"output_path": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -115,6 +120,12 @@ func archive(d *schema.ResourceData) error {
 	archiver := getArchiver(archiveType, outputPath)
 	if archiver == nil {
 		return fmt.Errorf("archive type not supported: %s", archiveType)
+	}
+
+	if archive, ok := d.GetOk("base_archive"); ok {
+		if err := archiver.CopyArchive(archive.(string)); err != nil {
+			return fmt.Errorf("error copying archive: %s", err)
+		}
 	}
 
 	if dir, ok := d.GetOk("source_dir"); ok {

--- a/builtin/providers/archive/data_source_archive_file_test.go
+++ b/builtin/providers/archive/data_source_archive_file_test.go
@@ -36,6 +36,13 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 				),
 			},
 			r.TestStep{
+				Config: testAccBaseArchiveFileConfig,
+				Check: r.ComposeTestCheckFunc(
+					testAccArchiveFileExists("zip_file_acc_test.zip", &fileSize),
+					r.TestCheckResourceAttrPtr("data.archive_file.foo", "output_size", &fileSize),
+				),
+			},
+			r.TestStep{
 				Config: testAccArchiveFileOutputPath,
 				Check: r.ComposeTestCheckFunc(
 					testAccArchiveFileExists(fmt.Sprintf("%s/test.zip", tmpDir), &fileSize),
@@ -88,6 +95,14 @@ var testAccArchiveFileDirConfig = `
 data "archive_file" "foo" {
   type        = "zip"
   source_dir  = "test-fixtures/test-dir"
+  output_path = "zip_file_acc_test.zip"
+}
+`
+var testAccBaseArchiveFileConfig = `
+data "archive_file" "foo" {
+  type        = "zip"
+  source_file  = "test-fixtures/test-file.txt"
+  base_archive = "test-fixtures/archive.zip"
   output_path = "zip_file_acc_test.zip"
 }
 `

--- a/builtin/providers/archive/zip_archiver_test.go
+++ b/builtin/providers/archive/zip_archiver_test.go
@@ -44,6 +44,26 @@ func TestZipArchiver_Dir(t *testing.T) {
 	})
 }
 
+func TestZipArchiver_CopyArchive(t *testing.T) {
+	zipfilepath := "archive-base.zip"
+	archiver := NewZipArchiver(zipfilepath)
+
+	if err := archiver.CopyArchive("./test-fixtures/archive.zip"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if err := archiver.ArchiveFile("./test-fixtures/test-file.txt"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureContents(t, zipfilepath, map[string][]byte{
+		"file1.txt":     []byte("This is file 1"),
+		"file2.txt":     []byte("This is file 2"),
+		"file3.txt":     []byte("This is file 3"),
+		"test-file.txt": []byte("This is test content"),
+	})
+}
+
 func ensureContents(t *testing.T, zipfilepath string, wants map[string][]byte) {
 	r, err := zip.OpenReader(zipfilepath)
 	if err != nil {

--- a/website/source/docs/providers/archive/d/archive_file.md
+++ b/website/source/docs/providers/archive/d/archive_file.md
@@ -31,6 +31,8 @@ NOTE: One of `source_content_filename` (with `source_content`), `source_file`, o
 
 * `output_path` - (required) The output of the archive file.
 
+* `base_archive` - (optional) Add contents of this archive file before adding `source_content`, `source_file` or `source_dir`.
+
 * `source_content` - (optional) Add only this content to the archive with `source_content_filename` as the filename.
 
 * `source_content_filename` - (optional) Set this as the filename when using `source_content`.


### PR DESCRIPTION
Using the new argument `base_archive` inside an `archive_file` resource, an existing archive file can be amended.

My primary use case is for AWS lambda functions with a large dependency tree that i would prefer not adding to the repository as individual files. The main lambda function file needs to be run through template_file.

I'm new to golang, let me know if there is anything i can do better.