### PR TITLE
Update documentation for aws_spot_datafeed_subscription.

### DIFF
--- a/website/source/docs/providers/aws/r/spot_datafeed_subscription.html.markdown
+++ b/website/source/docs/providers/aws/r/spot_datafeed_subscription.html.markdown
@@ -22,12 +22,13 @@ resource "aws_s3_bucket" "default" {
 
 resource "aws_spot_datafeed_subscription" "default" {
 	bucket = "${aws_s3_bucket.default.bucket}"
+	prefix = "my_subdirectory"
 }
 ```
 
 ## Argument Reference
 * `bucket` - (Required) The Amazon S3 bucket in which to store the Spot instance data feed.
-* `prefix` - (Optional) A prefix for the data feed file names.
+* `prefix` - (Optional) Path of folder inside bucket to place spot pricing data.
 
 
 ## Import


### PR DESCRIPTION
I've updated the documentation to be more accurate. I've just tested the function of "prefix" with AWS and confirmed it is a path inside an S3 bucket rather than a prefix on filenames.

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-data-feeds.html