### PR TITLE
provider/scaleway: update sdk

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_volume.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume.go
@@ -76,9 +76,7 @@ func resourceScalewayVolumeRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.Set("name", volume.Name)
-	if size, ok := volume.Size.(float64); ok {
-		d.Set("size_in_gb", uint64(size)/gb)
-	}
+	d.Set("size_in_gb", uint64(volume.Size)/gb)
 	d.Set("type", volume.VolumeType)
 	d.Set("server", "")
 	if volume.Server != nil {

--- a/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
@@ -71,7 +71,7 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 
 	// the API request requires most volume attributes to be unset to succeed
 	for k, v := range volumes {
-		v.Size = nil
+		v.Size = 0
 		v.CreationDate = ""
 		v.Organization = ""
 		v.ModificationDate = ""
@@ -192,7 +192,7 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 
 	// the API request requires most volume attributes to be unset to succeed
 	for k, v := range volumes {
-		v.Size = nil
+		v.Size = 0
 		v.CreationDate = ""
 		v.Organization = ""
 		v.ModificationDate = ""

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/api/api.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/api/api.go
@@ -147,7 +147,7 @@ type ScalewayVolume struct {
 	Identifier string `json:"id,omitempty"`
 
 	// Size is the allocated size of the volume
-	Size interface{} `json:"size,omitempty"`
+	Size uint64 `json:"size,omitempty"`
 
 	// CreationDate is the creation date of the volume
 	CreationDate string `json:"creation_date,omitempty"`
@@ -939,7 +939,7 @@ func (s *ScalewayAPI) response(method, uri string, content io.Reader) (resp *htt
 
 // GetResponsePaginate fetchs all resources and returns an http.Response object for the requested resource
 func (s *ScalewayAPI) GetResponsePaginate(apiURL, resource string, values url.Values) (*http.Response, error) {
-	resp, err := s.response("HEAD", fmt.Sprintf("%s/%s", strings.TrimRight(apiURL, "/"), resource), nil)
+	resp, err := s.response("HEAD", fmt.Sprintf("%s/%s?%s", strings.TrimRight(apiURL, "/"), resource, values.Encode()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -956,6 +956,9 @@ func (s *ScalewayAPI) GetResponsePaginate(apiURL, resource string, values url.Va
 	}
 
 	get := maxElem / perPage
+	if (float32(maxElem) / perPage) > float32(get) {
+		get++
+	}
 
 	if get <= 1 { // If there is 0 or 1 page of result, the response is not paginated
 		if len(values) == 0 {
@@ -985,38 +988,31 @@ func (s *ScalewayAPI) GetResponsePaginate(apiURL, resource string, values url.Va
 		if err = g.Wait(); err != nil {
 			return nil, err
 		}
-		newBody := make(map[string][]interface{})
-		body := make(map[string][]interface{})
+		newBody := make(map[string][]json.RawMessage)
+		body := make(map[string][]json.RawMessage)
 		key := ""
 		for i := 0; i < get; i++ {
 			res := <-ch
 			if res.StatusCode != http.StatusOK {
 				return res, nil
 			}
+			content, err := ioutil.ReadAll(res.Body)
+			res.Body.Close()
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(content, &body); err != nil {
+				return nil, err
+			}
+
 			if i == 0 {
 				resp = res
-				content, err := ioutil.ReadAll(res.Body)
-				res.Body.Close()
-				if err != nil {
-					return nil, err
-				}
-				if err := json.Unmarshal(content, &newBody); err != nil {
-					return nil, err
-				}
-				for k := range newBody {
+				for k := range body {
 					key = k
+					break
 				}
-			} else {
-				content, err := ioutil.ReadAll(res.Body)
-				res.Body.Close()
-				if err != nil {
-					return nil, err
-				}
-				if err := json.Unmarshal(content, &body); err != nil {
-					return nil, err
-				}
-				newBody[key] = append(newBody[key], body[key]...)
 			}
+			newBody[key] = append(newBody[key], body[key]...)
 		}
 		payload := new(bytes.Buffer)
 		if err := json.NewEncoder(payload).Encode(newBody); err != nil {
@@ -1509,7 +1505,9 @@ func (s *ScalewayAPI) GetImages() (*[]MarketImage, error) {
 			}
 		}
 	}
-	resp, err := s.GetResponsePaginate(s.computeAPI, "images?organization="+s.Organization, url.Values{})
+	values := url.Values{}
+	values.Set("organization", s.Organization)
+	resp, err := s.GetResponsePaginate(s.computeAPI, "images", values)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -1525,8 +1523,8 @@ func (s *ScalewayAPI) GetImages() (*[]MarketImage, error) {
 	if err = json.Unmarshal(body, &OrgaImages); err != nil {
 		return nil, err
 	}
+
 	for _, orgaImage := range OrgaImages.Images {
-		s.Cache.InsertImage(orgaImage.Identifier, "", orgaImage.Arch, orgaImage.Organization, orgaImage.Name, "")
 		images.Images = append(images.Images, MarketImage{
 			Categories:           []string{"MyImages"},
 			CreationDate:         orgaImage.CreationDate,
@@ -1545,7 +1543,8 @@ func (s *ScalewayAPI) GetImages() (*[]MarketImage, error) {
 								{
 									Arch: orgaImage.Arch,
 									ID:   orgaImage.Identifier,
-									Zone: "",
+									// TODO: fecth images from ams1 and par1
+									Zone: s.Region,
 								},
 							},
 						},
@@ -1553,6 +1552,7 @@ func (s *ScalewayAPI) GetImages() (*[]MarketImage, error) {
 				},
 			},
 		})
+		s.Cache.InsertImage(orgaImage.Identifier, s.Region, orgaImage.Arch, orgaImage.Organization, orgaImage.Name, "")
 	}
 	return &images.Images, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1816,10 +1816,10 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "YF6baE6Sl76/nVYo0JwJXCkJmGw=",
+			"checksumSHA1": "BfFS70stfaoDJYyCzky1Sr0D5UE=",
 			"path": "github.com/scaleway/scaleway-cli/pkg/api",
-			"revision": "88132ecdd39da62f7c73c5a8e1a383d7da5e0e09",
-			"revisionTime": "2016-10-27T15:40:24Z"
+			"revision": "790f00aee05c9264248f1090c062ac0513e5a191",
+			"revisionTime": "2016-11-07T15:30:35Z"
 		},
 		{
 			"checksumSHA1": "aU2+iXO1oHS4vBtAXXBgicA9YBY=",


### PR DESCRIPTION
the SDK updates includes a fix for the image cache, which might lead to wrong
images ids being returned on lookup. Strikes me as important.

all tests remain green:

```
make testacc TEST=./builtin/providers/scaleway TESTARGS='-run=TestAccScaleway'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/08 23:08:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScaleway -timeout 120m
=== RUN   TestAccScalewayDataSourceBootscript_Basic
--- PASS: TestAccScalewayDataSourceBootscript_Basic (1.54s)
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (1.79s)
=== RUN   TestAccScalewayDataSourceImage_Basic
--- PASS: TestAccScalewayDataSourceImage_Basic (9.08s)
=== RUN   TestAccScalewayDataSourceImage_Filtered
--- PASS: TestAccScalewayDataSourceImage_Filtered (8.19s)
=== RUN   TestAccScalewayIP_importBasic
--- PASS: TestAccScalewayIP_importBasic (2.30s)
=== RUN   TestAccScalewaySecurityGroup_importBasic
--- PASS: TestAccScalewaySecurityGroup_importBasic (2.31s)
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (117.82s)
=== RUN   TestAccScalewayVolume_importBasic
--- PASS: TestAccScalewayVolume_importBasic (3.84s)
=== RUN   TestAccScalewayIP_Basic
--- PASS: TestAccScalewayIP_Basic (11.75s)
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (5.97s)
=== RUN   TestAccScalewaySecurityGroup_Basic
--- PASS: TestAccScalewaySecurityGroup_Basic (4.26s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (105.26s)
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (99.81s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (136.25s)
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (459.29s)
=== RUN   TestAccScalewayVolume_Basic
--- PASS: TestAccScalewayVolume_Basic (5.10s)
```

related: scaleway/scaleway-cli#f6f7af3a29b09bb29d35aff84df4bf88b109e01b