### PR TITLE
terraform: prune orphan outputs in old graph

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/config/module"
-	"github.com/hashicorp/terraform/helper/experiment"
 )
 
 func TestContext2Apply_basic(t *testing.T) {
@@ -2291,10 +2290,6 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 }
 
 func TestContext2Apply_outputOrphanModule(t *testing.T) {
-	if !experiment.Enabled(experiment.X_newApply) {
-		t.SkipNow()
-	}
-
 	m := testModule(t, "apply-output-orphan-module")
 	p := testProvider("aws")
 	p.ApplyFn = testApplyFn

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -172,6 +172,9 @@ func (b *BuiltinGraphBuilder) Steps(path []string) []GraphTransformer {
 			// their dependencies.
 			&TargetsTransformer{Targets: b.Targets, Destroy: b.Destroy},
 
+			// Create orphan output nodes
+			&OrphanOutputTransformer{Module: b.Root, State: b.State},
+
 			// Prune the providers. This must happen only once because flattened
 			// modules might depend on empty providers.
 			&PruneProviderTransformer{},

--- a/terraform/node_output_orphan.go
+++ b/terraform/node_output_orphan.go
@@ -26,7 +26,10 @@ func (n *NodeOutputOrphan) Path() []string {
 
 // GraphNodeEvalable
 func (n *NodeOutputOrphan) EvalTree() EvalNode {
-	return &EvalDeleteOutput{
-		Name: n.OutputName,
+	return &EvalOpFilter{
+		Ops: []walkOperation{walkRefresh, walkApply, walkDestroy},
+		Node: &EvalDeleteOutput{
+			Name: n.OutputName,
+		},
 	}
 }


### PR DESCRIPTION
This makes the old graph also prune orphan outputs in modules.
This will fix shadow graph errors such as #9905 since the old graph will
also behave correctly in these scenarios.

Luckily, because orphan outputs don't rely on anything, we were able to
simply use the same transformer!