### PR TITLE
terraform: destroy edges should never point to self

### DIFF
--- a/terraform/test-fixtures/apply-provisioner-explicit-self-ref/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-explicit-self-ref/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+    foo = "bar"
+
+    provisioner "shell" {
+        command = "${aws_instance.foo.foo}"
+    }
+}

--- a/terraform/test-fixtures/transform-destroy-edge-self-ref/main.tf
+++ b/terraform/test-fixtures/transform-destroy-edge-self-ref/main.tf
@@ -1,0 +1,5 @@
+resource "test" "A" {
+    provisioner "foo" {
+        command = "${test.A.id}"
+    }
+}

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -182,7 +182,9 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 		// names "a_d" and "b_d" to reference our example.
 		for _, a_d := range dns {
 			for _, b_d := range depDestroyers {
-				g.Connect(dag.BasicEdge(b_d, a_d))
+				if b_d != a_d {
+					g.Connect(dag.BasicEdge(b_d, a_d))
+				}
 			}
 		}
 	}

--- a/terraform/transform_destroy_edge_test.go
+++ b/terraform/transform_destroy_edge_test.go
@@ -61,6 +61,23 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 	}
 }
 
+func TestDestroyEdgeTransformer_selfRef(t *testing.T) {
+	g := Graph{Path: RootModulePath}
+	g.Add(&graphNodeDestroyerTest{AddrString: "test.A"})
+	tf := &DestroyEdgeTransformer{
+		Module: testModule(t, "transform-destroy-edge-self-ref"),
+	}
+	if err := tf.Transform(&g); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformDestroyEdgeSelfRefStr)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
 type graphNodeCreatorTest struct {
 	AddrString string
 }
@@ -111,4 +128,8 @@ test.A (destroy)
 test.B (destroy)
   test.C (destroy)
 test.C (destroy)
+`
+
+const testTransformDestroyEdgeSelfRefStr = `
+test.A (destroy)
 `


### PR DESCRIPTION
Fixes #9920

This was an issue caught with the shadow graph. Self references in
provisioners were causing a self-edge on destroy apply graphs.

We need to explicitly check that we're not creating an edge to ourself.
This is also how the reference transformer works.