### PR TITLE
provider/google: Add google_iam_policy and google_project to sidebar

### DIFF
--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -10,6 +10,24 @@
 		<a href="/docs/providers/google/index.html">Google Provider</a>
 		</li>
 
+		<li<%= sidebar_current(/^docs-google-datasource/) %>>
+		<a href="#">Google Compute Platform Data Sources</a>
+		<ul class="nav nav-visible">
+			<li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
+			<a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
+			</li>
+		</ul>
+		</li>
+
+		<li<%= sidebar_current(/^docs-google-project/) %>>
+		<a href="#">Google Compute Platform Resources</a>
+		<ul class="nav nav-visible">
+			<li<%= sidebar_current("docs-google-project") %>>
+			<a href="/docs/providers/google/r/google_project.html">google_project</a>
+			</li>
+		</ul>
+		</li>
+
 		<li<%= sidebar_current(/^docs-google-compute/) %>>
 		<a href="#">Google Compute Engine Resources</a>
 		<ul class="nav nav-visible">


### PR DESCRIPTION
These resources were created in #8092, but not added to the sidebar. This fixes that so the docs are available on the website.
This may be a candidate for a push to stable-website outside of a release cycle, as these resources are already live.