### PR TITLE
Added AWS Redshift Enhanced VPC Routing

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -159,6 +159,12 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"enhanced_vpc_routing": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
 			"kms_key_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -302,6 +308,10 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 			restoreOpts.ElasticIp = aws.String(v.(string))
 		}
 
+		if v, ok := d.GetOk("enhanced_vpc_routing"); ok {
+			restoreOpts.EnhancedVpcRouting = aws.Bool(v.(bool))
+		}
+
 		if v, ok := d.GetOk("iam_roles"); ok {
 			restoreOpts.IamRoles = expandStringList(v.(*schema.Set).List())
 		}
@@ -364,6 +374,10 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 
 		if v, ok := d.GetOk("encrypted"); ok {
 			createOpts.Encrypted = aws.Bool(v.(bool))
+		}
+
+		if v, ok := d.GetOk("enhanced_vpc_routing"); ok {
+			createOpts.EnhancedVpcRouting = aws.Bool(v.(bool))
 		}
 
 		if v, ok := d.GetOk("kms_key_id"); ok {

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -481,6 +481,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("cluster_subnet_group_name", rsc.ClusterSubnetGroupName)
 	d.Set("availability_zone", rsc.AvailabilityZone)
 	d.Set("encrypted", rsc.Encrypted)
+	d.Set("enhanced_vpc_routing", rsc.EnhancedVpcRouting)
 	d.Set("kms_key_id", rsc.KmsKeyId)
 	d.Set("automated_snapshot_retention_period", rsc.AutomatedSnapshotRetentionPeriod)
 	d.Set("preferred_maintenance_window", rsc.PreferredMaintenanceWindow)
@@ -621,6 +622,11 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if d.HasChange("publicly_accessible") {
 		req.PubliclyAccessible = aws.Bool(d.Get("publicly_accessible").(bool))
+		requestUpdate = true
+	}
+
+	if d.HasChange("enhanced_vpc_routing") {
+		req.EnhancedVpcRouting = aws.Bool(d.Get("enhanced_vpc_routing").(bool))
 		requestUpdate = true
 	}
 

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -42,7 +42,8 @@ func TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled(t *testing.T) {
 	var v redshift.Cluster
 
 	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	config := fmt.Sprintf(testAccAWSRedshiftClusterConfig_enhancedVpcRoutingEnabled, ri)
+	preConfig := fmt.Sprintf(testAccAWSRedshiftClusterConfig_enhancedVpcRoutingEnabled, ri)
+	postConfig := fmt.Sprintf(testAccAWSRedshiftClusterConfig_enhancedVpcRoutingDisabled, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,13 +51,19 @@ func TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: config,
+				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "cluster_type", "single-node"),
-					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "enhanced_vpc_routing", "true"),
+				),
+			},
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "enhanced_vpc_routing", "false"),
 				),
 			},
 		},
@@ -506,6 +513,20 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
   enhanced_vpc_routing = true
+}
+`
+
+var testAccAWSRedshiftClusterConfig_enhancedVpcRoutingDisabled = `
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  availability_zone = "us-west-2a"
+  database_name = "mydb"
+  master_username = "foo_test"
+  master_password = "Mustbe8characters"
+  node_type = "dc1.large"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade = false
+  enhanced_vpc_routing = false
 }
 `
 

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -38,6 +38,31 @@ func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled(t *testing.T) {
+	var v redshift.Cluster
+
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	config := fmt.Sprintf(testAccAWSRedshiftClusterConfig_enhancedVpcRoutingEnabled, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "cluster_type", "single-node"),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "enhanced_vpc_routing", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRedshiftCluster_loggingEnabled(t *testing.T) {
 	var v redshift.Cluster
 
@@ -469,6 +494,20 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
 }`
+
+var testAccAWSRedshiftClusterConfig_enhancedVpcRoutingEnabled = `
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  availability_zone = "us-west-2a"
+  database_name = "mydb"
+  master_username = "foo_test"
+  master_password = "Mustbe8characters"
+  node_type = "dc1.large"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade = false
+  enhanced_vpc_routing = true
+}
+`
 
 var testAccAWSRedshiftClusterConfig_loggingDisabled = `
 resource "aws_redshift_cluster" "default" {

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -54,6 +54,7 @@ string.
 * `number_of_nodes` - (Optional) The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node. Default is 1.
 * `publicly_accessible` - (Optional) If true, the cluster can be accessed from a public network. Default is `true`.
 * `encrypted` - (Optional) If true , the data in the cluster is encrypted at rest.
+* `enhanced_vpc_routing` - (Optional) If true , enhanced VPC routing is enabled.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
 * `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is true.


### PR DESCRIPTION
Adds #9928 

```
anssharma@Ban-1Anssharma-M:~/Code/go/src/github.com/hashicorp/terraform|master⚡
⇒  make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/08 17:24:16 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (672.42s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	677.841s
```

/cc @stack72 @paddyforan 