### PR TITLE
Fix typo in the Google sidebar.

### DIFF
--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -11,7 +11,7 @@
 		</li>
 
 		<li<%= sidebar_current(/^docs-google-datasource/) %>>
-		<a href="#">Google Compute Platform Data Sources</a>
+		<a href="#">Google Cloud Platform Data Sources</a>
 		<ul class="nav nav-visible">
 			<li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
 			<a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
@@ -20,7 +20,7 @@
 		</li>
 
 		<li<%= sidebar_current(/^docs-google-project/) %>>
-		<a href="#">Google Compute Platform Resources</a>
+		<a href="#">Google Cloud Platform Resources</a>
 		<ul class="nav nav-visible">
 			<li<%= sidebar_current("docs-google-project") %>>
 			<a href="/docs/providers/google/r/google_project.html">google_project</a>


### PR DESCRIPTION
We have Google Compute Platform when we really mean Google Cloud
Platform. Whoops. I totally let this sneak in in #9969.