### PR TITLE
provider/scaleway: retry volume attachment

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
@@ -3,7 +3,9 @@ package scaleway
 import (
 	"fmt"
 	"log"
+	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/scaleway/scaleway-cli/pkg/api"
 )
@@ -80,11 +82,27 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 		volumes[k] = v
 	}
 
-	var req = api.ScalewayServerPatchDefinition{
-		Volumes: &volumes,
-	}
-	if err := scaleway.PatchServer(serverID, req); err != nil {
-		return fmt.Errorf("Failed attaching volume to server: %q", err)
+	if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		var req = api.ScalewayServerPatchDefinition{
+			Volumes: &volumes,
+		}
+		err := scaleway.PatchServer(serverID, req)
+
+		if err == nil {
+			return nil
+		}
+
+		if serr, ok := err.(api.ScalewayAPIError); ok {
+			log.Printf("[DEBUG] Error patching server: %q\n", serr.APIMessage)
+
+			if serr.StatusCode == 400 {
+				return resource.RetryableError(fmt.Errorf("Waiting for server update to succeed: %q", serr.APIMessage))
+			}
+		}
+
+		return resource.NonRetryableError(err)
+	}); err != nil {
+		return err
 	}
 
 	if startServerAgain {
@@ -185,10 +203,26 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 		volumes[k] = v
 	}
 
-	var req = api.ScalewayServerPatchDefinition{
-		Volumes: &volumes,
-	}
-	if err := scaleway.PatchServer(serverID, req); err != nil {
+	if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		var req = api.ScalewayServerPatchDefinition{
+			Volumes: &volumes,
+		}
+		err := scaleway.PatchServer(serverID, req)
+
+		if err == nil {
+			return nil
+		}
+
+		if serr, ok := err.(api.ScalewayAPIError); ok {
+			log.Printf("[DEBUG] Error patching server: %q\n", serr.APIMessage)
+
+			if serr.StatusCode == 400 {
+				return resource.RetryableError(fmt.Errorf("Waiting for server update to succeed: %q", serr.APIMessage))
+			}
+		}
+
+		return resource.NonRetryableError(err)
+	}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
this PR fixes a flakyness in the `scaleway_volume_attachment` resource, as
described below:

when attaching/ detaching a volume from a `scaleway_server`, the server ne
be stopped. even though the code already waits for the server to be stoppe
`PatchServer` calls gets a `400 server is being stopped or rebooted` error
response.

If the API returns the `400` we bail, leaving terraform in a broken state.

Assuming this is the only error that the API might return to us, as the payload
itself is correct, this retry behaviour should fix the issue.

Tests are green, and I could not reproduce the flakyness in multiple test runs: 
```
make testacc TEST=./builtin/providers/scaleway TESTARGS='-run=TestAccScalewayVolumeAttachment_Basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/08 22:21:30 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScalewayVolumeAttachment_Basic -timeout 120m
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (511.87s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/scaleway    511.884s
```

\cc @stack72 please take a look