### PR TITLE
provider/aws: Enable DeleteOnTermination in ENI when created by spot fleet

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -375,6 +375,7 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 		// the same request
 		ni := &ec2.InstanceNetworkInterfaceSpecification{
 			AssociatePublicIpAddress: aws.Bool(true),
+			DeleteOnTermination:      aws.Bool(true),
 			DeviceIndex:              aws.Int64(int64(0)),
 			SubnetId:                 aws.String(subnetId.(string)),
 			Groups:                   groupIds,


### PR DESCRIPTION
## Why
Spot fleet built by Terraform cannot delete ENI associated with spot instance when it delete spot instances. Especially, in case of specified `associate_public_ip_address` is true. I think that it should delete ENI when instances are deleted by spot fleet.

## Proposal
Enable `DeleteOnTermination` in `InstanceNetworkInterfaceSpecification`. By default, this behavior is the same in Manegement Console.

## Environment
Check behavior in following environment:
```
$ bin/terraform -v
Terraform v0.8.0-dev (4be9a42ab0662b2e242a484e85ae1a475d110db4+CHANGES)
```

## Checklists
- [x] Acceptance test coverage of new behavior
- [x] Documentation updates
- [x] Well-formed Code