### PR TITLE
provider/aws: allow empty value for autoscaling schedule parameters

### DIFF
--- a/website/source/docs/providers/aws/r/autoscaling_schedule.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_schedule.html.markdown
@@ -47,10 +47,10 @@ The following arguments are supported:
                           If you try to schedule your action in the past, Auto Scaling returns an error message.
 * `recurrence` - (Optional) The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format.
 * `min_size` - (Optional) The minimum size for the Auto Scaling group. Default
-0.
+0. Set to -1 if you don't want to change the minimum size at the scheduled time.
 * `max_size` - (Optional) The maximum size for the Auto Scaling group. Default
-0.
-* `desired_capacity` - (Optional) The number of EC2 instances that should be running in the group. Default 0.
+0. Set to -1 if you don't want to change the maximum size at the scheduled time.
+* `desired_capacity` - (Optional) The number of EC2 instances that should be running in the group. Default 0.  Set to -1 if you don't want to change the desired capacity at the scheduled time.
 
 ~> **NOTE:** When `start_time` and `end_time` are specified with `recurrence` , they form the boundaries of when the recurring action will start and stop.
 


### PR DESCRIPTION
Specifically, this allows you to create a schedule which only changes
some of the group parameters without changing others, by setting the
parameters you wish to remain empty to -1.  This means you can adjust
min or max size without affecting the desired capacity, for example.

The ad hoc support for -1 isn't as nice as having real support for
leaving values out (see #5694) but it solves a real use case.

Fixes #5681.