### PR TITLE
provider/google: throw an error for invalid disks

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -361,6 +361,13 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		disk.Boot = i == 0
 		disk.AutoDelete = d.Get(prefix + ".auto_delete").(bool)
 
+		if _, ok := d.GetOk(prefix + ".disk"); ok {
+			if _, ok := d.GetOk(prefix + ".type"); ok {
+				return fmt.Errorf(
+					"Error: cannot define both disk and type.")
+			}
+		}
+
 		// Load up the disk for this disk if specified
 		if v, ok := d.GetOk(prefix + ".disk"); ok {
 			diskName := v.(string)


### PR DESCRIPTION
When configuring an instance's attached disk, if the attached disk has
both the disk and type attributes set, it would previously cause
terraform to crash with a nil pointer exception. The root cause was that
we only instantiate the InitializeParams property of the disk if its
disk attribute isn't set, and we try to write to the InitializeParams
property when the type attribute is set. So setting both caused the
InitializeParams property to not be initialized, then written to.

Now we throw an error explaining that the configuration can't have both
the disk and the type set.

Fixes #6495.